### PR TITLE
feat: integrate platform resolve and async usage reporting

### DIFF
--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -1,4 +1,5 @@
 import secrets
+from collections.abc import Generator
 from datetime import UTC, datetime
 from typing import Annotated
 
@@ -201,11 +202,23 @@ async def verify_api_key_or_master_key(
     return api_key, False
 
 
+def get_db_if_needed(
+    config: Annotated[GatewayConfig, Depends(get_config)],
+) -> Generator[Session | None]:
+    """Get a database session in standalone mode, otherwise return None."""
+    if config.is_platform_mode:
+        yield None
+        return
+
+    yield from get_db()
+
+
 __all__ = [
     "get_config",
     "get_db",
     "reset_config",
     "set_config",
+    "get_db_if_needed",
     "verify_api_key",
     "verify_api_key_or_master_key",
     "verify_master_key",

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -1,21 +1,24 @@
+import asyncio
+import time
 import uuid
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from typing import Annotated, Any
 
+import httpx
 from any_llm import AnyLLM, LLMProvider, acompletion
 from any_llm.types.completion import (
     ChatCompletion,
     ChatCompletionChunk,
     CompletionUsage,
 )
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response, status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from gateway.api.deps import get_config, get_db, verify_api_key_or_master_key
+from gateway.api.deps import get_config, get_db_if_needed, verify_api_key_or_master_key
 from gateway.api.routes._helpers import resolve_user_id
 from gateway.auth.vertex_auth import setup_vertex_environment
 from gateway.core.config import GatewayConfig
@@ -28,6 +31,8 @@ from gateway.services.pricing_service import find_model_pricing
 from gateway.streaming import OPENAI_STREAM_FORMAT, streaming_generator
 
 router = APIRouter(prefix="/v1/chat", tags=["chat"])
+
+_USAGE_NON_RETRYABLE_STATUS_CODES = {401, 404, 409, 422}
 
 
 def rate_limit_headers(info: RateLimitInfo) -> dict[str, str]:
@@ -46,9 +51,7 @@ class ChatCompletionRequest(BaseModel):
 
     @field_validator("messages")
     @classmethod
-    def validate_message_structure(
-        cls, v: list[dict[str, Any]]
-    ) -> list[dict[str, Any]]:
+    def validate_message_structure(cls, v: list[dict[str, Any]]) -> list[dict[str, Any]]:
         for i, message in enumerate(v):
             if "role" not in message:
                 msg = f"messages[{i}]: 'role' is required"
@@ -145,12 +148,7 @@ async def log_usage(
     )
 
     usage_data = usage_override
-    if (
-        not usage_data
-        and response
-        and isinstance(response, ChatCompletion)
-        and response.usage
-    ):
+    if not usage_data and response and isinstance(response, ChatCompletion) and response.usage:
         usage_data = response.usage
 
     if usage_data:
@@ -167,23 +165,19 @@ async def log_usage(
 
         pricing = find_model_pricing(db, provider, model)
         if pricing:
-            cost = (
-                usage_data.prompt_tokens / 1_000_000
-            ) * pricing.input_price_per_million + (
+            cost = (usage_data.prompt_tokens / 1_000_000) * pricing.input_price_per_million + (
                 usage_data.completion_tokens / 1_000_000
             ) * pricing.output_price_per_million
             usage_log.cost = cost
             record_cost(str(provider or ""), model, cost)
 
             if user_id:
-                db.query(User).filter(
-                    User.user_id == user_id, User.deleted_at.is_(None)
-                ).update({User.spend: User.spend + cost})
+                db.query(User).filter(User.user_id == user_id, User.deleted_at.is_(None)).update(
+                    {User.spend: User.spend + cost}
+                )
         else:
             model_ref = f"{provider}:{model}" if provider else model
-            logger.warning(
-                f"No pricing configured for '{model_ref}'. Usage will be tracked without cost."
-            )
+            logger.warning(f"No pricing configured for '{model_ref}'. Usage will be tracked without cost.")
 
     try:
         db.add(usage_log)
@@ -193,15 +187,178 @@ async def log_usage(
         db.rollback()
 
 
+def _extract_platform_user_token(request: Request) -> str:
+    auth_header = request.headers.get("Authorization")
+    if not auth_header or not auth_header.startswith("Bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing authentication token",
+        )
+    token = auth_header[7:].strip()
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing authentication token",
+        )
+    return token
+
+
+def _split_model_selector(model_selector: str) -> tuple[str | None, str]:
+    if ":" in model_selector:
+        provider, model_name = model_selector.split(":", 1)
+        return provider or None, model_name
+    if "/" in model_selector:
+        provider, model_name = model_selector.split("/", 1)
+        return provider or None, model_name
+    return None, model_selector
+
+
+def _platform_url(base_url: str, path: str) -> str:
+    return f"{base_url.rstrip('/')}/{path.lstrip('/')}"
+
+
+def _safe_detail_from_platform(response: httpx.Response, fallback: str) -> str:
+    try:
+        payload = response.json()
+    except ValueError:
+        return fallback
+
+    detail = payload.get("detail") if isinstance(payload, dict) else None
+    return detail if isinstance(detail, str) else fallback
+
+
+async def _post_platform(
+    url: str,
+    headers: dict[str, str],
+    body: dict[str, Any],
+    timeout_seconds: float,
+) -> httpx.Response:
+    async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+        return await client.post(url, headers=headers, json=body)
+
+
+async def _resolve_platform_credentials(
+    config: GatewayConfig,
+    user_token: str,
+    model_selector: str,
+) -> tuple[str, str, str | None, str, bool, str]:
+    platform_base_url = config.platform.get("base_url")
+    if not platform_base_url:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Platform mode is misconfigured",
+        )
+
+    provider, model_name = _split_model_selector(model_selector)
+    timeout_ms = int(config.platform.get("resolve_timeout_ms", 5000))
+    resolve_url = _platform_url(platform_base_url, "/gateway/provider-keys/resolve")
+    resolve_headers = {
+        "X-Gateway-Token": config.platform_token or "",
+        "X-User-Token": user_token,
+    }
+    resolve_body: dict[str, Any] = {"model": model_name}
+    if provider:
+        resolve_body["provider"] = provider
+
+    try:
+        response = await _post_platform(
+            url=resolve_url,
+            headers=resolve_headers,
+            body=resolve_body,
+            timeout_seconds=timeout_ms / 1000,
+        )
+    except (httpx.TimeoutException, httpx.NetworkError):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authorization service unavailable",
+        ) from None
+
+    if response.status_code == 200:
+        payload = response.json()
+        return (
+            str(payload["provider"]),
+            str(payload["model"]),
+            payload.get("api_base"),
+            str(payload["api_key"]),
+            bool(payload.get("managed", False)),
+            str(payload["correlation_id"]),
+        )
+
+    if response.status_code in {401, 402, 403, 404, 429}:
+        detail = _safe_detail_from_platform(response, "Authorization request rejected")
+        headers: dict[str, str] | None = None
+        if response.status_code == 429 and response.headers.get("Retry-After"):
+            headers = {"Retry-After": response.headers["Retry-After"]}
+        raise HTTPException(status_code=response.status_code, detail=detail, headers=headers)
+
+    if response.status_code == 422 or response.status_code >= 500:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authorization service unavailable",
+        )
+
+    raise HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail="Authorization service unavailable",
+    )
+
+
+async def _report_platform_usage(
+    config: GatewayConfig,
+    correlation_id: str,
+    outcome: str,
+    usage: CompletionUsage | None,
+) -> None:
+    platform_base_url = config.platform.get("base_url")
+    if not platform_base_url:
+        return
+
+    timeout_ms = int(config.platform.get("usage_timeout_ms", 5000))
+    max_retries = int(config.platform.get("usage_max_retries", 3))
+    usage_url = _platform_url(platform_base_url, "/gateway/usage")
+    headers = {"X-Gateway-Token": config.platform_token or ""}
+
+    payload: dict[str, Any] = {"correlation_id": correlation_id, "status": outcome}
+    if outcome == "success":
+        token_usage = usage or CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+        payload["usage"] = {
+            "prompt_tokens": token_usage.prompt_tokens,
+            "completion_tokens": token_usage.completion_tokens,
+            "total_tokens": token_usage.total_tokens,
+        }
+
+    delay_seconds = 0.25
+    for attempt in range(1, max_retries + 1):
+        should_retry = False
+        try:
+            response = await _post_platform(
+                url=usage_url,
+                headers=headers,
+                body=payload,
+                timeout_seconds=timeout_ms / 1000,
+            )
+            if response.status_code == 204:
+                return
+            if response.status_code in _USAGE_NON_RETRYABLE_STATUS_CODES:
+                return
+            should_retry = response.status_code >= 500
+        except (httpx.TimeoutException, httpx.NetworkError):
+            should_retry = True
+
+        if not should_retry or attempt == max_retries:
+            return
+
+        await asyncio.sleep(delay_seconds)
+        delay_seconds *= 2
+
+
 @router.post("/completions", response_model=None)
 async def chat_completions(
     raw_request: Request,
     response: Response,
+    background_tasks: BackgroundTasks,
     request: ChatCompletionRequest,
-    auth_result: Annotated[
-        tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)
-    ],
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[Session | None, Depends(get_db_if_needed)],
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> ChatCompletion | StreamingResponse:
     """OpenAI-compatible chat completions endpoint.
@@ -214,36 +371,75 @@ async def chat_completions(
     - API key + user field: Use specified user (must exist)
     - API key without user field: Use virtual user created with API key
     """
