### PR TITLE
Rename any-llm to otari

### DIFF
--- a/.github/workflows/gateway-deploy-prod.yml
+++ b/.github/workflows/gateway-deploy-prod.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Download task definition
         run: |
           aws ecs describe-task-definition \
-            --task-definition any-llm-platform-gateway-task-production \
+            --task-definition otari-platform-gateway-task-production \
             --query taskDefinition \
             > task-definition.json
 
@@ -42,6 +42,6 @@ jobs:
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
           task-definition: new-task-definition.json
-          service: any-llm-platform-gateway-service-production
-          cluster: any-llm-platform-cluster-production
+          service: otari-platform-gateway-service-production
+          cluster: otari-platform-cluster-production
           wait-for-service-stability: true

--- a/.github/workflows/gateway-docker.yml
+++ b/.github/workflows/gateway-docker.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Download task definition
         run: |
           aws ecs describe-task-definition \
-            --task-definition any-llm-platform-gateway-task-development \
+            --task-definition otari-platform-gateway-task-development \
             --query taskDefinition \
             > task-definition.json
 
@@ -143,6 +143,6 @@ jobs:
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
           task-definition: new-task-definition.json
-          service: any-llm-platform-gateway-service-development
-          cluster: any-llm-platform-cluster-development
+          service: otari-platform-gateway-service-development
+          cluster: otari-platform-cluster-development
           wait-for-service-stability: true

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,6 @@ build/
 config.yml
 service_account.json
 gateway.db
-any-llm-gateway.db
+otari-gateway.db
 
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <picture>
-    <img src="https://raw.githubusercontent.com/mozilla-ai/any-llm/refs/heads/main/docs/public/images/any-llm-logo-mark.png" width="18%" alt="Project logo"/>
+    <img src="https://raw.githubusercontent.com/mozilla-ai/otari/refs/heads/main/docs/public/images/otari-logo-mark.png" width="18%" alt="Project logo"/>
   </picture>
 </p>
 
@@ -59,12 +59,12 @@ Open API docs at `http://localhost:8000/docs`.
 
 ## Start in platform mode
 
-Platform mode is enabled automatically when `ANY_LLM_PLATFORM_TOKEN` is set.
+Platform mode is enabled automatically when `OTARI_PLATFORM_TOKEN` is set.
 
 1) Export platform env vars:
 
 ```bash
-export ANY_LLM_PLATFORM_TOKEN=gw_xxx
+export OTARI_PLATFORM_TOKEN=gw_xxx
 export PLATFORM_BASE_URL=https://your-platform.example/api/v1
 ```
 
@@ -76,8 +76,8 @@ uv run gateway serve --config config.yml
 
 Notes:
 
-- `GATEWAY_MODE` is optional; effective mode is derived from `ANY_LLM_PLATFORM_TOKEN`.
-- If you explicitly set `GATEWAY_MODE=platform`, startup fails unless `ANY_LLM_PLATFORM_TOKEN` is also set.
+- `GATEWAY_MODE` is optional; effective mode is derived from `OTARI_PLATFORM_TOKEN`.
+- If you explicitly set `GATEWAY_MODE=platform`, startup fails unless `OTARI_PLATFORM_TOKEN` is also set.
 - In platform mode, local `providers` configuration is not used.
 
 ## First request (OpenAI SDK)

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -26,7 +26,7 @@ target_metadata = Base.metadata
 # Get database URL from config (if already set programmatically) or environment variables
 # Priority: Programmatically set URL -> GATEWAY_DATABASE_URL -> DATABASE_URL -> default
 if config.get_main_option("sqlalchemy.url") is None:
