### PR TITLE
feat: routing-policy fallback for chat completions (streaming + non-streaming)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Notes:
 - `GATEWAY_MODE` is optional; effective mode is derived from `OTARI_PLATFORM_TOKEN`.
 - If you explicitly set `GATEWAY_MODE=platform`, startup fails unless `OTARI_PLATFORM_TOKEN` is also set.
 - In platform mode, local `providers` configuration is not used.
+- The gateway/platform wire contract (resolve and usage endpoints, request/response shapes, retry semantics) is documented in [`docs/platform-protocol.md`](docs/platform-protocol.md).
 
 ## First request (OpenAI SDK)
 

--- a/docs/platform-protocol.md
+++ b/docs/platform-protocol.md
@@ -1,0 +1,177 @@
+# Platform protocol
+
+When the gateway runs in **platform mode** (`OTARI_PLATFORM_TOKEN` is set), it
+delegates per-request authorization and provider-credential resolution to a
+peer platform service over HTTP. This document describes the wire contract
+the gateway expects from that peer.
+
+The default peer implementation is [otari](https://github.com/mozilla-ai/otari),
+but any service that implements this contract can stand in.
+
+## Endpoints
+
+The gateway calls two endpoints, both rooted at `PLATFORM_BASE_URL`:
+
+| Endpoint | Purpose |
+|---|---|
+| `POST {base}/gateway/provider-keys/resolve` | Authorize a request and return one or more provider credentials to try |
+| `POST {base}/gateway/usage`                 | Report the outcome of an attempt back to the platform |
+
+## Authentication
+
+Both endpoints require `X-Gateway-Token: <gw_...>` in the request headers. This
+proves the caller is the gateway instance configured against this platform
+deployment. The resolve endpoint additionally requires `X-User-Token: <tk_...>`,
+which is the workspace API token forwarded opaquely from the end user's
+`Authorization: Bearer ...` header.
+
+## Resolve
+
+### Request
+
+```http
+POST /gateway/provider-keys/resolve
+X-Gateway-Token: gw_...
+X-User-Token: tk_...
+Content-Type: application/json
+
+{
+  "model": "gpt-4o-mini",
+  "provider": "openai"          // optional; otherwise inferred from model prefix
+}
+```
+
+### Response — multi-attempt shape (preferred)
+
+```json
+{
+  "request_id": "01HXY...",
+  "fallback_enabled": true,
+  "attempts": [
+    {
+      "attempt_id": "01HX1...",
+      "position": 0,
+      "provider": "anthropic",
+      "model": "claude-sonnet-4-5",
+      "api_key": "sk-ant-...",
+      "api_base": null,
+      "managed": false
+    },
+    {
+      "attempt_id": "01HX2...",
+      "position": 1,
+      "provider": "openai",
+      "model": "gpt-4o",
+      "api_key": "sk-...",
+      "api_base": "https://api.openai.com/v1",
+      "managed": false
+    }
+  ]
+}
+```
+
+The gateway walks `attempts` in order. On a retryable failure it moves to the
+next entry; on success it stops. The `attempt_id` of the entry that ultimately
+succeeded (or the last one tried, on total failure) is what the gateway echoes
+back via `X-Correlation-ID` and reports through `/gateway/usage`.
+
+`request_id` groups every `attempt_id` from the same resolve call so the
+platform can attribute spend, render trace timelines, and emit fallback events.
+The gateway also surfaces it as the `X-Otari-Request-ID` response header.
+
+`fallback_enabled` is informational — set by the platform when its routing
+policy actually allows fallback (i.e. the policy has multiple enabled entries
+and `fallback_enabled = true`). The gateway uses `len(attempts) > 1` for its
+own behaviour.
+
+`attempts` MUST contain at least one entry. An empty list is treated as a
+platform bug and surfaced as `502 Bad Gateway`.
+
+### Response — legacy single-attempt shape
+
+For backwards compatibility with older platform deployments, the gateway also
+accepts a flat payload:
+
+```json
+{
+  "provider": "openai",
+  "model": "gpt-4o-mini",
+  "api_key": "sk-...",
+  "api_base": "https://api.openai.com/v1",
+  "managed": true,
+  "correlation_id": "01HXC..."
+}
+```
+
+The gateway maps this onto a single-attempt route (`attempts = [{...}]`,
+`fallback_enabled = false`) and behaves as it always has — no retry loop, errors
+propagate to the client. New platform implementations should prefer the
+multi-attempt shape.
+
+### Failure
+
+| Status | Behaviour |
+|---|---|
+| `401`, `402`, `403`, `404`, `429` | Mapped through to the client as-is. `429`'s `Retry-After` header is preserved. |
+| `422`, `5xx`                      | Mapped to `502 Bad Gateway` with `detail = "Authorization service unavailable"`. |
+| Network/timeout                    | Mapped to `502 Bad Gateway`. |
+
+## Usage report
+
+After every attempt — successful or failed — the gateway sends:
+
+```http
+POST /gateway/usage
+X-Gateway-Token: gw_...
+Content-Type: application/json
+
+{
+  "correlation_id": "01HX1...",       // = the attempt_id from the resolve response
+  "status": "success" | "error",
+  "usage": {                           // present on success only
+    "prompt_tokens": 13,
+    "completion_tokens": 7,
+    "total_tokens": 20
+  },
+  "error_class": "http_401"            // present on error only; see below
+}
+```
+
+A multi-attempt request that walks two attempts produces two usage reports —
+one per attempt — sharing the same `request_id` (recoverable via the original
+resolve response). The platform is responsible for correlating them.
+
+`error_class` is a short tag describing why the attempt was abandoned:
+
+| Tag | Cause |
+|---|---|
+| `timeout` | `httpx.TimeoutException`, `asyncio.TimeoutError`, `TimeoutError` |
+| `conn_err` | `httpx.NetworkError` |
+| `http_<code>` | Provider returned an HTTP status code (e.g. `http_429`, `http_401`) |
+| `unknown` | Any other exception class |
+
+### Retry semantics
+
+The usage endpoint is called as a background task on the gateway side. It
+retries on transient failures (timeout, network error, 5xx) up to
+`PLATFORM_USAGE_MAX_RETRIES` times with exponential backoff
+(`0.25s`, `0.5s`, `1s`). It does **not** retry on `401`, `404`, `409`, `422` —
+those are treated as terminal client errors.
+
+## Streaming
+
+Streaming requests (`stream: true`) only ever try `attempts[0]`. Mid-stream
+failover would require either buffering the prefix (delaying the first byte)
+or a custom SSE event signalling the client to discard the partial response.
+Both options are out of scope for this version of the protocol. If the first
+attempt fails for a streaming request, the error propagates to the client.
+
+## Configuration
+
+| Env var | Default | Notes |
+|---|---|---|
+| `OTARI_PLATFORM_TOKEN` | — | Setting this enables platform mode. Legacy alias: `ANY_LLM_PLATFORM_TOKEN`. |
+| `PLATFORM_BASE_URL` | — | Required in platform mode. The gateway POSTs to `{base}/gateway/...`. |
+| `PLATFORM_RESOLVE_TIMEOUT_MS` | `5000` | Per-resolve timeout. |
+| `PLATFORM_USAGE_TIMEOUT_MS` | `5000` | Per-usage-report timeout. |
+| `PLATFORM_USAGE_MAX_RETRIES` | `3` | Max retries for transient usage-report failures. |

--- a/docs/platform-protocol.md
+++ b/docs/platform-protocol.md
@@ -17,6 +17,8 @@ The gateway calls two endpoints, both rooted at `PLATFORM_BASE_URL`:
 | `POST {base}/gateway/provider-keys/resolve` | Authorize a request and return one or more provider credentials to try |
 | `POST {base}/gateway/usage`                 | Report the outcome of an attempt back to the platform |
 
+`{base}` here means whatever you set `PLATFORM_BASE_URL` to — the gateway concatenates literally. The peer service is responsible for including any API-version prefix it exposes its own routes under. For the reference any-llm-platform deployment that prefix is `/api/v1`, so `PLATFORM_BASE_URL` is set to `http://backend:8000/api/v1` and the gateway ends up POSTing to `http://backend:8000/api/v1/gateway/provider-keys/resolve`.
+
 ## Authentication
 
 Both endpoints require `X-Gateway-Token: <gw_...>` in the request headers. This

--- a/docs/platform-protocol.md
+++ b/docs/platform-protocol.md
@@ -160,11 +160,43 @@ those are treated as terminal client errors.
 
 ## Streaming
 
-Streaming requests (`stream: true`) only ever try `attempts[0]`. Mid-stream
-failover would require either buffering the prefix (delaying the first byte)
-or a custom SSE event signalling the client to discard the partial response.
-Both options are out of scope for this version of the protocol. If the first
-attempt fails for a streaming request, the error propagates to the client.
+Streaming requests (`stream: true`) walk `attempts` just like non-streaming
+requests, with one structural difference: **the gateway can only fall through
+before any bytes have been flushed to the client.** Once an attempt yields its
+first chunk, the gateway commits to that attempt; any further error
+propagates to the SSE channel as today.
+
+The mechanism is a per-attempt **first-chunk gate**. For each attempt:
+
+1. Open the upstream stream (`acompletion(stream=True, ...)`). If this raises
+   — provider returned `401` / `5xx` / network error before the stream even
+   opened — classify the error: retryable failures move to the next attempt;
+   non-retryable failures propagate.
+2. Wait for the first chunk with a bounded timeout
+   (`STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS`, default 2000 ms). If the
+   upstream raises before yielding or the wait times out, move to the next
+   attempt.
+3. Once a first chunk is in hand, commit. Stitch it back onto the iterator
+   and start flushing SSE chunks to the client.
+
+**Latency contract:** zero added latency in the success case — the first
+chunk is held only for the microseconds it takes to call the SSE response
+builder. In the failure case, each abandoned attempt costs at most
+`first_chunk_timeout_seconds`.
+
+**What this catches:** auth errors (`401`/`403`), rate-limits (`429`),
+upstream `5xx`, connection failures, hung connections, "stream opens but
+errors before yielding."
+
+**What this doesn't catch:** errors that arrive *after* the first chunk has
+flushed (mid-stream connection drops, refusal messages embedded in normal
+content chunks). These are out of reach without either prefix-buffering
+(which would add visible latency on every request) or a client-cooperative
+restart event (which would break OpenAI SDK compatibility).
+
+Mid-stream failover is not currently planned. If a future client SDK starts
+honouring a custom restart event, it could be added behind that capability
+flag.
 
 ## Configuration
 
@@ -175,3 +207,4 @@ attempt fails for a streaming request, the error propagates to the client.
 | `PLATFORM_RESOLVE_TIMEOUT_MS` | `5000` | Per-resolve timeout. |
 | `PLATFORM_USAGE_TIMEOUT_MS` | `5000` | Per-usage-report timeout. |
 | `PLATFORM_USAGE_MAX_RETRIES` | `3` | Max retries for transient usage-report failures. |
+| `STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS` | `2000` | Per-attempt budget for the streaming first-chunk gate. |

--- a/docs/platform-protocol.md
+++ b/docs/platform-protocol.md
@@ -135,7 +135,9 @@ Content-Type: application/json
     "completion_tokens": 7,
     "total_tokens": 20
   },
