### PR TITLE
ci: publish gateway image to Docker Hub

### DIFF
--- a/.github/workflows/gateway-docker.yml
+++ b/.github/workflows/gateway-docker.yml
@@ -20,7 +20,7 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: mozillaai/gateway
+  IMAGE_NAME: mzai/gateway
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/gateway-docker.yml
+++ b/.github/workflows/gateway-docker.yml
@@ -20,7 +20,7 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: mzai/gateway
+  IMAGE_NAME: mozilla-ai/gateway
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/gateway-docker.yml
+++ b/.github/workflows/gateway-docker.yml
@@ -19,15 +19,14 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  REGISTRY: docker.io
+  IMAGE_NAME: mozillaai/gateway
 
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
@@ -43,8 +42,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   gateway:
     # if pulling from Docker Hub, use the following instead, and comment out the build section:
-    image: docker.io/mzai/gateway:latest
+    image: docker.io/mozilla-ai/gateway:latest
 
     # If you want to use a different port, change it here and in the config.yml file.
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   gateway:
     # if pulling from Docker Hub, use the following instead, and comment out the build section:
-    image: docker.io/mozillaai/gateway:latest
+    image: docker.io/mzai/gateway:latest
 
     # If you want to use a different port, change it here and in the config.yml file.
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   gateway:
-    # if pulling from ghcr.io, use the following instead, and comment out the build section:
-    image: ghcr.io/mozilla-ai/gateway:latest
+    # if pulling from Docker Hub, use the following instead, and comment out the build section:
+    image: docker.io/mozillaai/gateway:latest
 
     # If you want to use a different port, change it here and in the config.yml file.
     ports:


### PR DESCRIPTION
## Summary
- switch the Docker publish workflow from GHCR to Docker Hub (`docker.io/mozillaai/gateway`)
- authenticate publish jobs with Docker Hub secrets (`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`)
- update compose image reference and inline comment to pull from Docker Hub