### PR TITLE
feat: add POST /v1/responses endpoint for OpenAI Responses API

### DIFF
--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -10,6 +10,7 @@ from gateway.api.routes import (
     models,
     platform_mode,
     pricing,
+    responses,
     usage,
     users,
 )
@@ -25,6 +26,7 @@ def register_routers(app: FastAPI, config: GatewayConfig) -> None:
         return
 
     app.include_router(messages.router)
+    app.include_router(responses.router)
     app.include_router(embeddings.router)
     app.include_router(models.router)
     app.include_router(keys.router)

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -1,0 +1,206 @@
+from typing import Annotated, Any
+
+from any_llm import AnyLLM, aresponses
+from any_llm.types.completion import CompletionUsage
+from any_llm.types.responses import ResponseStreamEvent
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import Response as FastAPIResponse
+from fastapi.responses import StreamingResponse
+from openai.types.responses import ResponseUsage
+from openresponses_types.types import Usage as OpenResponsesUsage
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
+from gateway.api.routes._helpers import resolve_user_id
+from gateway.api.routes.chat import get_provider_kwargs, log_usage, rate_limit_headers
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger
+from gateway.models.entities import APIKey
+from gateway.rate_limit import check_rate_limit
+from gateway.services.budget_service import validate_user_budget
+from gateway.services.log_writer import LogWriter
+from gateway.streaming import RESPONSES_STREAM_FORMAT, streaming_generator
+
+router = APIRouter(prefix="/v1", tags=["responses"])
+
+_MASTER_KEY_USER_REQUIRED = "When using master key, 'user' field is required in request body"
+_API_KEY_VALIDATION_FAILED = "API key validation failed"
+_API_KEY_NO_USER = "API key has no associated user"
+
+
+class ResponsesRequest(BaseModel):
+    """OpenAI Responses API-compatible request."""
+
+    model_config = ConfigDict(extra="allow")
+
+    model: str
+    input: Any
+    stream: bool = False
+    user: str | None = None
+
+
+def _usage_to_completion_usage(
+    usage: ResponseUsage | OpenResponsesUsage | None,
+) -> CompletionUsage | None:
+    if usage is None:
+        return None
+    return CompletionUsage(
+        prompt_tokens=getattr(usage, "input_tokens", 0) or 0,
+        completion_tokens=getattr(usage, "output_tokens", 0) or 0,
+        total_tokens=getattr(usage, "total_tokens", 0) or 0,
+    )
+
+
+@router.post("/responses", response_model=None)
+async def create_response(
+    raw_request: Request,
+    response: FastAPIResponse,
+    request_body: ResponsesRequest,
+    auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    log_writer: Annotated[LogWriter, Depends(get_log_writer)],
+) -> dict[str, Any] | StreamingResponse:
+    """OpenAI-compatible Responses endpoint."""
+
+    api_key, is_master_key = auth_result
+    api_key_id = api_key.id if api_key else None
+
+    user_id = resolve_user_id(
+        user_id_from_request=request_body.user,
+        api_key=api_key,
+        is_master_key=is_master_key,
+        master_key_error=HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=_MASTER_KEY_USER_REQUIRED,
+        ),
+        no_api_key_error=HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=_API_KEY_VALIDATION_FAILED,
+        ),
+        no_user_error=HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=_API_KEY_NO_USER,
+        ),
+    )
+
+    rate_limit_info = check_rate_limit(raw_request, user_id)
+
+    _ = await validate_user_budget(db, user_id, request_body.model, strategy=config.budget_strategy)
+    if config.budget_strategy == "for_update":
+        await db.rollback()
+
+    provider, model = AnyLLM.split_model_provider(request_body.model)
+    provider_class = AnyLLM.get_provider_class(provider)
+    if not getattr(provider_class, "SUPPORTS_RESPONSES", False):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Provider '{provider.value}' does not support the Responses API",
+        )
+
+    provider_kwargs = get_provider_kwargs(config, provider)
+
+    request_fields = request_body.model_dump(exclude_none=True)
+    input_payload = request_fields.pop("input")
+    stream = bool(request_fields.pop("stream", False))
+    request_fields.pop("model", None)
+    request_fields.pop("user", None)
+    request_fields["user"] = user_id
+
+    call_kwargs: dict[str, Any] = {**provider_kwargs}
+    call_kwargs.update(request_fields)
+    call_kwargs["model"] = model
+    call_kwargs["provider"] = provider
+    call_kwargs["input_data"] = input_payload
+
+    try:
+        if stream:
+            call_kwargs["stream"] = True
+
+            def _format_chunk(event: ResponseStreamEvent) -> str:
+                return f"event: {event.type}\ndata: {event.model_dump_json(exclude_none=True)}\n\n"
+
+            def _extract_usage(event: ResponseStreamEvent) -> CompletionUsage | None:
+                response_obj = getattr(event, "response", None)
+                if response_obj and getattr(response_obj, "usage", None):
+                    return _usage_to_completion_usage(response_obj.usage)
+                return None
+
+            async def _on_complete(usage_data: CompletionUsage) -> None:
+                await log_usage(
+                    db=db,
+                    log_writer=log_writer,
+                    api_key_id=api_key_id,
+                    model=model,
+                    provider=provider,
+                    endpoint="/v1/responses",
+                    user_id=user_id,
+                    usage_override=usage_data,
+                )
+
+            async def _on_error(error: str) -> None:
+                await log_usage(
+                    db=db,
+                    log_writer=log_writer,
+                    api_key_id=api_key_id,
+                    model=model,
+                    provider=provider,
+                    endpoint="/v1/responses",
+                    user_id=user_id,
+                    error=error,
+                )
+
+            stream_result = await aresponses(**call_kwargs)
+            rl_headers = rate_limit_headers(rate_limit_info) if rate_limit_info else {}
+            return StreamingResponse(
+                streaming_generator(
+                    stream=stream_result,  # type: ignore[arg-type]
+                    format_chunk=_format_chunk,
+                    extract_usage=_extract_usage,
+                    fmt=RESPONSES_STREAM_FORMAT,
+                    on_complete=_on_complete,
+                    on_error=_on_error,
+                    label=f"{provider}:{model}",
+                ),
+                media_type="text/event-stream",
+                headers=rl_headers,
+            )
+
+        result = await aresponses(**call_kwargs)
+        usage_data = _usage_to_completion_usage(getattr(result, "usage", None))
+        await log_usage(
+            db=db,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            model=model,
+            provider=provider,
+            endpoint="/v1/responses",
+            user_id=user_id,
+            usage_override=usage_data,
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        await log_usage(
+            db=db,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            model=model,
+            provider=provider,
+            endpoint="/v1/responses",
+            user_id=user_id,
+            error=str(e),
+        )
+        logger.error("Provider call failed for %s:%s: %s", provider, model, e)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="LLM provider error",
+        ) from e
+
+    if rate_limit_info:
+        for key, value in rate_limit_headers(rate_limit_info).items():
+            response.headers[key] = value
+
+    return result.model_dump(exclude_none=True)

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -30,6 +30,12 @@ OPENAI_STREAM_FORMAT = StreamFormat(
     yield_done_on_error=True,
 )
 