-  "error_class": "http_401"            // present on error only; see below
+  "error_class": "http_401"            // optional on error; omitted when the
+                                       // gateway can't classify the failure
+                                       // (e.g. mid-stream errors). See below.
 }
 ```
 
@@ -151,6 +153,11 @@ resolve response). The platform is responsible for correlating them.
 | `conn_err` | `httpx.NetworkError` |
 | `http_<code>` | Provider returned an HTTP status code (e.g. `http_429`, `http_401`) |
 | `unknown` | Any other exception class |
+
+The field is **omitted entirely** when the gateway can't classify the failure
+back to an exception — this happens with mid-stream errors surfaced via the
+SSE channel, where only an error string is available. Treat a missing
+`error_class` as "uncategorised error" when aggregating.
 
 ### Retry semantics
 

--- a/docs/platform-protocol.md
+++ b/docs/platform-protocol.md
@@ -72,7 +72,7 @@ Content-Type: application/json
 }
 ```
 
-The gateway walks `attempts` in order. On a retryable failure it moves to the
+The gateway iterates `attempts` in order. On a retryable failure it moves to the
 next entry; on success it stops. The `attempt_id` of the entry that ultimately
 succeeded (or the last one tried, on total failure) is what the gateway echoes
 back via `X-Correlation-ID` and reports through `/gateway/usage`.
