### PR TITLE
metrics: drop user_id labels from rate and budget counters

### DIFF
--- a/src/gateway/metrics.py
+++ b/src/gateway/metrics.py
@@ -57,14 +57,12 @@ REQUEST_COST_DOLLARS = Histogram(
 RATE_LIMIT_HITS = Counter(
     "gateway_rate_limit_hits",
     "Total number of rate limit hits",
-    ["user_id"],
     registry=REGISTRY,
 )
 
 BUDGET_EXCEEDED = Counter(
     "gateway_budget_exceeded",
     "Total number of budget exceeded events",
-    ["user_id"],
     registry=REGISTRY,
 )
 
@@ -134,14 +132,14 @@ def record_cost(provider: str, model: str, cost: float) -> None:
     REQUEST_COST_DOLLARS.labels(provider=provider, model=model).observe(cost)
 
 
-def record_rate_limit_hit(user_id: str) -> None:
+def record_rate_limit_hit() -> None:
     """Record a rate limit hit."""
-    RATE_LIMIT_HITS.labels(user_id=user_id).inc()
+    RATE_LIMIT_HITS.inc()
 
 
-def record_budget_exceeded(user_id: str) -> None:
+def record_budget_exceeded() -> None:
     """Record a budget exceeded event."""
-    BUDGET_EXCEEDED.labels(user_id=user_id).inc()
+    BUDGET_EXCEEDED.inc()
 
 
 def record_auth_failure(reason: str) -> None:

--- a/src/gateway/rate_limit.py
+++ b/src/gateway/rate_limit.py
@@ -59,7 +59,7 @@ class RateLimiter:
         if len(current) >= self._rpm:
             oldest = current[0]
             retry_after = math.ceil(oldest - cutoff)
-            record_rate_limit_hit(user_id)
+            record_rate_limit_hit()
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
                 detail="Rate limit exceeded",

--- a/src/gateway/services/budget_service.py
+++ b/src/gateway/services/budget_service.py
@@ -104,7 +104,7 @@ async def validate_user_budget(db: Session, user_id: str, model: str | None = No
                 if user.spend >= budget.max_budget:
                     if model and _is_model_free(db, model):
                         return user
-                    record_budget_exceeded(user_id)
+                    record_budget_exceeded()
                     raise HTTPException(
                         status_code=status.HTTP_403_FORBIDDEN,
                         detail=f"User '{user_id}' has exceeded budget limit",

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -13,6 +13,7 @@ from gateway.core.config import API_KEY_HEADER, GatewayConfig
 from gateway.db import Base, get_db
 from gateway.main import create_app
 from gateway.metrics import REGISTRY
+
 from .conftest import _run_alembic_migrations
 
 

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -13,12 +13,12 @@ from gateway.core.config import API_KEY_HEADER, GatewayConfig
 from gateway.db import Base, get_db
 from gateway.main import create_app
 from gateway.metrics import REGISTRY
-from tests.gateway.conftest import _run_alembic_migrations
+from .conftest import _run_alembic_migrations
 
 
-def _sample(name: str, labels: dict[str, str]) -> float:
+def _sample(name: str, labels: dict[str, str] | None = None) -> float:
     """Read a metric sample value from the registry, returning 0.0 if not found."""
-    return REGISTRY.get_sample_value(name, labels) or 0.0
+    return REGISTRY.get_sample_value(name, labels or {}) or 0.0
 
 
 def _make_metrics_client(
@@ -166,7 +166,7 @@ def test_token_metrics_recorded(metrics_client: TestClient) -> None:
     async def mock_acompletion(**kwargs: Any) -> ChatCompletion:
         return mock_response
 
-    with patch("api.routes.chat.acompletion", new=mock_acompletion):
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
         resp = _chat_request(metrics_client, user_id)
 
     assert resp.status_code == 200
@@ -217,7 +217,7 @@ def test_cost_metric_recorded_with_pricing(metrics_client: TestClient) -> None:
     async def mock_acompletion(**kwargs: Any) -> ChatCompletion:
         return mock_response
 
-    with patch("api.routes.chat.acompletion", new=mock_acompletion):
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
         resp = _chat_request(metrics_client, user_id)
 
     assert resp.status_code == 200
@@ -230,14 +230,13 @@ def test_cost_metric_recorded_with_pricing(metrics_client: TestClient) -> None:
 def test_rate_limit_hit_metric(metrics_rate_limit_client: TestClient) -> None:
     user_id = _create_user(metrics_rate_limit_client, user_id="rl-metric-user")
 
-    labels = {"user_id": user_id}
-    before = _sample("gateway_rate_limit_hits_total", labels)
+    before = _sample("gateway_rate_limit_hits_total")
 
     async def mock_acompletion(**kwargs: Any) -> None:
         msg = "short-circuit"
         raise RuntimeError(msg)
 
-    with patch("api.routes.chat.acompletion", new=mock_acompletion):
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
         # Exhaust rate limit (rpm=2)
         for _ in range(2):
             _chat_request(metrics_rate_limit_client, user_id)
@@ -245,7 +244,7 @@ def test_rate_limit_hit_metric(metrics_rate_limit_client: TestClient) -> None:
         resp = _chat_request(metrics_rate_limit_client, user_id)
 
     assert resp.status_code == 429
-    assert _sample("gateway_rate_limit_hits_total", labels) - before >= 1.0
+    assert _sample("gateway_rate_limit_hits_total") - before >= 1.0
 
 
 def test_budget_exceeded_metric(metrics_client: TestClient) -> None:
@@ -268,13 +267,12 @@ def test_budget_exceeded_metric(metrics_client: TestClient) -> None:
     )
     assert user_resp.status_code == 200
 
-    labels = {"user_id": "budget-user"}
-    before = _sample("gateway_budget_exceeded_total", labels)
+    before = _sample("gateway_budget_exceeded_total")
 
     resp = _chat_request(metrics_client, "budget-user")
     assert resp.status_code == 403
 
-    assert _sample("gateway_budget_exceeded_total", labels) - before == 1.0
+    assert _sample("gateway_budget_exceeded_total") - before == 1.0
 
 
 def test_auth_failure_metric_missing_credentials(metrics_client: TestClient) -> None:

--- a/tests/unit/test_gateway_metrics.py
+++ b/tests/unit/test_gateway_metrics.py
@@ -57,21 +57,19 @@ def test_record_cost_observes_histogram() -> None:
 
 
 def test_record_rate_limit_hit_increments_counter() -> None:
-    labels = {"user_id": "rl-unit-user"}
-    before = _sample("gateway_rate_limit_hits_total", labels)
+    before = _sample("gateway_rate_limit_hits_total")
 
-    record_rate_limit_hit("rl-unit-user")
+    record_rate_limit_hit()
 
-    assert _sample("gateway_rate_limit_hits_total", labels) - before == 1.0
+    assert _sample("gateway_rate_limit_hits_total") - before == 1.0
 
 
 def test_record_budget_exceeded_increments_counter() -> None:
-    labels = {"user_id": "budget-unit-user"}
-    before = _sample("gateway_budget_exceeded_total", labels)
+    before = _sample("gateway_budget_exceeded_total")
 
-    record_budget_exceeded("budget-unit-user")
+    record_budget_exceeded()
 
-    assert _sample("gateway_budget_exceeded_total", labels) - before == 1.0
+    assert _sample("gateway_budget_exceeded_total") - before == 1.0
 
 
 def test_record_auth_failure_increments_counter() -> None:
@@ -195,11 +193,10 @@ def test_rate_limiter_records_metric_on_429() -> None:
     limiter = RateLimiter(rpm=1)
     limiter.check("metric-rl-user")
 
-    labels = {"user_id": "metric-rl-user"}
-    before = _sample("gateway_rate_limit_hits_total", labels)
+    before = _sample("gateway_rate_limit_hits_total")
 
     with pytest.raises(HTTPException) as exc_info:
         limiter.check("metric-rl-user")
 
     assert exc_info.value.status_code == 429
-    assert _sample("gateway_rate_limit_hits_total", labels) - before == 1.0
+    assert _sample("gateway_rate_limit_hits_total") - before == 1.0


### PR DESCRIPTION
## Summary
- remove high-cardinality `user_id` labels from `gateway_rate_limit_hits` and `gateway_budget_exceeded` counters
- update metric recording call sites to increment aggregate counters without per-user dimensions
- refresh unit/integration metric tests to assert the new bounded-label behavior

## Testing
- uv run pytest -v tests/unit/test_gateway_metrics.py tests/integration/test_metrics.py

## Issue
Closes #6