### PR TITLE
Rename Docker image from mzdotai/gateway to mzdotai/otari

### DIFF
--- a/.github/workflows/gateway-deploy-prod.yml
+++ b/.github/workflows/gateway-deploy-prod.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   AWS_REGION: us-east-2
-  IMAGE_NAME: mzdotai/gateway
+  IMAGE_NAME: mzdotai/otari
 
 jobs:
   deploy-production:

--- a/.github/workflows/gateway-docker.yml
+++ b/.github/workflows/gateway-docker.yml
@@ -20,7 +20,7 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: mzdotai/gateway
+  IMAGE_NAME: mzdotai/otari
   AWS_REGION: us-east-2
 
 jobs:
@@ -67,14 +67,14 @@ jobs:
           context: .
           file: Dockerfile
           load: true
-          tags: gateway-test:${{ github.sha }}
+          tags: otari-test:${{ github.sha }}
           build-args: |
             GATEWAY_VERSION=${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Run container liveness check
-        run: ./scripts/docker_liveness_check.sh gateway-test:${{ github.sha }}
+        run: ./scripts/docker_liveness_check.sh otari-test:${{ github.sha }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
@@ -110,7 +110,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: mzdotai/gateway
+          repository: mzdotai/otari
           readme-filepath: ./README.md
 
   deploy-development:

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ uv run pytest tests/unit/test_gateway_cli.py -v
 
 ## Docker
 
-The gateway image is published on [Docker Hub](https://hub.docker.com/r/mzdotai/gateway).
+The gateway image is published on [Docker Hub](https://hub.docker.com/r/mzdotai/otari).
 
 ### Run with docker compose (gateway + PostgreSQL)
 
@@ -142,7 +142,7 @@ docker compose up -d
 docker run --rm \
   -p 8000:8000 \
   -v "$(pwd)/config.yml:/app/config.yml:ro" \
-  mzdotai/gateway:latest \
+  mzdotai/otari:latest \
   gateway serve --config /app/config.yml
 ```
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,4 +4,4 @@ services:
       context: .
       dockerfile: Dockerfile
 
-    image: gateway:local
+    image: otari:local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   gateway:
     # if pulling from Docker Hub, use the following instead, and comment out the build section:
-    image: docker.io/mzdotai/gateway:latest
+    image: docker.io/mzdotai/otari:latest
 
     # If you want to use a different port, change it here and in the config.yml file.
     ports:

--- a/scripts/docker_liveness_check.sh
+++ b/scripts/docker_liveness_check.sh
@@ -4,7 +4,7 @@
 # Starts PostgreSQL, runs the gateway container, and validates health endpoints.
 #
 # Usage: ./scripts/docker_liveness_check.sh <image_tag>
-# Example: ./scripts/docker_liveness_check.sh gateway-test:abc123
+# Example: ./scripts/docker_liveness_check.sh otari-test:abc123
 #
 
 set -euo pipefail
@@ -13,7 +13,7 @@ IMAGE_TAG="${1:-}"
 
 if [[ -z "$IMAGE_TAG" ]]; then
     echo "Usage: $0 <image_tag>"
-    echo "Example: $0 gateway-test:latest"
+    echo "Example: $0 otari-test:latest"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Renames the Docker Hub image from `mzdotai/gateway` to `mzdotai/otari` across all CI workflows, compose files, scripts, and documentation
- Updates the CI test image from `gateway-test` to `otari-test`
- Updates the local dev image from `gateway:local` to `otari:local`

## Prerequisites

Before merging, the `mzdotai/otari` repository must be created on Docker Hub — otherwise CI pushes will fail.

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/gateway-docker.yml` | `IMAGE_NAME`, test image tag, dockerhub description repo |
| `.github/workflows/gateway-deploy-prod.yml` | `IMAGE_NAME` |
| `docker-compose.yml` | Production pull image |
| `docker-compose.override.yml` | Local dev image |
| `scripts/docker_liveness_check.sh` | Example references in comments |
| `README.md` | Docker Hub link and run example |