@@ -139,7 +139,7 @@ Content-Type: application/json
 }
 ```
 
-A multi-attempt request that walks two attempts produces two usage reports —
+A multi-attempt request that iterates two attempts produces two usage reports —
 one per attempt — sharing the same `request_id` (recoverable via the original
 resolve response). The platform is responsible for correlating them.
 
@@ -162,7 +162,7 @@ those are treated as terminal client errors.
 
 ## Streaming
 
-Streaming requests (`stream: true`) walk `attempts` just like non-streaming
+Streaming requests (`stream: true`) iterate `attempts` just like non-streaming
 requests, with one structural difference: **the gateway can only fall through
 before any bytes have been flushed to the client.** Once an attempt yields its
 first chunk, the gateway commits to that attempt; any further error

--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -19,6 +19,20 @@ _config: GatewayConfig | None = None
 _LAST_USED_UPDATE_INTERVAL_SECONDS = 300
 
 
+def _as_utc(value: datetime | None) -> datetime | None:
+    """Return ``value`` as a timezone-aware datetime in UTC.
+
+    SQLite stores ``DateTime(timezone=True)`` columns as naive strings and
+    returns them naive on read. PostgreSQL returns them as aware. Normalising
+    here keeps the subtraction/comparison call sites identical across both
+    backends — a naive value is *assumed* to be UTC, which matches how the
+    gateway writes them (always ``datetime.now(UTC)``).
+    """
+    if value is None or value.tzinfo is not None:
+        return value
+    return value.replace(tzinfo=UTC)
+
+
 def set_config(config: GatewayConfig) -> None:
     """Set the global config instance."""
     global _config  # noqa: PLW0603
@@ -99,7 +113,8 @@ async def _verify_and_update_api_key(db: AsyncSession, token: str) -> APIKey:
             detail="API key is inactive",
         )
 
-    if api_key.expires_at and api_key.expires_at < datetime.now(UTC):
+    expires_at = _as_utc(api_key.expires_at)
+    if expires_at is not None and expires_at < datetime.now(UTC):
         record_auth_failure("expired_key")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -107,9 +122,10 @@ async def _verify_and_update_api_key(db: AsyncSession, token: str) -> APIKey:
         )
 
     now = datetime.now(UTC)
+    last_used_at = _as_utc(api_key.last_used_at)
     should_update_last_used = (
-        api_key.last_used_at is None
-        or (now - api_key.last_used_at).total_seconds() >= _LAST_USED_UPDATE_INTERVAL_SECONDS
+        last_used_at is None
+        or (now - last_used_at).total_seconds() >= _LAST_USED_UPDATE_INTERVAL_SECONDS
     )
 
     if should_update_last_used:

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -567,33 +567,79 @@ async def chat_completions(
         if completion_kwargs.get("stream_options") is None:
             completion_kwargs["stream_options"] = {"include_usage": True}
 
-        return await _run_streaming(
-            completion_kwargs=completion_kwargs,
-            provider=provider,
-            model=model,
-            platform_mode=platform_mode,
-            correlation_id=correlation_id_for_stream,
-            config=config,
-            db=db,
-            log_writer=log_writer,
-            api_key_id=api_key_id,
-            user_id=user_id,
-            rate_limit_info=rate_limit_info,
-        )
+        try:
+            return await _run_streaming(
+                completion_kwargs=completion_kwargs,
+                provider=provider,
+                model=model,
+                platform_mode=platform_mode,
+                correlation_id=correlation_id_for_stream,
+                config=config,
+                db=db,
+                log_writer=log_writer,
+                api_key_id=api_key_id,
+                user_id=user_id,
+                rate_limit_info=rate_limit_info,
+            )
+        except HTTPException:
+            raise
+        except Exception as exc:
+            # Stream-creation failures (invalid model, missing API key, etc.)
+            # surface here before the StreamingResponse is yielded. Map to the
+            # same 504/502 envelope the non-streaming path uses so clients see
+            # a consistent error shape regardless of stream:true/false.
+            if platform_mode and correlation_id_for_stream:
+                background_tasks.add_task(
+                    _report_platform_usage,
+                    config,
+                    correlation_id_for_stream,
+                    "error",
+                    None,
+                    _classify_upstream_error(exc)[1],
+                )
+            elif db is not None:
+                await log_usage(
+                    db=db,
+                    log_writer=log_writer,
+                    api_key_id=api_key_id,
+                    model=model,
+                    provider=provider,
+                    endpoint="/v1/chat/completions",
+                    user_id=user_id,
+                    error=str(exc),
+                )
+            logger.error("Stream creation failed for %s:%s: %s", provider, model, exc)
+            if isinstance(exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
+                raise HTTPException(
+                    status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                    detail="LLM provider timeout",
+                ) from exc
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="LLM provider error",
+            ) from exc
 
     # ------------------------------------------------------------------
     # Non-streaming path: walk attempts on retryable failures.
     # ------------------------------------------------------------------
     if platform_mode:
-        assert route is not None
-        attempts_to_try = route.attempts
+        # Bind to a non-Optional local so mypy can narrow inside the retry loop
+        # below — assert-based narrowing doesn't survive across function calls
+        # in some mypy configurations.
+        if route is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Internal error: missing route context",
+            )
+        platform_route = route
+        attempts_to_try = platform_route.attempts
         if not attempts_to_try:
             # A spec-compliant platform always returns at least one attempt;
             # treating an empty list as a server bug is more useful than letting
             # the loop fall through silently with no `last_exc`.
             logger.error(
                 "Platform returned empty attempts list request_id=%s",
-                route.request_id,
+                platform_route.request_id,
             )
             raise HTTPException(
                 status_code=status.HTTP_502_BAD_GATEWAY,
@@ -646,7 +692,7 @@ async def chat_completions(
                 )
                 logger.warning(
                     "Provider call failed request_id=%s position=%d provider=%s model=%s error=%s retryable=%s",
-                    route.request_id,
+                    platform_route.request_id,
                     attempt.position,
                     attempt.provider,
                     attempt.model,
@@ -682,7 +728,7 @@ async def chat_completions(
         # All attempts exhausted with retryable errors.
         logger.error(
             "All upstream attempts failed request_id=%s failures=%s",
-            route.request_id,
+            platform_route.request_id,
             failures,
         )
         is_single_attempt = len(attempts_to_try) <= 1

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -3,7 +3,7 @@ import time
 import uuid
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
-from typing import Annotated, Any
+from typing import Annotated, Any, NamedTuple
 
 import httpx
 from any_llm import AnyLLM, LLMProvider, acompletion
@@ -228,11 +228,31 @@ async def _post_platform(
         return await client.post(url, headers=headers, json=body)
 
 
+class ResolvedAttempt(BaseModel):
+    """A single resolution attempt returned by the platform."""
+
+    attempt_id: str
+    position: int
+    provider: str
+    model: str
+    api_base: str | None = None
+    api_key: str
+    managed: bool
+
+
+class ResolvedRoute(BaseModel):
+    """The full resolution plan returned by the platform."""
+
+    request_id: str
+    fallback_enabled: bool
+    attempts: list[ResolvedAttempt]
+
+
 async def _resolve_platform_credentials(
     config: GatewayConfig,
     user_token: str,
     model_selector: str,
-) -> tuple[str, str, str | None, str, bool, str]:
+) -> ResolvedRoute:
     platform_base_url = config.platform.get("base_url")
     if not platform_base_url:
         raise HTTPException(
@@ -266,14 +286,7 @@ async def _resolve_platform_credentials(
 
     if response.status_code == 200:
         payload = response.json()
-        return (
-            str(payload["provider"]),
-            str(payload["model"]),
-            payload.get("api_base"),
-            str(payload["api_key"]),
-            bool(payload.get("managed", False)),
-            str(payload["correlation_id"]),
-        )
+        return _parse_resolve_payload(payload)
 
     if response.status_code in {401, 402, 403, 404, 429}:
         detail = _safe_detail_from_platform(response, "Authorization request rejected")
@@ -294,11 +307,98 @@ async def _resolve_platform_credentials(
     )
 
 
+def _parse_resolve_payload(payload: dict[str, Any]) -> ResolvedRoute:
+    """Build a ResolvedRoute from either the new attempts-list shape or the
+    legacy single-attempt shape.
+
+    The legacy shape lacks ``attempts``/``request_id`` and instead has the
+    primary attempt's fields at the top level (``provider``, ``model``,
+    ``api_key``, ``api_base``, ``managed``, ``correlation_id``). Older otari
+    deployments still respond this way; we map them onto a single-attempt route
+    so the rest of the gateway code never has to know.
+    """
+    attempts_payload = payload.get("attempts")
+    if attempts_payload is not None:
+        attempts = [
+            ResolvedAttempt(
+                attempt_id=str(att["attempt_id"]),
+                position=int(att["position"]),
+                provider=str(att["provider"]),
+                model=str(att["model"]),
+                api_base=att.get("api_base"),
+                api_key=str(att["api_key"]),
+                managed=bool(att.get("managed", False)),
+            )
+            for att in attempts_payload
+        ]
+        return ResolvedRoute(
+            request_id=str(payload["request_id"]),
+            fallback_enabled=bool(payload.get("fallback_enabled", False)),
+            attempts=attempts,
+        )
+
+    correlation_id = str(payload["correlation_id"])
+    return ResolvedRoute(
+        request_id=correlation_id,
+        fallback_enabled=False,
+        attempts=[
+            ResolvedAttempt(
+                attempt_id=correlation_id,
+                position=0,
+                provider=str(payload["provider"]),
+                model=str(payload["model"]),
+                api_base=payload.get("api_base"),
+                api_key=str(payload["api_key"]),
+                managed=bool(payload.get("managed", False)),
+            )
+        ],
+    )
+
+
+# Status codes that cause the gateway to move on to the next attempt in a
+# multi-attempt route. 401/403 are included because users configure multi-attempt
+# routing policies on the platform precisely to handle credential outages — when
+# they've opted in, an auth failure on one provider should fall through to the
+# next, not surface to the client. Single-attempt requests still see auth errors
+# directly because there's nothing to fall back to.
+_FALLBACK_RETRYABLE_STATUS_CODES = {401, 403, 408, 429, 500, 502, 503, 504}
+_FALLBACK_NON_RETRYABLE_STATUS_CODES = {400, 422}
+
+
+def _classify_upstream_error(exc: BaseException) -> tuple[bool, str]:
+    """Classify an upstream provider error.
+
+    Returns ``(retryable, error_class)``. ``error_class`` is a short string used
+    for logging and reporting back to the platform. Streaming-only failures still
+    pass through this classifier; the caller decides whether to actually retry.
+    """
+    if isinstance(exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
+        return True, "timeout"
+    if isinstance(exc, httpx.NetworkError):
+        return True, "conn_err"
+
+    status_code = getattr(exc, "status_code", None)
+    if status_code is None:
+        resp = getattr(exc, "response", None)
+        if resp is not None:
+            status_code = getattr(resp, "status_code", None)
+
+    if isinstance(status_code, int):
+        if status_code in _FALLBACK_NON_RETRYABLE_STATUS_CODES:
+            return False, f"http_{status_code}"
+        if status_code in _FALLBACK_RETRYABLE_STATUS_CODES or 500 <= status_code <= 599:
+            return True, f"http_{status_code}"
+        return False, f"http_{status_code}"
+
+    return False, "unknown"
+
+
 async def _report_platform_usage(
     config: GatewayConfig,
     correlation_id: str,
     outcome: str,
     usage: CompletionUsage | None,
+    error_class: str | None = None,
 ) -> None:
     platform_base_url = config.platform.get("base_url")
     if not platform_base_url:
@@ -317,6 +417,8 @@ async def _report_platform_usage(
             "completion_tokens": token_usage.completion_tokens,
             "total_tokens": token_usage.total_tokens,
         }
+    elif error_class is not None:
+        payload["error_class"] = error_class
 
     delay_seconds = 0.25
     for attempt in range(1, max_retries + 1):
@@ -374,27 +476,23 @@ async def chat_completions(
     user_id: str | None = None
     rate_limit_info: RateLimitInfo | None = None
     platform_mode = config.is_platform_mode
-    correlation_id: str | None = None
+    route: ResolvedRoute | None = None
 
     if platform_mode:
         user_token = _extract_platform_user_token(raw_request)
         start_time = time.perf_counter()
-        provider_name, model, api_base, resolved_api_key, managed, correlation_id = await _resolve_platform_credentials(
+        route = await _resolve_platform_credentials(
             config=config,
             user_token=user_token,
             model_selector=request.model,
         )
         resolve_latency_ms = (time.perf_counter() - start_time) * 1000
-        provider = LLMProvider(provider_name)
-        provider_kwargs = {"api_key": resolved_api_key}
-        if api_base:
-            provider_kwargs["api_base"] = api_base
-        response.headers["X-Correlation-ID"] = correlation_id
+        response.headers["X-Otari-Request-ID"] = route.request_id
         logger.info(
-            "Platform resolve succeeded provider=%s model=%s managed=%s resolve_latency_ms=%.2f",
-            provider_name,
-            model,
-            managed,
+            "Platform resolve succeeded request_id=%s attempts=%d fallback_enabled=%s resolve_latency_ms=%.2f",
+            route.request_id,
+            len(route.attempts),
+            route.fallback_enabled,
             resolve_latency_ms,
         )
     else:
@@ -428,113 +526,187 @@ async def chat_completions(
         _ = await validate_user_budget(db, user_id, request.model, strategy=config.budget_strategy)
         if config.budget_strategy == "for_update":
             await db.rollback()
+
+    # ------------------------------------------------------------------
+    # Streaming path: take the first attempt only — no fallback.
+    #
+    # Mid-stream failover would require either silently buffering the prefix
+    # (which delays the first byte) or a client-aware "restart" event (which
+    # breaks OpenAI-SDK compatibility). Both are out of scope for this version.
+    # If the only attempt fails, the error propagates to the client as today.
+    # ------------------------------------------------------------------
+    if request.stream:
+        if platform_mode:
+            assert route is not None
+            if not route.attempts:
+                logger.error(
+                    "Platform returned empty attempts list request_id=%s",
+                    route.request_id,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail="Authorization service returned no resolvable provider",
+                )
+            attempt = route.attempts[0]
+            provider = LLMProvider(attempt.provider)
+            model = attempt.model
+            provider_kwargs: dict[str, Any] = {"api_key": attempt.api_key}
+            if attempt.api_base:
+                provider_kwargs["api_base"] = attempt.api_base
+            correlation_id_for_stream: str | None = attempt.attempt_id
+            response.headers["X-Correlation-ID"] = attempt.attempt_id
+        else:
+            provider, model = AnyLLM.split_model_provider(request.model)
+            provider_kwargs = get_provider_kwargs(config, provider)
+            correlation_id_for_stream = None
+
+        request_fields = request.model_dump(exclude_unset=True)
+        if platform_mode:
+            request_fields["model"] = f"{provider.value}:{model}"
+        completion_kwargs = {**provider_kwargs, **request_fields}
+        if completion_kwargs.get("stream_options") is None:
+            completion_kwargs["stream_options"] = {"include_usage": True}
+
+        return await _run_streaming(
+            completion_kwargs=completion_kwargs,
+            provider=provider,
+            model=model,
+            platform_mode=platform_mode,
+            correlation_id=correlation_id_for_stream,
+            config=config,
+            db=db,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            user_id=user_id,
+            rate_limit_info=rate_limit_info,
+        )
+
+    # ------------------------------------------------------------------
+    # Non-streaming path: walk attempts on retryable failures.
+    # ------------------------------------------------------------------
+    if platform_mode:
+        assert route is not None
+        attempts_to_try = route.attempts
+        if not attempts_to_try:
+            # A spec-compliant platform always returns at least one attempt;
+            # treating an empty list as a server bug is more useful than letting
+            # the loop fall through silently with no `last_exc`.
+            logger.error(
+                "Platform returned empty attempts list request_id=%s",
+                route.request_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Authorization service returned no resolvable provider",
+            )
+    else:
         provider, model = AnyLLM.split_model_provider(request.model)
         provider_kwargs = get_provider_kwargs(config, provider)
+        attempts_to_try = []  # standalone path doesn't use the attempts list
 
-    # User request fields take precedence over provider config defaults
-    request_fields = request.model_dump(exclude_unset=True)
+    class _AttemptFailure(NamedTuple):
+        position: int
+        provider: str
+        model: str
+        error_class: str
+
+    failures: list[_AttemptFailure] = []
+    last_exc: BaseException | None = None
+
     if platform_mode:
-        request_fields["model"] = f"{provider.value}:{model}"
+        # Snapshot the client's request body once; only `model` and provider creds
+        # change per attempt.
+        base_request_fields = request.model_dump(exclude_unset=True)
+        for attempt in attempts_to_try:
+            attempt_provider = LLMProvider(attempt.provider)
+            attempt_model = attempt.model
+            attempt_kwargs: dict[str, Any] = {"api_key": attempt.api_key}
+            if attempt.api_base:
+                attempt_kwargs["api_base"] = attempt.api_base
 
-    completion_kwargs = {**provider_kwargs, **request_fields}
+            completion_kwargs = {
+                **attempt_kwargs,
+                **base_request_fields,
+                "model": f"{attempt_provider.value}:{attempt_model}",
+            }
 
-    if request.stream and completion_kwargs.get("stream_options") is None:
-        completion_kwargs["stream_options"] = {"include_usage": True}
-
-    try:
-        if request.stream:
-
-            def _format_chunk(chunk: ChatCompletionChunk) -> str:
-                return f"data: {chunk.model_dump_json()}\n\n"
-
-            def _extract_usage(chunk: ChatCompletionChunk) -> CompletionUsage | None:
-                if not chunk.usage:
-                    return None
-                return CompletionUsage(
-                    prompt_tokens=chunk.usage.prompt_tokens or 0,
-                    completion_tokens=chunk.usage.completion_tokens or 0,
-                    total_tokens=chunk.usage.total_tokens or 0,
+            try:
+                completion: ChatCompletion = await acompletion(**completion_kwargs)  # type: ignore[assignment]
+            except HTTPException:
+                raise
+            except BaseException as exc:
+                retryable, error_class = _classify_upstream_error(exc)
+                background_tasks.add_task(
+                    _report_platform_usage,
+                    config,
+                    attempt.attempt_id,
+                    "error",
+                    None,
+                    error_class,
                 )
+                logger.warning(
+                    "Provider call failed request_id=%s position=%d provider=%s model=%s error=%s retryable=%s",
+                    route.request_id,
+                    attempt.position,
+                    attempt.provider,
+                    attempt.model,
+                    error_class,
+                    retryable,
+                )
+                last_exc = exc
+                if not retryable:
+                    raise HTTPException(
+                        status_code=status.HTTP_502_BAD_GATEWAY,
+                        detail="LLM provider error",
+                    ) from exc
+                failures.append(
+                    _AttemptFailure(attempt.position, attempt.provider, attempt.model, error_class)
+                )
+                continue
 
-            async def _on_complete(usage_data: CompletionUsage) -> None:
-                if platform_mode and correlation_id:
-                    asyncio.create_task(
-                        _report_platform_usage(
-                            config=config,
-                            correlation_id=correlation_id,
-                            outcome="success",
-                            usage=usage_data,
-                        )
-                    )
-                    return
-
-                if db is None:
-                    return
-
-                    await log_usage(
-                        db=db,
-                        log_writer=log_writer,
-                        api_key_id=api_key_id,
-                        model=model,
-                        provider=provider,
-                        endpoint="/v1/chat/completions",
-                        user_id=user_id,
-                        usage_override=usage_data,
-                    )
-
-            async def _on_error(error: str) -> None:
-                if platform_mode and correlation_id:
-                    asyncio.create_task(
-                        _report_platform_usage(
-                            config=config,
-                            correlation_id=correlation_id,
-                            outcome="error",
-                            usage=None,
-                        )
-                    )
-                    return
-
-                if db is None:
-                    return
-
-                    await log_usage(
-                        db=db,
-                        log_writer=log_writer,
-                        api_key_id=api_key_id,
-                        model=model,
-                        provider=provider,
-                        endpoint="/v1/chat/completions",
-                        user_id=user_id,
-                        error=error,
-                    )
-
-            stream: AsyncIterator[ChatCompletionChunk] = await acompletion(**completion_kwargs)  # type: ignore[assignment]
-            rl_headers = rate_limit_headers(rate_limit_info) if rate_limit_info else {}
-            return StreamingResponse(
-                streaming_generator(
-                    stream=stream,
-                    format_chunk=_format_chunk,
-                    extract_usage=_extract_usage,
-                    fmt=OPENAI_STREAM_FORMAT,
-                    on_complete=_on_complete,
-                    on_error=_on_error,
-                    label=f"{provider}:{model}",
-                ),
-                media_type="text/event-stream",
-                headers=rl_headers,
-            )
-
-        completion: ChatCompletion = await acompletion(**completion_kwargs)  # type: ignore[assignment]
-        if platform_mode and correlation_id:
-            usage_data = completion.usage
+            # Success on this attempt.
             background_tasks.add_task(
                 _report_platform_usage,
                 config,
-                correlation_id,
+                attempt.attempt_id,
                 "success",
-                usage_data,
+                completion.usage,
+                None,
             )
-        elif db is not None:
+            response.headers["X-Correlation-ID"] = attempt.attempt_id
+            if rate_limit_info:
+                for key, value in rate_limit_headers(rate_limit_info).items():
+                    response.headers[key] = value
+            return completion
+
+        # All attempts exhausted with retryable errors.
+        logger.error(
+            "All upstream attempts failed request_id=%s failures=%s",
+            route.request_id,
+            failures,
+        )
+        is_single_attempt = len(attempts_to_try) <= 1
+        if last_exc is not None and isinstance(
+            last_exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)
+        ):
+            detail = "LLM provider timeout" if is_single_attempt else "All upstream providers timed out"
+            raise HTTPException(
+                status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                detail=detail,
+            ) from last_exc
+        detail = "LLM provider error" if is_single_attempt else "All upstream providers failed"
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=detail,
+        ) from last_exc
+
+    # Standalone path (no platform / no fallback).
+    request_fields = request.model_dump(exclude_unset=True)
+    completion_kwargs = {**provider_kwargs, **request_fields}
+
+    try:
+        completion = await acompletion(**completion_kwargs)  # type: ignore[assignment]
+        if db is not None:
             await log_usage(
                 db=db,
                 log_writer=log_writer,
@@ -545,19 +717,10 @@ async def chat_completions(
                 user_id=user_id,
                 response=completion,
             )
-
     except HTTPException:
         raise
     except Exception as e:
-        if platform_mode and correlation_id:
-            background_tasks.add_task(
-                _report_platform_usage,
-                config,
-                correlation_id,
-                "error",
-                None,
-            )
-        elif db is not None:
+        if db is not None:
             await log_usage(
                 db=db,
                 log_writer=log_writer,
@@ -585,3 +748,96 @@ async def chat_completions(
             response.headers[key] = value
 
     return completion
+
+
+async def _run_streaming(
+    *,
+    completion_kwargs: dict[str, Any],
+    provider: LLMProvider,
+    model: str,
+    platform_mode: bool,
+    correlation_id: str | None,
+    config: GatewayConfig,
+    db: AsyncSession | None,
+    log_writer: LogWriter,
+    api_key_id: str | None,
+    user_id: str | None,
+    rate_limit_info: RateLimitInfo | None,
+) -> StreamingResponse:
+    """Stream from a single attempt — no fallback in v1."""
+
+    def _format_chunk(chunk: ChatCompletionChunk) -> str:
+        return f"data: {chunk.model_dump_json()}\n\n"
+
+    def _extract_usage(chunk: ChatCompletionChunk) -> CompletionUsage | None:
+        if not chunk.usage:
+            return None
+        return CompletionUsage(
+            prompt_tokens=chunk.usage.prompt_tokens or 0,
+            completion_tokens=chunk.usage.completion_tokens or 0,
+            total_tokens=chunk.usage.total_tokens or 0,
+        )
+
+    async def _on_complete(usage_data: CompletionUsage) -> None:
+        if platform_mode and correlation_id:
+            asyncio.create_task(
+                _report_platform_usage(
+                    config=config,
+                    correlation_id=correlation_id,
+                    outcome="success",
+                    usage=usage_data,
+                )
+            )
+            return
+        if db is None:
+            return
+        await log_usage(
+            db=db,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            model=model,
+            provider=provider,
+            endpoint="/v1/chat/completions",
+            user_id=user_id,
+            usage_override=usage_data,
+        )
+
+    async def _on_error(error: str) -> None:
+        if platform_mode and correlation_id:
+            asyncio.create_task(
+                _report_platform_usage(
+                    config=config,
+                    correlation_id=correlation_id,
+                    outcome="error",
+                    usage=None,
+                )
+            )
+            return
+        if db is None:
+            return
+        await log_usage(
+            db=db,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            model=model,
+            provider=provider,
+            endpoint="/v1/chat/completions",
+            user_id=user_id,
+            error=error,
+        )
+
+    stream: AsyncIterator[ChatCompletionChunk] = await acompletion(**completion_kwargs)  # type: ignore[assignment]
+    rl_headers = rate_limit_headers(rate_limit_info) if rate_limit_info else {}
+    return StreamingResponse(
+        streaming_generator(
+            stream=stream,
+            format_chunk=_format_chunk,
+            extract_usage=_extract_usage,
+            fmt=OPENAI_STREAM_FORMAT,
+            on_complete=_on_complete,
+            on_error=_on_error,
+            label=f"{provider}:{model}",
+        ),
+        media_type="text/event-stream",
+        headers=rl_headers,
+    )

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -28,7 +28,12 @@ from gateway.rate_limit import RateLimitInfo, check_rate_limit
 from gateway.services.budget_service import validate_user_budget
 from gateway.services.log_writer import LogWriter
 from gateway.services.pricing_service import find_model_pricing
-from gateway.streaming import OPENAI_STREAM_FORMAT, streaming_generator
+from gateway.streaming import (
+    OPENAI_STREAM_FORMAT,
+    StreamingAttemptFailure,
+    streaming_generator,
+    walk_streaming_attempts,
+)
 
 router = APIRouter(prefix="/v1/chat", tags=["chat"])
 
@@ -537,67 +542,69 @@ async def chat_completions(
     # ------------------------------------------------------------------
     if request.stream:
         if platform_mode:
-            assert route is not None
-            if not route.attempts:
-                logger.error(
-                    "Platform returned empty attempts list request_id=%s",
-                    route.request_id,
-                )
+            if route is None or not route.attempts:
+                if route is not None:
+                    logger.error(
+                        "Platform returned empty attempts list request_id=%s",
+                        route.request_id,
+                    )
                 raise HTTPException(
                     status_code=status.HTTP_502_BAD_GATEWAY,
                     detail="Authorization service returned no resolvable provider",
                 )
-            attempt = route.attempts[0]
-            provider = LLMProvider(attempt.provider)
-            model = attempt.model
-            provider_kwargs: dict[str, Any] = {"api_key": attempt.api_key}
-            if attempt.api_base:
-                provider_kwargs["api_base"] = attempt.api_base
-            correlation_id_for_stream: str | None = attempt.attempt_id
-            response.headers["X-Correlation-ID"] = attempt.attempt_id
-        else:
-            provider, model = AnyLLM.split_model_provider(request.model)
-            provider_kwargs = get_provider_kwargs(config, provider)
-            correlation_id_for_stream = None
+            try:
+                return await _run_streaming_with_fallback(
+                    route=route,
+                    request=request,
+                    response=response,
+                    config=config,
+                    background_tasks=background_tasks,
+                    rate_limit_info=rate_limit_info,
+                )
+            except HTTPException:
+                raise
+            except Exception as exc:
+                # Every attempt failed before any bytes were flushed.
+                logger.error(
+                    "All streaming attempts failed request_id=%s: %s",
+                    route.request_id,
+                    exc,
+                )
+                if isinstance(
+                    exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)
+                ):
+                    raise HTTPException(
+                        status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                        detail=(
+                            "LLM provider timeout"
+                            if len(route.attempts) <= 1
+                            else "All upstream providers timed out"
+                        ),
+                    ) from exc
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=(
+                        "LLM provider error"
+                        if len(route.attempts) <= 1
+                        else "All upstream providers failed"
+                    ),
+                ) from exc
+
+        # Standalone path: single attempt, no fallback (unchanged from v1.0).
+        provider, model = AnyLLM.split_model_provider(request.model)
+        provider_kwargs = get_provider_kwargs(config, provider)
 
         request_fields = request.model_dump(exclude_unset=True)
-        if platform_mode:
-            request_fields["model"] = f"{provider.value}:{model}"
         completion_kwargs = {**provider_kwargs, **request_fields}
         if completion_kwargs.get("stream_options") is None:
             completion_kwargs["stream_options"] = {"include_usage": True}
 
         try:
-            return await _run_streaming(
-                completion_kwargs=completion_kwargs,
-                provider=provider,
-                model=model,
-                platform_mode=platform_mode,
-                correlation_id=correlation_id_for_stream,
-                config=config,
-                db=db,
-                log_writer=log_writer,
-                api_key_id=api_key_id,
-                user_id=user_id,
-                rate_limit_info=rate_limit_info,
-            )
+            stream: AsyncIterator[ChatCompletionChunk] = await acompletion(**completion_kwargs)  # type: ignore[assignment]
         except HTTPException:
             raise
         except Exception as exc:
-            # Stream-creation failures (invalid model, missing API key, etc.)
-            # surface here before the StreamingResponse is yielded. Map to the
-            # same 504/502 envelope the non-streaming path uses so clients see
-            # a consistent error shape regardless of stream:true/false.
-            if platform_mode and correlation_id_for_stream:
-                background_tasks.add_task(
-                    _report_platform_usage,
-                    config,
-                    correlation_id_for_stream,
-                    "error",
-                    None,
-                    _classify_upstream_error(exc)[1],
-                )
-            elif db is not None:
+            if db is not None:
                 await log_usage(
                     db=db,
                     log_writer=log_writer,
@@ -618,6 +625,20 @@ async def chat_completions(
                 status_code=status.HTTP_502_BAD_GATEWAY,
                 detail="LLM provider error",
             ) from exc
+
+        return _build_streaming_response(
+            stream=stream,
+            provider=provider,
+            model=model,
+            platform_mode=False,
+            correlation_id=None,
+            config=config,
+            db=db,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            user_id=user_id,
+            rate_limit_info=rate_limit_info,
+        )
 
     # ------------------------------------------------------------------
     # Non-streaming path: walk attempts on retryable failures.
@@ -796,21 +817,21 @@ async def chat_completions(
     return completion
 
 
-async def _run_streaming(
+def _build_streaming_response(
     *,
-    completion_kwargs: dict[str, Any],
+    stream: AsyncIterator[ChatCompletionChunk],
     provider: LLMProvider,
     model: str,
     platform_mode: bool,
     correlation_id: str | None,
     config: GatewayConfig,
     db: AsyncSession | None,
-    log_writer: LogWriter,
+    log_writer: LogWriter | None,
     api_key_id: str | None,
     user_id: str | None,
     rate_limit_info: RateLimitInfo | None,
 ) -> StreamingResponse:
-    """Stream from a single attempt — no fallback in v1."""
+    """Wrap an already-opened upstream stream in an SSE response."""
 
     def _format_chunk(chunk: ChatCompletionChunk) -> str:
         return f"data: {chunk.model_dump_json()}\n\n"
@@ -835,7 +856,7 @@ async def _run_streaming(
                 )
             )
             return
-        if db is None:
+        if db is None or log_writer is None:
             return
         await log_usage(
             db=db,
@@ -859,7 +880,7 @@ async def _run_streaming(
                 )
             )
             return
-        if db is None:
+        if db is None or log_writer is None:
             return
         await log_usage(
             db=db,
@@ -872,8 +893,13 @@ async def _run_streaming(
             error=error,
         )
 
-    stream: AsyncIterator[ChatCompletionChunk] = await acompletion(**completion_kwargs)  # type: ignore[assignment]
     rl_headers = rate_limit_headers(rate_limit_info) if rate_limit_info else {}
+    # StreamingResponse builds its own response object, so headers we want on
+    # the wire have to be passed in here — assigning to the dependency-injected
+    # `Response` object doesn't propagate to streaming responses.
+    headers = dict(rl_headers)
+    if platform_mode and correlation_id:
+        headers["X-Correlation-ID"] = correlation_id
     return StreamingResponse(
         streaming_generator(
             stream=stream,
@@ -885,5 +911,85 @@ async def _run_streaming(
             label=f"{provider}:{model}",
         ),
         media_type="text/event-stream",
-        headers=rl_headers,
+        headers=headers,
+    )
+
+
+async def _run_streaming_with_fallback(
+    *,
+    route: ResolvedRoute,
+    request: ChatCompletionRequest,
+    response: Response,
+    config: GatewayConfig,
+    background_tasks: BackgroundTasks,
+    rate_limit_info: RateLimitInfo | None,
+) -> StreamingResponse:
+    """Walk route.attempts for a streaming request, falling through on any
+    attempt that fails before its first chunk arrives.
+
+    Once an attempt yields its first chunk, we commit and start flushing to the
+    client — errors past that point propagate to the SSE channel as today.
+    """
+    base_request_fields = request.model_dump(exclude_unset=True)
+    first_chunk_timeout_seconds = (
+        int(config.platform.get("streaming_first_chunk_timeout_ms", 2000)) / 1000
+    )
+
+    async def _build_for_attempt(
+        attempt: ResolvedAttempt,
+    ) -> AsyncIterator[ChatCompletionChunk]:
+        attempt_provider = LLMProvider(attempt.provider)
+        provider_kwargs: dict[str, Any] = {"api_key": attempt.api_key}
+        if attempt.api_base:
+            provider_kwargs["api_base"] = attempt.api_base
+        completion_kwargs = {
+            **provider_kwargs,
+            **base_request_fields,
+            "model": f"{attempt_provider.value}:{attempt.model}",
+        }
+        if completion_kwargs.get("stream_options") is None:
+            completion_kwargs["stream_options"] = {"include_usage": True}
+        return await acompletion(**completion_kwargs)  # type: ignore[return-value]
+
+    async def _on_attempt_failed(
+        attempt: ResolvedAttempt, failure: StreamingAttemptFailure
+    ) -> None:
+        background_tasks.add_task(
+            _report_platform_usage,
+            config,
+            attempt.attempt_id,
+            "error",
+            None,
+            failure.error_class,
+        )
+        logger.warning(
+            "Streaming attempt failed request_id=%s position=%d provider=%s model=%s error=%s",
+            route.request_id,
+            attempt.position,
+            attempt.provider,
+            attempt.model,
+            failure.error_class,
+        )
+
+    chosen, stream = await walk_streaming_attempts(
+        attempts=route.attempts,
+        build_stream=_build_for_attempt,
+        classify_error=_classify_upstream_error,
+        on_attempt_failed=_on_attempt_failed,
+        first_chunk_timeout_seconds=first_chunk_timeout_seconds,
+    )
+
+    response.headers["X-Correlation-ID"] = chosen.attempt_id
+    return _build_streaming_response(
+        stream=stream,
+        provider=LLMProvider(chosen.provider),
+        model=chosen.model,
+        platform_mode=True,
+        correlation_id=chosen.attempt_id,
+        config=config,
+        db=None,  # platform mode doesn't use the local DB
+        log_writer=None,  # unused when db is None
+        api_key_id=None,
+        user_id=None,
+        rate_limit_info=rate_limit_info,
     )

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -632,6 +632,7 @@ async def chat_completions(
             model=model,
             platform_mode=False,
             correlation_id=None,
+            request_id=None,
             config=config,
             db=db,
             log_writer=log_writer,
@@ -824,6 +825,7 @@ def _build_streaming_response(
     model: str,
     platform_mode: bool,
     correlation_id: str | None,
+    request_id: str | None,
     config: GatewayConfig,
     db: AsyncSession | None,
     log_writer: LogWriter | None,
@@ -900,6 +902,8 @@ def _build_streaming_response(
     headers = dict(rl_headers)
     if platform_mode and correlation_id:
         headers["X-Correlation-ID"] = correlation_id
+    if platform_mode and request_id:
+        headers["X-Otari-Request-ID"] = request_id
     return StreamingResponse(
         streaming_generator(
             stream=stream,
@@ -979,13 +983,13 @@ async def _run_streaming_with_fallback(
         first_chunk_timeout_seconds=first_chunk_timeout_seconds,
     )
 
-    response.headers["X-Correlation-ID"] = chosen.attempt_id
     return _build_streaming_response(
         stream=stream,
         provider=LLMProvider(chosen.provider),
         model=chosen.model,
         platform_mode=True,
         correlation_id=chosen.attempt_id,
+        request_id=route.request_id,
         config=config,
         db=None,  # platform mode doesn't use the local DB
         log_writer=None,  # unused when db is None

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -533,12 +533,14 @@ async def chat_completions(
             await db.rollback()
 
     # ------------------------------------------------------------------
-    # Streaming path: take the first attempt only — no fallback.
+    # Streaming path: iterate `route.attempts` before any bytes are flushed,
+    # then commit to the first attempt that yields a chunk. Implemented in
+    # `_run_streaming_with_fallback` via `iterate_streaming_attempts`.
     #
-    # Mid-stream failover would require either silently buffering the prefix
-    # (which delays the first byte) or a client-aware "restart" event (which
-    # breaks OpenAI-SDK compatibility). Both are out of scope for this version.
-    # If the only attempt fails, the error propagates to the client as today.
+    # Mid-stream failover (after first chunk) is out of scope: recovering
+    # would require either silently buffering the prefix (delays first byte)
+    # or a client-aware "restart" event (breaks OpenAI-SDK compatibility).
+    # Errors after first chunk propagate to the client.
     # ------------------------------------------------------------------
     if request.stream:
         if platform_mode:

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -31,8 +31,8 @@ from gateway.services.pricing_service import find_model_pricing
 from gateway.streaming import (
     OPENAI_STREAM_FORMAT,
     StreamingAttemptFailure,
+    iterate_streaming_attempts,
     streaming_generator,
-    walk_streaming_attempts,
 )
 
 router = APIRouter(prefix="/v1/chat", tags=["chat"])
@@ -642,7 +642,7 @@ async def chat_completions(
         )
 
     # ------------------------------------------------------------------
-    # Non-streaming path: walk attempts on retryable failures.
+    # Non-streaming path: iterate attempts on retryable failures.
     # ------------------------------------------------------------------
     if platform_mode:
         # Bind to a non-Optional local so mypy can narrow inside the retry loop
@@ -928,7 +928,7 @@ async def _run_streaming_with_fallback(
     background_tasks: BackgroundTasks,
     rate_limit_info: RateLimitInfo | None,
 ) -> StreamingResponse:
-    """Walk route.attempts for a streaming request, falling through on any
+    """Iterate route.attempts for a streaming request, falling through on any
     attempt that fails before its first chunk arrives.
 
     Once an attempt yields its first chunk, we commit and start flushing to the
@@ -975,7 +975,7 @@ async def _run_streaming_with_fallback(
             failure.error_class,
         )
 
-    chosen, stream = await walk_streaming_attempts(
+    chosen, stream = await iterate_streaming_attempts(
         attempts=route.attempts,
         build_stream=_build_for_attempt,
         classify_error=_classify_upstream_error,

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -168,6 +168,15 @@ def _apply_platform_env_overrides(config: dict[str, Any]) -> None:
         "PLATFORM_RESOLVE_TIMEOUT_MS": ("resolve_timeout_ms", int),
         "PLATFORM_USAGE_TIMEOUT_MS": ("usage_timeout_ms", int),
         "PLATFORM_USAGE_MAX_RETRIES": ("usage_max_retries", int),
+        # Per-attempt budget for streaming fallback: how long to wait for the
+        # first chunk from each attempt before treating it as hung and moving
+        # to the next entry in the routing policy. Tunable per deployment;
+        # v1.2 will move this onto the routing_policy schema for per-policy
+        # control.
+        "STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS": (
+            "streaming_first_chunk_timeout_ms",
+            int,
+        ),
     }
 
     for env_name, (field_name, caster) in env_mappings.items():

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -1,13 +1,29 @@
 """Shared SSE streaming utilities for gateway routes."""
 
+import asyncio
 import json
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from contextlib import suppress
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeVar
 
 from any_llm.types.completion import CompletionUsage
 
 from gateway.log_config import logger
+
+A = TypeVar("A")  # Attempt-like, opaque to this module
+C = TypeVar("C")  # Chunk type emitted by the upstream stream
+
+
+DEFAULT_FIRST_CHUNK_TIMEOUT_SECONDS = 2.0
+
+
+@dataclass(frozen=True)
+class StreamingAttemptFailure:
+    """The reason an attempt was abandoned before any bytes were flushed."""
+
+    error_class: str
+    exception: BaseException
 
 
 @dataclass(frozen=True)
@@ -96,3 +112,99 @@ async def streaming_generator(
         except Exception as log_err:
             logger.error("Failed to log streaming error usage: %s", log_err)
         logger.error("Streaming error for %s: %s", label, e)
+
+
+async def walk_streaming_attempts(
+    attempts: Sequence[A],
+    build_stream: Callable[[A], Awaitable[AsyncIterator[C]]],
+    classify_error: Callable[[BaseException], tuple[bool, str]],
+    on_attempt_failed: Callable[[A, StreamingAttemptFailure], Awaitable[None]],
+    first_chunk_timeout_seconds: float = DEFAULT_FIRST_CHUNK_TIMEOUT_SECONDS,
+) -> tuple[A, AsyncIterator[C]]:
+    """Walk ``attempts`` until one yields its first chunk; return that attempt
+    and an iterator that re-emits the chunk followed by the rest of the stream.
+
+    For each attempt:
+
+    1. ``build_stream(attempt)`` is awaited — typically wraps ``acompletion``.
+       If it raises, classify the error: retryable errors call
+       ``on_attempt_failed`` and continue; non-retryable errors propagate.
+    2. The first chunk is awaited with a ``first_chunk_timeout_seconds`` cap.
+       If the timeout fires or the upstream raises before yielding, the same
+       classification logic applies and we move on.
+    3. Once a first chunk is in hand, we commit — the function returns and
+       the caller flushes the response. Errors after this point reach the
+       client; they cannot be hidden without buffering the entire stream.
+
+    This is the streaming-mode analogue of the non-streaming retry loop in
+    ``chat.py``. The contract is identical: skip-and-continue on retryable
+    failures, raise on the first non-retryable failure, raise the last
+    exception if every attempt is exhausted.
+
+    Latency contract: zero added latency in the success case — we hold the
+    first chunk only long enough to call this function's caller. In the
+    failure case, each abandoned attempt costs at most
+    ``first_chunk_timeout_seconds``.
+    """
+    last_exception: BaseException | None = None
+
+    for attempt in attempts:
+        try:
+            stream = await build_stream(attempt)
+        except BaseException as exc:
+            retryable, error_class = classify_error(exc)
+            await on_attempt_failed(attempt, StreamingAttemptFailure(error_class, exc))
+            last_exception = exc
+            if not retryable:
+                raise
+            continue
+
+        try:
+            first_chunk: C = await asyncio.wait_for(
+                stream.__anext__(),
+                timeout=first_chunk_timeout_seconds,
+            )
+        except StopAsyncIteration:
+            # Stream completed without yielding. Unusual but valid — commit
+            # with an empty iterator so the caller still gets a clean SSE
+            # close sequence rather than another upstream attempt.
+            return attempt, _empty_async_iter()
+        except asyncio.TimeoutError as exc:
+            await on_attempt_failed(
+                attempt, StreamingAttemptFailure("timeout", exc),
+            )
+            await _close_stream_quietly(stream)
+            last_exception = exc
+            continue
+        except BaseException as exc:
+            retryable, error_class = classify_error(exc)
+            await on_attempt_failed(attempt, StreamingAttemptFailure(error_class, exc))
+            await _close_stream_quietly(stream)
+            last_exception = exc
+            if not retryable:
+                raise
+            continue
+
+        return attempt, _stitched(first_chunk, stream)
+
+    if last_exception is not None:
+        raise last_exception
+    raise RuntimeError("walk_streaming_attempts: no attempts provided")
+
+
+async def _stitched(first: C, remaining: AsyncIterator[C]) -> AsyncIterator[C]:
+    yield first
+    async for chunk in remaining:
+        yield chunk
+
+
+async def _empty_async_iter() -> AsyncIterator[C]:
+    return
+    yield  # unreachable; makes this a generator
+
+
+async def _close_stream_quietly(stream: AsyncIterator[Any]) -> None:
+    close = getattr(stream, "aclose", None)
+    if callable(close):
+        with suppress(BaseException):
+            await close()

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -128,19 +128,22 @@ async def iterate_streaming_attempts(
     For each attempt:
 
     1. ``build_stream(attempt)`` is awaited — typically wraps ``acompletion``.
-       If it raises, classify the error: retryable errors call
-       ``on_attempt_failed`` and continue; non-retryable errors propagate.
+       If it raises, the error is classified, ``on_attempt_failed`` is called
+       so the caller can record per-attempt failure metadata (regardless of
+       whether the error is retryable), then retryable errors continue to the
+       next attempt and non-retryable errors propagate.
     2. The first chunk is awaited with a ``first_chunk_timeout_seconds`` cap.
        If the timeout fires or the upstream raises before yielding, the same
-       classification logic applies and we move on.
+       classification + ``on_attempt_failed`` logic applies.
     3. Once a first chunk is in hand, we commit — the function returns and
        the caller flushes the response. Errors after this point reach the
        client; they cannot be hidden without buffering the entire stream.
 
     This is the streaming-mode analogue of the non-streaming retry loop in
-    ``chat.py``. The contract is identical: skip-and-continue on retryable
-    failures, raise on the first non-retryable failure, raise the last
-    exception if every attempt is exhausted.
+    ``chat.py``. The contract is identical: ``on_attempt_failed`` records every
+    failed attempt, retryable failures skip-and-continue, non-retryable
+    failures propagate immediately, and the last exception is raised if every
+    attempt is exhausted with retryable failures.
 
     Latency contract: zero added latency in the success case — we hold the
     first chunk only long enough to call this function's caller. In the

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -114,15 +114,16 @@ async def streaming_generator(
         logger.error("Streaming error for %s: %s", label, e)
 
 
-async def walk_streaming_attempts(
+async def iterate_streaming_attempts(
     attempts: Sequence[A],
     build_stream: Callable[[A], Awaitable[AsyncIterator[C]]],
     classify_error: Callable[[BaseException], tuple[bool, str]],
     on_attempt_failed: Callable[[A, StreamingAttemptFailure], Awaitable[None]],
     first_chunk_timeout_seconds: float = DEFAULT_FIRST_CHUNK_TIMEOUT_SECONDS,
 ) -> tuple[A, AsyncIterator[C]]:
-    """Walk ``attempts`` until one yields its first chunk; return that attempt
-    and an iterator that re-emits the chunk followed by the rest of the stream.
+    """Iterate over ``attempts`` until one yields its first chunk; return that
+    attempt and an iterator that re-emits the chunk followed by the rest of
+    the stream.
 
     For each attempt:
 
@@ -189,7 +190,7 @@ async def walk_streaming_attempts(
 
     if last_exception is not None:
         raise last_exception
-    raise RuntimeError("walk_streaming_attempts: no attempts provided")
+    raise RuntimeError("iterate_streaming_attempts: no attempts provided")
 
 
 async def _stitched(first: C, remaining: AsyncIterator[C]) -> AsyncIterator[C]:

--- a/tests/integration/test_platform_mode_chat.py
+++ b/tests/integration/test_platform_mode_chat.py
@@ -488,6 +488,10 @@ def test_platform_mode_streaming_falls_through_on_first_attempt_failure(
 
     assert response.status_code == 200
     assert response.headers["X-Correlation-ID"] == "stream-att-openai"
+    # StreamingResponse builds its own response object, so X-Otari-Request-ID
+    # has to be set in the StreamingResponse headers directly — assigning to
+    # the dependency-injected Response object doesn't propagate.
+    assert response.headers["X-Otari-Request-ID"] == "stream-req-1"
     # Both attempts were tried in order — anthropic first, then openai succeeded.
     assert [m for m in calls if "anthropic" in m or "openai" in m] == [
         "anthropic:claude-haiku-4-5",

--- a/tests/integration/test_platform_mode_chat.py
+++ b/tests/integration/test_platform_mode_chat.py
@@ -371,3 +371,197 @@ def test_platform_mode_maps_resolve_validation_error_to_bad_gateway(
 
     assert response.status_code == 502
     assert response.json() == {"detail": "Authorization service unavailable"}
+
+
+# ---------------------------------------------------------------------------
+# Streaming fallback (v1.1)
+# ---------------------------------------------------------------------------
+
+
+def test_platform_mode_streaming_falls_through_on_first_attempt_failure(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Streaming request whose first attempt errors before any chunk → falls
+    through to the second attempt; client sees a clean 200 SSE stream from
+    the second provider."""
+    from collections.abc import AsyncIterator
+
+    from any_llm.types.completion import ChatCompletionChunk
+
+    usage_reports: list[dict[str, Any]] = []
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json={
+                    "request_id": "stream-req-1",
+                    "fallback_enabled": True,
+                    "attempts": [
+                        {
+                            "attempt_id": "stream-att-anthropic",
+                            "position": 0,
+                            "provider": "anthropic",
+                            "model": "claude-haiku-4-5",
+                            "api_key": "sk-ant-broken",
+                            "api_base": None,
+                            "managed": False,
+                        },
+                        {
+                            "attempt_id": "stream-att-openai",
+                            "position": 1,
+                            "provider": "openai",
+                            "model": "gpt-4o-mini",
+                            "api_key": "sk-openai-real",
+                            "api_base": "https://api.openai.com/v1",
+                            "managed": False,
+                        },
+                    ],
+                },
+            )
+        usage_reports.append(body)
+        return httpx.Response(204)
+
+    calls: list[str] = []
+
+    class _FakeApiStatusError(Exception):
+        # status_code on the exception is what _classify_upstream_error reads;
+        # 401 is in _FALLBACK_RETRYABLE_STATUS_CODES so the gateway will move
+        # on to the next attempt.
+        status_code = 401
+
+    async def fake_acompletion(**kwargs: Any) -> Any:
+        model = kwargs.get("model", "")
+        calls.append(model)
+        if "anthropic" in model:
+            raise _FakeApiStatusError("simulated upstream 401")
+
+        async def _success_stream() -> AsyncIterator[ChatCompletionChunk]:
+            yield ChatCompletionChunk.model_validate(
+                {
+                    "id": "chunk-1",
+                    "object": "chat.completion.chunk",
+                    "created": 1700000000,
+                    "model": "gpt-4o-mini",
+                    "choices": [
+                        {"index": 0, "delta": {"content": "hi"}, "finish_reason": None}
+                    ],
+                }
+            )
+            yield ChatCompletionChunk.model_validate(
+                {
+                    "id": "chunk-2",
+                    "object": "chat.completion.chunk",
+                    "created": 1700000000,
+                    "model": "gpt-4o-mini",
+                    "choices": [
+                        {"index": 0, "delta": {}, "finish_reason": "stop"}
+                    ],
+                    "usage": {
+                        "prompt_tokens": 5,
+                        "completion_tokens": 1,
+                        "total_tokens": 6,
+                    },
+                }
+            )
+
+        return _success_stream()
+
+    monkeypatch.setattr("gateway.api.routes.chat._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.acompletion", fake_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["X-Correlation-ID"] == "stream-att-openai"
+    # Both attempts were tried in order — anthropic first, then openai succeeded.
+    assert [m for m in calls if "anthropic" in m or "openai" in m] == [
+        "anthropic:claude-haiku-4-5",
+        "openai:gpt-4o-mini",
+    ]
+    # The body should be a valid SSE stream from openai.
+    body = response.text
+    assert "data:" in body
+    assert "hi" in body
+
+    # The failed anthropic attempt should have reported an error to the platform.
+    error_reports = [r for r in usage_reports if r.get("status") == "error"]
+    assert len(error_reports) == 1
+    assert error_reports[0]["correlation_id"] == "stream-att-anthropic"
+
+
+def test_platform_mode_streaming_returns_502_when_all_attempts_fail(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If every attempt fails before yielding, the gateway returns 502 with
+    the multi-attempt error wording instead of starting an SSE stream."""
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json={
+                    "request_id": "stream-req-fail",
+                    "fallback_enabled": True,
+                    "attempts": [
+                        {
+                            "attempt_id": "att-a",
+                            "position": 0,
+                            "provider": "anthropic",
+                            "model": "claude-haiku-4-5",
+                            "api_key": "sk-ant-broken",
+                            "api_base": None,
+                            "managed": False,
+                        },
+                        {
+                            "attempt_id": "att-b",
+                            "position": 1,
+                            "provider": "openai",
+                            "model": "gpt-4o-mini",
+                            "api_key": "sk-openai-broken",
+                            "api_base": None,
+                            "managed": False,
+                        },
+                    ],
+                },
+            )
+        return httpx.Response(204)
+
+    async def fake_acompletion(**kwargs: Any) -> Any:
+        raise RuntimeError("simulated upstream failure")
+
+    monkeypatch.setattr("gateway.api.routes.chat._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.acompletion", fake_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 502
+    assert response.json() == {"detail": "All upstream providers failed"}

--- a/tests/integration/test_platform_mode_chat.py
+++ b/tests/integration/test_platform_mode_chat.py
@@ -84,12 +84,19 @@ def test_platform_mode_sets_correlation_id_and_reports_usage(
             return httpx.Response(
                 200,
                 json={
-                    "provider": "openai",
-                    "model": "gpt-4o-mini",
-                    "api_key": "sk-platform-key",
-                    "api_base": "https://api.openai.com/v1",
-                    "managed": True,
-                    "correlation_id": "7af2c39d-4eb8-4b3f-8242-46a97f7d5e68",
+                    "request_id": "7af2c39d-4eb8-4b3f-8242-46a97f7d5e68",
+                    "fallback_enabled": False,
+                    "attempts": [
+                        {
+                            "attempt_id": "7af2c39d-4eb8-4b3f-8242-46a97f7d5e68",
+                            "position": 0,
+                            "provider": "openai",
+                            "model": "gpt-4o-mini",
+                            "api_key": "sk-platform-key",
+                            "api_base": "https://api.openai.com/v1",
+                            "managed": True,
+                        }
+                    ],
                 },
             )
 
@@ -138,10 +145,17 @@ def test_platform_mode_sets_correlation_id_and_reports_usage(
     ]
 
 
-def test_platform_mode_maps_provider_timeout(
+def test_platform_mode_accepts_legacy_resolve_shape(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """An older otari (pre-fallback) returns a flat resolve payload.
+
+    Gateway must accept it and treat it as a single-attempt route so deployments
+    where the platform side hasn't been upgraded yet still work.
+    """
+    usage_reports: list[dict[str, Any]] = []
+
     async def fake_post_platform(
         url: str,
         headers: dict[str, str],
@@ -157,7 +171,73 @@ def test_platform_mode_maps_provider_timeout(
                     "api_key": "sk-platform-key",
                     "api_base": "https://api.openai.com/v1",
                     "managed": True,
-                    "correlation_id": "41a9667f-0af7-4ddf-8468-65c5f5c2af57",
+                    "correlation_id": "9b2cce4a-5e91-4c19-9ad5-17a83f72b001",
+                },
+            )
+
+        usage_reports.append(body)
+        return httpx.Response(204)
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        return ChatCompletion(
+            id="chatcmpl-legacy",
+            object="chat.completion",
+            created=1700000000,
+            model="gpt-4o-mini",
+            choices=[
+                Choice(
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="hi"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=CompletionUsage(prompt_tokens=4, completion_tokens=2, total_tokens=6),
+        )
+
+    monkeypatch.setattr("gateway.api.routes.chat._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.acompletion", fake_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+    # Gateway maps the legacy correlation_id onto attempt_id, so X-Correlation-ID
+    # still carries the same value as before.
+    assert response.headers["X-Correlation-ID"] == "9b2cce4a-5e91-4c19-9ad5-17a83f72b001"
+    assert usage_reports[0]["correlation_id"] == "9b2cce4a-5e91-4c19-9ad5-17a83f72b001"
+    assert usage_reports[0]["status"] == "success"
+
+
+def test_platform_mode_maps_provider_timeout(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json={
+                    "request_id": "41a9667f-0af7-4ddf-8468-65c5f5c2af57",
+                    "fallback_enabled": False,
+                    "attempts": [
+                        {
+                            "attempt_id": "41a9667f-0af7-4ddf-8468-65c5f5c2af57",
+                            "position": 0,
+                            "provider": "openai",
+                            "model": "gpt-4o-mini",
+                            "api_key": "sk-platform-key",
+                            "api_base": "https://api.openai.com/v1",
+                            "managed": True,
+                        }
+                    ],
                 },
             )
 
@@ -220,12 +300,19 @@ def test_platform_mode_usage_retries_only_transient_failures(
             return httpx.Response(
                 200,
                 json={
-                    "provider": "openai",
-                    "model": "gpt-4o-mini",
-                    "api_key": "sk-platform-key",
-                    "api_base": "https://api.openai.com/v1",
-                    "managed": True,
-                    "correlation_id": "e655dc9a-6d90-4207-b371-f58d521a7a81",
+                    "request_id": "e655dc9a-6d90-4207-b371-f58d521a7a81",
+                    "fallback_enabled": False,
+                    "attempts": [
+                        {
+                            "attempt_id": "e655dc9a-6d90-4207-b371-f58d521a7a81",
+                            "position": 0,
+                            "provider": "openai",
+                            "model": "gpt-4o-mini",
+                            "api_key": "sk-platform-key",
+                            "api_base": "https://api.openai.com/v1",
+                            "managed": True,
+                        }
+                    ],
                 },
             )
 

--- a/tests/unit/test_deps_as_utc.py
+++ b/tests/unit/test_deps_as_utc.py
@@ -1,0 +1,50 @@
+"""Unit tests for the ``_as_utc`` helper in ``gateway.api.deps``.
+
+Regression coverage for the SQLite-naive-datetime bug surfaced during
+manual QA on PR #58: ``DateTime(timezone=True)`` columns come back naive
+from SQLite, so any code that subtracts them from ``datetime.now(UTC)``
+crashed with ``TypeError: can't subtract offset-naive and offset-aware
+datetimes``. The helper normalises the read side; these tests pin the
+contract.
+"""
+
+from datetime import UTC, datetime, timedelta, timezone
+
+from gateway.api.deps import _as_utc
+
+
+def test_none_passes_through() -> None:
+    assert _as_utc(None) is None
+
+
+def test_naive_datetime_is_promoted_to_utc() -> None:
+    naive = datetime(2026, 5, 19, 12, 0, 0)
+    out = _as_utc(naive)
+    assert out is not None
+    assert out.tzinfo is UTC
+
+
+def test_aware_utc_datetime_unchanged() -> None:
+    aware = datetime(2026, 5, 19, 12, 0, 0, tzinfo=UTC)
+    out = _as_utc(aware)
+    assert out is aware
+
+
+def test_aware_non_utc_datetime_unchanged() -> None:
+    # Important: we don't convert non-UTC aware datetimes — the gateway
+    # only ever writes UTC, so a non-UTC aware value would be a deliberate
+    # caller decision. The helper just guarantees `tzinfo is not None`.
+    plus_two = timezone(timedelta(hours=2))
+    aware = datetime(2026, 5, 19, 12, 0, 0, tzinfo=plus_two)
+    out = _as_utc(aware)
+    assert out is aware
+
+
+def test_subtracting_normalised_naive_does_not_raise() -> None:
+    # The original bug: subtracting a naive value from `datetime.now(UTC)`
+    # raises TypeError. After normalisation it must succeed.
+    naive_last_used = datetime(2026, 5, 19, 12, 0, 0)
+    normalised = _as_utc(naive_last_used)
+    assert normalised is not None
+    delta = datetime.now(UTC) - normalised
+    assert delta.total_seconds() >= 0


### PR DESCRIPTION
## Summary

Extends the gateway's platform-mode resolve protocol to support an ordered list of resolution attempts. When the platform peer returns multiple attempts (driven by a user-configured routing policy on the platform side), the gateway walks them in order and falls through to the next entry on retryable upstream failures. Covers **both non-streaming and streaming** requests.

Single-attempt resolves and older platform peers using the flat legacy shape continue to work unchanged.

## Why this change

A user who configures a fallback chain like `[anthropic/claude-sonnet-4-5, openai/gpt-4o]` on the platform side wants the gateway to handle a regional outage transparently — Anthropic 401 / 429 / 5xx falls through to OpenAI without the client seeing the failure. The gateway is the only place that observes upstream errors at request time, so the retry loop has to live here. Policy is configured platform-side; gateway just walks whatever ordered list it gets back.

## What's in this PR

### `feat(chat)`: non-streaming fallback walk
- New `ResolvedAttempt` / `ResolvedRoute` Pydantic models for the parsed resolve payload.
- `_parse_resolve_payload` accepts **either** the new `attempts[]` shape **or** the legacy single-attempt shape (flat `provider`/`model`/`api_key`/... + top-level `correlation_id`). Backwards compatible — older platform peers don't need to change anything.
- For each attempt, classify failures via `_classify_upstream_error` (timeouts, connection errors, 5xx, 429, 408, **and 401/403** → retryable; 400/422/404 → not). Each attempt sends a usage report so the platform attributes spend correctly.
- Empty `attempts[]` returns 502 with a clear message rather than falling through silently.
- New optional `error_class` field on usage reports (`timeout` / `conn_err` / `http_<code>` / `unknown`).
- New `X-Otari-Request-ID` response header surfaces the resolve `request_id` (groups all attempts for a single request).

### `feat(streaming)`: streaming fallback via first-chunk gate
- Streaming requests now walk `attempts[]` the same way non-streaming requests do.
- Per-attempt **first-chunk gate**: open the upstream stream, wait up to `STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS` (default 2000 ms) for the first chunk. If the upstream raises before yielding or the wait times out, fall through to the next attempt. As soon as a chunk lands, commit — bytes flow to the client and any further errors propagate to the SSE channel.
- **Latency contract: zero added latency in the success case** — the first-chunk-arrival event is itself the "this attempt is alive" signal; there's no fixed buffer window to wait through. Failure-path latency is bounded by the per-attempt timeout.
- New `walk_streaming_attempts()` helper in `gateway/streaming.py`, generic over attempt type.
- `X-Correlation-ID` is now set on the `StreamingResponse.headers` directly (mutating the dependency-injected `Response` doesn't propagate to streaming responses).

### `docs`: protocol spec + roadmap
- `docs/platform-protocol.md` documents both endpoints, both response shapes (legacy + multi-attempt), retry semantics, the error-class taxonomy, the streaming first-chunk-gate, and the relevant config env vars.
- `docs/routing-roadmap.md` captures the design intent for v1.2 (policy-level timeouts), v1.3 (per-entry retries with backoff), and v1.4 (global latency budget) so future contributors have a coherent target without committing to scope here.
- README's "Start in platform mode" section links to the protocol doc.

## Why 401/403 are retryable

These are usually terminal client errors and a single-attempt request still surfaces them directly. They become retryable **only** inside a multi-attempt route — i.e. when the user has explicitly configured a fallback chain on the platform side. The whole point of the policy is that one provider's bad credentials should fall through to the next, not surface to the client. Comments at the constant declaration explain this.

## Tests

- 94 tests pass (84 existing unit + 10 platform-mode integration including 3 new tests covering: backwards-compat legacy shape, streaming fall-through on first-attempt failure, streaming all-attempts-fail returns 502).
- No behavioral regressions in standalone mode.
- OpenAPI spec freshness check (`scripts/generate_openapi.py --check`) passes — gateway's own surface didn't change; the resolve and usage shapes are in the platform peer's API.
- mypy clean.

## AI Usage

Drafted with Claude Code (Claude Opus 4.7). Reviewed and validated locally before submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)