### PR TITLE
security: require auth for pricing read endpoints

### DIFF
--- a/src/gateway/api/routes/pricing.py
+++ b/src/gateway/api/routes/pricing.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from gateway.api.deps import get_db, verify_master_key
+from gateway.api.deps import get_db, verify_api_key_or_master_key, verify_master_key
 from gateway.models.entities import ModelPricing
 
 router = APIRouter(prefix="/v1/pricing", tags=["pricing"])
@@ -75,7 +75,7 @@ async def set_pricing(
     return PricingResponse.from_model(pricing)
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(verify_api_key_or_master_key)])
 async def list_pricing(
     db: Annotated[Session, Depends(get_db)],
     skip: Annotated[int, Query(ge=0)] = 0,
@@ -87,7 +87,7 @@ async def list_pricing(
     return [PricingResponse.from_model(pricing) for pricing in pricings]
 
 
-@router.get("/{model_key}")
+@router.get("/{model_key}", dependencies=[Depends(verify_api_key_or_master_key)])
 async def get_pricing(
     model_key: str,
     db: Annotated[Session, Depends(get_db)],

--- a/tests/integration/test_pagination_bounds.py
+++ b/tests/integration/test_pagination_bounds.py
@@ -33,9 +33,9 @@ def test_budgets_list_rejects_excessive_limit(client: TestClient, master_key_hea
     assert response.status_code == 422
 
 
-def test_pricing_list_rejects_excessive_limit(client: TestClient) -> None:
+def test_pricing_list_rejects_excessive_limit(client: TestClient, master_key_header: dict[str, str]) -> None:
     """Test that /v1/pricing rejects limit > 1000."""
-    response = client.get("/v1/pricing?limit=10000")
+    response = client.get("/v1/pricing?limit=10000", headers=master_key_header)
     assert response.status_code == 422
 
 

--- a/tests/integration/test_user_budget.py
+++ b/tests/integration/test_user_budget.py
@@ -149,10 +149,26 @@ def test_get_pricing(client: TestClient, master_key_header: dict[str, str]) -> N
         headers=master_key_header,
     )
 
-    response = client.get("/v1/pricing/openai:gpt-4o")
+    response = client.get("/v1/pricing/openai:gpt-4o", headers=master_key_header)
     assert response.status_code == 200
     data = response.json()
     assert data["model_key"] == "openai:gpt-4o"
+
+
+def test_get_pricing_requires_auth(client: TestClient, master_key_header: dict[str, str]) -> None:
+    """Pricing reads require API key or master key authentication."""
+    client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "openai:gpt-4o",
+            "input_price_per_million": 2.5,
+            "output_price_per_million": 10.0,
+        },
+        headers=master_key_header,
+    )
+
+    response = client.get("/v1/pricing/openai:gpt-4o")
+    assert response.status_code == 401
 
 
 def test_user_with_budget(client: TestClient, master_key_header: dict[str, str]) -> None:


### PR DESCRIPTION
## Summary
- require `verify_api_key_or_master_key` on pricing list and pricing detail read endpoints
- align pricing read policy with protected write/delete behavior to treat pricing as authenticated configuration data
- update integration coverage for authenticated pagination and add explicit unauthenticated-read rejection coverage

## Testing
- uv run pytest -v tests/integration/test_user_budget.py::test_get_pricing tests/integration/test_user_budget.py::test_get_pricing_requires_auth tests/integration/test_pagination_bounds.py::test_pricing_list_rejects_excessive_limit tests/integration/test_pricing_budget_validation.py::test_negative_pricing_rejected

## Issue
Closes #9