### PR TITLE
Rename AWS ECS cluster and service to otari-ai naming convention

### DIFF
--- a/.github/workflows/gateway-deploy-prod.yml
+++ b/.github/workflows/gateway-deploy-prod.yml
@@ -42,6 +42,6 @@ jobs:
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
           task-definition: new-task-definition.json
-          service: otari-platform-gateway-service-production
-          cluster: otari-platform-cluster-production
+          service: otari-ai-service-production
+          cluster: otari-ai-cluster-production
           wait-for-service-stability: true

--- a/.github/workflows/gateway-docker.yml
+++ b/.github/workflows/gateway-docker.yml
@@ -143,6 +143,6 @@ jobs:
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
           task-definition: new-task-definition.json
-          service: otari-platform-gateway-service-development
-          cluster: otari-platform-cluster-development
+          service: otari-ai-service-development
+          cluster: otari-ai-cluster-development
           wait-for-service-stability: true


### PR DESCRIPTION
## Summary
- Renames ECS cluster and service references from `otari-platform-*` to `otari-ai-*` in production and development deploy workflows
- **Production** (`gateway-deploy-prod.yml`): `otari-platform-cluster-production` → `otari-ai-cluster-production`, `otari-platform-gateway-service-production` → `otari-ai-service-production`
- **Development** (`gateway-docker.yml`): `otari-platform-cluster-development` → `otari-ai-cluster-development`, `otari-platform-gateway-service-development` → `otari-ai-service-development`