### PR TITLE
Rebalance test pyramid toward unit-focused coverage

### DIFF
--- a/.github/workflows/gateway-tests.yml
+++ b/.github/workflows/gateway-tests.yml
@@ -42,11 +42,17 @@ jobs:
       run: |
          uv sync --dev --frozen
 
+    - name: Run gateway unit tests
+      env:
+        GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      run: |
+        uv run pytest tests/unit -v --cov --cov-report=xml -n auto
+
     - name: Run gateway integration tests
       env:
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       run: |
-        uv run pytest tests/integration tests/unit -v --cov --cov-report=xml --cov-append -n auto
+        uv run pytest tests/integration -v --cov --cov-report=xml --cov-append -n auto
 
     - name: Upload coverage
       uses: codecov/codecov-action@v5

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
-.PHONY: help dev test
+.PHONY: help dev test test-unit test-integration
 
-help:
+	help:
 	@printf "Available targets:\n"
 	@printf "  dev  Run gateway with uvicorn --reload using .env\n"
-	@printf "  test Run gateway test suite\n"
+	@printf "  test Run full test suite (unit + integration)\n"
+	@printf "  test-unit Run unit tests\n"
+	@printf "  test-integration Run integration tests\n"
 
 dev:
 	@set -a; \
@@ -12,4 +14,10 @@ dev:
 	uv run --env-file .env uvicorn gateway.dev:create_dev_app --factory --app-dir src --reload --host "$${GATEWAY_HOST:-0.0.0.0}" --port "$${GATEWAY_PORT:-8000}" --reload-dir src
 
 test:
-	uv run pytest -v tests/integration tests/unit/test_gateway_*.py
+	uv run pytest -v tests/unit tests/integration
+
+test-unit:
+	uv run pytest -v tests/unit
+
+test-integration:
+	uv run pytest -v tests/integration

--- a/tests/integration/test_rate_limiting.py
+++ b/tests/integration/test_rate_limiting.py
@@ -1,162 +1,18 @@
-"""Tests for per-user rate limiting."""
+"""Integration tests for request-level rate limiting behavior."""
 
 from collections.abc import Generator
 from typing import Any
 from unittest.mock import patch
 
 import pytest
-from fastapi import HTTPException
 from fastapi.testclient import TestClient
-from pydantic import ValidationError
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session, sessionmaker
 
 from gateway.core.config import API_KEY_HEADER, GatewayConfig
 from gateway.db import Base, get_db
 from gateway.main import create_app
-from gateway.rate_limit import RateLimiter, RateLimitInfo
 from tests.gateway.conftest import _run_alembic_migrations
-
-
-def test_rate_limiter_allows_under_limit() -> None:
-    """Test that requests under the limit are allowed."""
-    limiter = RateLimiter(rpm=5)
-    for _ in range(5):
-        limiter.check("user-1")
-
-
-def test_rate_limiter_returns_rate_limit_info() -> None:
-    """Test that check() returns RateLimitInfo with correct values."""
-    limiter = RateLimiter(rpm=5)
-    info = limiter.check("user-1")
-    assert isinstance(info, RateLimitInfo)
-    assert info.limit == 5
-    assert info.remaining == 4
-
-    info2 = limiter.check("user-1")
-    assert info2.remaining == 3
-
-
-def test_rate_limiter_reset_is_wall_clock() -> None:
-    """Test that reset uses wall-clock time, not monotonic time."""
-    limiter = RateLimiter(rpm=5)
-
-    with patch("rate_limit.time") as mock_time:
-        mock_time.monotonic.return_value = 1000.0
-        mock_time.time.return_value = 1700000000.0
-        info = limiter.check("user-1")
-
-    # reset should be based on wall-clock time (~60s from now), not monotonic
-    assert info.reset == pytest.approx(1700000060.0, abs=1.0)
-
-
-def test_rate_limiter_rejects_over_limit() -> None:
-    """Test that requests over the limit are rejected with 429."""
-    limiter = RateLimiter(rpm=3)
-    for _ in range(3):
-        limiter.check("user-1")
-
-    with pytest.raises(HTTPException) as exc_info:
-        limiter.check("user-1")
-    assert exc_info.value.status_code == 429
-
-
-def test_rate_limiter_429_includes_retry_after() -> None:
-    """Test that 429 response includes a Retry-After header."""
-    limiter = RateLimiter(rpm=1)
-    limiter.check("user-1")
-
-    with pytest.raises(HTTPException) as exc_info:
-        limiter.check("user-1")
-    assert exc_info.value.headers is not None
-    assert "Retry-After" in exc_info.value.headers
-    retry_after = int(exc_info.value.headers["Retry-After"])
-    assert 1 <= retry_after <= 60
-
-
-def test_rate_limiter_per_user_isolation() -> None:
-    """Test that rate limits are tracked independently per user."""
-    limiter = RateLimiter(rpm=2)
-    limiter.check("user-1")
-    limiter.check("user-1")
-
-    # user-2 should still be allowed
-    limiter.check("user-2")
-    limiter.check("user-2")
-
-    # user-1 should be blocked, user-2 also blocked
-    with pytest.raises(HTTPException):
-        limiter.check("user-1")
-    with pytest.raises(HTTPException):
-        limiter.check("user-2")
-
-
-def test_rate_limiter_window_expiry() -> None:
-    """Test that requests are allowed again after the window expires."""
-    limiter = RateLimiter(rpm=2)
-
-    with patch("rate_limit.time") as mock_time:
-        mock_time.monotonic.return_value = 1000.0
-        mock_time.time.return_value = 1700000000.0
-        limiter.check("user-1")
-        limiter.check("user-1")
-
-        with pytest.raises(HTTPException):
-            limiter.check("user-1")
-
-        # Fast-forward past the 60s window
-        mock_time.monotonic.return_value = 1061.0
-        mock_time.time.return_value = 1700000061.0
-        info = limiter.check("user-1")
-        assert info.remaining == 1
-
-
-def test_rate_limiter_cleanup() -> None:
-    """Test that stale user entries are cleaned up periodically."""
-    limiter = RateLimiter(rpm=100)
-    limiter._CLEANUP_INTERVAL = 3  # trigger cleanup quickly
-
-    with patch("rate_limit.time") as mock_time:
-        mock_time.monotonic.return_value = 1000.0
-        mock_time.time.return_value = 1700000000.0
-
-        # Create entries for stale-user
-        limiter.check("stale-user")
-        limiter.check("stale-user")
-
-        # Fast-forward so stale-user's timestamps expire
-        mock_time.monotonic.return_value = 1061.0
-        mock_time.time.return_value = 1700000061.0
-
-        # Third call triggers cleanup (interval=3)
-        limiter.check("active-user")
-
-        assert "stale-user" not in limiter._requests
-        assert "active-user" in limiter._requests
-
-
-def test_config_rejects_zero_rate_limit() -> None:
-    """Test that rate_limit_rpm=0 is rejected by validation."""
-    with pytest.raises(ValidationError):
-        GatewayConfig(rate_limit_rpm=0)
-
-
-def test_config_rejects_negative_rate_limit() -> None:
-    """Test that rate_limit_rpm=-1 is rejected by validation."""
-    with pytest.raises(ValidationError):
-        GatewayConfig(rate_limit_rpm=-1)
-
-
-def test_config_accepts_positive_rate_limit() -> None:
-    """Test that rate_limit_rpm=1 is accepted."""
-    config = GatewayConfig(rate_limit_rpm=1)
-    assert config.rate_limit_rpm == 1
-
-
-def test_config_accepts_none_rate_limit() -> None:
-    """Test that rate_limit_rpm=None (disabled) is accepted."""
-    config = GatewayConfig(rate_limit_rpm=None)
-    assert config.rate_limit_rpm is None
 
 
 class _MockCompletionError(Exception):
