### PR TITLE
feat(chat): MCP tool-use support with streaming

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -74,6 +74,33 @@
             ],
             "title": "Max Tokens"
           },
+          "max_tool_iterations": {
+            "anyOf": [
+              {
+                "maximum": 25.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Tool Iterations"
+          },
+          "mcp_servers": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/McpServerConfig"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mcp Servers"
+          },
           "messages": {
             "items": {
               "additionalProperties": true,
@@ -544,6 +571,65 @@
           "metadata"
         ],
         "title": "KeyInfo",
+        "type": "object"
+      },
+      "McpServerConfig": {
+        "description": "Inline MCP server configuration accepted on the chat completions request.\n\nStreamable HTTP transport. The `url` must be reachable from the gateway process.\n\nURL safety is enforced at parse time:\n\n* SSRF guard rejects private, link-local, and reserved IP ranges. Loopback is\n  allowed by default (sidecars, dev) \u2014 set ``GATEWAY_MCP_ALLOW_LOOPBACK=false`` to disable.\n* Plain ``http://`` is rejected when ``authorization_token`` is set, to keep\n  bearer tokens off the wire in cleartext.",
+        "properties": {
+          "allowed_tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Tools"
+          },
+          "authorization_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Authorization Token"
+          },
+          "name": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "purpose_hint": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Purpose Hint"
+          },
+          "url": {
+            "minLength": 1,
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "url"
+        ],
+        "title": "McpServerConfig",
         "type": "object"
       },
       "MessagesRequest": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "asyncpg>=0.29.0",
     "click>=8.1.0",
     "fastapi>=0.115.0",
+    "mcp>=1.0.0",
     "prometheus-client>=0.20.0",
     "psycopg2-binary>=2.9.9",
     "pydantic-settings>=2.0.0",

--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -124,8 +124,7 @@ async def _verify_and_update_api_key(db: AsyncSession, token: str) -> APIKey:
     now = datetime.now(UTC)
     last_used_at = _as_utc(api_key.last_used_at)
     should_update_last_used = (
-        last_used_at is None
-        or (now - last_used_at).total_seconds() >= _LAST_USED_UPDATE_INTERVAL_SECONDS
+        last_used_at is None or (now - last_used_at).total_seconds() >= _LAST_USED_UPDATE_INTERVAL_SECONDS
     )
 
     if should_update_last_used:

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -583,24 +583,16 @@ async def chat_completions(
                     route.request_id,
                     exc,
                 )
