### PR TITLE
feat(chat): resolve workspace-scoped MCP server ids in platform mode

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -229,6 +229,21 @@
             ],
             "title": "Max Tool Iterations"
           },
+          "mcp_server_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mcp Server Ids"
+          },
           "mcp_servers": {
             "anyOf": [
               {

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -563,10 +563,21 @@ async def _resolve_platform_mcp_servers(
             for s in payload.get("servers", [])
         ]
 
-    if response.status_code in {401, 403, 404}:
+    # Mirror the status-code semantics of `_resolve_platform_credentials`:
+    # client errors (auth/quota/not-found/rate-limit) are forwarded so the
+    # caller sees the real status (and can honour Retry-After on 429), while
+    # the platform's server-side or unexpected responses collapse to 502.
+    if response.status_code in {401, 402, 403, 404, 429}:
+        detail = _safe_detail_from_platform(response, "MCP server resolution failed")
+        response_headers: dict[str, str] | None = None
+        if response.status_code == 429 and response.headers.get("Retry-After"):
+            response_headers = {"Retry-After": response.headers["Retry-After"]}
+        raise HTTPException(status_code=response.status_code, detail=detail, headers=response_headers)
+
+    if response.status_code == 422 or response.status_code >= 500:
         raise HTTPException(
-            status_code=response.status_code,
-            detail=_safe_detail_from_platform(response, "MCP server resolution failed"),
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authorization service unavailable",
         )
 
     raise HTTPException(

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -659,6 +659,7 @@ async def chat_completions(
     rate_limit_info: RateLimitInfo | None = None
     platform_mode = config.is_platform_mode
     route: ResolvedRoute | None = None
+    user_token: str | None = None  # set inside the platform_mode branch; referenced again later
 
     if platform_mode:
         user_token = _extract_platform_user_token(raw_request)
@@ -722,6 +723,7 @@ async def chat_completions(
             detail="mcp_server_ids is only available in platform mode",
         )
     if platform_mode and request.mcp_server_ids:
+        assert user_token is not None  # guaranteed by the platform_mode branch above
         resolved_mcp_servers = await _resolve_platform_mcp_servers(
             config=config,
             user_token=user_token,

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -84,7 +84,13 @@ def _is_code_execution_tool_type(type_value: Any) -> bool:
 # don't accept as ``acompletion`` kwargs. Strip these from the model_dump
 # before forwarding to upstream — Anthropic in particular rejects unknown
 # kwargs with a hard error.
-_GATEWAY_INTERNAL_FIELDS = ("mcp_servers", "tools_header", "max_tool_iterations", "user")
+_GATEWAY_INTERNAL_FIELDS = (
+    "mcp_servers",
+    "mcp_server_ids",
+    "tools_header",
+    "max_tool_iterations",
+    "user",
+)
 
 
 def _strip_gateway_fields(
@@ -176,6 +182,7 @@ class ChatCompletionRequest(BaseModel):
     tool_choice: str | dict[str, Any] | None = None
     response_format: dict[str, Any] | None = None
     mcp_servers: list[McpServerConfig] | None = None
+    mcp_server_ids: list[uuid.UUID] | None = None
     tools_header: str | None = Field(
         default=None,
         max_length=4000,
@@ -512,6 +519,62 @@ def _classify_upstream_error(exc: BaseException) -> tuple[bool, str]:
     return False, "unknown"
 
 
+async def _resolve_platform_mcp_servers(
+    config: GatewayConfig,
+    user_token: str,
+    mcp_server_ids: list[uuid.UUID],
+) -> list[McpServerConfig]:
+    """Swap workspace-scoped MCP server ids for inline configs by calling the platform."""
+    platform_base_url = config.platform.get("base_url")
+    if not platform_base_url:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Platform mode is misconfigured",
+        )
+
+    timeout_ms = int(config.platform.get("resolve_timeout_ms", 5000))
+    resolve_url = _platform_url(platform_base_url, "/gateway/mcp-servers/resolve")
+    headers = {
+        "X-Gateway-Token": config.platform_token or "",
+        "X-User-Token": user_token,
+    }
+    body: dict[str, Any] = {"mcp_server_ids": [str(uid) for uid in mcp_server_ids]}
+
+    try:
+        response = await _post_platform(
+            url=resolve_url, headers=headers, body=body, timeout_seconds=timeout_ms / 1000
+        )
+    except (httpx.TimeoutException, httpx.NetworkError):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authorization service unavailable",
+        ) from None
+
+    if response.status_code == 200:
+        payload = response.json()
+        return [
+            McpServerConfig(
+                name=s["name"],
+                url=s["url"],
+                authorization_token=s.get("authorization_token"),
+                purpose_hint=s.get("purpose_hint"),
+                allowed_tools=s.get("allowed_tools"),
+            )
+            for s in payload.get("servers", [])
+        ]
+
+    if response.status_code in {401, 403, 404}:
+        raise HTTPException(
+            status_code=response.status_code,
+            detail=_safe_detail_from_platform(response, "MCP server resolution failed"),
+        )
+
+    raise HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail="Authorization service unavailable",
+    )
+
+
 async def _report_platform_usage(
     config: GatewayConfig,
     correlation_id: str,
@@ -645,6 +708,26 @@ async def chat_completions(
         _ = await validate_user_budget(db, user_id, request.model, strategy=config.budget_strategy)
         if config.budget_strategy == "for_update":
             await db.rollback()
+
+    # Workspace-scoped MCP server references (platform mode only). Callers
+    # pass `mcp_server_ids: [uuid, ...]` instead of inlining each config; we
+    # resolve them against the platform's `/gateway/mcp-servers/resolve`
+    # endpoint and merge with any inline `mcp_servers` so the downstream
+    # MCP loop sees a single list. In standalone mode there's no platform
+    # to consult, so we reject the field with a 400 rather than silently
+    # ignoring it.
+    if request.mcp_server_ids and not platform_mode:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="mcp_server_ids is only available in platform mode",
+        )
+    if platform_mode and request.mcp_server_ids:
+        resolved_mcp_servers = await _resolve_platform_mcp_servers(
+            config=config,
+            user_token=user_token,
+            mcp_server_ids=request.mcp_server_ids,
+        )
+        request.mcp_servers = (request.mcp_servers or []) + resolved_mcp_servers
 
     # Per-request opt-in for sandboxed code execution. Matches Anthropic /
     # OpenAI's wire shape: caller adds {"type": "code_execution"} to their

--- a/tests/unit/test_mcp_server_id_resolve.py
+++ b/tests/unit/test_mcp_server_id_resolve.py
@@ -29,7 +29,9 @@ def _ok_response(servers: list[dict[str, Any]]) -> httpx.Response:
 async def test_resolve_returns_configs(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 
-    async def fake_post(*, url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float) -> httpx.Response:
+    async def fake_post(
+        *, url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
         captured["url"] = url
         captured["headers"] = headers
         captured["body"] = body

--- a/tests/unit/test_mcp_server_id_resolve.py
+++ b/tests/unit/test_mcp_server_id_resolve.py
@@ -125,3 +125,58 @@ async def test_resolve_misconfigured_platform_500() -> None:
     with pytest.raises(HTTPException) as ei:
         await _resolve_platform_mcp_servers(_config(base_url=None), "tk", [uuid.uuid4()])
     assert ei.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_resolve_429_passthrough_with_retry_after(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A platform 429 should forward verbatim (status + Retry-After header)
+    so clients can back off correctly, matching `_resolve_platform_credentials`."""
+
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return httpx.Response(429, json={"detail": "slow down"}, headers={"Retry-After": "30"})
+
+    monkeypatch.setattr(chat_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_mcp_servers(_config(), "tk", [uuid.uuid4()])
+    assert ei.value.status_code == 429
+    assert ei.value.headers == {"Retry-After": "30"}
+    assert ei.value.detail == "slow down"
+
+
+@pytest.mark.asyncio
+async def test_resolve_402_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    """402 (payment required / quota) should forward verbatim, matching
+    `_resolve_platform_credentials`'s behaviour for the same code."""
+
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return httpx.Response(402, json={"detail": "quota exhausted"})
+
+    monkeypatch.setattr(chat_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_mcp_servers(_config(), "tk", [uuid.uuid4()])
+    assert ei.value.status_code == 402
+    assert ei.value.detail == "quota exhausted"
+
+
+@pytest.mark.asyncio
+async def test_resolve_422_collapses_to_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    """422 from the platform indicates a gateway↔platform schema mismatch,
+    not something the caller can usefully act on — collapse to 502 like
+    `_resolve_platform_credentials` does."""
+
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return httpx.Response(422, json={"detail": "schema mismatch"})
+
+    monkeypatch.setattr(chat_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_mcp_servers(_config(), "tk", [uuid.uuid4()])
+    assert ei.value.status_code == 502

--- a/tests/unit/test_mcp_server_id_resolve.py
+++ b/tests/unit/test_mcp_server_id_resolve.py
@@ -1,0 +1,125 @@
+"""Unit tests for resolving workspace-scoped MCP server ids via the platform service."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from gateway.api.routes import chat as chat_module
+from gateway.api.routes.chat import _resolve_platform_mcp_servers
+from gateway.models.mcp import McpServerConfig
+
+
+def _config(*, base_url: str | None = "https://platform.local") -> Any:
+    cfg = MagicMock()
+    cfg.platform = {"base_url": base_url, "resolve_timeout_ms": 5000} if base_url else {}
+    cfg.platform_token = "gw_test_token"
+    return cfg
+
+
+def _ok_response(servers: list[dict[str, Any]]) -> httpx.Response:
+    return httpx.Response(200, json={"servers": servers})
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_configs(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_post(*, url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float) -> httpx.Response:
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["body"] = body
+        return _ok_response(
+            [
+                {
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "name": "calendar",
+                    "url": "https://example.com/mcp",
+                    "authorization_token": "ya29.x",
+                    "purpose_hint": "scheduling",
+                    "allowed_tools": ["list_events"],
+                },
+            ]
+        )
+
+    monkeypatch.setattr(chat_module, "_post_platform", fake_post)
+
+    ids = [uuid.UUID("11111111-1111-1111-1111-111111111111")]
+    out = await _resolve_platform_mcp_servers(_config(), "tk_user", ids)
+
+    assert isinstance(out[0], McpServerConfig)
+    assert out[0].name == "calendar"
+    assert out[0].authorization_token == "ya29.x"
+    assert out[0].purpose_hint == "scheduling"
+    assert out[0].allowed_tools == ["list_events"]
+
+    assert captured["url"].endswith("/gateway/mcp-servers/resolve")
+    assert captured["headers"]["X-Gateway-Token"] == "gw_test_token"
+    assert captured["headers"]["X-User-Token"] == "tk_user"
+    assert captured["body"] == {"mcp_server_ids": ["11111111-1111-1111-1111-111111111111"]}
+
+
+@pytest.mark.asyncio
+async def test_resolve_empty_servers_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return _ok_response([])
+
+    monkeypatch.setattr(chat_module, "_post_platform", fake_post)
+    out = await _resolve_platform_mcp_servers(_config(), "tk", [uuid.uuid4()])
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_404_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return httpx.Response(404, json={"detail": "MCPServer not found"})
+
+    monkeypatch.setattr(chat_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_mcp_servers(_config(), "tk", [uuid.uuid4()])
+    assert ei.value.status_code == 404
+    assert ei.value.detail == "MCPServer not found"
+
+
+@pytest.mark.asyncio
+async def test_resolve_5xx_maps_to_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return httpx.Response(503, text="busy")
+
+    monkeypatch.setattr(chat_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_mcp_servers(_config(), "tk", [uuid.uuid4()])
+    assert ei.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_resolve_network_error_maps_to_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        raise httpx.NetworkError("connection refused")
+
+    monkeypatch.setattr(chat_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_mcp_servers(_config(), "tk", [uuid.uuid4()])
+    assert ei.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_resolve_misconfigured_platform_500() -> None:
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_mcp_servers(_config(base_url=None), "tk", [uuid.uuid4()])
+    assert ei.value.status_code == 500


### PR DESCRIPTION
## Summary

Stacked on top of #63. Adds platform-mode resolution of workspace-scoped MCP server ids.

Callers can reference an MCP server by `mcp_server_ids: [uuid, ...]` instead of inlining the full config. The gateway resolves the ids against the configured platform service (same dual-token auth pattern as `/gateway/provider-keys/resolve` — `X-Gateway-Token` + `X-User-Token`), converts each result back into an `McpServerConfig`, merges with any inline `mcp_servers`, and feeds the merged set into the existing MCP loop from #63.

In standalone mode, `mcp_server_ids` returns 400 — there's no platform service to consult.

## Wire shape

```jsonc
// Inline (works in any mode, from #63)
{ "mcp_servers": [{ "name": "...", "url": "...", "authorization_token": "..." }] }

// By reference (platform mode only, this PR)
{ "mcp_server_ids": ["uuid-1", "uuid-2"] }

// Both at once is fine — they merge
{ "mcp_servers": [...], "mcp_server_ids": [...] }
```

## Platform-side contract

For this to be useful, the platform service needs to implement:

```
POST /gateway/mcp-servers/resolve
Headers: X-Gateway-Token, X-User-Token
Body:    { "mcp_server_ids": ["uuid", ...] }
Returns: { "servers": [
  { "name": "...", "url": "...", "authorization_token": "?", "purpose_hint": "?", "allowed_tools": "?" },
  ...
]}
```

Generic contract — any service that speaks the gateway-platform protocol can implement it.

## Test plan

- [x] 115 unit tests pass (`tests/unit/`)
- [x] mypy + ruff clean
- [x] httpx-mocked tests covering: happy path resolve, 404 passthrough, 5xx → 502, network error → 502, misconfigured-platform → 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)