### PR TITLE
fix: resolve mypy type errors and regenerate OpenAPI spec

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -766,6 +766,10 @@
             "title": "Created At",
             "type": "string"
           },
+          "effective_at": {
+            "title": "Effective At",
+            "type": "string"
+          },
           "input_price_per_million": {
             "title": "Input Price Per Million",
             "type": "number"
@@ -785,6 +789,7 @@
         },
         "required": [
           "model_key",
+          "effective_at",
           "input_price_per_million",
           "output_price_per_million",
           "created_at",
@@ -793,9 +798,57 @@
         "title": "PricingResponse",
         "type": "object"
       },
+      "ResponsesRequest": {
+        "additionalProperties": true,
+        "description": "OpenAI Responses API-compatible request.",
+        "properties": {
+          "input": {
+            "title": "Input"
+          },
+          "model": {
+            "title": "Model",
+            "type": "string"
+          },
+          "stream": {
+            "default": false,
+            "title": "Stream",
+            "type": "boolean"
+          },
+          "user": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User"
+          }
+        },
+        "required": [
+          "model",
+          "input"
+        ],
+        "title": "ResponsesRequest",
+        "type": "object"
+      },
       "SetPricingRequest": {
         "description": "Request model for setting model pricing.",
         "properties": {
+          "effective_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "ISO 8601 datetime from which this price applies. Defaults to now if omitted.",
+            "title": "Effective At"
+          },
           "input_price_per_million": {
             "description": "Price per 1M input tokens",
             "minimum": 0.0,
@@ -956,6 +1009,136 @@
           }
         },
         "title": "UpdateUserRequest",
+        "type": "object"
+      },
+      "UsageEntry": {
+        "description": "A single usage log entry.",
+        "properties": {
+          "api_key_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Key Id"
+          },
+          "completion_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completion Tokens"
+          },
+          "cost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost"
+          },
+          "endpoint": {
+            "title": "Endpoint",
+            "type": "string"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "model": {
+            "title": "Model",
+            "type": "string"
+          },
+          "prompt_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt Tokens"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "timestamp": {
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "total_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Tokens"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": [
+          "id",
+          "user_id",
+          "api_key_id",
+          "timestamp",
+          "model",
+          "provider",
+          "endpoint",
+          "prompt_tokens",
+          "completion_tokens",
+          "total_tokens",
+          "cost",
+          "status",
+          "error_message"
+        ],
+        "title": "UsageEntry",
         "type": "object"
       },
       "UsageLogResponse": {
@@ -1221,7 +1404,7 @@
   "info": {
     "description": "A clean FastAPI gateway for any-llm with API key management",
     "title": "any-llm-gateway",
-    "version": "0.0.0.dev0"
+    "version": "0.0.0-dev"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -2044,7 +2227,7 @@
     },
     "/v1/pricing/{model_key}": {
       "delete": {
-        "description": "Delete pricing for a model.",
+        "description": "Delete pricing entries for a model.",
         "operationId": "delete_pricing_v1_pricing__model_key__delete",
         "parameters": [
           {
@@ -2054,6 +2237,25 @@
             "schema": {
               "title": "Model Key",
               "type": "string"
+            }
+          },
+          {
+            "description": "ISO datetime identifying a specific pricing row to delete",
+            "in": "query",
+            "name": "effective_at",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "ISO datetime identifying a specific pricing row to delete",
+              "title": "Effective At"
             }
           }
         ],
@@ -2078,7 +2280,7 @@
         ]
       },
       "get": {
-        "description": "Get pricing for a specific model.",
+        "description": "Get pricing for a specific model as of a timestamp.",
         "operationId": "get_pricing_v1_pricing__model_key__get",
         "parameters": [
           {
@@ -2088,6 +2290,25 @@
             "schema": {
               "title": "Model Key",
               "type": "string"
+            }
+          },
+          {
+            "description": "ISO datetime for effective lookup",
+            "in": "query",
+            "name": "as_of",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "ISO datetime for effective lookup",
+              "title": "as_of"
             }
           }
         ],
