### PR TITLE
fix platform-mode detection from gateway token

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,29 @@ uv run gateway serve --config config.yml
 
 Open API docs at `http://localhost:8000/docs`.
 
+## Start in platform mode
+
+Platform mode is enabled automatically when `ANY_LLM_PLATFORM_TOKEN` is set.
+
+1) Export platform env vars:
+
+```bash
+export ANY_LLM_PLATFORM_TOKEN=gw_xxx
+export PLATFORM_BASE_URL=https://your-platform.example/api/v1
+```
+
+2) Start the gateway:
+
+```bash
+uv run gateway serve --config config.yml
+```
+
+Notes:
+
+- `GATEWAY_MODE` is optional; effective mode is derived from `ANY_LLM_PLATFORM_TOKEN`.
+- If you explicitly set `GATEWAY_MODE=platform`, startup fails unless `ANY_LLM_PLATFORM_TOKEN` is also set.
+- In platform mode, local `providers` configuration is not used.
+
 ## First request (OpenAI SDK)
 
 On startup, the gateway can bootstrap an API key in logs. Export it as `GATEWAY_API_KEY`, then call the gateway as an OpenAI-compatible server:

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -91,13 +91,6 @@ class GatewayConfig(BaseSettings):
             msg = "GATEWAY_MODE=platform requires ANY_LLM_PLATFORM_TOKEN to be set."
             raise ValueError(msg)
 
-        if configured_mode == "standalone" and token_present:
-            msg = (
-                "ANY_LLM_PLATFORM_TOKEN is set but GATEWAY_MODE=standalone. "
-                "Remove the token or switch to platform mode."
-            )
-            raise ValueError(msg)
-
 
 def load_config(config_path: str | None = None) -> GatewayConfig:
     """Load configuration from file and environment variables.

--- a/tests/integration/test_config_env_loading.py
+++ b/tests/integration/test_config_env_loading.py
@@ -99,10 +99,12 @@ def test_load_config_rejects_platform_mode_without_token(tmp_path: Path, monkeyp
         load_config(str(config_file))
 
 
-def test_load_config_rejects_conflicting_mode_and_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_config_prefers_platform_mode_when_token_is_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     config_file = tmp_path / "gateway.yml"
     config_file.write_text("mode: standalone\n", encoding="utf-8")
     monkeypatch.setenv("ANY_LLM_PLATFORM_TOKEN", "gw_test_token")
 
-    with pytest.raises(ValueError, match="GATEWAY_MODE=standalone"):
-        load_config(str(config_file))
+    config = load_config(str(config_file))
+
+    assert config.mode == "standalone"
+    assert config.is_platform_mode


### PR DESCRIPTION
## Summary
- make `ANY_LLM_PLATFORM_TOKEN` the effective mode source of truth by allowing startup when `GATEWAY_MODE=standalone` is set but a platform token is present
- keep the explicit guardrail that `GATEWAY_MODE=platform` requires `ANY_LLM_PLATFORM_TOKEN`
- document platform startup behavior in the README and update config-loading integration coverage

## Validation
- `uv run pytest tests/integration/test_config_env_loading.py -v`
- `uv run pytest tests/integration/test_platform_mode_surface.py -v`