### PR TITLE
ci: update Docker Hub org references to mzdotai

### DIFF
--- a/.github/workflows/gateway-docker.yml
+++ b/.github/workflows/gateway-docker.yml
@@ -20,7 +20,7 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: mozilla-ai/gateway
+  IMAGE_NAME: mzdotai/gateway
 
 jobs:
   build-and-push-image:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   gateway:
     # if pulling from Docker Hub, use the following instead, and comment out the build section:
-    image: docker.io/mozilla-ai/gateway:latest
+    image: docker.io/mzdotai/gateway:latest
 
     # If you want to use a different port, change it here and in the config.yml file.
     ports:


### PR DESCRIPTION
## Summary
- Update the Docker publish workflow image namespace from `mozilla-ai/gateway` to `mzdotai/gateway`.
- Update the `docker-compose.yml` pull example to use `docker.io/mzdotai/gateway:latest`.
- Keep local development and CI behavior unchanged aside from the Docker Hub org target.