@@ -2116,6 +2337,210 @@
         "summary": "Get Pricing",
         "tags": [
           "pricing"
+        ]
+      }
+    },
+    "/v1/pricing/{model_key}/history": {
+      "get": {
+        "description": "Return the full pricing history for a model.",
+        "operationId": "get_pricing_history_v1_pricing__model_key__history_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "model_key",
+            "required": true,
+            "schema": {
+              "title": "Model Key",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/PricingResponse"
+                  },
+                  "title": "Response Get Pricing History V1 Pricing  Model Key  History Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Pricing History",
+        "tags": [
+          "pricing"
+        ]
+      }
+    },
+    "/v1/responses": {
+      "post": {
+        "description": "OpenAI-compatible Responses endpoint.",
+        "operationId": "create_response_v1_responses_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResponsesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Response",
+        "tags": [
+          "responses"
+        ]
+      }
+    },
+    "/v1/usage": {
+      "get": {
+        "description": "List usage logs ordered by timestamp (most recent first).\n\nSupports optional filters for time range and user. Paginated via skip/limit.\nTimestamps accept either ISO 8601 strings or Unix epoch seconds (numeric).",
+        "operationId": "list_usage_v1_usage_get",
+        "parameters": [
+          {
+            "description": "Return logs with timestamp >= start_date (ISO 8601 or Unix epoch seconds)",
+            "in": "query",
+            "name": "start_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return logs with timestamp >= start_date (ISO 8601 or Unix epoch seconds)",
+              "title": "Start Date"
+            }
+          },
+          {
+            "description": "Return logs with timestamp < end_date (ISO 8601 or Unix epoch seconds)",
+            "in": "query",
+            "name": "end_date",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return logs with timestamp < end_date (ISO 8601 or Unix epoch seconds)",
+              "title": "End Date"
+            }
+          },
+          {
+            "description": "Filter to a single user",
+            "in": "query",
+            "name": "user_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to a single user",
+              "title": "User Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Skip",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/UsageEntry"
+                  },
+                  "title": "Response List Usage V1 Usage Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Usage",
+        "tags": [
+          "usage"
         ]
       }
     },

