### PR TITLE
Implementation for add-rerank-endpoint in gateway.

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1317,6 +1317,75 @@
         "title": "PricingResponse",
         "type": "object"
       },
+      "RerankRequest": {
+        "description": "Rerank request.",
+        "properties": {
+          "documents": {
+            "description": "List of document strings to rerank",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Documents",
+            "type": "array"
+          },
+          "max_tokens_per_doc": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-document truncation limit",
+            "title": "Max Tokens Per Doc"
+          },
+          "model": {
+            "description": "Provider-prefixed model ID, e.g. 'cohere:rerank-v3.5'",
+            "title": "Model",
+            "type": "string"
+          },
+          "query": {
+            "description": "The search query to rerank documents against",
+            "title": "Query",
+            "type": "string"
+          },
+          "top_n": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Maximum number of results to return",
+            "title": "Top N"
+          },
+          "user": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "User ID for usage attribution",
+            "title": "User"
+          }
+        },
+        "required": [
+          "model",
+          "query",
+          "documents"
+        ],
+        "title": "RerankRequest",
+        "type": "object"
+      },
       "ResponsesRequest": {
         "additionalProperties": true,
         "description": "OpenAI Responses API-compatible request.",
@@ -3380,6 +3449,46 @@
         "summary": "Get Pricing History",
         "tags": [
           "pricing"
+        ]
+      }
+    },
+    "/v1/rerank": {
+      "post": {
+        "description": "Rerank documents by relevance to a query.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
+        "operationId": "create_rerank_v1_rerank_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RerankRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Rerank",
+        "tags": [
+          "rerank"
         ]
       }
     },

--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -14,6 +14,7 @@ from gateway.api.routes import (
     moderations,
     platform_mode,
     pricing,
+    rerank,
     responses,
     usage,
     users,
@@ -34,6 +35,7 @@ def register_routers(app: FastAPI, config: GatewayConfig) -> None:
     app.include_router(embeddings.router)
     app.include_router(images.router)
     app.include_router(audio.router)
+    app.include_router(rerank.router)
     app.include_router(batches.router)
     app.include_router(moderations.router)
     app.include_router(models.router)

--- a/src/gateway/api/routes/rerank.py
+++ b/src/gateway/api/routes/rerank.py
@@ -1,0 +1,161 @@
+"""Rerank endpoint — reorder documents by relevance to a query."""
+
+import uuid
+from datetime import UTC, datetime
+from typing import Annotated, Any
+
+from any_llm import AnyLLM
+
+try:
+    from any_llm import arerank  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover – available once any-llm ships rerank support
+    arerank = None
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
+from gateway.api.routes._helpers import resolve_user_id
+from gateway.api.routes.chat import get_provider_kwargs, rate_limit_headers
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger
+from gateway.models.entities import APIKey, UsageLog
+from gateway.rate_limit import check_rate_limit
+from gateway.services.budget_service import validate_user_budget
+from gateway.services.log_writer import LogWriter
+from gateway.services.pricing_service import find_model_pricing
+
+router = APIRouter(prefix="/v1", tags=["rerank"])
+
+
+class RerankRequest(BaseModel):
+    """Rerank request."""
+
+    model: str = Field(description="Provider-prefixed model ID, e.g. 'cohere:rerank-v3.5'")
+    query: str = Field(description="The search query to rerank documents against")
+    documents: list[str] = Field(description="List of document strings to rerank", min_length=1)
+    top_n: int | None = Field(default=None, description="Maximum number of results to return", gt=0)
+    max_tokens_per_doc: int | None = Field(default=None, description="Per-document truncation limit", gt=0)
+    user: str | None = Field(default=None, description="User ID for usage attribution")
+
+
+@router.post("/rerank", response_model=None)
+async def create_rerank(
+    raw_request: Request,
+    response: Response,
+    request: RerankRequest,
+    auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    log_writer: Annotated[LogWriter, Depends(get_log_writer)],
+) -> Any:
+    """Rerank documents by relevance to a query.
+
+    Authentication modes:
+    - Master key + user field: Use specified user (must exist)
+    - API key + user field: Use specified user (must exist)
+    - API key without user field: Use virtual user created with API key
+    """
+    api_key, is_master_key = auth_result
+    api_key_id = api_key.id if api_key else None
+
+    user_id = resolve_user_id(
+        user_id_from_request=request.user,
+        api_key=api_key,
+        is_master_key=is_master_key,
+        master_key_error=HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="When using master key, 'user' field is required in request body",
+        ),
+        no_api_key_error=HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key validation failed",
+        ),
+        no_user_error=HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key has no associated user",
+        ),
+    )
+
+    rate_limit_info = check_rate_limit(raw_request, user_id)
+
+    _ = await validate_user_budget(db, user_id, request.model, strategy=config.budget_strategy)
+    if config.budget_strategy == "for_update":
+        await db.rollback()
+
+    provider, model = AnyLLM.split_model_provider(request.model)
+
+    provider_kwargs = get_provider_kwargs(config, provider)
+
+    rerank_kwargs: dict[str, Any] = {
+        "model": model,
+        "query": request.query,
+        "documents": request.documents,
+        "provider": provider,
+        **provider_kwargs,
+    }
+    if request.top_n is not None:
+        rerank_kwargs["top_n"] = request.top_n
+    if request.max_tokens_per_doc is not None:
+        rerank_kwargs["max_tokens_per_doc"] = request.max_tokens_per_doc
+
+    try:
+        result = await arerank(**rerank_kwargs)
+
+        total_tokens = result.usage.total_tokens if result.usage and result.usage.total_tokens else 0
+
+        usage_log = UsageLog(
+            id=str(uuid.uuid4()),
+            api_key_id=api_key_id,
+            user_id=user_id,
+            timestamp=datetime.now(UTC),
+            model=model,
+            provider=provider,
+            endpoint="/v1/rerank",
+            status="success",
+            prompt_tokens=total_tokens,
+            completion_tokens=0,
+            total_tokens=total_tokens,
+        )
+
+        if total_tokens:
+            pricing = await find_model_pricing(db, provider, model, as_of=usage_log.timestamp)
+            if pricing:
+                cost = (total_tokens / 1_000_000) * pricing.input_price_per_million
+                usage_log.cost = cost
+            else:
+                model_ref = f"{provider}:{model}" if provider else model
+                logger.warning(
+                    "No pricing configured for '%s'. Cost will not be tracked for this rerank request.",
+                    model_ref,
+                )
+
+        await log_writer.put(usage_log)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        error_log = UsageLog(
+            id=str(uuid.uuid4()),
+            api_key_id=api_key_id,
+            user_id=user_id,
+            timestamp=datetime.now(UTC),
+            model=model,
+            provider=provider,
+            endpoint="/v1/rerank",
+            status="error",
+            error_message=str(e),
+        )
+        await log_writer.put(error_log)
+
+        logger.error("Provider call failed for %s:%s: %s", provider, model, e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="The request could not be completed by the provider",
+        ) from e
+
+    if rate_limit_info:
+        for key, value in rate_limit_headers(rate_limit_info).items():
+            response.headers[key] = value
+
+    return result