-    api_key, is_master_key = auth_result
-
-    user_id = resolve_user_id(
-        user_id_from_request=request.user,
-        api_key=api_key,
-        is_master_key=is_master_key,
-        master_key_error=HTTPException(
+    if not request.model.strip():
+        raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="When using master key, 'user' field is required in request body",
-        ),
-        no_api_key_error=HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="API key validation failed",
-        ),
-        no_user_error=HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="API key has no associated user",
-        ),
-    )
+            detail="Invalid request: model is required",
+        )
 
-    rate_limit_info = check_rate_limit(raw_request, user_id)
+    api_key: APIKey | None = None
+    user_id: str | None = None
+    rate_limit_info: RateLimitInfo | None = None
+    platform_mode = config.is_platform_mode
+    correlation_id: str | None = None
 
-    _ = await validate_user_budget(db, user_id, request.model)
+    if platform_mode:
+        user_token = _extract_platform_user_token(raw_request)
+        start_time = time.perf_counter()
+        provider_name, model, api_base, resolved_api_key, managed, correlation_id = await _resolve_platform_credentials(
+            config=config,
+            user_token=user_token,
+            model_selector=request.model,
+        )
+        resolve_latency_ms = (time.perf_counter() - start_time) * 1000
+        provider = LLMProvider(provider_name)
+        provider_kwargs = {"api_key": resolved_api_key}
+        if api_base:
+            provider_kwargs["api_base"] = api_base
+        response.headers["X-Correlation-ID"] = correlation_id
+        logger.info(
+            "Platform resolve succeeded provider=%s model=%s managed=%s resolve_latency_ms=%.2f",
+            provider_name,
+            model,
+            managed,
+            resolve_latency_ms,
+        )
+    else:
+        if db is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Database session unavailable",
+            )
 