--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -218,7 +218,8 @@ async def get_db_if_needed(
 
 
 def get_log_writer(request: Request) -> LogWriter:
-    return request.app.state.log_writer
+    writer: LogWriter = request.app.state.log_writer
+    return writer
 
 
 __all__ = [

--- a/src/gateway/api/routes/pricing.py
+++ b/src/gateway/api/routes/pricing.py
@@ -93,7 +93,7 @@ async def _get_effective_pricing(
 async def _get_pricing_history(db: AsyncSession, model_keys: list[str]) -> list[ModelPricing]:
     for key in model_keys:
         stmt = select(ModelPricing).where(ModelPricing.model_key == key).order_by(ModelPricing.effective_at.desc())
-        pricings = (await db.execute(stmt)).scalars().all()
+        pricings = list((await db.execute(stmt)).scalars().all())
         if pricings:
             return pricings
     return []

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -203,4 +203,4 @@ async def create_response(
         for key, value in rate_limit_headers(rate_limit_info).items():
             response.headers[key] = value
 
-    return result.model_dump(exclude_none=True)
+    return result.model_dump(exclude_none=True)  # type: ignore[union-attr]

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -1,4 +1,6 @@
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from typing import Any, Callable
 
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
@@ -152,9 +154,9 @@ def _validate_platform_config(config: GatewayConfig) -> None:
         raise ValueError(msg)
 
 
-def _create_lifespan(config: GatewayConfig):  # noqa: ANN201 - FastAPI contract
+def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
     @asynccontextmanager
-    async def lifespan(app: FastAPI):
+    async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         log_writer: LogWriter
         if config.is_platform_mode:
             log_writer = NoopLogWriter()

--- a/src/gateway/services/budget_service.py
+++ b/src/gateway/services/budget_service.py
@@ -81,7 +81,8 @@ async def _cas_reset_user_budget(db: AsyncSession, user: User, budget: Budget, n
         .execution_options(synchronize_session=False)
     )
 
-    if result.rowcount and result.rowcount > 0:
+    rowcount = getattr(result, "rowcount", 0)
+    if rowcount and rowcount > 0:
         reset_log = BudgetResetLog(
             user_id=user.user_id,
             budget_id=budget.budget_id,

--- a/src/gateway/services/log_writer.py
+++ b/src/gateway/services/log_writer.py
@@ -145,7 +145,7 @@ class BatchLogWriter:
 def create_log_writer(strategy: str) -> LogWriter:
     if strategy == "batch":
         return BatchLogWriter()
-    return SingleLogWriter()  # type: ignore[return-value]
+    return SingleLogWriter()
 
 
 class NoopLogWriter:

--- a/tests/integration/test_atomic_spend_update.py
+++ b/tests/integration/test_atomic_spend_update.py
@@ -1,10 +1,11 @@
 """Tests for atomic spend update via SQL expression."""
 
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import pytest
 from any_llm.types.completion import CompletionUsage
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.routes.chat import log_usage
 from gateway.models.entities import ModelPricing, User
@@ -12,7 +13,7 @@ from gateway.services.log_writer import SingleLogWriter
 
 
 @pytest.mark.asyncio
-async def test_spend_update_uses_sql_expression(async_db: Session, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_spend_update_uses_sql_expression(async_db: AsyncSession, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that _log_usage updates spend atomically via SQL, not Python read-modify-write."""
     # Set up user with initial spend
     user = User(user_id="atomic-user", spend=5.0)
@@ -31,7 +32,7 @@ async def test_spend_update_uses_sql_expression(async_db: Session, monkeypatch: 
     writer = SingleLogWriter()
 
     @asynccontextmanager
-    async def _session_cm():
+    async def _session_cm() -> AsyncGenerator[AsyncSession, None]:
         yield async_db
 
     monkeypatch.setattr("gateway.services.log_writer.create_session", lambda: _session_cm())
@@ -59,7 +60,7 @@ async def test_spend_update_uses_sql_expression(async_db: Session, monkeypatch: 
 
 
 @pytest.mark.asyncio
-async def test_multiple_spend_updates_accumulate(async_db: Session, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_multiple_spend_updates_accumulate(async_db: AsyncSession, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that multiple sequential spend updates accumulate correctly."""
     user = User(user_id="multi-spend-user", spend=0.0)
     async_db.add(user)
@@ -75,7 +76,7 @@ async def test_multiple_spend_updates_accumulate(async_db: Session, monkeypatch:
     writer = SingleLogWriter()
 
     @asynccontextmanager
-    async def _session_cm():
+    async def _session_cm() -> AsyncGenerator[AsyncSession, None]:
         yield async_db
 
     monkeypatch.setattr("gateway.services.log_writer.create_session", lambda: _session_cm())

--- a/tests/integration/test_log_usage_commit_scope.py
+++ b/tests/integration/test_log_usage_commit_scope.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 import pytest
 from any_llm.types.completion import CompletionUsage
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.routes.chat import log_usage
 from gateway.models.entities import ModelPricing, UsageLog
@@ -29,7 +30,7 @@ class StubLogWriter:
 
 
 @pytest.mark.asyncio
-async def test_log_usage_records_usage_data(async_db) -> None:
+async def test_log_usage_records_usage_data(async_db: AsyncSession) -> None:
     pricing = ModelPricing(model_key="openai:gpt-4o", input_price_per_million=2.0, output_price_per_million=4.0)
     async_db.add(pricing)
     await async_db.commit()
@@ -56,7 +57,7 @@ async def test_log_usage_records_usage_data(async_db) -> None:
 
 
 @pytest.mark.asyncio
-async def test_log_usage_records_error(async_db) -> None:
+async def test_log_usage_records_error(async_db: AsyncSession) -> None:
     writer = StubLogWriter()
 
     await log_usage(

--- a/tests/integration/test_pricing_config.py
+++ b/tests/integration/test_pricing_config.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 import pytest
 from any_llm.types.completion import CompletionUsage
 from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from gateway.api.routes.chat import log_usage
@@ -340,7 +341,7 @@ def test_pricing_initialization_with_no_config(postgres_url: str, test_db: Sessi
 
 
 @pytest.mark.asyncio
-async def test_log_usage_finds_pricing_with_legacy_slash_format(async_db) -> None:
+async def test_log_usage_finds_pricing_with_legacy_slash_format(async_db: AsyncSession) -> None:
     """Test that log_usage falls back to legacy slash format when colon format is absent."""
 
     class _Writer:
@@ -349,6 +350,12 @@ async def test_log_usage_finds_pricing_with_legacy_slash_format(async_db) -> Non
 
         async def put(self, log: UsageLog) -> None:
             self.logs.append(log)
+
+        async def start(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            pass
 
     legacy_pricing = ModelPricing(
         model_key="openai/gpt-4",
@@ -378,7 +385,7 @@ async def test_log_usage_finds_pricing_with_legacy_slash_format(async_db) -> Non
 
 
 @pytest.mark.asyncio
-async def test_log_usage_finds_pricing_with_colon_format(async_db) -> None:
+async def test_log_usage_finds_pricing_with_colon_format(async_db: AsyncSession) -> None:
     """Test that log_usage uses canonical colon pricing when available."""
 
     class _Writer:
@@ -387,6 +394,12 @@ async def test_log_usage_finds_pricing_with_colon_format(async_db) -> None:
 
         async def put(self, log: UsageLog) -> None:
             self.logs.append(log)
+
+        async def start(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            pass
 
     pricing = ModelPricing(
         model_key="openai:gpt-4",

--- a/tests/integration/test_responses_endpoint.py
+++ b/tests/integration/test_responses_endpoint.py
@@ -185,6 +185,7 @@ def test_responses_endpoint_preserves_encrypted_reasoning_fields(
     assert result.status_code == 200
     assert result.json()["reasoning"]["encrypted_content"] == "***"
 
+    assert mock_call.await_args is not None
     kwargs = mock_call.await_args.kwargs
     assert kwargs["include"] == ["reasoning.encrypted_content"]
     assert kwargs["reasoning"] == {"effort": "medium"}

--- a/tests/integration/test_timezone_consistency.py
+++ b/tests/integration/test_timezone_consistency.py
@@ -1,13 +1,14 @@
 """Tests for timezone-aware datetime consistency."""
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.routes.chat import log_usage
 from gateway.models.entities import UsageLog
 
 
 @pytest.mark.asyncio
-async def test_usage_log_timestamp_is_timezone_aware(async_db) -> None:
+async def test_usage_log_timestamp_is_timezone_aware(async_db: AsyncSession) -> None:
     """Test that usage log timestamps are stored with timezone info."""
 
     class _Writer:
@@ -16,6 +17,12 @@ async def test_usage_log_timestamp_is_timezone_aware(async_db) -> None:
 
         async def put(self, log: UsageLog) -> None:
             self.logs.append(log)
+
+        async def start(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            pass
 
     writer = _Writer()
     await log_usage(

--- a/tests/integration/test_transaction_safety.py
+++ b/tests/integration/test_transaction_safety.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.core.config import API_KEY_HEADER
 from gateway.models.entities import Budget, User
@@ -104,7 +104,7 @@ def test_set_pricing_rollback_on_commit_failure(
 
 
 @pytest.mark.asyncio
-async def test_reset_user_budget_rollback_on_commit_failure(async_db: Session) -> None:
+async def test_reset_user_budget_rollback_on_commit_failure(async_db: AsyncSession) -> None:
     """reset_user_budget rolls back and re-raises when commit fails."""
     from datetime import UTC, datetime
 
@@ -126,21 +126,21 @@ async def test_reset_user_budget_rollback_on_commit_failure(async_db: Session) -
 
 
 @pytest.mark.asyncio
-async def test_is_model_free_catches_value_error(async_db: Session) -> None:
+async def test_is_model_free_catches_value_error(async_db: AsyncSession) -> None:
     """_is_model_free returns False on ValueError from split_model_provider."""
     result = await _is_model_free(async_db, "completely-invalid-model-string-no-provider")
     assert result is False
 
 
 @pytest.mark.asyncio
-async def test_is_model_free_catches_unsupported_provider_error(async_db: Session) -> None:
+async def test_is_model_free_catches_unsupported_provider_error(async_db: AsyncSession) -> None:
     """_is_model_free returns False on UnsupportedProviderError from split_model_provider."""
     result = await _is_model_free(async_db, "unknown:some-model")
     assert result is False
 
 
 @pytest.mark.asyncio
-async def test_is_model_free_catches_sqlalchemy_error(async_db: Session) -> None:
+async def test_is_model_free_catches_sqlalchemy_error(async_db: AsyncSession) -> None:
     """_is_model_free returns False on SQLAlchemy errors during pricing lookup."""
     with patch(
         "gateway.services.budget_service.find_model_pricing",
@@ -151,7 +151,7 @@ async def test_is_model_free_catches_sqlalchemy_error(async_db: Session) -> None
 
 
 @pytest.mark.asyncio
-async def test_is_model_free_does_not_catch_unexpected_errors(async_db: Session) -> None:
+async def test_is_model_free_does_not_catch_unexpected_errors(async_db: AsyncSession) -> None:
     """_is_model_free does not swallow unexpected non-DB, non-ValueError exceptions."""
     with (
         patch("gateway.services.budget_service.find_model_pricing", side_effect=RuntimeError("unexpected")),

--- a/tests/integration/test_user_delete_preserve_logs.py
+++ b/tests/integration/test_user_delete_preserve_logs.py
@@ -104,7 +104,7 @@ def test_delete_user_preserves_budget_reset_logs(
             usage=CompletionUsage(prompt_tokens=5, completion_tokens=1, total_tokens=6),
         )
 
-        async def _mock_acompletion(**kwargs: Any) -> ChatCompletion:  # type: ignore[name-defined]
+        async def _mock_acompletion(**kwargs: Any) -> ChatCompletion:
             return mock_response
 
         mock_acompletion.side_effect = _mock_acompletion

--- a/tests/unit/test_gateway_users_repository.py
+++ b/tests/unit/test_gateway_users_repository.py
@@ -15,7 +15,7 @@ async def test_get_active_user_applies_for_update_when_requested() -> None:
     await get_active_user(db, "user-1", for_update=True)
 
     executed_stmt = db.execute.call_args.args[0]
-    assert executed_stmt._for_update_arg is not None  # type: ignore[attr-defined]
+    assert executed_stmt._for_update_arg is not None
 
 
 @pytest.mark.asyncio
@@ -28,4 +28,4 @@ async def test_get_active_user_skips_for_update_when_not_requested() -> None:
     await get_active_user(db, "user-2", for_update=False)
 
     executed_stmt = db.execute.call_args.args[0]
-    assert executed_stmt._for_update_arg is None  # type: ignore[attr-defined]
+    assert executed_stmt._for_update_arg is None

--- a/tests/unit/test_log_writer.py
+++ b/tests/unit/test_log_writer.py
@@ -1,3 +1,4 @@
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock
 
@@ -15,7 +16,7 @@ async def test_single_log_writer_rolls_back_on_failure(monkeypatch: pytest.Monke
     session.commit.side_effect = SQLAlchemyError("boom")
 
     @asynccontextmanager
-    async def _session_cm():  # type: ignore[return-annnotation]
+    async def _session_cm() -> AsyncGenerator[AsyncMock, None]:
         yield session
 
     monkeypatch.setattr("gateway.services.log_writer.create_session", lambda: _session_cm())


### PR DESCRIPTION
## Summary
- Fix all 40 mypy type errors that were failing the Gateway Typecheck CI job on main
- Regenerate the OpenAPI spec to match current route definitions (was out of date since the responses endpoint merge)

## Changes

### Source fixes (6 files)
- log_writer.py: Remove stale type: ignore - SingleLogWriter now satisfies the LogWriter protocol
- deps.py: Assign request.app.state.log_writer to a typed local variable to avoid no-any-return
- budget_service.py: Use getattr for rowcount access on Result[Any]
- pricing.py: Wrap .scalars().all() in list() to match the list return annotation
- main.py: Add return type annotations to _create_lifespan and lifespan
- responses.py: Add type: ignore[union-attr] for .model_dump() on aresponses union return type

### Test fixes (8 files)
- Fix AsyncSession vs Session type annotations in test_transaction_safety.py and test_atomic_spend_update.py
- Add missing start/stop methods to LogWriter test stubs
- Add missing parameter type annotations in tests
- Remove stale type: ignore comments
- Assert mock_call.await_args is not None in test_responses_endpoint.py

### OpenAPI spec
- Regenerated docs/public/openapi.json to include the /v1/responses endpoint