### PR TITLE
feat(asyncio): async DB layer, budget strategies, and log writer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,3 @@
+mode: platform
+platform:
+  base_url: http://localhost:8100/api/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ requires-python = ">=3.13"
 dependencies = [
     "any-llm-sdk[all]",
     "alembic>=1.13.0",
+    "aiosqlite>=0.19.0",
+    "asyncpg>=0.29.0",
     "click>=8.1.0",
     "fastapi>=0.115.0",
     "prometheus-client>=0.20.0",
@@ -17,7 +19,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
     "pyyaml>=6.0",
-    "sqlalchemy>=2.0.0",
+    "sqlalchemy[asyncio]>=2.0.0",
     "uvicorn[standard]>=0.30.0",
 ]
 

--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -1,17 +1,19 @@
 import secrets
-from collections.abc import Generator
+from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import Depends, HTTPException, Request, status
+from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.auth.models import hash_key
 from gateway.core.config import API_KEY_HEADER, GatewayConfig
 from gateway.core.database import get_db
 from gateway.metrics import record_auth_failure
 from gateway.models.entities import APIKey
+from gateway.services.log_writer import LogWriter
 
 _config: GatewayConfig | None = None
 _LAST_USED_UPDATE_INTERVAL_SECONDS = 300
@@ -67,7 +69,7 @@ def _extract_bearer_token(request: Request, config: GatewayConfig) -> str:
     )
 
 
-def _verify_and_update_api_key(db: Session, token: str) -> APIKey:
+async def _verify_and_update_api_key(db: AsyncSession, token: str) -> APIKey:
     """Verify API key token and update last_used_at."""
     try:
         key_hash = hash_key(token)
@@ -78,7 +80,8 @@ def _verify_and_update_api_key(db: Session, token: str) -> APIKey:
             detail=f"Invalid API key format: {e}",
         ) from e
 
-    api_key = db.query(APIKey).filter(APIKey.key_hash == key_hash).first()
+    result = await db.execute(select(APIKey).where(APIKey.key_hash == key_hash))
+    api_key = result.scalar_one_or_none()
 
     if not api_key:
         record_auth_failure("invalid_key")
@@ -110,9 +113,9 @@ def _verify_and_update_api_key(db: Session, token: str) -> APIKey:
     if should_update_last_used:
         api_key.last_used_at = now
         try:
-            db.commit()
+            await db.commit()
         except SQLAlchemyError:
-            db.rollback()
+            await db.rollback()
 
     return api_key
 
