### PR TITLE
feat: add POST /v1/audio/transcriptions and /v1/audio/speech endpoints

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1,6 +1,148 @@
 {
   "components": {
     "schemas": {
+      "AudioSpeechRequest": {
+        "description": "OpenAI-compatible audio speech (TTS) request.",
+        "properties": {
+          "input": {
+            "title": "Input",
+            "type": "string"
+          },
+          "instructions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instructions"
+          },
+          "model": {
+            "title": "Model",
+            "type": "string"
+          },
+          "response_format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Response Format"
+          },
+          "speed": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Speed"
+          },
+          "user": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User"
+          },
+          "voice": {
+            "title": "Voice",
+            "type": "string"
+          }
+        },
+        "required": [
+          "model",
+          "input",
+          "voice"
+        ],
+        "title": "AudioSpeechRequest",
+        "type": "object"
+      },
+      "Body_create_transcription_v1_audio_transcriptions_post": {
+        "properties": {
+          "file": {
+            "contentMediaType": "application/octet-stream",
+            "title": "File",
+            "type": "string"
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          },
+          "model": {
+            "title": "Model",
+            "type": "string"
+          },
+          "prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt"
+          },
+          "response_format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Response Format"
+          },
+          "temperature": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Temperature"
+          },
+          "user": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User"
+          }
+        },
+        "required": [
+          "file",
+          "model"
+        ],
+        "title": "Body_create_transcription_v1_audio_transcriptions_post",
+        "type": "object"
+      },
       "BudgetResponse": {
         "description": "Response model for budget information.",
         "properties": {
@@ -1649,6 +1791,86 @@
         "summary": "Health Readiness",
         "tags": [
           "health"
+        ]
+      }
+    },
+    "/v1/audio/speech": {
+      "post": {
+        "description": "OpenAI-compatible audio speech (TTS) endpoint.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
+        "operationId": "create_speech_v1_audio_speech_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AudioSpeechRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Speech",
+        "tags": [
+          "audio"
+        ]
+      }
+    },
+    "/v1/audio/transcriptions": {
+      "post": {
+        "description": "OpenAI-compatible audio transcription endpoint.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
+        "operationId": "create_transcription_v1_audio_transcriptions_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_create_transcription_v1_audio_transcriptions_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Transcription",
+        "tags": [
+          "audio"
         ]
       }
     },

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1813,9 +1813,45 @@
             "content": {
               "application/json": {
                 "schema": {}
+              },
+              "audio/L16": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/aac": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/flac": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/mpeg": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/opus": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
+              },
+              "audio/wav": {
+                "schema": {
+                  "format": "binary",
+                  "type": "string"
+                }
               }
             },