@@ -167,7 +23,6 @@ def _make_rate_limit_client(
     postgres_url: str,
     rate_limit_rpm: int | None,
 ) -> Generator[TestClient]:
-    """Create a TestClient with the given rate_limit_rpm config."""
     config = GatewayConfig(
         database_url=postgres_url,
         master_key="test-master-key",
@@ -181,7 +36,9 @@ def _make_rate_limit_client(
     app = create_app(config)
 
     def override_get_db() -> Generator[Session]:
-        testing_session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+        testing_session_local = sessionmaker(
+            autocommit=False, autoflush=False, bind=engine
+        )
         db = testing_session_local()
         try:
             yield db
@@ -202,27 +59,27 @@ def _make_rate_limit_client(
 
 @pytest.fixture
 def rate_limit_client(postgres_url: str) -> Generator[TestClient]:
-    """TestClient with rate_limit_rpm=3."""
     yield from _make_rate_limit_client(postgres_url, rate_limit_rpm=3)
 
 
 @pytest.fixture
 def no_rate_limit_client(postgres_url: str) -> Generator[TestClient]:
-    """TestClient with rate limiting disabled."""
     yield from _make_rate_limit_client(postgres_url, rate_limit_rpm=None)
 
 
 def _create_test_user(client: TestClient, master_key: str = "test-master-key") -> str:
-    """Create a test user and return the user_id."""
     header = {API_KEY_HEADER: f"Bearer {master_key}"}
-    resp = client.post("/v1/users", json={"user_id": "rl-test-user", "alias": "RL"}, headers=header)
+    resp = client.post(
+        "/v1/users", json={"user_id": "rl-test-user", "alias": "RL"}, headers=header
+    )
     assert resp.status_code == 200
     result: str = resp.json()["user_id"]
     return result
 
 
-def _chat_request(client: TestClient, user_id: str, master_key: str = "test-master-key") -> Any:
-    """Send a chat completion request using the master key."""
+def _chat_request(
+    client: TestClient, user_id: str, master_key: str = "test-master-key"
+) -> Any:
     header = {API_KEY_HEADER: f"Bearer {master_key}"}
     return client.post(
         "/v1/chat/completions",
@@ -236,8 +93,12 @@ def _chat_request(client: TestClient, user_id: str, master_key: str = "test-mast
 
 
 def test_rate_limit_headers_on_success(rate_limit_client: TestClient) -> None:
-    """Test that successful responses include rate limit headers."""
-    from any_llm.types.completion import ChatCompletion, ChatCompletionMessage, Choice, CompletionUsage
+    from any_llm.types.completion import (
+        ChatCompletion,
+        ChatCompletionMessage,
+        Choice,
+        CompletionUsage,
+    )
 
     user_id = _create_test_user(rate_limit_client)
 
@@ -266,24 +127,20 @@ def test_rate_limit_headers_on_success(rate_limit_client: TestClient) -> None:
     assert resp.headers["X-RateLimit-Limit"] == "3"
     assert resp.headers["X-RateLimit-Remaining"] == "2"
     assert "X-RateLimit-Reset" in resp.headers
-    # Reset should be a plausible Unix timestamp (wall-clock based)
     reset = int(resp.headers["X-RateLimit-Reset"])
     assert reset > 1_000_000_000
 
 
 def test_rate_limit_returns_429_with_retry_after(rate_limit_client: TestClient) -> None:
-    """Test that exceeding rate limit returns 429 with Retry-After."""
     user_id = _create_test_user(rate_limit_client)
 
     async def mock_acompletion(**kwargs: Any) -> None:
         raise _MockCompletionError
 
     with patch("api.routes.chat.acompletion", new=mock_acompletion):
-        # Exhaust the limit (rpm=3)
         for _ in range(3):
             _chat_request(rate_limit_client, user_id)
 
-        # Next request should be rate-limited
         resp = _chat_request(rate_limit_client, user_id)
 
     assert resp.status_code == 429
@@ -291,14 +148,12 @@ def test_rate_limit_returns_429_with_retry_after(rate_limit_client: TestClient) 
 
 
 def test_no_rate_limit_allows_unlimited(no_rate_limit_client: TestClient) -> None:
-    """Test that requests are not limited when rate_limit_rpm is None."""
     user_id = _create_test_user(no_rate_limit_client)
 
     async def mock_acompletion(**kwargs: Any) -> None:
         raise _MockCompletionError
 
     with patch("api.routes.chat.acompletion", new=mock_acompletion):
-        # Should never get 429
         for _ in range(10):
             resp = _chat_request(no_rate_limit_client, user_id)
             assert resp.status_code != 429

--- a/tests/integration/test_shared_helpers.py
+++ b/tests/integration/test_shared_helpers.py
@@ -1,164 +1,11 @@
-"""Tests for shared gateway helpers: get_active_user, resolve_user_id, from_model factories."""
+"""Integration tests for helper wiring through API endpoints."""
 
-from datetime import UTC, datetime
-from unittest.mock import MagicMock
-
-import pytest
-from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
-from gateway.api.routes._helpers import resolve_user_id
-from gateway.api.routes.budgets import BudgetResponse
-from gateway.api.routes.pricing import PricingResponse
 
-
-def _make_error(detail: str, status_code: int = 400) -> HTTPException:
-    return HTTPException(status_code=status_code, detail=detail)
-
-
-def test_resolve_user_id_master_key_with_user() -> None:
-    user_id = resolve_user_id(
-        user_id_from_request="user-1",
-        api_key=None,
-        is_master_key=True,
-        master_key_error=_make_error("master key requires user"),
-        no_api_key_error=_make_error("no api key"),
-        no_user_error=_make_error("no user"),
-    )
-    assert user_id == "user-1"
-
-
-def test_resolve_user_id_master_key_without_user() -> None:
-    with pytest.raises(HTTPException) as exc_info:
-        resolve_user_id(
-            user_id_from_request=None,
-            api_key=None,
-            is_master_key=True,
-            master_key_error=_make_error("master key requires user"),
-            no_api_key_error=_make_error("no api key"),
-            no_user_error=_make_error("no user"),
-        )
-    assert exc_info.value.detail == "master key requires user"
-
-
-def test_resolve_user_id_api_key_with_request_user() -> None:
-    api_key = MagicMock()
-    api_key.user_id = "key-user"
-    user_id = resolve_user_id(
-        user_id_from_request="explicit-user",
-        api_key=api_key,
-        is_master_key=False,
-        master_key_error=_make_error("master key requires user"),
-        no_api_key_error=_make_error("no api key"),
-        no_user_error=_make_error("no user"),
-    )
-    assert user_id == "explicit-user"
-
-
-def test_resolve_user_id_falls_back_to_api_key() -> None:
-    api_key = MagicMock()
-    api_key.user_id = "key-user"
-    user_id = resolve_user_id(
-        user_id_from_request=None,
-        api_key=api_key,
-        is_master_key=False,
-        master_key_error=_make_error("master key requires user"),
-        no_api_key_error=_make_error("no api key"),
-        no_user_error=_make_error("no user"),
-    )
-    assert user_id == "key-user"
-
-
-def test_resolve_user_id_no_api_key() -> None:
-    with pytest.raises(HTTPException) as exc_info:
-        resolve_user_id(
-            user_id_from_request=None,
-            api_key=None,
-            is_master_key=False,
-            master_key_error=_make_error("master key requires user"),
-            no_api_key_error=_make_error("no api key", 500),
-            no_user_error=_make_error("no user"),
-        )
-    assert exc_info.value.detail == "no api key"
-    assert exc_info.value.status_code == 500
-
-
-def test_resolve_user_id_api_key_without_user() -> None:
-    api_key = MagicMock()
-    api_key.user_id = None
-    with pytest.raises(HTTPException) as exc_info:
-        resolve_user_id(
-            user_id_from_request=None,
-            api_key=api_key,
-            is_master_key=False,
-            master_key_error=_make_error("master key requires user"),
-            no_api_key_error=_make_error("no api key"),
-            no_user_error=_make_error("no user", 500),
-        )
-    assert exc_info.value.detail == "no user"
-    assert exc_info.value.status_code == 500
-
-
-def test_resolve_user_id_empty_string_treated_as_missing() -> None:
-    with pytest.raises(HTTPException) as exc_info:
-        resolve_user_id(
-            user_id_from_request="",
-            api_key=None,
-            is_master_key=True,
-            master_key_error=_make_error("master key requires user"),
-            no_api_key_error=_make_error("no api key"),
-            no_user_error=_make_error("no user"),
-        )
-    assert exc_info.value.detail == "master key requires user"
-
-
-def test_budget_response_from_model() -> None:
-    budget = MagicMock()
-    budget.budget_id = "budget-1"
-    budget.max_budget = 100.0
-    budget.budget_duration_sec = 86400
-    budget.created_at = datetime(2025, 1, 1, tzinfo=UTC)
-    budget.updated_at = datetime(2025, 1, 2, tzinfo=UTC)
-
-    resp = BudgetResponse.from_model(budget)
-    assert resp.budget_id == "budget-1"
-    assert resp.max_budget == 100.0
-    assert resp.budget_duration_sec == 86400
-    assert resp.created_at == "2025-01-01T00:00:00+00:00"
-    assert resp.updated_at == "2025-01-02T00:00:00+00:00"
-
-
-def test_budget_response_from_model_nullable_fields() -> None:
-    budget = MagicMock()
-    budget.budget_id = "budget-2"
-    budget.max_budget = None
-    budget.budget_duration_sec = None
-    budget.created_at = datetime(2025, 6, 15, tzinfo=UTC)
-    budget.updated_at = datetime(2025, 6, 15, tzinfo=UTC)
-
-    resp = BudgetResponse.from_model(budget)
-    assert resp.max_budget is None
-    assert resp.budget_duration_sec is None
-
-
-def test_pricing_response_from_model() -> None:
-    pricing = MagicMock()
-    pricing.model_key = "openai:gpt-4"
-    pricing.input_price_per_million = 30.0
-    pricing.output_price_per_million = 60.0
-    pricing.created_at = datetime(2025, 3, 1, tzinfo=UTC)
-    pricing.updated_at = datetime(2025, 3, 2, tzinfo=UTC)
-
-    resp = PricingResponse.from_model(pricing)
-    assert resp.model_key == "openai:gpt-4"
-    assert resp.input_price_per_million == 30.0
-    assert resp.output_price_per_million == 60.0
-    assert resp.created_at == "2025-03-01T00:00:00+00:00"
-    assert resp.updated_at == "2025-03-02T00:00:00+00:00"
-
-
-def test_get_active_user_via_budget_endpoint(client: TestClient, master_key_header: dict[str, str]) -> None:
-    """Verify get_active_user is wired correctly through the users API."""
+def test_get_active_user_via_budget_endpoint(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
     client.post(
         "/v1/users",
         json={"user_id": "helper-test-user", "alias": "Helper Test"},
@@ -169,8 +16,9 @@ def test_get_active_user_via_budget_endpoint(client: TestClient, master_key_head
     assert resp.json()["user_id"] == "helper-test-user"
 
 
-def test_get_active_user_returns_none_for_deleted(client: TestClient, master_key_header: dict[str, str]) -> None:
-    """Deleted users should not be returned by get_active_user."""
+def test_get_active_user_returns_none_for_deleted(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
     client.post(
         "/v1/users",
         json={"user_id": "to-delete-user"},
@@ -181,13 +29,16 @@ def test_get_active_user_returns_none_for_deleted(client: TestClient, master_key
     assert resp.status_code == 404
 
 
-def test_get_active_user_returns_none_for_nonexistent(client: TestClient, master_key_header: dict[str, str]) -> None:
+def test_get_active_user_returns_none_for_nonexistent(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
     resp = client.get("/v1/users/nonexistent-user", headers=master_key_header)
     assert resp.status_code == 404
 
 
-def test_budget_from_model_roundtrip(client: TestClient, master_key_header: dict[str, str]) -> None:
-    """BudgetResponse.from_model produces the same output the API returns."""
+def test_budget_from_model_roundtrip(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
     resp = client.post(
         "/v1/budgets",
         json={"max_budget": 50.0, "budget_duration_sec": 3600},
@@ -199,8 +50,9 @@ def test_budget_from_model_roundtrip(client: TestClient, master_key_header: dict
     assert data["budget_duration_sec"] == 3600
 
 
-def test_pricing_from_model_roundtrip(client: TestClient, master_key_header: dict[str, str]) -> None:
-    """PricingResponse.from_model produces the same output the API returns."""
+def test_pricing_from_model_roundtrip(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
     resp = client.post(
         "/v1/pricing",
         json={
@@ -217,11 +69,15 @@ def test_pricing_from_model_roundtrip(client: TestClient, master_key_header: dic
     assert data["output_price_per_million"] == 10.0
 
 
-def test_resolve_user_id_chat_master_key_requires_user(client: TestClient, master_key_header: dict[str, str]) -> None:
-    """Chat endpoint with master key but no user field should return 400."""
+def test_resolve_user_id_chat_master_key_requires_user(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
     resp = client.post(
         "/v1/chat/completions",
-        json={"model": "openai:gpt-4o", "messages": [{"role": "user", "content": "hi"}]},
+        json={
+            "model": "openai:gpt-4o",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
         headers=master_key_header,
     )
     assert resp.status_code == 400
@@ -231,7 +87,6 @@ def test_resolve_user_id_chat_master_key_requires_user(client: TestClient, maste
 def test_resolve_user_id_messages_master_key_requires_user(
     client: TestClient, master_key_header: dict[str, str]
 ) -> None:
-    """Messages endpoint with master key but no metadata.user_id should return 400."""
     resp = client.post(
         "/v1/messages",
         json={

--- a/tests/unit/test_env_var_resolution.py
+++ b/tests/unit/test_env_var_resolution.py
@@ -1,4 +1,4 @@
-"""Tests for environment variable resolution in config."""
+"""Unit tests for environment variable resolution in config."""
 
 import os
 
@@ -8,7 +8,6 @@ from gateway.core.config import _resolve_env_vars
 
 
 def test_resolve_existing_env_var() -> None:
-    """Test that existing env vars are resolved."""
     os.environ["TEST_RESOLVE_VAR"] = "resolved_value"
     try:
         result = _resolve_env_vars({"key": "${TEST_RESOLVE_VAR}"})
@@ -18,15 +17,12 @@ def test_resolve_existing_env_var() -> None:
 
 
 def test_resolve_missing_env_var_raises() -> None:
-    """Test that missing env vars raise ValueError instead of using placeholder."""
-    # Ensure the var does not exist
     os.environ.pop("DEFINITELY_MISSING_VAR", None)
     with pytest.raises(ValueError, match="DEFINITELY_MISSING_VAR"):
         _resolve_env_vars({"key": "${DEFINITELY_MISSING_VAR}"})
 
 
 def test_resolve_nested_dict() -> None:
-    """Test that env vars are resolved recursively in nested dicts."""
     os.environ["TEST_NESTED_VAR"] = "nested_value"
     try:
         result = _resolve_env_vars({"outer": {"inner": "${TEST_NESTED_VAR}"}})
@@ -36,7 +32,6 @@ def test_resolve_nested_dict() -> None:
 
 
 def test_resolve_list_values() -> None:
-    """Test that env vars are resolved in list values."""
     os.environ["TEST_LIST_VAR"] = "list_value"
     try:
         result = _resolve_env_vars({"items": ["${TEST_LIST_VAR}", "literal"]})
@@ -46,24 +41,23 @@ def test_resolve_list_values() -> None:
 
 
 def test_non_env_var_strings_pass_through() -> None:
-    """Test that strings not matching ${...} pattern pass through unchanged."""
     result = _resolve_env_vars({"key": "just a string"})
     assert result["key"] == "just a string"
 
 
 def test_partial_env_var_syntax_passes_through() -> None:
-    """Test that partial env var syntax (not matching ${...}) passes through."""
     result = _resolve_env_vars({"key": "${PARTIAL"})
     assert result["key"] == "${PARTIAL"
 
 
 def test_inline_substitution() -> None:
-    """Test that env vars embedded in a larger string are substituted."""
     os.environ["TEST_DB_USER"] = "admin"
     os.environ["TEST_DB_ROLE"] = "readwrite"
     os.environ["TEST_DB_HOST"] = "db.example.com"
     try:
-        result = _resolve_env_vars({"url": "postgresql://${TEST_DB_USER}:${TEST_DB_ROLE}@${TEST_DB_HOST}/mydb"})
+        result = _resolve_env_vars(
+            {"url": "postgresql://${TEST_DB_USER}:${TEST_DB_ROLE}@${TEST_DB_HOST}/mydb"}
+        )
         assert result["url"] == "postgresql://admin:readwrite@db.example.com/mydb"
     finally:
         del os.environ["TEST_DB_USER"]
@@ -72,18 +66,18 @@ def test_inline_substitution() -> None:
 
 
 def test_inline_substitution_missing_var_raises() -> None:
-    """Test that a missing var in an inline string raises ValueError."""
     os.environ["TEST_INLINE_OK"] = "present"
     os.environ.pop("TEST_INLINE_MISSING", None)
     try:
         with pytest.raises(ValueError, match="TEST_INLINE_MISSING"):
-            _resolve_env_vars({"url": "prefix-${TEST_INLINE_OK}-${TEST_INLINE_MISSING}-suffix"})
+            _resolve_env_vars(
+                {"url": "prefix-${TEST_INLINE_OK}-${TEST_INLINE_MISSING}-suffix"}
+            )
     finally:
         del os.environ["TEST_INLINE_OK"]
 
 
 def test_single_inline_var_with_surrounding_text() -> None:
-    """Test a single var reference with surrounding text."""
     os.environ["TEST_PORT"] = "5432"
     try:
         result = _resolve_env_vars({"host": "localhost:${TEST_PORT}"})

--- a/tests/unit/test_global_state_reset.py
+++ b/tests/unit/test_global_state_reset.py
@@ -1,4 +1,4 @@
-"""Tests for global state reset functions."""
+"""Unit tests for module-level state reset helpers."""
 
 import pytest
 
@@ -8,7 +8,6 @@ from gateway.core.database import reset_db
 
 
 def test_reset_config_clears_state() -> None:
-    """Test that reset_config clears the global config."""
     config = GatewayConfig(
         database_url="postgresql://localhost/test",
         master_key="test",
@@ -23,14 +22,8 @@ def test_reset_config_clears_state() -> None:
 
 
 def test_reset_db_allows_reinit() -> None:
-    """Test that reset_db clears state so init_db can be called again.
-
-    We can't fully test init_db without a database, but we can verify
-    reset_db doesn't raise and clears the module state.
-    """
     from core import database
 
-    # Verify the function exists and runs without error when nothing is initialized
     reset_db()
 
     assert database._engine is None

--- a/tests/unit/test_rate_limiter_core.py
+++ b/tests/unit/test_rate_limiter_core.py
@@ -1,0 +1,130 @@
+"""Unit tests for rate limiter core behavior and config validation."""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from gateway.core.config import GatewayConfig
+from gateway.rate_limit import RateLimitInfo, RateLimiter
+
+
+def test_rate_limiter_allows_under_limit() -> None:
+    limiter = RateLimiter(rpm=5)
+    for _ in range(5):
+        limiter.check("user-1")
+
+
+def test_rate_limiter_returns_rate_limit_info() -> None:
+    limiter = RateLimiter(rpm=5)
+    info = limiter.check("user-1")
+    assert isinstance(info, RateLimitInfo)
+    assert info.limit == 5
+    assert info.remaining == 4
+
+    info2 = limiter.check("user-1")
+    assert info2.remaining == 3
+
+
+def test_rate_limiter_reset_is_wall_clock() -> None:
+    limiter = RateLimiter(rpm=5)
+
+    with patch("gateway.rate_limit.time") as mock_time:
+        mock_time.monotonic.return_value = 1000.0
+        mock_time.time.return_value = 1700000000.0
+        info = limiter.check("user-1")
+
+    assert info.reset == pytest.approx(1700000060.0, abs=1.0)
+
+
+def test_rate_limiter_rejects_over_limit() -> None:
+    limiter = RateLimiter(rpm=3)
+    for _ in range(3):
+        limiter.check("user-1")
+
+    with pytest.raises(HTTPException) as exc_info:
+        limiter.check("user-1")
+    assert exc_info.value.status_code == 429
+
+
+def test_rate_limiter_429_includes_retry_after() -> None:
+    limiter = RateLimiter(rpm=1)
+    limiter.check("user-1")
+
+    with pytest.raises(HTTPException) as exc_info:
+        limiter.check("user-1")
+    assert exc_info.value.headers is not None
+    assert "Retry-After" in exc_info.value.headers
+    retry_after = int(exc_info.value.headers["Retry-After"])
+    assert 1 <= retry_after <= 60
+
+
+def test_rate_limiter_per_user_isolation() -> None:
+    limiter = RateLimiter(rpm=2)
+    limiter.check("user-1")
+    limiter.check("user-1")
+    limiter.check("user-2")
+    limiter.check("user-2")
+
+    with pytest.raises(HTTPException):
+        limiter.check("user-1")
+    with pytest.raises(HTTPException):
+        limiter.check("user-2")
+
+
+def test_rate_limiter_window_expiry() -> None:
+    limiter = RateLimiter(rpm=2)
+
+    with patch("gateway.rate_limit.time") as mock_time:
+        mock_time.monotonic.return_value = 1000.0
+        mock_time.time.return_value = 1700000000.0
+        limiter.check("user-1")
+        limiter.check("user-1")
+
+        with pytest.raises(HTTPException):
+            limiter.check("user-1")
+
+        mock_time.monotonic.return_value = 1061.0
+        mock_time.time.return_value = 1700000061.0
+        info = limiter.check("user-1")
+        assert info.remaining == 1
+
+
+def test_rate_limiter_cleanup() -> None:
+    limiter = RateLimiter(rpm=100)
+    limiter._CLEANUP_INTERVAL = 3
+
+    with patch("gateway.rate_limit.time") as mock_time:
+        mock_time.monotonic.return_value = 1000.0
+        mock_time.time.return_value = 1700000000.0
+
+        limiter.check("stale-user")
+        limiter.check("stale-user")
+
+        mock_time.monotonic.return_value = 1061.0
+        mock_time.time.return_value = 1700000061.0
+        limiter.check("active-user")
+
+        assert "stale-user" not in limiter._requests
+        assert "active-user" in limiter._requests
+
+
+def test_config_rejects_zero_rate_limit() -> None:
+    with pytest.raises(ValidationError):
+        GatewayConfig(rate_limit_rpm=0)
+
+
+def test_config_rejects_negative_rate_limit() -> None:
+    with pytest.raises(ValidationError):
+        GatewayConfig(rate_limit_rpm=-1)
+
+
+def test_config_accepts_positive_rate_limit() -> None:
+    config = GatewayConfig(rate_limit_rpm=1)
+    assert config.rate_limit_rpm == 1
+
+
+def test_config_accepts_none_rate_limit() -> None:
+    config = GatewayConfig(rate_limit_rpm=None)
+    assert config.rate_limit_rpm is None

--- a/tests/unit/test_shared_helpers_pure.py
+++ b/tests/unit/test_shared_helpers_pure.py
@@ -1,0 +1,156 @@
+"""Unit tests for pure helper behavior shared by route handlers."""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from gateway.api.routes._helpers import resolve_user_id
+from gateway.api.routes.budgets import BudgetResponse
+from gateway.api.routes.pricing import PricingResponse
+
+
+def _make_error(detail: str, status_code: int = 400) -> HTTPException:
+    return HTTPException(status_code=status_code, detail=detail)
+
+
+def test_resolve_user_id_master_key_with_user() -> None:
+    user_id = resolve_user_id(
+        user_id_from_request="user-1",
+        api_key=None,
+        is_master_key=True,
+        master_key_error=_make_error("master key requires user"),
+        no_api_key_error=_make_error("no api key"),
+        no_user_error=_make_error("no user"),
+    )
+    assert user_id == "user-1"
+
+
+def test_resolve_user_id_master_key_without_user() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_user_id(
+            user_id_from_request=None,
+            api_key=None,
+            is_master_key=True,
+            master_key_error=_make_error("master key requires user"),
+            no_api_key_error=_make_error("no api key"),
+            no_user_error=_make_error("no user"),
+        )
+    assert exc_info.value.detail == "master key requires user"
+
+
+def test_resolve_user_id_api_key_with_request_user() -> None:
+    api_key = MagicMock()
+    api_key.user_id = "key-user"
+    user_id = resolve_user_id(
+        user_id_from_request="explicit-user",
+        api_key=api_key,
+        is_master_key=False,
+        master_key_error=_make_error("master key requires user"),
+        no_api_key_error=_make_error("no api key"),
+        no_user_error=_make_error("no user"),
+    )
+    assert user_id == "explicit-user"
+
+
+def test_resolve_user_id_falls_back_to_api_key() -> None:
+    api_key = MagicMock()
+    api_key.user_id = "key-user"
+    user_id = resolve_user_id(
+        user_id_from_request=None,
+        api_key=api_key,
+        is_master_key=False,
+        master_key_error=_make_error("master key requires user"),
+        no_api_key_error=_make_error("no api key"),
+        no_user_error=_make_error("no user"),
+    )
+    assert user_id == "key-user"
+
+
+def test_resolve_user_id_no_api_key() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_user_id(
+            user_id_from_request=None,
+            api_key=None,
+            is_master_key=False,
+            master_key_error=_make_error("master key requires user"),
+            no_api_key_error=_make_error("no api key", 500),
+            no_user_error=_make_error("no user"),
+        )
+    assert exc_info.value.detail == "no api key"
+    assert exc_info.value.status_code == 500
+
+
+def test_resolve_user_id_api_key_without_user() -> None:
+    api_key = MagicMock()
+    api_key.user_id = None
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_user_id(
+            user_id_from_request=None,
+            api_key=api_key,
+            is_master_key=False,
+            master_key_error=_make_error("master key requires user"),
+            no_api_key_error=_make_error("no api key"),
+            no_user_error=_make_error("no user", 500),
+        )
+    assert exc_info.value.detail == "no user"
+    assert exc_info.value.status_code == 500
+
+
+def test_resolve_user_id_empty_string_treated_as_missing() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_user_id(
+            user_id_from_request="",
+            api_key=None,
+            is_master_key=True,
+            master_key_error=_make_error("master key requires user"),
+            no_api_key_error=_make_error("no api key"),
+            no_user_error=_make_error("no user"),
+        )
+    assert exc_info.value.detail == "master key requires user"
+
+
+def test_budget_response_from_model() -> None:
+    budget = MagicMock()
+    budget.budget_id = "budget-1"
+    budget.max_budget = 100.0
+    budget.budget_duration_sec = 86400
+    budget.created_at = datetime(2025, 1, 1, tzinfo=UTC)
+    budget.updated_at = datetime(2025, 1, 2, tzinfo=UTC)
+
+    resp = BudgetResponse.from_model(budget)
+    assert resp.budget_id == "budget-1"
+    assert resp.max_budget == 100.0
+    assert resp.budget_duration_sec == 86400
+    assert resp.created_at == "2025-01-01T00:00:00+00:00"
+    assert resp.updated_at == "2025-01-02T00:00:00+00:00"
+
+
+def test_budget_response_from_model_nullable_fields() -> None:
+    budget = MagicMock()
+    budget.budget_id = "budget-2"
+    budget.max_budget = None
+    budget.budget_duration_sec = None
+    budget.created_at = datetime(2025, 6, 15, tzinfo=UTC)
+    budget.updated_at = datetime(2025, 6, 15, tzinfo=UTC)
+
+    resp = BudgetResponse.from_model(budget)
+    assert resp.max_budget is None
+    assert resp.budget_duration_sec is None
+
+
+def test_pricing_response_from_model() -> None:
+    pricing = MagicMock()
+    pricing.model_key = "openai:gpt-4"
+    pricing.input_price_per_million = 30.0
+    pricing.output_price_per_million = 60.0
+    pricing.created_at = datetime(2025, 3, 1, tzinfo=UTC)
+    pricing.updated_at = datetime(2025, 3, 2, tzinfo=UTC)
+
+    resp = PricingResponse.from_model(pricing)
+    assert resp.model_key == "openai:gpt-4"
+    assert resp.input_price_per_million == 30.0
+    assert resp.output_price_per_million == 60.0
+    assert resp.created_at == "2025-03-01T00:00:00+00:00"
+    assert resp.updated_at == "2025-03-02T00:00:00+00:00"

--- a/tests/unit/test_stream_options_injection.py
+++ b/tests/unit/test_stream_options_injection.py
@@ -1,4 +1,4 @@
-"""Tests for automatic stream_options injection on streaming requests."""
+"""Unit tests for automatic stream_options injection behavior."""
 
 from typing import Any
 
@@ -6,7 +6,6 @@ from gateway.api.routes.chat import ChatCompletionRequest
 
 
 def test_stream_options_accepted_by_request_model() -> None:
-    """ChatCompletionRequest should accept stream_options from clients."""
     request = ChatCompletionRequest(
         model="openai:gpt-4",
         messages=[{"role": "user", "content": "Hello"}],
@@ -17,7 +16,6 @@ def test_stream_options_accepted_by_request_model() -> None:
 
 
 def test_stream_options_defaults_to_none() -> None:
-    """stream_options should default to None when not provided."""
     request = ChatCompletionRequest(
         model="openai:gpt-4",
         messages=[{"role": "user", "content": "Hello"}],
@@ -26,7 +24,6 @@ def test_stream_options_defaults_to_none() -> None:
 
 
 def test_stream_options_excluded_when_unset() -> None:
-    """stream_options should not appear in model_dump(exclude_unset=True) when not set."""
     request = ChatCompletionRequest(
         model="openai:gpt-4",
         messages=[{"role": "user", "content": "Hello"}],
@@ -37,7 +34,6 @@ def test_stream_options_excluded_when_unset() -> None:
 
 
 def test_stream_options_included_when_set() -> None:
-    """stream_options should appear in model_dump(exclude_unset=True) when explicitly set."""
     request = ChatCompletionRequest(
         model="openai:gpt-4",
         messages=[{"role": "user", "content": "Hello"}],
@@ -52,7 +48,6 @@ def _build_completion_kwargs(
     request_body: dict[str, Any],
     provider_kwargs: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Simulate the kwargs-building logic from the chat_completions handler."""
     request = ChatCompletionRequest(**request_body)
     request_fields = request.model_dump(exclude_unset=True)
     completion_kwargs: dict[str, Any] = {**(provider_kwargs or {}), **request_fields}
@@ -64,7 +59,6 @@ def _build_completion_kwargs(
 
 
 def test_auto_injects_stream_options_for_streaming() -> None:
-    """Gateway should inject stream_options when client sends stream=True without stream_options."""
     kwargs = _build_completion_kwargs(
         {
             "model": "openai:gpt-4",
@@ -76,7 +70,6 @@ def test_auto_injects_stream_options_for_streaming() -> None:
 
 
 def test_no_injection_for_non_streaming() -> None:
-    """Non-streaming requests should not get stream_options injected."""
     kwargs = _build_completion_kwargs(
         {
             "model": "openai:gpt-4",
@@ -87,7 +80,6 @@ def test_no_injection_for_non_streaming() -> None:
 
 
 def test_preserves_client_stream_options() -> None:
-    """When the client explicitly sets stream_options, the gateway should not override them."""
     custom = {"include_usage": False, "custom_field": "value"}
     kwargs = _build_completion_kwargs(
         {

--- a/tests/unit/test_streaming_generator.py
+++ b/tests/unit/test_streaming_generator.py
@@ -1,15 +1,15 @@
-"""Tests for the shared streaming_generator utility."""
+"""Unit tests for the shared streaming_generator utility."""
 
 from collections.abc import AsyncIterator
 
 import pytest
+from any_llm.types.completion import CompletionUsage
 
 from gateway.streaming import (
     ANTHROPIC_STREAM_FORMAT,
     OPENAI_STREAM_FORMAT,
     streaming_generator,
 )
-from any_llm.types.completion import CompletionUsage
 
 _PROVIDER_CRASHED = "provider crashed"
 _LOGGING_FAILED = "logging failed too"
@@ -26,13 +26,12 @@ def _extract_usage(chunk: str) -> CompletionUsage | None:
 
 
 async def _items(*values: str) -> AsyncIterator[str]:
-    for v in values:
-        yield v
+    for value in values:
+        yield value
 
 
 @pytest.mark.asyncio
 async def test_streaming_generator_success_with_usage() -> None:
-    """Test successful streaming with usage tracking."""
     completed_usage: list[CompletionUsage] = []
 
     async def on_complete(usage: CompletionUsage) -> None:
@@ -61,7 +60,6 @@ async def test_streaming_generator_success_with_usage() -> None:
 
 @pytest.mark.asyncio
 async def test_streaming_generator_no_usage_skips_on_complete() -> None:
-    """Test that on_complete is not called when no usage data is received."""
     completed = False
 
     async def on_complete(usage: CompletionUsage) -> None:
@@ -89,7 +87,6 @@ async def test_streaming_generator_no_usage_skips_on_complete() -> None:
 
 @pytest.mark.asyncio
 async def test_streaming_generator_error_openai_format() -> None:
-    """Test error handling emits OpenAI-style error and [DONE]."""
     error_logged: list[str] = []
 
     async def on_complete(usage: CompletionUsage) -> None:
@@ -122,7 +119,6 @@ async def test_streaming_generator_error_openai_format() -> None:
 
 @pytest.mark.asyncio
 async def test_streaming_generator_error_anthropic_format() -> None:
-    """Test error handling emits Anthropic-style error without done marker."""
     error_logged: list[str] = []
 
     async def on_complete(usage: CompletionUsage) -> None:
@@ -155,8 +151,6 @@ async def test_streaming_generator_error_anthropic_format() -> None:
 
 @pytest.mark.asyncio
 async def test_streaming_generator_error_logging_failure_is_swallowed() -> None:
-    """Test that failures in on_error don't propagate to the caller."""
-
     async def on_complete(usage: CompletionUsage) -> None:
         pytest.fail("on_complete should not be called on error")
 

--- a/tests/unit/test_streaming_token_aggregation.py
+++ b/tests/unit/test_streaming_token_aggregation.py
@@ -1,11 +1,11 @@
-"""Tests for streaming token aggregation logic."""
+"""Unit tests for streaming token aggregation logic."""
+
+from any_llm.types.completion import CompletionUsage
 
 from gateway.streaming import _merge_usage
-from any_llm.types.completion import CompletionUsage
 
 
 def test_merge_usage_cumulative() -> None:
-    """Test that _merge_usage keeps last non-zero value for cumulative providers."""
     chunks = [
         CompletionUsage(prompt_tokens=100, completion_tokens=10, total_tokens=110),
         CompletionUsage(prompt_tokens=100, completion_tokens=20, total_tokens=120),
@@ -22,7 +22,6 @@ def test_merge_usage_cumulative() -> None:
 
 
 def test_merge_usage_final_chunk_only() -> None:
-    """Test that _merge_usage works when only the last chunk has usage."""
     base = CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
     final = CompletionUsage(prompt_tokens=50, completion_tokens=200, total_tokens=250)
 
@@ -34,7 +33,6 @@ def test_merge_usage_final_chunk_only() -> None:
 
 
 def test_merge_usage_preserves_current_on_zero_update() -> None:
-    """Test that _merge_usage preserves current values when update has zeros."""
     current = CompletionUsage(prompt_tokens=100, completion_tokens=50, total_tokens=150)
     update = CompletionUsage(prompt_tokens=0, completion_tokens=75, total_tokens=0)
 


### PR DESCRIPTION
## Summary
- move pure logic tests from `tests/integration` to `tests/unit` for config resolution, stream option injection, streaming utilities, token aggregation, and global-state reset behavior
- split mixed suites so integration tests keep API/DB wiring checks while pure helper/rate-limiter behavior now runs as unit tests
- update local and CI test orchestration to run unit and integration tiers explicitly (`Makefile` targets + separate CI test steps)

## Why
- improves testing pyramid shape by keeping integration tests focused on boundaries and shifting deterministic logic checks to fast unit tests
- preserves behavioral coverage while reducing dependence on heavy fixtures for pure code paths

## Validation
- `uv run pytest -v tests/unit`
- `uv run pytest -v tests/integration`
- `make test`