-    provider, model = AnyLLM.split_model_provider(request.model)
+        api_key, is_master_key = await verify_api_key_or_master_key(raw_request, db, config)
+        user_id = resolve_user_id(
+            user_id_from_request=request.user,
+            api_key=api_key,
+            is_master_key=is_master_key,
+            master_key_error=HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="When using master key, 'user' field is required in request body",
+            ),
+            no_api_key_error=HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="API key validation failed",
+            ),
+            no_user_error=HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="API key has no associated user",
+            ),
+        )
 
-    provider_kwargs = get_provider_kwargs(config, provider)
+        rate_limit_info = check_rate_limit(raw_request, user_id)
+        _ = await validate_user_budget(db, user_id, request.model)
+        provider, model = AnyLLM.split_model_provider(request.model)
+        provider_kwargs = get_provider_kwargs(config, provider)
 
     # User request fields take precedence over provider config defaults
     request_fields = request.model_dump(exclude_unset=True)
+    if platform_mode:
+        request_fields["model"] = f"{provider.value}:{model}"
+
     completion_kwargs = {**provider_kwargs, **request_fields}
 
     if request.stream and completion_kwargs.get("stream_options") is None:
@@ -265,6 +461,20 @@ async def chat_completions(
                 )
 
             async def _on_complete(usage_data: CompletionUsage) -> None:
+                if platform_mode and correlation_id:
+                    asyncio.create_task(
+                        _report_platform_usage(
+                            config=config,
+                            correlation_id=correlation_id,
+                            outcome="success",
+                            usage=usage_data,
+                        )
+                    )
+                    return
+
+                if db is None:
+                    return
+
                 await log_usage(
                     db=db,
                     api_key_obj=api_key,
@@ -276,6 +486,20 @@ async def chat_completions(
                 )
 
             async def _on_error(error: str) -> None:
+                if platform_mode and correlation_id:
+                    asyncio.create_task(
+                        _report_platform_usage(
+                            config=config,
+                            correlation_id=correlation_id,
+                            outcome="error",
+                            usage=None,
+                        )
+                    )
+                    return
+
+                if db is None:
+                    return
+
                 await log_usage(
                     db=db,
                     api_key_obj=api_key,
@@ -286,9 +510,7 @@ async def chat_completions(
                     error=error,
                 )
 
-            stream: AsyncIterator[ChatCompletionChunk] = await acompletion(
-                **completion_kwargs
-            )  # type: ignore[assignment]
+            stream: AsyncIterator[ChatCompletionChunk] = await acompletion(**completion_kwargs)  # type: ignore[assignment]
             rl_headers = rate_limit_headers(rate_limit_info) if rate_limit_info else {}
             return StreamingResponse(
                 streaming_generator(
@@ -305,30 +527,57 @@ async def chat_completions(
             )
 
         completion: ChatCompletion = await acompletion(**completion_kwargs)  # type: ignore[assignment]
-        await log_usage(
-            db=db,
-            api_key_obj=api_key,
-            model=model,
-            provider=provider,
-            endpoint="/v1/chat/completions",
-            user_id=user_id,
-            response=completion,
-        )
+        if platform_mode and correlation_id:
+            usage_data = completion.usage
+            background_tasks.add_task(
+                _report_platform_usage,
+                config,
+                correlation_id,
+                "success",
+                usage_data,
+            )
+        elif db is not None:
+            await log_usage(
+                db=db,
+                api_key_obj=api_key,
+                model=model,
+                provider=provider,
+                endpoint="/v1/chat/completions",
+                user_id=user_id,
+                response=completion,
+            )
 
+    except HTTPException:
+        raise
     except Exception as e:
-        await log_usage(
-            db=db,
-            api_key_obj=api_key,
-            model=model,
-            provider=provider,
-            endpoint="/v1/chat/completions",
-            user_id=user_id,
-            error=str(e),
-        )
+        if platform_mode and correlation_id:
+            background_tasks.add_task(
+                _report_platform_usage,
+                config,
+                correlation_id,
+                "error",
+                None,
+            )
+        elif db is not None:
+            await log_usage(
+                db=db,
+                api_key_obj=api_key,
+                model=model,
+                provider=provider,
+                endpoint="/v1/chat/completions",
+                user_id=user_id,
+                error=str(e),
+            )
+
         logger.error("Provider call failed for %s:%s: %s", provider, model, e)
+        if isinstance(e, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
+            raise HTTPException(
+                status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                detail="LLM provider timeout",
+            ) from e
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="The request could not be completed by the provider",
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="LLM provider error",
         ) from e
 
     if rate_limit_info:

--- a/src/gateway/api/routes/health.py
+++ b/src/gateway/api/routes/health.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import text
 
@@ -9,6 +10,23 @@ from gateway.log_config import logger
 from gateway.version import __version__
 
 router = APIRouter(prefix="/health", tags=["health"])
+
+
+async def _check_platform_reachability(config: GatewayConfig) -> bool:
+    platform_base_url = config.platform.get("base_url")
+    if not platform_base_url:
+        return False
+
+    health_path = config.platform.get("health_path", "/utils/health-check/")
+    timeout_ms = int(config.platform.get("resolve_timeout_ms", 5000))
+    health_url = f"{platform_base_url.rstrip('/')}/{health_path.lstrip('/')}"
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout_ms / 1000) as client:
+            response = await client.get(health_url)
+        return response.status_code < 500
+    except (httpx.TimeoutException, httpx.NetworkError):
+        return False
 
 
 @router.get("")
@@ -21,6 +39,7 @@ async def health_check(config: GatewayConfig = Depends(get_config)) -> dict[str,
     payload: dict[str, str] = {"status": "healthy"}
     if config.is_platform_mode:
         payload["mode"] = "platform"
+        payload["platform_reachable"] = "yes" if await _check_platform_reachability(config) else "no"
     return payload
 
 
@@ -57,9 +76,21 @@ async def health_readiness(config: GatewayConfig = Depends(get_config)) -> dict[
 
     """
     if config.is_platform_mode:
+        platform_reachable = await _check_platform_reachability(config)
+        if not platform_reachable:
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "status": "unhealthy",
+                    "mode": "platform",
+                    "platform": "unavailable",
+                    "version": __version__,
+                },
+            )
         return {
             "status": "healthy",
             "mode": "platform",
+            "platform": "connected",
             "version": __version__,
         }
 

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -148,6 +148,14 @@ def create_app(config: GatewayConfig) -> FastAPI:
 
     """
     config.validate_mode_selection()
+    if config.is_platform_mode:
+        if not config.platform.get("base_url"):
+            msg = "platform.base_url is required when platform mode is active"
+            raise ValueError(msg)
+        if config.providers:
+            msg = "Local provider credentials are not supported in platform mode"
+            raise ValueError(msg)
+
     set_config(config)
 
     if not config.is_platform_mode:

--- a/tests/integration/test_error_detail_leakage.py
+++ b/tests/integration/test_error_detail_leakage.py
@@ -20,11 +20,9 @@ def test_provider_error_does_not_leak_details(
         },
         headers=api_key_header,
     )
-    assert response.status_code == 500
+    assert response.status_code == 502
     detail = response.json()["detail"]
-    # Should not contain provider-specific error details
-    assert "api" not in detail.lower() or "provider" in detail.lower()
-    assert "could not be completed" in detail.lower()
+    assert detail == "LLM provider error"
 
 
 def test_health_readiness_does_not_leak_db_details(client: TestClient) -> None:

--- a/tests/integration/test_platform_mode_chat.py
+++ b/tests/integration/test_platform_mode_chat.py
@@ -1,0 +1,285 @@
+from typing import Any
+
+import httpx
+import pytest
+from any_llm.types.completion import (
+    ChatCompletion,
+    ChatCompletionMessage,
+    Choice,
+    CompletionUsage,
+)
+from fastapi.testclient import TestClient
+
+from gateway.api.deps import reset_config
+from gateway.core.config import GatewayConfig
+from gateway.core.database import reset_db
+from gateway.main import create_app
+
+
+@pytest.fixture
+def platform_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("ANY_LLM_PLATFORM_TOKEN", "gw_test_token")
+    app = create_app(
+        GatewayConfig(
+            mode="platform",
+            platform={"base_url": "http://platform.test/api/v1"},
+        )
+    )
+
+    with TestClient(app) as client:
+        yield client
+
+    reset_config()
+    reset_db()
+
+
+def test_platform_mode_requires_authorization_header(platform_client: TestClient) -> None:
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={"model": "openai:gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Missing authentication token"}
+
+
+def test_platform_mode_maps_resolve_unauthorized(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "Invalid user token"})
+
+    monkeypatch.setattr("gateway.api.routes.chat._post_platform", fake_post_platform)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={"model": "openai:gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid user token"}
+
+
+def test_platform_mode_sets_correlation_id_and_reports_usage(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    usage_reports: list[dict[str, Any]] = []
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json={
+                    "provider": "openai",
+                    "model": "gpt-4o-mini",
+                    "api_key": "sk-platform-key",
+                    "api_base": "https://api.openai.com/v1",
+                    "managed": True,
+                    "correlation_id": "7af2c39d-4eb8-4b3f-8242-46a97f7d5e68",
+                },
+            )
+
+        usage_reports.append(body)
+        return httpx.Response(204)
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        assert kwargs["model"] == "openai:gpt-4o-mini"
+        assert kwargs["api_key"] == "sk-platform-key"
+        return ChatCompletion(
+            id="chatcmpl-platform",
+            object="chat.completion",
+            created=1700000000,
+            model="gpt-4o-mini",
+            choices=[
+                Choice(
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="hello"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=CompletionUsage(prompt_tokens=10, completion_tokens=7, total_tokens=17),
+        )
+
+    monkeypatch.setattr("gateway.api.routes.chat._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.acompletion", fake_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["X-Correlation-ID"] == "7af2c39d-4eb8-4b3f-8242-46a97f7d5e68"
+    assert usage_reports == [
+        {
+            "correlation_id": "7af2c39d-4eb8-4b3f-8242-46a97f7d5e68",
+            "status": "success",
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 7,
+                "total_tokens": 17,
+            },
+        }
+    ]
+
+
+def test_platform_mode_maps_provider_timeout(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json={
+                    "provider": "openai",
+                    "model": "gpt-4o-mini",
+                    "api_key": "sk-platform-key",
+                    "api_base": "https://api.openai.com/v1",
+                    "managed": True,
+                    "correlation_id": "41a9667f-0af7-4ddf-8468-65c5f5c2af57",
+                },
+            )
+
+        return httpx.Response(204)
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        raise TimeoutError("provider timeout")
+
+    monkeypatch.setattr("gateway.api.routes.chat._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.acompletion", fake_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 504
+    assert response.json() == {"detail": "LLM provider timeout"}
+
+
+def test_platform_mode_propagates_resolve_rate_limit_retry_after(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        return httpx.Response(429, json={"detail": "Rate limited"}, headers={"Retry-After": "11"})
+
+    monkeypatch.setattr("gateway.api.routes.chat._post_platform", fake_post_platform)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={"model": "openai:gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 429
+    assert response.headers["Retry-After"] == "11"
+    assert response.json() == {"detail": "Rate limited"}
+
+
+def test_platform_mode_usage_retries_only_transient_failures(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    usage_calls: list[dict[str, Any]] = []
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json={
+                    "provider": "openai",
+                    "model": "gpt-4o-mini",
+                    "api_key": "sk-platform-key",
+                    "api_base": "https://api.openai.com/v1",
+                    "managed": True,
+                    "correlation_id": "e655dc9a-6d90-4207-b371-f58d521a7a81",
+                },
+            )
+
+        usage_calls.append(body)
+        if len(usage_calls) == 1:
+            return httpx.Response(500)
+        return httpx.Response(204)
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        return ChatCompletion(
+            id="chatcmpl-platform",
+            object="chat.completion",
+            created=1700000000,
+            model="gpt-4o-mini",
+            choices=[
+                Choice(
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="hello"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=CompletionUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+    monkeypatch.setattr("gateway.api.routes.chat._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.acompletion", fake_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+    assert response.status_code == 200
+    assert len(usage_calls) == 2
+
+
+def test_platform_mode_maps_resolve_validation_error_to_bad_gateway(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        return httpx.Response(422, json={"detail": "missing headers"})
+
+    monkeypatch.setattr("gateway.api.routes.chat._post_platform", fake_post_platform)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 502
+    assert response.json() == {"detail": "Authorization service unavailable"}

--- a/tests/integration/test_platform_mode_chat.py
+++ b/tests/integration/test_platform_mode_chat.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from typing import Any
 
 import httpx
@@ -17,7 +18,7 @@ from gateway.main import create_app
 
 
 @pytest.fixture
-def platform_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+def platform_client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient]:
     monkeypatch.setenv("ANY_LLM_PLATFORM_TOKEN", "gw_test_token")
     app = create_app(
         GatewayConfig(

--- a/tests/integration/test_platform_mode_surface.py
+++ b/tests/integration/test_platform_mode_surface.py
@@ -21,7 +21,10 @@ def test_platform_mode_starts_without_database(monkeypatch: pytest.MonkeyPatch) 
         response = client.get("/health")
 
     assert response.status_code == 200
-    assert response.json() == {"status": "healthy", "mode": "platform"}
+    payload = response.json()
+    assert payload["status"] == "healthy"
+    assert payload["mode"] == "platform"
+    assert payload["platform_reachable"] in {"yes", "no"}
 
     reset_config()
     reset_db()
@@ -51,6 +54,57 @@ def test_platform_mode_disables_local_management_endpoints(monkeypatch: pytest.M
     assert budgets_response.json() == expected
     assert spend_response.status_code == 404
     assert spend_response.json() == expected
+
+    reset_config()
+    reset_db()
+
+
+def test_platform_mode_health_reports_reachability(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANY_LLM_PLATFORM_TOKEN", "gw_test_token")
+
+    async def _reachable(_: GatewayConfig) -> bool:
+        return True
+
+    monkeypatch.setattr("gateway.api.routes.health._check_platform_reachability", _reachable)
+
+    config = GatewayConfig(
+        mode="platform",
+        platform={"base_url": "http://localhost:8100/api/v1"},
+    )
+    app = create_app(config)
+
+    with TestClient(app) as client:
+        response = client.get("/health")
+        readiness_response = client.get("/health/readiness")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy", "mode": "platform", "platform_reachable": "yes"}
+    assert readiness_response.status_code == 200
+    assert readiness_response.json()["platform"] == "connected"
+
+    reset_config()
+    reset_db()
+
+
+def test_platform_mode_readiness_fails_when_platform_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANY_LLM_PLATFORM_TOKEN", "gw_test_token")
+
+    async def _unreachable(_: GatewayConfig) -> bool:
+        return False
+
+    monkeypatch.setattr("gateway.api.routes.health._check_platform_reachability", _unreachable)
+
+    config = GatewayConfig(
+        mode="platform",
+        platform={"base_url": "http://localhost:8100/api/v1"},
+    )
+    app = create_app(config)
+
+    with TestClient(app) as client:
+        response = client.get("/health/readiness")
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["platform"] == "unavailable"
 
     reset_config()
     reset_db()

--- a/tests/integration/test_streaming_error_event.py
+++ b/tests/integration/test_streaming_error_event.py
@@ -27,5 +27,5 @@ def test_streaming_creation_error_returns_http_error(
         headers=api_key_header,
     )
 
-    assert response.status_code == 500
-    assert "provider" in response.json()["detail"].lower()
+    assert response.status_code == 502
+    assert response.json() == {"detail": "LLM provider error"}

--- a/tests/integration/test_usage_tracking.py
+++ b/tests/integration/test_usage_tracking.py
@@ -270,7 +270,7 @@ async def test_failed_request_logs_error(
         headers=api_key_header,
     )
 
-    assert response.status_code == 500
+    assert response.status_code == 502
 
     engine = create_engine(test_config.database_url)
     session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
## Summary
- route platform-mode chat completions through platform resolve before provider execution, map resolve/provider failures to the required gateway status codes, and return `X-Correlation-ID`
- add asynchronous platform usage reporting with retry-on-transient behavior and no retries for permanent failures
- extend platform health/readiness to include platform reachability and add startup validation so platform mode requires `platform.base_url` and rejects local provider credentials

## Testing
- uv run pytest -v tests/integration/test_platform_mode_chat.py tests/integration/test_platform_mode_surface.py tests/integration/test_streaming_error_event.py
- uv run pytest -v tests/integration/test_rate_limiting.py tests/integration/test_client_args.py tests/integration/test_provider_kwargs_override.py tests/integration/test_message_validation.py tests/integration/test_streaming_error_event.py tests/integration/test_metrics.py
- uv run mypy src
- uv run ruff check src tests