### PR TITLE
chore: enforce mypy checks and tighten typing

### DIFF
--- a/.github/workflows/gateway-lint.yml
+++ b/.github/workflows/gateway-lint.yml
@@ -38,3 +38,6 @@ jobs:
 
     - name: Run Ruff lint
       run: uv run ruff check src tests scripts
+
+    - name: Run mypy type check
+      run: uv run mypy

--- a/.github/workflows/gateway-typecheck.yml
+++ b/.github/workflows/gateway-typecheck.yml
@@ -1,4 +1,4 @@
-name: Gateway Lint
+name: Gateway Typecheck
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - 'scripts/**'
       - 'pyproject.toml'
       - 'uv.lock'
-      - '.github/workflows/gateway-lint.yml'
+      - '.github/workflows/gateway-typecheck.yml'
   pull_request:
     branches: [ main ]
     paths:
@@ -18,11 +18,11 @@ on:
       - 'scripts/**'
       - 'pyproject.toml'
       - 'uv.lock'
-      - '.github/workflows/gateway-lint.yml'
+      - '.github/workflows/gateway-typecheck.yml'
   workflow_dispatch:
 
 jobs:
-  lint:
+  typecheck:
     runs-on: ubuntu-latest
 
     steps:
@@ -36,5 +36,5 @@ jobs:
     - name: Install dependencies
       run: uv sync --dev --frozen
 
-    - name: Run Ruff lint
-      run: uv run ruff check src tests scripts
+    - name: Run mypy type check
+      run: uv run mypy

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev test test-unit test-integration lint
+.PHONY: help dev test test-unit test-integration lint typecheck
 
 help:
 	@printf "Available targets:\n"
@@ -7,6 +7,7 @@ help:
 	@printf "  test-unit Run unit tests\n"
 	@printf "  test-integration Run integration tests\n"
 	@printf "  lint Run Ruff lint checks\n"
+	@printf "  typecheck Run mypy type checks\n"
 
 dev:
 	@set -a; \
@@ -25,3 +26,6 @@ test-integration:
 
 lint:
 	uv run ruff check src tests scripts
+
+typecheck:
+	uv run mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,12 @@ select = ["E", "F", "I"]
 [tool.ruff.lint.per-file-ignores]
 "scripts/generate_openapi.py" = ["E402"]
 "tests/integration/conftest.py" = ["E402"]
+
+[tool.mypy]
+python_version = "3.13"
+strict = true
+files = ["src", "tests", "scripts"]
+
+[[tool.mypy.overrides]]
+module = ["testcontainers.*"]
+ignore_missing_imports = true

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -13,6 +13,7 @@ import json
 import sys
 import tempfile
 from pathlib import Path
+from typing import cast
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SRC_ROOT = REPO_ROOT / "src"
@@ -23,7 +24,7 @@ from gateway.core.config import GatewayConfig
 from gateway.main import create_app
 
 
-def generate_openapi_spec() -> dict:
+def generate_openapi_spec() -> dict[str, object]:
     """Generate OpenAPI specification from FastAPI app.
 
     Returns:
@@ -34,10 +35,10 @@ def generate_openapi_spec() -> dict:
         database_url = f"sqlite:///{Path(tmpdir) / 'openapi.db'}"
         config = GatewayConfig(database_url=database_url, bootstrap_api_key=False)
         app = create_app(config)
-        return app.openapi()
+        return cast(dict[str, object], app.openapi())
 
 
-def write_spec(spec: dict, output_path: Path) -> None:
+def write_spec(spec: dict[str, object], output_path: Path) -> None:
     """Write OpenAPI spec to file with pretty formatting.
 
     Args:
@@ -51,7 +52,7 @@ def write_spec(spec: dict, output_path: Path) -> None:
         f.write("\n")
 
 
-def check_spec(spec: dict, existing_path: Path) -> bool:
+def check_spec(spec: dict[str, object], existing_path: Path) -> bool:
     """Check if generated spec matches existing file.
 
     Args:
@@ -67,19 +68,24 @@ def check_spec(spec: dict, existing_path: Path) -> bool:
         return False
 
     with open(existing_path, encoding="utf-8") as f:
-        existing_spec = json.load(f)
+        existing_spec = cast(dict[str, object], json.load(f))
 
     # Create copies to avoid modifying originals
     spec_copy = spec.copy()
     existing_copy = existing_spec.copy()
 
     # Remove version from comparison since it's dynamically generated from git
-    if "info" in spec_copy and "version" in spec_copy["info"]:
-        spec_copy["info"] = spec_copy["info"].copy()
-        spec_copy["info"].pop("version")
-    if "info" in existing_copy and "version" in existing_copy["info"]:
-        existing_copy["info"] = existing_copy["info"].copy()
-        existing_copy["info"].pop("version")
+    spec_info = spec_copy.get("info")
+    if isinstance(spec_info, dict):
+        spec_info_copy = dict(spec_info)
+        spec_info_copy.pop("version", None)
+        spec_copy["info"] = spec_info_copy
+
+    existing_info = existing_copy.get("info")
+    if isinstance(existing_info, dict):
+        existing_info_copy = dict(existing_info)
+        existing_info_copy.pop("version", None)
+        existing_copy["info"] = existing_info_copy
 
     generated_json = json.dumps(spec_copy, indent=2, sort_keys=True)
     existing_json = json.dumps(existing_copy, indent=2, sort_keys=True)

--- a/tests/integration/test_config_env_loading.py
+++ b/tests/integration/test_config_env_loading.py
@@ -1,9 +1,9 @@
 import os
 from pathlib import Path
 
-import core.config as config_module
 import pytest
 
+import gateway.core.config as config_module
 from gateway.core.config import load_config
 
 


### PR DESCRIPTION
## Summary
- add repository-level mypy configuration in `pyproject.toml` with strict mode and a targeted override for `testcontainers.*`
- enforce type checking in CI by adding a mypy step to the lint workflow and expose a local `make typecheck` target
- tighten typing in `scripts/generate_openapi.py` and switch integration test import from legacy `core.*` alias to `gateway.core.*` for better type analysis

## Validation
- `uv run mypy`
- `uv run ruff check src tests scripts`
- `uv run pytest tests/integration/test_config_env_loading.py -q`