-            "description": "Successful Response"
+            "description": "Audio bytes in the requested format"
           },
           "422": {
             "content": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "psycopg2-binary>=2.9.9",
     "pydantic-settings>=2.0.0",
     "python-dotenv>=1.0.0",
+    "python-multipart>=0.0.18",
     "pyyaml>=6.0",
     "sqlalchemy[asyncio]>=2.0.0",
     "uvicorn[standard]>=0.30.0",

--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
 from gateway.api.routes import (
+    audio,
     budgets,
     chat,
     embeddings,
@@ -30,6 +31,7 @@ def register_routers(app: FastAPI, config: GatewayConfig) -> None:
     app.include_router(responses.router)
     app.include_router(embeddings.router)
     app.include_router(images.router)
+    app.include_router(audio.router)
     app.include_router(models.router)
     app.include_router(keys.router)
     app.include_router(users.router)

--- a/src/gateway/api/routes/audio.py
+++ b/src/gateway/api/routes/audio.py
@@ -1,0 +1,304 @@
+"""OpenAI-compatible audio transcription and speech endpoints."""
+
+import uuid
+from datetime import UTC, datetime
+from typing import Annotated, Any
+
+from any_llm import AnyLLM, aspeech, atranscription
+from any_llm.types.audio import Transcription
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, Response, UploadFile, status
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
+from gateway.api.routes._helpers import resolve_user_id
+from gateway.api.routes.chat import get_provider_kwargs, rate_limit_headers
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger
+from gateway.models.entities import APIKey, UsageLog
+from gateway.rate_limit import check_rate_limit
+from gateway.services.budget_service import validate_user_budget
+from gateway.services.log_writer import LogWriter
+from gateway.services.pricing_service import find_model_pricing
+
+router = APIRouter(prefix="/v1", tags=["audio"])
+
+# Mapping from response_format to MIME type for speech endpoint
+_SPEECH_CONTENT_TYPES: dict[str | None, str] = {
+    None: "audio/mpeg",
+    "mp3": "audio/mpeg",
+    "opus": "audio/opus",
+    "aac": "audio/aac",
+    "flac": "audio/flac",
+    "wav": "audio/wav",
+    "pcm": "audio/L16",
+}
+
+
+@router.post("/audio/transcriptions", response_model=None)
+async def create_transcription(
+    raw_request: Request,
+    response: Response,
+    auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    log_writer: Annotated[LogWriter, Depends(get_log_writer)],
+    file: UploadFile = File(...),
+    model: str = Form(...),
+    language: str | None = Form(None),
+    prompt: str | None = Form(None),
+    response_format: str | None = Form(None),
+    temperature: float | None = Form(None),
+    user: str | None = Form(None),
+) -> dict[str, Any]:
+    """OpenAI-compatible audio transcription endpoint.
+
+    Authentication modes:
+    - Master key + user field: Use specified user (must exist)
+    - API key + user field: Use specified user (must exist)
+    - API key without user field: Use virtual user created with API key
+    """
+    api_key, is_master_key = auth_result
+    api_key_id = api_key.id if api_key else None
+
+    user_id = resolve_user_id(
+        user_id_from_request=user,
+        api_key=api_key,
+        is_master_key=is_master_key,
+        master_key_error=HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="When using master key, 'user' field is required in request body",
+        ),
+        no_api_key_error=HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key validation failed",
+        ),
+        no_user_error=HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key has no associated user",
+        ),
+    )
+
+    rate_limit_info = check_rate_limit(raw_request, user_id)
+
+    _ = await validate_user_budget(db, user_id, model, strategy=config.budget_strategy)
+    if config.budget_strategy == "for_update":
+        await db.rollback()
+
+    provider, model_name = AnyLLM.split_model_provider(model)
+
+    provider_kwargs = get_provider_kwargs(config, provider)
+
+    file_bytes = await file.read()
+
+    transcription_kwargs: dict[str, Any] = {
+        "model": model_name,
+        "file": file_bytes,
+        "provider": provider,
+        **provider_kwargs,
+    }
+    if language is not None:
+        transcription_kwargs["language"] = language
+    if prompt is not None:
+        transcription_kwargs["prompt"] = prompt
+    if response_format is not None:
+        transcription_kwargs["response_format"] = response_format
+    if temperature is not None:
+        transcription_kwargs["temperature"] = temperature
+
+    try:
+        result: Transcription = await atranscription(**transcription_kwargs)
+
+        usage_log = UsageLog(
+            id=str(uuid.uuid4()),
+            api_key_id=api_key_id,
+            user_id=user_id,
+            timestamp=datetime.now(UTC),
+            model=model_name,
+            provider=provider,
+            endpoint="/v1/audio/transcriptions",
+            status="success",
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+        )
+
+        pricing = await find_model_pricing(db, provider, model_name, as_of=usage_log.timestamp)
+        if pricing:
+            cost = pricing.input_price_per_million
+            usage_log.cost = cost
+        else:
+            model_ref = f"{provider}:{model_name}" if provider else model_name
+            logger.warning("No pricing configured for '%s'. Usage will be tracked without cost.", model_ref)
+
+        await log_writer.put(usage_log)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        error_log = UsageLog(
+            id=str(uuid.uuid4()),
+            api_key_id=api_key_id,
+            user_id=user_id,
+            timestamp=datetime.now(UTC),
+            model=model_name,
+            provider=provider,
+            endpoint="/v1/audio/transcriptions",
+            status="error",
+            error_message=str(e),
+        )
+        await log_writer.put(error_log)
+
+        logger.error("Provider call failed for %s:%s: %s", provider, model_name, e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="The request could not be completed by the provider",
+        ) from e
+
+    if rate_limit_info:
+        for key, value in rate_limit_headers(rate_limit_info).items():
+            response.headers[key] = value
+
+    return result.model_dump()
+
+
+class AudioSpeechRequest(BaseModel):
+    """OpenAI-compatible audio speech (TTS) request."""
+
+    model: str
+    input: str
+    voice: str
+    instructions: str | None = None
+    response_format: str | None = None
+    speed: float | None = None
+    user: str | None = None
+
+
+@router.post("/audio/speech", response_model=None)
+async def create_speech(
+    raw_request: Request,
+    response: Response,
+    request: AudioSpeechRequest,
+    auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    log_writer: Annotated[LogWriter, Depends(get_log_writer)],
+) -> StreamingResponse:
+    """OpenAI-compatible audio speech (TTS) endpoint.
+
+    Authentication modes:
+    - Master key + user field: Use specified user (must exist)
+    - API key + user field: Use specified user (must exist)
+    - API key without user field: Use virtual user created with API key
+    """
+    api_key, is_master_key = auth_result
+    api_key_id = api_key.id if api_key else None
+
+    user_id = resolve_user_id(
+        user_id_from_request=request.user,
+        api_key=api_key,
+        is_master_key=is_master_key,
+        master_key_error=HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="When using master key, 'user' field is required in request body",
+        ),
+        no_api_key_error=HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key validation failed",
+        ),
+        no_user_error=HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key has no associated user",
+        ),
+    )
+
+    rate_limit_info = check_rate_limit(raw_request, user_id)
+
+    _ = await validate_user_budget(db, user_id, request.model, strategy=config.budget_strategy)
+    if config.budget_strategy == "for_update":
+        await db.rollback()
+
+    provider, model_name = AnyLLM.split_model_provider(request.model)
+
+    provider_kwargs = get_provider_kwargs(config, provider)
+
+    speech_kwargs: dict[str, Any] = {
+        "model": model_name,
+        "input": request.input,
+        "voice": request.voice,
+        "provider": provider,
+        **provider_kwargs,
+    }
+    if request.instructions is not None:
+        speech_kwargs["instructions"] = request.instructions
+    if request.response_format is not None:
+        speech_kwargs["response_format"] = request.response_format
+    if request.speed is not None:
+        speech_kwargs["speed"] = request.speed
+
+    try:
+        audio_bytes: bytes = await aspeech(**speech_kwargs)
+
+        usage_log = UsageLog(
+            id=str(uuid.uuid4()),
+            api_key_id=api_key_id,
+            user_id=user_id,
+            timestamp=datetime.now(UTC),
+            model=model_name,
+            provider=provider,
+            endpoint="/v1/audio/speech",
+            status="success",
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+        )
+
+        pricing = await find_model_pricing(db, provider, model_name, as_of=usage_log.timestamp)
+        if pricing:
+            cost = pricing.input_price_per_million
+            usage_log.cost = cost
+        else:
+            model_ref = f"{provider}:{model_name}" if provider else model_name
+            logger.warning("No pricing configured for '%s'. Usage will be tracked without cost.", model_ref)
+
+        await log_writer.put(usage_log)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        error_log = UsageLog(
+            id=str(uuid.uuid4()),
+            api_key_id=api_key_id,
+            user_id=user_id,
+            timestamp=datetime.now(UTC),
+            model=model_name,
+            provider=provider,
+            endpoint="/v1/audio/speech",
+            status="error",
+            error_message=str(e),
+        )
+        await log_writer.put(error_log)
+
+        logger.error("Provider call failed for %s:%s: %s", provider, model_name, e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="The request could not be completed by the provider",
+        ) from e
+
+    if rate_limit_info:
+        # StreamingResponse doesn't allow setting headers after creation,
+        # so we include them in the response constructor
+        pass
+
+    content_type = _SPEECH_CONTENT_TYPES.get(request.response_format, "audio/mpeg")
+
+    headers: dict[str, str] = {}
+    if rate_limit_info:
+        headers.update(rate_limit_headers(rate_limit_info))
+
+    return StreamingResponse(
+        content=iter([audio_bytes]),
+        media_type=content_type,
+        headers=headers,
+    )