--- a/src/gateway/api/routes/rerank.py
+++ b/src/gateway/api/routes/rerank.py
@@ -4,12 +4,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import Annotated, Any
 
-from any_llm import AnyLLM
-
-try:
-    from any_llm import arerank  # type: ignore[attr-defined]
-except ImportError:  # pragma: no cover – available once any-llm ships rerank support
-    arerank = None
+from any_llm import AnyLLM, arerank
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -98,12 +93,6 @@ async def create_rerank(
         rerank_kwargs["top_n"] = request.top_n
     if request.max_tokens_per_doc is not None:
         rerank_kwargs["max_tokens_per_doc"] = request.max_tokens_per_doc
-
-    if arerank is None:
-        raise HTTPException(
-            status_code=status.HTTP_501_NOT_IMPLEMENTED,
-            detail="Rerank is not available — the installed any-llm SDK does not include rerank support",
-        )
 
     try:
         result = await arerank(**rerank_kwargs)

--- a/src/gateway/api/routes/rerank.py
+++ b/src/gateway/api/routes/rerank.py
@@ -99,10 +99,16 @@ async def create_rerank(
     if request.max_tokens_per_doc is not None:
         rerank_kwargs["max_tokens_per_doc"] = request.max_tokens_per_doc
 
+    if arerank is None:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="Rerank is not available — the installed any-llm SDK does not include rerank support",
+        )
+
     try:
         result = await arerank(**rerank_kwargs)
 
-        total_tokens = result.usage.total_tokens if result.usage and result.usage.total_tokens else 0
+        total_tokens = result.usage.total_tokens if result.usage else None
 
         usage_log = UsageLog(
             id=str(uuid.uuid4()),
@@ -118,15 +124,15 @@ async def create_rerank(
             total_tokens=total_tokens,
         )
 
-        if total_tokens:
+        if result.usage:
             pricing = await find_model_pricing(db, provider, model, as_of=usage_log.timestamp)
-            if pricing:
+            if pricing and total_tokens:
                 cost = (total_tokens / 1_000_000) * pricing.input_price_per_million
                 usage_log.cost = cost
-            else:
+            elif not pricing:
                 model_ref = f"{provider}:{model}" if provider else model
                 logger.warning(
-                    "No pricing configured for '%s'. Cost will not be tracked for this rerank request.",
+                    "No pricing configured for '%s'. Usage will be tracked without cost.",
                     model_ref,
                 )
 

--- a/tests/integration/test_rerank_endpoint.py
+++ b/tests/integration/test_rerank_endpoint.py
@@ -1,0 +1,265 @@
+"""Integration tests for the POST /v1/rerank endpoint."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+
+class _RerankUsage(BaseModel):
+    """Mock RerankUsage for testing until SDK ships rerank types."""
+
+    total_tokens: int | None = None
+
+
+class _RerankResult(BaseModel):
+    """Mock RerankResult for testing."""
+
+    index: int
+    relevance_score: float
+
+
+class _RerankMeta(BaseModel):
+    """Mock RerankMeta for testing."""
+
+    billed_units: dict[str, float] | None = None
+    tokens: dict[str, int] | None = None
+
+
+class _RerankResponse(BaseModel):
+    """Mock RerankResponse for testing."""
+
+    id: str
+    results: list[_RerankResult]
+    meta: _RerankMeta | None = None
+    usage: _RerankUsage | None = None
+
+
+def _mock_rerank_response() -> _RerankResponse:
+    """Create a mock RerankResponse for testing."""
+    return _RerankResponse(
+        id="rerank-test-123",
+        results=[
+            _RerankResult(index=0, relevance_score=0.95),
+            _RerankResult(index=2, relevance_score=0.80),
+            _RerankResult(index=1, relevance_score=0.30),
+        ],
+        meta=_RerankMeta(
+            billed_units={"search_units": 1.0},
+            tokens={"input_tokens": 100},
+        ),
+        usage=_RerankUsage(total_tokens=100),
+    )
+
+
+RERANK_PAYLOAD: dict[str, Any] = {
+    "model": "cohere:rerank-v3.5",
+    "query": "What is the capital of France?",
+    "documents": ["Paris is the capital.", "Berlin is in Germany."],
+}
+
+
+def test_rerank_requires_auth(client: TestClient) -> None:
+    """POST /v1/rerank requires authentication."""
+    resp = client.post("/v1/rerank", json=RERANK_PAYLOAD)
+    assert resp.status_code == 401
+
+
+def test_rerank_with_api_key(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/rerank works with API key authentication."""
+    with patch(
+        "gateway.api.routes.rerank.arerank",
+        new_callable=AsyncMock,
+        return_value=_mock_rerank_response(),
+    ):
+        resp = client.post("/v1/rerank", json=RERANK_PAYLOAD, headers=api_key_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "results" in data
+    assert len(data["results"]) == 3
+    assert data["results"][0]["relevance_score"] == 0.95
+
+
+def test_rerank_master_key_requires_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """POST /v1/rerank with master key requires 'user' field."""
+    with patch(
+        "gateway.api.routes.rerank.arerank",
+        new_callable=AsyncMock,
+        return_value=_mock_rerank_response(),
+    ):
+        resp = client.post("/v1/rerank", json=RERANK_PAYLOAD, headers=master_key_header)
+    assert resp.status_code == 400
+    assert "user" in resp.json()["detail"].lower()
+
+
+def test_rerank_master_key_with_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """POST /v1/rerank with master key + user field succeeds."""
+    payload = {**RERANK_PAYLOAD, "user": test_user["user_id"]}
+    with patch(
+        "gateway.api.routes.rerank.arerank",
+        new_callable=AsyncMock,
+        return_value=_mock_rerank_response(),
+    ):
+        resp = client.post("/v1/rerank", json=payload, headers=master_key_header)
+    assert resp.status_code == 200
+
+
+def test_rerank_provider_error(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/rerank returns 500 when the provider fails."""
+    with patch(
+        "gateway.api.routes.rerank.arerank",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("provider down"),
+    ):
+        resp = client.post("/v1/rerank", json=RERANK_PAYLOAD, headers=api_key_header)
+    assert resp.status_code == 500
+    assert "provider" in resp.json()["detail"].lower()
+
+
+def test_rerank_logs_usage(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """POST /v1/rerank creates a usage log entry."""
+    user_id = api_key_obj["user_id"]
+
+    with patch(
+        "gateway.api.routes.rerank.arerank",
+        new_callable=AsyncMock,
+        return_value=_mock_rerank_response(),
+    ):
+        resp = client.post("/v1/rerank", json=RERANK_PAYLOAD, headers=api_key_header)
+    assert resp.status_code == 200
+
+    usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
+    assert usage_resp.status_code == 200
+    logs = usage_resp.json()
+    rerank_logs = [log for log in logs if log["endpoint"] == "/v1/rerank"]
+    assert len(rerank_logs) >= 1
+    assert rerank_logs[0]["status"] == "success"
+    assert rerank_logs[0]["prompt_tokens"] == 100
+    assert rerank_logs[0]["completion_tokens"] == 0
+
+
+def test_rerank_logs_error_on_failure(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """POST /v1/rerank logs an error entry when the provider fails."""
+    user_id = api_key_obj["user_id"]
+
+    with patch(
+        "gateway.api.routes.rerank.arerank",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("provider down"),
+    ):
+        resp = client.post("/v1/rerank", json=RERANK_PAYLOAD, headers=api_key_header)
+    assert resp.status_code == 500
+
+    usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
+    assert usage_resp.status_code == 200
+    logs = usage_resp.json()
+    error_logs = [log for log in logs if log["endpoint"] == "/v1/rerank" and log["status"] == "error"]
+    assert len(error_logs) >= 1
+    assert "provider down" in error_logs[0]["error_message"]
+
+
+def test_rerank_empty_documents_422(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/rerank returns 422 when documents list is empty."""
+    payload = {**RERANK_PAYLOAD, "documents": []}
+    resp = client.post("/v1/rerank", json=payload, headers=api_key_header)
+    assert resp.status_code == 422
+
+
+def test_rerank_top_n_zero_422(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/rerank returns 422 when top_n is 0."""
+    payload = {**RERANK_PAYLOAD, "top_n": 0}
+    resp = client.post("/v1/rerank", json=payload, headers=api_key_header)
+    assert resp.status_code == 422
+
+
+def test_rerank_top_n_negative_422(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/rerank returns 422 when top_n is negative."""
+    payload = {**RERANK_PAYLOAD, "top_n": -1}
+    resp = client.post("/v1/rerank", json=payload, headers=api_key_header)
+    assert resp.status_code == 422
+
+
+@pytest.mark.parametrize("extra_field,value", [("top_n", 2), ("max_tokens_per_doc", 512)])
+def test_rerank_optional_fields_forwarded(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    extra_field: str,
+    value: int,
+) -> None:
+    """POST /v1/rerank forwards top_n and max_tokens_per_doc to the SDK."""
+    mock = AsyncMock(return_value=_mock_rerank_response())
+    payload = {**RERANK_PAYLOAD, extra_field: value}
+    with patch("gateway.api.routes.rerank.arerank", mock):
+        resp = client.post("/v1/rerank", json=payload, headers=api_key_header)
+    assert resp.status_code == 200
+    call_kwargs = mock.call_args.kwargs
+    assert call_kwargs.get(extra_field) == value
+
+
+def test_rerank_cost_tracked_with_pricing(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """POST /v1/rerank calculates cost when model pricing exists."""
+    client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "cohere:rerank-v3.5",
+            "input_price_per_million": 2.0,
+            "output_price_per_million": 0.0,
+        },
+        headers=master_key_header,
+    )
+
+    user_id = api_key_obj["user_id"]
+
+    with patch(
+        "gateway.api.routes.rerank.arerank",
+        new_callable=AsyncMock,
+        return_value=_mock_rerank_response(),
+    ):
+        resp = client.post("/v1/rerank", json=RERANK_PAYLOAD, headers=api_key_header)
+    assert resp.status_code == 200
+
+    usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
+    logs = usage_resp.json()
+    rerank_logs = [log for log in logs if log["endpoint"] == "/v1/rerank"]
+    assert len(rerank_logs) >= 1
+    assert rerank_logs[0]["cost"] is not None
+    assert rerank_logs[0]["cost"] > 0

--- a/tests/integration/test_rerank_endpoint.py
+++ b/tests/integration/test_rerank_endpoint.py
@@ -57,7 +57,7 @@ def _mock_rerank_response() -> _RerankResponse:
 RERANK_PAYLOAD: dict[str, Any] = {
     "model": "cohere:rerank-v3.5",
     "query": "What is the capital of France?",
-    "documents": ["Paris is the capital.", "Berlin is in Germany."],
+    "documents": ["Paris is the capital.", "Berlin is in Germany.", "Madrid is in Spain."],
 }
 
 


### PR DESCRIPTION
## Summary

Implementation for add-rerank-endpoint in gateway.

## Changes

- Regenerate OpenAPI spec with /v1/rerank endpoint
- Add integration tests for /v1/rerank endpoint
- Add POST /v1/rerank route handler and register router

## Testing

- See commit history for test additions.