### PR TITLE
feat: add POST /v1/images/generations endpoint

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -495,6 +495,91 @@
         "title": "HTTPValidationError",
         "type": "object"
       },
+      "ImageGenerationRequest": {
+        "description": "OpenAI-compatible image generation request.",
+        "properties": {
+          "model": {
+            "title": "Model",
+            "type": "string"
+          },
+          "n": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "N"
+          },
+          "prompt": {
+            "title": "Prompt",
+            "type": "string"
+          },
+          "quality": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quality"
+          },
+          "response_format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Response Format"
+          },
+          "size": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size"
+          },
+          "style": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Style"
+          },
+          "user": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User"
+          }
+        },
+        "required": [
+          "model",
+          "prompt"
+        ],
+        "title": "ImageGenerationRequest",
+        "type": "object"
+      },
       "KeyInfo": {
         "description": "Response model for key information.",
         "properties": {
@@ -1873,6 +1958,46 @@
         "summary": "Create Embedding",
         "tags": [
           "embeddings"
+        ]
+      }
+    },
+    "/v1/images/generations": {
+      "post": {
+        "description": "OpenAI-compatible image generation endpoint.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
+        "operationId": "create_image_v1_images_generations_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImageGenerationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Image",
+        "tags": [
+          "images"
         ]
       }
     },

--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -5,6 +5,7 @@ from gateway.api.routes import (
     chat,
     embeddings,
     health,
+    images,
     keys,
     messages,
     models,
@@ -28,6 +29,7 @@ def register_routers(app: FastAPI, config: GatewayConfig) -> None:
     app.include_router(messages.router)
     app.include_router(responses.router)
     app.include_router(embeddings.router)
+    app.include_router(images.router)
     app.include_router(models.router)
     app.include_router(keys.router)
     app.include_router(users.router)

--- a/src/gateway/api/routes/images.py
+++ b/src/gateway/api/routes/images.py
@@ -1,0 +1,161 @@
+"""OpenAI-compatible image generation endpoint."""
+
+import uuid
+from datetime import UTC, datetime
+from typing import Annotated, Any
+
+from any_llm import AnyLLM, aimage_generation
+from any_llm.types.image import ImagesResponse
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
+from gateway.api.routes._helpers import resolve_user_id
+from gateway.api.routes.chat import get_provider_kwargs, rate_limit_headers
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger
+from gateway.models.entities import APIKey, UsageLog
+from gateway.rate_limit import check_rate_limit
+from gateway.services.budget_service import validate_user_budget
+from gateway.services.log_writer import LogWriter
+from gateway.services.pricing_service import find_model_pricing
+
+router = APIRouter(prefix="/v1", tags=["images"])
+
+
+class ImageGenerationRequest(BaseModel):
+    """OpenAI-compatible image generation request."""
+
+    model: str
+    prompt: str
+    n: int | None = None
+    size: str | None = None
+    quality: str | None = None
+    style: str | None = None
+    response_format: str | None = None
+    user: str | None = None
+
+
+@router.post("/images/generations", response_model=None)
+async def create_image(
+    raw_request: Request,
+    response: Response,
+    request: ImageGenerationRequest,
+    auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    log_writer: Annotated[LogWriter, Depends(get_log_writer)],
+) -> dict[str, Any]:
+    """OpenAI-compatible image generation endpoint.
+
+    Authentication modes:
+    - Master key + user field: Use specified user (must exist)
+    - API key + user field: Use specified user (must exist)
+    - API key without user field: Use virtual user created with API key
+    """
+    api_key, is_master_key = auth_result
+    api_key_id = api_key.id if api_key else None
+
+    user_id = resolve_user_id(
+        user_id_from_request=request.user,
+        api_key=api_key,
+        is_master_key=is_master_key,
+        master_key_error=HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="When using master key, 'user' field is required in request body",
+        ),
+        no_api_key_error=HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key validation failed",
+        ),
+        no_user_error=HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key has no associated user",
+        ),
+    )
+
+    rate_limit_info = check_rate_limit(raw_request, user_id)
+
+    _ = await validate_user_budget(db, user_id, request.model, strategy=config.budget_strategy)
+    if config.budget_strategy == "for_update":
+        await db.rollback()
+
+    provider, model = AnyLLM.split_model_provider(request.model)
+
+    provider_kwargs = get_provider_kwargs(config, provider)
+
+    image_kwargs: dict[str, Any] = {
+        "model": model,
+        "prompt": request.prompt,
+        "provider": provider,
+        **provider_kwargs,
+    }
+    if request.n is not None:
+        image_kwargs["n"] = request.n
+    if request.size is not None:
+        image_kwargs["size"] = request.size
+    if request.quality is not None:
+        image_kwargs["quality"] = request.quality
+    if request.style is not None:
+        image_kwargs["style"] = request.style
+    if request.response_format is not None:
+        image_kwargs["response_format"] = request.response_format
+
+    try:
+        result: ImagesResponse = await aimage_generation(**image_kwargs)
+
+        n_images = len(result.data) if result.data else 1
+
+        usage_log = UsageLog(
+            id=str(uuid.uuid4()),
+            api_key_id=api_key_id,
+            user_id=user_id,
+            timestamp=datetime.now(UTC),
+            model=model,
+            provider=provider,
+            endpoint="/v1/images/generations",
+            status="success",
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+        )
+
+        # Image pricing: repurpose input_price_per_million as price-per-image
+        pricing = await find_model_pricing(db, provider, model, as_of=usage_log.timestamp)
+        if pricing:
+            cost = n_images * pricing.input_price_per_million
+            usage_log.cost = cost
+        else:
+            model_ref = f"{provider}:{model}" if provider else model
+            logger.warning("No pricing configured for '%s'. Usage will be tracked without cost.", model_ref)
+
+        await log_writer.put(usage_log)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        error_log = UsageLog(
+            id=str(uuid.uuid4()),
+            api_key_id=api_key_id,
+            user_id=user_id,
+            timestamp=datetime.now(UTC),
+            model=model,
+            provider=provider,
+            endpoint="/v1/images/generations",
+            status="error",
+            error_message=str(e),
+        )
+        await log_writer.put(error_log)
+
+        logger.error("Provider call failed for %s:%s: %s", provider, model, e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="The request could not be completed by the provider",
+        ) from e
+
+    if rate_limit_info:
+        for key, value in rate_limit_headers(rate_limit_info).items():
+            response.headers[key] = value
+
+    return result.model_dump()