-                if isinstance(
-                    exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)
-                ):
+                if isinstance(exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
                     raise HTTPException(
                         status_code=status.HTTP_504_GATEWAY_TIMEOUT,
                         detail=(
-                            "LLM provider timeout"
-                            if len(route.attempts) <= 1
-                            else "All upstream providers timed out"
+                            "LLM provider timeout" if len(route.attempts) <= 1 else "All upstream providers timed out"
                         ),
                     ) from exc
                 raise HTTPException(
                     status_code=status.HTTP_502_BAD_GATEWAY,
-                    detail=(
-                        "LLM provider error"
-                        if len(route.attempts) <= 1
-                        else "All upstream providers failed"
-                    ),
+                    detail=("LLM provider error" if len(route.attempts) <= 1 else "All upstream providers failed"),
                 ) from exc
 
         # Standalone path: single attempt, no fallback (unchanged from v1.0).
@@ -627,14 +619,15 @@ async def chat_completions(
 
         try:
             if mcp_server_configs:
+                # Bind the truthy value to a non-Optional local so mypy can
+                # narrow inside the nested `_mcp_stream` closure.
+                pool_configs = mcp_server_configs
 
                 async def _mcp_stream() -> AsyncIterator[ChatCompletionChunk]:
-                    async with MCPClientPool(mcp_server_configs) as pool:
+                    async with MCPClientPool(pool_configs) as pool:
                         kwargs = {
                             **completion_kwargs,
-                            "messages": inject_purpose_hints(
-                                completion_kwargs["messages"], pool.purpose_hints()
-                            ),
+                            "messages": inject_purpose_hints(completion_kwargs["messages"], pool.purpose_hints()),
                         }
                         async for chunk in mcp_tool_loop_stream(
                             completion_kwargs=kwargs,
@@ -755,9 +748,7 @@ async def chat_completions(
                     async with MCPClientPool(mcp_server_configs) as pool:
                         mcp_kwargs = {
                             **completion_kwargs,
-                            "messages": inject_purpose_hints(
-                                completion_kwargs["messages"], pool.purpose_hints()
-                            ),
+                            "messages": inject_purpose_hints(completion_kwargs["messages"], pool.purpose_hints()),
                         }
                         completion: ChatCompletion = await mcp_tool_loop(
                             completion_kwargs=mcp_kwargs,
@@ -793,9 +784,7 @@ async def chat_completions(
                         status_code=status.HTTP_502_BAD_GATEWAY,
                         detail="LLM provider error",
                     ) from exc
-                failures.append(
-                    _AttemptFailure(attempt.position, attempt.provider, attempt.model, error_class)
-                )
+                failures.append(_AttemptFailure(attempt.position, attempt.provider, attempt.model, error_class))
                 continue
 
             # Success on this attempt.
@@ -820,9 +809,7 @@ async def chat_completions(
             failures,
         )
         is_single_attempt = len(attempts_to_try) <= 1
-        if last_exc is not None and isinstance(
-            last_exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)
-        ):
+        if last_exc is not None and isinstance(last_exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
             detail = "LLM provider timeout" if is_single_attempt else "All upstream providers timed out"
             raise HTTPException(
                 status_code=status.HTTP_504_GATEWAY_TIMEOUT,
@@ -847,9 +834,7 @@ async def chat_completions(
             async with MCPClientPool(mcp_server_configs) as pool:
                 mcp_kwargs = {
                     **completion_kwargs,
-                    "messages": inject_purpose_hints(
-                        completion_kwargs["messages"], pool.purpose_hints()
-                    ),
+                    "messages": inject_purpose_hints(completion_kwargs["messages"], pool.purpose_hints()),
                 }
                 completion = await mcp_tool_loop(
                     completion_kwargs=mcp_kwargs,
@@ -1019,9 +1004,7 @@ async def _run_streaming_with_fallback(
     client — errors past that point propagate to the SSE channel as today.
     """
     base_request_fields = request.model_dump(exclude_unset=True)
-    first_chunk_timeout_seconds = (
-        int(config.platform.get("streaming_first_chunk_timeout_ms", 2000)) / 1000
-    )
+    first_chunk_timeout_seconds = int(config.platform.get("streaming_first_chunk_timeout_ms", 2000)) / 1000
 
     async def _build_for_attempt(
         attempt: ResolvedAttempt,
@@ -1039,9 +1022,7 @@ async def _run_streaming_with_fallback(
             completion_kwargs["stream_options"] = {"include_usage": True}
         return await acompletion(**completion_kwargs)  # type: ignore[return-value]
 
-    async def _on_attempt_failed(
-        attempt: ResolvedAttempt, failure: StreamingAttemptFailure
-    ) -> None:
+    async def _on_attempt_failed(attempt: ResolvedAttempt, failure: StreamingAttemptFailure) -> None:
         background_tasks.add_task(
             _report_platform_usage,
             config,

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -24,9 +24,18 @@ from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.metrics import record_cost, record_tokens
 from gateway.models.entities import APIKey, UsageLog
+from gateway.models.mcp import McpServerConfig
 from gateway.rate_limit import RateLimitInfo, check_rate_limit
 from gateway.services.budget_service import validate_user_budget
 from gateway.services.log_writer import LogWriter
+from gateway.services.mcp_client import MCPClientPool
+from gateway.services.mcp_loop import (
+    DEFAULT_MAX_TOOL_ITERATIONS,
+    MAX_TOOL_ITERATIONS_CAP,
+    inject_purpose_hints,
+    mcp_tool_loop,
+    mcp_tool_loop_stream,
+)
 from gateway.services.pricing_service import find_model_pricing
 from gateway.streaming import (
     OPENAI_STREAM_FORMAT,
@@ -73,6 +82,8 @@ class ChatCompletionRequest(BaseModel):
     tools: list[dict[str, Any]] | None = None
     tool_choice: str | dict[str, Any] | None = None
     response_format: dict[str, Any] | None = None
+    mcp_servers: list[McpServerConfig] | None = None
+    max_tool_iterations: int | None = Field(default=None, ge=1, le=MAX_TOOL_ITERATIONS_CAP)
 
 
 def get_provider_kwargs(
@@ -596,13 +607,45 @@ async def chat_completions(
         provider, model = AnyLLM.split_model_provider(request.model)
         provider_kwargs = get_provider_kwargs(config, provider)
 
+        # Standalone streaming path: single attempt, optionally wrapped in
+        # the MCP tool-use loop. When `mcp_servers` is set the tool loop owns
+        # the stream and re-emits chunks; the multi-attempt fallback
+        # (`_run_streaming_with_fallback`) is intentionally not used because
+        # an MCP-driven request shouldn't silently swap providers mid-loop.
+        mcp_server_configs = request.mcp_servers
+        max_tool_iterations = min(
+            request.max_tool_iterations or DEFAULT_MAX_TOOL_ITERATIONS,
+            MAX_TOOL_ITERATIONS_CAP,
+        )
+
         request_fields = request.model_dump(exclude_unset=True)
+        request_fields.pop("mcp_servers", None)
+        request_fields.pop("max_tool_iterations", None)
         completion_kwargs = {**provider_kwargs, **request_fields}
         if completion_kwargs.get("stream_options") is None:
             completion_kwargs["stream_options"] = {"include_usage": True}
 
         try:
-            stream: AsyncIterator[ChatCompletionChunk] = await acompletion(**completion_kwargs)  # type: ignore[assignment]
+            if mcp_server_configs:
+
+                async def _mcp_stream() -> AsyncIterator[ChatCompletionChunk]:
+                    async with MCPClientPool(mcp_server_configs) as pool:
+                        kwargs = {
+                            **completion_kwargs,
+                            "messages": inject_purpose_hints(
+                                completion_kwargs["messages"], pool.purpose_hints()
+                            ),
+                        }
+                        async for chunk in mcp_tool_loop_stream(
+                            completion_kwargs=kwargs,
+                            pool=pool,
+                            max_iterations=max_tool_iterations,
+                        ):
+                            yield chunk
+
+                stream: AsyncIterator[ChatCompletionChunk] = _mcp_stream()
+            else:
+                stream = await acompletion(**completion_kwargs)  # type: ignore[assignment]
         except HTTPException:
             raise
         except Exception as exc:
@@ -644,12 +687,19 @@ async def chat_completions(
         )
 
     # ------------------------------------------------------------------
-    # Non-streaming path: iterate attempts on retryable failures.
+    # Non-streaming path. Routing-policy fallback (`route.attempts`) and MCP
+    # tool-use loops are mutually exclusive: when `mcp_servers` is set we run
+    # a single MCP loop against the primary attempt's credentials and skip
+    # the per-attempt retry walk (see PR design note — an MCP-driven request
+    # shouldn't silently swap providers between tool-use rounds).
     # ------------------------------------------------------------------
+    mcp_server_configs = request.mcp_servers
+    max_tool_iterations = min(
+        request.max_tool_iterations or DEFAULT_MAX_TOOL_ITERATIONS,
+        MAX_TOOL_ITERATIONS_CAP,
+    )
+
     if platform_mode:
-        # Bind to a non-Optional local so mypy can narrow inside the retry loop
-        # below — assert-based narrowing doesn't survive across function calls
-        # in some mypy configurations.
         if route is None:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -658,9 +708,6 @@ async def chat_completions(
         platform_route = route
         attempts_to_try = platform_route.attempts
         if not attempts_to_try:
-            # A spec-compliant platform always returns at least one attempt;
-            # treating an empty list as a server bug is more useful than letting
-            # the loop fall through silently with no `last_exc`.
             logger.error(
                 "Platform returned empty attempts list request_id=%s",
                 platform_route.request_id,
@@ -669,6 +716,9 @@ async def chat_completions(
                 status_code=status.HTTP_502_BAD_GATEWAY,
                 detail="Authorization service returned no resolvable provider",
             )
+        # MCP mode: collapse to the primary attempt, no per-attempt fallback.
+        if mcp_server_configs:
+            attempts_to_try = attempts_to_try[:1]
     else:
         provider, model = AnyLLM.split_model_provider(request.model)
         provider_kwargs = get_provider_kwargs(config, provider)
@@ -684,9 +734,9 @@ async def chat_completions(
     last_exc: BaseException | None = None
 
     if platform_mode:
-        # Snapshot the client's request body once; only `model` and provider creds
-        # change per attempt.
         base_request_fields = request.model_dump(exclude_unset=True)
+        base_request_fields.pop("mcp_servers", None)
+        base_request_fields.pop("max_tool_iterations", None)
         for attempt in attempts_to_try:
             attempt_provider = LLMProvider(attempt.provider)
             attempt_model = attempt.model
@@ -701,7 +751,21 @@ async def chat_completions(
             }
 
             try:
-                completion: ChatCompletion = await acompletion(**completion_kwargs)  # type: ignore[assignment]
+                if mcp_server_configs:
+                    async with MCPClientPool(mcp_server_configs) as pool:
+                        mcp_kwargs = {
+                            **completion_kwargs,
+                            "messages": inject_purpose_hints(
+                                completion_kwargs["messages"], pool.purpose_hints()
+                            ),
+                        }
+                        completion: ChatCompletion = await mcp_tool_loop(
+                            completion_kwargs=mcp_kwargs,
+                            pool=pool,
+                            max_iterations=max_tool_iterations,
+                        )
+                else:
+                    completion = await acompletion(**completion_kwargs)  # type: ignore[assignment]
             except HTTPException:
                 raise
             except BaseException as exc:
@@ -770,12 +834,30 @@ async def chat_completions(
             detail=detail,
         ) from last_exc
 
-    # Standalone path (no platform / no fallback).
+    # Standalone path (no platform / no fallback). Same MCP semantics as
+    # platform mode above: if `mcp_servers` is set, the request goes through
+    # the tool-use loop instead of a single ``acompletion`` call.
     request_fields = request.model_dump(exclude_unset=True)
+    request_fields.pop("mcp_servers", None)
+    request_fields.pop("max_tool_iterations", None)
     completion_kwargs = {**provider_kwargs, **request_fields}
 
     try:
-        completion = await acompletion(**completion_kwargs)  # type: ignore[assignment]
+        if mcp_server_configs:
+            async with MCPClientPool(mcp_server_configs) as pool:
+                mcp_kwargs = {
+                    **completion_kwargs,
+                    "messages": inject_purpose_hints(
+                        completion_kwargs["messages"], pool.purpose_hints()
+                    ),
+                }
+                completion = await mcp_tool_loop(
+                    completion_kwargs=mcp_kwargs,
+                    pool=pool,
+                    max_iterations=max_tool_iterations,
+                )
+        else:
+            completion = await acompletion(**completion_kwargs)  # type: ignore[assignment]
         if db is not None:
             await log_usage(
                 db=db,

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -32,6 +32,7 @@ from gateway.services.mcp_client import MCPClientPool
 from gateway.services.mcp_loop import (
     DEFAULT_MAX_TOOL_ITERATIONS,
     MAX_TOOL_ITERATIONS_CAP,
+    MaxToolIterationsExceeded,
     inject_purpose_hints,
     mcp_tool_loop,
     mcp_tool_loop_stream,
@@ -759,6 +760,20 @@ async def chat_completions(
                     completion = await acompletion(**completion_kwargs)  # type: ignore[assignment]
             except HTTPException:
                 raise
+            except MaxToolIterationsExceeded as exc:
+                # The gateway's own iteration cap was hit, not an upstream
+                # failure. Surface a distinct 422 so callers can tell a
+                # runaway tool loop apart from a provider outage.
+                logger.warning(
+                    "Tool loop iteration cap hit request_id=%s position=%d cap=%d",
+                    platform_route.request_id,
+                    attempt.position,
+                    max_tool_iterations,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=str(exc),
+                ) from exc
             except BaseException as exc:
                 retryable, error_class = _classify_upstream_error(exc)
                 background_tasks.add_task(
@@ -856,6 +871,25 @@ async def chat_completions(
             )
     except HTTPException:
         raise
+    except MaxToolIterationsExceeded as e:
+        # Gateway-owned cap, not an upstream provider failure. 422 lets
+        # callers distinguish a runaway tool loop from a real outage.
+        logger.warning("Tool loop iteration cap hit (standalone): cap=%d", max_tool_iterations)
+        if db is not None:
+            await log_usage(
+                db=db,
+                log_writer=log_writer,
+                api_key_id=api_key_id,
+                model=model,
+                provider=provider,
+                endpoint="/v1/chat/completions",
+                user_id=user_id,
+                error=str(e),
+            )
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(e),
+        ) from e
     except Exception as e:
         if db is not None:
             await log_usage(

--- a/src/gateway/models/mcp.py
+++ b/src/gateway/models/mcp.py
@@ -1,0 +1,19 @@
+"""Request-body models for inline MCP server configuration on /v1/chat/completions."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class McpServerConfig(BaseModel):
+    """Inline MCP server configuration accepted on the chat completions request.
+
+    Streamable HTTP transport. The `url` must be reachable from the gateway process
+    (public, sidecar, cluster-internal, or localhost are all fine).
+    """
+
+    name: str = Field(min_length=1, max_length=128)
+    url: str = Field(min_length=1)
+    authorization_token: str | None = None
+    purpose_hint: str | None = Field(default=None, max_length=2000)
+    allowed_tools: list[str] | None = None

--- a/src/gateway/models/mcp.py
+++ b/src/gateway/models/mcp.py
@@ -2,14 +2,22 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+from gateway.services.url_safety import UnsafeURLError, validate_mcp_url
 
 
 class McpServerConfig(BaseModel):
     """Inline MCP server configuration accepted on the chat completions request.
 
-    Streamable HTTP transport. The `url` must be reachable from the gateway process
-    (public, sidecar, cluster-internal, or localhost are all fine).
+    Streamable HTTP transport. The `url` must be reachable from the gateway process.
+
+    URL safety is enforced at parse time:
+
+    * SSRF guard rejects private, link-local, and reserved IP ranges. Loopback is
+      allowed by default (sidecars, dev) — set ``GATEWAY_MCP_ALLOW_LOOPBACK=false`` to disable.
+    * Plain ``http://`` is rejected when ``authorization_token`` is set, to keep
+      bearer tokens off the wire in cleartext.
     """
 
     name: str = Field(min_length=1, max_length=128)
@@ -17,3 +25,11 @@ class McpServerConfig(BaseModel):
     authorization_token: str | None = None
     purpose_hint: str | None = Field(default=None, max_length=2000)
     allowed_tools: list[str] | None = None
+
+    @model_validator(mode="after")
+    def _check_url_safety(self) -> "McpServerConfig":
+        try:
+            validate_mcp_url(self.url, has_authorization_token=bool(self.authorization_token))
+        except UnsafeURLError as exc:
+            raise ValueError(str(exc)) from exc
+        return self

--- a/src/gateway/services/mcp_client.py
+++ b/src/gateway/services/mcp_client.py
@@ -87,7 +87,12 @@ class MCPClientPool:
             if allowed is not None and tool.name not in allowed:
                 continue
             if tool.name in self._tool_owner:
-                # Name collision across servers: keep the first server's tool.
+                # Tool-name collision policy: **first server wins**. Subsequent servers'
+                # tools with the same name are dropped entirely — they're not added to
+                # `_tool_owner` or `openai_tools`, so the model never sees them and the
+                # loop never tries to dispatch to them. Logged as a warning; not an error
+                # because legitimate setups can have overlapping tool names across servers
+                # (e.g. two filesystem MCPs both exposing `read_file`).
                 logger.warning(
                     "MCP tool name collision on %r; %s already owns it, %s skipped",
                     tool.name,
@@ -111,16 +116,43 @@ class MCPClientPool:
         return [(s.name, s.purpose_hint) for s in self._servers.values() if s.purpose_hint]
 
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
-        """Execute a tool call against its owning MCP server. Returns flattened text."""
+        """Execute a tool call against its owning MCP server and flatten the result to text.
+
+        MCP supports rich content blocks (image, embedded resource, structured data). This
+        flattener concatenates text blocks verbatim and renders non-text blocks as a brief
+        ``[type=…]`` placeholder so the model can at least see that *something* came back.
+        For tools that return images or large embedded resources, this is intentionally
+        lossy — fine for the current text-tool use case, but a future improvement is to
+        pass image content through as multimodal message blocks when the model supports it.
+        """
         owner = self._tool_owner.get(name)
         if owner is None:
             raise KeyError(f"No MCP server owns tool {name!r}")
         result = await self._servers[owner].session.call_tool(name, arguments)
         parts: list[str] = []
         for block in result.content:
-            text = getattr(block, "text", None)
-            parts.append(text if isinstance(text, str) else str(block))
-        flattened = "\n".join(parts)
+            parts.append(_render_content_block(block))
+        flattened = "\n".join(p for p in parts if p)
         if result.isError:
             return f"[tool error] {flattened}"
         return flattened
+
+
+def _render_content_block(block: Any) -> str:
+    """Render an MCP content block as a single string for inclusion in a tool message."""
+    text = getattr(block, "text", None)
+    if isinstance(text, str):
+        return text
+    btype = getattr(block, "type", None) or type(block).__name__.lower()
+    # ImageContent has `data` (base64) and `mimeType`; just summarize.
+    if btype in ("image", "image_content", "imagecontent"):
+        mime = getattr(block, "mimeType", None) or getattr(block, "mime_type", None) or "image"
+        data = getattr(block, "data", None)
+        size = len(data) if isinstance(data, (str, bytes)) else "?"
+        return f"[image type={mime} bytes_b64={size}]"
+    # EmbeddedResource has a `resource` with `uri` and either `text` or `blob`.
+    if btype in ("resource", "embedded_resource", "embeddedresource"):
+        resource = getattr(block, "resource", None)
+        uri = getattr(resource, "uri", None) if resource else None
+        return f"[resource uri={uri or '?'}]"
+    return f"[content type={btype}]"

--- a/src/gateway/services/mcp_client.py
+++ b/src/gateway/services/mcp_client.py
@@ -1,0 +1,126 @@
+"""MCP client pool for the gateway.
+
+Holds a set of live MCP sessions for the duration of a single chat-completion
+request, exposes the union of their tools in OpenAI tool format, and routes
+tool calls back to the owning server.
+
+Use as an async context manager so sessions are cleaned up when the request
+ends or the loop exits:
+
+    async with MCPClientPool(configs) as pool:
+        tools = pool.openai_tools
+        result_text = await pool.call_tool(name, arguments)
+"""
+
+from __future__ import annotations
+
+from contextlib import AsyncExitStack
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+from gateway.log_config import logger
+
+if TYPE_CHECKING:
+    from mcp.types import Tool as MCPTool
+
+    from gateway.models.mcp import McpServerConfig
+
+
+def mcp_tool_to_openai(tool: MCPTool) -> dict[str, Any]:
+    """Convert an MCP Tool descriptor to an OpenAI-format function tool definition."""
+    return {
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description or "",
+            "parameters": tool.inputSchema or {"type": "object", "properties": {}},
+        },
+    }
+
+
+@dataclass
+class _ConnectedServer:
+    name: str
+    session: ClientSession
+    tools: list[dict[str, Any]] = field(default_factory=list)
+    purpose_hint: str | None = None
+
+
+class MCPClientPool:
+    """Manages concurrent MCP sessions for one request lifetime."""
+
+    def __init__(self, configs: list[McpServerConfig]):
+        self._configs = configs
+        self._stack = AsyncExitStack()
+        self._servers: dict[str, _ConnectedServer] = {}
+        self._tool_owner: dict[str, str] = {}
+
+    async def __aenter__(self) -> MCPClientPool:
+        try:
+            for cfg in self._configs:
+                self._servers[cfg.name] = await self._connect(cfg)
+        except BaseException:
+            await self._stack.aclose()
+            raise
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self._stack.aclose()
+
+    async def _connect(self, cfg: McpServerConfig) -> _ConnectedServer:
+        headers: dict[str, str] | None = None
+        if cfg.authorization_token:
+            headers = {"Authorization": f"Bearer {cfg.authorization_token}"}
+
+        transport = await self._stack.enter_async_context(streamablehttp_client(cfg.url, headers=headers))
+        read, write, _ = transport
+        session = await self._stack.enter_async_context(ClientSession(read, write))
+        await session.initialize()
+
+        listed = await session.list_tools()
+        allowed = set(cfg.allowed_tools) if cfg.allowed_tools else None
+        openai_tools: list[dict[str, Any]] = []
+        for tool in listed.tools:
+            if allowed is not None and tool.name not in allowed:
+                continue
+            if tool.name in self._tool_owner:
+                # Name collision across servers: keep the first server's tool.
+                logger.warning(
+                    "MCP tool name collision on %r; %s already owns it, %s skipped",
+                    tool.name,
+                    self._tool_owner[tool.name],
+                    cfg.name,
+                )
+                continue
+            openai_tools.append(mcp_tool_to_openai(tool))
+            self._tool_owner[tool.name] = cfg.name
+
+        return _ConnectedServer(name=cfg.name, session=session, tools=openai_tools, purpose_hint=cfg.purpose_hint)
+
+    @property
+    def openai_tools(self) -> list[dict[str, Any]]:
+        return [t for s in self._servers.values() for t in s.tools]
+
+    def owns_tool(self, name: str) -> bool:
+        return name in self._tool_owner
+
+    def purpose_hints(self) -> list[tuple[str, str]]:
+        return [(s.name, s.purpose_hint) for s in self._servers.values() if s.purpose_hint]
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+        """Execute a tool call against its owning MCP server. Returns flattened text."""
+        owner = self._tool_owner.get(name)
+        if owner is None:
+            raise KeyError(f"No MCP server owns tool {name!r}")
+        result = await self._servers[owner].session.call_tool(name, arguments)
+        parts: list[str] = []
+        for block in result.content:
+            text = getattr(block, "text", None)
+            parts.append(text if isinstance(text, str) else str(block))
+        flattened = "\n".join(parts)
+        if result.isError:
+            return f"[tool error] {flattened}"
+        return flattened

--- a/src/gateway/services/mcp_loop.py
+++ b/src/gateway/services/mcp_loop.py
@@ -18,7 +18,6 @@ from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
 from any_llm import acompletion
-from any_llm.types.completion import ChatCompletionMessageFunctionToolCall
 
 from gateway.log_config import logger
 
@@ -196,6 +195,10 @@ async def mcp_tool_loop(
             return completion
 
         sdk_calls = choice.message.tool_calls or []
+        # Duck-type the SDK tool-call: any object with a `.function` attribute is a
+        # function tool-call. We avoid `isinstance` here because `acompletion`'s
+        # return type uses the OpenAI SDK's class, while any_llm exposes a
+        # same-named but distinct class alias.
         tool_calls = [
             {
                 "id": tc.id,
@@ -203,7 +206,7 @@ async def mcp_tool_loop(
                 "function": {"name": tc.function.name, "arguments": tc.function.arguments},
             }
             for tc in sdk_calls
-            if isinstance(tc, ChatCompletionMessageFunctionToolCall)
+            if hasattr(tc, "function")
         ]
         mcp_calls, has_foreign = _execute_split(tool_calls, pool)
         if has_foreign or not mcp_calls:

--- a/src/gateway/services/mcp_loop.py
+++ b/src/gateway/services/mcp_loop.py
@@ -1,0 +1,224 @@
+"""Streaming-aware MCP tool-use loop.
+
+Wraps one or more `acompletion` calls so that when the model emits tool_calls
+for tools owned by the MCPClientPool, the loop executes them against the MCP
+servers, appends the assistant + tool result messages to the conversation, and
+re-calls the provider for the next iteration. Tool calls for user-supplied
+(non-MCP) tools end the loop and bubble up to the caller untouched.
+
+Both streaming and non-streaming variants are provided. The streaming variant
+yields `ChatCompletionChunk` objects across the entire loop as a single
+`AsyncIterator`, which can be fed into the existing `streaming_generator`.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
+
+from any_llm import acompletion
+from any_llm.types.completion import ChatCompletionMessageFunctionToolCall
+
+from gateway.log_config import logger
+
+if TYPE_CHECKING:
+    from any_llm.types.completion import ChatCompletion, ChatCompletionChunk
+
+    from gateway.services.mcp_client import MCPClientPool
+
+MAX_TOOL_ITERATIONS_CAP = 25
+DEFAULT_MAX_TOOL_ITERATIONS = 10
+
+
+class MaxToolIterationsExceeded(Exception):
+    """Raised when the loop fails to reach a non-tool-call finish in N rounds."""
+
+
+def inject_purpose_hints(messages: list[dict[str, Any]], hints: list[tuple[str, str]]) -> list[dict[str, Any]]:
+    """Prepend or extend the system message with per-server usage hints. Returns a new list."""
+    if not hints:
+        return messages
+
+    lines = ["You have access to the following MCP tool servers:"]
+    for name, hint in hints:
+        lines.append(f"- {name}: {hint}")
+    block = "\n".join(lines)
+
+    out = list(messages)
+    if out and out[0].get("role") == "system":
+        existing = out[0].get("content") or ""
+        out[0] = {**out[0], "content": f"{existing}\n\n{block}" if existing else block}
+    else:
+        out.insert(0, {"role": "system", "content": block})
+    return out
+
+
+def _accumulate_tool_call_deltas(slots: dict[int, dict[str, Any]], deltas: list[Any]) -> None:
+    """Merge incremental streaming tool_call deltas into per-index slots."""
+    for delta in deltas:
+        idx = delta.index
+        slot = slots.setdefault(
+            idx, {"id": None, "type": "function", "function": {"name": "", "arguments": ""}}
+        )
+        if getattr(delta, "id", None):
+            slot["id"] = delta.id
+        if getattr(delta, "type", None):
+            slot["type"] = delta.type
+        fn = getattr(delta, "function", None)
+        if fn is not None:
+            if getattr(fn, "name", None):
+                slot["function"]["name"] += fn.name
+            if getattr(fn, "arguments", None):
+                slot["function"]["arguments"] += fn.arguments
+
+
+def _finalize_tool_calls(slots: dict[int, dict[str, Any]]) -> list[dict[str, Any]]:
+    return [slots[i] for i in sorted(slots)]
+
+
+def _execute_split(tool_calls: list[dict[str, Any]], pool: MCPClientPool) -> tuple[list[dict[str, Any]], bool]:
+    """Return (mcp_owned_calls, has_foreign_calls). Foreign = user-supplied, gateway can't execute."""
+    mcp_calls: list[dict[str, Any]] = []
+    has_foreign = False
+    for tc in tool_calls:
+        name = tc.get("function", {}).get("name", "")
+        if pool.owns_tool(name):
+            mcp_calls.append(tc)
+        else:
+            has_foreign = True
+    return mcp_calls, has_foreign
+
+
+async def _execute_mcp_calls(pool: MCPClientPool, mcp_calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Run each MCP tool call and return the resulting tool-role messages."""
+    out: list[dict[str, Any]] = []
+    for tc in mcp_calls:
+        name = tc["function"]["name"]
+        try:
+            args = json.loads(tc["function"]["arguments"] or "{}")
+        except json.JSONDecodeError:
+            args = {}
+        try:
+            text = await pool.call_tool(name, args)
+        except Exception as exc:  # noqa: BLE001 — surface failure as tool error for the model
+            logger.warning("MCP tool %s execution failed: %s", name, exc)
+            text = f"[tool error] {exc}"
+        out.append({"role": "tool", "tool_call_id": tc["id"] or "", "content": text})
+    return out
+
+
+async def mcp_tool_loop_stream(
+    *,
+    completion_kwargs: dict[str, Any],
+    pool: MCPClientPool,
+    max_iterations: int,
+) -> AsyncIterator[ChatCompletionChunk]:
+    """Yield chunks across multiple `acompletion(stream=True)` calls, with MCP execution between rounds.
+
+    All chunks from intermediate iterations (including the tool_call deltas) are yielded to the
+    caller, so a client that wants to render "thinking" gets it for free. The loop terminates as
+    soon as an iteration's finish_reason is anything other than "tool_calls", or when the model
+    requests a tool the gateway doesn't own.
+    """
+    messages = list(completion_kwargs.get("messages") or [])
+    user_tools = list(completion_kwargs.get("tools") or [])
+    merged_tools = user_tools + pool.openai_tools
+
+    base = {k: v for k, v in completion_kwargs.items() if k not in {"messages", "tools"}}
+    base["stream"] = True
+
+    for _ in range(max_iterations):
+        kwargs: dict[str, Any] = {**base, "messages": messages}
+        if merged_tools:
+            kwargs["tools"] = merged_tools
+
+        stream: AsyncIterator[ChatCompletionChunk] = await acompletion(**kwargs)  # type: ignore[assignment]
+        slots: dict[int, dict[str, Any]] = {}
+        finish_reason: str | None = None
+
+        async for chunk in stream:
+            if chunk.choices:
+                choice = chunk.choices[0]
+                delta = getattr(choice, "delta", None)
+                if delta is not None and getattr(delta, "tool_calls", None):
+                    _accumulate_tool_call_deltas(slots, delta.tool_calls)
+                if choice.finish_reason:
+                    finish_reason = choice.finish_reason
+            yield chunk
+
+        if finish_reason != "tool_calls":
+            return
+
+        tool_calls = _finalize_tool_calls(slots)
+        mcp_calls, has_foreign = _execute_split(tool_calls, pool)
+        if has_foreign or not mcp_calls:
+            return
+
+        messages.append({"role": "assistant", "tool_calls": mcp_calls})
+        messages.extend(await _execute_mcp_calls(pool, mcp_calls))
+
+    raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")
+
+
+async def mcp_tool_loop(
+    *,
+    completion_kwargs: dict[str, Any],
+    pool: MCPClientPool,
+    max_iterations: int,
+) -> ChatCompletion:
+    """Non-streaming variant. Accumulates usage across iterations into the returned completion."""
+    messages = list(completion_kwargs.get("messages") or [])
+    user_tools = list(completion_kwargs.get("tools") or [])
+    merged_tools = user_tools + pool.openai_tools
+
+    base = {k: v for k, v in completion_kwargs.items() if k not in {"messages", "tools", "stream"}}
+
+    acc_prompt = 0
+    acc_completion = 0
+
+    for _ in range(max_iterations):
+        kwargs: dict[str, Any] = {**base, "messages": messages, "stream": False}
+        if merged_tools:
+            kwargs["tools"] = merged_tools
+
+        completion: ChatCompletion = await acompletion(**kwargs)  # type: ignore[assignment]
+        if completion.usage:
+            acc_prompt += completion.usage.prompt_tokens or 0
+            acc_completion += completion.usage.completion_tokens or 0
+
+        if not completion.choices:
+            return completion
+
+        choice = completion.choices[0]
+        if choice.finish_reason != "tool_calls":
+            _fold_usage(completion, acc_prompt, acc_completion)
+            return completion
+
+        sdk_calls = choice.message.tool_calls or []
+        tool_calls = [
+            {
+                "id": tc.id,
+                "type": "function",
+                "function": {"name": tc.function.name, "arguments": tc.function.arguments},
+            }
+            for tc in sdk_calls
+            if isinstance(tc, ChatCompletionMessageFunctionToolCall)
+        ]
+        mcp_calls, has_foreign = _execute_split(tool_calls, pool)
+        if has_foreign or not mcp_calls:
+            _fold_usage(completion, acc_prompt, acc_completion)
+            return completion
+
+        messages.append({"role": "assistant", "tool_calls": mcp_calls})
+        messages.extend(await _execute_mcp_calls(pool, mcp_calls))
+
+    raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")
+
+
+def _fold_usage(completion: ChatCompletion, prompt_total: int, completion_total: int) -> None:
+    if completion.usage is None:
+        return
+    completion.usage.prompt_tokens = prompt_total
+    completion.usage.completion_tokens = completion_total
+    completion.usage.total_tokens = prompt_total + completion_total

--- a/src/gateway/services/mcp_loop.py
+++ b/src/gateway/services/mcp_loop.py
@@ -29,6 +29,11 @@ if TYPE_CHECKING:
 MAX_TOOL_ITERATIONS_CAP = 25
 DEFAULT_MAX_TOOL_ITERATIONS = 10
 
+# Lead-in for the per-server purpose-hint block we prepend to the system message.
+# Surfaced as a constant so phrasing can be tuned for different model families
+# (open-weight models in particular benefit from more directive language).
+PURPOSE_HINT_HEADER = "You have access to the following MCP tool servers:"
+
 
 class MaxToolIterationsExceeded(Exception):
     """Raised when the loop fails to reach a non-tool-call finish in N rounds."""
@@ -39,7 +44,7 @@ def inject_purpose_hints(messages: list[dict[str, Any]], hints: list[tuple[str, 
     if not hints:
         return messages
 
-    lines = ["You have access to the following MCP tool servers:"]
+    lines = [PURPOSE_HINT_HEADER]
     for name, hint in hints:
         lines.append(f"- {name}: {hint}")
     block = "\n".join(lines)
@@ -90,7 +95,13 @@ def _execute_split(tool_calls: list[dict[str, Any]], pool: MCPClientPool) -> tup
 
 
 async def _execute_mcp_calls(pool: MCPClientPool, mcp_calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Run each MCP tool call and return the resulting tool-role messages."""
+    """Run each MCP tool call and return the resulting tool-role messages.
+
+    Tool failures (network errors, server errors, schema mismatches) are converted to a
+    ``[tool error] …`` message so the model can recover. Cancellation and programming
+    errors (KeyboardInterrupt, asyncio.CancelledError, MemoryError) are left to propagate —
+    those are not "the tool failed, retry"; the request itself is going away.
+    """
     out: list[dict[str, Any]] = []
     for tc in mcp_calls:
         name = tc["function"]["name"]
@@ -100,7 +111,7 @@ async def _execute_mcp_calls(pool: MCPClientPool, mcp_calls: list[dict[str, Any]
             args = {}
         try:
             text = await pool.call_tool(name, args)
-        except Exception as exc:  # noqa: BLE001 — surface failure as tool error for the model
+        except (OSError, RuntimeError, ValueError, KeyError, TypeError) as exc:
             logger.warning("MCP tool %s execution failed: %s", name, exc)
             text = f"[tool error] {exc}"
         out.append({"role": "tool", "tool_call_id": tc["id"] or "", "content": text})

--- a/src/gateway/services/mcp_loop.py
+++ b/src/gateway/services/mcp_loop.py
@@ -62,9 +62,7 @@ def _accumulate_tool_call_deltas(slots: dict[int, dict[str, Any]], deltas: list[
     """Merge incremental streaming tool_call deltas into per-index slots."""
     for delta in deltas:
         idx = delta.index
-        slot = slots.setdefault(
-            idx, {"id": None, "type": "function", "function": {"name": "", "arguments": ""}}
-        )
+        slot = slots.setdefault(idx, {"id": None, "type": "function", "function": {"name": "", "arguments": ""}})
         if getattr(delta, "id", None):
             slot["id"] = delta.id
         if getattr(delta, "type", None):

--- a/src/gateway/services/mcp_loop.py
+++ b/src/gateway/services/mcp_loop.py
@@ -95,10 +95,13 @@ def _execute_split(tool_calls: list[dict[str, Any]], pool: MCPClientPool) -> tup
 async def _execute_mcp_calls(pool: MCPClientPool, mcp_calls: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Run each MCP tool call and return the resulting tool-role messages.
 
-    Tool failures (network errors, server errors, schema mismatches) are converted to a
-    ``[tool error] …`` message so the model can recover. Cancellation and programming
-    errors (KeyboardInterrupt, asyncio.CancelledError, MemoryError) are left to propagate —
-    those are not "the tool failed, retry"; the request itself is going away.
+    Tool failures (network errors, server errors, schema mismatches, MCP-specific
+    or httpx-level transport errors) are converted to a ``[tool error] …`` message
+    so the model can recover. Only cancellation/interrupt-class exceptions
+    (``asyncio.CancelledError``, ``KeyboardInterrupt``) escape — they inherit
+    from ``BaseException`` and never reach the ``Exception`` clause. That's the
+    standard idiom for "treat tool failures as recoverable, let cancellation
+    propagate".
     """
     out: list[dict[str, Any]] = []
     for tc in mcp_calls:
@@ -109,7 +112,7 @@ async def _execute_mcp_calls(pool: MCPClientPool, mcp_calls: list[dict[str, Any]
             args = {}
         try:
             text = await pool.call_tool(name, args)
-        except (OSError, RuntimeError, ValueError, KeyError, TypeError) as exc:
+        except Exception as exc:  # noqa: BLE001 — see docstring
             logger.warning("MCP tool %s execution failed: %s", name, exc)
             text = f"[tool error] {exc}"
         out.append({"role": "tool", "tool_call_id": tc["id"] or "", "content": text})
@@ -124,10 +127,18 @@ async def mcp_tool_loop_stream(
 ) -> AsyncIterator[ChatCompletionChunk]:
     """Yield chunks across multiple `acompletion(stream=True)` calls, with MCP execution between rounds.
 
-    All chunks from intermediate iterations (including the tool_call deltas) are yielded to the
-    caller, so a client that wants to render "thinking" gets it for free. The loop terminates as
-    soon as an iteration's finish_reason is anything other than "tool_calls", or when the model
-    requests a tool the gateway doesn't own.
+    Tool-call deltas from intermediate iterations are streamed straight through to the
+    caller (so clients that want to render "thinking" still get those bytes), but the
+    *terminal* chunk of each intermediate iteration — the one carrying
+    ``finish_reason="tool_calls"`` — is buffered and dropped if the loop is going to
+    iterate again. Forwarding that chunk would tell an OpenAI-compatible client "this
+    is the final answer", and most SDKs stop reading at that point; subsequent
+    iterations' content would be silently truncated.
+
+    The terminal chunk is forwarded in three cases:
+      * the iteration ended with a non-``tool_calls`` finish_reason (e.g. ``stop``),
+      * the model produced foreign tool_calls (caller needs to dispatch them), or
+      * the model produced no MCP-owned calls at all (loop exits, terminal goes through).
     """
     messages = list(completion_kwargs.get("messages") or [])
     user_tools = list(completion_kwargs.get("tools") or [])
@@ -144,25 +155,47 @@ async def mcp_tool_loop_stream(
         stream: AsyncIterator[ChatCompletionChunk] = await acompletion(**kwargs)  # type: ignore[assignment]
         slots: dict[int, dict[str, Any]] = {}
         finish_reason: str | None = None
+        pending_terminal: ChatCompletionChunk | None = None
 
         async for chunk in stream:
+            chunk_is_terminal = False
             if chunk.choices:
                 choice = chunk.choices[0]
                 delta = getattr(choice, "delta", None)
                 if delta is not None and getattr(delta, "tool_calls", None):
                     _accumulate_tool_call_deltas(slots, delta.tool_calls)
                 if choice.finish_reason:
-                    finish_reason = choice.finish_reason
+                    # Sticky-tool-calls: a trailing ``stop`` chunk from
+                    # Anthropic must not override ``tool_calls`` we've
+                    # already seen on this same iteration.
+                    if not (finish_reason == "tool_calls" and choice.finish_reason != "tool_calls"):
+                        finish_reason = choice.finish_reason
+                    chunk_is_terminal = True
+            if chunk_is_terminal:
+                pending_terminal = chunk
+                continue
             yield chunk
 
         if finish_reason != "tool_calls":
+            if pending_terminal is not None:
+                yield pending_terminal
             return
 
         tool_calls = _finalize_tool_calls(slots)
         mcp_calls, has_foreign = _execute_split(tool_calls, pool)
         if has_foreign or not mcp_calls:
+            # Mixed (has_foreign with mcp_calls) is handled the same as
+            # all-foreign here: the terminal chunk is forwarded so the
+            # client sees the full tool_calls set, and any MCP-owned calls
+            # in a mixed batch are left for a follow-up turn (the
+            # non-streaming variant filters them out; rewriting deltas
+            # mid-stream is too invasive to do here).
+            if pending_terminal is not None:
+                yield pending_terminal
             return
 
+        # All-MCP: silently drop the terminal so the client doesn't think
+        # this iteration's response was the final answer.
         messages.append({"role": "assistant", "tool_calls": mcp_calls})
         messages.extend(await _execute_mcp_calls(pool, mcp_calls))
 
@@ -218,7 +251,30 @@ async def mcp_tool_loop(
             if hasattr(tc, "function")
         ]
         mcp_calls, has_foreign = _execute_split(tool_calls, pool)
-        if has_foreign or not mcp_calls:
+        if has_foreign:
+            # Mixed batch: execute the MCP-owned subset internally so its
+            # work isn't wasted, then filter those calls out of the returned
+            # completion so the caller only sees tool_calls it can itself
+            # dispatch. The conversation continues client-side; if the
+            # caller wants to keep using the gateway's MCP tools they'll
+            # send the foreign-tool results back on the next request.
+            if mcp_calls:
+                await _execute_mcp_calls(pool, mcp_calls)
+                foreign_sdk_calls = [
+                    tc for tc in sdk_calls if hasattr(tc, "function") and not pool.owns_tool(tc.function.name)
+                ]
+                try:
+                    choice.message.tool_calls = foreign_sdk_calls or None
+                except (AttributeError, TypeError):
+                    # If the SDK model is frozen, fall back to leaving the
+                    # original list. Cleaner UX requires SDK mutability.
+                    logger.warning(
+                        "MCP-mixed: could not filter tool_calls on response; client will see MCP calls "
+                        "the gateway already executed (no-op on the client side).",
+                    )
+            _fold_usage(completion, acc_prompt, acc_completion)
+            return completion
+        if not mcp_calls:
             _fold_usage(completion, acc_prompt, acc_completion)
             return completion
 

--- a/src/gateway/services/url_safety.py
+++ b/src/gateway/services/url_safety.py
@@ -1,0 +1,112 @@
+"""URL safety checks for inline MCP server endpoints.
+
+Two concerns:
+
+1. **SSRF.** A request body could otherwise point the gateway at internal services
+   (AWS IMDS, internal databases, cluster-local endpoints) and exfiltrate data via
+   the tool-list response. We resolve the host and reject private, link-local, and
+   reserved IP ranges. Loopback is allowed by default since it's genuinely useful
+   for local dev and same-host sidecar deployments — set ``GATEWAY_MCP_ALLOW_LOOPBACK=false``
+   to disable.
+
+2. **TLS-with-token.** A bearer token over an ``http://`` URL is exfiltratable by
+   any on-path observer. If the caller provides a token, the URL must be HTTPS.
+
+These checks are intentionally conservative: DNS rebinding can defeat host-based
+allowlists. Production deployments should also enforce egress policy at the
+network layer.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+from urllib.parse import urlparse
+
+
+class UnsafeURLError(ValueError):
+    """Raised when an MCP server URL is rejected by the safety checks."""
+
+
+def _allow_loopback() -> bool:
+    return os.environ.get("GATEWAY_MCP_ALLOW_LOOPBACK", "true").lower() not in {"0", "false", "no"}
+
+
+def _allow_private_hosts() -> bool:
+    return os.environ.get("GATEWAY_MCP_ALLOW_PRIVATE_HOSTS", "false").lower() in {"1", "true", "yes"}
+
+
+def _resolve_all(host: str) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return []
+    out: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    for info in infos:
+        sockaddr = info[4]
+        try:
+            out.append(ipaddress.ip_address(sockaddr[0]))
+        except ValueError:
+            continue
+    return out
+
+
+def validate_mcp_url(url: str, *, has_authorization_token: bool) -> None:
+    """Reject URLs that are unsafe for the gateway to fetch.
+
+    Raises :class:`UnsafeURLError` on rejection. Returns ``None`` on accept.
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"}:
+        raise UnsafeURLError(f"MCP server URL must use http or https, got {scheme!r}")
+    if scheme == "http" and has_authorization_token:
+        raise UnsafeURLError(
+            "MCP server URL must use https when an authorization_token is set"
+        )
+
+    host = parsed.hostname
+    if not host:
+        raise UnsafeURLError("MCP server URL must include a hostname")
+
+    if _allow_private_hosts():
+        return
+
+    try:
+        literal = ipaddress.ip_address(host)
+        addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = [literal]
+    except ValueError:
+        addresses = _resolve_all(host)
+        if not addresses:
+            # Couldn't resolve — allow through; the request will fail at fetch time.
+            # Don't leak resolution success/failure via reject behaviour.
+            return
+
+    for addr in addresses:
+        if addr.is_loopback and _allow_loopback():
+            continue
+        reason = _blocked_reason(addr)
+        if reason is not None:
+            raise UnsafeURLError(
+                f"MCP server host {host!r} resolves to {addr} which is {reason}; "
+                "rejecting to prevent SSRF. Set GATEWAY_MCP_ALLOW_PRIVATE_HOSTS=true to override."
+            )
+
+
+def _blocked_reason(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> str | None:
+    # Order matters: is_private returns True for unspecified/loopback/link-local too,
+    # so more specific labels go first to produce useful error messages.
+    if addr.is_unspecified:
+        return "unspecified (0.0.0.0/::)"
+    if addr.is_loopback:
+        return "loopback"
+    if addr.is_link_local:
+        return "link-local"
+    if addr.is_multicast:
+        return "multicast"
+    if addr.is_private:
+        return "in a private range (RFC 1918 / ULA)"
+    if addr.is_reserved:
+        return "in a reserved range"
+    return None

--- a/src/gateway/services/url_safety.py
+++ b/src/gateway/services/url_safety.py
@@ -62,9 +62,7 @@ def validate_mcp_url(url: str, *, has_authorization_token: bool) -> None:
     if scheme not in {"http", "https"}:
         raise UnsafeURLError(f"MCP server URL must use http or https, got {scheme!r}")
     if scheme == "http" and has_authorization_token:
-        raise UnsafeURLError(
-            "MCP server URL must use https when an authorization_token is set"
-        )
+        raise UnsafeURLError("MCP server URL must use https when an authorization_token is set")
 
     host = parsed.hostname
     if not host:

--- a/src/gateway/services/url_safety.py
+++ b/src/gateway/services/url_safety.py
@@ -77,9 +77,19 @@ def validate_mcp_url(url: str, *, has_authorization_token: bool) -> None:
     except ValueError:
         addresses = _resolve_all(host)
         if not addresses:
-            # Couldn't resolve — allow through; the request will fail at fetch time.
-            # Don't leak resolution success/failure via reject behaviour.
-            return
+            # Couldn't resolve the host at validation time. Rejecting is the
+            # safer default: a hostname that fails to resolve here could
+            # later resolve to an internal address at fetch time (the
+            # classic DNS-rebinding TOCTOU). Operators that explicitly want
+            # to allow unresolvable hostnames (private DNS,
+            # hosts-file-driven setups, etc.) can opt in via
+            # GATEWAY_MCP_ALLOW_PRIVATE_HOSTS, which short-circuits this
+            # whole function above.
+            raise UnsafeURLError(
+                f"MCP server host {host!r} could not be resolved at validation time; "
+                "rejecting to avoid DNS-rebinding (a later lookup could resolve to a "
+                "private address). Set GATEWAY_MCP_ALLOW_PRIVATE_HOSTS=true to override."
+            )
 
     for addr in addresses:
         if addr.is_loopback and _allow_loopback():

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -175,7 +175,8 @@ async def iterate_streaming_attempts(
             return attempt, _empty_async_iter()
         except asyncio.TimeoutError as exc:
             await on_attempt_failed(
-                attempt, StreamingAttemptFailure("timeout", exc),
+                attempt,
+                StreamingAttemptFailure("timeout", exc),
             )
             await _close_stream_quietly(stream)
             last_exception = exc

--- a/tests/integration/test_embeddings_endpoint.py
+++ b/tests/integration/test_embeddings_endpoint.py
@@ -178,9 +178,7 @@ def test_embeddings_optional_fields(
     """POST /v1/embeddings forwards optional OpenAI fields."""
     mock_resp = _mock_embedding_response()
     values = {"encoding_format": "float", "dimensions": 256}
-    with patch(
-        "gateway.api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp
-    ) as mock:
+    with patch("gateway.api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp) as mock:
         resp = client.post(
             "/v1/embeddings",
             json={

--- a/tests/integration/test_platform_mode_chat.py
+++ b/tests/integration/test_platform_mode_chat.py
@@ -449,9 +449,7 @@ def test_platform_mode_streaming_falls_through_on_first_attempt_failure(
                     "object": "chat.completion.chunk",
                     "created": 1700000000,
                     "model": "gpt-4o-mini",
-                    "choices": [
-                        {"index": 0, "delta": {"content": "hi"}, "finish_reason": None}
-                    ],
+                    "choices": [{"index": 0, "delta": {"content": "hi"}, "finish_reason": None}],
                 }
             )
             yield ChatCompletionChunk.model_validate(
@@ -460,9 +458,7 @@ def test_platform_mode_streaming_falls_through_on_first_attempt_failure(
                     "object": "chat.completion.chunk",
                     "created": 1700000000,
                     "model": "gpt-4o-mini",
-                    "choices": [
-                        {"index": 0, "delta": {}, "finish_reason": "stop"}
-                    ],
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
                     "usage": {
                         "prompt_tokens": 5,
                         "completion_tokens": 1,

--- a/tests/integration/test_shared_helpers.py
+++ b/tests/integration/test_shared_helpers.py
@@ -3,9 +3,7 @@
 from fastapi.testclient import TestClient
 
 
-def test_get_active_user_via_budget_endpoint(
-    client: TestClient, master_key_header: dict[str, str]
-) -> None:
+def test_get_active_user_via_budget_endpoint(client: TestClient, master_key_header: dict[str, str]) -> None:
     client.post(
         "/v1/users",
         json={"user_id": "helper-test-user", "alias": "Helper Test"},
@@ -16,9 +14,7 @@ def test_get_active_user_via_budget_endpoint(
     assert resp.json()["user_id"] == "helper-test-user"
 
 
-def test_get_active_user_returns_none_for_deleted(
-    client: TestClient, master_key_header: dict[str, str]
-) -> None:
+def test_get_active_user_returns_none_for_deleted(client: TestClient, master_key_header: dict[str, str]) -> None:
     client.post(
         "/v1/users",
         json={"user_id": "to-delete-user"},
@@ -29,16 +25,12 @@ def test_get_active_user_returns_none_for_deleted(
     assert resp.status_code == 404
 
 
-def test_get_active_user_returns_none_for_nonexistent(
-    client: TestClient, master_key_header: dict[str, str]
-) -> None:
+def test_get_active_user_returns_none_for_nonexistent(client: TestClient, master_key_header: dict[str, str]) -> None:
     resp = client.get("/v1/users/nonexistent-user", headers=master_key_header)
     assert resp.status_code == 404
 
 
-def test_budget_from_model_roundtrip(
-    client: TestClient, master_key_header: dict[str, str]
-) -> None:
+def test_budget_from_model_roundtrip(client: TestClient, master_key_header: dict[str, str]) -> None:
     resp = client.post(
         "/v1/budgets",
         json={"max_budget": 50.0, "budget_duration_sec": 3600},
@@ -50,9 +42,7 @@ def test_budget_from_model_roundtrip(
     assert data["budget_duration_sec"] == 3600
 
 
-def test_pricing_from_model_roundtrip(
-    client: TestClient, master_key_header: dict[str, str]
-) -> None:
+def test_pricing_from_model_roundtrip(client: TestClient, master_key_header: dict[str, str]) -> None:
     resp = client.post(
         "/v1/pricing",
         json={
@@ -69,9 +59,7 @@ def test_pricing_from_model_roundtrip(
     assert data["output_price_per_million"] == 10.0
 
 
-def test_resolve_user_id_chat_master_key_requires_user(
-    client: TestClient, master_key_header: dict[str, str]
-) -> None:
+def test_resolve_user_id_chat_master_key_requires_user(client: TestClient, master_key_header: dict[str, str]) -> None:
     resp = client.post(
         "/v1/chat/completions",
         json={

--- a/tests/unit/test_env_var_resolution.py
+++ b/tests/unit/test_env_var_resolution.py
@@ -55,9 +55,7 @@ def test_inline_substitution() -> None:
     os.environ["TEST_DB_ROLE"] = "readwrite"
     os.environ["TEST_DB_HOST"] = "db.example.com"
     try:
-        result = _resolve_env_vars(
-            {"url": "postgresql://${TEST_DB_USER}:${TEST_DB_ROLE}@${TEST_DB_HOST}/mydb"}
-        )
+        result = _resolve_env_vars({"url": "postgresql://${TEST_DB_USER}:${TEST_DB_ROLE}@${TEST_DB_HOST}/mydb"})
         assert result["url"] == "postgresql://admin:readwrite@db.example.com/mydb"
     finally:
         del os.environ["TEST_DB_USER"]
@@ -70,9 +68,7 @@ def test_inline_substitution_missing_var_raises() -> None:
     os.environ.pop("TEST_INLINE_MISSING", None)
     try:
         with pytest.raises(ValueError, match="TEST_INLINE_MISSING"):
-            _resolve_env_vars(
-                {"url": "prefix-${TEST_INLINE_OK}-${TEST_INLINE_MISSING}-suffix"}
-            )
+            _resolve_env_vars({"url": "prefix-${TEST_INLINE_OK}-${TEST_INLINE_MISSING}-suffix"})
     finally:
         del os.environ["TEST_INLINE_OK"]
 

--- a/tests/unit/test_mcp_loop.py
+++ b/tests/unit/test_mcp_loop.py
@@ -23,8 +23,6 @@ from any_llm.types.completion import (
     ChoiceDeltaToolCallFunction as DeltaFn,
 )
 
-_FinishReason = Literal["stop", "length", "tool_calls", "content_filter", "function_call"]
-
 from gateway.services import mcp_loop as mcp_loop_module
 from gateway.services.mcp_loop import (
     MaxToolIterationsExceeded,
@@ -34,6 +32,8 @@ from gateway.services.mcp_loop import (
     mcp_tool_loop,
     mcp_tool_loop_stream,
 )
+
+_FinishReason = Literal["stop", "length", "tool_calls", "content_filter", "function_call"]
 
 
 class _FakePool:
@@ -297,6 +297,43 @@ async def test_loop_foreign_tool_returns_to_caller_without_execution(monkeypatch
     )
     assert out.choices[0].finish_reason == "tool_calls"
     assert pool.calls == []
+
+
+@pytest.mark.asyncio
+async def test_loop_handles_duck_typed_tool_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression: ensure the loop dispatches tool_calls produced by *any* SDK whose
+    function-tool-call class isn't the one any_llm aliases. The OpenAI SDK returns
+    its own class; an isinstance check against any_llm's class would silently skip
+    every call. The loop must duck-type."""
+
+    from types import SimpleNamespace
+
+    sdk_tool_call = SimpleNamespace(
+        id="call_alien",
+        type="function",
+        function=SimpleNamespace(name="fetch_url", arguments='{"u":"x"}'),
+    )
+    first = _completion(finish="tool_calls")
+    # Replace the test helper's any_llm-typed tool_calls with a foreign-class duck-typed object.
+    first.choices[0].message.tool_calls = cast(Any, [sdk_tool_call])
+
+    responses = iter([first, _completion(finish="stop", content="done")])
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        return next(responses)
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    pool = _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})
+    out = await mcp_tool_loop(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "fetch"}]},
+        pool=pool,  # type: ignore[arg-type]
+        max_iterations=5,
+    )
+    assert out.choices[0].finish_reason == "stop"
+    assert pool.calls == [("fetch_url", {"u": "x"})], (
+        "loop must execute duck-typed function tool_calls"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mcp_loop.py
+++ b/tests/unit/test_mcp_loop.py
@@ -1,0 +1,387 @@
+"""Unit tests for the MCP tool-use loop and its pure helpers."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any, Literal, cast
+
+import pytest
+from any_llm.types.completion import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    ChatCompletionMessage,
+    ChatCompletionMessageFunctionToolCall,
+    Choice,
+    ChoiceDelta,
+    ChoiceDeltaToolCall,
+    ChunkChoice,
+    CompletionUsage,
+    Function,
+)
+from any_llm.types.completion import (
+    ChoiceDeltaToolCallFunction as DeltaFn,
+)
+
+_FinishReason = Literal["stop", "length", "tool_calls", "content_filter", "function_call"]
+
+from gateway.services import mcp_loop as mcp_loop_module
+from gateway.services.mcp_loop import (
+    MaxToolIterationsExceeded,
+    _accumulate_tool_call_deltas,
+    _finalize_tool_calls,
+    inject_purpose_hints,
+    mcp_tool_loop,
+    mcp_tool_loop_stream,
+)
+
+
+class _FakePool:
+    """Stand-in for MCPClientPool that satisfies the loop's protocol."""
+
+    def __init__(
+        self,
+        tool_names: list[str],
+        purpose_hints: list[tuple[str, str]] | None = None,
+        results: dict[str, str] | None = None,
+    ):
+        self._tool_names = set(tool_names)
+        self._hints = purpose_hints or []
+        self._results = results or {}
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    @property
+    def openai_tools(self) -> list[dict[str, Any]]:
+        return [
+            {"type": "function", "function": {"name": n, "description": "", "parameters": {}}}
+            for n in sorted(self._tool_names)
+        ]
+
+    def owns_tool(self, name: str) -> bool:
+        return name in self._tool_names
+
+    def purpose_hints(self) -> list[tuple[str, str]]:
+        return list(self._hints)
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+        self.calls.append((name, arguments))
+        if name not in self._results:
+            return f"ran {name}"
+        return self._results[name]
+
+
+def _completion(
+    *,
+    finish: _FinishReason,
+    content: str | None = None,
+    tool_calls: list[tuple[str, str, str]] | None = None,
+    prompt: int = 1,
+    completion_tokens: int = 1,
+) -> ChatCompletion:
+    """Build a ChatCompletion. tool_calls items are (id, name, arguments_json)."""
+    sdk_calls = (
+        [
+            ChatCompletionMessageFunctionToolCall(
+                id=tc[0], type="function", function=Function(name=tc[1], arguments=tc[2])
+            )
+            for tc in tool_calls
+        ]
+        if tool_calls
+        else None
+    )
+    message = ChatCompletionMessage(role="assistant", content=content, tool_calls=cast(Any, sdk_calls))
+    return ChatCompletion(
+        id="cmpl-1",
+        choices=[Choice(finish_reason=finish, index=0, message=message)],
+        created=0,
+        model="fake",
+        object="chat.completion",
+        usage=CompletionUsage(
+            prompt_tokens=prompt, completion_tokens=completion_tokens, total_tokens=prompt + completion_tokens
+        ),
+    )
+
+
+def _chunk(
+    *,
+    finish: _FinishReason | None = None,
+    content: str | None = None,
+    tool_calls: list[tuple[int, str | None, str | None, str | None]] | None = None,
+) -> ChatCompletionChunk:
+    """Build a streaming chunk. tool_calls items are (index, id, name_delta, args_delta)."""
+    delta_tool_calls = (
+        [
+            ChoiceDeltaToolCall(
+                index=tc[0],
+                id=tc[1],
+                type="function" if tc[1] is not None else None,
+                function=DeltaFn(name=tc[2], arguments=tc[3]) if (tc[2] or tc[3]) else None,
+            )
+            for tc in tool_calls
+        ]
+        if tool_calls
+        else None
+    )
+    delta = ChoiceDelta(role="assistant", content=content, tool_calls=delta_tool_calls)
+    return ChatCompletionChunk(
+        id="cmpl-1",
+        choices=[ChunkChoice(delta=delta, finish_reason=finish, index=0)],
+        created=0,
+        model="fake",
+        object="chat.completion.chunk",
+    )
+
+
+# ---------- pure helpers ----------
+
+
+def test_inject_purpose_hints_no_hints_returns_unchanged() -> None:
+    msgs = [{"role": "user", "content": "hi"}]
+    assert inject_purpose_hints(msgs, []) == msgs
+
+
+def test_inject_purpose_hints_prepends_when_no_system() -> None:
+    msgs = [{"role": "user", "content": "hi"}]
+    out = inject_purpose_hints(msgs, [("calendar", "for scheduling")])
+    assert out[0]["role"] == "system"
+    assert "calendar" in out[0]["content"]
+    assert out[1] == {"role": "user", "content": "hi"}
+
+
+def test_inject_purpose_hints_extends_existing_system() -> None:
+    msgs = [{"role": "system", "content": "be helpful"}, {"role": "user", "content": "hi"}]
+    out = inject_purpose_hints(msgs, [("cal", "use it")])
+    assert out[0]["role"] == "system"
+    assert "be helpful" in out[0]["content"]
+    assert "cal" in out[0]["content"]
+
+
+def test_finalize_tool_calls_orders_by_index() -> None:
+    slots: dict[int, dict[str, Any]] = {}
+    _accumulate_tool_call_deltas(
+        slots,
+        [
+            ChoiceDeltaToolCall(index=1, id="b", type="function", function=DeltaFn(name="t2", arguments="{}")),
+            ChoiceDeltaToolCall(index=0, id="a", type="function", function=DeltaFn(name="t1", arguments="{}")),
+        ],
+    )
+    out = _finalize_tool_calls(slots)
+    assert [c["id"] for c in out] == ["a", "b"]
+
+
+def test_accumulate_concatenates_argument_chunks() -> None:
+    slots: dict[int, dict[str, Any]] = {}
+    _accumulate_tool_call_deltas(
+        slots,
+        [ChoiceDeltaToolCall(index=0, id="a", type="function", function=DeltaFn(name="t", arguments='{"x":'))],
+    )
+    _accumulate_tool_call_deltas(
+        slots,
+        [ChoiceDeltaToolCall(index=0, id=None, type=None, function=DeltaFn(name=None, arguments=' "y"}'))],
+    )
+    out = _finalize_tool_calls(slots)
+    assert json.loads(out[0]["function"]["arguments"]) == {"x": "y"}
+
+
+# ---------- non-streaming loop ----------
+
+
+@pytest.mark.asyncio
+async def test_loop_returns_immediately_when_model_returns_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        calls.append(kwargs)
+        return _completion(finish="stop", content="hi there")
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    pool = _FakePool(tool_names=["fetch_url"])
+    out = await mcp_tool_loop(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "hi"}]},
+        pool=pool,  # type: ignore[arg-type]
+        max_iterations=5,
+    )
+    assert out.choices[0].message.content == "hi there"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_loop_executes_mcp_tool_and_completes(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = iter(
+        [
+            _completion(finish="tool_calls", tool_calls=[("call_1", "fetch_url", '{"u":"x"}')]),
+            _completion(finish="stop", content="fetched: ok"),
+        ]
+    )
+    captured_messages: list[list[dict[str, Any]]] = []
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        captured_messages.append(kwargs["messages"])
+        return next(responses)
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    pool = _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})
+    out = await mcp_tool_loop(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "fetch x"}]},
+        pool=pool,  # type: ignore[arg-type]
+        max_iterations=5,
+    )
+
+    assert out.choices[0].finish_reason == "stop"
+    assert pool.calls == [("fetch_url", {"u": "x"})]
+    # second call should have assistant tool_calls msg and tool result msg appended
+    second_msgs = captured_messages[1]
+    assert second_msgs[-2]["role"] == "assistant"
+    assert second_msgs[-2]["tool_calls"][0]["function"]["name"] == "fetch_url"
+    assert second_msgs[-1] == {"role": "tool", "tool_call_id": "call_1", "content": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_loop_accumulates_usage_across_iterations(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = iter(
+        [
+            _completion(finish="tool_calls", tool_calls=[("c1", "fetch_url", "{}")], prompt=10, completion_tokens=2),
+            _completion(finish="stop", content="done", prompt=12, completion_tokens=3),
+        ]
+    )
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        return next(responses)
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    out = await mcp_tool_loop(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+        pool=_FakePool(tool_names=["fetch_url"]),  # type: ignore[arg-type]
+        max_iterations=5,
+    )
+    assert out.usage is not None
+    assert out.usage.prompt_tokens == 22
+    assert out.usage.completion_tokens == 5
+    assert out.usage.total_tokens == 27
+
+
+@pytest.mark.asyncio
+async def test_loop_max_iter_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        return _completion(finish="tool_calls", tool_calls=[("c", "fetch_url", "{}")])
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    with pytest.raises(MaxToolIterationsExceeded):
+        await mcp_tool_loop(
+            completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+            pool=_FakePool(tool_names=["fetch_url"]),  # type: ignore[arg-type]
+            max_iterations=2,
+        )
+
+
+@pytest.mark.asyncio
+async def test_loop_foreign_tool_returns_to_caller_without_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        return _completion(finish="tool_calls", tool_calls=[("c", "user_tool", "{}")])
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    pool = _FakePool(tool_names=["fetch_url"])  # doesn't own user_tool
+    out = await mcp_tool_loop(
+        completion_kwargs={
+            "model": "fake",
+            "messages": [{"role": "user", "content": "go"}],
+            "tools": [{"type": "function", "function": {"name": "user_tool", "parameters": {}}}],
+        },
+        pool=pool,  # type: ignore[arg-type]
+        max_iterations=5,
+    )
+    assert out.choices[0].finish_reason == "tool_calls"
+    assert pool.calls == []
+
+
+@pytest.mark.asyncio
+async def test_loop_tool_execution_failure_appears_as_tool_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = iter(
+        [
+            _completion(finish="tool_calls", tool_calls=[("c", "fetch_url", "{}")]),
+            _completion(finish="stop", content="recovered"),
+        ]
+    )
+    captured: list[list[dict[str, Any]]] = []
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        captured.append(kwargs["messages"])
+        return next(responses)
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    class FailingPool(_FakePool):
+        async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+            raise RuntimeError("upstream down")
+
+    pool = FailingPool(tool_names=["fetch_url"])
+    out = await mcp_tool_loop(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+        pool=pool,  # type: ignore[arg-type]
+        max_iterations=5,
+    )
+    assert out.choices[0].message.content == "recovered"
+    tool_msg = captured[1][-1]
+    assert tool_msg["role"] == "tool"
+    assert "tool error" in tool_msg["content"]
+    assert "upstream down" in tool_msg["content"]
+
+
+# ---------- streaming loop ----------
+
+
+async def _async_iter(*chunks: ChatCompletionChunk) -> AsyncIterator[ChatCompletionChunk]:
+    for c in chunks:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_stream_loop_passes_chunks_through_and_terminates(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_acompletion(**kwargs: Any) -> AsyncIterator[ChatCompletionChunk]:
+        return _async_iter(_chunk(content="hi"), _chunk(content=" there", finish="stop"))
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    pieces: list[str | None] = []
+    async for c in mcp_tool_loop_stream(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "hi"}]},
+        pool=_FakePool(tool_names=[]),  # type: ignore[arg-type]
+        max_iterations=3,
+    ):
+        pieces.append(c.choices[0].delta.content if c.choices else None)
+    assert pieces == ["hi", " there"]
+
+
+@pytest.mark.asyncio
+async def test_stream_loop_runs_mcp_tool_and_continues(monkeypatch: pytest.MonkeyPatch) -> None:
+    iter_streams = iter(
+        [
+            _async_iter(
+                _chunk(tool_calls=[(0, "call_1", "fetch_url", "{}")]),
+                _chunk(finish="tool_calls"),
+            ),
+            _async_iter(_chunk(content="all done", finish="stop")),
+        ]
+    )
+
+    async def fake_acompletion(**kwargs: Any) -> AsyncIterator[ChatCompletionChunk]:
+        return next(iter_streams)
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    pool = _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})
+    finishes: list[str | None] = []
+    async for c in mcp_tool_loop_stream(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+        pool=pool,  # type: ignore[arg-type]
+        max_iterations=5,
+    ):
+        if c.choices and c.choices[0].finish_reason:
+            finishes.append(c.choices[0].finish_reason)
+    assert finishes == ["tool_calls", "stop"]
+    assert pool.calls == [("fetch_url", {})]

--- a/tests/unit/test_mcp_loop.py
+++ b/tests/unit/test_mcp_loop.py
@@ -331,9 +331,7 @@ async def test_loop_handles_duck_typed_tool_calls(monkeypatch: pytest.MonkeyPatc
         max_iterations=5,
     )
     assert out.choices[0].finish_reason == "stop"
-    assert pool.calls == [("fetch_url", {"u": "x"})], (
-        "loop must execute duck-typed function tool_calls"
-    )
+    assert pool.calls == [("fetch_url", {"u": "x"})], "loop must execute duck-typed function tool_calls"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mcp_loop.py
+++ b/tests/unit/test_mcp_loop.py
@@ -394,6 +394,11 @@ async def test_stream_loop_passes_chunks_through_and_terminates(monkeypatch: pyt
 
 @pytest.mark.asyncio
 async def test_stream_loop_runs_mcp_tool_and_continues(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Intermediate ``tool_calls`` terminal chunks are dropped — forwarding them
+    would make OpenAI-compatible clients stop reading before the final answer.
+
+    See ``mcp_tool_loop_stream`` docstring for the rationale.
+    """
     iter_streams = iter(
         [
             _async_iter(
@@ -418,5 +423,81 @@ async def test_stream_loop_runs_mcp_tool_and_continues(monkeypatch: pytest.Monke
     ):
         if c.choices and c.choices[0].finish_reason:
             finishes.append(c.choices[0].finish_reason)
-    assert finishes == ["tool_calls", "stop"]
+    # Only the final iteration's `stop` is forwarded; the intermediate
+    # `tool_calls` terminal is suppressed.
+    assert finishes == ["stop"]
     assert pool.calls == [("fetch_url", {})]
+
+
+@pytest.mark.asyncio
+async def test_stream_loop_forwards_terminal_when_model_emits_foreign_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the model asks for a *foreign* tool, the loop terminates and the
+    terminal ``tool_calls`` chunk MUST reach the client so they know to dispatch.
+    """
+    iter_streams = iter(
+        [
+            _async_iter(
+                _chunk(tool_calls=[(0, "call_1", "user_tool", "{}")]),
+                _chunk(finish="tool_calls"),
+            ),
+        ]
+    )
+
+    async def fake_acompletion(**kwargs: Any) -> AsyncIterator[ChatCompletionChunk]:
+        return next(iter_streams)
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    pool = _FakePool(tool_names=["fetch_url"])  # doesn't own user_tool
+    finishes: list[str | None] = []
+    async for c in mcp_tool_loop_stream(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+        pool=pool,  # type: ignore[arg-type]
+        max_iterations=5,
+    ):
+        if c.choices and c.choices[0].finish_reason:
+            finishes.append(c.choices[0].finish_reason)
+    assert finishes == ["tool_calls"]
+    assert pool.calls == []
+
+
+@pytest.mark.asyncio
+async def test_loop_mixed_tools_executes_mcp_and_returns_only_foreign(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-streaming variant: if the model emits a mix of MCP and foreign
+    tool_calls, the loop executes the MCP subset internally and filters those
+    out of the returned completion. The caller only sees what they can
+    themselves dispatch.
+    """
+    only_completion = _completion(
+        finish="tool_calls",
+        tool_calls=[
+            ("mcp_id", "fetch_url", "{}"),
+            ("user_id", "user_tool", "{}"),
+        ],
+    )
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        return only_completion
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    pool = _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})
+    out = await mcp_tool_loop(
+        completion_kwargs={
+            "model": "fake",
+            "messages": [{"role": "user", "content": "go"}],
+            "tools": [{"type": "function", "function": {"name": "user_tool", "parameters": {}}}],
+        },
+        pool=pool,  # type: ignore[arg-type]
+        max_iterations=5,
+    )
+    # MCP subset was executed internally.
+    assert pool.calls == [("fetch_url", {})]
+    # Returned completion only carries the foreign call for the client.
+    remaining = out.choices[0].message.tool_calls or []
+    remaining_names = [tc.function.name for tc in remaining if hasattr(tc, "function")]
+    assert remaining_names == ["user_tool"]

--- a/tests/unit/test_url_safety.py
+++ b/tests/unit/test_url_safety.py
@@ -1,0 +1,59 @@
+"""Unit tests for `gateway.services.url_safety`."""
+
+import pytest
+
+from gateway.services.url_safety import UnsafeURLError, validate_mcp_url
+
+
+def test_public_https_accepted() -> None:
+    validate_mcp_url("https://example.com/mcp", has_authorization_token=True)
+
+
+def test_public_http_accepted_without_token() -> None:
+    validate_mcp_url("http://example.com/mcp", has_authorization_token=False)
+
+
+def test_public_http_rejected_with_token() -> None:
+    with pytest.raises(UnsafeURLError, match="https"):
+        validate_mcp_url("http://example.com/mcp", has_authorization_token=True)
+
+
+def test_loopback_allowed_by_default() -> None:
+    validate_mcp_url("http://127.0.0.1:9201/mcp", has_authorization_token=False)
+
+
+def test_loopback_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GATEWAY_MCP_ALLOW_LOOPBACK", "false")
+    with pytest.raises(UnsafeURLError, match="loopback"):
+        validate_mcp_url("http://127.0.0.1/mcp", has_authorization_token=False)
+
+
+def test_rfc1918_rejected() -> None:
+    for ip in ("10.0.0.5", "172.16.5.5", "192.168.1.1"):
+        with pytest.raises(UnsafeURLError, match="private"):
+            validate_mcp_url(f"https://{ip}/mcp", has_authorization_token=False)
+
+
+def test_link_local_rejected() -> None:
+    with pytest.raises(UnsafeURLError, match="link-local"):
+        validate_mcp_url("https://169.254.169.254/latest/", has_authorization_token=False)
+
+
+def test_ipv6_link_local_rejected() -> None:
+    with pytest.raises(UnsafeURLError, match="link-local"):
+        validate_mcp_url("https://[fe80::1]/mcp", has_authorization_token=False)
+
+
+def test_non_http_scheme_rejected() -> None:
+    with pytest.raises(UnsafeURLError, match="http or https"):
+        validate_mcp_url("ftp://example.com/mcp", has_authorization_token=False)
+
+
+def test_no_host_rejected() -> None:
+    with pytest.raises(UnsafeURLError, match="hostname"):
+        validate_mcp_url("https:///mcp", has_authorization_token=False)
+
+
+def test_private_override_allows_internal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GATEWAY_MCP_ALLOW_PRIVATE_HOSTS", "true")
+    validate_mcp_url("https://10.0.0.5/mcp", has_authorization_token=False)

--- a/tests/unit/test_url_safety.py
+++ b/tests/unit/test_url_safety.py
@@ -57,3 +57,26 @@ def test_no_host_rejected() -> None:
 def test_private_override_allows_internal(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GATEWAY_MCP_ALLOW_PRIVATE_HOSTS", "true")
     validate_mcp_url("https://10.0.0.5/mcp", has_authorization_token=False)
+
+
+def test_unresolvable_host_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hostnames that fail to resolve are rejected (DNS-rebinding TOCTOU).
+
+    A name that doesn't resolve at validation time could resolve to an internal
+    address at fetch time. Operators that genuinely want this behaviour opt in
+    via GATEWAY_MCP_ALLOW_PRIVATE_HOSTS.
+    """
+    from gateway.services import url_safety
+
+    monkeypatch.setattr(url_safety, "_resolve_all", lambda _host: [])
+    with pytest.raises(UnsafeURLError, match="could not be resolved"):
+        validate_mcp_url("https://does-not-exist.invalid/mcp", has_authorization_token=False)
+
+
+def test_unresolvable_host_allowed_with_private_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The private-hosts opt-out also covers unresolvable hostnames."""
+    from gateway.services import url_safety
+
+    monkeypatch.setenv("GATEWAY_MCP_ALLOW_PRIVATE_HOSTS", "true")
+    monkeypatch.setattr(url_safety, "_resolve_all", lambda _host: [])
+    validate_mcp_url("https://does-not-exist.invalid/mcp", has_authorization_token=False)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -855,6 +855,7 @@ dependencies = [
     { name = "asyncpg" },
     { name = "click" },
     { name = "fastapi" },
+    { name = "mcp" },
     { name = "prometheus-client" },
     { name = "psycopg2-binary" },
     { name = "pydantic-settings" },
@@ -885,6 +886,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "mcp", specifier = ">=1.0.0" },
     { name = "prometheus-client", specifier = ">=0.20.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
@@ -1159,6 +1161,15 @@ http2 = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "huggingface-hub"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1370,6 +1381,33 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "langchain-core"
 version = "1.2.28"
 source = { registry = "https://pypi.org/simple" }
@@ -1553,6 +1591,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
 ]
 
 [[package]]
@@ -2295,6 +2358,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pynacl"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2431,6 +2508,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.28"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2026.1.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -2489,6 +2575,19 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2526,6 +2625,72 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
 ]
 
 [[package]]
@@ -2634,6 +2799,19 @@ wheels = [
 [package.optional-dependencies]
 asyncio = [
     { name = "greenlet" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds MCP tool-use support to `/v1/chat/completions`. When a request body includes `mcp_servers`, the gateway connects to each server (Streamable HTTP), exposes its tools to the model in OpenAI function-tool format, runs an internal tool-use loop (executes tool calls, feeds results back, re-streams the model's response), and returns the final assistant message to the caller. Streaming-aware.

Any model the gateway can route to — open-weight or frontier — gains MCP tool-use through this code path. The model never knows MCP exists; it sees a regular `tools[]` array.

## What's in it

**The loop itself** (`src/gateway/services/mcp_loop.py`)
- Streaming and non-streaming variants. The streaming variant yields chunks across multiple inner `acompletion` calls as a single `AsyncIterator[ChatCompletionChunk]`, so the existing SSE pipeline (`streaming_generator`) is unchanged.
- Tool execution surfaces failures as `role: "tool"` messages with `[tool error]` so the model can recover. Cancellation and programming errors propagate.
- Per-iteration cap (`max_tool_iterations`, default 10, server cap 25). Configurable per-request.
- Multi-turn tool calls in a single round are dispatched together.

**MCP client** (`src/gateway/services/mcp_client.py`)
- `MCPClientPool` is an async-context-managed pool of live MCP sessions for one request's lifetime.
- Converts MCP tools to OpenAI function-tool format. Tool name collisions across servers: first server wins, later same-named tools dropped entirely.
- Smart content-block flattening: text passes through verbatim; image and embedded-resource blocks render as informative `[image type=… ]` / `[resource uri=…]` placeholders.

**URL safety** (`src/gateway/services/url_safety.py`)
- Rejects RFC 1918 / link-local / multicast / unspecified / reserved IP ranges. DNS resolution is checked too.
- Loopback allowed by default (sidecars, dev). Override via `GATEWAY_MCP_ALLOW_LOOPBACK=false`.
- Operator-wide opt-out via `GATEWAY_MCP_ALLOW_PRIVATE_HOSTS=true`.
- Plain `http://` URLs rejected when an `authorization_token` is set — credentials don't go on the wire in cleartext.

**Request body fields**
```jsonc
{
  "mcp_servers": [
    {
      "name": "calendar",
      "url": "https://my-calendar.example.com/mcp",
      "authorization_token": "...",
      "purpose_hint": "Use for any question about the user's schedule.",
      "allowed_tools": ["search_events", "list_events"]
    }
  ],
  "max_tool_iterations": 10
}
```

## Test plan

- [x] 115 unit tests pass (`tests/unit/`)
- [x] mypy + ruff clean on touched files
- [x] End-to-end smoke verified against a real local llamafile + a real local MCP server: model emits tool_calls, gateway executes against MCP, model returns correct final answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)