### PR TITLE
feat: add platform mode startup gating and API surface

### DIFF
--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -8,13 +8,21 @@ from gateway.api.routes import (
     keys,
     messages,
     models,
+    platform_mode,
     pricing,
     users,
 )
+from gateway.core.config import GatewayConfig
 
 
-def register_routers(app: FastAPI) -> None:
+def register_routers(app: FastAPI, config: GatewayConfig) -> None:
     app.include_router(chat.router)
+    app.include_router(health.router)
+
+    if config.is_platform_mode:
+        app.include_router(platform_mode.router)
+        return
+
     app.include_router(messages.router)
     app.include_router(embeddings.router)
     app.include_router(models.router)
@@ -22,4 +30,3 @@ def register_routers(app: FastAPI) -> None:
     app.include_router(users.router)
     app.include_router(budgets.router)
     app.include_router(pricing.router)
-    app.include_router(health.router)

--- a/src/gateway/api/routes/health.py
+++ b/src/gateway/api/routes/health.py
@@ -1,9 +1,10 @@
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import text
 
-from gateway.api.deps import get_db
+from gateway.api.deps import get_config, get_db
+from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.version import __version__
 
@@ -11,13 +12,16 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 
 @router.get("")
-async def health_check() -> dict[str, str]:
+async def health_check(config: GatewayConfig = Depends(get_config)) -> dict[str, str]:
     """General health check endpoint.
 
     Returns basic health status. For infrastructure monitoring,
     use /health/readiness or /health/liveness instead.
     """
-    return {"status": "healthy"}
+    payload: dict[str, str] = {"status": "healthy"}
+    if config.is_platform_mode:
+        payload["mode"] = "platform"
+    return payload
 
 
 @router.get("/liveness")
@@ -35,7 +39,7 @@ async def health_liveness() -> str:
 
 
 @router.get("/readiness")
-async def health_readiness() -> dict[str, Any]:
+async def health_readiness(config: GatewayConfig = Depends(get_config)) -> dict[str, Any]:
     """Readiness probe endpoint.
 
     Checks if the gateway is ready to serve requests by validating:
@@ -52,6 +56,13 @@ async def health_readiness() -> dict[str, Any]:
         HTTPException: 503 if service is not ready
 
     """
+    if config.is_platform_mode:
+        return {
+            "status": "healthy",
+            "mode": "platform",
+            "version": __version__,
+        }
+
     try:
         db_gen = get_db()
         db = next(db_gen)

