### PR TITLE
chore: bake GATEWAY_VERSION into Docker image at build time

### DIFF
--- a/.github/workflows/gateway-docker.yml
+++ b/.github/workflows/gateway-docker.yml
@@ -62,6 +62,8 @@ jobs:
           file: Dockerfile
           load: true
           tags: gateway-test:${{ github.sha }}
+          build-args: |
+            GATEWAY_VERSION=${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -77,6 +79,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GATEWAY_VERSION=${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
           cache-from: type=gha
 
   update-dockerhub-description:

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
 
+ARG GATEWAY_VERSION=0.0.0-dev
+ENV GATEWAY_VERSION=${GATEWAY_VERSION}
 ENV GATEWAY_HOST=0.0.0.0
 ENV GATEWAY_PORT=8000
 


### PR DESCRIPTION
## Summary

- Adds a `GATEWAY_VERSION` build arg to the Dockerfile so the published image reports the correct version at runtime (via `/health`) instead of the default `0.0.0-dev`.
- Passes the commit SHA (or release tag on release events) as the build arg in the Docker publish workflow.

## Details

| Trigger | `GATEWAY_VERSION` value |
|---|---|
| Push to `main` / `workflow_dispatch` | Full commit SHA |
| Release (`published`) | Release tag (e.g. `v1.2.3`) |

The env var can still be overridden at deploy time in K8s if needed, since the Dockerfile `ENV` is just the default.