-    database_url = os.getenv("GATEWAY_DATABASE_URL") or os.getenv("DATABASE_URL") or "sqlite:///./any-llm-gateway.db"
+    database_url = os.getenv("GATEWAY_DATABASE_URL") or os.getenv("DATABASE_URL") or "sqlite:///./otari-gateway.db"
     config.set_main_option("sqlalchemy.url", database_url)
 
 # other values from the config, defined by the needs of env.py,

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,4 +1,4 @@
-# Configuration for any-llm-gateway
+# Configuration for otari-gateway
 
 # Database connection URL
 database_url: "postgresql://gateway:gateway@postgres:5432/gateway"

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1402,8 +1402,8 @@
     }
   },
   "info": {
-    "description": "A clean FastAPI gateway for any-llm with API key management",
-    "title": "any-llm-gateway",
+    "description": "A clean FastAPI gateway for otari with API key management",
+    "title": "otari-gateway",
     "version": "0.0.0-dev"
   },
   "openapi": "3.1.0",
@@ -1712,7 +1712,7 @@
     },
     "/v1/chat/completions": {
       "post": {
-        "description": "OpenAI-compatible chat completions endpoint.\n\nSupports both streaming and non-streaming responses.\nHandles reasoning content from any-llm providers.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
+        "description": "OpenAI-compatible chat completions endpoint.\n\nSupports both streaming and non-streaming responses.\nHandles reasoning content from otari providers.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
         "operationId": "chat_completions_v1_chat_completions_post",
         "requestBody": {
           "content": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "gateway"
 version = "0.0.0"
-description = "any-llm gateway service"
+description = "otari gateway service"
 requires-python = ">=3.13"
 dependencies = [
     "any-llm-sdk[all]",
@@ -38,7 +38,6 @@ dev = [
 
 [project.scripts]
 gateway = "gateway.cli:main"
-any-llm-gateway = "gateway.cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate OpenAPI specification for the any-llm-gateway.
+"""Generate OpenAPI specification for the otari-gateway.
 
 This script creates the FastAPI application and exports its OpenAPI specification
 to a JSON file. It can be run in two modes:

--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -9,7 +9,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.auth.models import hash_key
-from gateway.core.config import API_KEY_HEADER, LEGACY_API_KEY_HEADER, GatewayConfig
+from gateway.core.config import API_KEY_HEADER, LEGACY_API_KEY_HEADERS, GatewayConfig
 from gateway.core.database import get_db
 from gateway.metrics import record_auth_failure
 from gateway.models.entities import APIKey
@@ -42,15 +42,18 @@ def reset_config() -> None:
 def _extract_bearer_token(request: Request, config: GatewayConfig) -> str:
     """Extract and validate Bearer token from request header.
 
-    Checks the canonical AnyLLM-Key header first, then the legacy
-    X-AnyLLM-Key alias (back-compat), then falls back to the standard
-    Authorization header.
+    Checks the canonical Otari-Key header first, then the legacy
+    AnyLLM-Key / X-AnyLLM-Key aliases (back-compat), then falls back
+    to the standard Authorization header.
     """
-    auth_header = (
-        request.headers.get(API_KEY_HEADER)
-        or request.headers.get(LEGACY_API_KEY_HEADER)
-        or request.headers.get("Authorization")
-    )
+    auth_header = request.headers.get(API_KEY_HEADER)
+    if not auth_header:
+        for legacy in LEGACY_API_KEY_HEADERS:
+            auth_header = request.headers.get(legacy)
+            if auth_header:
+                break
+    if not auth_header:
+        auth_header = request.headers.get("Authorization")
 
     if auth_header:
         if not auth_header.startswith("Bearer "):
@@ -129,7 +132,7 @@ async def verify_api_key(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> APIKey:
-    """Verify API key from AnyLLM-Key header.
+    """Verify API key from Otari-Key header.
 
     Args:
         request: FastAPI request object
@@ -151,7 +154,7 @@ async def verify_master_key(
     request: Request,
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> None:
-    """Verify master key from AnyLLM-Key header.
+    """Verify master key from Otari-Key header.
 
     Args:
         request: FastAPI request object
@@ -181,7 +184,7 @@ async def verify_api_key_or_master_key(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> tuple[APIKey | None, bool]:
-    """Verify either API key or master key from AnyLLM-Key header.
+    """Verify either API key or master key from Otari-Key header.
 
     Args:
         request: FastAPI request object

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -356,7 +356,7 @@ async def chat_completions(
     """OpenAI-compatible chat completions endpoint.
 
     Supports both streaming and non-streaming responses.
-    Handles reasoning content from any-llm providers.
+    Handles reasoning content from otari providers.
 
     Authentication modes:
     - Master key + user field: Use specified user (must exist)

--- a/src/gateway/auth/vertex_auth.py
+++ b/src/gateway/auth/vertex_auth.py
@@ -13,7 +13,7 @@ def setup_vertex_environment(
     project: str | None = None,
     location: str | None = None,
 ) -> dict[str, Any]:
-    """Build request-local Vertex AI client kwargs for any-llm.
+    """Build request-local Vertex AI client kwargs for otari.
 
     The Vertex provider passes these kwargs directly to `google.genai.Client`,
     so this function avoids process-global environment mutation.

--- a/src/gateway/cli.py
+++ b/src/gateway/cli.py
@@ -16,7 +16,7 @@ from gateway.main import create_app
 
 @click.group()
 def cli() -> None:
-    """any-llm-gateway CLI."""
+    """otari-gateway CLI."""
 
 
 @cli.command()
@@ -93,7 +93,7 @@ def serve(
         )
         logger.warning("Set GATEWAY_MASTER_KEY environment variable or use --master-key flag.")
 
-    logger.info("Starting any-llm-gateway on %s:%s", gateway_config.host, gateway_config.port)
+    logger.info("Starting otari-gateway on %s:%s", gateway_config.host, gateway_config.port)
     if gateway_config.is_platform_mode:
         logger.info("Database: disabled (platform mode)")
     else:
@@ -178,9 +178,6 @@ def migrate(config: str | None, database_url: str | None, revision: str) -> None
 
 def main() -> None:
     """Entry point for the CLI."""
-    invoked_as = os.path.basename(sys.argv[0])
-    if invoked_as == "any-llm-gateway":
-        click.echo("'any-llm-gateway' is deprecated. Use 'gateway' instead.", err=True)
     cli()
 
 

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -9,8 +9,8 @@ from dotenv import load_dotenv
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-API_KEY_HEADER = "AnyLLM-Key"
-LEGACY_API_KEY_HEADER = "X-AnyLLM-Key"  # Back-compat alias; prefer API_KEY_HEADER.
+API_KEY_HEADER = "Otari-Key"
+LEGACY_API_KEY_HEADERS = ("AnyLLM-Key", "X-AnyLLM-Key")  # Back-compat aliases; prefer API_KEY_HEADER.
 
 
 class PricingConfig(BaseModel):
@@ -35,7 +35,7 @@ class GatewayConfig(BaseSettings):
     )
 
     database_url: str = Field(
-        default="sqlite:///./any-llm-gateway.db",
+        default="sqlite:///./otari-gateway.db",
         description="Database connection URL (SQLite default for local use; PostgreSQL recommended for production)",
     )
     auto_migrate: bool = Field(
@@ -104,7 +104,9 @@ class GatewayConfig(BaseSettings):
 
     @property
     def platform_token(self) -> str | None:
-        token = os.getenv("ANY_LLM_PLATFORM_TOKEN", "").strip()
+        token = os.getenv("OTARI_PLATFORM_TOKEN", "").strip()
+        if not token:
+            token = os.getenv("ANY_LLM_PLATFORM_TOKEN", "").strip()
         return token if token else None
 
     @property
@@ -125,7 +127,7 @@ class GatewayConfig(BaseSettings):
 
         token_present = self.platform_token is not None
         if configured_mode == "platform" and not token_present:
-            msg = "GATEWAY_MODE=platform requires ANY_LLM_PLATFORM_TOKEN to be set."
+            msg = "GATEWAY_MODE=platform requires OTARI_PLATFORM_TOKEN to be set."
             raise ValueError(msg)
 
 

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -10,7 +10,7 @@ from typing_extensions import override
 
 from gateway.api.deps import set_config
 from gateway.api.main import register_routers
-from gateway.core.config import API_KEY_HEADER, LEGACY_API_KEY_HEADER, GatewayConfig
+from gateway.core.config import API_KEY_HEADER, LEGACY_API_KEY_HEADERS, GatewayConfig
 from gateway.core.database import create_session, init_db
 from gateway.rate_limit import RateLimiter
 from gateway.services.bootstrap_service import bootstrap_first_api_key
@@ -78,7 +78,7 @@ _ROOT_TUTORIAL_HTML = """<!doctype html>
     <main>
       <h1>AI Gateway (Proxy Server)</h1>
       <div class="sub">
-        <a class="link" href="https://mozilla-ai.github.io/any-llm/gateway/quickstart/">Gateway Quickstart</a>
+        <a class="link" href="https://mozilla-ai.github.io/otari/gateway/quickstart/">Gateway Quickstart</a>
       </div>
 
       <p class="note">
@@ -185,8 +185,8 @@ def create_app(config: GatewayConfig) -> FastAPI:
     set_config(config)
 
     app = FastAPI(
-        title="any-llm-gateway",
-        description="A clean FastAPI gateway for any-llm with API key management",
+        title="otari-gateway",
+        description="A clean FastAPI gateway for otari with API key management",
         version=__version__,
         docs_url="/docs" if config.enable_docs else None,
         redoc_url="/redoc" if config.enable_docs else None,
@@ -211,7 +211,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
                 "Content-Type",
                 "Authorization",
                 API_KEY_HEADER,
-                LEGACY_API_KEY_HEADER,
+                *LEGACY_API_KEY_HEADERS,
             ],
         )
 

--- a/tests/integration/test_config_env_loading.py
+++ b/tests/integration/test_config_env_loading.py
@@ -75,7 +75,7 @@ def test_load_config_platform_env_overrides(tmp_path: Path, monkeypatch: pytest.
     config_file = tmp_path / "gateway.yml"
     config_file.write_text("mode: platform\n", encoding="utf-8")
 
-    monkeypatch.setenv("ANY_LLM_PLATFORM_TOKEN", "gw_test_token")
+    monkeypatch.setenv("OTARI_PLATFORM_TOKEN", "gw_test_token")
     monkeypatch.setenv("PLATFORM_BASE_URL", "http://localhost:8100/api/v1")
     monkeypatch.setenv("PLATFORM_RESOLVE_TIMEOUT_MS", "1234")
     monkeypatch.setenv("PLATFORM_USAGE_TIMEOUT_MS", "2345")
@@ -93,16 +93,17 @@ def test_load_config_platform_env_overrides(tmp_path: Path, monkeypatch: pytest.
 def test_load_config_rejects_platform_mode_without_token(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     config_file = tmp_path / "gateway.yml"
     config_file.write_text("mode: platform\n", encoding="utf-8")
+    monkeypatch.delenv("OTARI_PLATFORM_TOKEN", raising=False)
     monkeypatch.delenv("ANY_LLM_PLATFORM_TOKEN", raising=False)
 
-    with pytest.raises(ValueError, match="ANY_LLM_PLATFORM_TOKEN"):
+    with pytest.raises(ValueError, match="OTARI_PLATFORM_TOKEN"):
         load_config(str(config_file))
 
 
 def test_load_config_prefers_platform_mode_when_token_is_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     config_file = tmp_path / "gateway.yml"
     config_file.write_text("mode: standalone\n", encoding="utf-8")
-    monkeypatch.setenv("ANY_LLM_PLATFORM_TOKEN", "gw_test_token")
+    monkeypatch.setenv("OTARI_PLATFORM_TOKEN", "gw_test_token")
 
     config = load_config(str(config_file))
 

--- a/tests/integration/test_key_management.py
+++ b/tests/integration/test_key_management.py
@@ -291,7 +291,7 @@ def test_inactive_api_key_rejected(
 
 def test_authorization_header_accepted(client: TestClient, test_config: GatewayConfig) -> None:
     """Test that Authorization header works as fallback for OpenAI client compatibility."""
-    # Use Authorization header instead of X-AnyLLM-Key
+    # Use Authorization header instead of Otari-Key
     auth_header = {"Authorization": f"Bearer {test_config.master_key}"}
 
     response = client.post(

--- a/tests/integration/test_platform_mode_chat.py
+++ b/tests/integration/test_platform_mode_chat.py
@@ -19,7 +19,7 @@ from gateway.main import create_app
 
 @pytest.fixture
 def platform_client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient]:
-    monkeypatch.setenv("ANY_LLM_PLATFORM_TOKEN", "gw_test_token")
+    monkeypatch.setenv("OTARI_PLATFORM_TOKEN", "gw_test_token")
     app = create_app(
         GatewayConfig(
             mode="platform",

--- a/tests/integration/test_platform_mode_surface.py
+++ b/tests/integration/test_platform_mode_surface.py
@@ -8,7 +8,7 @@ from gateway.main import create_app
 
 
 def test_platform_mode_starts_without_database(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ANY_LLM_PLATFORM_TOKEN", "gw_test_token")
+    monkeypatch.setenv("OTARI_PLATFORM_TOKEN", "gw_test_token")
 
     config = GatewayConfig(
         mode="platform",
@@ -31,7 +31,7 @@ def test_platform_mode_starts_without_database(monkeypatch: pytest.MonkeyPatch) 
 
 
 def test_platform_mode_disables_local_management_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ANY_LLM_PLATFORM_TOKEN", "gw_test_token")
+    monkeypatch.setenv("OTARI_PLATFORM_TOKEN", "gw_test_token")
 
     config = GatewayConfig(
         mode="platform",
@@ -60,7 +60,7 @@ def test_platform_mode_disables_local_management_endpoints(monkeypatch: pytest.M
 
 
 def test_platform_mode_health_reports_reachability(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ANY_LLM_PLATFORM_TOKEN", "gw_test_token")
+    monkeypatch.setenv("OTARI_PLATFORM_TOKEN", "gw_test_token")
 
     async def _reachable(_: GatewayConfig) -> bool:
         return True
@@ -87,7 +87,7 @@ def test_platform_mode_health_reports_reachability(monkeypatch: pytest.MonkeyPat
 
 
 def test_platform_mode_readiness_fails_when_platform_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ANY_LLM_PLATFORM_TOKEN", "gw_test_token")
+    monkeypatch.setenv("OTARI_PLATFORM_TOKEN", "gw_test_token")
 
     async def _unreachable(_: GatewayConfig) -> bool:
         return False

--- a/tests/unit/test_extract_bearer_token.py
+++ b/tests/unit/test_extract_bearer_token.py
@@ -10,7 +10,7 @@ from fastapi import HTTPException
 from starlette.requests import Request
 
 from gateway.api.deps import _extract_bearer_token
-from gateway.core.config import API_KEY_HEADER, LEGACY_API_KEY_HEADER, GatewayConfig
+from gateway.core.config import API_KEY_HEADER, LEGACY_API_KEY_HEADERS, GatewayConfig
 
 
 def _make_request(headers: dict[str, str]) -> Request:
@@ -56,7 +56,7 @@ def test_canonical_takes_precedence_over_authorization(config: GatewayConfig) ->
 
 
 def test_legacy_header_returns_token(config: GatewayConfig) -> None:
-    request = _make_request({LEGACY_API_KEY_HEADER: "Bearer token-legacy"})
+    request = _make_request({LEGACY_API_KEY_HEADERS[0]: "Bearer token-legacy"})
 
     assert _extract_bearer_token(request, config) == "token-legacy"
 
@@ -65,7 +65,7 @@ def test_canonical_takes_precedence_over_legacy(config: GatewayConfig) -> None:
     request = _make_request(
         {
             API_KEY_HEADER: "Bearer canonical-wins",
-            LEGACY_API_KEY_HEADER: "Bearer legacy-loses",
+            LEGACY_API_KEY_HEADERS[0]: "Bearer legacy-loses",
         }
     )
 
@@ -75,7 +75,7 @@ def test_canonical_takes_precedence_over_legacy(config: GatewayConfig) -> None:
 def test_legacy_takes_precedence_over_authorization(config: GatewayConfig) -> None:
     request = _make_request(
         {
-            LEGACY_API_KEY_HEADER: "Bearer legacy-wins",
+            LEGACY_API_KEY_HEADERS[0]: "Bearer legacy-wins",
             "Authorization": "Bearer authorization-loses",
         }
     )
@@ -84,7 +84,7 @@ def test_legacy_takes_precedence_over_authorization(config: GatewayConfig) -> No
 
 
 def test_malformed_legacy_header_raises_401(config: GatewayConfig) -> None:
-    request = _make_request({LEGACY_API_KEY_HEADER: "NotBearer token-bad"})
+    request = _make_request({LEGACY_API_KEY_HEADERS[0]: "NotBearer token-bad"})
 
     with pytest.raises(HTTPException) as exc_info:
         _extract_bearer_token(request, config)

--- a/tests/unit/test_gateway_cli.py
+++ b/tests/unit/test_gateway_cli.py
@@ -6,28 +6,7 @@ import gateway.cli as gateway_cli
 from gateway.core.config import GatewayConfig
 
 
-def test_main_warns_for_deprecated_binary_name(
-    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
-) -> None:
-    called = False
-
-    def fake_cli() -> None:
-        nonlocal called
-        called = True
-
-    monkeypatch.setattr(gateway_cli, "cli", fake_cli)
-    monkeypatch.setattr(sys, "argv", ["any-llm-gateway", "serve"])
-
-    gateway_cli.main()
-
-    captured = capsys.readouterr()
-    assert "'any-llm-gateway' is deprecated. Use 'gateway' instead." in captured.err
-    assert called
-
-
-def test_main_does_not_warn_for_gateway_binary_name(
-    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_main_invokes_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     called = False
 
     def fake_cli() -> None:
@@ -39,12 +18,10 @@ def test_main_does_not_warn_for_gateway_binary_name(
 
     gateway_cli.main()
 
-    captured = capsys.readouterr()
-    assert captured.err == ""
     assert called
 
 
 def test_gateway_config_defaults_to_sqlite() -> None:
     config = GatewayConfig()
-    assert config.database_url == "sqlite:///./any-llm-gateway.db"
+    assert config.database_url == "sqlite:///./otari-gateway.db"
     assert config.bootstrap_api_key is True

--- a/tests/unit/test_gateway_root_page.py
+++ b/tests/unit/test_gateway_root_page.py
@@ -21,4 +21,4 @@ def test_root_tutorial_page_is_available(tmp_path: Path) -> None:
     assert "bootstrap API key" in response.text
     assert "from openai import OpenAI" in response.text
     assert "YOUR_BOOTSTRAP_GATEWAY_KEY" in response.text
-    assert "mozilla-ai.github.io/any-llm/gateway/quickstart" in response.text
+    assert "mozilla-ai.github.io/otari/gateway/quickstart" in response.text


### PR DESCRIPTION
## Summary

- Rename all `any-llm` references to `otari` across the project
- Rename API header `AnyLLM-Key` → `Otari-Key`, with `AnyLLM-Key` and `X-AnyLLM-Key` kept as backward-compatible legacy aliases
- Rename env var `ANY_LLM_PLATFORM_TOKEN` → `OTARI_PLATFORM_TOKEN`, with fallback to old name for backward compat
- Rename default SQLite DB filename `any-llm-gateway.db` → `otari-gateway.db`
- Update FastAPI app title/description, CLI docstrings, log messages, documentation URLs
- Rename AWS ECS resource names in CI/CD workflows (`any-llm-platform-*` → `otari-platform-*`)
- Remove legacy `any-llm-gateway` CLI entrypoint from `pyproject.toml`
- Regenerate `docs/public/openapi.json`

## What stays unchanged

- All `from any_llm import ...` statements (external SDK package, not being renamed)
- `any-llm-sdk[all]` dependency in `pyproject.toml`
- `uv.lock` (external package names unchanged)

## Backward compatibility

| Item | New canonical | Legacy (still works) |
|------|--------------|---------------------|
| API header | `Otari-Key` | `AnyLLM-Key`, `X-AnyLLM-Key` |
| Env var | `OTARI_PLATFORM_TOKEN` | `ANY_LLM_PLATFORM_TOKEN` |

## Testing

- All 84 unit tests pass
- Lint passes
- OpenAPI spec check passes