### PR TITLE
feat(gateway): rename auth header to AnyLLM-Key (RFC 6648)

### DIFF
--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -42,9 +42,8 @@ def reset_config() -> None:
 def _extract_bearer_token(request: Request, config: GatewayConfig) -> str:
     """Extract and validate Bearer token from request header.
 
-    Checks AnyLLM-Key first, then falls back to standard Authorization header
-    for OpenAI client compatibility, then falls back to x-api-key header
-    for Anthropic client compatibility.
+    Checks the canonical AnyLLM-Key header first, then falls back to the
+    standard Authorization header.
     """
     auth_header = request.headers.get(API_KEY_HEADER) or request.headers.get("Authorization")
 
@@ -56,11 +55,6 @@ def _extract_bearer_token(request: Request, config: GatewayConfig) -> str:
                 detail="Invalid header format. Expected 'Bearer <token>'",
             )
         return auth_header[7:]
-
-    # Fallback: x-api-key header (Anthropic client compatibility, no Bearer prefix).
-    api_key = request.headers.get("x-api-key")
-    if api_key:
-        return api_key
 
     record_auth_failure("missing_credentials")
     raise HTTPException(

--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -42,7 +42,7 @@ def reset_config() -> None:
 def _extract_bearer_token(request: Request, config: GatewayConfig) -> str:
     """Extract and validate Bearer token from request header.
 
-    Checks X-AnyLLM-Key first, then falls back to standard Authorization header
+    Checks AnyLLM-Key first, then falls back to standard Authorization header
     for OpenAI client compatibility, then falls back to x-api-key header
     for Anthropic client compatibility.
     """
@@ -57,7 +57,7 @@ def _extract_bearer_token(request: Request, config: GatewayConfig) -> str:
             )
         return auth_header[7:]
 
-    # Fallback: x-api-key header (Anthropic client compatibility, no Bearer prefix)
+    # Fallback: x-api-key header (Anthropic client compatibility, no Bearer prefix).
     api_key = request.headers.get("x-api-key")
     if api_key:
         return api_key
@@ -130,7 +130,7 @@ async def verify_api_key(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> APIKey:
-    """Verify API key from X-AnyLLM-Key header.
+    """Verify API key from AnyLLM-Key header.
 
     Args:
         request: FastAPI request object
@@ -152,7 +152,7 @@ async def verify_master_key(
     request: Request,
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> None:
-    """Verify master key from X-AnyLLM-Key header.
+    """Verify master key from AnyLLM-Key header.
 
     Args:
         request: FastAPI request object
@@ -182,7 +182,7 @@ async def verify_api_key_or_master_key(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> tuple[APIKey | None, bool]:
-    """Verify either API key or master key from X-AnyLLM-Key header.
+    """Verify either API key or master key from AnyLLM-Key header.
 
     Args:
         request: FastAPI request object

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -9,8 +9,6 @@ from dotenv import load_dotenv
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-# HTTP request header name for gateway Bearer authentication. Follows RFC 6648
-# (no `X-` prefix).
 API_KEY_HEADER = "AnyLLM-Key"
 
 

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -9,7 +9,9 @@ from dotenv import load_dotenv
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-API_KEY_HEADER = "X-AnyLLM-Key"
+# HTTP request header name for gateway Bearer authentication. Follows RFC 6648
+# (no `X-` prefix).
+API_KEY_HEADER = "AnyLLM-Key"
 
 
 class PricingConfig(BaseModel):

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -211,7 +211,6 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 "Content-Type",
                 "Authorization",
                 API_KEY_HEADER,
-                "x-api-key",
             ],
         )
 

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -10,7 +10,7 @@ from typing_extensions import override
 
 from gateway.api.deps import set_config
 from gateway.api.main import register_routers
-from gateway.core.config import GatewayConfig
+from gateway.core.config import API_KEY_HEADER, GatewayConfig
 from gateway.core.database import create_session, init_db
 from gateway.rate_limit import RateLimiter
 from gateway.services.bootstrap_service import bootstrap_first_api_key
@@ -210,7 +210,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
             allow_headers=[
                 "Content-Type",
                 "Authorization",
-                "X-AnyLLM-Key",
+                API_KEY_HEADER,
                 "x-api-key",
             ],
         )

--- a/tests/integration/test_client_args.py
+++ b/tests/integration/test_client_args.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from gateway.core.config import GatewayConfig
+from gateway.core.config import API_KEY_HEADER, GatewayConfig
 from gateway.db import get_db
 from gateway.main import create_app
 
