### PR TITLE
feat(gateway): add GET /v1/usage bulk endpoint with time range filters

### DIFF
--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -10,6 +10,7 @@ from gateway.api.routes import (
     models,
     platform_mode,
     pricing,
+    usage,
     users,
 )
 from gateway.core.config import GatewayConfig
@@ -30,3 +31,4 @@ def register_routers(app: FastAPI, config: GatewayConfig) -> None:
     app.include_router(users.router)
     app.include_router(budgets.router)
     app.include_router(pricing.router)
+    app.include_router(usage.router)

--- a/src/gateway/api/routes/usage.py
+++ b/src/gateway/api/routes/usage.py
@@ -1,0 +1,90 @@
+"""Bulk usage log endpoint.
+
+Provides a single query interface over all usage logs with optional
+time range and user filters, ordered newest-first. Intended for
+external systems that need to sync usage data (billing, analytics).
+"""
+
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.api.deps import get_db, verify_master_key
+from gateway.models.entities import UsageLog
+
+router = APIRouter(prefix="/v1/usage", tags=["usage"])
+
+
+class UsageEntry(BaseModel):
+    """A single usage log entry."""
+
+    id: str
+    user_id: str | None
+    api_key_id: str | None
+    timestamp: str
+    model: str
+    provider: str | None
+    endpoint: str
+    prompt_tokens: int | None
+    completion_tokens: int | None
+    total_tokens: int | None
+    cost: float | None
+    status: str
+    error_message: str | None
+
+    @classmethod
+    def from_model(cls, log: UsageLog) -> "UsageEntry":
+        return cls(
+            id=log.id,
+            user_id=log.user_id,
+            api_key_id=log.api_key_id,
+            timestamp=log.timestamp.isoformat(),
+            model=log.model,
+            provider=log.provider,
+            endpoint=log.endpoint,
+            prompt_tokens=log.prompt_tokens,
+            completion_tokens=log.completion_tokens,
+            total_tokens=log.total_tokens,
+            cost=log.cost,
+            status=log.status,
+            error_message=log.error_message,
+        )
+
+
+@router.get("", dependencies=[Depends(verify_master_key)])
+async def list_usage(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    start_date: datetime | None = Query(
+        default=None,
+        description="Return logs with timestamp >= start_date (ISO 8601 or Unix epoch seconds)",
+    ),
+    end_date: datetime | None = Query(
+        default=None,
+        description="Return logs with timestamp < end_date (ISO 8601 or Unix epoch seconds)",
+    ),
+    user_id: str | None = Query(default=None, description="Filter to a single user"),
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=1000)] = 100,
+) -> list[UsageEntry]:
+    """List usage logs ordered by timestamp (most recent first).
+
+    Supports optional filters for time range and user. Paginated via skip/limit.
+    Timestamps accept either ISO 8601 strings or Unix epoch seconds (numeric).
+    """
+
+    stmt = select(UsageLog)
+    if start_date is not None:
+        stmt = stmt.where(UsageLog.timestamp >= start_date)
+    if end_date is not None:
+        stmt = stmt.where(UsageLog.timestamp < end_date)
+    if user_id is not None:
+        stmt = stmt.where(UsageLog.user_id == user_id)
+
+    stmt = stmt.order_by(UsageLog.timestamp.desc()).offset(skip).limit(limit)
+    result = await db.execute(stmt)
+    logs = result.scalars().all()
+    return [UsageEntry.from_model(log) for log in logs]

