### PR TITLE
perf: throttle api key last_used_at commit frequency

### DIFF
--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -13,6 +13,7 @@ from gateway.metrics import record_auth_failure
 from gateway.models.entities import APIKey
 
 _config: GatewayConfig | None = None
+_LAST_USED_UPDATE_INTERVAL_SECONDS = 300
 
 
 def set_config(config: GatewayConfig) -> None:
@@ -99,11 +100,18 @@ def _verify_and_update_api_key(db: Session, token: str) -> APIKey:
             detail="API key has expired",
         )
 
-    api_key.last_used_at = datetime.now(UTC)
-    try:
-        db.commit()
-    except SQLAlchemyError:
-        db.rollback()
+    now = datetime.now(UTC)
+    should_update_last_used = (
+        api_key.last_used_at is None
+        or (now - api_key.last_used_at).total_seconds() >= _LAST_USED_UPDATE_INTERVAL_SECONDS
+    )
+
+    if should_update_last_used:
+        api_key.last_used_at = now
+        try:
+            db.commit()
+        except SQLAlchemyError:
+            db.rollback()
 
     return api_key
 

--- a/tests/integration/test_key_management.py
+++ b/tests/integration/test_key_management.py
@@ -1,11 +1,12 @@
 from datetime import UTC, datetime, timedelta
-from unittest.mock import patch
 from typing import Any
+from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
 from gateway.core.config import API_KEY_HEADER, GatewayConfig
-from tests.gateway.conftest import MODEL_NAME
+
+from .conftest import MODEL_NAME
 
 
 def test_create_api_key(client: TestClient, master_key_header: dict[str, str]) -> None:

--- a/tests/integration/test_key_management.py
+++ b/tests/integration/test_key_management.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
 from typing import Any
 
 from fastapi.testclient import TestClient
@@ -209,6 +210,47 @@ def test_api_key_last_used_tracking(
 
     assert updated_last_used is not None
     assert updated_last_used != initial_last_used
+
+
+def test_api_key_last_used_tracking_throttles_db_writes(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """Requests within the throttle window should not rewrite last_used_at."""
+    create_response = client.post(
+        "/v1/keys",
+        json={"key_name": "usage-throttle"},
+        headers=master_key_header,
+    )
+    api_key = create_response.json()
+
+    first_use = datetime(2026, 1, 1, tzinfo=UTC)
+    second_use = first_use + timedelta(seconds=60)
+
+    with patch("gateway.api.deps.datetime") as mock_datetime:
+        mock_datetime.now.return_value = first_use
+        response = client.get(
+            "/v1/models",
+            headers={API_KEY_HEADER: f"Bearer {api_key['key']}"},
+        )
+        assert response.status_code == 200
+
+    first_state = client.get(f"/v1/keys/{api_key['id']}", headers=master_key_header)
+    first_last_used = first_state.json()["last_used_at"]
+
+    with patch("gateway.api.deps.datetime") as mock_datetime:
+        mock_datetime.now.return_value = second_use
+        response = client.get(
+            "/v1/models",
+            headers={API_KEY_HEADER: f"Bearer {api_key['key']}"},
+        )
+        assert response.status_code == 200
+
+    second_state = client.get(f"/v1/keys/{api_key['id']}", headers=master_key_header)
+    second_last_used = second_state.json()["last_used_at"]
+
+    assert first_last_used is not None
+    assert second_last_used == first_last_used
 
 
 def test_inactive_api_key_rejected(


### PR DESCRIPTION
## Summary
- add a 5-minute throttle window before persisting `api_keys.last_used_at` updates in auth dependency logic
- keep authentication semantics unchanged while removing unnecessary commit pressure on every authenticated request
- add integration coverage proving repeated requests inside the throttle window do not rewrite `last_used_at`

## Testing
- uv run pytest -v tests/integration/test_key_management.py::test_api_key_last_used_tracking tests/integration/test_key_management.py::test_api_key_last_used_tracking_throttles_db_writes tests/integration/test_transaction_safety.py::test_auth_commit_failure_does_not_break_verification

## Issue
Closes #4