@@ -87,7 +87,7 @@ async def test_client_args_passed_to_acompletion(
         captured_kwargs.update(kwargs)
         raise MockCompletionError
 
-    master_key_header = {"X-AnyLLM-Key": "Bearer test-master-key"}
+    master_key_header = {API_KEY_HEADER: "Bearer test-master-key"}
 
     response = client_with_client_args.post(
         "/v1/users",

--- a/tests/integration/test_messages_endpoint.py
+++ b/tests/integration/test_messages_endpoint.py
@@ -76,24 +76,6 @@ def test_messages_endpoint_requires_auth(
     assert response.status_code == 401
 
 
-def test_messages_endpoint_x_api_key_header(
-    client: TestClient,
-    api_key_obj: dict[str, Any],
-    messages_request_body: dict[str, Any],
-) -> None:
-    """Test authentication via x-api-key header (Anthropic client compatibility)."""
-    mock_response = _make_message_response()
-
-    with patch("gateway.api.routes.messages.amessages", new_callable=AsyncMock, return_value=mock_response):
-        response = client.post(
-            "/v1/messages",
-            json=messages_request_body,
-            headers={"x-api-key": api_key_obj["key"]},
-        )
-
-    assert response.status_code == 200
-
-
 def test_messages_endpoint_master_key_requires_user(
     client: TestClient,
     master_key_header: dict[str, str],

--- a/tests/integration/test_provider_kwargs_override.py
+++ b/tests/integration/test_provider_kwargs_override.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, text
 
 from gateway.api.routes.chat import get_provider_kwargs
-from gateway.core.config import GatewayConfig
+from gateway.core.config import API_KEY_HEADER, GatewayConfig
 from gateway.db import Base, get_db
 from gateway.main import create_app
 
@@ -89,7 +89,7 @@ async def test_user_model_not_overridden_by_provider_config(
         captured_kwargs.update(kwargs)
         raise _MockCompletionError
 
-    master_key_header = {"X-AnyLLM-Key": "Bearer test-master-key"}
+    master_key_header = {API_KEY_HEADER: "Bearer test-master-key"}
 
     response = client_with_model_in_provider.post(
         "/v1/users",
@@ -125,7 +125,7 @@ async def test_unset_optional_fields_do_not_override_provider_defaults(
         captured_kwargs.update(kwargs)
         raise _MockCompletionError
 
-    master_key_header = {"X-AnyLLM-Key": "Bearer test-master-key"}
+    master_key_header = {API_KEY_HEADER: "Bearer test-master-key"}
 
     with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
         client_with_model_in_provider.post(

--- a/tests/unit/test_extract_bearer_token.py
+++ b/tests/unit/test_extract_bearer_token.py
@@ -1,0 +1,112 @@
+"""Unit tests for the gateway's Bearer-token extraction.
+
+These tests exercise ``_extract_bearer_token`` directly — a pure function over
+``Request.headers`` — so they cover all precedence and malformed-input branches
+without needing the full FastAPI stack or a database.
+"""
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from gateway.api.deps import _extract_bearer_token
+from gateway.core.config import API_KEY_HEADER, GatewayConfig
+
+
+def _make_request(headers: dict[str, str]) -> Request:
+    """Build a minimal ASGI ``Request`` with the provided headers."""
+    scope: dict[str, object] = {
+        "type": "http",
+        "method": "POST",
+        "path": "/",
+        "query_string": b"",
+        "headers": [(name.lower().encode("latin-1"), value.encode("latin-1")) for name, value in headers.items()],
+        "state": {},
+    }
+    return Request(scope)
+
+
+@pytest.fixture
+def config() -> GatewayConfig:
+    """A minimal config object; ``_extract_bearer_token`` does not read fields from it."""
+    return GatewayConfig(master_key="test-master-key", auto_migrate=False)
+
+
+def test_canonical_header_returns_token(config: GatewayConfig) -> None:
+    request = _make_request({API_KEY_HEADER: "Bearer token-canonical"})
+
+    assert _extract_bearer_token(request, config) == "token-canonical"
+
+
+def test_authorization_header_returns_token(config: GatewayConfig) -> None:
+    request = _make_request({"Authorization": "Bearer token-auth"})
+
+    assert _extract_bearer_token(request, config) == "token-auth"
+
+
+def test_x_api_key_returns_raw_key(config: GatewayConfig) -> None:
+    request = _make_request({"x-api-key": "raw-anthropic-key"})
+
+    assert _extract_bearer_token(request, config) == "raw-anthropic-key"
+
+
+def test_canonical_takes_precedence_over_authorization(config: GatewayConfig) -> None:
+    request = _make_request(
+        {
+            API_KEY_HEADER: "Bearer canonical-wins",
+            "Authorization": "Bearer authorization-loses",
+        }
+    )
+
+    assert _extract_bearer_token(request, config) == "canonical-wins"
+
+
+def test_canonical_takes_precedence_over_x_api_key(config: GatewayConfig) -> None:
+    request = _make_request(
+        {
+            API_KEY_HEADER: "Bearer canonical-wins",
+            "x-api-key": "x-api-key-loses",
+        }
+    )
+
+    assert _extract_bearer_token(request, config) == "canonical-wins"
+
+
+def test_authorization_takes_precedence_over_x_api_key(config: GatewayConfig) -> None:
+    request = _make_request(
+        {
+            "Authorization": "Bearer authorization-wins",
+            "x-api-key": "x-api-key-loses",
+        }
+    )
+
+    assert _extract_bearer_token(request, config) == "authorization-wins"
+
+
+def test_malformed_canonical_header_raises_401(config: GatewayConfig) -> None:
+    request = _make_request({API_KEY_HEADER: "NotBearer token-bad"})
+
+    with pytest.raises(HTTPException) as exc_info:
+        _extract_bearer_token(request, config)
+
+    assert exc_info.value.status_code == 401
+    assert "Bearer" in exc_info.value.detail
+
+
+def test_malformed_authorization_header_raises_401(config: GatewayConfig) -> None:
+    request = _make_request({"Authorization": "Basic abc123"})
+
+    with pytest.raises(HTTPException) as exc_info:
+        _extract_bearer_token(request, config)
+
+    assert exc_info.value.status_code == 401
+
+
+def test_missing_credentials_raises_401(config: GatewayConfig) -> None:
+    request = _make_request({})
+
+    with pytest.raises(HTTPException) as exc_info:
+        _extract_bearer_token(request, config)
+
+    assert exc_info.value.status_code == 401
+    assert API_KEY_HEADER in exc_info.value.detail

--- a/tests/unit/test_extract_bearer_token.py
+++ b/tests/unit/test_extract_bearer_token.py
@@ -44,12 +44,6 @@ def test_authorization_header_returns_token(config: GatewayConfig) -> None:
     assert _extract_bearer_token(request, config) == "token-auth"
 
 
-def test_x_api_key_returns_raw_key(config: GatewayConfig) -> None:
-    request = _make_request({"x-api-key": "raw-anthropic-key"})
-
-    assert _extract_bearer_token(request, config) == "raw-anthropic-key"
-
-
 def test_canonical_takes_precedence_over_authorization(config: GatewayConfig) -> None:
     request = _make_request(
         {
@@ -59,28 +53,6 @@ def test_canonical_takes_precedence_over_authorization(config: GatewayConfig) ->
     )
 
     assert _extract_bearer_token(request, config) == "canonical-wins"
-
-
-def test_canonical_takes_precedence_over_x_api_key(config: GatewayConfig) -> None:
-    request = _make_request(
-        {
-            API_KEY_HEADER: "Bearer canonical-wins",
-            "x-api-key": "x-api-key-loses",
-        }
-    )
-
-    assert _extract_bearer_token(request, config) == "canonical-wins"
-
-
-def test_authorization_takes_precedence_over_x_api_key(config: GatewayConfig) -> None:
-    request = _make_request(
-        {
-            "Authorization": "Bearer authorization-wins",
-            "x-api-key": "x-api-key-loses",
-        }
-    )
-
-    assert _extract_bearer_token(request, config) == "authorization-wins"
 
 
 def test_malformed_canonical_header_raises_401(config: GatewayConfig) -> None:


### PR DESCRIPTION
## Summary

Rename the gateway's Bearer-authentication header from `X-AnyLLM-Key` to `AnyLLM-Key`, so the name follows [RFC 6648](https://datatracker.ietf.org/doc/html/rfc6648) (no `X-` prefix). The gateway has no live deployments yet, so there is no backward-compatibility path — this is a simple rename plus removal of the now-unneeded `x-api-key` compat fallback.

### What changes

- `core/config.py`: `API_KEY_HEADER` flips to `"AnyLLM-Key"`.
- `api/deps.py`: `_extract_bearer_token` accepts `AnyLLM-Key` first, then `Authorization`. The `x-api-key` Anthropic-compat fallback is removed. The three `verify_*` docstrings reference the new header name.
- `main.py`: the CORS `allow_headers` list uses the `API_KEY_HEADER` constant and drops the `x-api-key` entry.
- `tests/integration/test_client_args.py`, `tests/integration/test_provider_kwargs_override.py`: hard-coded header literals replaced with `API_KEY_HEADER`.
- `tests/integration/test_messages_endpoint.py`: `x-api-key` auth test removed (path no longer exists).
- `tests/unit/test_extract_bearer_token.py` (new): unit tests of `_extract_bearer_token` covering `AnyLLM-Key`/`Authorization` precedence, malformed (non-`Bearer`) input on each header, and the missing-credentials 401.

### History

Earlier revisions of this PR shipped a full RFC 6648 / 9745 / 8594 deprecation design (legacy header kept, `Deprecation`/`Sunset` response headers, `DeprecationHeadersMiddleware`). `@tbille` pointed out the gateway is not yet live, so there is no old name to deprecate; the branch was force-pushed to drop the deprecation machinery. A follow-up review flagged the remaining `x-api-key` compat fallback on the same grounds — that has now been removed too.

### Commits

1. `feat(gateway): rename API_KEY_HEADER from X-AnyLLM-Key to AnyLLM-Key`
2. `test(gateway): cover bearer-token extraction precedence and error paths`
3. `refactor(gateway): drop x-api-key fallback from bearer extraction`

## Test plan

- [x] `make test` — 313 passed, 9 skipped, no regressions
- [x] `make lint` — clean
- [x] `make typecheck` — clean
- [x] Unit tests cover precedence between `AnyLLM-Key` and `Authorization`, malformed-input branches on each, and the missing-credentials 401