--- a/tests/integration/test_usage_endpoint.py
+++ b/tests/integration/test_usage_endpoint.py
@@ -1,0 +1,297 @@
+"""Integration tests for the bulk usage endpoint."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from gateway.models.entities import UsageLog, User
+
+USAGE_PATH = "/v1/usage"
+
+
+def _ensure_user(db: Session, user_id: str) -> None:
+    if db.query(User).filter(User.user_id == user_id).first() is None:
+        db.add(User(user_id=user_id, alias=user_id, spend=0.0, blocked=False))
+        db.flush()
+
+
+def _make_log(
+    db: Session,
+    *,
+    user_id: str,
+    timestamp: datetime,
+    api_key_id: str | None = None,
+    model: str = "gpt-4",
+    provider: str | None = "openai",
+    endpoint: str = "/v1/chat/completions",
+    prompt_tokens: int | None = 10,
+    completion_tokens: int | None = 5,
+    total_tokens: int | None = 15,
+    cost: float | None = 0.01,
+    status: str = "success",
+    error_message: str | None = None,
+    log_id: str | None = None,
+) -> UsageLog:
+    _ensure_user(db, user_id)
+    log = UsageLog(
+        id=log_id or str(uuid.uuid4()),
+        user_id=user_id,
+        api_key_id=api_key_id,
+        timestamp=timestamp,
+        model=model,
+        provider=provider,
+        endpoint=endpoint,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+        cost=cost,
+        status=status,
+        error_message=error_message,
+    )
+    db.add(log)
+    return log
+
+
+def test_list_usage_requires_master_key(client: TestClient) -> None:
+    response = client.get(USAGE_PATH)
+    assert response.status_code == 401
+
+
+def test_list_usage_returns_empty_when_no_logs(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    response = client.get(USAGE_PATH, headers=master_key_header)
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_list_usage_orders_newest_first(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    db_session: Session,
+) -> None:
+    now = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
+    older = now - timedelta(hours=1)
+    _make_log(db_session, user_id="order-user", timestamp=older)
+    _make_log(db_session, user_id="order-user", timestamp=now)
+    db_session.commit()
+
+    response = client.get(USAGE_PATH, headers=master_key_header)
+    assert response.status_code == 200
+    data = response.json()
+    assert [entry["timestamp"] for entry in data] == [now.isoformat(), older.isoformat()]
+
+
+def test_list_usage_filter_by_start_date(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    db_session: Session,
+) -> None:
+    earlier = datetime(2025, 2, 1, 10, 0, tzinfo=UTC)
+    later = datetime(2025, 2, 1, 12, 0, tzinfo=UTC)
+    _make_log(db_session, user_id="start-user", timestamp=earlier)
+    _make_log(db_session, user_id="start-user", timestamp=later)
+    db_session.commit()
+
+    response = client.get(
+        USAGE_PATH,
+        headers=master_key_header,
+        params={"start_date": later.isoformat()},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["timestamp"] == later.isoformat()
+
+
+def test_list_usage_filter_by_end_date(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    db_session: Session,
+) -> None:
+    earlier = datetime(2025, 3, 1, 8, 0, tzinfo=UTC)
+    later = datetime(2025, 3, 1, 9, 0, tzinfo=UTC)
+    _make_log(db_session, user_id="end-user", timestamp=earlier)
+    _make_log(db_session, user_id="end-user", timestamp=later)
+    db_session.commit()
+
+    response = client.get(
+        USAGE_PATH,
+        headers=master_key_header,
+        params={"end_date": later.isoformat()},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["timestamp"] == earlier.isoformat()
+
+
+def test_list_usage_filter_by_time_range(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    db_session: Session,
+) -> None:
+    base = datetime(2025, 4, 1, 0, 0, tzinfo=UTC)
+    before = base - timedelta(hours=1)
+    inside = base + timedelta(minutes=30)
+    after = base + timedelta(hours=2)
+    _make_log(db_session, user_id="range-user", timestamp=before)
+    _make_log(db_session, user_id="range-user", timestamp=base)
+    _make_log(db_session, user_id="range-user", timestamp=inside)
+    _make_log(db_session, user_id="range-user", timestamp=after)
+    db_session.commit()
+
+    response = client.get(
+        USAGE_PATH,
+        headers=master_key_header,
+        params={
+            "start_date": base.isoformat(),
+            "end_date": (base + timedelta(hours=2)).isoformat(),
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    timestamps = [entry["timestamp"] for entry in data]
+    assert timestamps == [inside.isoformat(), base.isoformat()]
+
+
+def test_list_usage_filter_by_user_id(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    db_session: Session,
+) -> None:
+    timestamp = datetime(2025, 5, 1, 15, 0, tzinfo=UTC)
+    _make_log(db_session, user_id="filter-a", timestamp=timestamp)
+    _make_log(db_session, user_id="filter-b", timestamp=timestamp)
+    db_session.commit()
+
+    response = client.get(
+        USAGE_PATH,
+        headers=master_key_header,
+        params={"user_id": "filter-b"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["user_id"] == "filter-b"
+
+
+def test_list_usage_pagination(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    db_session: Session,
+) -> None:
+    base = datetime(2025, 6, 1, 12, 0, tzinfo=UTC)
+    timestamps = []
+    for idx in range(5):
+        ts = base + timedelta(minutes=idx)
+        timestamps.append(ts)
+        _make_log(db_session, user_id="pager", timestamp=ts)
+    db_session.commit()
+
+    response = client.get(
+        USAGE_PATH,
+        headers=master_key_header,
+        params={"skip": 1, "limit": 2},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    expected_order = [ts.isoformat() for ts in sorted(timestamps, reverse=True)]
+    assert [entry["timestamp"] for entry in data] == expected_order[1:3]
+
+
+def test_list_usage_response_shape(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    db_session: Session,
+) -> None:
+    timestamp = datetime(2025, 7, 1, 9, 30, tzinfo=UTC)
+    log = _make_log(
+        db_session,
+        user_id="shape-user",
+        timestamp=timestamp,
+        api_key_id=None,
+        model="gpt-4o",
+        provider="openai",
+        endpoint="/custom",
+        prompt_tokens=42,
+        completion_tokens=7,
+        total_tokens=49,
+        cost=1.23,
+        status="error",
+        error_message="capacity",
+        log_id="shape-log-id",
+    )
+    db_session.commit()
+
+    response = client.get(USAGE_PATH, headers=master_key_header)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0] == {
+        "id": log.id,
+        "user_id": "shape-user",
+        "api_key_id": None,
+        "timestamp": timestamp.isoformat(),
+        "model": "gpt-4o",
+        "provider": "openai",
+        "endpoint": "/custom",
+        "prompt_tokens": 42,
+        "completion_tokens": 7,
+        "total_tokens": 49,
+        "cost": 1.23,
+        "status": "error",
+        "error_message": "capacity",
+    }
+
+
+def test_list_usage_limit_max_enforced(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    response = client.get(
+        USAGE_PATH,
+        headers=master_key_header,
+        params={"limit": 1001},
+    )
+    assert response.status_code == 422
+
+
+def test_list_usage_skip_negative_rejected(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    response = client.get(
+        USAGE_PATH,
+        headers=master_key_header,
+        params={"skip": -1},
+    )
+    assert response.status_code == 422
+
+
+def test_list_usage_filter_by_epoch_seconds(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    db_session: Session,
+) -> None:
+    older = datetime(2025, 8, 1, 0, 0, tzinfo=UTC)
+    newer = datetime(2025, 8, 2, 0, 0, tzinfo=UTC)
+    midpoint_epoch = int((older + timedelta(hours=12)).timestamp())
+    _make_log(db_session, user_id="epoch-user", timestamp=older)
+    _make_log(db_session, user_id="epoch-user", timestamp=newer)
+    db_session.commit()
+
+    response = client.get(
+        USAGE_PATH,
+        headers=master_key_header,
+        params={"start_date": midpoint_epoch},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["timestamp"] == newer.isoformat()


### PR DESCRIPTION
## Summary
- Adds `GET /v1/usage` endpoint for querying all usage logs across users
- Supports `start_date`, `end_date` (half-open `[start, end)` window), and `user_id` query params
- Accepts ISO 8601 strings or Unix epoch seconds for timestamps
- Results ordered by timestamp DESC, paginated via skip/limit (max 1000)
- Master key authentication required

Ported from https://github.com/mozilla-ai/any-llm/pull/999

Co-Authored-By: Julian Bright <brightsparc@gmail.com>