### PR TITLE
auth: make Vertex credential setup request-local

### DIFF
--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -90,10 +90,12 @@ def get_provider_kwargs(
             vertex_project = provider_config.get("project")
             vertex_location = provider_config.get("location")
 
-            setup_vertex_environment(
-                credentials=vertex_creds,
-                project=vertex_project,
-                location=vertex_location,
+            kwargs.update(
+                setup_vertex_environment(
+                    credentials=vertex_creds,
+                    project=vertex_project,
+                    location=vertex_location,
+                )
             )
             if "client_args" in provider_config:
                 kwargs["client_args"] = provider_config["client_args"]

--- a/src/gateway/auth/vertex_auth.py
+++ b/src/gateway/auth/vertex_auth.py
@@ -40,10 +40,10 @@ def setup_vertex_environment(
                 if os.path.exists(credentials):
                     with open(credentials, encoding="utf-8") as f:
                         json_obj = json.load(f)
-                    kwargs["credentials"] = service_account.Credentials.from_service_account_file(credentials)
+                    kwargs["credentials"] = service_account.Credentials.from_service_account_file(credentials)  # type: ignore[no-untyped-call]
                 else:
                     json_obj = json.loads(credentials)
-                    kwargs["credentials"] = service_account.Credentials.from_service_account_info(json_obj)
+                    kwargs["credentials"] = service_account.Credentials.from_service_account_info(json_obj)  # type: ignore[no-untyped-call]
             except Exception as e:  # noqa: BLE001
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -52,7 +52,7 @@ def setup_vertex_environment(
         elif isinstance(credentials, dict):
             json_obj = credentials
             try:
-                kwargs["credentials"] = service_account.Credentials.from_service_account_info(credentials)
+                kwargs["credentials"] = service_account.Credentials.from_service_account_info(credentials)  # type: ignore[no-untyped-call]
             except Exception as e:  # noqa: BLE001
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/src/gateway/auth/vertex_auth.py
+++ b/src/gateway/auth/vertex_auth.py
@@ -1,26 +1,11 @@
-"""Helper module for loading Google Cloud Vertex AI credentials."""
+"""Helpers for preparing Vertex AI client kwargs safely per request."""
 
-import atexit
 import json
 import os
-import tempfile
 from typing import Any
 
 from fastapi import HTTPException, status
-
-_temp_credential_file: str | None = None
-
-
-def _cleanup_temp_credentials() -> None:
-    """Remove temporary credential file on process exit."""
-    if _temp_credential_file and os.path.exists(_temp_credential_file):
-        try:
-            os.remove(_temp_credential_file)
-        except OSError:
-            pass
-
-
-atexit.register(_cleanup_temp_credentials)
+from google.oauth2 import service_account
 
 
 def setup_vertex_environment(
@@ -28,11 +13,10 @@ def setup_vertex_environment(
     project: str | None = None,
     location: str | None = None,
 ) -> dict[str, Any]:
-    """Vertex AI environment variables setup for any-llm.
+    """Build request-local Vertex AI client kwargs for any-llm.
 
-    The google.genai.Client used by any-llm reads credentials from environment variables.
-    This function sets up GOOGLE_APPLICATION_CREDENTIALS, GOOGLE_CLOUD_PROJECT,
-    and GOOGLE_CLOUD_LOCATION as needed.
+    The Vertex provider passes these kwargs directly to `google.genai.Client`,
+    so this function avoids process-global environment mutation.
 
     Args:
         credentials: Path to service account JSON file, JSON string, or dict
@@ -40,67 +24,64 @@ def setup_vertex_environment(
         location: Optional GCP location (default: "us-central1")
 
     Returns:
-        Empty dict (environment is configured via env vars)
+        Dict of kwargs for provider initialization
 
     Raises:
         HTTPException: If credentials cannot be loaded or project cannot be determined
 
     """
-    global _temp_credential_file  # noqa: PLW0603
-
-    env_updates: dict[str, str] = {}
+    kwargs: dict[str, Any] = {}
 
     if credentials is not None:
-        json_obj = None
+        json_obj: dict[str, Any] | None = None
 
         if isinstance(credentials, str):
             try:
                 if os.path.exists(credentials):
                     with open(credentials, encoding="utf-8") as f:
                         json_obj = json.load(f)
-                    env_updates["GOOGLE_APPLICATION_CREDENTIALS"] = credentials
+                    kwargs["credentials"] = service_account.Credentials.from_service_account_file(credentials)
                 else:
                     json_obj = json.loads(credentials)
-            except Exception as e:
+                    kwargs["credentials"] = service_account.Credentials.from_service_account_info(json_obj)
+            except Exception as e:  # noqa: BLE001
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                     detail="Unable to load vertex credentials",
                 ) from e
         elif isinstance(credentials, dict):
             json_obj = credentials
+            try:
+                kwargs["credentials"] = service_account.Credentials.from_service_account_info(credentials)
+            except Exception as e:  # noqa: BLE001
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Unable to load vertex credentials",
+                ) from e
         else:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Invalid credentials type: {type(credentials)}",
             )
 
-        if json_obj and "GOOGLE_APPLICATION_CREDENTIALS" not in env_updates:
-            if _temp_credential_file and os.path.exists(_temp_credential_file):
-                env_updates["GOOGLE_APPLICATION_CREDENTIALS"] = _temp_credential_file
-            else:
-                temp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
-                json.dump(json_obj, temp_file)
-                temp_file.close()
-                _temp_credential_file = temp_file.name
-                env_updates["GOOGLE_APPLICATION_CREDENTIALS"] = _temp_credential_file
-
         if project is None and json_obj:
             project = json_obj.get("project_id")
 
     if project:
-        env_updates["GOOGLE_CLOUD_PROJECT"] = project
+        kwargs["project"] = project
     elif "GOOGLE_CLOUD_PROJECT" not in os.environ:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Could not resolve GCP project ID from credentials or configuration",
         )
+    else:
+        kwargs["project"] = os.environ["GOOGLE_CLOUD_PROJECT"]
 
     if location:
-        env_updates["GOOGLE_CLOUD_LOCATION"] = location
+        kwargs["location"] = location
     elif "GOOGLE_CLOUD_LOCATION" not in os.environ:
-        env_updates["GOOGLE_CLOUD_LOCATION"] = "us-central1"
+        kwargs["location"] = "us-central1"
+    else:
+        kwargs["location"] = os.environ["GOOGLE_CLOUD_LOCATION"]
 
-    for key, value in env_updates.items():
-        os.environ[key] = value
-
-    return {}
+    return kwargs

--- a/tests/integration/test_vertex_credential_cleanup.py
+++ b/tests/integration/test_vertex_credential_cleanup.py
@@ -5,6 +5,7 @@ from unittest.mock import sentinel
 
 import pytest
 from fastapi import HTTPException
+from google.oauth2 import service_account
 
 from gateway.auth.vertex_auth import setup_vertex_environment
 
@@ -18,7 +19,6 @@ def test_setup_vertex_environment_returns_kwargs_without_env_mutation() -> None:
     os.environ["GOOGLE_CLOUD_LOCATION"] = "europe-west1"
 
     try:
-        from gateway.auth import vertex_auth
 
         def _fake_from_info(info: dict[str, object]) -> object:
             assert info["project_id"] == "config-project"
@@ -26,7 +26,7 @@ def test_setup_vertex_environment_returns_kwargs_without_env_mutation() -> None:
 
         with pytest.MonkeyPatch.context() as mp:
             mp.setattr(
-                vertex_auth.service_account.Credentials,
+                service_account.Credentials,
                 "from_service_account_info",
                 _fake_from_info,
             )

--- a/tests/integration/test_vertex_credential_cleanup.py
+++ b/tests/integration/test_vertex_credential_cleanup.py
@@ -1,74 +1,76 @@
-"""Tests for Vertex AI credential file caching and cleanup."""
+"""Tests for request-local Vertex credential handling."""
 
-import json
 import os
+from unittest.mock import sentinel
 
-from gateway.auth import vertex_auth
+import pytest
+from fastapi import HTTPException
+
 from gateway.auth.vertex_auth import setup_vertex_environment
 
 
-def test_temp_credential_file_reused_across_calls() -> None:
-    """Test that repeated calls reuse the same temp credential file."""
-    # Reset cached file
-    original = vertex_auth._temp_credential_file
-    vertex_auth._temp_credential_file = None
+def test_setup_vertex_environment_returns_kwargs_without_env_mutation() -> None:
+    """Credentials are resolved into client kwargs without mutating process env."""
+    original_project = os.environ.get("GOOGLE_CLOUD_PROJECT")
+    original_location = os.environ.get("GOOGLE_CLOUD_LOCATION")
 
-    creds = {"type": "service_account", "project_id": "test-project"}
-
-    try:
-        setup_vertex_environment(credentials=creds, project="test-project")
-        first_file = vertex_auth._temp_credential_file
-        assert first_file is not None
-        assert os.path.exists(first_file)
-
-        setup_vertex_environment(credentials=creds, project="test-project")
-        second_file = vertex_auth._temp_credential_file
-
-        assert first_file == second_file, "Should reuse the same temp file"
-    finally:
-        # Clean up
-        if vertex_auth._temp_credential_file and os.path.exists(
-            vertex_auth._temp_credential_file
-        ):
-            os.remove(vertex_auth._temp_credential_file)
-        vertex_auth._temp_credential_file = original
-        # Clean up env vars we set
-        for var in [
-            "GOOGLE_APPLICATION_CREDENTIALS",
-            "GOOGLE_CLOUD_PROJECT",
-            "GOOGLE_CLOUD_LOCATION",
-        ]:
-            os.environ.pop(var, None)
-
-
-def test_temp_credential_file_contains_valid_json() -> None:
-    """Test that the temp credential file contains valid JSON."""
-    original = vertex_auth._temp_credential_file
-    vertex_auth._temp_credential_file = None
-
-    creds = {
-        "type": "service_account",
-        "project_id": "test-project",
-        "client_email": "test@test.iam.gserviceaccount.com",
-    }
+    os.environ["GOOGLE_CLOUD_PROJECT"] = "existing-project"
+    os.environ["GOOGLE_CLOUD_LOCATION"] = "europe-west1"
 
     try:
-        setup_vertex_environment(credentials=creds, project="test-project")
-        temp_file = vertex_auth._temp_credential_file
-        assert temp_file is not None
+        from gateway.auth import vertex_auth
 
-        with open(temp_file, encoding="utf-8") as f:
-            loaded = json.load(f)
-        assert loaded["project_id"] == "test-project"
+        def _fake_from_info(info: dict[str, object]) -> object:
+            assert info["project_id"] == "config-project"
+            return sentinel.credentials
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                vertex_auth.service_account.Credentials,
+                "from_service_account_info",
+                _fake_from_info,
+            )
+            kwargs = setup_vertex_environment(
+                credentials={"project_id": "config-project", "private_key": "unused"},
+                location="us-central1",
+            )
+
+        assert kwargs["credentials"] is sentinel.credentials
+        assert kwargs["project"] == "config-project"
+        assert kwargs["location"] == "us-central1"
+        assert os.environ["GOOGLE_CLOUD_PROJECT"] == "existing-project"
+        assert os.environ["GOOGLE_CLOUD_LOCATION"] == "europe-west1"
     finally:
-        if vertex_auth._temp_credential_file and os.path.exists(
-            vertex_auth._temp_credential_file
-        ):
-            os.remove(vertex_auth._temp_credential_file)
-        vertex_auth._temp_credential_file = original
-        for var in [
-            "GOOGLE_APPLICATION_CREDENTIALS",
-            "GOOGLE_CLOUD_PROJECT",
-            "GOOGLE_CLOUD_LOCATION",
-        ]:
-            os.environ.pop(var, None)
+        if original_project is None:
+            os.environ.pop("GOOGLE_CLOUD_PROJECT", None)
+        else:
+            os.environ["GOOGLE_CLOUD_PROJECT"] = original_project
+
+        if original_location is None:
+            os.environ.pop("GOOGLE_CLOUD_LOCATION", None)
+        else:
+            os.environ["GOOGLE_CLOUD_LOCATION"] = original_location
+
+
+def test_setup_vertex_environment_uses_env_fallbacks() -> None:
+    """Project and location fall back to env when explicit values are missing."""
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("GOOGLE_CLOUD_PROJECT", "env-project")
+        mp.setenv("GOOGLE_CLOUD_LOCATION", "env-location")
+
+        kwargs = setup_vertex_environment(credentials=None)
+
+    assert kwargs == {"project": "env-project", "location": "env-location"}
+
+
+def test_setup_vertex_environment_requires_project_resolution() -> None:
+    """Project resolution failure raises a clear 400 error."""
+    with pytest.MonkeyPatch.context() as mp:
+        mp.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        mp.delenv("GOOGLE_CLOUD_LOCATION", raising=False)
+
+        with pytest.raises(HTTPException) as exc:
+            setup_vertex_environment(credentials=None)
+
+    assert exc.value.status_code == 400
+    assert "Could not resolve GCP project ID" in str(exc.value.detail)


### PR DESCRIPTION
## Summary
- refactor Vertex credential setup to build request-local `google.genai.Client` kwargs instead of mutating global environment variables
- resolve service account credentials into `google.oauth2.service_account.Credentials` objects per request and keep project/location explicit in provider kwargs
- replace temp-file reuse tests with coverage that verifies no process env mutation and correct fallback/error behavior

## Testing
- uv run pytest -v tests/integration/test_vertex_credential_cleanup.py tests/integration/test_client_args.py

## Issue
Closes #2