@@ -124,7 +127,7 @@ def _is_valid_master_key(token: str, config: GatewayConfig) -> bool:
 
 async def verify_api_key(
     request: Request,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> APIKey:
     """Verify API key from X-AnyLLM-Key header.
@@ -142,7 +145,7 @@ async def verify_api_key(
 
     """
     token = _extract_bearer_token(request, config)
-    return _verify_and_update_api_key(db, token)
+    return await _verify_and_update_api_key(db, token)
 
 
 async def verify_master_key(
@@ -176,7 +179,7 @@ async def verify_master_key(
 
 async def verify_api_key_or_master_key(
     request: Request,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> tuple[APIKey | None, bool]:
     """Verify either API key or master key from X-AnyLLM-Key header.
@@ -198,19 +201,24 @@ async def verify_api_key_or_master_key(
     if _is_valid_master_key(token, config):
         return None, True
 
-    api_key = _verify_and_update_api_key(db, token)
+    api_key = await _verify_and_update_api_key(db, token)
     return api_key, False
 
 
-def get_db_if_needed(
+async def get_db_if_needed(
     config: Annotated[GatewayConfig, Depends(get_config)],
-) -> Generator[Session | None]:
+) -> AsyncGenerator[AsyncSession | None, None]:
     """Get a database session in standalone mode, otherwise return None."""
     if config.is_platform_mode:
         yield None
         return
 
-    yield from get_db()
+    async for db in get_db():
+        yield db
+
+
+def get_log_writer(request: Request) -> LogWriter:
+    return request.app.state.log_writer
 
 
 __all__ = [
@@ -219,6 +227,7 @@ __all__ = [
     "reset_config",
     "set_config",
     "get_db_if_needed",
+    "get_log_writer",
     "verify_api_key",
     "verify_api_key_or_master_key",
     "verify_master_key",

--- a/src/gateway/api/routes/budgets.py
+++ b/src/gateway/api/routes/budgets.py
@@ -2,8 +2,9 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
+from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_db, verify_master_key
 from gateway.models.entities import Budget
@@ -51,7 +52,7 @@ class UpdateBudgetRequest(BaseModel):
 @router.post("", dependencies=[Depends(verify_master_key)])
 async def create_budget(
     request: CreateBudgetRequest,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> BudgetResponse:
     """Create a new budget."""
     budget = Budget(
@@ -61,26 +62,27 @@ async def create_budget(
 
     db.add(budget)
     try:
-        db.commit()
+        await db.commit()
     except SQLAlchemyError:
-        db.rollback()
+        await db.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Database error",
         ) from None
-    db.refresh(budget)
+    await db.refresh(budget)
 
     return BudgetResponse.from_model(budget)
 
 
 @router.get("", dependencies=[Depends(verify_master_key)])
 async def list_budgets(
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     skip: Annotated[int, Query(ge=0)] = 0,
     limit: Annotated[int, Query(ge=1, le=1000)] = 100,
 ) -> list[BudgetResponse]:
     """List all budgets with pagination."""
-    budgets = db.query(Budget).offset(skip).limit(limit).all()
+    result = await db.execute(select(Budget).offset(skip).limit(limit))
+    budgets = result.scalars().all()
 
     return [BudgetResponse.from_model(budget) for budget in budgets]
 
@@ -88,10 +90,11 @@ async def list_budgets(
 @router.get("/{budget_id}", dependencies=[Depends(verify_master_key)])
 async def get_budget(
     budget_id: str,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> BudgetResponse:
     """Get details of a specific budget."""
-    budget = db.query(Budget).filter(Budget.budget_id == budget_id).first()
+    result = await db.execute(select(Budget).where(Budget.budget_id == budget_id))
+    budget = result.scalar_one_or_none()
 
     if not budget:
         raise HTTPException(
@@ -106,10 +109,11 @@ async def get_budget(
 async def update_budget(
     budget_id: str,
     request: UpdateBudgetRequest,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> BudgetResponse:
     """Update a budget."""
-    budget = db.query(Budget).filter(Budget.budget_id == budget_id).first()
+    result = await db.execute(select(Budget).where(Budget.budget_id == budget_id))
+    budget = result.scalar_one_or_none()
 
     if not budget:
         raise HTTPException(
@@ -123,14 +127,14 @@ async def update_budget(
         budget.budget_duration_sec = request.budget_duration_sec
 
     try:
-        db.commit()
+        await db.commit()
     except SQLAlchemyError:
-        db.rollback()
+        await db.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Database error",
         ) from None
-    db.refresh(budget)
+    await db.refresh(budget)
 
     return BudgetResponse.from_model(budget)
 
@@ -138,10 +142,11 @@ async def update_budget(
 @router.delete("/{budget_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(verify_master_key)])
 async def delete_budget(
     budget_id: str,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     """Delete a budget."""
-    budget = db.query(Budget).filter(Budget.budget_id == budget_id).first()
+    result = await db.execute(select(Budget).where(Budget.budget_id == budget_id))
+    budget = result.scalar_one_or_none()
 
     if not budget:
         raise HTTPException(
@@ -149,11 +154,11 @@ async def delete_budget(
             detail=f"Budget with id '{budget_id}' not found",
         )
 
-    db.delete(budget)
+    await db.delete(budget)
     try:
-        db.commit()
+        await db.commit()
     except SQLAlchemyError:
-        db.rollback()
+        await db.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Database error",

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -15,18 +15,18 @@ from any_llm.types.completion import (
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response, status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, field_validator
-from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.api.deps import get_config, get_db_if_needed, verify_api_key_or_master_key
+from gateway.api.deps import get_config, get_db_if_needed, get_log_writer, verify_api_key_or_master_key
 from gateway.api.routes._helpers import resolve_user_id
 from gateway.auth.vertex_auth import setup_vertex_environment
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.metrics import record_cost, record_tokens
-from gateway.models.entities import APIKey, UsageLog, User
+from gateway.models.entities import APIKey, UsageLog
 from gateway.rate_limit import RateLimitInfo, check_rate_limit
 from gateway.services.budget_service import validate_user_budget
+from gateway.services.log_writer import LogWriter
 from gateway.services.pricing_service import find_model_pricing
 from gateway.streaming import OPENAI_STREAM_FORMAT, streaming_generator
 
@@ -111,8 +111,9 @@ def get_provider_kwargs(
 
 
 async def log_usage(
-    db: Session,
-    api_key_obj: APIKey | None,
+    db: AsyncSession,
+    log_writer: LogWriter,
+    api_key_id: str | None,
     model: str,
     provider: str | None,
     endpoint: str,
@@ -125,7 +126,7 @@ async def log_usage(
 
     Args:
         db: Database session
-        api_key_obj: API key object (None if using master key)
+        api_key_id: API key identifier (None if using master key)
         model: Model name
         provider: Provider name
         endpoint: Endpoint path
@@ -137,7 +138,7 @@ async def log_usage(
     """
     usage_log = UsageLog(
         id=str(uuid.uuid4()),
-        api_key_id=api_key_obj.id if api_key_obj else None,
+        api_key_id=api_key_id,
         user_id=user_id,
         timestamp=datetime.now(UTC),
         model=model,
@@ -163,28 +164,18 @@ async def log_usage(
             usage_data.completion_tokens,
         )
 
-        pricing = find_model_pricing(db, provider, model)
-        if pricing:
-            cost = (usage_data.prompt_tokens / 1_000_000) * pricing.input_price_per_million + (
-                usage_data.completion_tokens / 1_000_000
-            ) * pricing.output_price_per_million
-            usage_log.cost = cost
-            record_cost(str(provider or ""), model, cost)
+    pricing = await find_model_pricing(db, provider, model)
+    if pricing:
+        cost = (usage_data.prompt_tokens / 1_000_000) * pricing.input_price_per_million + (
+            usage_data.completion_tokens / 1_000_000
+        ) * pricing.output_price_per_million
+        usage_log.cost = cost
+        record_cost(str(provider or ""), model, cost)
+    else:
+        model_ref = f"{provider}:{model}" if provider else model
+        logger.warning(f"No pricing configured for '{model_ref}'. Usage will be tracked without cost.")
 
-            if user_id:
-                db.query(User).filter(User.user_id == user_id, User.deleted_at.is_(None)).update(
-                    {User.spend: User.spend + cost}
-                )
-        else:
-            model_ref = f"{provider}:{model}" if provider else model
-            logger.warning(f"No pricing configured for '{model_ref}'. Usage will be tracked without cost.")
-
-    try:
-        db.add(usage_log)
-        db.commit()
-    except SQLAlchemyError as e:
-        logger.error("Failed to log usage to database: %s", e)
-        db.rollback()
+    await log_writer.put(usage_log)
 
 
 def _extract_platform_user_token(request: Request) -> str:
@@ -358,8 +349,9 @@ async def chat_completions(
     response: Response,
     background_tasks: BackgroundTasks,
     request: ChatCompletionRequest,
-    db: Annotated[Session | None, Depends(get_db_if_needed)],
+    db: Annotated[AsyncSession | None, Depends(get_db_if_needed)],
     config: Annotated[GatewayConfig, Depends(get_config)],
+    log_writer: Annotated[LogWriter, Depends(get_log_writer)],
 ) -> ChatCompletion | StreamingResponse:
     """OpenAI-compatible chat completions endpoint.
 
@@ -378,6 +370,7 @@ async def chat_completions(
         )
 
     api_key: APIKey | None = None
+    api_key_id: str | None = None
     user_id: str | None = None
     rate_limit_info: RateLimitInfo | None = None
     platform_mode = config.is_platform_mode
@@ -412,6 +405,7 @@ async def chat_completions(
             )
 
         api_key, is_master_key = await verify_api_key_or_master_key(raw_request, db, config)
+        api_key_id = api_key.id if api_key else None
         user_id = resolve_user_id(
             user_id_from_request=request.user,
             api_key=api_key,
@@ -431,7 +425,9 @@ async def chat_completions(
         )
 
         rate_limit_info = check_rate_limit(raw_request, user_id)
-        _ = await validate_user_budget(db, user_id, request.model)
+        _ = await validate_user_budget(db, user_id, request.model, strategy=config.budget_strategy)
+        if config.budget_strategy == "for_update":
+            await db.rollback()
         provider, model = AnyLLM.split_model_provider(request.model)
         provider_kwargs = get_provider_kwargs(config, provider)
 
@@ -475,15 +471,16 @@ async def chat_completions(
                 if db is None:
                     return
 
-                await log_usage(
-                    db=db,
-                    api_key_obj=api_key,
-                    model=model,
-                    provider=provider,
-                    endpoint="/v1/chat/completions",
-                    user_id=user_id,
-                    usage_override=usage_data,
-                )
+                    await log_usage(
+                        db=db,
+                        log_writer=log_writer,
+                        api_key_id=api_key_id,
+                        model=model,
+                        provider=provider,
+                        endpoint="/v1/chat/completions",
+                        user_id=user_id,
+                        usage_override=usage_data,
+                    )
 
             async def _on_error(error: str) -> None:
                 if platform_mode and correlation_id:
@@ -500,15 +497,16 @@ async def chat_completions(
                 if db is None:
                     return
 
-                await log_usage(
-                    db=db,
-                    api_key_obj=api_key,
-                    model=model,
-                    provider=provider,
-                    endpoint="/v1/chat/completions",
-                    user_id=user_id,
-                    error=error,
-                )
+                    await log_usage(
+                        db=db,
+                        log_writer=log_writer,
+                        api_key_id=api_key_id,
+                        model=model,
+                        provider=provider,
+                        endpoint="/v1/chat/completions",
+                        user_id=user_id,
+                        error=error,
+                    )
 
             stream: AsyncIterator[ChatCompletionChunk] = await acompletion(**completion_kwargs)  # type: ignore[assignment]
             rl_headers = rate_limit_headers(rate_limit_info) if rate_limit_info else {}
@@ -539,7 +537,8 @@ async def chat_completions(
         elif db is not None:
             await log_usage(
                 db=db,
-                api_key_obj=api_key,
+                log_writer=log_writer,
+                api_key_id=api_key_id,
                 model=model,
                 provider=provider,
                 endpoint="/v1/chat/completions",
@@ -561,7 +560,8 @@ async def chat_completions(
         elif db is not None:
             await log_usage(
                 db=db,
-                api_key_obj=api_key,
+                log_writer=log_writer,
+                api_key_id=api_key_id,
                 model=model,
                 provider=provider,
                 endpoint="/v1/chat/completions",

--- a/src/gateway/api/routes/embeddings.py
+++ b/src/gateway/api/routes/embeddings.py
@@ -8,17 +8,17 @@ from any_llm import AnyLLM, aembedding
 from any_llm.types.completion import CreateEmbeddingResponse
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, Field
-from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.api.deps import get_config, get_db, verify_api_key_or_master_key
+from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
 from gateway.api.routes._helpers import resolve_user_id
 from gateway.api.routes.chat import get_provider_kwargs, rate_limit_headers
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
-from gateway.models.entities import APIKey, UsageLog, User
+from gateway.models.entities import APIKey, UsageLog
 from gateway.rate_limit import check_rate_limit
 from gateway.services.budget_service import validate_user_budget
+from gateway.services.log_writer import LogWriter
 from gateway.services.pricing_service import find_model_pricing
 
 router = APIRouter(prefix="/v1", tags=["embeddings"])
@@ -39,11 +39,10 @@ async def create_embedding(
     raw_request: Request,
     response: Response,
     request: EmbeddingRequest,
-    auth_result: Annotated[
-        tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)
-    ],
-    db: Annotated[Session, Depends(get_db)],
+    auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
+    log_writer: Annotated[LogWriter, Depends(get_log_writer)],
 ) -> CreateEmbeddingResponse:
     """OpenAI-compatible embeddings endpoint.
 
@@ -53,6 +52,7 @@ async def create_embedding(
     - API key without user field: Use virtual user created with API key
     """
     api_key, is_master_key = auth_result
+    api_key_id = api_key.id if api_key else None
 
     user_id = resolve_user_id(
         user_id_from_request=request.user,
@@ -74,7 +74,9 @@ async def create_embedding(
 
     rate_limit_info = check_rate_limit(raw_request, user_id)
 
-    _ = await validate_user_budget(db, user_id, request.model)
+    _ = await validate_user_budget(db, user_id, request.model, strategy=config.budget_strategy)
+    if config.budget_strategy == "for_update":
+        await db.rollback()
 
     provider, model = AnyLLM.split_model_provider(request.model)
 
@@ -96,7 +98,7 @@ async def create_embedding(
 
         usage_log = UsageLog(
             id=str(uuid.uuid4()),
-            api_key_id=api_key.id if api_key else None,
+            api_key_id=api_key_id,
             user_id=user_id,
             timestamp=datetime.now(UTC),
             model=model,
@@ -109,35 +111,22 @@ async def create_embedding(
         )
 
         if result.usage:
-            pricing = find_model_pricing(db, provider, model)
+            pricing = await find_model_pricing(db, provider, model)
             if pricing:
-                cost = (
-                    result.usage.prompt_tokens / 1_000_000
-                ) * pricing.input_price_per_million
+                cost = (result.usage.prompt_tokens / 1_000_000) * pricing.input_price_per_million
                 usage_log.cost = cost
-
-                db.query(User).filter(
-                    User.user_id == user_id, User.deleted_at.is_(None)
-                ).update({User.spend: User.spend + cost})
             else:
                 model_ref = f"{provider}:{model}" if provider else model
-                logger.warning(
-                    f"No pricing configured for '{model_ref}'. Usage will be tracked without cost."
-                )
+                logger.warning(f"No pricing configured for '{model_ref}'. Usage will be tracked without cost.")
 
-        try:
-            db.add(usage_log)
-            db.commit()
-        except SQLAlchemyError as e:
-            logger.error("Failed to log usage to database: %s", e)
-            db.rollback()
+        await log_writer.put(usage_log)
 
     except HTTPException:
         raise
     except Exception as e:
         error_log = UsageLog(
             id=str(uuid.uuid4()),
-            api_key_id=api_key.id if api_key else None,
+            api_key_id=api_key_id,
             user_id=user_id,
             timestamp=datetime.now(UTC),
             model=model,
@@ -146,12 +135,7 @@ async def create_embedding(
             status="error",
             error_message=str(e),
         )
-        try:
-            db.add(error_log)
-            db.commit()
-        except SQLAlchemyError as log_err:
-            logger.error("Failed to log usage to database: %s", log_err)
-            db.rollback()
+        await log_writer.put(error_log)
 
         logger.error("Provider call failed for %s:%s: %s", provider, model, e)
         raise HTTPException(

--- a/src/gateway/api/routes/health.py
+++ b/src/gateway/api/routes/health.py
@@ -1,10 +1,11 @@
-from typing import Any
+from typing import Annotated, Any
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.api.deps import get_config, get_db
+from gateway.api.deps import get_config, get_db_if_needed
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.version import __version__
@@ -58,7 +59,10 @@ async def health_liveness() -> str:
 
 
 @router.get("/readiness")
-async def health_readiness(config: GatewayConfig = Depends(get_config)) -> dict[str, Any]:
+async def health_readiness(
+    config: GatewayConfig = Depends(get_config),
+    db: Annotated[AsyncSession | None, Depends(get_db_if_needed)] = None,
+) -> dict[str, Any]:
     """Readiness probe endpoint.
 
     Checks if the gateway is ready to serve requests by validating:
@@ -94,20 +98,15 @@ async def health_readiness(config: GatewayConfig = Depends(get_config)) -> dict[
             "version": __version__,
         }
 
-    try:
-        db_gen = get_db()
-        db = next(db_gen)
-        try:
-            db.execute(text("SELECT 1"))
-            db_status = "connected"
-        finally:
-            try:
-                next(db_gen)
-            except StopIteration:
-                pass
+    if db is None:
+        raise HTTPException(
+            status_code=503,
+            detail={"status": "unhealthy", "database": "unavailable", "version": __version__},
+        )
 
-    except HTTPException:
-        raise
+    try:
+        await db.execute(text("SELECT 1"))
+        db_status = "connected"
     except Exception as e:
         logger.error("Database connectivity check failed: %s", e)
         raise HTTPException(

--- a/src/gateway/api/routes/keys.py
+++ b/src/gateway/api/routes/keys.py
@@ -4,8 +4,9 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
+from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_db, verify_master_key
 from gateway.auth.models import generate_api_key, hash_key
@@ -74,7 +75,7 @@ class UpdateKeyRequest(BaseModel):
 @router.post("", dependencies=[Depends(verify_master_key)])
 async def create_key(
     request: CreateKeyRequest,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> CreateKeyResponse:
     """Create a new API key.
 
@@ -88,7 +89,8 @@ async def create_key(
     key_id = uuid.uuid4()
 
     if request.user_id:
-        user = db.query(User).filter(User.user_id == request.user_id).first()
+        result = await db.execute(select(User).where(User.user_id == request.user_id))
+        user = result.scalar_one_or_none()
         if not user:
             user = User(
                 user_id=request.user_id,
@@ -120,14 +122,14 @@ async def create_key(
 
     db.add(db_key)
     try:
-        db.commit()
+        await db.commit()
     except SQLAlchemyError:
-        db.rollback()
+        await db.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Database error",
         ) from None
-    db.refresh(db_key)
+    await db.refresh(db_key)
 
     key_info = KeyInfo.from_model(db_key)
     return CreateKeyResponse(
@@ -138,7 +140,7 @@ async def create_key(
 
 @router.get("", dependencies=[Depends(verify_master_key)])
 async def list_keys(
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     skip: Annotated[int, Query(ge=0)] = 0,
     limit: Annotated[int, Query(ge=1, le=1000)] = 100,
 ) -> list[KeyInfo]:
@@ -146,7 +148,8 @@ async def list_keys(
 
     Requires master key authentication.
     """
-    keys = db.query(APIKey).offset(skip).limit(limit).all()
+    result = await db.execute(select(APIKey).offset(skip).limit(limit))
+    keys = result.scalars().all()
 
     return [KeyInfo.from_model(key) for key in keys]
 
@@ -154,13 +157,14 @@ async def list_keys(
 @router.get("/{key_id}", dependencies=[Depends(verify_master_key)])
 async def get_key(
     key_id: str,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> KeyInfo:
     """Get details of a specific API key.
 
     Requires master key authentication.
     """
-    key = db.query(APIKey).filter(APIKey.id == key_id).first()
+    result = await db.execute(select(APIKey).where(APIKey.id == key_id))
+    key = result.scalar_one_or_none()
 
     if not key:
         raise HTTPException(
@@ -175,13 +179,14 @@ async def get_key(
 async def update_key(
     key_id: str,
     request: UpdateKeyRequest,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> KeyInfo:
     """Update an API key.
 
     Requires master key authentication.
     """
-    key = db.query(APIKey).filter(APIKey.id == key_id).first()
+    result = await db.execute(select(APIKey).where(APIKey.id == key_id))
+    key = result.scalar_one_or_none()
 
     if not key:
         raise HTTPException(
@@ -199,14 +204,14 @@ async def update_key(
         key.metadata_ = request.metadata
 
     try:
-        db.commit()
+        await db.commit()
     except SQLAlchemyError:
-        db.rollback()
+        await db.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Database error",
         ) from None
-    db.refresh(key)
+    await db.refresh(key)
 
     return KeyInfo.from_model(key)
 
@@ -214,13 +219,14 @@ async def update_key(
 @router.delete("/{key_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(verify_master_key)])
 async def delete_key(
     key_id: str,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     """Delete (revoke) an API key.
 
     Requires master key authentication.
     """
-    key = db.query(APIKey).filter(APIKey.id == key_id).first()
+    result = await db.execute(select(APIKey).where(APIKey.id == key_id))
+    key = result.scalar_one_or_none()
 
     if not key:
         raise HTTPException(
@@ -228,11 +234,11 @@ async def delete_key(
             detail=f"API key with id '{key_id}' not found",
         )
 
-    db.delete(key)
+    await db.delete(key)
     try:
-        db.commit()
+        await db.commit()
     except SQLAlchemyError:
-        db.rollback()
+        await db.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Database error",

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -11,9 +11,9 @@ from any_llm.types.messages import (
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.api.deps import get_config, get_db, verify_api_key_or_master_key
+from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
 from gateway.api.routes._helpers import resolve_user_id
 from gateway.api.routes.chat import get_provider_kwargs, log_usage, rate_limit_headers
 from gateway.core.config import GatewayConfig
@@ -21,6 +21,7 @@ from gateway.log_config import logger
 from gateway.models.entities import APIKey
 from gateway.rate_limit import check_rate_limit
 from gateway.services.budget_service import validate_user_budget
+from gateway.services.log_writer import LogWriter
 from gateway.streaming import ANTHROPIC_STREAM_FORMAT, streaming_generator
 
 router = APIRouter(prefix="/v1", tags=["messages"])
@@ -55,9 +56,7 @@ def _anthropic_error(error_type: str, message: str, status_code: int) -> HTTPExc
 
 _ERR_INVALID_REQUEST = "invalid_request_error"
 _ERR_API = "api_error"
-_MASTER_KEY_USER_REQUIRED = (
-    "When using master key, 'metadata.user_id' is required in request body"
-)
+_MASTER_KEY_USER_REQUIRED = "When using master key, 'metadata.user_id' is required in request body"
 _API_KEY_VALIDATION_FAILED = "API key validation failed"
 _API_KEY_NO_USER = "API key has no associated user"
 _PROVIDER_ERROR = "The request could not be completed by the provider"
@@ -68,14 +67,14 @@ async def create_message(
     raw_request: Request,
     response: Response,
     request: MessagesRequest,
-    auth_result: Annotated[
-        tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)
-    ],
-    db: Annotated[Session, Depends(get_db)],
+    auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
+    log_writer: Annotated[LogWriter, Depends(get_log_writer)],
 ) -> dict[str, Any] | StreamingResponse:
     """Anthropic Messages API-compatible endpoint."""
     api_key, is_master_key = auth_result
+    api_key_id = api_key.id if api_key else None
     user_from_metadata = request.metadata.get("user_id") if request.metadata else None
     user_id = resolve_user_id(
         user_id_from_request=str(user_from_metadata) if user_from_metadata else None,
@@ -100,7 +99,9 @@ async def create_message(
 
     rate_limit_info = check_rate_limit(raw_request, user_id)
 
-    _ = await validate_user_budget(db, user_id, request.model)
+    _ = await validate_user_budget(db, user_id, request.model, strategy=config.budget_strategy)
+    if config.budget_strategy == "for_update":
+        await db.rollback()
 
     provider, model = AnyLLM.split_model_provider(request.model)
 
@@ -139,7 +140,8 @@ async def create_message(
             async def _on_complete(usage_data: CompletionUsage) -> None:
                 await log_usage(
                     db=db,
-                    api_key_obj=api_key,
+                    log_writer=log_writer,
+                    api_key_id=api_key_id,
                     model=model,
                     provider=provider,
                     endpoint="/v1/messages",
@@ -150,7 +152,8 @@ async def create_message(
             async def _on_error(error: str) -> None:
                 await log_usage(
                     db=db,
-                    api_key_obj=api_key,
+                    log_writer=log_writer,
+                    api_key_id=api_key_id,
                     model=model,
                     provider=provider,
                     endpoint="/v1/messages",
@@ -184,7 +187,8 @@ async def create_message(
             )
             await log_usage(
                 db=db,
-                api_key_obj=api_key,
+                log_writer=log_writer,
+                api_key_id=api_key_id,
                 model=model,
                 provider=provider,
                 endpoint="/v1/messages",
@@ -197,7 +201,8 @@ async def create_message(
     except Exception as e:
         await log_usage(
             db=db,
-            api_key_obj=api_key,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
             model=model,
             provider=provider,
             endpoint="/v1/messages",

--- a/src/gateway/api/routes/models.py
+++ b/src/gateway/api/routes/models.py
@@ -5,7 +5,8 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_db, verify_api_key_or_master_key
 from gateway.models.entities import ModelPricing
@@ -43,24 +44,26 @@ def _model_from_pricing(pricing: ModelPricing) -> ModelObject:
 
 @router.get("/models", dependencies=[Depends(verify_api_key_or_master_key)])
 async def list_models(
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ModelListResponse:
     """List all available models.
 
     Returns models derived from the model_pricing table in an
     OpenAI-compatible format.
     """
-    pricings = db.query(ModelPricing).order_by(ModelPricing.model_key).all()
+    result = await db.execute(select(ModelPricing).order_by(ModelPricing.model_key))
+    pricings = result.scalars().all()
     return ModelListResponse(data=[_model_from_pricing(p) for p in pricings])
 
 
 @router.get("/models/{model_id:path}", dependencies=[Depends(verify_api_key_or_master_key)])
 async def get_model(
     model_id: str,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ModelObject:
     """Get details for a specific model."""
-    pricing = db.query(ModelPricing).filter(ModelPricing.model_key == model_id).first()
+    result = await db.execute(select(ModelPricing).where(ModelPricing.model_key == model_id))
+    pricing = result.scalar_one_or_none()
 
     if not pricing:
         raise HTTPException(

--- a/src/gateway/api/routes/pricing.py
+++ b/src/gateway/api/routes/pricing.py
@@ -3,8 +3,9 @@ from typing import Annotated
 from any_llm import AnyLLM
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
+from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_db, verify_api_key_or_master_key, verify_master_key
 from gateway.models.entities import ModelPricing
@@ -44,12 +45,13 @@ class PricingResponse(BaseModel):
 @router.post("", dependencies=[Depends(verify_master_key)])
 async def set_pricing(
     request: SetPricingRequest,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> PricingResponse:
     """Set or update pricing for a model."""
     provider, model_name = AnyLLM.split_model_provider(request.model_key)
     normalized_key = f"{provider.value}:{model_name}"
-    pricing = db.query(ModelPricing).filter(ModelPricing.model_key == normalized_key).first()
+    result = await db.execute(select(ModelPricing).where(ModelPricing.model_key == normalized_key))
+    pricing = result.scalar_one_or_none()
 
     if pricing:
         pricing.input_price_per_million = request.input_price_per_million
@@ -63,26 +65,27 @@ async def set_pricing(
         db.add(pricing)
 
     try:
-        db.commit()
+        await db.commit()
     except SQLAlchemyError:
-        db.rollback()
+        await db.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Database error",
         ) from None
-    db.refresh(pricing)
+    await db.refresh(pricing)
 
     return PricingResponse.from_model(pricing)
 
 
 @router.get("", dependencies=[Depends(verify_api_key_or_master_key)])
 async def list_pricing(
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     skip: Annotated[int, Query(ge=0)] = 0,
     limit: Annotated[int, Query(ge=1, le=1000)] = 100,
 ) -> list[PricingResponse]:
     """List all model pricing."""
-    pricings = db.query(ModelPricing).offset(skip).limit(limit).all()
+    result = await db.execute(select(ModelPricing).offset(skip).limit(limit))
+    pricings = result.scalars().all()
 
     return [PricingResponse.from_model(pricing) for pricing in pricings]
 
@@ -90,10 +93,11 @@ async def list_pricing(
 @router.get("/{model_key}", dependencies=[Depends(verify_api_key_or_master_key)])
 async def get_pricing(
     model_key: str,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> PricingResponse:
     """Get pricing for a specific model."""
-    pricing = db.query(ModelPricing).filter(ModelPricing.model_key == model_key).first()
+    result = await db.execute(select(ModelPricing).where(ModelPricing.model_key == model_key))
+    pricing = result.scalar_one_or_none()
 
     if not pricing:
         raise HTTPException(
@@ -107,10 +111,11 @@ async def get_pricing(
 @router.delete("/{model_key}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(verify_master_key)])
 async def delete_pricing(
     model_key: str,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     """Delete pricing for a model."""
-    pricing = db.query(ModelPricing).filter(ModelPricing.model_key == model_key).first()
+    result = await db.execute(select(ModelPricing).where(ModelPricing.model_key == model_key))
+    pricing = result.scalar_one_or_none()
 
     if not pricing:
         raise HTTPException(
@@ -118,11 +123,11 @@ async def delete_pricing(
             detail=f"Pricing for model '{model_key}' not found",
         )
 
-    db.delete(pricing)
+    await db.delete(pricing)
     try:
-        db.commit()
+        await db.commit()
     except SQLAlchemyError:
-        db.rollback()
+        await db.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Database error",

--- a/src/gateway/api/routes/users.py
+++ b/src/gateway/api/routes/users.py
@@ -3,8 +3,9 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
+from sqlalchemy import select, update
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_db, verify_master_key
 from gateway.models.entities import APIKey, Budget, UsageLog, User
@@ -102,15 +103,26 @@ class UsageLogResponse(BaseModel):
 @router.post("", dependencies=[Depends(verify_master_key)])
 async def create_user(
     request: CreateUserRequest,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> UserResponse:
     """Create a new user."""
-    existing_user = db.query(User).filter(User.user_id == request.user_id).first()
+    result = await db.execute(select(User).where(User.user_id == request.user_id))
+    existing_user = result.scalar_one_or_none()
     if existing_user and existing_user.deleted_at is None:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"User with id '{request.user_id}' already exists",
         )
+
+    budget: Budget | None = None
+    if request.budget_id:
+        budget_result = await db.execute(select(Budget).where(Budget.budget_id == request.budget_id))
+        budget = budget_result.scalar_one_or_none()
+        if not budget:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Budget with id '{request.budget_id}' not found",
+            )
 
     if existing_user and existing_user.deleted_at is not None:
         user = existing_user
@@ -132,40 +144,36 @@ async def create_user(
         )
         db.add(user)
 
-    if request.budget_id:
-        budget = db.query(Budget).filter(Budget.budget_id == request.budget_id).first()
-        if not budget:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Budget with id '{request.budget_id}' not found",
-            )
-
+    if budget is not None:
         now = datetime.now(UTC)
         user.budget_started_at = now
         if budget.budget_duration_sec:
             user.next_budget_reset_at = calculate_next_reset(now, budget.budget_duration_sec)
+        else:
+            user.next_budget_reset_at = None
 
     try:
-        db.commit()
+        await db.commit()
     except SQLAlchemyError:
-        db.rollback()
+        await db.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Database error",
         ) from None
-    db.refresh(user)
+    await db.refresh(user)
 
     return UserResponse.from_model(user)
 
 
 @router.get("", dependencies=[Depends(verify_master_key)])
 async def list_users(
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     skip: Annotated[int, Query(ge=0)] = 0,
     limit: Annotated[int, Query(ge=1, le=1000)] = 100,
 ) -> list[UserResponse]:
     """List all users with pagination."""
-    users = db.query(User).filter(User.deleted_at.is_(None)).offset(skip).limit(limit).all()
+    result = await db.execute(select(User).where(User.deleted_at.is_(None)).offset(skip).limit(limit))
+    users = result.scalars().all()
 
     return [UserResponse.from_model(user) for user in users]
 
@@ -173,10 +181,10 @@ async def list_users(
 @router.get("/{user_id}", dependencies=[Depends(verify_master_key)])
 async def get_user(
     user_id: str,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> UserResponse:
     """Get details of a specific user."""
-    user = get_active_user(db, user_id)
+    user = await get_active_user(db, user_id)
 
     if not user:
         raise HTTPException(
@@ -191,10 +199,10 @@ async def get_user(
 async def update_user(
     user_id: str,
     request: UpdateUserRequest,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> UserResponse:
     """Update a user."""
-    user = get_active_user(db, user_id)
+    user = await get_active_user(db, user_id)
 
     if not user:
         raise HTTPException(
@@ -205,7 +213,8 @@ async def update_user(
     if request.alias is not None:
         user.alias = request.alias
     if request.budget_id is not None:
-        budget = db.query(Budget).filter(Budget.budget_id == request.budget_id).first()
+        budget_result = await db.execute(select(Budget).where(Budget.budget_id == request.budget_id))
+        budget = budget_result.scalar_one_or_none()
         if not budget:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -225,14 +234,14 @@ async def update_user(
         user.metadata_ = request.metadata
 
     try:
-        db.commit()
+        await db.commit()
     except SQLAlchemyError:
-        db.rollback()
+        await db.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Database error",
         ) from None
-    db.refresh(user)
+    await db.refresh(user)
 
     return UserResponse.from_model(user)
 
@@ -240,10 +249,10 @@ async def update_user(
 @router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(verify_master_key)])
 async def delete_user(
     user_id: str,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
     """Delete a user."""
-    user = get_active_user(db, user_id)
+    user = await get_active_user(db, user_id)
 
     if not user:
         raise HTTPException(
@@ -251,13 +260,18 @@ async def delete_user(
             detail=f"User with id '{user_id}' not found",
         )
 
-    db.query(APIKey).filter(APIKey.user_id == user_id).update({"is_active": False}, synchronize_session="fetch")
+    await db.execute(
+        update(APIKey)
+        .where(APIKey.user_id == user_id)
+        .values(is_active=False)
+        .execution_options(synchronize_session=False)
+    )
     user.deleted_at = datetime.now(UTC)
 
     try:
-        db.commit()
+        await db.commit()
     except SQLAlchemyError:
-        db.rollback()
+        await db.rollback()
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Database error",
@@ -267,25 +281,26 @@ async def delete_user(
 @router.get("/{user_id}/usage", dependencies=[Depends(verify_master_key)])
 async def get_user_usage(
     user_id: str,
-    db: Annotated[Session, Depends(get_db)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     skip: Annotated[int, Query(ge=0)] = 0,
     limit: Annotated[int, Query(ge=1, le=1000)] = 100,
 ) -> list[UsageLogResponse]:
     """Get usage history for a specific user."""
-    user = db.query(User).filter(User.user_id == user_id).first()
+    result = await db.execute(select(User).where(User.user_id == user_id))
+    user = result.scalar_one_or_none()
     if not user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"User with id '{user_id}' not found",
         )
 
-    usage_logs = (
-        db.query(UsageLog)
-        .filter(UsageLog.user_id == user_id)
+    usage_result = await db.execute(
+        select(UsageLog)
+        .where(UsageLog.user_id == user_id)
         .order_by(UsageLog.timestamp.desc())
         .offset(skip)
         .limit(limit)
-        .all()
     )
+    usage_logs = usage_result.scalars().all()
 
     return [UsageLogResponse.from_model(log) for log in usage_logs]

--- a/src/gateway/cli.py
+++ b/src/gateway/cli.py
@@ -130,7 +130,7 @@ def init_db(config: str | None, database_url: str | None) -> None:
 
     click.echo(f"Initializing database: {gateway_config.database_url}")
 
-    db_init(gateway_config.database_url)
+    db_init(gateway_config)
 
     click.echo("Database initialized successfully!")
 

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -36,6 +36,25 @@ class GatewayConfig(BaseSettings):
         default=True,
         description="Automatically run database migrations on startup",
     )
+    db_pool_size: int = Field(
+        default=10,
+        ge=1,
+        description="Number of persistent connections in the DB pool per worker.",
+    )
+    db_max_overflow: int = Field(
+        default=20,
+        ge=0,
+        description="Extra connections the pool can open above db_pool_size during bursts.",
+    )
+    db_pool_timeout: float = Field(
+        default=30.0,
+        ge=0,
+        description="Seconds to wait for an available connection before raising TimeoutError.",
+    )
+    db_pool_recycle: int = Field(
+        default=-1,
+        description="Recycle connections older than this many seconds. -1 disables.",
+    )
     host: str = Field(default="0.0.0.0", description="Host to bind the server to")  # noqa: S104
     port: int = Field(default=8000, description="Port to bind the server to")
     master_key: str | None = Field(default=None, description="Master key for protecting management endpoints")
@@ -65,6 +84,14 @@ class GatewayConfig(BaseSettings):
     bootstrap_api_key: bool = Field(
         default=True,
         description="Create a first-use API key on startup when no API keys exist",
+    )
+    log_writer_strategy: str = Field(
+        default="single",
+        description="How usage log rows are written: 'single' (inline) or 'batch' (background).",
+    )
+    budget_strategy: str = Field(
+        default="for_update",
+        description="Budget validation strategy: 'for_update' (default), 'cas' (lock-free), or 'disabled'.",
     )
     mode: str = Field(default="standalone", description="Gateway operating mode: standalone or platform")
     platform: dict[str, Any] = Field(default_factory=dict, description="Platform integration settings")

--- a/src/gateway/core/database.py
+++ b/src/gateway/core/database.py
@@ -1,72 +1,151 @@
-from collections.abc import Generator
+"""Async database initialization helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator, AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
 from alembic import command
 from alembic.config import Config
-from sqlalchemy import create_engine, event
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy import event
+from sqlalchemy.engine import URL, make_url
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
 
-_engine = None
-_SessionLocal = None
+from gateway.core.config import GatewayConfig
 
-
-def init_db(database_url: str, auto_migrate: bool = True) -> None:
-    """Initialize database connection and optionally run migrations.
-
-    Args:
-        database_url: Database connection URL
-        auto_migrate: If True, automatically run migrations to head. If False, skip migrations.
-    """
-    global _engine, _SessionLocal  # noqa: PLW0603
-
-    engine_kwargs: dict[str, Any] = {"pool_pre_ping": True}
-    if database_url.startswith("sqlite"):
-        engine_kwargs["connect_args"] = {"check_same_thread": False}
-
-    _engine = create_engine(database_url, **engine_kwargs)
-
-    if _engine.dialect.name == "sqlite":
-
-        @event.listens_for(_engine, "connect")
-        def _set_sqlite_pragma(dbapi_connection: Any, _: Any) -> None:
-            cursor = dbapi_connection.cursor()
-            cursor.execute("PRAGMA foreign_keys=ON")
-            cursor.close()
-
-    _SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=_engine)
-
-    if auto_migrate:
-        alembic_cfg = Config()
-        alembic_dir = Path(__file__).resolve().parents[3] / "alembic"
-        alembic_cfg.set_main_option("script_location", str(alembic_dir))
-        alembic_cfg.set_main_option("sqlalchemy.url", database_url)
-
-        command.upgrade(alembic_cfg, "head")
+_engine: AsyncEngine | None = None
+_SessionLocal: async_sessionmaker[AsyncSession] | None = None
+_SYNC_DATABASE_URL: str | None = None
 
 
-def get_db() -> Generator[Session]:
-    """Get database session for dependency injection."""
+def _to_async_url(database_url: str) -> tuple[str, dict[str, Any]]:
+    """Convert a sync SQLAlchemy URL into its async equivalent."""
+
+    url: URL = make_url(database_url)
+    connect_args: dict[str, Any] = {}
+    drivername = url.drivername
+
+    if drivername.startswith("sqlite"):
+        async_url = url.set(drivername="sqlite+aiosqlite")
+        connect_args["check_same_thread"] = False
+        return async_url.render_as_string(hide_password=False), connect_args
+
+    if drivername in {"postgresql", "postgresql+psycopg2"}:
+        query = dict(url.query)
+        sslmode = query.pop("sslmode", None)
+        async_url = url.set(drivername="postgresql+asyncpg", query=query)
+        if sslmode:
+            connect_args["ssl"] = sslmode
+        return async_url.render_as_string(hide_password=False), connect_args
+
+    if drivername == "postgresql+asyncpg":
+        return database_url, connect_args
+
+    return database_url, connect_args
+
+
+def _run_migrations(database_url: str) -> None:
+    alembic_cfg = Config()
+    alembic_dir = Path(__file__).resolve().parents[3] / "alembic"
+    alembic_cfg.set_main_option("script_location", str(alembic_dir))
+    alembic_cfg.set_main_option("sqlalchemy.url", database_url)
+    alembic_cfg.attributes["configure_logger"] = False
+    command.upgrade(alembic_cfg, "head")
+
+
+def _enable_sqlite_foreign_keys(engine: AsyncEngine) -> None:
+    sync_engine = engine.sync_engine
+
+    @event.listens_for(sync_engine, "connect")
+    def _set_sqlite_pragma(dbapi_connection: Any, _: Any) -> None:  # noqa: ANN001, ANN202
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+
+def init_db(config: GatewayConfig) -> None:
+    """Initialize async database engine and optionally run migrations."""
+
+    global _engine, _SessionLocal, _SYNC_DATABASE_URL  # noqa: PLW0603
+
+    database_url = config.database_url
+    async_url, connect_args = _to_async_url(database_url)
+
+    is_sqlite = async_url.startswith("sqlite+aiosqlite")
+
+    engine_kwargs: dict[str, Any] = {"pool_pre_ping": True, "connect_args": connect_args}
+    if is_sqlite:
+        engine_kwargs["poolclass"] = NullPool
+    else:
+        engine_kwargs["pool_size"] = config.db_pool_size
+        engine_kwargs["max_overflow"] = config.db_max_overflow
+        engine_kwargs["pool_timeout"] = config.db_pool_timeout
+        if config.db_pool_recycle >= 0:
+            engine_kwargs["pool_recycle"] = config.db_pool_recycle
+
+    _engine = create_async_engine(async_url, **engine_kwargs)
+    _SessionLocal = async_sessionmaker(_engine, expire_on_commit=False)
+    _SYNC_DATABASE_URL = database_url
+
+    if is_sqlite:
+        _enable_sqlite_foreign_keys(_engine)
+
+    if config.auto_migrate:
+        _run_migrations(database_url)
+
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    """FastAPI dependency that yields an AsyncSession."""
+
     if _SessionLocal is None:
         msg = "Database not initialized. Call init_db() first."
         raise RuntimeError(msg)
 
-    db = _SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
+    async with _SessionLocal() as session:
+        yield session
+
+
+@asynccontextmanager
+async def create_session() -> AsyncIterator[AsyncSession]:
+    """Async context manager for creating sessions outside request scope."""
+
+    if _SessionLocal is None:
+        msg = "Database not initialized. Call init_db() first."
+        raise RuntimeError(msg)
+
+    async with _SessionLocal() as session:
+        yield session
 
 
 def reset_db() -> None:
-    """Reset database state. Intended for testing only.
+    """Dispose the active engine so it can be re-initialized (testing helper)."""
 
-    Disposes the engine connection pool and clears the module-level references
-    so that init_db() can be called again with different parameters.
-    """
-    global _engine, _SessionLocal  # noqa: PLW0603
+    global _engine, _SessionLocal, _SYNC_DATABASE_URL  # noqa: PLW0603
 
-    if _engine is not None:
-        _engine.dispose()
+    engine = _engine
     _engine = None
     _SessionLocal = None
+    _SYNC_DATABASE_URL = None
+
+    if engine is None:
+        return
+
+    dispose_coro = engine.dispose()
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(dispose_coro)
+    else:
+        loop.create_task(dispose_coro)
+
+
+__all__ = [
+    "create_session",
+    "get_db",
+    "init_db",
+    "reset_db",
+]

--- a/src/gateway/db/__init__.py
+++ b/src/gateway/db/__init__.py
@@ -1,4 +1,4 @@
-from gateway.core.database import get_db, init_db, reset_db
+from gateway.core.database import create_session, get_db, init_db, reset_db
 from gateway.models.entities import (
     APIKey,
     Base,
@@ -19,6 +19,7 @@ __all__ = [
     "UsageLog",
     "User",
     "get_active_user",
+    "create_session",
     "get_db",
     "init_db",
     "reset_db",

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -1,3 +1,5 @@
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
@@ -7,9 +9,10 @@ from typing_extensions import override
 from gateway.api.deps import set_config
 from gateway.api.main import register_routers
 from gateway.core.config import GatewayConfig
-from gateway.core.database import get_db, init_db
+from gateway.core.database import create_session, init_db
 from gateway.rate_limit import RateLimiter
 from gateway.services.bootstrap_service import bootstrap_first_api_key
+from gateway.services.log_writer import LogWriter, NoopLogWriter, create_log_writer
 from gateway.services.pricing_init_service import initialize_pricing_from_config
 from gateway.version import __version__
 
@@ -137,36 +140,47 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         return response
 
 
-def create_app(config: GatewayConfig) -> FastAPI:
-    """Create and configure FastAPI application.
-
-    Args:
-        config: Gateway configuration
-
-    Returns:
-        Configured FastAPI application
-
-    """
+def _validate_platform_config(config: GatewayConfig) -> None:
     config.validate_mode_selection()
-    if config.is_platform_mode:
-        if not config.platform.get("base_url"):
-            msg = "platform.base_url is required when platform mode is active"
-            raise ValueError(msg)
-        if config.providers:
-            msg = "Local provider credentials are not supported in platform mode"
-            raise ValueError(msg)
-
-    set_config(config)
-
     if not config.is_platform_mode:
-        init_db(config.database_url, auto_migrate=config.auto_migrate)
+        return
+    if not config.platform.get("base_url"):
+        msg = "platform.base_url is required when platform mode is active"
+        raise ValueError(msg)
+    if config.providers:
+        msg = "Local provider credentials are not supported in platform mode"
+        raise ValueError(msg)
 
-        db = next(get_db())
+
+def _create_lifespan(config: GatewayConfig):  # noqa: ANN201 - FastAPI contract
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        log_writer: LogWriter
+        if config.is_platform_mode:
+            log_writer = NoopLogWriter()
+        else:
+            init_db(config)
+            async with create_session() as session:
+                await bootstrap_first_api_key(config, session)
+                await initialize_pricing_from_config(config, session)
+            log_writer = create_log_writer(config.log_writer_strategy)
+
+        await log_writer.start()
+        app.state.log_writer = log_writer
+
         try:
-            bootstrap_first_api_key(config, db)
-            initialize_pricing_from_config(config, db)
+            yield
         finally:
-            db.close()
+            await log_writer.stop()
+
+    return lifespan
+
+
+def create_app(config: GatewayConfig) -> FastAPI:
+    """Create and configure FastAPI application."""
+
+    _validate_platform_config(config)
+    set_config(config)
 
     app = FastAPI(
         title="any-llm-gateway",
@@ -175,6 +189,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
         docs_url="/docs" if config.enable_docs else None,
         redoc_url="/redoc" if config.enable_docs else None,
         openapi_url="/openapi.json" if config.enable_docs else None,
+        lifespan=_create_lifespan(config),
     )
 
     @app.get("/", response_class=HTMLResponse, include_in_schema=False)

--- a/src/gateway/metrics.py
+++ b/src/gateway/metrics.py
@@ -73,6 +73,33 @@ AUTH_FAILURES = Counter(
     registry=REGISTRY,
 )
 
+LOG_WRITER_QUEUE_DEPTH = Gauge(
+    "gateway_usage_log_queue_depth",
+    "Number of usage log entries waiting to be written",
+    registry=REGISTRY,
+)
+
+LOG_WRITER_BATCH_SIZE = Histogram(
+    "gateway_usage_log_batch_size",
+    "Number of rows per flush batch",
+    ["writer"],
+    registry=REGISTRY,
+)
+
+LOG_WRITER_FLUSH_DURATION = Histogram(
+    "gateway_usage_log_flush_duration_seconds",
+    "Time spent flushing usage log batches",
+    ["writer", "result"],
+    registry=REGISTRY,
+)
+
+LOG_WRITER_ROWS = Counter(
+    "gateway_usage_log_rows",
+    "Total usage log rows by outcome",
+    ["writer", "result"],
+    registry=REGISTRY,
+)
+
 
 _PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
 
@@ -145,3 +172,9 @@ def record_budget_exceeded() -> None:
 def record_auth_failure(reason: str) -> None:
     """Record an authentication failure."""
     AUTH_FAILURES.labels(reason=reason).inc()
+
+
+log_writer_queue_depth = LOG_WRITER_QUEUE_DEPTH
+log_writer_batch_size = LOG_WRITER_BATCH_SIZE
+log_writer_flush_duration = LOG_WRITER_FLUSH_DURATION
+log_writer_rows = LOG_WRITER_ROWS

--- a/src/gateway/repositories/users_repository.py
+++ b/src/gateway/repositories/users_repository.py
@@ -1,21 +1,14 @@
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.models.entities import User
 
 
-def get_active_user(db: Session, user_id: str, *, for_update: bool = False) -> User | None:
-    """Query for a non-deleted user by user_id.
+async def get_active_user(db: AsyncSession, user_id: str, *, for_update: bool = False) -> User | None:
+    """Query for a non-deleted user by user_id."""
 
-    Args:
-        db: Database session
-        user_id: User identifier
-        for_update: If True, acquire a row-level lock (SELECT ... FOR UPDATE)
-
-    Returns:
-        User object if found and not soft-deleted, else None
-
-    """
-    query = db.query(User).filter(User.user_id == user_id, User.deleted_at.is_(None))
-    if for_update and (not db.bind or db.bind.dialect.name != "sqlite"):
-        query = query.with_for_update()
-    return query.first()
+    stmt = select(User).where(User.user_id == user_id, User.deleted_at.is_(None))
+    if for_update:
+        stmt = stmt.with_for_update()
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()

--- a/src/gateway/services/bootstrap_service.py
+++ b/src/gateway/services/bootstrap_service.py
@@ -1,7 +1,8 @@
 import uuid
 
+from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.auth import generate_api_key, hash_key
 from gateway.core.config import GatewayConfig
@@ -9,16 +10,13 @@ from gateway.log_config import logger
 from gateway.models.entities import APIKey, User
 
 
-def bootstrap_first_api_key(config: GatewayConfig, db: Session) -> None:
-    """Create a first API key for new installations.
+async def bootstrap_first_api_key(config: GatewayConfig, db: AsyncSession) -> None:
+    """Create a first API key for new installations."""
 
-    If bootstrap is enabled and no API keys exist, this creates one API key
-    and one associated virtual user, then prints the plain key once.
-    """
     if not config.bootstrap_api_key:
         return
 
-    existing_key = db.query(APIKey.id).first()
+    existing_key = (await db.execute(select(APIKey.id).limit(1))).scalar_one_or_none()
     if existing_key:
         return
 
@@ -42,9 +40,9 @@ def bootstrap_first_api_key(config: GatewayConfig, db: Session) -> None:
     db.add(db_key)
 
     try:
-        db.commit()
+        await db.commit()
     except SQLAlchemyError:
-        db.rollback()
+        await db.rollback()
         raise
 
     logger.warning(

--- a/src/gateway/services/budget_service.py
+++ b/src/gateway/services/budget_service.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 from datetime import UTC, datetime, timedelta
 
 from any_llm import AnyLLM
 from any_llm.exceptions import AnyLLMError
 from fastapi import HTTPException, status
+from sqlalchemy import select, update
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.log_config import logger
 from gateway.metrics import record_budget_exceeded
@@ -27,17 +30,11 @@ def calculate_next_reset(start: datetime, duration_sec: int) -> datetime:
     return start + timedelta(seconds=duration_sec)
 
 
-def reset_user_budget(db: Session, user: User, budget: Budget, now: datetime) -> None:
-    """Reset user's budget spend and schedule next reset.
+async def reset_user_budget(db: AsyncSession, user: User, budget: Budget, now: datetime) -> None:
+    """Reset user's budget spend and schedule next reset."""
 
-    Args:
-        db: Database session
-        user: User object to reset
-        budget: Budget object associated with user
-        now: Current timestamp to use for reset timing
-
-    """
-    previous_spend = user.spend
+    previous_spend = float(user.spend)
+    user_id_str = user.user_id
 
     user.spend = 0.0
     user.budget_started_at = now
@@ -57,14 +54,67 @@ def reset_user_budget(db: Session, user: User, budget: Budget, now: datetime) ->
     db.add(reset_log)
 
     try:
-        db.commit()
+        await db.commit()
+        await db.refresh(user)
     except SQLAlchemyError as e:
-        db.rollback()
-        logger.error("Failed to commit budget reset for user '%s': %s", user.user_id, e)
+        await db.rollback()
+        logger.error("Failed to commit budget reset for user '%s': %s", user_id_str, e)
         raise
 
 
-async def validate_user_budget(db: Session, user_id: str, model: str | None = None) -> User:
+async def _cas_reset_user_budget(db: AsyncSession, user: User, budget: Budget, now: datetime) -> User:
+    next_reset_at = calculate_next_reset(now, budget.budget_duration_sec) if budget.budget_duration_sec else None
+
+    result = await db.execute(
+        update(User)
+        .where(
+            User.user_id == user.user_id,
+            User.deleted_at.is_(None),
+            User.next_budget_reset_at.is_not(None),
+            User.next_budget_reset_at <= now,
+        )
+        .values(
+            spend=0.0,
+            budget_started_at=now,
+            next_budget_reset_at=next_reset_at,
+        )
+        .execution_options(synchronize_session=False)
+    )
+
+    if result.rowcount and result.rowcount > 0:
+        reset_log = BudgetResetLog(
+            user_id=user.user_id,
+            budget_id=budget.budget_id,
+            previous_spend=float(user.spend),
+            reset_at=now,
+            next_reset_at=next_reset_at,
+        )
+        db.add(reset_log)
+        try:
+            await db.commit()
+        except SQLAlchemyError as e:
+            await db.rollback()
+            logger.error("Failed to commit CAS budget reset for user '%s': %s", user.user_id, e)
+            raise
+        refreshed = await get_active_user(db, user.user_id)
+        return refreshed or user
+
+    await db.rollback()
+    return user
+
+
+async def _get_budget(db: AsyncSession, budget_id: str) -> Budget | None:
+    result = await db.execute(select(Budget).where(Budget.budget_id == budget_id))
+    return result.scalar_one_or_none()
+
+
+async def validate_user_budget(
+    db: AsyncSession,
+    user_id: str,
+    model: str | None = None,
+    *,
+    strategy: str = "for_update",
+) -> User:
     """Validate user exists, is not blocked, and has available budget.
 
     Args:
@@ -79,7 +129,13 @@ async def validate_user_budget(db: Session, user_id: str, model: str | None = No
         HTTPException: If user is blocked, doesn't exist, or exceeded budget
 
     """
-    user = get_active_user(db, user_id)
+    normalized_strategy = strategy or "for_update"
+    normalized_strategy = normalized_strategy.strip().lower()
+    if normalized_strategy not in {"for_update", "cas", "disabled"}:
+        normalized_strategy = "for_update"
+
+    lock_for_update = normalized_strategy == "for_update"
+    user = await get_active_user(db, user_id, for_update=lock_for_update)
 
     if not user:
         raise HTTPException(
@@ -93,27 +149,33 @@ async def validate_user_budget(db: Session, user_id: str, model: str | None = No
             detail=f"User '{user_id}' is blocked",
         )
 
-    if user.budget_id:
-        budget = db.query(Budget).filter(Budget.budget_id == user.budget_id).first()
-        if budget:
-            now = datetime.now(UTC)
-            if user.next_budget_reset_at and now >= user.next_budget_reset_at:
-                reset_user_budget(db, user, budget, now)
+    if normalized_strategy == "disabled" or not user.budget_id:
+        return user
 
-            if budget.max_budget is not None:
-                if user.spend >= budget.max_budget:
-                    if model and _is_model_free(db, model):
-                        return user
-                    record_budget_exceeded()
-                    raise HTTPException(
-                        status_code=status.HTTP_403_FORBIDDEN,
-                        detail=f"User '{user_id}' has exceeded budget limit",
-                    )
+    budget = await _get_budget(db, user.budget_id)
+    if not budget:
+        return user
+
+    now = datetime.now(UTC)
+    if user.next_budget_reset_at and now >= user.next_budget_reset_at:
+        if normalized_strategy == "cas":
+            user = await _cas_reset_user_budget(db, user, budget, now)
+        else:
+            await reset_user_budget(db, user, budget, now)
+
+    if budget.max_budget is not None and user.spend >= budget.max_budget:
+        if model and await _is_model_free(db, model):
+            return user
+        record_budget_exceeded()
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"User '{user_id}' has exceeded budget limit",
+        )
 
     return user
 
 
-def _is_model_free(db: Session, model: str) -> bool:
+async def _is_model_free(db: AsyncSession, model: str) -> bool:
     """Check if a model is free (both input and output prices are 0).
 
     Args:
@@ -127,7 +189,7 @@ def _is_model_free(db: Session, model: str) -> bool:
     try:
         provider, model_name = AnyLLM.split_model_provider(model)
         provider_str = provider.value if provider else None
-        pricing = find_model_pricing(db, provider_str, model_name)
+        pricing = await find_model_pricing(db, provider_str, model_name)
         if pricing:
             return pricing.input_price_per_million == 0 and pricing.output_price_per_million == 0
     except (AnyLLMError, ValueError, SQLAlchemyError) as e:

--- a/src/gateway/services/log_writer.py
+++ b/src/gateway/services/log_writer.py
@@ -1,0 +1,161 @@
+"""Usage log writer implementations."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Protocol
+
+from sqlalchemy import update
+from sqlalchemy.exc import SQLAlchemyError
+
+from gateway.core.database import create_session
+from gateway.log_config import logger
+from gateway.metrics import (
+    log_writer_batch_size,
+    log_writer_flush_duration,
+    log_writer_queue_depth,
+    log_writer_rows,
+)
+from gateway.models.entities import UsageLog, User
+
+
+class LogWriter(Protocol):
+    async def put(self, log: UsageLog) -> None: ...
+
+    async def start(self) -> None: ...
+
+    async def stop(self) -> None: ...
+
+
+class SingleLogWriter:
+    """Write each usage log inline, one transaction per event."""
+
+    async def put(self, log: UsageLog) -> None:
+        async with create_session() as db:
+            try:
+                db.add(log)
+                if log.cost and log.user_id:
+                    await db.execute(
+                        update(User)
+                        .where(User.user_id == log.user_id, User.deleted_at.is_(None))
+                        .values(spend=User.spend + log.cost)
+                    )
+                await db.commit()
+                log_writer_rows.labels(writer="single", result="written").inc()
+            except SQLAlchemyError as e:  # pragma: no cover - defensive logging
+                await db.rollback()
+                logger.error("SingleLogWriter failed: %s", e)
+                log_writer_rows.labels(writer="single", result="dropped").inc()
+
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        pass
+
+
+class BatchLogWriter:
+    """Queue usage logs and flush in batches."""
+
+    def __init__(self, max_batch: int = 100, flush_interval: float = 1.0) -> None:
+        self._queue: asyncio.Queue[UsageLog] = asyncio.Queue()
+        self._max_batch = max_batch
+        self._flush_interval = flush_interval
+        self._task: asyncio.Task[None] | None = None
+
+    async def put(self, log: UsageLog) -> None:
+        await self._queue.put(log)
+        log_writer_queue_depth.set(self._queue.qsize())
+
+    async def start(self) -> None:
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        await self._flush_all()
+
+    async def _run(self) -> None:
+        while True:
+            try:
+                batch = await self._collect_batch()
+                if batch:
+                    await self._flush(batch)
+            except asyncio.CancelledError:  # pragma: no cover - cooperative cancel
+                break
+            except Exception as e:  # pragma: no cover - defensive logging
+                logger.error("BatchLogWriter loop error: %s", e)
+
+    async def _collect_batch(self) -> list[UsageLog]:
+        batch: list[UsageLog] = []
+        try:
+            item = await asyncio.wait_for(self._queue.get(), timeout=self._flush_interval)
+            batch.append(item)
+            self._queue.task_done()
+        except asyncio.TimeoutError:
+            return batch
+
+        while len(batch) < self._max_batch:
+            try:
+                item = self._queue.get_nowait()
+                batch.append(item)
+                self._queue.task_done()
+            except asyncio.QueueEmpty:
+                break
+        return batch
+
+    async def _flush(self, batch: list[UsageLog]) -> None:
+        start = time.monotonic()
+        log_writer_batch_size.labels(writer="batch").observe(len(batch))
+        try:
+            async with create_session() as db:
+                for log in batch:
+                    db.add(log)
+                    if log.cost and log.user_id:
+                        await db.execute(
+                            update(User)
+                            .where(User.user_id == log.user_id, User.deleted_at.is_(None))
+                            .values(spend=User.spend + log.cost)
+                        )
+                await db.commit()
+                log_writer_rows.labels(writer="batch", result="written").inc(len(batch))
+            log_writer_flush_duration.labels(writer="batch", result="ok").observe(time.monotonic() - start)
+        except SQLAlchemyError as e:  # pragma: no cover - defensive logging
+            logger.error("BatchLogWriter flush failed, dropping %d rows: %s", len(batch), e)
+            log_writer_rows.labels(writer="batch", result="dropped").inc(len(batch))
+            log_writer_flush_duration.labels(writer="batch", result="error").observe(time.monotonic() - start)
+
+    async def _flush_all(self) -> None:
+        batch: list[UsageLog] = []
+        while not self._queue.empty():
+            try:
+                batch.append(self._queue.get_nowait())
+                self._queue.task_done()
+            except asyncio.QueueEmpty:
+                break
+        if batch:
+            await self._flush(batch)
+
+
+def create_log_writer(strategy: str) -> LogWriter:
+    if strategy == "batch":
+        return BatchLogWriter()
+    return SingleLogWriter()  # type: ignore[return-value]
+
+
+class NoopLogWriter:
+    """LogWriter implementation that discards all writes (used when DB is unavailable)."""
+
+    async def put(self, log: UsageLog) -> None:  # noqa: D401,B027 - trivial no-op
+        return None
+
+    async def start(self) -> None:  # noqa: D401,B027
+        return None
+
+    async def stop(self) -> None:  # noqa: D401,B027
+        return None

--- a/src/gateway/services/pricing_init_service.py
+++ b/src/gateway/services/pricing_init_service.py
@@ -1,28 +1,18 @@
 """Pricing initialization from configuration."""
 
 from any_llm import AnyLLM
+from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import ModelPricing
 
 
-def initialize_pricing_from_config(config: GatewayConfig, db: Session) -> None:
-    """Initialize model pricing from configuration file.
+async def initialize_pricing_from_config(config: GatewayConfig, db: AsyncSession) -> None:
+    """Initialize model pricing from configuration file."""
 
-    Loads pricing from config.pricing and stores it in the database.
-    Database pricing takes precedence - if pricing exists in DB, it is not overwritten.
-
-    Args:
-        config: Gateway configuration containing pricing definitions
-        db: Database session
-
-    Raises:
-        ValueError: If pricing is defined for a model from an unconfigured provider
-
-    """
     if not config.pricing:
         logger.debug("No pricing configuration found in config file")
         return
@@ -44,8 +34,8 @@ def initialize_pricing_from_config(config: GatewayConfig, db: Session) -> None:
         output_price = pricing_config.output_price_per_million
 
         existing_pricing = (
-            db.query(ModelPricing).filter(ModelPricing.model_key == model_key).first()
-        )
+            await db.execute(select(ModelPricing).where(ModelPricing.model_key == model_key))
+        ).scalar_one_or_none()
 
         if existing_pricing:
             logger.warning(
@@ -62,16 +52,11 @@ def initialize_pricing_from_config(config: GatewayConfig, db: Session) -> None:
             output_price_per_million=output_price,
         )
         db.add(new_pricing)
-        logger.info(
-            "Added pricing for '%s': input=$%s/M, output=$%s/M",
-            model_key,
-            input_price,
-            output_price,
-        )
+        logger.info("Added pricing for '%s': input=$%s/M, output=$%s/M", model_key, input_price, output_price)
 
     try:
-        db.commit()
+        await db.commit()
     except SQLAlchemyError:
-        db.rollback()
+        await db.rollback()
         raise
     logger.info("Pricing initialization complete")

--- a/src/gateway/services/pricing_service.py
+++ b/src/gateway/services/pricing_service.py
@@ -1,25 +1,20 @@
 """Shared pricing lookup utilities."""
 
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.models.entities import ModelPricing
 
 
-def find_model_pricing(db: Session, provider: str | None, model: str) -> ModelPricing | None:
-    """Look up model pricing, falling back to legacy slash-separated key format.
+async def find_model_pricing(db: AsyncSession, provider: str | None, model: str) -> ModelPricing | None:
+    """Look up model pricing, falling back to legacy slash-separated key format."""
 
-    Args:
-        db: Database session
-        provider: Provider name (e.g., "openai") or None
-        model: Model name (e.g., "gpt-4")
-
-    Returns:
-        ModelPricing object if found, None otherwise
-
-    """
     model_key = f"{provider}:{model}" if provider else model
-    pricing = db.query(ModelPricing).filter(ModelPricing.model_key == model_key).first()
-    if not pricing and provider:
-        legacy_key = f"{provider}/{model}"
-        pricing = db.query(ModelPricing).filter(ModelPricing.model_key == legacy_key).first()
-    return pricing
+    result = await db.execute(select(ModelPricing).where(ModelPricing.model_key == model_key))
+    pricing = result.scalar_one_or_none()
+    if pricing or not provider:
+        return pricing
+
+    legacy_key = f"{provider}/{model}"
+    legacy_result = await db.execute(select(ModelPricing).where(ModelPricing.model_key == legacy_key))
+    return legacy_result.scalar_one_or_none()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,19 +1,22 @@
+import asyncio
 import os
 import socket
 import sys
 import threading
 import time
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Callable, Generator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import pytest
+import pytest_asyncio
 import uvicorn
 from alembic import command
 from alembic.config import Config
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import Session, sessionmaker
 from testcontainers.postgres import PostgresContainer
 
@@ -41,15 +44,41 @@ def _run_alembic_migrations(database_url: str) -> None:
     command.upgrade(alembic_cfg, "head")
 
 
+def _to_async_url(database_url: str) -> str:
+    if database_url.startswith("postgresql+psycopg2://"):
+        return database_url.replace("postgresql+psycopg2://", "postgresql+asyncpg://", 1)
+    if database_url.startswith("postgresql://"):
+        return database_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    if database_url.startswith("sqlite:///") and not database_url.startswith("sqlite+aiosqlite"):
+        return database_url.replace("sqlite:///", "sqlite+aiosqlite:///", 1)
+    return database_url
+
+
+def build_async_session_override(
+    database_url: str,
+) -> tuple[Callable[[], AsyncGenerator[AsyncSession, None]], Callable[[], None]]:
+    """Return an async get_db override for ad-hoc FastAPI apps."""
+
+    async_engine = create_async_engine(_to_async_url(database_url), pool_pre_ping=True)
+    async_session_factory = async_sessionmaker(async_engine, expire_on_commit=False)
+
+    async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
+        async with async_session_factory() as session:
+            yield session
+
+    def dispose() -> None:
+        pass
+
+    return override_get_db, dispose
+
+
 @pytest.fixture(scope="session")
 def postgres_url() -> Generator[str]:
     """Get PostgreSQL URL from environment or start temporary container."""
     if url := os.getenv("TEST_DATABASE_URL"):
         yield url
     else:
-        postgres = PostgresContainer(
-            "postgres:17", username="test", password="test", dbname="test_db"
-        )  # noqa: S106
+        postgres = PostgresContainer("postgres:17", username="test", password="test", dbname="test_db")  # noqa: S106
         postgres.start()
         try:
             yield postgres.get_connection_url()
@@ -74,6 +103,26 @@ def test_db(postgres_url: str) -> Generator[Session]:
         with engine.connect() as conn:
             conn.execute(text("DROP TABLE IF EXISTS alembic_version CASCADE"))
             conn.commit()
+
+
+@pytest_asyncio.fixture
+async def async_db(postgres_url: str) -> AsyncGenerator[AsyncSession, None]:
+    """Create an async test database session."""
+    _run_alembic_migrations(postgres_url)
+    async_engine = create_async_engine(_to_async_url(postgres_url), pool_pre_ping=True)
+    async_session_factory = async_sessionmaker(async_engine, expire_on_commit=False)
+
+    try:
+        async with async_session_factory() as session:
+            yield session
+    finally:
+        await async_engine.dispose()
+        engine = create_engine(postgres_url, pool_pre_ping=True)
+        Base.metadata.drop_all(bind=engine)
+        with engine.connect() as conn:
+            conn.execute(text("DROP TABLE IF EXISTS alembic_version CASCADE"))
+            conn.commit()
+        engine.dispose()
 
 
 @pytest.fixture
@@ -103,21 +152,15 @@ def test_config(postgres_url: str) -> GatewayConfig:
 @pytest.fixture
 def client(test_config: GatewayConfig) -> Generator[TestClient]:
     """Create a test client for the FastAPI app."""
-    from sqlalchemy import text
-
     _run_alembic_migrations(test_config.database_url)
     engine = create_engine(test_config.database_url, pool_pre_ping=True)
+    async_engine = create_async_engine(_to_async_url(test_config.database_url), pool_pre_ping=True)
+    async_session_factory = async_sessionmaker(async_engine, expire_on_commit=False)
     app = create_app(test_config)
 
-    def override_get_db() -> Generator[Session]:
-        testing_session_local = sessionmaker(
-            autocommit=False, autoflush=False, bind=engine
-        )
-        db = testing_session_local()
-        try:
-            yield db
-        finally:
-            db.close()
+    async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
+        async with async_session_factory() as session:
+            yield session
 
     app.dependency_overrides[get_db] = override_get_db
 
@@ -129,6 +172,12 @@ def client(test_config: GatewayConfig) -> Generator[TestClient]:
         with engine.connect() as conn:
             conn.execute(text("DROP TABLE IF EXISTS alembic_version CASCADE"))
             conn.commit()
+        try:
+            asyncio.run(async_engine.dispose())
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            loop.run_until_complete(async_engine.dispose())
+            loop.close()
 
 
 @pytest.fixture
@@ -139,9 +188,7 @@ def master_key_header(test_config: GatewayConfig) -> dict[str, str]:
 
 
 @pytest.fixture
-def api_key_obj(
-    client: TestClient, master_key_header: dict[str, str]
-) -> dict[str, Any]:
+def api_key_obj(client: TestClient, master_key_header: dict[str, str]) -> dict[str, Any]:
     """Create a test API key and return its details."""
     response = client.post(
         "/v1/keys",
@@ -154,9 +201,7 @@ def api_key_obj(
 
 
 @pytest.fixture
-def api_key_header(
-    test_config: GatewayConfig, api_key_obj: dict[str, Any]
-) -> dict[str, str]:
+def api_key_header(test_config: GatewayConfig, api_key_obj: dict[str, Any]) -> dict[str, str]:
     """Return authentication header with API key."""
     header_name = API_KEY_HEADER
     return {header_name: f"Bearer {api_key_obj['key']}"}
@@ -188,9 +233,7 @@ def test_messages_with_longer_response() -> list[dict[str, str]]:
 
 
 @pytest.fixture
-def model_pricing(
-    client: TestClient, master_key_header: dict[str, str]
-) -> dict[str, Any]:
+def model_pricing(client: TestClient, master_key_header: dict[str, str]) -> dict[str, Any]:
     """Create model pricing for gemini-2.5-flash."""
     response = client.post(
         "/v1/pricing",
@@ -215,9 +258,7 @@ class LiveServer:
 
 
 @pytest.fixture
-def live_server(
-    test_config: GatewayConfig, api_key_obj: dict[str, Any]
-) -> Generator[LiveServer]:
+def live_server(test_config: GatewayConfig, api_key_obj: dict[str, Any]) -> Generator[LiveServer]:
     """Start a live uvicorn server and yield its URL and API key."""
     # Find an available port
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:

--- a/tests/integration/test_atomic_spend_update.py
+++ b/tests/integration/test_atomic_spend_update.py
@@ -1,33 +1,45 @@
 """Tests for atomic spend update via SQL expression."""
 
+from contextlib import asynccontextmanager
+
 import pytest
 from any_llm.types.completion import CompletionUsage
 from sqlalchemy.orm import Session
 
 from gateway.api.routes.chat import log_usage
 from gateway.models.entities import ModelPricing, User
+from gateway.services.log_writer import SingleLogWriter
 
 
 @pytest.mark.asyncio
-async def test_spend_update_uses_sql_expression(test_db: Session) -> None:
+async def test_spend_update_uses_sql_expression(async_db: Session, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that _log_usage updates spend atomically via SQL, not Python read-modify-write."""
     # Set up user with initial spend
     user = User(user_id="atomic-user", spend=5.0)
-    test_db.add(user)
+    async_db.add(user)
 
     pricing = ModelPricing(
         model_key="openai:gpt-4o",
         input_price_per_million=2.5,
         output_price_per_million=10.0,
     )
-    test_db.add(pricing)
-    test_db.commit()
+    async_db.add(pricing)
+    await async_db.commit()
 
     usage = CompletionUsage(prompt_tokens=1_000_000, completion_tokens=100_000, total_tokens=1_100_000)
 
+    writer = SingleLogWriter()
+
+    @asynccontextmanager
+    async def _session_cm():
+        yield async_db
+
+    monkeypatch.setattr("gateway.services.log_writer.create_session", lambda: _session_cm())
+
     await log_usage(
-        db=test_db,
-        api_key_obj=None,
+        db=async_db,
+        log_writer=writer,
+        api_key_id=None,
         model="gpt-4o",
         provider="openai",
         endpoint="/v1/chat/completions",
@@ -35,9 +47,8 @@ async def test_spend_update_uses_sql_expression(test_db: Session) -> None:
         usage_override=usage,
     )
 
-    # Refresh from database
-    test_db.expire_all()
-    updated_user = test_db.query(User).filter(User.user_id == "atomic-user").first()
+    await async_db.refresh(user)
+    updated_user = user
     assert updated_user is not None
 
     # Expected cost: (1M / 1M) * 2.5 + (100K / 1M) * 10.0 = 2.5 + 1.0 = 3.5
@@ -48,24 +59,33 @@ async def test_spend_update_uses_sql_expression(test_db: Session) -> None:
 
 
 @pytest.mark.asyncio
-async def test_multiple_spend_updates_accumulate(test_db: Session) -> None:
+async def test_multiple_spend_updates_accumulate(async_db: Session, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that multiple sequential spend updates accumulate correctly."""
     user = User(user_id="multi-spend-user", spend=0.0)
-    test_db.add(user)
+    async_db.add(user)
 
     pricing = ModelPricing(
         model_key="openai:gpt-4o",
         input_price_per_million=10.0,
         output_price_per_million=10.0,
     )
-    test_db.add(pricing)
-    test_db.commit()
+    async_db.add(pricing)
+    await async_db.commit()
+
+    writer = SingleLogWriter()
+
+    @asynccontextmanager
+    async def _session_cm():
+        yield async_db
+
+    monkeypatch.setattr("gateway.services.log_writer.create_session", lambda: _session_cm())
 
     for _ in range(3):
         usage = CompletionUsage(prompt_tokens=1_000_000, completion_tokens=1_000_000, total_tokens=2_000_000)
         await log_usage(
-            db=test_db,
-            api_key_obj=None,
+            db=async_db,
+            log_writer=writer,
+            api_key_id=None,
             model="gpt-4o",
             provider="openai",
             endpoint="/v1/chat/completions",
@@ -73,8 +93,8 @@ async def test_multiple_spend_updates_accumulate(test_db: Session) -> None:
             usage_override=usage,
         )
 
-    test_db.expire_all()
-    updated_user = test_db.query(User).filter(User.user_id == "multi-spend-user").first()
+    await async_db.refresh(user)
+    updated_user = user
     assert updated_user is not None
 
     # Each call: (1M/1M)*10 + (1M/1M)*10 = 20.0, x3 = 60.0

--- a/tests/integration/test_budget_race_condition.py
+++ b/tests/integration/test_budget_race_condition.py
@@ -12,28 +12,28 @@ from gateway.services.budget_service import validate_user_budget
 
 @pytest.mark.asyncio
 async def test_validate_user_budget_reads_user_without_locking(
-    test_db: Any,
+    async_db: Any,
 ) -> None:
     """validate_user_budget should allow under-limit users without lock contention."""
     budget = Budget(
         budget_id="race-budget",
         max_budget=10.0,
     )
-    test_db.add(budget)
+    async_db.add(budget)
 
     user = User(
         user_id="race-user",
         spend=9.99,
         budget_id="race-budget",
     )
-    test_db.add(user)
-    test_db.commit()
+    async_db.add(user)
+    await async_db.commit()
 
     with patch(
         "gateway.services.budget_service.get_active_user",
         wraps=get_active_user,
     ) as mock_get_active_user:
-        result = await validate_user_budget(test_db, "race-user")
+        result = await validate_user_budget(async_db, "race-user", strategy="cas")
 
     assert result.user_id == "race-user"
     assert mock_get_active_user.call_args.kwargs.get("for_update", False) is False
@@ -41,7 +41,7 @@ async def test_validate_user_budget_reads_user_without_locking(
 
 @pytest.mark.asyncio
 async def test_budget_check_rejects_at_limit(
-    test_db: Any,
+    async_db: Any,
 ) -> None:
     """Test that a user at or over budget limit is rejected."""
     from fastapi import HTTPException
@@ -50,16 +50,16 @@ async def test_budget_check_rejects_at_limit(
         budget_id="full-budget",
         max_budget=10.0,
     )
-    test_db.add(budget)
+    async_db.add(budget)
 
     user = User(
         user_id="full-user",
         spend=10.0,
         budget_id="full-budget",
     )
-    test_db.add(user)
-    test_db.commit()
+    async_db.add(user)
+    await async_db.commit()
 
     with pytest.raises(HTTPException) as exc_info:
-        await validate_user_budget(test_db, "full-user")
+        await validate_user_budget(async_db, "full-user")
     assert exc_info.value.status_code == 403

--- a/tests/integration/test_client_args.py
+++ b/tests/integration/test_client_args.py
@@ -1,17 +1,19 @@
-from collections.abc import Generator
+import asyncio
+from collections.abc import AsyncGenerator, Generator
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import Session, sessionmaker
 
 from gateway.core.config import GatewayConfig
 from gateway.db import get_db
 from gateway.main import create_app
 
-from .conftest import _run_alembic_migrations
+from .conftest import _run_alembic_migrations, _to_async_url
 
 
 class MockCompletionError(Exception):
@@ -49,15 +51,13 @@ def client_with_client_args(config_with_client_args: GatewayConfig) -> Generator
 
     _run_alembic_migrations(config_with_client_args.database_url)
     engine = create_engine(config_with_client_args.database_url, pool_pre_ping=True)
+    async_engine = create_async_engine(_to_async_url(config_with_client_args.database_url), pool_pre_ping=True)
+    async_session_factory = async_sessionmaker(async_engine, expire_on_commit=False)
     app = create_app(config_with_client_args)
 
-    def override_get_db() -> Generator[Session]:
-        testing_session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-        db = testing_session_local()
-        try:
-            yield db
-        finally:
-            db.close()
+    async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
+        async with async_session_factory() as session:
+            yield session
 
     app.dependency_overrides[get_db] = override_get_db
 
@@ -69,6 +69,12 @@ def client_with_client_args(config_with_client_args: GatewayConfig) -> Generator
         with engine.connect() as conn:
             conn.execute(text("DROP TABLE IF EXISTS alembic_version CASCADE"))
             conn.commit()
+        try:
+            asyncio.run(async_engine.dispose())
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            loop.run_until_complete(async_engine.dispose())
+            loop.close()
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_cors_configuration.py
+++ b/tests/integration/test_cors_configuration.py
@@ -9,6 +9,8 @@ from gateway.core.config import GatewayConfig
 from gateway.db import get_db
 from gateway.main import create_app
 
+from .conftest import build_async_session_override
+
 
 def test_cors_disabled_by_default(postgres_url: str, test_db: Session) -> None:
     """Test that CORS middleware is not added when cors_allow_origins is empty."""
@@ -20,16 +22,16 @@ def test_cors_disabled_by_default(postgres_url: str, test_db: Session) -> None:
     )
 
     app = create_app(config)
-
-    def override_get_db() -> Any:
-        yield test_db
-
+    override_get_db, dispose_override = build_async_session_override(postgres_url)
     app.dependency_overrides[get_db] = override_get_db
 
-    with TestClient(app) as client:
-        response = client.get("/health", headers={"Origin": "https://evil.com"})
-        assert response.status_code == 200
-        assert "access-control-allow-origin" not in response.headers
+    try:
+        with TestClient(app) as client:
+            response = client.get("/health", headers={"Origin": "https://evil.com"})
+            assert response.status_code == 200
+            assert "access-control-allow-origin" not in response.headers
+    finally:
+        dispose_override()
 
 
 def test_cors_with_specific_origins(postgres_url: str, test_db: Session) -> None:
@@ -43,23 +45,23 @@ def test_cors_with_specific_origins(postgres_url: str, test_db: Session) -> None
     )
 
     app = create_app(config)
-
-    def override_get_db() -> Any:
-        yield test_db
-
+    override_get_db, dispose_override = build_async_session_override(postgres_url)
     app.dependency_overrides[get_db] = override_get_db
 
-    with TestClient(app) as client:
-        # Trusted origin should get CORS headers
-        response = client.get("/health", headers={"Origin": "https://trusted.com"})
-        assert response.status_code == 200
-        assert response.headers.get("access-control-allow-origin") == "https://trusted.com"
-        assert response.headers.get("access-control-allow-credentials") == "true"
+    try:
+        with TestClient(app) as client:
+            # Trusted origin should get CORS headers
+            response = client.get("/health", headers={"Origin": "https://trusted.com"})
+            assert response.status_code == 200
+            assert response.headers.get("access-control-allow-origin") == "https://trusted.com"
+            assert response.headers.get("access-control-allow-credentials") == "true"
 
-        # Untrusted origin should not get CORS headers
-        response = client.get("/health", headers={"Origin": "https://evil.com"})
-        assert response.status_code == 200
-        assert response.headers.get("access-control-allow-origin") != "https://evil.com"
+            # Untrusted origin should not get CORS headers
+            response = client.get("/health", headers={"Origin": "https://evil.com"})
+            assert response.status_code == 200
+            assert response.headers.get("access-control-allow-origin") != "https://evil.com"
+    finally:
+        dispose_override()
 
 
 def test_cors_wildcard_disables_credentials(postgres_url: str, test_db: Session) -> None:
@@ -73,15 +75,15 @@ def test_cors_wildcard_disables_credentials(postgres_url: str, test_db: Session)
     )
 
     app = create_app(config)
-
-    def override_get_db() -> Any:
-        yield test_db
-
+    override_get_db, dispose_override = build_async_session_override(postgres_url)
     app.dependency_overrides[get_db] = override_get_db
 
-    with TestClient(app) as client:
-        response = client.get("/health", headers={"Origin": "https://any-site.com"})
-        assert response.status_code == 200
-        assert response.headers.get("access-control-allow-origin") == "*"
-        # Credentials should NOT be allowed with wildcard
-        assert response.headers.get("access-control-allow-credentials") != "true"
+    try:
+        with TestClient(app) as client:
+            response = client.get("/health", headers={"Origin": "https://any-site.com"})
+            assert response.status_code == 200
+            assert response.headers.get("access-control-allow-origin") == "*"
+            # Credentials should NOT be allowed with wildcard
+            assert response.headers.get("access-control-allow-credentials") != "true"
+    finally:
+        dispose_override()

--- a/tests/integration/test_find_model_pricing.py
+++ b/tests/integration/test_find_model_pricing.py
@@ -1,54 +1,60 @@
 """Tests for the shared find_model_pricing helper."""
 
-from sqlalchemy.orm import Session
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.db import ModelPricing
 from gateway.services.pricing_service import find_model_pricing
 
 
-def test_find_pricing_colon_format(test_db: Session) -> None:
+@pytest.mark.asyncio
+async def test_find_pricing_colon_format(async_db: AsyncSession) -> None:
     """Test lookup with canonical colon-separated key."""
-    test_db.add(ModelPricing(model_key="openai:gpt-4", input_price_per_million=30.0, output_price_per_million=60.0))
-    test_db.commit()
+    async_db.add(ModelPricing(model_key="openai:gpt-4", input_price_per_million=30.0, output_price_per_million=60.0))
+    await async_db.commit()
 
-    pricing = find_model_pricing(test_db, "openai", "gpt-4")
+    pricing = await find_model_pricing(async_db, "openai", "gpt-4")
     assert pricing is not None
     assert pricing.input_price_per_million == 30.0
 
 
-def test_find_pricing_legacy_slash_fallback(test_db: Session) -> None:
+@pytest.mark.asyncio
+async def test_find_pricing_legacy_slash_fallback(async_db: AsyncSession) -> None:
     """Test fallback to legacy slash-separated key when colon key is missing."""
-    test_db.add(ModelPricing(model_key="openai/gpt-4", input_price_per_million=30.0, output_price_per_million=60.0))
-    test_db.commit()
+    async_db.add(ModelPricing(model_key="openai/gpt-4", input_price_per_million=30.0, output_price_per_million=60.0))
+    await async_db.commit()
 
-    pricing = find_model_pricing(test_db, "openai", "gpt-4")
+    pricing = await find_model_pricing(async_db, "openai", "gpt-4")
     assert pricing is not None
     assert pricing.model_key == "openai/gpt-4"
 
 
-def test_find_pricing_no_provider(test_db: Session) -> None:
+@pytest.mark.asyncio
+async def test_find_pricing_no_provider(async_db: AsyncSession) -> None:
     """Test lookup without a provider uses model name directly."""
-    test_db.add(ModelPricing(model_key="gpt-4", input_price_per_million=30.0, output_price_per_million=60.0))
-    test_db.commit()
+    async_db.add(ModelPricing(model_key="gpt-4", input_price_per_million=30.0, output_price_per_million=60.0))
+    await async_db.commit()
 
-    pricing = find_model_pricing(test_db, None, "gpt-4")
+    pricing = await find_model_pricing(async_db, None, "gpt-4")
     assert pricing is not None
     assert pricing.model_key == "gpt-4"
 
 
-def test_find_pricing_not_found(test_db: Session) -> None:
+@pytest.mark.asyncio
+async def test_find_pricing_not_found(async_db: AsyncSession) -> None:
     """Test that None is returned when no pricing exists."""
-    pricing = find_model_pricing(test_db, "openai", "nonexistent-model")
+    pricing = await find_model_pricing(async_db, "openai", "nonexistent-model")
     assert pricing is None
 
 
-def test_find_pricing_colon_preferred_over_slash(test_db: Session) -> None:
+@pytest.mark.asyncio
+async def test_find_pricing_colon_preferred_over_slash(async_db: AsyncSession) -> None:
     """Test that colon format is returned when both formats exist."""
-    test_db.add(ModelPricing(model_key="openai:gpt-4", input_price_per_million=30.0, output_price_per_million=60.0))
-    test_db.add(ModelPricing(model_key="openai/gpt-4", input_price_per_million=10.0, output_price_per_million=20.0))
-    test_db.commit()
+    async_db.add(ModelPricing(model_key="openai:gpt-4", input_price_per_million=30.0, output_price_per_million=60.0))
+    async_db.add(ModelPricing(model_key="openai/gpt-4", input_price_per_million=10.0, output_price_per_million=20.0))
+    await async_db.commit()
 
-    pricing = find_model_pricing(test_db, "openai", "gpt-4")
+    pricing = await find_model_pricing(async_db, "openai", "gpt-4")
     assert pricing is not None
     assert pricing.model_key == "openai:gpt-4"
     assert pricing.input_price_per_million == 30.0

--- a/tests/integration/test_log_usage_commit_scope.py
+++ b/tests/integration/test_log_usage_commit_scope.py
@@ -1,94 +1,75 @@
-"""Tests for usage logging commit scope isolation."""
+"""Tests for usage logging via the log writer abstraction."""
 
-from unittest.mock import patch
+from __future__ import annotations
+
+from dataclasses import dataclass
 
 import pytest
 from any_llm.types.completion import CompletionUsage
-from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import Session
 
 from gateway.api.routes.chat import log_usage
-from gateway.models.entities import UsageLog
+from gateway.models.entities import ModelPricing, UsageLog
+
+
+@dataclass
+class StubLogWriter:
+    logs: list[UsageLog]
+
+    def __init__(self) -> None:
+        self.logs = []
+
+    async def put(self, log: UsageLog) -> None:
+        self.logs.append(log)
+
+    async def start(self) -> None:  # pragma: no cover - not used
+        return None
+
+    async def stop(self) -> None:  # pragma: no cover - not used
+        return None
 
 
 @pytest.mark.asyncio
-async def test_log_usage_creates_usage_log(test_db: Session) -> None:
-    """Test that log_usage successfully creates a usage log entry."""
-    usage = CompletionUsage(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+async def test_log_usage_records_usage_data(async_db) -> None:
+    pricing = ModelPricing(model_key="openai:gpt-4o", input_price_per_million=2.0, output_price_per_million=4.0)
+    async_db.add(pricing)
+    await async_db.commit()
+
+    usage = CompletionUsage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+    writer = StubLogWriter()
 
     await log_usage(
-        db=test_db,
-        api_key_obj=None,
+        db=async_db,
+        log_writer=writer,
+        api_key_id=None,
         model="gpt-4o",
         provider="openai",
         endpoint="/v1/chat/completions",
         usage_override=usage,
     )
 
-    log = test_db.query(UsageLog).first()
-    assert log is not None
-    assert log.prompt_tokens == 100
-    assert log.completion_tokens == 50
+    assert len(writer.logs) == 1
+    log = writer.logs[0]
+    assert log.prompt_tokens == 1000
+    assert log.completion_tokens == 500
+    assert log.cost == pytest.approx((1000 / 1_000_000) * 2.0 + (500 / 1_000_000) * 4.0)
     assert log.status == "success"
 
 
 @pytest.mark.asyncio
-async def test_log_usage_records_error(test_db: Session) -> None:
-    """Test that log_usage records error status and message."""
+async def test_log_usage_records_error(async_db) -> None:
+    writer = StubLogWriter()
+
     await log_usage(
-        db=test_db,
-        api_key_obj=None,
+        db=async_db,
+        log_writer=writer,
+        api_key_id=None,
         model="gpt-4o",
         provider="openai",
         endpoint="/v1/chat/completions",
         error="Provider timeout",
     )
 
-    log = test_db.query(UsageLog).first()
-    assert log is not None
+    assert len(writer.logs) == 1
+    log = writer.logs[0]
     assert log.status == "error"
     assert log.error_message == "Provider timeout"
-
-
-@pytest.mark.asyncio
-async def test_log_usage_does_not_use_savepoint(test_db: Session) -> None:
-    """Test that log_usage commits directly without a savepoint."""
-    usage = CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
-
-    with patch.object(test_db, "begin_nested", wraps=test_db.begin_nested) as mock_nested:
-        await log_usage(
-            db=test_db,
-            api_key_obj=None,
-            model="gpt-4o",
-            provider="openai",
-            endpoint="/v1/chat/completions",
-            usage_override=usage,
-        )
-        mock_nested.assert_not_called()
-
-    log = test_db.query(UsageLog).first()
-    assert log is not None
-    assert log.total_tokens == 15
-
-
-@pytest.mark.asyncio
-async def test_log_usage_rollback_on_commit_failure(test_db: Session) -> None:
-    """Test that log_usage rolls back cleanly when commit fails."""
-    usage = CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
-
-    with (
-        patch.object(test_db, "commit", side_effect=OperationalError("db", {}, Exception("db gone"))),
-        patch.object(test_db, "rollback", wraps=test_db.rollback) as mock_rollback,
-    ):
-        await log_usage(
-            db=test_db,
-            api_key_obj=None,
-            model="gpt-4o",
-            provider="openai",
-            endpoint="/v1/chat/completions",
-            usage_override=usage,
-        )
-        mock_rollback.assert_called_once()
-
-    log = test_db.query(UsageLog).first()
-    assert log is None

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -1,20 +1,21 @@
 """Tests for Prometheus metrics instrumentation."""
 
-from collections.abc import Generator
+import asyncio
+from collections.abc import AsyncGenerator, Generator
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, text
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from gateway.core.config import API_KEY_HEADER, GatewayConfig
 from gateway.db import Base, get_db
 from gateway.main import create_app
 from gateway.metrics import REGISTRY
 
-from .conftest import _run_alembic_migrations
+from .conftest import _run_alembic_migrations, _to_async_url
 
 
 def _sample(name: str, labels: dict[str, str] | None = None) -> float:
@@ -39,15 +40,13 @@ def _make_metrics_client(
     )
     _run_alembic_migrations(postgres_url)
     engine = create_engine(postgres_url, pool_pre_ping=True)
+    async_engine = create_async_engine(_to_async_url(postgres_url), pool_pre_ping=True)
+    async_session_factory = async_sessionmaker(async_engine, expire_on_commit=False)
     app = create_app(config)
 
-    def override_get_db() -> Generator[Session]:
-        testing_session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-        db = testing_session_local()
-        try:
-            yield db
-        finally:
-            db.close()
+    async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
+        async with async_session_factory() as session:
+            yield session
 
     app.dependency_overrides[get_db] = override_get_db
 
@@ -59,6 +58,12 @@ def _make_metrics_client(
         with engine.connect() as conn:
             conn.execute(text("DROP TABLE IF EXISTS alembic_version CASCADE"))
             conn.commit()
+        try:
+            asyncio.run(async_engine.dispose())
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            loop.run_until_complete(async_engine.dispose())
+            loop.close()
 
 
 @pytest.fixture

--- a/tests/integration/test_pricing_config.py
+++ b/tests/integration/test_pricing_config.py
@@ -13,6 +13,8 @@ from gateway.db import ModelPricing, get_db
 from gateway.main import create_app
 from gateway.models.entities import UsageLog
 
+from .conftest import build_async_session_override
+
 
 def test_pricing_loaded_from_config(postgres_url: str, test_db: Session) -> None:
     """Test that pricing is loaded from config file on startup."""
@@ -35,24 +37,24 @@ def test_pricing_loaded_from_config(postgres_url: str, test_db: Session) -> None
     )
 
     app = create_app(config)
-
-    def override_get_db() -> Any:
-        yield test_db
-
+    override_get_db, dispose_override = build_async_session_override(postgres_url)
     app.dependency_overrides[get_db] = override_get_db
 
-    with TestClient(app):
-        # Check GPT-4 pricing
-        pricing = test_db.query(ModelPricing).filter(ModelPricing.model_key == "openai:gpt-4").first()
-        assert pricing is not None, "GPT-4 pricing should be loaded from config"
-        assert pricing.input_price_per_million == 30.0
-        assert pricing.output_price_per_million == 60.0
+    try:
+        with TestClient(app):
+            # Check GPT-4 pricing
+            pricing = test_db.query(ModelPricing).filter(ModelPricing.model_key == "openai:gpt-4").first()
+            assert pricing is not None, "GPT-4 pricing should be loaded from config"
+            assert pricing.input_price_per_million == 30.0
+            assert pricing.output_price_per_million == 60.0
 
-        # Check GPT-3.5 pricing
-        pricing = test_db.query(ModelPricing).filter(ModelPricing.model_key == "openai:gpt-3.5-turbo").first()
-        assert pricing is not None, "GPT-3.5-turbo pricing should be loaded from config"
-        assert pricing.input_price_per_million == 0.5
-        assert pricing.output_price_per_million == 1.5
+            # Check GPT-3.5 pricing
+            pricing = test_db.query(ModelPricing).filter(ModelPricing.model_key == "openai:gpt-3.5-turbo").first()
+            assert pricing is not None, "GPT-3.5-turbo pricing should be loaded from config"
+            assert pricing.input_price_per_million == 0.5
+            assert pricing.output_price_per_million == 1.5
+    finally:
+        dispose_override()
 
 
 def test_database_pricing_takes_precedence(postgres_url: str, test_db: Session) -> None:
@@ -82,22 +84,22 @@ def test_database_pricing_takes_precedence(postgres_url: str, test_db: Session) 
 
     # Create app (which loads config pricing)
     app = create_app(config)
-
-    def override_get_db() -> Any:
-        yield test_db
-
+    override_get_db, dispose_override = build_async_session_override(postgres_url)
     app.dependency_overrides[get_db] = override_get_db
 
-    with TestClient(app):
-        # Check that database pricing was preserved
-        pricing = test_db.query(ModelPricing).filter(ModelPricing.model_key == "openai:gpt-4").first()
-        assert pricing is not None
-        # Should keep database values, not config values
-        assert pricing.input_price_per_million == 25.0
-        assert pricing.output_price_per_million == 50.0
+    try:
+        with TestClient(app):
+            # Check that database pricing was preserved
+            pricing = test_db.query(ModelPricing).filter(ModelPricing.model_key == "openai:gpt-4").first()
+            assert pricing is not None
+            # Should keep database values, not config values
+            assert pricing.input_price_per_million == 25.0
+            assert pricing.output_price_per_million == 50.0
+    finally:
+        dispose_override()
 
 
-def test_pricing_validation_requires_configured_provider(postgres_url: str, test_db: Session) -> None:
+def test_pricing_validation_requires_configured_provider(postgres_url: str) -> None:
     """Test that pricing initialization fails if provider is not configured."""
     # Config with pricing for a provider that's not in providers list
     config = GatewayConfig(
@@ -115,8 +117,11 @@ def test_pricing_validation_requires_configured_provider(postgres_url: str, test
     )
 
     # Should raise ValueError when trying to initialize pricing
+    app = create_app(config)
+
     with pytest.raises(ValueError, match="provider 'anthropic' is not configured"):
-        create_app(config)
+        with TestClient(app):
+            pass
 
 
 def test_pricing_loaded_from_config_normalizes_legacy_slash_format(postgres_url: str, test_db: Session) -> None:
@@ -136,21 +141,21 @@ def test_pricing_loaded_from_config_normalizes_legacy_slash_format(postgres_url:
     )
 
     app = create_app(config)
-
-    def override_get_db() -> Any:
-        yield test_db
-
+    override_get_db, dispose_override = build_async_session_override(postgres_url)
     app.dependency_overrides[get_db] = override_get_db
 
-    with TestClient(app):
-        # Pricing should be stored with canonical colon format, not slash
-        pricing_slash = test_db.query(ModelPricing).filter(ModelPricing.model_key == "openai/gpt-4").first()
-        assert pricing_slash is None, "Pricing should not be stored with legacy slash format"
+    try:
+        with TestClient(app):
+            # Pricing should be stored with canonical colon format, not slash
+            pricing_slash = test_db.query(ModelPricing).filter(ModelPricing.model_key == "openai/gpt-4").first()
+            assert pricing_slash is None, "Pricing should not be stored with legacy slash format"
 
-        pricing_colon = test_db.query(ModelPricing).filter(ModelPricing.model_key == "openai:gpt-4").first()
-        assert pricing_colon is not None, "Pricing should be stored with canonical colon format"
-        assert pricing_colon.input_price_per_million == 30.0
-        assert pricing_colon.output_price_per_million == 60.0
+            pricing_colon = test_db.query(ModelPricing).filter(ModelPricing.model_key == "openai:gpt-4").first()
+            assert pricing_colon is not None, "Pricing should be stored with canonical colon format"
+            assert pricing_colon.input_price_per_million == 30.0
+            assert pricing_colon.output_price_per_million == 60.0
+    finally:
+        dispose_override()
 
 
 def test_set_pricing_api_normalizes_legacy_slash_format(
@@ -184,73 +189,90 @@ def test_pricing_initialization_with_no_config(postgres_url: str, test_db: Sessi
     )
 
     app = create_app(config)
-
-    def override_get_db() -> Any:
-        yield test_db
-
+    override_get_db, dispose_override = build_async_session_override(postgres_url)
     app.dependency_overrides[get_db] = override_get_db
 
-    with TestClient(app):
-        # App should start successfully
-        # No pricing should be in database
-        pricing_count = test_db.query(ModelPricing).count()
-        assert pricing_count == 0, "No pricing should be loaded when config is empty"
+    try:
+        with TestClient(app):
+            # App should start successfully
+            # No pricing should be in database
+            pricing_count = test_db.query(ModelPricing).count()
+            assert pricing_count == 0, "No pricing should be loaded when config is empty"
+    finally:
+        dispose_override()
 
 
 @pytest.mark.asyncio
-async def test_log_usage_finds_pricing_with_legacy_slash_format(test_db: Session) -> None:
-    """Test that _log_usage falls back to legacy slash format when colon format is not found."""
-    # Simulate pricing stored with legacy slash format (e.g., from before normalization fix)
+async def test_log_usage_finds_pricing_with_legacy_slash_format(async_db) -> None:
+    """Test that log_usage falls back to legacy slash format when colon format is absent."""
+
+    class _Writer:
+        def __init__(self) -> None:
+            self.logs: list[UsageLog] = []
+
+        async def put(self, log: UsageLog) -> None:
+            self.logs.append(log)
+
     legacy_pricing = ModelPricing(
         model_key="openai/gpt-4",
         input_price_per_million=30.0,
         output_price_per_million=60.0,
     )
-    test_db.add(legacy_pricing)
-    test_db.commit()
+    async_db.add(legacy_pricing)
+    await async_db.commit()
 
     usage = CompletionUsage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+    writer = _Writer()
 
     await log_usage(
-        db=test_db,
-        api_key_obj=None,
+        db=async_db,
+        log_writer=writer,
+        api_key_id=None,
         model="gpt-4",
         provider="openai",
         endpoint="/v1/chat/completions",
         usage_override=usage,
     )
 
-    log = test_db.query(UsageLog).first()
-    assert log is not None
-    assert log.cost is not None, "Cost should be calculated via legacy slash format fallback"
+    assert len(writer.logs) == 1
+    log = writer.logs[0]
     expected_cost = (1000 / 1_000_000) * 30.0 + (500 / 1_000_000) * 60.0
-    assert abs(log.cost - expected_cost) < 0.0001
+    assert log.cost == pytest.approx(expected_cost)
 
 
 @pytest.mark.asyncio
-async def test_log_usage_finds_pricing_with_colon_format(test_db: Session) -> None:
-    """Test that _log_usage finds pricing with canonical colon format."""
+async def test_log_usage_finds_pricing_with_colon_format(async_db) -> None:
+    """Test that log_usage uses canonical colon pricing when available."""
+
+    class _Writer:
+        def __init__(self) -> None:
+            self.logs: list[UsageLog] = []
+
+        async def put(self, log: UsageLog) -> None:
+            self.logs.append(log)
+
     pricing = ModelPricing(
         model_key="openai:gpt-4",
         input_price_per_million=30.0,
         output_price_per_million=60.0,
     )
-    test_db.add(pricing)
-    test_db.commit()
+    async_db.add(pricing)
+    await async_db.commit()
 
     usage = CompletionUsage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+    writer = _Writer()
 
     await log_usage(
-        db=test_db,
-        api_key_obj=None,
+        db=async_db,
+        log_writer=writer,
+        api_key_id=None,
         model="gpt-4",
         provider="openai",
         endpoint="/v1/chat/completions",
         usage_override=usage,
     )
 
-    log = test_db.query(UsageLog).first()
-    assert log is not None
-    assert log.cost is not None, "Cost should be calculated with canonical colon format"
+    assert len(writer.logs) == 1
+    log = writer.logs[0]
     expected_cost = (1000 / 1_000_000) * 30.0 + (500 / 1_000_000) * 60.0
-    assert abs(log.cost - expected_cost) < 0.0001
+    assert log.cost == pytest.approx(expected_cost)

--- a/tests/integration/test_provider_kwargs_override.py
+++ b/tests/integration/test_provider_kwargs_override.py
@@ -8,14 +8,13 @@ import pytest
 from any_llm import LLMProvider
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, text
-from sqlalchemy.orm import Session, sessionmaker
 
 from gateway.api.routes.chat import get_provider_kwargs
 from gateway.core.config import GatewayConfig
 from gateway.db import Base, get_db
 from gateway.main import create_app
 
-from .conftest import _run_alembic_migrations
+from .conftest import _run_alembic_migrations, build_async_session_override
 
 
 class _MockCompletionError(Exception):
@@ -46,21 +45,14 @@ def client_with_model_in_provider(config_with_model_in_provider: GatewayConfig) 
     _run_alembic_migrations(config_with_model_in_provider.database_url)
     engine = create_engine(config_with_model_in_provider.database_url, pool_pre_ping=True)
     app = create_app(config_with_model_in_provider)
-
-    def override_get_db() -> Generator[Session]:
-        testing_session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-        db = testing_session_local()
-        try:
-            yield db
-        finally:
-            db.close()
-
+    override_get_db, dispose_override = build_async_session_override(config_with_model_in_provider.database_url)
     app.dependency_overrides[get_db] = override_get_db
 
     try:
         with TestClient(app) as test_client:
             yield test_client
     finally:
+        dispose_override()
         Base.metadata.drop_all(bind=engine)
         with engine.connect() as conn:
             conn.execute(text("DROP TABLE IF EXISTS alembic_version CASCADE"))

--- a/tests/integration/test_rate_limiting.py
+++ b/tests/integration/test_rate_limiting.py
@@ -7,13 +7,12 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, text
-from sqlalchemy.orm import Session, sessionmaker
 
 from gateway.core.config import API_KEY_HEADER, GatewayConfig
 from gateway.db import Base, get_db
 from gateway.main import create_app
 
-from .conftest import _run_alembic_migrations
+from .conftest import _run_alembic_migrations, build_async_session_override
 
 
 class _MockCompletionError(Exception):
@@ -35,23 +34,14 @@ def _make_rate_limit_client(
     _run_alembic_migrations(postgres_url)
     engine = create_engine(postgres_url, pool_pre_ping=True)
     app = create_app(config)
-
-    def override_get_db() -> Generator[Session]:
-        testing_session_local = sessionmaker(
-            autocommit=False, autoflush=False, bind=engine
-        )
-        db = testing_session_local()
-        try:
-            yield db
-        finally:
-            db.close()
-
+    override_get_db, dispose_override = build_async_session_override(postgres_url)
     app.dependency_overrides[get_db] = override_get_db
 
     try:
         with TestClient(app) as test_client:
             yield test_client
     finally:
+        dispose_override()
         Base.metadata.drop_all(bind=engine)
         with engine.connect() as conn:
             conn.execute(text("DROP TABLE IF EXISTS alembic_version CASCADE"))
@@ -70,17 +60,13 @@ def no_rate_limit_client(postgres_url: str) -> Generator[TestClient]:
 
 def _create_test_user(client: TestClient, master_key: str = "test-master-key") -> str:
     header = {API_KEY_HEADER: f"Bearer {master_key}"}
-    resp = client.post(
-        "/v1/users", json={"user_id": "rl-test-user", "alias": "RL"}, headers=header
-    )
+    resp = client.post("/v1/users", json={"user_id": "rl-test-user", "alias": "RL"}, headers=header)
     assert resp.status_code == 200
     result: str = resp.json()["user_id"]
     return result
 
 
-def _chat_request(
-    client: TestClient, user_id: str, master_key: str = "test-master-key"
-) -> Any:
+def _chat_request(client: TestClient, user_id: str, master_key: str = "test-master-key") -> Any:
     header = {API_KEY_HEADER: f"Bearer {master_key}"}
     return client.post(
         "/v1/chat/completions",

--- a/tests/integration/test_timezone_consistency.py
+++ b/tests/integration/test_timezone_consistency.py
@@ -1,25 +1,35 @@
 """Tests for timezone-aware datetime consistency."""
 
 import pytest
-from sqlalchemy.orm import Session
 
 from gateway.api.routes.chat import log_usage
 from gateway.models.entities import UsageLog
 
 
 @pytest.mark.asyncio
-async def test_usage_log_timestamp_is_timezone_aware(test_db: Session) -> None:
+async def test_usage_log_timestamp_is_timezone_aware(async_db) -> None:
     """Test that usage log timestamps are stored with timezone info."""
+
+    class _Writer:
+        def __init__(self) -> None:
+            self.logs: list[UsageLog] = []
+
+        async def put(self, log: UsageLog) -> None:
+            self.logs.append(log)
+
+    writer = _Writer()
     await log_usage(
-        db=test_db,
-        api_key_obj=None,
+        db=async_db,
+        log_writer=writer,
+        api_key_id=None,
         model="gpt-4o",
         provider="openai",
         endpoint="/v1/chat/completions",
         error="test error",
     )
 
-    log = test_db.query(UsageLog).first()
+    assert writer.logs
+    log = writer.logs[0]
     assert log is not None
     assert log.timestamp is not None
     # The timestamp should be timezone-aware (has tzinfo)

--- a/tests/integration/test_transaction_safety.py
+++ b/tests/integration/test_transaction_safety.py
@@ -3,12 +3,10 @@
 from unittest.mock import patch
 
 import pytest
-from any_llm.types.completion import CompletionUsage
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
 
-from gateway.api.routes.chat import log_usage
 from gateway.core.config import API_KEY_HEADER
 from gateway.models.entities import Budget, User
 from gateway.services.budget_service import _is_model_free, reset_user_budget
@@ -20,7 +18,7 @@ def test_create_user_rollback_on_commit_failure(
 ) -> None:
     """create_user rolls back and returns 500 when commit fails."""
     with patch(
-        "gateway.api.routes.users.Session.commit",
+        "gateway.api.routes.users.AsyncSession.commit",
         side_effect=OperationalError("db", {}, Exception("connection lost")),
     ):
         resp = client.post(
@@ -39,7 +37,7 @@ def test_delete_user_rollback_on_commit_failure(
     client.post("/v1/users", json={"user_id": "del-fail-user"}, headers=master_key_header)
 
     with patch(
-        "gateway.api.routes.users.Session.commit",
+        "gateway.api.routes.users.AsyncSession.commit",
         side_effect=OperationalError("db", {}, Exception("connection lost")),
     ):
         resp = client.delete("/v1/users/del-fail-user", headers=master_key_header)
@@ -56,7 +54,7 @@ def test_create_key_rollback_on_commit_failure(
 ) -> None:
     """create_key rolls back on commit failure."""
     with patch(
-        "gateway.api.routes.keys.Session.commit",
+        "gateway.api.routes.keys.AsyncSession.commit",
         side_effect=OperationalError("db", {}, Exception("connection lost")),
     ):
         resp = client.post(
@@ -73,7 +71,7 @@ def test_create_budget_rollback_on_commit_failure(
 ) -> None:
     """create_budget rolls back on commit failure."""
     with patch(
-        "gateway.api.routes.budgets.Session.commit",
+        "gateway.api.routes.budgets.AsyncSession.commit",
         side_effect=OperationalError("db", {}, Exception("connection lost")),
     ):
         resp = client.post(
@@ -90,7 +88,7 @@ def test_set_pricing_rollback_on_commit_failure(
 ) -> None:
     """set_pricing rolls back on commit failure."""
     with patch(
-        "gateway.api.routes.pricing.Session.commit",
+        "gateway.api.routes.pricing.AsyncSession.commit",
         side_effect=OperationalError("db", {}, Exception("connection lost")),
     ):
         resp = client.post(
@@ -105,56 +103,61 @@ def test_set_pricing_rollback_on_commit_failure(
     assert resp.status_code == 500
 
 
-def test_reset_user_budget_rollback_on_commit_failure(test_db: Session) -> None:
+@pytest.mark.asyncio
+async def test_reset_user_budget_rollback_on_commit_failure(async_db: Session) -> None:
     """reset_user_budget rolls back and re-raises when commit fails."""
     from datetime import UTC, datetime
 
     user = User(user_id="reset-fail-user", spend=50.0)
     budget = Budget(max_budget=100.0, budget_duration_sec=3600)
-    test_db.add_all([user, budget])
-    test_db.commit()
+    async_db.add_all([user, budget])
+    await async_db.commit()
 
     now = datetime.now(UTC)
 
     with (
-        patch.object(test_db, "commit", side_effect=OperationalError("db", {}, Exception("disk full"))),
-        patch.object(test_db, "rollback", wraps=test_db.rollback) as mock_rollback,
+        patch.object(async_db, "commit", side_effect=OperationalError("db", {}, Exception("disk full"))),
+        patch.object(async_db, "rollback", wraps=async_db.rollback) as mock_rollback,
     ):
         with pytest.raises(OperationalError):
-            reset_user_budget(test_db, user, budget, now)
+            await reset_user_budget(async_db, user, budget, now)
 
         mock_rollback.assert_called_once()
 
 
-def test_is_model_free_catches_value_error(test_db: Session) -> None:
+@pytest.mark.asyncio
+async def test_is_model_free_catches_value_error(async_db: Session) -> None:
     """_is_model_free returns False on ValueError from split_model_provider."""
-    result = _is_model_free(test_db, "completely-invalid-model-string-no-provider")
+    result = await _is_model_free(async_db, "completely-invalid-model-string-no-provider")
     assert result is False
 
 
-def test_is_model_free_catches_unsupported_provider_error(test_db: Session) -> None:
+@pytest.mark.asyncio
+async def test_is_model_free_catches_unsupported_provider_error(async_db: Session) -> None:
     """_is_model_free returns False on UnsupportedProviderError from split_model_provider."""
-    result = _is_model_free(test_db, "unknown:some-model")
+    result = await _is_model_free(async_db, "unknown:some-model")
     assert result is False
 
 
-def test_is_model_free_catches_sqlalchemy_error(test_db: Session) -> None:
+@pytest.mark.asyncio
+async def test_is_model_free_catches_sqlalchemy_error(async_db: Session) -> None:
     """_is_model_free returns False on SQLAlchemy errors during pricing lookup."""
     with patch(
         "gateway.services.budget_service.find_model_pricing",
         side_effect=OperationalError("db", {}, Exception("connection lost")),
     ):
-        result = _is_model_free(test_db, "openai:gpt-4o")
+        result = await _is_model_free(async_db, "openai:gpt-4o")
         assert result is False
 
 
-def test_is_model_free_does_not_catch_unexpected_errors(test_db: Session) -> None:
+@pytest.mark.asyncio
+async def test_is_model_free_does_not_catch_unexpected_errors(async_db: Session) -> None:
     """_is_model_free does not swallow unexpected non-DB, non-ValueError exceptions."""
     with (
         patch("gateway.services.budget_service.find_model_pricing", side_effect=RuntimeError("unexpected")),
         pytest.raises(RuntimeError, match="unexpected"),
     ):
-        _is_model_free(test_db, "openai:gpt-4o")
+        await _is_model_free(async_db, "openai:gpt-4o")
 
 
 def test_auth_commit_failure_does_not_break_verification(
@@ -170,7 +173,7 @@ def test_auth_commit_failure_does_not_break_verification(
     api_key = key_resp.json()["key"]
 
     with patch(
-        "gateway.api.deps.Session.commit",
+        "gateway.api.deps.AsyncSession.commit",
         side_effect=OperationalError("db", {}, Exception("connection lost")),
     ):
         resp = client.get(
@@ -181,38 +184,3 @@ def test_auth_commit_failure_does_not_break_verification(
         # The /v1/users endpoint requires master key, so we may get 401
         # (API key not accepted as master key), but crucially not 500.
         assert resp.status_code != 500
-
-
-@pytest.mark.asyncio
-async def test_log_usage_catches_sqlalchemy_error(test_db: Session) -> None:
-    """log_usage catches SQLAlchemyError and rolls back without raising."""
-    usage = CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
-
-    with patch.object(test_db, "commit", side_effect=OperationalError("db", {}, Exception("gone"))):
-        await log_usage(
-            db=test_db,
-            api_key_obj=None,
-            model="gpt-4o",
-            provider="openai",
-            endpoint="/v1/chat/completions",
-            usage_override=usage,
-        )
-
-
-@pytest.mark.asyncio
-async def test_log_usage_does_not_catch_non_db_errors(test_db: Session) -> None:
-    """log_usage does not swallow non-SQLAlchemy exceptions like RuntimeError."""
-    usage = CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
-
-    with (
-        patch.object(test_db, "commit", side_effect=RuntimeError("unexpected")),
-        pytest.raises(RuntimeError, match="unexpected"),
-    ):
-        await log_usage(
-            db=test_db,
-            api_key_obj=None,
-            model="gpt-4o",
-            provider="openai",
-            endpoint="/v1/chat/completions",
-            usage_override=usage,
-        )

--- a/tests/integration/test_user_delete_preserve_logs.py
+++ b/tests/integration/test_user_delete_preserve_logs.py
@@ -1,8 +1,10 @@
 """Tests for preserving usage and budget reset logs when soft-deleting users."""
 
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from unittest.mock import patch
 
+from any_llm.types.completion import ChatCompletion, ChatCompletionMessage, Choice, CompletionUsage
 from fastapi.testclient import TestClient
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -83,9 +85,29 @@ def test_delete_user_preserves_budget_reset_logs(
     with (
         patch("gateway.services.budget_service.datetime") as mock_dt_budget,
         patch("gateway.api.routes.chat.datetime") as mock_dt_chat,
+        patch("gateway.api.routes.chat.acompletion") as mock_acompletion,
     ):
         mock_dt_budget.now.return_value = time_after_reset
         mock_dt_chat.now.return_value = time_after_reset
+        mock_response = ChatCompletion(
+            id="chatcmpl-reset",
+            object="chat.completion",
+            created=int(time_after_reset.timestamp()),
+            model=MODEL_NAME,
+            choices=[
+                Choice(
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="ok"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=CompletionUsage(prompt_tokens=5, completion_tokens=1, total_tokens=6),
+        )
+
+        async def _mock_acompletion(**kwargs: Any) -> ChatCompletion:  # type: ignore[name-defined]
+            return mock_response
+
+        mock_acompletion.side_effect = _mock_acompletion
         client.post(
             "/v1/chat/completions",
             json={"model": MODEL_NAME, "messages": test_messages, "user": "reset-user"},

--- a/tests/unit/test_gateway_bootstrap.py
+++ b/tests/unit/test_gateway_bootstrap.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
@@ -11,7 +12,10 @@ from gateway.main import create_app
 def test_create_app_bootstraps_first_api_key(tmp_path: Path) -> None:
     database_path = tmp_path / "bootstrap.db"
     config = GatewayConfig(database_url=f"sqlite:///{database_path}")
-    create_app(config)
+    app = create_app(config)
+
+    with TestClient(app):
+        pass
 
     engine = create_engine(config.database_url)
     with Session(engine) as db:
@@ -31,8 +35,13 @@ def test_create_app_does_not_create_second_bootstrap_key(tmp_path: Path) -> None
     database_path = tmp_path / "bootstrap-once.db"
     config = GatewayConfig(database_url=f"sqlite:///{database_path}")
 
-    create_app(config)
-    create_app(config)
+    app = create_app(config)
+    with TestClient(app):
+        pass
+    # Second startup should not create another key
+    app_again = create_app(config)
+    with TestClient(app_again):
+        pass
 
     engine = create_engine(config.database_url)
     with Session(engine) as db:
@@ -46,7 +55,9 @@ def test_create_app_skips_bootstrap_when_disabled(tmp_path: Path) -> None:
     database_path = tmp_path / "no-bootstrap.db"
     config = GatewayConfig(database_url=f"sqlite:///{database_path}", bootstrap_api_key=False)
 
-    create_app(config)
+    app = create_app(config)
+    with TestClient(app):
+        pass
 
     engine = create_engine(config.database_url)
     with Session(engine) as db:

--- a/tests/unit/test_gateway_users_repository.py
+++ b/tests/unit/test_gateway_users_repository.py
@@ -1,41 +1,31 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from gateway.repositories.users_repository import get_active_user
 
 
-def test_get_active_user_skips_for_update_on_sqlite() -> None:
-    db = MagicMock()
-    db.bind.dialect.name = "sqlite"
-    query = db.query.return_value
-    query.filter.return_value = query
-    query.first.return_value = object()
+@pytest.mark.asyncio
+async def test_get_active_user_applies_for_update_when_requested() -> None:
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = object()
+    db.execute = AsyncMock(return_value=result)
 
-    get_active_user(db, "user-1", for_update=True)
+    await get_active_user(db, "user-1", for_update=True)
 
-    query.with_for_update.assert_not_called()
-
-
-def test_get_active_user_uses_for_update_on_non_sqlite() -> None:
-    db = MagicMock()
-    db.bind.dialect.name = "postgresql"
-    query = db.query.return_value
-    query.filter.return_value = query
-    query.with_for_update.return_value = query
-    query.first.return_value = object()
-
-    get_active_user(db, "user-1", for_update=True)
-
-    query.with_for_update.assert_called_once_with()
+    executed_stmt = db.execute.call_args.args[0]
+    assert executed_stmt._for_update_arg is not None  # type: ignore[attr-defined]
 
 
-def test_get_active_user_uses_for_update_when_bind_is_missing() -> None:
-    db = MagicMock()
-    db.bind = None
-    query = db.query.return_value
-    query.filter.return_value = query
-    query.with_for_update.return_value = query
-    query.first.return_value = object()
+@pytest.mark.asyncio
+async def test_get_active_user_skips_for_update_when_not_requested() -> None:
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = object()
+    db.execute = AsyncMock(return_value=result)
 
-    get_active_user(db, "user-1", for_update=True)
+    await get_active_user(db, "user-2", for_update=False)
 
-    query.with_for_update.assert_called_once_with()
+    executed_stmt = db.execute.call_args.args[0]
+    assert executed_stmt._for_update_arg is None  # type: ignore[attr-defined]

--- a/tests/unit/test_log_writer.py
+++ b/tests/unit/test_log_writer.py
@@ -1,0 +1,27 @@
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from gateway.models.entities import UsageLog
+from gateway.services.log_writer import SingleLogWriter
+
+
+@pytest.mark.asyncio
+async def test_single_log_writer_rolls_back_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.commit.side_effect = SQLAlchemyError("boom")
+
+    @asynccontextmanager
+    async def _session_cm():  # type: ignore[return-annnotation]
+        yield session
+
+    monkeypatch.setattr("gateway.services.log_writer.create_session", lambda: _session_cm())
+    writer = SingleLogWriter()
+
+    log = UsageLog(id="log", model="test-model", endpoint="/v1/test", status="success")
+    await writer.put(log)
+
+    session.rollback.assert_awaited()

--- a/uv.lock
+++ b/uv.lock
@@ -101,6 +101,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.18.4"
 source = { registry = "https://pypi.org/simple" }
@@ -231,6 +240,38 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
 ]
 
 [[package]]
@@ -808,8 +849,10 @@ name = "gateway"
 version = "0.0.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiosqlite" },
     { name = "alembic" },
     { name = "any-llm-sdk", extra = ["all"] },
+    { name = "asyncpg" },
     { name = "click" },
     { name = "fastapi" },
     { name = "prometheus-client" },
@@ -817,7 +860,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
-    { name = "sqlalchemy" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -836,8 +879,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.19.0" },
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "any-llm-sdk", extras = ["all"] },
+    { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "prometheus-client", specifier = ">=0.20.0" },
@@ -845,7 +890,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "sqlalchemy", specifier = ">=2.0.0" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
 
@@ -922,6 +967,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -930,6 +976,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -938,6 +985,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -2581,6 +2629,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/95/32107c4d13be077a9cae61e9ae49966a35dc4bf442a8852dd871db31f62e/sqlalchemy-2.0.48-cp314-cp314t-win32.whl", hash = "sha256:b8438ec5594980d405251451c5b7ea9aa58dda38eb7ac35fb7e4c696712ee24f", size = 2147209, upload-time = "2026-03-02T15:52:54.274Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d7/1e073da7a4bc645eb83c76067284a0374e643bc4be57f14cc6414656f92c/sqlalchemy-2.0.48-cp314-cp314t-win_amd64.whl", hash = "sha256:d854b3970067297f3a7fbd7a4683587134aa9b3877ee15aa29eea478dc68f933", size = 2182198, upload-time = "2026-03-02T15:52:55.606Z" },
     { url = "https://files.pythonhosted.org/packages/46/2c/9664130905f03db57961b8980b05cab624afd114bf2be2576628a9f22da4/sqlalchemy-2.0.48-py3-none-any.whl", hash = "sha256:a66fe406437dd65cacd96a72689a3aaaecaebbcd62d81c5ac1c0fdbeac835096", size = 1940202, upload-time = "2026-03-02T15:52:43.285Z" },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "greenlet" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Converts entire DB layer from sync `psycopg2` + `Session` to async `asyncpg` + `AsyncSession`. Contended DB calls now yield to the event loop instead of blocking it.
- Adds pluggable `budget_strategy` config: `for_update` (default/legacy), `cas` (lock-free, recommended), `disabled` (skip budget checks)
- Adds pluggable `log_writer_strategy` config: `single` (inline, default), `batch` (background flush for high-throughput)
- Adds DB pool tuning config: `db_pool_size`, `db_max_overflow`, `db_pool_timeout`, `db_pool_recycle`
- Adds new Prometheus metrics for log writer queue depth, batch size, flush duration, and row counts
- App startup uses FastAPI lifespan for proper async initialization and graceful shutdown
- Alembic migrations remain sync (psycopg2) for compatibility

Ported from https://github.com/mozilla-ai/any-llm/pull/1001

Co-Authored-By: Julian Bright <brightsparc@gmail.com>