### PR TITLE
feat(pricing): add effective_at to model_pricing for historical price tracking

### DIFF
--- a/alembic/versions/a1b2c3d4e5f6_add_effective_at_to_model_pricing.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_effective_at_to_model_pricing.py
@@ -1,0 +1,66 @@
+"""add effective_at to model_pricing
+
+Revision ID: a1b2c3d4e5f6
+Revises: 967575f779b7
+Create Date: 2026-04-13 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | Sequence[str] | None = "967575f779b7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add effective_at column and composite primary key."""
+
+    op.add_column(
+        "model_pricing",
+        sa.Column("effective_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    conn = op.get_bind()
+    is_sqlite = conn.dialect.name == "sqlite"
+    conn.execute(sa.text("UPDATE model_pricing SET effective_at = created_at WHERE effective_at IS NULL"))
+
+    with op.batch_alter_table("model_pricing") as batch_op:
+        batch_op.alter_column(
+            "effective_at",
+            existing_type=sa.DateTime(timezone=True),
+            nullable=False,
+        )
+        if not is_sqlite:
+            batch_op.drop_constraint("model_pricing_pkey", type_="primary")
+        batch_op.create_primary_key("model_pricing_pkey", ["model_key", "effective_at"])
+
+
+def downgrade() -> None:
+    """Revert to single-column primary key on model_key."""
+
+    conn = op.get_bind()
+    is_sqlite = conn.dialect.name == "sqlite"
+    conn.execute(
+        sa.text(
+            """
+            DELETE FROM model_pricing
+            WHERE effective_at < (
+                SELECT MAX(mp2.effective_at)
+                FROM model_pricing AS mp2
+                WHERE mp2.model_key = model_pricing.model_key
+            )
+            """
+        )
+    )
+
+    with op.batch_alter_table("model_pricing") as batch_op:
+        if not is_sqlite:
+            batch_op.drop_constraint("model_pricing_pkey", type_="primary")
+        batch_op.create_primary_key("model_pricing_pkey", ["model_key"])
+        batch_op.drop_column("effective_at")

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -164,16 +164,16 @@ async def log_usage(
             usage_data.completion_tokens,
         )
 
-    pricing = await find_model_pricing(db, provider, model)
-    if pricing:
-        cost = (usage_data.prompt_tokens / 1_000_000) * pricing.input_price_per_million + (
-            usage_data.completion_tokens / 1_000_000
-        ) * pricing.output_price_per_million
-        usage_log.cost = cost
-        record_cost(str(provider or ""), model, cost)
-    else:
-        model_ref = f"{provider}:{model}" if provider else model
-        logger.warning(f"No pricing configured for '{model_ref}'. Usage will be tracked without cost.")
+        pricing = await find_model_pricing(db, provider, model, as_of=usage_log.timestamp)
+        if pricing:
+            cost = (usage_data.prompt_tokens / 1_000_000) * pricing.input_price_per_million + (
+                usage_data.completion_tokens / 1_000_000
+            ) * pricing.output_price_per_million
+            usage_log.cost = cost
+            record_cost(str(provider or ""), model, cost)
+        else:
+            model_ref = f"{provider}:{model}" if provider else model
+            logger.warning(f"No pricing configured for '{model_ref}'. Usage will be tracked without cost.")
 
     await log_writer.put(usage_log)
 

--- a/src/gateway/api/routes/embeddings.py
+++ b/src/gateway/api/routes/embeddings.py
@@ -111,7 +111,7 @@ async def create_embedding(
         )
 
         if result.usage:
-            pricing = await find_model_pricing(db, provider, model)
+            pricing = await find_model_pricing(db, provider, model, as_of=usage_log.timestamp)
             if pricing:
                 cost = (result.usage.prompt_tokens / 1_000_000) * pricing.input_price_per_million
                 usage_log.cost = cost

--- a/src/gateway/api/routes/models.py
+++ b/src/gateway/api/routes/models.py
@@ -5,7 +5,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_db, verify_api_key_or_master_key
@@ -51,7 +51,25 @@ async def list_models(
     Returns models derived from the model_pricing table in an
     OpenAI-compatible format.
     """
-    result = await db.execute(select(ModelPricing).order_by(ModelPricing.model_key))
+    latest_effective = (
+        select(
+            ModelPricing.model_key.label("model_key"),
+            func.max(ModelPricing.effective_at).label("effective_at"),
+        )
+        .group_by(ModelPricing.model_key)
+        .subquery()
+    )
+
+    stmt = (
+        select(ModelPricing)
+        .join(
+            latest_effective,
+            (ModelPricing.model_key == latest_effective.c.model_key)
+            & (ModelPricing.effective_at == latest_effective.c.effective_at),
+        )
+        .order_by(ModelPricing.model_key)
+    )
+    result = await db.execute(stmt)
     pricings = result.scalars().all()
     return ModelListResponse(data=[_model_from_pricing(p) for p in pricings])
 
@@ -62,8 +80,13 @@ async def get_model(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> ModelObject:
     """Get details for a specific model."""
-    result = await db.execute(select(ModelPricing).where(ModelPricing.model_key == model_id))
-    pricing = result.scalar_one_or_none()
+    stmt = (
+        select(ModelPricing)
+        .where(ModelPricing.model_key == model_id)
+        .order_by(ModelPricing.effective_at.desc())
+        .limit(1)
+    )
+    pricing = (await db.execute(stmt)).scalar_one_or_none()
 
     if not pricing:
         raise HTTPException(

--- a/src/gateway/api/routes/pricing.py
+++ b/src/gateway/api/routes/pricing.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Annotated
 
 from any_llm import AnyLLM
@@ -9,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_db, verify_api_key_or_master_key, verify_master_key
 from gateway.models.entities import ModelPricing
+from gateway.services.pricing_service import normalize_effective_at
 
 router = APIRouter(prefix="/v1/pricing", tags=["pricing"])
 
@@ -19,12 +21,17 @@ class SetPricingRequest(BaseModel):
     model_key: str = Field(description="Model identifier in format 'provider:model'")
     input_price_per_million: float = Field(ge=0, description="Price per 1M input tokens")
     output_price_per_million: float = Field(ge=0, description="Price per 1M output tokens")
+    effective_at: datetime | None = Field(
+        default=None,
+        description="ISO 8601 datetime from which this price applies. Defaults to now if omitted.",
+    )
 
 
 class PricingResponse(BaseModel):
     """Response model for model pricing."""
 
     model_key: str
+    effective_at: str
     input_price_per_million: float
     output_price_per_million: float
     created_at: str
@@ -35,11 +42,61 @@ class PricingResponse(BaseModel):
         """Create a PricingResponse from a ModelPricing ORM model."""
         return cls(
             model_key=pricing.model_key,
+            effective_at=pricing.effective_at.isoformat(),
             input_price_per_million=pricing.input_price_per_million,
             output_price_per_million=pricing.output_price_per_million,
             created_at=pricing.created_at.isoformat(),
             updated_at=pricing.updated_at.isoformat(),
         )
+
+
+def _candidate_model_keys(raw_key: str) -> list[str]:
+    """Return possible stored keys for a provided selector."""
+
+    candidates = [raw_key]
+    try:
+        provider, model_name = AnyLLM.split_model_provider(raw_key)
+    except ValueError:
+        return candidates
+
+    provider_value = provider.value if provider else None
+    if not provider_value:
+        return candidates
+
+    for key in (f"{provider_value}:{model_name}", f"{provider_value}/{model_name}"):
+        if key not in candidates:
+            candidates.append(key)
+    return candidates
+
+
+async def _get_effective_pricing(
+    db: AsyncSession,
+    model_keys: list[str],
+    as_of: datetime,
+) -> ModelPricing | None:
+    for key in model_keys:
+        stmt = (
+            select(ModelPricing)
+            .where(
+                ModelPricing.model_key == key,
+                ModelPricing.effective_at <= as_of,
+            )
+            .order_by(ModelPricing.effective_at.desc())
+            .limit(1)
+        )
+        pricing = (await db.execute(stmt)).scalar_one_or_none()
+        if pricing:
+            return pricing
+    return None
+
+
+async def _get_pricing_history(db: AsyncSession, model_keys: list[str]) -> list[ModelPricing]:
+    for key in model_keys:
+        stmt = select(ModelPricing).where(ModelPricing.model_key == key).order_by(ModelPricing.effective_at.desc())
+        pricings = (await db.execute(stmt)).scalars().all()
+        if pricings:
+            return pricings
+    return []
 
 
 @router.post("", dependencies=[Depends(verify_master_key)])
@@ -50,7 +107,13 @@ async def set_pricing(
     """Set or update pricing for a model."""
     provider, model_name = AnyLLM.split_model_provider(request.model_key)
     normalized_key = f"{provider.value}:{model_name}"
-    result = await db.execute(select(ModelPricing).where(ModelPricing.model_key == normalized_key))
+    effective_at = normalize_effective_at(request.effective_at)
+    result = await db.execute(
+        select(ModelPricing).where(
+            ModelPricing.model_key == normalized_key,
+            ModelPricing.effective_at == effective_at,
+        )
+    )
     pricing = result.scalar_one_or_none()
 
     if pricing:
@@ -59,6 +122,7 @@ async def set_pricing(
     else:
         pricing = ModelPricing(
             model_key=normalized_key,
+            effective_at=effective_at,
             input_price_per_million=request.input_price_per_million,
             output_price_per_million=request.output_price_per_million,
         )
@@ -84,20 +148,46 @@ async def list_pricing(
     limit: Annotated[int, Query(ge=1, le=1000)] = 100,
 ) -> list[PricingResponse]:
     """List all model pricing."""
-    result = await db.execute(select(ModelPricing).offset(skip).limit(limit))
+    stmt = (
+        select(ModelPricing)
+        .order_by(ModelPricing.model_key, ModelPricing.effective_at.desc())
+        .offset(skip)
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
     pricings = result.scalars().all()
 
     return [PricingResponse.from_model(pricing) for pricing in pricings]
 
 
-@router.get("/{model_key}", dependencies=[Depends(verify_api_key_or_master_key)])
+@router.get("/{model_key:path}/history", dependencies=[Depends(verify_api_key_or_master_key)])
+async def get_pricing_history(
+    model_key: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> list[PricingResponse]:
+    """Return the full pricing history for a model."""
+
+    candidates = _candidate_model_keys(model_key)
+    pricings = await _get_pricing_history(db, candidates)
+    if not pricings:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Pricing for model '{model_key}' not found",
+        )
+
+    return [PricingResponse.from_model(pricing) for pricing in pricings]
+
+
+@router.get("/{model_key:path}", dependencies=[Depends(verify_api_key_or_master_key)])
 async def get_pricing(
     model_key: str,
     db: Annotated[AsyncSession, Depends(get_db)],
+    as_of: Annotated[datetime | None, Query(description="ISO datetime for effective lookup", title="as_of")] = None,
 ) -> PricingResponse:
-    """Get pricing for a specific model."""
-    result = await db.execute(select(ModelPricing).where(ModelPricing.model_key == model_key))
-    pricing = result.scalar_one_or_none()
+    """Get pricing for a specific model as of a timestamp."""
+
+    candidates = _candidate_model_keys(model_key)
+    pricing = await _get_effective_pricing(db, candidates, normalize_effective_at(as_of))
 
     if not pricing:
         raise HTTPException(
@@ -108,22 +198,59 @@ async def get_pricing(
     return PricingResponse.from_model(pricing)
 
 
-@router.delete("/{model_key}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(verify_master_key)])
+@router.delete(
+    "/{model_key:path}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(verify_master_key)],
+)
 async def delete_pricing(
     model_key: str,
     db: Annotated[AsyncSession, Depends(get_db)],
+    effective_at: Annotated[
+        datetime | None,
+        Query(
+            description="ISO datetime identifying a specific pricing row to delete",
+        ),
+    ] = None,
 ) -> None:
-    """Delete pricing for a model."""
-    result = await db.execute(select(ModelPricing).where(ModelPricing.model_key == model_key))
-    pricing = result.scalar_one_or_none()
+    """Delete pricing entries for a model."""
 
-    if not pricing:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Pricing for model '{model_key}' not found",
-        )
+    candidates = _candidate_model_keys(model_key)
+    targets: list[ModelPricing] = []
 
-    await db.delete(pricing)
+    if effective_at is not None:
+        normalized_effective_at = normalize_effective_at(effective_at)
+        for key in candidates:
+            stmt = (
+                select(ModelPricing)
+                .where(
+                    ModelPricing.model_key == key,
+                    ModelPricing.effective_at == normalized_effective_at,
+                )
+                .limit(1)
+            )
+            pricing = (await db.execute(stmt)).scalar_one_or_none()
+            if pricing:
+                targets = [pricing]
+                break
+        if not targets:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=(
+                    f"Pricing for model '{model_key}' with effective_at {normalized_effective_at.isoformat()} not found"
+                ),
+            )
+    else:
+        targets = await _get_pricing_history(db, candidates)
+        if not targets:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Pricing for model '{model_key}' not found",
+            )
+
+    for pricing in targets:
+        await db.delete(pricing)
+
     try:
         await db.commit()
     except SQLAlchemyError:

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -1,5 +1,6 @@
 import os
 import re
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -16,6 +17,10 @@ class PricingConfig(BaseModel):
 
     input_price_per_million: float = Field(ge=0)
     output_price_per_million: float = Field(ge=0)
+    effective_at: datetime | None = Field(
+        default=None,
+        description="ISO 8601 datetime from which this price applies. Defaults to now if omitted.",
+    )
 
 
 class GatewayConfig(BaseSettings):

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -120,6 +120,11 @@ class ModelPricing(Base):
     __tablename__ = "model_pricing"
 
     model_key: Mapped[str] = mapped_column(primary_key=True)
+    effective_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        primary_key=True,
+        default=lambda: datetime.now(UTC),
+    )
     input_price_per_million: Mapped[float] = mapped_column()
     output_price_per_million: Mapped[float] = mapped_column()
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
@@ -133,6 +138,7 @@ class ModelPricing(Base):
         """Convert model to dictionary."""
         return {
             "model_key": self.model_key,
+            "effective_at": self.effective_at.isoformat() if self.effective_at else None,
             "input_price_per_million": self.input_price_per_million,
             "output_price_per_million": self.output_price_per_million,
             "created_at": self.created_at.isoformat() if self.created_at else None,

--- a/src/gateway/services/pricing_init_service.py
+++ b/src/gateway/services/pricing_init_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import ModelPricing
+from gateway.services.pricing_service import normalize_effective_at
 
 
 async def initialize_pricing_from_config(config: GatewayConfig, db: AsyncSession) -> None:
@@ -32,14 +33,20 @@ async def initialize_pricing_from_config(config: GatewayConfig, db: AsyncSession
 
         input_price = pricing_config.input_price_per_million
         output_price = pricing_config.output_price_per_million
+        effective_at = normalize_effective_at(pricing_config.effective_at)
 
         existing_pricing = (
-            await db.execute(select(ModelPricing).where(ModelPricing.model_key == model_key))
+            await db.execute(
+                select(ModelPricing).where(
+                    ModelPricing.model_key == model_key,
+                    ModelPricing.effective_at == effective_at,
+                )
+            )
         ).scalar_one_or_none()
 
         if existing_pricing:
             logger.warning(
-                f"Pricing for model '{model_key}' already exists in database. "
+                f"Pricing for model '{model_key}' effective {effective_at.isoformat()} already exists in database. "
                 f"Keeping database value (input: ${existing_pricing.input_price_per_million}/M, "
                 f"output: ${existing_pricing.output_price_per_million}/M). "
                 f"To update, use the pricing API or delete the existing entry."
@@ -48,6 +55,7 @@ async def initialize_pricing_from_config(config: GatewayConfig, db: AsyncSession
 
         new_pricing = ModelPricing(
             model_key=model_key,
+            effective_at=effective_at,
             input_price_per_million=input_price,
             output_price_per_million=output_price,
         )

--- a/src/gateway/services/pricing_service.py
+++ b/src/gateway/services/pricing_service.py
@@ -1,20 +1,50 @@
 """Shared pricing lookup utilities."""
 
+from datetime import UTC, datetime
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.models.entities import ModelPricing
 
 
-async def find_model_pricing(db: AsyncSession, provider: str | None, model: str) -> ModelPricing | None:
-    """Look up model pricing, falling back to legacy slash-separated key format."""
+def normalize_effective_at(value: datetime | None) -> datetime:
+    """Normalize a datetime to an aware UTC timestamp, defaulting to now."""
 
+    normalized = value or datetime.now(UTC)
+    if normalized.tzinfo is None:
+        return normalized.replace(tzinfo=UTC)
+    return normalized.astimezone(UTC)
+
+
+async def _find_by_model_key(db: AsyncSession, model_key: str, as_of: datetime) -> ModelPricing | None:
+    stmt = (
+        select(ModelPricing)
+        .where(
+            ModelPricing.model_key == model_key,
+            ModelPricing.effective_at <= as_of,
+        )
+        .order_by(ModelPricing.effective_at.desc())
+        .limit(1)
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def find_model_pricing(
+    db: AsyncSession,
+    provider: str | None,
+    model: str,
+    *,
+    as_of: datetime | None = None,
+) -> ModelPricing | None:
+    """Look up model pricing as of a timestamp, with legacy key fallback."""
+
+    lookup_time = normalize_effective_at(as_of)
     model_key = f"{provider}:{model}" if provider else model
-    result = await db.execute(select(ModelPricing).where(ModelPricing.model_key == model_key))
-    pricing = result.scalar_one_or_none()
+    pricing = await _find_by_model_key(db, model_key, lookup_time)
     if pricing or not provider:
         return pricing
 
     legacy_key = f"{provider}/{model}"
-    legacy_result = await db.execute(select(ModelPricing).where(ModelPricing.model_key == legacy_key))
-    return legacy_result.scalar_one_or_none()
+    return await _find_by_model_key(db, legacy_key, lookup_time)

--- a/tests/integration/test_client_args.py
+++ b/tests/integration/test_client_args.py
@@ -7,7 +7,6 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.orm import Session, sessionmaker
 
 from gateway.core.config import GatewayConfig
 from gateway.db import get_db

--- a/tests/integration/test_cors_configuration.py
+++ b/tests/integration/test_cors_configuration.py
@@ -1,7 +1,5 @@
 """Tests for CORS configuration."""
 
-from typing import Any
-
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 

--- a/tests/integration/test_find_model_pricing.py
+++ b/tests/integration/test_find_model_pricing.py
@@ -1,5 +1,7 @@
 """Tests for the shared find_model_pricing helper."""
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -10,7 +12,14 @@ from gateway.services.pricing_service import find_model_pricing
 @pytest.mark.asyncio
 async def test_find_pricing_colon_format(async_db: AsyncSession) -> None:
     """Test lookup with canonical colon-separated key."""
-    async_db.add(ModelPricing(model_key="openai:gpt-4", input_price_per_million=30.0, output_price_per_million=60.0))
+    async_db.add(
+        ModelPricing(
+            model_key="openai:gpt-4",
+            effective_at=datetime(2025, 1, 1, tzinfo=UTC),
+            input_price_per_million=30.0,
+            output_price_per_million=60.0,
+        )
+    )
     await async_db.commit()
 
     pricing = await find_model_pricing(async_db, "openai", "gpt-4")
@@ -21,7 +30,14 @@ async def test_find_pricing_colon_format(async_db: AsyncSession) -> None:
 @pytest.mark.asyncio
 async def test_find_pricing_legacy_slash_fallback(async_db: AsyncSession) -> None:
     """Test fallback to legacy slash-separated key when colon key is missing."""
-    async_db.add(ModelPricing(model_key="openai/gpt-4", input_price_per_million=30.0, output_price_per_million=60.0))
+    async_db.add(
+        ModelPricing(
+            model_key="openai/gpt-4",
+            effective_at=datetime(2025, 1, 1, tzinfo=UTC),
+            input_price_per_million=30.0,
+            output_price_per_million=60.0,
+        )
+    )
     await async_db.commit()
 
     pricing = await find_model_pricing(async_db, "openai", "gpt-4")
@@ -32,7 +48,14 @@ async def test_find_pricing_legacy_slash_fallback(async_db: AsyncSession) -> Non
 @pytest.mark.asyncio
 async def test_find_pricing_no_provider(async_db: AsyncSession) -> None:
     """Test lookup without a provider uses model name directly."""
-    async_db.add(ModelPricing(model_key="gpt-4", input_price_per_million=30.0, output_price_per_million=60.0))
+    async_db.add(
+        ModelPricing(
+            model_key="gpt-4",
+            effective_at=datetime(2025, 1, 1, tzinfo=UTC),
+            input_price_per_million=30.0,
+            output_price_per_million=60.0,
+        )
+    )
     await async_db.commit()
 
     pricing = await find_model_pricing(async_db, None, "gpt-4")
@@ -50,11 +73,100 @@ async def test_find_pricing_not_found(async_db: AsyncSession) -> None:
 @pytest.mark.asyncio
 async def test_find_pricing_colon_preferred_over_slash(async_db: AsyncSession) -> None:
     """Test that colon format is returned when both formats exist."""
-    async_db.add(ModelPricing(model_key="openai:gpt-4", input_price_per_million=30.0, output_price_per_million=60.0))
-    async_db.add(ModelPricing(model_key="openai/gpt-4", input_price_per_million=10.0, output_price_per_million=20.0))
+    async_db.add(
+        ModelPricing(
+            model_key="openai:gpt-4",
+            effective_at=datetime(2025, 1, 1, tzinfo=UTC),
+            input_price_per_million=30.0,
+            output_price_per_million=60.0,
+        )
+    )
+    async_db.add(
+        ModelPricing(
+            model_key="openai/gpt-4",
+            effective_at=datetime(2025, 1, 1, tzinfo=UTC),
+            input_price_per_million=10.0,
+            output_price_per_million=20.0,
+        )
+    )
     await async_db.commit()
 
     pricing = await find_model_pricing(async_db, "openai", "gpt-4")
     assert pricing is not None
     assert pricing.model_key == "openai:gpt-4"
     assert pricing.input_price_per_million == 30.0
+
+
+@pytest.mark.asyncio
+async def test_find_pricing_defaults_to_now(async_db: AsyncSession) -> None:
+    """When as_of is omitted, the latest effective price is returned."""
+
+    async_db.add(
+        ModelPricing(
+            model_key="openai:gpt-4",
+            effective_at=datetime(2025, 1, 1, tzinfo=UTC),
+            input_price_per_million=10.0,
+            output_price_per_million=20.0,
+        )
+    )
+    async_db.add(
+        ModelPricing(
+            model_key="openai:gpt-4",
+            effective_at=datetime(2025, 2, 1, tzinfo=UTC),
+            input_price_per_million=30.0,
+            output_price_per_million=60.0,
+        )
+    )
+    await async_db.commit()
+
+    pricing = await find_model_pricing(async_db, "openai", "gpt-4")
+    assert pricing is not None
+    assert pricing.input_price_per_million == 30.0
+
+
+@pytest.mark.asyncio
+async def test_find_pricing_future_prices_ignored(async_db: AsyncSession) -> None:
+    """Future-effective pricing should not be returned for present lookups."""
+
+    future_effective = datetime.now(UTC) + timedelta(days=10)
+    async_db.add(
+        ModelPricing(
+            model_key="openai:gpt-4",
+            effective_at=future_effective,
+            input_price_per_million=99.0,
+            output_price_per_million=199.0,
+        )
+    )
+    await async_db.commit()
+
+    pricing = await find_model_pricing(async_db, "openai", "gpt-4")
+    assert pricing is None
+
+
+@pytest.mark.asyncio
+async def test_find_pricing_with_explicit_as_of(async_db: AsyncSession) -> None:
+    """Providing as_of returns the matching historical price."""
+
+    older = datetime(2025, 1, 1, tzinfo=UTC)
+    newer = datetime(2025, 2, 1, tzinfo=UTC)
+    async_db.add(
+        ModelPricing(
+            model_key="openai:gpt-4",
+            effective_at=older,
+            input_price_per_million=5.0,
+            output_price_per_million=10.0,
+        )
+    )
+    async_db.add(
+        ModelPricing(
+            model_key="openai:gpt-4",
+            effective_at=newer,
+            input_price_per_million=12.0,
+            output_price_per_million=24.0,
+        )
+    )
+    await async_db.commit()
+
+    pricing = await find_model_pricing(async_db, "openai", "gpt-4", as_of=older)
+    assert pricing is not None
+    assert pricing.input_price_per_million == 5.0

--- a/tests/integration/test_models_endpoint.py
+++ b/tests/integration/test_models_endpoint.py
@@ -1,5 +1,6 @@
 """Tests for the GET /v1/models endpoint."""
 
+from datetime import UTC, datetime
 from typing import Any
 
 from fastapi.testclient import TestClient
@@ -35,6 +36,35 @@ def test_list_models_returns_configured_models(
     assert "created" in model
     assert isinstance(model["created"], int)
     assert "owned_by" in model
+
+
+def test_list_models_deduplicates_effective_entries(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """Only the latest effective pricing per model is returned."""
+
+    model_key = "openai:gpt-4o"
+    older = datetime(2025, 1, 1, tzinfo=UTC)
+    newer = datetime(2025, 2, 1, tzinfo=UTC)
+
+    for effective_at, input_price in ((older, 1.0), (newer, 2.0)):
+        resp = client.post(
+            "/v1/pricing",
+            json={
+                "model_key": model_key,
+                "input_price_per_million": input_price,
+                "output_price_per_million": 3.0,
+                "effective_at": effective_at.isoformat(),
+            },
+            headers=master_key_header,
+        )
+        assert resp.status_code == 200
+
+    resp = client.get("/v1/models", headers=master_key_header)
+    assert resp.status_code == 200
+    models = [m for m in resp.json()["data"] if m["id"] == model_key]
+    assert len(models) == 1
 
 
 def test_list_models_owned_by_from_provider(

--- a/tests/integration/test_pricing_config.py
+++ b/tests/integration/test_pricing_config.py
@@ -1,6 +1,6 @@
 """Tests for pricing configuration from config file."""
 
-from typing import Any
+from datetime import UTC, datetime
 
 import pytest
 from any_llm.types.completion import CompletionUsage
@@ -53,6 +53,38 @@ def test_pricing_loaded_from_config(postgres_url: str, test_db: Session) -> None
             assert pricing is not None, "GPT-3.5-turbo pricing should be loaded from config"
             assert pricing.input_price_per_million == 0.5
             assert pricing.output_price_per_million == 1.5
+    finally:
+        dispose_override()
+
+
+def test_pricing_loaded_with_explicit_effective_at(postgres_url: str, test_db: Session) -> None:
+    """Configuration respects explicitly provided effective_at timestamps."""
+
+    effective_at = datetime(2025, 1, 15, tzinfo=UTC)
+    config = GatewayConfig(
+        database_url=postgres_url,
+        master_key="test-master-key",
+        host="127.0.0.1",
+        port=8000,
+        providers={"openai": {"api_key": "test-key"}},
+        pricing={
+            "openai:gpt-4": PricingConfig(
+                input_price_per_million=30.0,
+                output_price_per_million=60.0,
+                effective_at=effective_at,
+            ),
+        },
+    )
+
+    app = create_app(config)
+    override_get_db, dispose_override = build_async_session_override(postgres_url)
+    app.dependency_overrides[get_db] = override_get_db
+
+    try:
+        with TestClient(app):
+            pricing = test_db.query(ModelPricing).filter(ModelPricing.model_key == "openai:gpt-4").first()
+            assert pricing is not None
+            assert pricing.effective_at == effective_at
     finally:
         dispose_override()
 
@@ -175,6 +207,111 @@ def test_set_pricing_api_normalizes_legacy_slash_format(
     assert response.status_code == 200
     data = response.json()
     assert data["model_key"] == "gemini:gemini-2.5-flash", "API should normalize slash to colon format"
+
+
+def test_pricing_history_endpoint_returns_entries(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """GET /v1/pricing/{model_key}/history returns versions in descending order."""
+
+    model_key = "openai:gpt-4"
+    first_effective = datetime(2025, 1, 1, tzinfo=UTC)
+    second_effective = datetime(2025, 2, 1, tzinfo=UTC)
+
+    for effective_at, input_price in [(first_effective, 20.0), (second_effective, 25.0)]:
+        resp = client.post(
+            "/v1/pricing",
+            json={
+                "model_key": model_key,
+                "input_price_per_million": input_price,
+                "output_price_per_million": 40.0,
+                "effective_at": effective_at.isoformat(),
+            },
+            headers=master_key_header,
+        )
+        assert resp.status_code == 200
+
+    history_resp = client.get(f"/v1/pricing/{model_key}/history", headers=master_key_header)
+    assert history_resp.status_code == 200
+    history = history_resp.json()
+    assert [entry["effective_at"] for entry in history] == [
+        second_effective.isoformat(),
+        first_effective.isoformat(),
+    ]
+
+
+def test_get_pricing_respects_as_of(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """GET /v1/pricing/{model_key} returns the effective price at a timestamp."""
+
+    model_key = "anthropic:claude-3"
+    early = datetime(2025, 3, 1, tzinfo=UTC)
+    later = datetime(2025, 4, 1, tzinfo=UTC)
+
+    for effective_at, input_price in [(early, 15.0), (later, 18.0)]:
+        resp = client.post(
+            "/v1/pricing",
+            json={
+                "model_key": model_key,
+                "input_price_per_million": input_price,
+                "output_price_per_million": 30.0,
+                "effective_at": effective_at.isoformat(),
+            },
+            headers=master_key_header,
+        )
+        assert resp.status_code == 200
+
+    latest_resp = client.get(f"/v1/pricing/{model_key}", headers=master_key_header)
+    assert latest_resp.status_code == 200
+    assert latest_resp.json()["input_price_per_million"] == 18.0
+
+    old_resp = client.get(
+        f"/v1/pricing/{model_key}",
+        params={"as_of": early.isoformat()},
+        headers=master_key_header,
+    )
+    assert old_resp.status_code == 200
+    assert old_resp.json()["input_price_per_million"] == 15.0
+
+
+def test_delete_pricing_with_effective_at(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """Deleting with effective_at removes only the targeted row."""
+
+    model_key = "openai:gpt-4o"
+    old_effective = datetime(2025, 5, 1, tzinfo=UTC)
+    new_effective = datetime(2025, 5, 15, tzinfo=UTC)
+
+    for effective_at in (old_effective, new_effective):
+        resp = client.post(
+            "/v1/pricing",
+            json={
+                "model_key": model_key,
+                "input_price_per_million": 1.0,
+                "output_price_per_million": 2.0,
+                "effective_at": effective_at.isoformat(),
+            },
+            headers=master_key_header,
+        )
+        assert resp.status_code == 200
+
+    delete_resp = client.delete(
+        f"/v1/pricing/{model_key}",
+        params={"effective_at": old_effective.isoformat()},
+        headers=master_key_header,
+    )
+    assert delete_resp.status_code == 204
+
+    history_resp = client.get(f"/v1/pricing/{model_key}/history", headers=master_key_header)
+    assert history_resp.status_code == 200
+    history = history_resp.json()
+    assert len(history) == 1
+    assert history[0]["effective_at"] == new_effective.isoformat()
 
 
 def test_pricing_initialization_with_no_config(postgres_url: str, test_db: Session) -> None:

--- a/tests/unit/test_shared_helpers_pure.py
+++ b/tests/unit/test_shared_helpers_pure.py
@@ -143,6 +143,7 @@ def test_budget_response_from_model_nullable_fields() -> None:
 def test_pricing_response_from_model() -> None:
     pricing = MagicMock()
     pricing.model_key = "openai:gpt-4"
+    pricing.effective_at = datetime(2025, 2, 1, tzinfo=UTC)
     pricing.input_price_per_million = 30.0
     pricing.output_price_per_million = 60.0
     pricing.created_at = datetime(2025, 3, 1, tzinfo=UTC)
@@ -150,6 +151,7 @@ def test_pricing_response_from_model() -> None:
 
     resp = PricingResponse.from_model(pricing)
     assert resp.model_key == "openai:gpt-4"
+    assert resp.effective_at == "2025-02-01T00:00:00+00:00"
     assert resp.input_price_per_million == 30.0
     assert resp.output_price_per_million == 60.0
     assert resp.created_at == "2025-03-01T00:00:00+00:00"


### PR DESCRIPTION
## Summary
- Adds `effective_at` column to `ModelPricing` with composite PK `(model_key, effective_at)` for historical price tracking
- `find_model_pricing()` selects the price in effect at the request timestamp
- New `GET /v1/pricing/{model_key}/history` endpoint for viewing all price entries
- Pricing API supports `effective_at` on create/get/delete, config supports it in YAML
- Cost lookups now use request timestamp for billing accuracy

Ported from https://github.com/mozilla-ai/any-llm/pull/995

Co-Authored-By: Julian Bright <brightsparc@gmail.com>