### PR TITLE
docs: add Docker Hub run instructions and auto-sync README

### DIFF
--- a/.github/workflows/gateway-docker.yml
+++ b/.github/workflows/gateway-docker.yml
@@ -78,3 +78,21 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
+
+  update-dockerhub-description:
+    runs-on: ubuntu-latest
+    needs: build-and-push-image
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: mzdotai/gateway
+          readme-filepath: ./README.md

--- a/README.md
+++ b/README.md
@@ -127,9 +127,23 @@ uv run pytest tests/unit/test_gateway_cli.py -v
 
 ## Docker
 
+The gateway image is published on [Docker Hub](https://hub.docker.com/r/mzdotai/gateway).
+
+### Run with docker compose (gateway + PostgreSQL)
+
 ```bash
 cp config.example.yml config.yml
-docker compose up --build
+docker compose up -d
+```
+
+### Run with docker only
+
+```bash
+docker run --rm \
+  -p 8000:8000 \
+  -v "$(pwd)/config.yml:/app/config.yml:ro" \
+  mzdotai/gateway:latest \
+  gateway serve --config /app/config.yml
 ```
 
 Gateway will be available at `http://localhost:8000`.


### PR DESCRIPTION
## Summary
- Update README Docker section with `docker compose up -d` and standalone `docker run` examples using `mzdotai/gateway:latest`
- Add `update-dockerhub-description` job to the Docker CI workflow to auto-sync README.md as the Docker Hub overview