### PR TITLE
Fix Vary header merge in security middleware

### DIFF
--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -130,7 +130,13 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         if not request.url.path.startswith(_PUBLIC_PREFIXES):
             response.headers["Cache-Control"] = "private, no-store, no-cache"
-            response.headers["Vary"] = "Authorization"
+            vary_values = {
+                part.strip()
+                for part in response.headers.get("Vary", "").split(",")
+                if part.strip()
+            }
+            vary_values.add("Authorization")
+            response.headers["Vary"] = ", ".join(sorted(vary_values))
         return response
 
 


### PR DESCRIPTION
## Summary
- preserve any pre-existing `Vary` header values when adding `Authorization` in `SecurityHeadersMiddleware`
- avoid overwriting CORS/proxy cache semantics by merging and de-duplicating values

## Validation
- `uv run pytest tests/integration/test_cache_control_headers.py -v`
- `make test` currently fails at collection in this repo due baseline import errors (`tests.gateway`/`core` not found), unrelated to this change