### PR TITLE
feat(gateway): accept legacy X-AnyLLM-Key header for back-compat

### DIFF
--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -9,7 +9,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.auth.models import hash_key
-from gateway.core.config import API_KEY_HEADER, GatewayConfig
+from gateway.core.config import API_KEY_HEADER, LEGACY_API_KEY_HEADER, GatewayConfig
 from gateway.core.database import get_db
 from gateway.metrics import record_auth_failure
 from gateway.models.entities import APIKey
@@ -42,10 +42,15 @@ def reset_config() -> None:
 def _extract_bearer_token(request: Request, config: GatewayConfig) -> str:
     """Extract and validate Bearer token from request header.
 
-    Checks the canonical AnyLLM-Key header first, then falls back to the
-    standard Authorization header.
+    Checks the canonical AnyLLM-Key header first, then the legacy
+    X-AnyLLM-Key alias (back-compat), then falls back to the standard
+    Authorization header.
     """
-    auth_header = request.headers.get(API_KEY_HEADER) or request.headers.get("Authorization")
+    auth_header = (
+        request.headers.get(API_KEY_HEADER)
+        or request.headers.get(LEGACY_API_KEY_HEADER)
+        or request.headers.get("Authorization")
+    )
 
     if auth_header:
         if not auth_header.startswith("Bearer "):

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 API_KEY_HEADER = "AnyLLM-Key"
+LEGACY_API_KEY_HEADER = "X-AnyLLM-Key"  # Back-compat alias; prefer API_KEY_HEADER.
 
 
 class PricingConfig(BaseModel):

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -10,7 +10,7 @@ from typing_extensions import override
 
 from gateway.api.deps import set_config
 from gateway.api.main import register_routers
-from gateway.core.config import API_KEY_HEADER, GatewayConfig
+from gateway.core.config import API_KEY_HEADER, LEGACY_API_KEY_HEADER, GatewayConfig
 from gateway.core.database import create_session, init_db
 from gateway.rate_limit import RateLimiter
 from gateway.services.bootstrap_service import bootstrap_first_api_key
@@ -211,6 +211,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 "Content-Type",
                 "Authorization",
                 API_KEY_HEADER,
+                LEGACY_API_KEY_HEADER,
             ],
         )
 

--- a/tests/unit/test_extract_bearer_token.py
+++ b/tests/unit/test_extract_bearer_token.py
@@ -10,7 +10,7 @@ from fastapi import HTTPException
 from starlette.requests import Request
 
 from gateway.api.deps import _extract_bearer_token
-from gateway.core.config import API_KEY_HEADER, GatewayConfig
+from gateway.core.config import API_KEY_HEADER, LEGACY_API_KEY_HEADER, GatewayConfig
 
 
 def _make_request(headers: dict[str, str]) -> Request:
@@ -53,6 +53,44 @@ def test_canonical_takes_precedence_over_authorization(config: GatewayConfig) ->
     )
 
     assert _extract_bearer_token(request, config) == "canonical-wins"
+
+
+def test_legacy_header_returns_token(config: GatewayConfig) -> None:
+    request = _make_request({LEGACY_API_KEY_HEADER: "Bearer token-legacy"})
+
+    assert _extract_bearer_token(request, config) == "token-legacy"
+
+
+def test_canonical_takes_precedence_over_legacy(config: GatewayConfig) -> None:
+    request = _make_request(
+        {
+            API_KEY_HEADER: "Bearer canonical-wins",
+            LEGACY_API_KEY_HEADER: "Bearer legacy-loses",
+        }
+    )
+
+    assert _extract_bearer_token(request, config) == "canonical-wins"
+
+
+def test_legacy_takes_precedence_over_authorization(config: GatewayConfig) -> None:
+    request = _make_request(
+        {
+            LEGACY_API_KEY_HEADER: "Bearer legacy-wins",
+            "Authorization": "Bearer authorization-loses",
+        }
+    )
+
+    assert _extract_bearer_token(request, config) == "legacy-wins"
+
+
+def test_malformed_legacy_header_raises_401(config: GatewayConfig) -> None:
+    request = _make_request({LEGACY_API_KEY_HEADER: "NotBearer token-bad"})
+
+    with pytest.raises(HTTPException) as exc_info:
+        _extract_bearer_token(request, config)
+
+    assert exc_info.value.status_code == 401
+    assert "Bearer" in exc_info.value.detail
 
 
 def test_malformed_canonical_header_raises_401(config: GatewayConfig) -> None:


### PR DESCRIPTION
## Summary
- PR #45 renamed the auth header from `X-AnyLLM-Key` to `AnyLLM-Key` (RFC 6648) without a migration path, breaking any client still sending the old name.
- Restore back-compat by also accepting `X-AnyLLM-Key` as an alias of `AnyLLM-Key`. Precedence is `AnyLLM-Key` > `X-AnyLLM-Key` > `Authorization`, so the canonical header wins when both are present.
- Allow the legacy header through CORS preflight so browser clients aren't blocked.

## Changes
- `src/gateway/core/config.py`: add `LEGACY_API_KEY_HEADER = "X-AnyLLM-Key"` constant.
- `src/gateway/api/deps.py`: include the legacy header in `_extract_bearer_token`, between the canonical header and the `Authorization` fallback.
- `src/gateway/main.py`: add `LEGACY_API_KEY_HEADER` to the CORS `allow_headers` list.
- `tests/unit/test_extract_bearer_token.py`: cover legacy-header success, canonical-beats-legacy precedence, legacy-beats-Authorization precedence, and malformed-legacy-raises-401.

## Scope notes
- Kept intentionally minimal per request. The Anthropic `x-api-key` shim removed in e26c7c3 is **not** reintroduced here.
- No deprecation logging — silent acceptance, as requested.
- No API surface change; OpenAPI spec is unaffected.

## Test plan
- `uv run pytest tests/unit/test_extract_bearer_token.py -v` — 10 pass (4 new + 6 existing).
- `uv run pytest tests/unit tests/integration/test_messages_endpoint.py tests/integration/test_client_args.py tests/integration/test_provider_kwargs_override.py -v` — 97 pass.
- `uv run ruff check src tests scripts` — clean.
- `uv run mypy src` — clean.
- `uv run python scripts/generate_openapi.py --check` — up to date.