--- a/src/gateway/api/routes/audio.py
+++ b/src/gateway/api/routes/audio.py
@@ -20,9 +20,11 @@ from gateway.models.entities import APIKey, UsageLog
 from gateway.rate_limit import check_rate_limit
 from gateway.services.budget_service import validate_user_budget
 from gateway.services.log_writer import LogWriter
-from gateway.services.pricing_service import find_model_pricing
 
 router = APIRouter(prefix="/v1", tags=["audio"])
+
+# Maximum upload size for audio files (25 MB, matching OpenAI's limit)
+_MAX_AUDIO_UPLOAD_BYTES = 25 * 1024 * 1024
 
 # Mapping from response_format to MIME type for speech endpoint
 _SPEECH_CONTENT_TYPES: dict[str | None, str] = {
@@ -91,6 +93,11 @@ async def create_transcription(
     provider_kwargs = get_provider_kwargs(config, provider)
 
     file_bytes = await file.read()
+    if len(file_bytes) > _MAX_AUDIO_UPLOAD_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"Audio file exceeds maximum upload size of {_MAX_AUDIO_UPLOAD_BYTES // (1024 * 1024)} MB",
+        )
 
     transcription_kwargs: dict[str, Any] = {
         "model": model_name,
@@ -124,13 +131,8 @@ async def create_transcription(
             total_tokens=0,
         )
 
-        pricing = await find_model_pricing(db, provider, model_name, as_of=usage_log.timestamp)
-        if pricing:
-            cost = pricing.input_price_per_million
-            usage_log.cost = cost
-        else:
-            model_ref = f"{provider}:{model_name}" if provider else model_name
-            logger.warning("No pricing configured for '%s'. Usage will be tracked without cost.", model_ref)
+        # Audio transcription lacks a measurable usage unit (tokens, seconds, etc.)
+        # so cost is left unset until a dedicated pricing metric is available.
 
         await log_writer.put(usage_log)
 
@@ -175,7 +177,23 @@ class AudioSpeechRequest(BaseModel):
     user: str | None = None
 
 
-@router.post("/audio/speech", response_model=None)
+@router.post(
+    "/audio/speech",
+    response_model=None,
+    responses={
+        200: {
+            "description": "Audio bytes in the requested format",
+            "content": {
+                "audio/mpeg": {"schema": {"type": "string", "format": "binary"}},
+                "audio/opus": {"schema": {"type": "string", "format": "binary"}},
+                "audio/aac": {"schema": {"type": "string", "format": "binary"}},
+                "audio/flac": {"schema": {"type": "string", "format": "binary"}},
+                "audio/wav": {"schema": {"type": "string", "format": "binary"}},
+                "audio/L16": {"schema": {"type": "string", "format": "binary"}},
+            },
+        },
+    },
+)
 async def create_speech(
     raw_request: Request,
     response: Response,
@@ -254,13 +272,8 @@ async def create_speech(
             total_tokens=0,
         )
 
-        pricing = await find_model_pricing(db, provider, model_name, as_of=usage_log.timestamp)
-        if pricing:
-            cost = pricing.input_price_per_million
-            usage_log.cost = cost
-        else:
-            model_ref = f"{provider}:{model_name}" if provider else model_name
-            logger.warning("No pricing configured for '%s'. Usage will be tracked without cost.", model_ref)
+        # Audio speech lacks a measurable usage unit (tokens, seconds, characters, etc.)
+        # so cost is left unset until a dedicated pricing metric is available.
 
         await log_writer.put(usage_log)
 
@@ -285,11 +298,6 @@ async def create_speech(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="The request could not be completed by the provider",
         ) from e
-
-    if rate_limit_info:
-        # StreamingResponse doesn't allow setting headers after creation,
-        # so we include them in the response constructor
-        pass
 
     content_type = _SPEECH_CONTENT_TYPES.get(request.response_format, "audio/mpeg")
 

--- a/tests/integration/test_audio_endpoint.py
+++ b/tests/integration/test_audio_endpoint.py
@@ -1,0 +1,364 @@
+"""Tests for the POST /v1/audio/transcriptions and POST /v1/audio/speech endpoints."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from any_llm.types.audio import Transcription
+from fastapi.testclient import TestClient
+
+
+def _mock_transcription_response() -> Transcription:
+    """Build a real Transcription for testing."""
+    return Transcription(text="Hello, world!")
+
+
+FAKE_AUDIO_BYTES = b"fake-audio-content-mp3"
+
+
+# === Transcription tests ===
+
+
+def test_transcription_requires_auth(client: TestClient) -> None:
+    """POST /v1/audio/transcriptions requires authentication."""
+    resp = client.post(
+        "/v1/audio/transcriptions",
+        files={"file": ("test.mp3", b"audio-data", "audio/mpeg")},
+        data={"model": "openai:whisper-1"},
+    )
+    assert resp.status_code == 401
+
+
+def test_transcription_with_api_key(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/audio/transcriptions works with API key authentication."""
+    mock_resp = _mock_transcription_response()
+    with patch("gateway.api.routes.audio.atranscription", new_callable=AsyncMock, return_value=mock_resp):
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.mp3", b"audio-data", "audio/mpeg")},
+            data={"model": "openai:whisper-1"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["text"] == "Hello, world!"
+
+
+def test_transcription_master_key_requires_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """POST /v1/audio/transcriptions with master key requires 'user' field."""
+    mock_resp = _mock_transcription_response()
+    with patch("gateway.api.routes.audio.atranscription", new_callable=AsyncMock, return_value=mock_resp):
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.mp3", b"audio-data", "audio/mpeg")},
+            data={"model": "openai:whisper-1"},
+            headers=master_key_header,
+        )
+    assert resp.status_code == 400
+    assert "user" in resp.json()["detail"].lower()
+
+
+def test_transcription_master_key_with_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """POST /v1/audio/transcriptions with master key + user field succeeds."""
+    mock_resp = _mock_transcription_response()
+    with patch("gateway.api.routes.audio.atranscription", new_callable=AsyncMock, return_value=mock_resp):
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.mp3", b"audio-data", "audio/mpeg")},
+            data={"model": "openai:whisper-1", "user": test_user["user_id"]},
+            headers=master_key_header,
+        )
+    assert resp.status_code == 200
+
+
+def test_transcription_provider_error(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/audio/transcriptions returns 500 when the provider fails."""
+    with patch(
+        "gateway.api.routes.audio.atranscription",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("provider down"),
+    ):
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.mp3", b"audio-data", "audio/mpeg")},
+            data={"model": "openai:whisper-1"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 500
+    assert "provider" in resp.json()["detail"].lower()
+
+
+def test_transcription_logs_usage(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """POST /v1/audio/transcriptions creates a usage log entry."""
+    mock_resp = _mock_transcription_response()
+    user_id = api_key_obj["user_id"]
+
+    with patch("gateway.api.routes.audio.atranscription", new_callable=AsyncMock, return_value=mock_resp):
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.mp3", b"audio-data", "audio/mpeg")},
+            data={"model": "openai:whisper-1"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+
+    usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
+    assert usage_resp.status_code == 200
+    logs = usage_resp.json()
+    transcription_logs = [log for log in logs if log["endpoint"] == "/v1/audio/transcriptions"]
+    assert len(transcription_logs) >= 1
+    assert transcription_logs[0]["status"] == "success"
+    assert transcription_logs[0]["prompt_tokens"] == 0
+
+
+def test_transcription_logs_error_on_failure(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """POST /v1/audio/transcriptions logs an error entry when the provider fails."""
+    user_id = api_key_obj["user_id"]
+
+    with patch(
+        "gateway.api.routes.audio.atranscription",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("provider down"),
+    ):
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.mp3", b"audio-data", "audio/mpeg")},
+            data={"model": "openai:whisper-1"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 500
+
+    usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
+    assert usage_resp.status_code == 200
+    logs = usage_resp.json()
+    error_logs = [log for log in logs if log["endpoint"] == "/v1/audio/transcriptions" and log["status"] == "error"]
+    assert len(error_logs) >= 1
+    assert "provider down" in error_logs[0]["error_message"]
+
+
+@pytest.mark.parametrize("extra_field", ["language", "prompt", "response_format", "temperature"])
+def test_transcription_optional_fields(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    extra_field: str,
+) -> None:
+    """POST /v1/audio/transcriptions forwards optional fields."""
+    mock_resp = _mock_transcription_response()
+    values = {"language": "en", "prompt": "Previous context", "response_format": "verbose_json", "temperature": "0.2"}
+    with patch("gateway.api.routes.audio.atranscription", new_callable=AsyncMock, return_value=mock_resp) as mock:
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.mp3", b"audio-data", "audio/mpeg")},
+            data={"model": "openai:whisper-1", extra_field: values[extra_field]},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+    call_kwargs = mock.call_args.kwargs
+    assert extra_field in call_kwargs
+
+
+# === Speech tests ===
+
+
+def test_speech_requires_auth(client: TestClient) -> None:
+    """POST /v1/audio/speech requires authentication."""
+    resp = client.post(
+        "/v1/audio/speech",
+        json={"model": "openai:tts-1", "input": "Hello", "voice": "alloy"},
+    )
+    assert resp.status_code == 401
+
+
+def test_speech_with_api_key(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/audio/speech works with API key authentication."""
+    with patch("gateway.api.routes.audio.aspeech", new_callable=AsyncMock, return_value=FAKE_AUDIO_BYTES):
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"model": "openai:tts-1", "input": "Hello", "voice": "alloy"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "audio/mpeg"
+    assert resp.content == FAKE_AUDIO_BYTES
+
+
+def test_speech_content_type_matches_format(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/audio/speech returns correct Content-Type for each format."""
+    format_types = {
+        "opus": "audio/opus",
+        "aac": "audio/aac",
+        "flac": "audio/flac",
+        "wav": "audio/wav",
+    }
+    for fmt, expected_type in format_types.items():
+        with patch("gateway.api.routes.audio.aspeech", new_callable=AsyncMock, return_value=FAKE_AUDIO_BYTES):
+            resp = client.post(
+                "/v1/audio/speech",
+                json={"model": "openai:tts-1", "input": "Hi", "voice": "alloy", "response_format": fmt},
+                headers=api_key_header,
+            )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == expected_type, f"Expected {expected_type} for {fmt}"
+
+
+def test_speech_master_key_requires_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """POST /v1/audio/speech with master key requires 'user' field."""
+    with patch("gateway.api.routes.audio.aspeech", new_callable=AsyncMock, return_value=FAKE_AUDIO_BYTES):
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"model": "openai:tts-1", "input": "Hello", "voice": "alloy"},
+            headers=master_key_header,
+        )
+    assert resp.status_code == 400
+    assert "user" in resp.json()["detail"].lower()
+
+
+def test_speech_master_key_with_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """POST /v1/audio/speech with master key + user field succeeds."""
+    with patch("gateway.api.routes.audio.aspeech", new_callable=AsyncMock, return_value=FAKE_AUDIO_BYTES):
+        resp = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "openai:tts-1",
+                "input": "Hello",
+                "voice": "alloy",
+                "user": test_user["user_id"],
+            },
+            headers=master_key_header,
+        )
+    assert resp.status_code == 200
+
+
+def test_speech_provider_error(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/audio/speech returns 500 when the provider fails."""
+    with patch(
+        "gateway.api.routes.audio.aspeech",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("provider down"),
+    ):
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"model": "openai:tts-1", "input": "Hello", "voice": "alloy"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 500
+    assert "provider" in resp.json()["detail"].lower()
+
+
+def test_speech_logs_usage(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """POST /v1/audio/speech creates a usage log entry."""
+    user_id = api_key_obj["user_id"]
+
+    with patch("gateway.api.routes.audio.aspeech", new_callable=AsyncMock, return_value=FAKE_AUDIO_BYTES):
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"model": "openai:tts-1", "input": "Hello", "voice": "alloy"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+
+    usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
+    assert usage_resp.status_code == 200
+    logs = usage_resp.json()
+    speech_logs = [log for log in logs if log["endpoint"] == "/v1/audio/speech"]
+    assert len(speech_logs) >= 1
+    assert speech_logs[0]["status"] == "success"
+    assert speech_logs[0]["prompt_tokens"] == 0
+
+
+def test_speech_logs_error_on_failure(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """POST /v1/audio/speech logs an error entry when the provider fails."""
+    user_id = api_key_obj["user_id"]
+
+    with patch(
+        "gateway.api.routes.audio.aspeech",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("provider down"),
+    ):
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"model": "openai:tts-1", "input": "Hello", "voice": "alloy"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 500
+
+    usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
+    assert usage_resp.status_code == 200
+    logs = usage_resp.json()
+    error_logs = [log for log in logs if log["endpoint"] == "/v1/audio/speech" and log["status"] == "error"]
+    assert len(error_logs) >= 1
+    assert "provider down" in error_logs[0]["error_message"]
+
+
+@pytest.mark.parametrize("extra_field", ["response_format", "speed", "instructions"])
+def test_speech_optional_fields(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    extra_field: str,
+) -> None:
+    """POST /v1/audio/speech forwards optional fields."""
+    values = {"response_format": "opus", "speed": 1.5, "instructions": "Speak slowly"}
+    with patch("gateway.api.routes.audio.aspeech", new_callable=AsyncMock, return_value=FAKE_AUDIO_BYTES) as mock:
+        resp = client.post(
+            "/v1/audio/speech",
+            json={
+                "model": "openai:tts-1",
+                "input": "Hello",
+                "voice": "alloy",
+                extra_field: values[extra_field],
+            },
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+    call_kwargs = mock.call_args.kwargs
+    assert extra_field in call_kwargs
+    assert call_kwargs[extra_field] == values[extra_field]

--- a/uv.lock
+++ b/uv.lock
@@ -850,6 +850,7 @@ dependencies = [
     { name = "psycopg2-binary" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
@@ -881,6 +882,7 @@ requires-dist = [
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
@@ -2497,11 +2499,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.28"
+version = "0.0.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add OpenAI-compatible audio transcription (`POST /v1/audio/transcriptions`) and speech/TTS (`POST /v1/audio/speech`) endpoints
- Proxies through `any_llm`'s `atranscription()` and `aspeech()` functions
- Adds `python-multipart` dependency for file upload support

## Details

**Transcription endpoint** (`POST /v1/audio/transcriptions`):
- Accepts `multipart/form-data` with audio file upload via FastAPI `UploadFile`
- Form fields: `model` (required), `file` (required), `language`, `prompt`, `response_format`, `temperature`, `user`
- Reads file bytes, forwards to `atranscription()` via any_llm
- Returns JSON transcription response

**Speech endpoint** (`POST /v1/audio/speech`):
- Accepts JSON body: `model`, `input`, `voice` (required), `instructions`, `response_format`, `speed`, `user`
- Returns `StreamingResponse` with raw binary audio
- Content-Type set per format: `audio/mpeg` (mp3), `audio/opus`, `audio/aac`, `audio/flac`, `audio/wav`, `audio/L16` (pcm)

**Both endpoints** follow standard gateway flow: auth, rate limiting, budget validation, usage logging, error handling.

**New dependency:** `python-multipart>=0.0.18` (required by FastAPI for `UploadFile`/`File`/`Form`)

**Tests:** `tests/integration/test_audio_endpoint.py` — 22 tests:
- 11 transcription: auth, API key, master key, provider error, usage logging, error logging, optional fields (language, prompt, response_format, temperature)
- 11 speech: auth, API key, content type mapping, master key, provider error, usage logging, error logging, optional fields (response_format, speed, instructions)

**Dependencies:** Requires [mozilla-ai/any-llm#1036](https://github.com/mozilla-ai/any-llm/pull/1036) for `atranscription()`/`aspeech()` support in the SDK.