### PR TITLE
feat(gateway): config to disable FastAPI docs endpoints (on by default)

### DIFF
--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -58,6 +58,10 @@ class GatewayConfig(BaseSettings):
         default=False,
         description="Enable Prometheus metrics endpoint at /metrics",
     )
+    enable_docs: bool = Field(
+        default=True,
+        description="Enable FastAPI docs endpoints (/docs, /redoc, /openapi.json). Enabled by default.",
+    )
     bootstrap_api_key: bool = Field(
         default=True,
         description="Create a first-use API key on startup when no API keys exist",

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -172,6 +172,9 @@ def create_app(config: GatewayConfig) -> FastAPI:
         title="any-llm-gateway",
         description="A clean FastAPI gateway for any-llm with API key management",
         version=__version__,
+        docs_url="/docs" if config.enable_docs else None,
+        redoc_url="/redoc" if config.enable_docs else None,
+        openapi_url="/openapi.json" if config.enable_docs else None,
     )
 
     @app.get("/", response_class=HTMLResponse, include_in_schema=False)


### PR DESCRIPTION
## Summary
- Adds `enable_docs: bool = True` to `GatewayConfig`, using the existing `GATEWAY_` env prefix so operators can flip it via `GATEWAY_ENABLE_DOCS=false`
- Wires the flag into `create_app` so `docs_url`/`redoc_url`/`openapi_url` become `None` when disabled
- Default is `true` to preserve existing behavior

Ported from https://github.com/mozilla-ai/any-llm/pull/997

Co-Authored-By: Julian Bright <brightsparc@gmail.com>