--- a/src/gateway/api/routes/platform_mode.py
+++ b/src/gateway/api/routes/platform_mode.py
@@ -1,0 +1,33 @@
+from fastapi import APIRouter, HTTPException, status
+
+_DISABLED_DETAIL = "This endpoint is not available in platform mode. Manage this resource via the platform UI."
+
+router = APIRouter(tags=["platform-mode"])
+
+
+def _raise_disabled() -> None:
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_DISABLED_DETAIL)
+
+
+@router.api_route("/v1/users/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+@router.api_route("/v1/users", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+async def users_disabled() -> None:
+    _raise_disabled()
+
+
+@router.api_route("/v1/keys/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+@router.api_route("/v1/keys", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+async def keys_disabled() -> None:
+    _raise_disabled()
+
+
+@router.api_route("/v1/budgets/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+@router.api_route("/v1/budgets", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+async def budgets_disabled() -> None:
+    _raise_disabled()
+
+
+@router.api_route("/v1/spend/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+@router.api_route("/v1/spend", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+async def spend_disabled() -> None:
+    _raise_disabled()

--- a/src/gateway/cli.py
+++ b/src/gateway/cli.py
@@ -44,9 +44,7 @@ def cli() -> None:
 @click.option(
     "--log-level",
     default=logging.INFO,
-    type=click.Choice(
-        [logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL]
-    ),
+    type=click.Choice([logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL]),
     help="Logging level",
 )
 def serve(
@@ -60,7 +58,10 @@ def serve(
     log_level: int,
 ) -> None:
     """Start the gateway server."""
-    gateway_config = load_config(config)
+    try:
+        gateway_config = load_config(config)
+    except ValueError as e:
+        raise click.ClickException(str(e)) from e
     setup_logger(level=log_level)
 
     if host:
@@ -74,23 +75,32 @@ def serve(
     if auto_migrate is not None:
         gateway_config.auto_migrate = auto_migrate
 
+    gateway_config.validate_mode_selection()
+
+    if gateway_config.is_platform_mode:
+        platform_base_url = gateway_config.platform.get("base_url")
+        if not platform_base_url:
+            raise click.ClickException("platform.base_url is required when platform mode is active")
+        if gateway_config.providers:
+            raise click.ClickException(
+                "Local provider credentials are not supported in platform mode. Remove configured providers."
+            )
+        logger.info("Platform mode active. Base URL: %s", platform_base_url)
+
     if not gateway_config.master_key:
         logger.warning(
             "No master key configured. Key management endpoints will be unavailable.",
         )
-        logger.warning(
-            "Set GATEWAY_MASTER_KEY environment variable or use --master-key flag."
-        )
+        logger.warning("Set GATEWAY_MASTER_KEY environment variable or use --master-key flag.")
 
-    logger.info(
-        "Starting any-llm-gateway on %s:%s", gateway_config.host, gateway_config.port
-    )
-    logger.info("Database: %s", gateway_config.database_url)
+    logger.info("Starting any-llm-gateway on %s:%s", gateway_config.host, gateway_config.port)
+    if gateway_config.is_platform_mode:
+        logger.info("Database: disabled (platform mode)")
+    else:
+        logger.info("Database: %s", gateway_config.database_url)
 
     if gateway_config.providers:
-        logger.info(
-            "Configured providers: %s", ", ".join(gateway_config.providers.keys())
-        )
+        logger.info("Configured providers: %s", ", ".join(gateway_config.providers.keys()))
 
     app = create_app(gateway_config)
 
@@ -107,9 +117,7 @@ def serve(
 
 
 @cli.command()
-@click.option(
-    "--config", "-c", type=click.Path(exists=True), help="Path to config YAML file"
-)
+@click.option("--config", "-c", type=click.Path(exists=True), help="Path to config YAML file")
 @click.option("--database-url", envvar="DATABASE_URL", help="Database connection URL")
 def init_db(config: str | None, database_url: str | None) -> None:
     """Initialize the database schema."""
@@ -128,9 +136,7 @@ def init_db(config: str | None, database_url: str | None) -> None:
 
 
 @cli.command()
-@click.option(
-    "--config", "-c", type=click.Path(exists=True), help="Path to config YAML file"
-)
+@click.option("--config", "-c", type=click.Path(exists=True), help="Path to config YAML file")
 @click.option("--database-url", envvar="DATABASE_URL", help="Database connection URL")
 @click.option("--revision", default="head", help="Target revision (default: head)")
 def migrate(config: str | None, database_url: str | None, revision: str) -> None:

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -62,6 +62,38 @@ class GatewayConfig(BaseSettings):
         default=True,
         description="Create a first-use API key on startup when no API keys exist",
     )
+    mode: str = Field(default="standalone", description="Gateway operating mode: standalone or platform")
+    platform: dict[str, Any] = Field(default_factory=dict, description="Platform integration settings")
+
+    @property
+    def platform_token(self) -> str | None:
+        token = os.getenv("ANY_LLM_PLATFORM_TOKEN", "").strip()
+        return token if token else None
+
+    @property
+    def effective_mode(self) -> str:
+        if self.platform_token:
+            return "platform"
+        return "standalone"
+
+    @property
+    def is_platform_mode(self) -> bool:
+        return self.effective_mode == "platform"
+
+    def validate_mode_selection(self) -> None:
+        configured_mode = self.mode.strip().lower()
+        if configured_mode not in {"standalone", "platform"}:
+            msg = "Invalid GATEWAY_MODE value. Expected 'standalone' or 'platform'."
+            raise ValueError(msg)
+
+        token_present = self.platform_token is not None
+        if configured_mode == "platform" and not token_present:
+            msg = "GATEWAY_MODE=platform requires ANY_LLM_PLATFORM_TOKEN to be set."
+            raise ValueError(msg)
+
+        if configured_mode == "standalone" and token_present:
+            msg = "ANY_LLM_PLATFORM_TOKEN is set but GATEWAY_MODE=standalone. Remove the token or switch to platform mode."
+            raise ValueError(msg)
 
 
 def load_config(config_path: str | None = None) -> GatewayConfig:
@@ -84,7 +116,33 @@ def load_config(config_path: str | None = None) -> GatewayConfig:
             if yaml_config:
                 config_dict = _resolve_env_vars(yaml_config)
 
-    return GatewayConfig(**config_dict)
+    _apply_platform_env_overrides(config_dict)
+
+    config = GatewayConfig(**config_dict)
+    config.validate_mode_selection()
+    return config
+
+
+def _apply_platform_env_overrides(config: dict[str, Any]) -> None:
+    platform = config.get("platform")
+    if not isinstance(platform, dict):
+        platform = {}
+
+    env_mappings: dict[str, tuple[str, type[Any]]] = {
+        "PLATFORM_BASE_URL": ("base_url", str),
+        "PLATFORM_RESOLVE_TIMEOUT_MS": ("resolve_timeout_ms", int),
+        "PLATFORM_USAGE_TIMEOUT_MS": ("usage_timeout_ms", int),
+        "PLATFORM_USAGE_MAX_RETRIES": ("usage_max_retries", int),
+    }
+
+    for env_name, (field_name, caster) in env_mappings.items():
+        value = os.getenv(env_name)
+        if value is None or value == "":
+            continue
+        platform[field_name] = caster(value)
+
+    if platform:
+        config["platform"] = platform
 
 
 def _load_dotenv(config_path: str | None = None) -> None:

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -92,7 +92,10 @@ class GatewayConfig(BaseSettings):
             raise ValueError(msg)
 
         if configured_mode == "standalone" and token_present:
-            msg = "ANY_LLM_PLATFORM_TOKEN is set but GATEWAY_MODE=standalone. Remove the token or switch to platform mode."
+            msg = (
+                "ANY_LLM_PLATFORM_TOKEN is set but GATEWAY_MODE=standalone. "
+                "Remove the token or switch to platform mode."
+            )
             raise ValueError(msg)
 
 

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -147,15 +147,18 @@ def create_app(config: GatewayConfig) -> FastAPI:
         Configured FastAPI application
 
     """
-    init_db(config.database_url, auto_migrate=config.auto_migrate)
+    config.validate_mode_selection()
     set_config(config)
 
-    db = next(get_db())
-    try:
-        bootstrap_first_api_key(config, db)
-        initialize_pricing_from_config(config, db)
-    finally:
-        db.close()
+    if not config.is_platform_mode:
+        init_db(config.database_url, auto_migrate=config.auto_migrate)
+
+        db = next(get_db())
+        try:
+            bootstrap_first_api_key(config, db)
+            initialize_pricing_from_config(config, db)
+        finally:
+            db.close()
 
     app = FastAPI(
         title="any-llm-gateway",
@@ -194,7 +197,9 @@ def create_app(config: GatewayConfig) -> FastAPI:
     else:
         app.state.rate_limiter = None
 
-    register_routers(app)
+    app.state.gateway_mode = config.effective_mode
+
+    register_routers(app, config)
 
     if config.enable_metrics:
         from gateway.metrics import metrics_endpoint

--- a/tests/integration/test_config_env_loading.py
+++ b/tests/integration/test_config_env_loading.py
@@ -69,3 +69,40 @@ def test_load_config_skips_duplicate_dotenv_paths(tmp_path: Path, monkeypatch: p
     load_config(str(config_file))
 
     assert calls == [env_file]
+
+
+def test_load_config_platform_env_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_file = tmp_path / "gateway.yml"
+    config_file.write_text("mode: platform\n", encoding="utf-8")
+
+    monkeypatch.setenv("ANY_LLM_PLATFORM_TOKEN", "gw_test_token")
+    monkeypatch.setenv("PLATFORM_BASE_URL", "http://localhost:8100/api/v1")
+    monkeypatch.setenv("PLATFORM_RESOLVE_TIMEOUT_MS", "1234")
+    monkeypatch.setenv("PLATFORM_USAGE_TIMEOUT_MS", "2345")
+    monkeypatch.setenv("PLATFORM_USAGE_MAX_RETRIES", "7")
+
+    config = load_config(str(config_file))
+
+    assert config.is_platform_mode
+    assert config.platform["base_url"] == "http://localhost:8100/api/v1"
+    assert config.platform["resolve_timeout_ms"] == 1234
+    assert config.platform["usage_timeout_ms"] == 2345
+    assert config.platform["usage_max_retries"] == 7
+
+
+def test_load_config_rejects_platform_mode_without_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_file = tmp_path / "gateway.yml"
+    config_file.write_text("mode: platform\n", encoding="utf-8")
+    monkeypatch.delenv("ANY_LLM_PLATFORM_TOKEN", raising=False)
+
+    with pytest.raises(ValueError, match="ANY_LLM_PLATFORM_TOKEN"):
+        load_config(str(config_file))
+
+
+def test_load_config_rejects_conflicting_mode_and_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_file = tmp_path / "gateway.yml"
+    config_file.write_text("mode: standalone\n", encoding="utf-8")
+    monkeypatch.setenv("ANY_LLM_PLATFORM_TOKEN", "gw_test_token")
+
+    with pytest.raises(ValueError, match="GATEWAY_MODE=standalone"):
+        load_config(str(config_file))

--- a/tests/integration/test_platform_mode_surface.py
+++ b/tests/integration/test_platform_mode_surface.py
@@ -1,0 +1,56 @@
+from fastapi.testclient import TestClient
+import pytest
+
+from gateway.api.deps import reset_config
+from gateway.core.config import GatewayConfig
+from gateway.core.database import reset_db
+from gateway.main import create_app
+
+
+def test_platform_mode_starts_without_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANY_LLM_PLATFORM_TOKEN", "gw_test_token")
+
+    config = GatewayConfig(
+        mode="platform",
+        database_url="postgresql://127.0.0.1:1/does-not-exist",
+        platform={"base_url": "http://localhost:8100/api/v1"},
+    )
+    app = create_app(config)
+
+    with TestClient(app) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy", "mode": "platform"}
+
+    reset_config()
+    reset_db()
+
+
+def test_platform_mode_disables_local_management_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANY_LLM_PLATFORM_TOKEN", "gw_test_token")
+
+    config = GatewayConfig(
+        mode="platform",
+        platform={"base_url": "http://localhost:8100/api/v1"},
+    )
+    app = create_app(config)
+
+    with TestClient(app) as client:
+        users_response = client.post("/v1/users", json={"user_id": "u1"})
+        keys_response = client.get("/v1/keys")
+        budgets_response = client.get("/v1/budgets")
+        spend_response = client.get("/v1/spend")
+
+    expected = {"detail": "This endpoint is not available in platform mode. Manage this resource via the platform UI."}
+    assert users_response.status_code == 404
+    assert users_response.json() == expected
+    assert keys_response.status_code == 404
+    assert keys_response.json() == expected
+    assert budgets_response.status_code == 404
+    assert budgets_response.json() == expected
+    assert spend_response.status_code == 404
+    assert spend_response.json() == expected
+
+    reset_config()
+    reset_db()

--- a/tests/integration/test_platform_mode_surface.py
+++ b/tests/integration/test_platform_mode_surface.py
@@ -1,5 +1,5 @@
-from fastapi.testclient import TestClient
 import pytest
+from fastapi.testclient import TestClient
 
 from gateway.api.deps import reset_config
 from gateway.core.config import GatewayConfig


### PR DESCRIPTION
## Summary
- add platform mode selection rules gated by `ANY_LLM_PLATFORM_TOKEN`, including conflict/fail-fast validation for `GATEWAY_MODE`
- skip database initialization in platform mode, expose mode in health endpoints, and require platform startup settings in CLI
- limit platform mode API surface and return explicit 404 guidance for local management endpoints (`/v1/users`, `/v1/keys`, `/v1/budgets`, `/v1/spend`)

## Testing
- uv run pytest -v tests/integration/test_config_env_loading.py tests/integration/test_platform_mode_surface.py tests/integration/test_health.py tests/unit/test_gateway_cli.py