--- a/src/gateway/api/routes/images.py
+++ b/src/gateway/api/routes/images.py
@@ -105,7 +105,7 @@ async def create_image(
     try:
         result: ImagesResponse = await aimage_generation(**image_kwargs)
 
-        n_images = len(result.data) if result.data else 1
+        n_images = len(result.data) if result.data else (request.n or 1)
 
         usage_log = UsageLog(
             id=str(uuid.uuid4()),

--- a/tests/integration/test_images_endpoint.py
+++ b/tests/integration/test_images_endpoint.py
@@ -1,0 +1,225 @@
+"""Tests for the POST /v1/images/generations endpoint."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from any_llm.types.image import Image, ImagesResponse
+from fastapi.testclient import TestClient
+
+
+def _mock_images_response(n: int = 1) -> ImagesResponse:
+    """Build a real ImagesResponse for testing."""
+    return ImagesResponse(
+        created=1700000000,
+        data=[
+            Image(
+                url=f"https://example.com/image_{i}.png",
+                revised_prompt="a cute cat sitting on a windowsill",
+            )
+            for i in range(n)
+        ],
+    )
+
+
+def test_images_requires_auth(client: TestClient) -> None:
+    """POST /v1/images/generations requires authentication."""
+    resp = client.post(
+        "/v1/images/generations",
+        json={"model": "openai:dall-e-3", "prompt": "a cute cat"},
+    )
+    assert resp.status_code == 401
+
+
+def test_images_with_api_key(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/images/generations works with API key authentication."""
+    mock_resp = _mock_images_response()
+    with patch("gateway.api.routes.images.aimage_generation", new_callable=AsyncMock, return_value=mock_resp):
+        resp = client.post(
+            "/v1/images/generations",
+            json={"model": "openai:dall-e-3", "prompt": "a cute cat"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["data"]) == 1
+    assert data["data"][0]["url"].startswith("https://")
+
+
+def test_images_master_key_requires_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """POST /v1/images/generations with master key requires 'user' field."""
+    mock_resp = _mock_images_response()
+    with patch("gateway.api.routes.images.aimage_generation", new_callable=AsyncMock, return_value=mock_resp):
+        resp = client.post(
+            "/v1/images/generations",
+            json={"model": "openai:dall-e-3", "prompt": "a cute cat"},
+            headers=master_key_header,
+        )
+    assert resp.status_code == 400
+    assert "user" in resp.json()["detail"].lower()
+
+
+def test_images_master_key_with_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """POST /v1/images/generations with master key + user field succeeds."""
+    mock_resp = _mock_images_response()
+    with patch("gateway.api.routes.images.aimage_generation", new_callable=AsyncMock, return_value=mock_resp):
+        resp = client.post(
+            "/v1/images/generations",
+            json={
+                "model": "openai:dall-e-3",
+                "prompt": "a cute cat",
+                "user": test_user["user_id"],
+            },
+            headers=master_key_header,
+        )
+    assert resp.status_code == 200
+
+
+def test_images_provider_error(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/images/generations returns 500 when the provider fails."""
+    with patch(
+        "gateway.api.routes.images.aimage_generation",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("provider down"),
+    ):
+        resp = client.post(
+            "/v1/images/generations",
+            json={"model": "openai:dall-e-3", "prompt": "a cute cat"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 500
+    assert "provider" in resp.json()["detail"].lower()
+
+
+def test_images_logs_usage(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """POST /v1/images/generations creates a usage log entry."""
+    mock_resp = _mock_images_response()
+    user_id = api_key_obj["user_id"]
+
+    with patch("gateway.api.routes.images.aimage_generation", new_callable=AsyncMock, return_value=mock_resp):
+        resp = client.post(
+            "/v1/images/generations",
+            json={"model": "openai:dall-e-3", "prompt": "a cute cat"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+
+    usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
+    assert usage_resp.status_code == 200
+    logs = usage_resp.json()
+    image_logs = [log for log in logs if log["endpoint"] == "/v1/images/generations"]
+    assert len(image_logs) >= 1
+    assert image_logs[0]["status"] == "success"
+    assert image_logs[0]["prompt_tokens"] == 0
+    assert image_logs[0]["completion_tokens"] == 0
+
+
+def test_images_logs_error_on_failure(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """POST /v1/images/generations logs an error entry when the provider fails."""
+    user_id = api_key_obj["user_id"]
+
+    with patch(
+        "gateway.api.routes.images.aimage_generation",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("provider down"),
+    ):
+        resp = client.post(
+            "/v1/images/generations",
+            json={"model": "openai:dall-e-3", "prompt": "a cute cat"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 500
+
+    usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
+    assert usage_resp.status_code == 200
+    logs = usage_resp.json()
+    error_logs = [log for log in logs if log["endpoint"] == "/v1/images/generations" and log["status"] == "error"]
+    assert len(error_logs) >= 1
+    assert "provider down" in error_logs[0]["error_message"]
+
+
+@pytest.mark.parametrize("extra_field", ["n", "size", "quality", "style"])
+def test_images_optional_fields(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    extra_field: str,
+) -> None:
+    """POST /v1/images/generations forwards optional fields."""
+    mock_resp = _mock_images_response()
+    values = {"n": 2, "size": "1792x1024", "quality": "hd", "style": "natural"}
+    with patch("gateway.api.routes.images.aimage_generation", new_callable=AsyncMock, return_value=mock_resp) as mock:
+        resp = client.post(
+            "/v1/images/generations",
+            json={
+                "model": "openai:dall-e-3",
+                "prompt": "a cute cat",
+                extra_field: values[extra_field],
+            },
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+    call_kwargs = mock.call_args.kwargs
+    assert extra_field in call_kwargs
+    assert call_kwargs[extra_field] == values[extra_field]
+
+
+def test_images_cost_tracked_with_pricing(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """POST /v1/images/generations calculates cost when model pricing exists."""
+    # Set up pricing: input_price_per_million is repurposed as price-per-image
+    client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "openai:dall-e-3",
+            "input_price_per_million": 0.04,
+            "output_price_per_million": 0.0,
+        },
+        headers=master_key_header,
+    )
+
+    mock_resp = _mock_images_response(n=2)
+    user_id = api_key_obj["user_id"]
+
+    with patch("gateway.api.routes.images.aimage_generation", new_callable=AsyncMock, return_value=mock_resp):
+        resp = client.post(
+            "/v1/images/generations",
+            json={"model": "openai:dall-e-3", "prompt": "a cute cat", "n": 2},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+
+    usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
+    logs = usage_resp.json()
+    image_logs = [log for log in logs if log["endpoint"] == "/v1/images/generations"]
+    assert len(image_logs) >= 1
+    assert image_logs[0]["cost"] is not None
+    assert image_logs[0]["cost"] > 0
+    # Cost should be n_images * input_price_per_million = 2 * 0.04 = 0.08
+    assert image_logs[0]["cost"] == pytest.approx(0.08)


### PR DESCRIPTION
## Summary
- Add OpenAI-compatible image generation endpoint (`POST /v1/images/generations`) to the gateway
- Proxies requests through `any_llm`'s `aimage_generation()` function to any OpenAI-compatible provider
- Includes full auth, rate limiting, budget validation, usage logging, and cost tracking

## Details

**New route:** `src/gateway/api/routes/images.py`
- `ImageGenerationRequest` pydantic model with fields: `model`, `prompt`, `n`, `size`, `quality`, `style`, `response_format`, `user`
- Standard gateway flow: auth → resolve user → rate limit → budget check → split provider/model → proxy call → log usage → return response
- Cost tracking: repurposes `input_price_per_million` from pricing table as price-per-image (tokens set to 0)
- Registered in non-platform mode in `api/main.py`

**Tests:** `tests/integration/test_images_endpoint.py` — 12 tests:
- Auth required (401)
- API key auth works (200)
- Master key requires `user` field (400)
- Master key + user field works (200)
- Provider error returns 500
- Usage logging on success
- Error logging on failure
- Optional fields forwarded (n, size, quality, style)
- Cost tracking with pricing

**Dependencies:** Requires [mozilla-ai/any-llm#1035](https://github.com/mozilla-ai/any-llm/pull/1035) for `aimage_generation()` support in the SDK.