### PR TITLE
tests: fix stale integration import and patch paths

### DIFF
--- a/tests/integration/test_budget_reset.py
+++ b/tests/integration/test_budget_reset.py
@@ -6,7 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from gateway.services.budget_service import calculate_next_reset
-from tests.gateway.conftest import MODEL_NAME
+from .conftest import MODEL_NAME
 
 _HAS_GEMINI_KEY = bool(os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"))
 
@@ -147,7 +147,7 @@ def test_budget_actually_resets_when_duration_passes(
 
     initial_time = datetime(2025, 10, 1, 12, 0, 0, tzinfo=UTC)
 
-    with patch("api.routes.users.datetime") as mock_datetime:
+    with patch("gateway.api.routes.users.datetime") as mock_datetime:
         mock_datetime.now.return_value = initial_time
 
         client.post(
@@ -161,10 +161,10 @@ def test_budget_actually_resets_when_duration_passes(
     user_data = user_response.json()
     assert user_data["spend"] == 0.0
 
-    with patch("services.budget_service.datetime") as mock_datetime_budget:
+    with patch("gateway.services.budget_service.datetime") as mock_datetime_budget:
         mock_datetime_budget.now.return_value = initial_time
 
-        with patch("api.routes.chat.datetime") as mock_datetime_chat:
+        with patch("gateway.api.routes.chat.datetime") as mock_datetime_chat:
             mock_datetime_chat.now.return_value = initial_time
 
             response = client.post(
@@ -186,10 +186,10 @@ def test_budget_actually_resets_when_duration_passes(
 
     time_after_reset = initial_time + timedelta(seconds=61)
 
-    with patch("services.budget_service.datetime") as mock_datetime_budget:
+    with patch("gateway.services.budget_service.datetime") as mock_datetime_budget:
         mock_datetime_budget.now.return_value = time_after_reset
 
-        with patch("api.routes.chat.datetime") as mock_datetime_chat:
+        with patch("gateway.api.routes.chat.datetime") as mock_datetime_chat:
             mock_datetime_chat.now.return_value = time_after_reset
 
             response = client.post(
@@ -224,7 +224,7 @@ def test_per_user_reset_schedules_with_actual_reset(client: TestClient, master_k
     user_a_time = datetime(2025, 10, 1, 0, 0, 0, tzinfo=UTC)
     user_b_time = datetime(2025, 10, 2, 0, 0, 0, tzinfo=UTC)
 
-    with patch("api.routes.users.datetime") as mock_datetime:
+    with patch("gateway.api.routes.users.datetime") as mock_datetime:
         mock_datetime.now.return_value = user_a_time
 
         response_a = client.post(
@@ -233,7 +233,7 @@ def test_per_user_reset_schedules_with_actual_reset(client: TestClient, master_k
             headers=master_key_header,
         )
 
-    with patch("api.routes.users.datetime") as mock_datetime:
+    with patch("gateway.api.routes.users.datetime") as mock_datetime:
         mock_datetime.now.return_value = user_b_time
 
         response_b = client.post(

--- a/tests/integration/test_budget_reset.py
+++ b/tests/integration/test_budget_reset.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from gateway.services.budget_service import calculate_next_reset
+
 from .conftest import MODEL_NAME
 
 _HAS_GEMINI_KEY = bool(os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"))

--- a/tests/integration/test_client_args.py
+++ b/tests/integration/test_client_args.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from gateway.core.config import GatewayConfig
 from gateway.db import get_db
 from gateway.main import create_app
-from tests.gateway.conftest import _run_alembic_migrations
+from .conftest import _run_alembic_migrations
 
 
 class MockCompletionError(Exception):
@@ -90,7 +90,7 @@ async def test_client_args_passed_to_acompletion(
     )
     assert response.status_code == 200
 
-    with patch("api.routes.chat.acompletion", new=mock_acompletion):
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
         client_with_client_args.post(
             "/v1/chat/completions",
             json={
@@ -121,7 +121,7 @@ async def test_provider_config_without_client_args(
         captured_kwargs.update(kwargs)
         raise MockCompletionError
 
-    with patch("api.routes.chat.acompletion", new=mock_acompletion):
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
         client.post(
             "/v1/chat/completions",
             json={

--- a/tests/integration/test_client_args.py
+++ b/tests/integration/test_client_args.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from gateway.core.config import GatewayConfig
 from gateway.db import get_db
 from gateway.main import create_app
+
 from .conftest import _run_alembic_migrations
 
 

--- a/tests/integration/test_embeddings_endpoint.py
+++ b/tests/integration/test_embeddings_endpoint.py
@@ -30,7 +30,7 @@ def test_embeddings_with_api_key(
 ) -> None:
     """POST /v1/embeddings works with API key authentication."""
     mock_resp = _mock_embedding_response()
-    with patch("api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp):
+    with patch("gateway.api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp):
         resp = client.post(
             "/v1/embeddings",
             json={"model": "openai:text-embedding-3-small", "input": "hello"},
@@ -48,7 +48,7 @@ def test_embeddings_master_key_requires_user(
 ) -> None:
     """POST /v1/embeddings with master key requires 'user' field."""
     mock_resp = _mock_embedding_response()
-    with patch("api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp):
+    with patch("gateway.api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp):
         resp = client.post(
             "/v1/embeddings",
             json={"model": "openai:text-embedding-3-small", "input": "hello"},
@@ -65,7 +65,7 @@ def test_embeddings_master_key_with_user(
 ) -> None:
     """POST /v1/embeddings with master key + user field succeeds."""
     mock_resp = _mock_embedding_response()
-    with patch("api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp):
+    with patch("gateway.api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp):
         resp = client.post(
             "/v1/embeddings",
             json={
@@ -84,7 +84,7 @@ def test_embeddings_list_input(
 ) -> None:
     """POST /v1/embeddings accepts a list of strings as input."""
     mock_resp = _mock_embedding_response()
-    with patch("api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp):
+    with patch("gateway.api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp):
         resp = client.post(
             "/v1/embeddings",
             json={"model": "openai:text-embedding-3-small", "input": ["hello", "world"]},
@@ -99,7 +99,7 @@ def test_embeddings_provider_error(
 ) -> None:
     """POST /v1/embeddings returns 500 when the provider fails."""
     with patch(
-        "api.routes.embeddings.aembedding",
+        "gateway.api.routes.embeddings.aembedding",
         new_callable=AsyncMock,
         side_effect=RuntimeError("provider down"),
     ):
@@ -122,7 +122,7 @@ def test_embeddings_logs_usage(
     mock_resp = _mock_embedding_response()
     user_id = api_key_obj["user_id"]
 
-    with patch("api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp):
+    with patch("gateway.api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp):
         resp = client.post(
             "/v1/embeddings",
             json={"model": "openai:text-embedding-3-small", "input": "hello"},
@@ -150,7 +150,7 @@ def test_embeddings_logs_error_on_failure(
     user_id = api_key_obj["user_id"]
 
     with patch(
-        "api.routes.embeddings.aembedding",
+        "gateway.api.routes.embeddings.aembedding",
         new_callable=AsyncMock,
         side_effect=RuntimeError("provider down"),
     ):
@@ -179,7 +179,7 @@ def test_embeddings_optional_fields(
     mock_resp = _mock_embedding_response()
     values = {"encoding_format": "float", "dimensions": 256}
     with patch(
-        "api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp
+        "gateway.api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp
     ) as mock:
         resp = client.post(
             "/v1/embeddings",
@@ -216,7 +216,7 @@ def test_embeddings_cost_tracked_with_pricing(
     mock_resp = _mock_embedding_response()
     user_id = api_key_obj["user_id"]
 
-    with patch("api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp):
+    with patch("gateway.api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp):
         resp = client.post(
             "/v1/embeddings",
             json={"model": "openai:text-embedding-3-small", "input": "hello"},

--- a/tests/integration/test_gateway_completion.py
+++ b/tests/integration/test_gateway_completion.py
@@ -5,10 +5,10 @@ from typing import TYPE_CHECKING, Any
 import pytest
 from fastapi.testclient import TestClient
 
-from tests.gateway.conftest import MODEL_NAME
+from .conftest import MODEL_NAME
 
 if TYPE_CHECKING:
-    from tests.gateway.conftest import LiveServer
+    from .conftest import LiveServer
 
 
 _HAS_GEMINI_KEY = bool(os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"))

--- a/tests/integration/test_key_management.py
+++ b/tests/integration/test_key_management.py
@@ -4,6 +4,7 @@ from typing import Any
 from fastapi.testclient import TestClient
 
 from gateway.core.config import API_KEY_HEADER, GatewayConfig
+
 from .conftest import MODEL_NAME
 
 

--- a/tests/integration/test_key_management.py
+++ b/tests/integration/test_key_management.py
@@ -4,7 +4,7 @@ from typing import Any
 from fastapi.testclient import TestClient
 
 from gateway.core.config import API_KEY_HEADER, GatewayConfig
-from tests.gateway.conftest import MODEL_NAME
+from .conftest import MODEL_NAME
 
 
 def test_create_api_key(client: TestClient, master_key_header: dict[str, str]) -> None:

--- a/tests/integration/test_messages_endpoint.py
+++ b/tests/integration/test_messages_endpoint.py
@@ -48,7 +48,7 @@ def test_messages_endpoint_basic_completion(
     mock_response = _make_message_response()
     messages_request_body["metadata"] = {"user_id": "test-user"}
 
-    with patch("api.routes.messages.amessages", new_callable=AsyncMock, return_value=mock_response):
+    with patch("gateway.api.routes.messages.amessages", new_callable=AsyncMock, return_value=mock_response):
         response = client.post(
             "/v1/messages",
             json=messages_request_body,
@@ -84,7 +84,7 @@ def test_messages_endpoint_x_api_key_header(
     """Test authentication via x-api-key header (Anthropic client compatibility)."""
     mock_response = _make_message_response()
 
-    with patch("api.routes.messages.amessages", new_callable=AsyncMock, return_value=mock_response):
+    with patch("gateway.api.routes.messages.amessages", new_callable=AsyncMock, return_value=mock_response):
         response = client.post(
             "/v1/messages",
             json=messages_request_body,
@@ -102,7 +102,7 @@ def test_messages_endpoint_master_key_requires_user(
     """Test that master key auth requires user_id in metadata."""
     mock_response = _make_message_response()
 
-    with patch("api.routes.messages.amessages", new_callable=AsyncMock, return_value=mock_response):
+    with patch("gateway.api.routes.messages.amessages", new_callable=AsyncMock, return_value=mock_response):
         response = client.post(
             "/v1/messages",
             json=messages_request_body,
@@ -159,7 +159,7 @@ def test_messages_endpoint_with_tools(
         "metadata": {"user_id": "test-user"},
     }
 
-    with patch("api.routes.messages.amessages", new_callable=AsyncMock, return_value=tool_use_response):
+    with patch("gateway.api.routes.messages.amessages", new_callable=AsyncMock, return_value=tool_use_response):
         response = client.post(
             "/v1/messages",
             json=request_body,
@@ -183,7 +183,7 @@ def test_messages_endpoint_provider_error_format(
     messages_request_body["metadata"] = {"user_id": "test-user"}
 
     with patch(
-        "api.routes.messages.amessages",
+        "gateway.api.routes.messages.amessages",
         new_callable=AsyncMock,
         side_effect=RuntimeError("Provider unavailable"),
     ):
@@ -207,7 +207,7 @@ def test_messages_endpoint_bearer_auth(
     """Test authentication via standard Bearer token."""
     mock_response = _make_message_response()
 
-    with patch("api.routes.messages.amessages", new_callable=AsyncMock, return_value=mock_response):
+    with patch("gateway.api.routes.messages.amessages", new_callable=AsyncMock, return_value=mock_response):
         response = client.post(
             "/v1/messages",
             json=messages_request_body,

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -13,6 +13,7 @@ from gateway.core.config import API_KEY_HEADER, GatewayConfig
 from gateway.db import Base, get_db
 from gateway.main import create_app
 from gateway.metrics import REGISTRY
+
 from .conftest import _run_alembic_migrations
 
 

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -13,7 +13,7 @@ from gateway.core.config import API_KEY_HEADER, GatewayConfig
 from gateway.db import Base, get_db
 from gateway.main import create_app
 from gateway.metrics import REGISTRY
-from tests.gateway.conftest import _run_alembic_migrations
+from .conftest import _run_alembic_migrations
 
 
 def _sample(name: str, labels: dict[str, str]) -> float:
@@ -166,7 +166,7 @@ def test_token_metrics_recorded(metrics_client: TestClient) -> None:
     async def mock_acompletion(**kwargs: Any) -> ChatCompletion:
         return mock_response
 
-    with patch("api.routes.chat.acompletion", new=mock_acompletion):
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
         resp = _chat_request(metrics_client, user_id)
 
     assert resp.status_code == 200
@@ -217,7 +217,7 @@ def test_cost_metric_recorded_with_pricing(metrics_client: TestClient) -> None:
     async def mock_acompletion(**kwargs: Any) -> ChatCompletion:
         return mock_response
 
-    with patch("api.routes.chat.acompletion", new=mock_acompletion):
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
         resp = _chat_request(metrics_client, user_id)
 
     assert resp.status_code == 200
@@ -237,7 +237,7 @@ def test_rate_limit_hit_metric(metrics_rate_limit_client: TestClient) -> None:
         msg = "short-circuit"
         raise RuntimeError(msg)
 
-    with patch("api.routes.chat.acompletion", new=mock_acompletion):
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
         # Exhaust rate limit (rpm=2)
         for _ in range(2):
             _chat_request(metrics_rate_limit_client, user_id)

--- a/tests/integration/test_provider_kwargs_override.py
+++ b/tests/integration/test_provider_kwargs_override.py
@@ -14,7 +14,7 @@ from gateway.api.routes.chat import get_provider_kwargs
 from gateway.core.config import GatewayConfig
 from gateway.db import Base, get_db
 from gateway.main import create_app
-from tests.gateway.conftest import _run_alembic_migrations
+from .conftest import _run_alembic_migrations
 
 
 class _MockCompletionError(Exception):
@@ -105,7 +105,7 @@ async def test_user_model_not_overridden_by_provider_config(
     )
     assert response.status_code == 200
 
-    with patch("api.routes.chat.acompletion", new=mock_acompletion):
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
         client_with_model_in_provider.post(
             "/v1/chat/completions",
             json={
@@ -134,7 +134,7 @@ async def test_unset_optional_fields_do_not_override_provider_defaults(
 
     master_key_header = {"X-AnyLLM-Key": "Bearer test-master-key"}
 
-    with patch("api.routes.chat.acompletion", new=mock_acompletion):
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
         client_with_model_in_provider.post(
             "/v1/chat/completions",
             json={

--- a/tests/integration/test_provider_kwargs_override.py
+++ b/tests/integration/test_provider_kwargs_override.py
@@ -14,6 +14,7 @@ from gateway.api.routes.chat import get_provider_kwargs
 from gateway.core.config import GatewayConfig
 from gateway.db import Base, get_db
 from gateway.main import create_app
+
 from .conftest import _run_alembic_migrations
 
 

--- a/tests/integration/test_rate_limiting.py
+++ b/tests/integration/test_rate_limiting.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from gateway.core.config import API_KEY_HEADER, GatewayConfig
 from gateway.db import Base, get_db
 from gateway.main import create_app
-from tests.gateway.conftest import _run_alembic_migrations
+from .conftest import _run_alembic_migrations
 
 
 class _MockCompletionError(Exception):
@@ -120,7 +120,7 @@ def test_rate_limit_headers_on_success(rate_limit_client: TestClient) -> None:
     async def mock_acompletion(**kwargs: Any) -> ChatCompletion:
         return mock_response
 
-    with patch("api.routes.chat.acompletion", new=mock_acompletion):
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
         resp = _chat_request(rate_limit_client, user_id)
 
     assert resp.status_code == 200
@@ -137,7 +137,7 @@ def test_rate_limit_returns_429_with_retry_after(rate_limit_client: TestClient) 
     async def mock_acompletion(**kwargs: Any) -> None:
         raise _MockCompletionError
 
-    with patch("api.routes.chat.acompletion", new=mock_acompletion):
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
         for _ in range(3):
             _chat_request(rate_limit_client, user_id)
 
@@ -153,7 +153,7 @@ def test_no_rate_limit_allows_unlimited(no_rate_limit_client: TestClient) -> Non
     async def mock_acompletion(**kwargs: Any) -> None:
         raise _MockCompletionError
 
-    with patch("api.routes.chat.acompletion", new=mock_acompletion):
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
         for _ in range(10):
             resp = _chat_request(no_rate_limit_client, user_id)
             assert resp.status_code != 429

--- a/tests/integration/test_rate_limiting.py
+++ b/tests/integration/test_rate_limiting.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from gateway.core.config import API_KEY_HEADER, GatewayConfig
 from gateway.db import Base, get_db
 from gateway.main import create_app
+
 from .conftest import _run_alembic_migrations
 
 

--- a/tests/integration/test_transaction_safety.py
+++ b/tests/integration/test_transaction_safety.py
@@ -20,7 +20,7 @@ def test_create_user_rollback_on_commit_failure(
 ) -> None:
     """create_user rolls back and returns 500 when commit fails."""
     with patch(
-        "api.routes.users.Session.commit",
+        "gateway.api.routes.users.Session.commit",
         side_effect=OperationalError("db", {}, Exception("connection lost")),
     ):
         resp = client.post(
@@ -39,7 +39,7 @@ def test_delete_user_rollback_on_commit_failure(
     client.post("/v1/users", json={"user_id": "del-fail-user"}, headers=master_key_header)
 
     with patch(
-        "api.routes.users.Session.commit",
+        "gateway.api.routes.users.Session.commit",
         side_effect=OperationalError("db", {}, Exception("connection lost")),
     ):
         resp = client.delete("/v1/users/del-fail-user", headers=master_key_header)
@@ -56,7 +56,7 @@ def test_create_key_rollback_on_commit_failure(
 ) -> None:
     """create_key rolls back on commit failure."""
     with patch(
-        "api.routes.keys.Session.commit",
+        "gateway.api.routes.keys.Session.commit",
         side_effect=OperationalError("db", {}, Exception("connection lost")),
     ):
         resp = client.post(
@@ -73,7 +73,7 @@ def test_create_budget_rollback_on_commit_failure(
 ) -> None:
     """create_budget rolls back on commit failure."""
     with patch(
-        "api.routes.budgets.Session.commit",
+        "gateway.api.routes.budgets.Session.commit",
         side_effect=OperationalError("db", {}, Exception("connection lost")),
     ):
         resp = client.post(
@@ -90,7 +90,7 @@ def test_set_pricing_rollback_on_commit_failure(
 ) -> None:
     """set_pricing rolls back on commit failure."""
     with patch(
-        "api.routes.pricing.Session.commit",
+        "gateway.api.routes.pricing.Session.commit",
         side_effect=OperationalError("db", {}, Exception("connection lost")),
     ):
         resp = client.post(
@@ -141,7 +141,7 @@ def test_is_model_free_catches_unsupported_provider_error(test_db: Session) -> N
 def test_is_model_free_catches_sqlalchemy_error(test_db: Session) -> None:
     """_is_model_free returns False on SQLAlchemy errors during pricing lookup."""
     with patch(
-        "services.budget_service.find_model_pricing",
+        "gateway.services.budget_service.find_model_pricing",
         side_effect=OperationalError("db", {}, Exception("connection lost")),
     ):
         result = _is_model_free(test_db, "openai:gpt-4o")
@@ -151,7 +151,7 @@ def test_is_model_free_catches_sqlalchemy_error(test_db: Session) -> None:
 def test_is_model_free_does_not_catch_unexpected_errors(test_db: Session) -> None:
     """_is_model_free does not swallow unexpected non-DB, non-ValueError exceptions."""
     with (
-        patch("services.budget_service.find_model_pricing", side_effect=RuntimeError("unexpected")),
+        patch("gateway.services.budget_service.find_model_pricing", side_effect=RuntimeError("unexpected")),
         pytest.raises(RuntimeError, match="unexpected"),
     ):
         _is_model_free(test_db, "openai:gpt-4o")
@@ -170,7 +170,7 @@ def test_auth_commit_failure_does_not_break_verification(
     api_key = key_resp.json()["key"]
 
     with patch(
-        "api.deps.Session.commit",
+        "gateway.api.deps.Session.commit",
         side_effect=OperationalError("db", {}, Exception("connection lost")),
     ):
         resp = client.get(

--- a/tests/integration/test_usage_tracking.py
+++ b/tests/integration/test_usage_tracking.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import sessionmaker
 
 from gateway.core.config import GatewayConfig
 from gateway.models.entities import UsageLog, User
-from tests.gateway.conftest import MODEL_NAME
+from .conftest import MODEL_NAME
 
 _HAS_GEMINI_KEY = bool(os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"))
 

--- a/tests/integration/test_usage_tracking.py
+++ b/tests/integration/test_usage_tracking.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import sessionmaker
 
 from gateway.core.config import GatewayConfig
 from gateway.models.entities import UsageLog, User
+
 from .conftest import MODEL_NAME
 
 _HAS_GEMINI_KEY = bool(os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"))

--- a/tests/integration/test_user_delete_preserve_logs.py
+++ b/tests/integration/test_user_delete_preserve_logs.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from gateway.core.config import API_KEY_HEADER
 from gateway.models.entities import APIKey, BudgetResetLog, UsageLog
-from tests.gateway.conftest import MODEL_NAME
+from .conftest import MODEL_NAME
 
 
 def test_delete_user_preserves_usage_logs(
@@ -70,7 +70,7 @@ def test_delete_user_preserves_budget_reset_logs(
     )
 
     initial_time = datetime(2025, 10, 1, 12, 0, 0, tzinfo=UTC)
-    with patch("api.routes.users.datetime") as mock_dt:
+    with patch("gateway.api.routes.users.datetime") as mock_dt:
         mock_dt.now.return_value = initial_time
         client.post(
             "/v1/users",
@@ -80,8 +80,8 @@ def test_delete_user_preserves_budget_reset_logs(
 
     time_after_reset = initial_time + timedelta(seconds=61)
     with (
-        patch("services.budget_service.datetime") as mock_dt_budget,
-        patch("api.routes.chat.datetime") as mock_dt_chat,
+        patch("gateway.services.budget_service.datetime") as mock_dt_budget,
+        patch("gateway.api.routes.chat.datetime") as mock_dt_chat,
     ):
         mock_dt_budget.now.return_value = time_after_reset
         mock_dt_chat.now.return_value = time_after_reset

--- a/tests/integration/test_user_delete_preserve_logs.py
+++ b/tests/integration/test_user_delete_preserve_logs.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 
 from gateway.core.config import API_KEY_HEADER
 from gateway.models.entities import APIKey, BudgetResetLog, UsageLog
+
 from .conftest import MODEL_NAME
 
 

--- a/tests/unit/test_global_state_reset.py
+++ b/tests/unit/test_global_state_reset.py
@@ -22,7 +22,7 @@ def test_reset_config_clears_state() -> None:
 
 
 def test_reset_db_allows_reinit() -> None:
-    from core import database
+    from gateway.core import database
 
     reset_db()
 


### PR DESCRIPTION
## Summary
- replace stale integration imports of `tests.gateway.conftest` with package-relative imports from `tests/integration/conftest.py`
- update stale `patch(...)` targets from legacy module paths (`api.*`, `services.*`) to the actual `gateway.*` package layout
- fix unit test global-state reset import to `gateway.core.database` so test collection/runtime resolve consistently

## Testing
- uv run pytest -v tests/integration/test_rate_limiting.py tests/integration/test_messages_endpoint.py tests/unit/test_global_state_reset.py
- uv run pytest tests/integration --collect-only -q

## Issue
Closes #1