+RESPONSES_STREAM_FORMAT = StreamFormat(
+    done_marker="data: [DONE]\n\n",
+    error_payload=f"event: error\ndata: {_OPENAI_ERROR}\n\n",
+    yield_done_on_error=False,
+)
+
 ANTHROPIC_STREAM_FORMAT = StreamFormat(
     done_marker="event: done\ndata: {}\n\n",
     error_payload=f"event: error\ndata: {_ANTHROPIC_ERROR}\n\n",

--- a/tests/integration/test_responses_endpoint.py
+++ b/tests/integration/test_responses_endpoint.py
@@ -1,0 +1,293 @@
+"""Tests for the /v1/responses gateway endpoint."""
+
+import json
+from typing import Any, AsyncIterator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway.core.config import API_KEY_HEADER
+
+
+class _FakeUsage:
+    def __init__(self, input_tokens: int, output_tokens: int, total_tokens: int | None = None) -> None:
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self.total_tokens = total_tokens or input_tokens + output_tokens
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any], usage: _FakeUsage | None = None) -> None:
+        self._payload = payload
+        self.usage = usage
+
+    def model_dump(self, *, exclude_none: bool = False) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeStreamEvent:
+    def __init__(self, event_type: str, payload: dict[str, Any], response: _FakeResponse | None = None) -> None:
+        self.type = event_type
+        self._payload = payload
+        self.response = response
+
+    def model_dump_json(self, *, exclude_none: bool = False) -> str:
+        return json.dumps(self._payload)
+
+
+@pytest.fixture
+def responses_request_body(test_user: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "model": "openai:gpt-4o-mini",
+        "input": {"type": "text", "text": "Hello"},
+        "user": test_user["user_id"],
+    }
+
+
+def _make_stream(events: list[_FakeStreamEvent]) -> AsyncIterator[_FakeStreamEvent]:
+    async def _generator() -> AsyncIterator[_FakeStreamEvent]:
+        for event in events:
+            yield event
+
+    return _generator()
+
+
+def _make_failing_stream(
+    events: list[_FakeStreamEvent],
+    exc: Exception,
+) -> AsyncIterator[_FakeStreamEvent]:
+    async def _generator() -> AsyncIterator[_FakeStreamEvent]:
+        for event in events:
+            yield event
+        raise exc
+
+    return _generator()
+
+
+def test_responses_endpoint_basic_completion(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    responses_request_body: dict[str, Any],
+) -> None:
+    """Test basic non-streaming Responses call."""
+
+    fake_usage = _FakeUsage(input_tokens=10, output_tokens=20)
+    fake_payload = {"id": "resp_123", "output": [{"type": "message", "content": "Hello"}]}
+
+    with patch(
+        "gateway.api.routes.responses.aresponses",
+        new_callable=AsyncMock,
+        return_value=_FakeResponse(fake_payload, fake_usage),
+    ):
+        result = client.post("/v1/responses", json=responses_request_body, headers=master_key_header)
+
+    assert result.status_code == 200
+    data = result.json()
+    assert data["id"] == "resp_123"
+    assert data["output"][0]["content"] == "Hello"
+
+
+def test_responses_endpoint_master_key_requires_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    responses_request_body: dict[str, Any],
+) -> None:
+    """Master key authentication requires explicit user field."""
+
+    responses_request_body.pop("user")
+
+    with patch("gateway.api.routes.responses.aresponses", new_callable=AsyncMock) as mock_call:
+        result = client.post("/v1/responses", json=responses_request_body, headers=master_key_header)
+
+    assert result.status_code == 400
+    assert result.json()["detail"] == "When using master key, 'user' field is required in request body"
+    mock_call.assert_not_called()
+
+
+def test_responses_endpoint_rejects_unsupported_provider(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    responses_request_body: dict[str, Any],
+) -> None:
+    """Requests to providers without Responses support are rejected."""
+
+    responses_request_body["model"] = "anthropic:claude-3-5"
+
+    class _UnsupportedProvider:
+        SUPPORTS_RESPONSES = False
+
+    with (
+        patch("gateway.api.routes.responses.aresponses", new_callable=AsyncMock) as mock_call,
+        patch("gateway.api.routes.responses.AnyLLM.get_provider_class", return_value=_UnsupportedProvider),
+    ):
+        result = client.post("/v1/responses", json=responses_request_body, headers=master_key_header)
+
+    assert result.status_code == 400
+    assert "does not support" in result.json()["detail"]
+    mock_call.assert_not_called()
+
+
+def test_responses_endpoint_streaming(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    responses_request_body: dict[str, Any],
+) -> None:
+    """Streaming responses emit SSE events and done marker."""
+
+    responses_request_body["stream"] = True
+    events = [
+        _FakeStreamEvent("response.created", {"event": "created"}),
+        _FakeStreamEvent(
+            "response.completed",
+            {"event": "completed"},
+            response=_FakeResponse({}, usage=_FakeUsage(5, 7)),
+        ),
+    ]
+
+    with patch("gateway.api.routes.responses.aresponses", new_callable=AsyncMock, return_value=_make_stream(events)):
+        resp = client.post("/v1/responses", json=responses_request_body, headers=master_key_header)
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+
+    lines = list(resp.iter_lines())
+
+    assert "event: response.created" in lines
+    assert "event: response.completed" in lines
+    data_lines = [line for line in lines if line.startswith("data: ") and line != "data: [DONE]"]
+    assert data_lines, "Expected at least one payload data line"
+    json.loads(data_lines[0][6:])
+    assert "data: [DONE]" in lines
+
+
+def test_responses_endpoint_preserves_encrypted_reasoning_fields(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    responses_request_body: dict[str, Any],
+) -> None:
+    """Ensure reasoning fields pass through untouched."""
+
+    responses_request_body.update(
+        {
+            "reasoning": {"effort": "medium"},
+            "include": ["reasoning.encrypted_content"],
+        }
+    )
+
+    payload = {"id": "resp_reasoning", "reasoning": {"encrypted_content": "***"}}
+
+    with patch(
+        "gateway.api.routes.responses.aresponses", new_callable=AsyncMock, return_value=_FakeResponse(payload)
+    ) as mock_call:
+        result = client.post("/v1/responses", json=responses_request_body, headers=master_key_header)
+
+    assert result.status_code == 200
+    assert result.json()["reasoning"]["encrypted_content"] == "***"
+
+    kwargs = mock_call.await_args.kwargs
+    assert kwargs["include"] == ["reasoning.encrypted_content"]
+    assert kwargs["reasoning"] == {"effort": "medium"}
+
+
+def test_responses_endpoint_bearer_auth(
+    client: TestClient,
+    api_key_obj: dict[str, Any],
+    responses_request_body: dict[str, Any],
+) -> None:
+    """Standard Bearer auth header is accepted."""
+
+    headers = {API_KEY_HEADER: f"Bearer {api_key_obj['key']}"}
+
+    with patch(
+        "gateway.api.routes.responses.aresponses",
+        new_callable=AsyncMock,
+        return_value=_FakeResponse({"id": "resp_token"}),
+    ):
+        result = client.post("/v1/responses", json=responses_request_body, headers=headers)
+
+    assert result.status_code == 200
+    assert result.json()["id"] == "resp_token"
+
+
+def test_responses_endpoint_provider_error_non_streaming(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    responses_request_body: dict[str, Any],
+) -> None:
+    """Provider failures bubble up as HTTP 502 errors."""
+
+    with patch(
+        "gateway.api.routes.responses.aresponses",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("boom"),
+    ):
+        result = client.post("/v1/responses", json=responses_request_body, headers=master_key_header)
+
+    assert result.status_code == 502
+    assert result.json() == {"detail": "LLM provider error"}
+
+
+def test_responses_endpoint_provider_error_streaming(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    responses_request_body: dict[str, Any],
+) -> None:
+    """Provider errors before the stream starts return HTTP error."""
+
+    responses_request_body["stream"] = True
+
+    with patch(
+        "gateway.api.routes.responses.aresponses",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("boom"),
+    ):
+        result = client.post("/v1/responses", json=responses_request_body, headers=master_key_header)
+
+    assert result.status_code == 502
+    assert result.json() == {"detail": "LLM provider error"}
+
+
+def test_responses_endpoint_no_usage_data(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    responses_request_body: dict[str, Any],
+) -> None:
+    """Responses without usage data still succeed."""
+
+    payload = {"id": "resp_no_usage", "output": []}
+
+    with patch(
+        "gateway.api.routes.responses.aresponses",
+        new_callable=AsyncMock,
+        return_value=_FakeResponse(payload, usage=None),
+    ):
+        result = client.post("/v1/responses", json=responses_request_body, headers=master_key_header)
+
+    assert result.status_code == 200
+    assert result.json()["id"] == "resp_no_usage"
+
+
+def test_responses_endpoint_streaming_mid_stream_error(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    responses_request_body: dict[str, Any],
+) -> None:
+    """Streaming errors emit SSE error events without DONE marker."""
+
+    responses_request_body["stream"] = True
+    events = [_FakeStreamEvent("response.created", {"event": "created"})]
+
+    with patch(
+        "gateway.api.routes.responses.aresponses",
+        new_callable=AsyncMock,
+        return_value=_make_failing_stream(events, RuntimeError("stream boom")),
+    ):
+        resp = client.post("/v1/responses", json=responses_request_body, headers=master_key_header)
+
+    assert resp.status_code == 200
+    lines = list(resp.iter_lines())
+    assert "event: response.created" in lines
+    assert "event: error" in lines
+    assert any(line.startswith('data: {"error"') for line in lines)
+    assert "data: [DONE]" not in lines


### PR DESCRIPTION
## Summary
- Adds `POST /v1/responses` route for OpenAI-compatible Responses API support
- Reuses the SDK's `aresponses()` implementation with full auth/budget/rate-limit enforcement
- Only allows providers where `SUPPORTS_RESPONSES=True`
- Preserves Responses-only fields (reasoning, include, etc.) via `ConfigDict(extra="allow")`
- Supports both streaming (SSE with `event: {type}` format) and non-streaming responses
- Adds `RESPONSES_STREAM_FORMAT` to shared streaming utilities

Ported from https://github.com/mozilla-ai/any-llm/pull/992

Co-Authored-By: Julian Bright <brightsparc@gmail.com>