### PR TITLE
feat: auto-discover models from configured providers for /v1/models

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1151,6 +1151,16 @@
           "owned_by": {
             "title": "Owned By",
             "type": "string"
+          },
+          "pricing": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ModelPricingInfo"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
@@ -1161,136 +1171,23 @@
         "title": "ModelObject",
         "type": "object"
       },
-      "ModerationRequest": {
-        "description": "OpenAI-compatible moderation request.",
+      "ModelPricingInfo": {
+        "description": "Pricing information for a model.",
         "properties": {
-          "input": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "items": {
-                  "additionalProperties": true,
-                  "type": "object"
-                },
-                "type": "array"
-              }
-            ],
-            "description": "Text, list of texts, or list of content-part dicts to moderate",
-            "title": "Input"
+          "input_price_per_million": {
+            "title": "Input Price Per Million",
+            "type": "number"
           },
-          "model": {
-            "title": "Model",
-            "type": "string"
-          },
-          "user": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User"
+          "output_price_per_million": {
+            "title": "Output Price Per Million",
+            "type": "number"
           }
         },
         "required": [
-          "model",
-          "input"
+          "input_price_per_million",
+          "output_price_per_million"
         ],
-        "title": "ModerationRequest",
-        "type": "object"
-      },
-      "ModerationResponse": {
-        "description": "Normalized moderation response across providers.",
-        "properties": {
-          "id": {
-            "title": "Id",
-            "type": "string"
-          },
-          "model": {
-            "title": "Model",
-            "type": "string"
-          },
-          "results": {
-            "items": {
-              "$ref": "#/components/schemas/ModerationResult"
-            },
-            "title": "Results",
-            "type": "array"
-          }
-        },
-        "required": [
-          "id",
-          "model",
-          "results"
-        ],
-        "title": "ModerationResponse",
-        "type": "object"
-      },
-      "ModerationResult": {
-        "description": "A single moderation decision, typically one per input item.",
-        "properties": {
-          "categories": {
-            "additionalProperties": {
-              "type": "boolean"
-            },
-            "title": "Categories",
-            "type": "object"
-          },
-          "category_applied_input_types": {
-            "anyOf": [
-              {
-                "additionalProperties": {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Category Applied Input Types"
-          },
-          "category_scores": {
-            "additionalProperties": {
-              "type": "number"
-            },
-            "title": "Category Scores",
-            "type": "object"
-          },
-          "flagged": {
-            "title": "Flagged",
-            "type": "boolean"
-          },
-          "provider_raw": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Provider Raw"
-          }
-        },
-        "required": [
-          "flagged"
-        ],
-        "title": "ModerationResult",
+        "title": "ModelPricingInfo",
         "type": "object"
       },
       "PricingResponse": {
@@ -1330,75 +1227,6 @@
           "updated_at"
         ],
         "title": "PricingResponse",
-        "type": "object"
-      },
-      "RerankRequest": {
-        "description": "Rerank request.",
-        "properties": {
-          "documents": {
-            "description": "List of document strings to rerank",
-            "items": {
-              "type": "string"
-            },
-            "minItems": 1,
-            "title": "Documents",
-            "type": "array"
-          },
-          "max_tokens_per_doc": {
-            "anyOf": [
-              {
-                "exclusiveMinimum": 0.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Per-document truncation limit",
-            "title": "Max Tokens Per Doc"
-          },
-          "model": {
-            "description": "Provider-prefixed model ID, e.g. 'cohere:rerank-v3.5'",
-            "title": "Model",
-            "type": "string"
-          },
-          "query": {
-            "description": "The search query to rerank documents against",
-            "title": "Query",
-            "type": "string"
-          },
-          "top_n": {
-            "anyOf": [
-              {
-                "exclusiveMinimum": 0.0,
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Maximum number of results to return",
-            "title": "Top N"
-          },
-          "user": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "User ID for usage attribution",
-            "title": "User"
-          }
-        },
-        "required": [
-          "model",
-          "query",
-          "documents"
-        ],
-        "title": "RerankRequest",
         "type": "object"
       },
       "ResponsesRequest": {
@@ -3087,8 +2915,28 @@
     },
     "/v1/models": {
       "get": {
-        "description": "List all available models.\n\nReturns models derived from the model_pricing table in an\nOpenAI-compatible format.",
+        "description": "List all available models.\n\nReturns models auto-discovered from configured providers, enriched with\npricing data from the model_pricing table when available. Models that only\nexist in the pricing table are also included for backward compatibility.",
         "operationId": "list_models_v1_models_get",
+        "parameters": [
+          {
+            "description": "Filter models by provider name",
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter models by provider name",
+              "title": "Provider"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -3099,6 +2947,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "List Models",
@@ -3147,60 +3005,6 @@
         "summary": "Get Model",
         "tags": [
           "models"
-        ]
-      }
-    },
-    "/v1/moderations": {
-      "post": {
-        "description": "OpenAI-compatible moderations endpoint.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
-        "operationId": "create_moderation_v1_moderations_post",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "include_raw",
-            "required": false,
-            "schema": {
-              "default": false,
-              "title": "Include Raw",
-              "type": "boolean"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ModerationRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ModerationResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Create Moderation",
-        "tags": [
-          "moderations"
         ]
       }
     },
@@ -3464,46 +3268,6 @@
         "summary": "Get Pricing History",
         "tags": [
           "pricing"
-        ]
-      }
-    },
-    "/v1/rerank": {
-      "post": {
-        "description": "Rerank documents by relevance to a query.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
-        "operationId": "create_rerank_v1_rerank_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RerankRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Create Rerank",
-        "tags": [
-          "rerank"
         ]
       }
     },

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1190,6 +1190,138 @@
         "title": "ModelPricingInfo",
         "type": "object"
       },
+      "ModerationRequest": {
+        "description": "OpenAI-compatible moderation request.",
+        "properties": {
+          "input": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "Text, list of texts, or list of content-part dicts to moderate",
+            "title": "Input"
+          },
+          "model": {
+            "title": "Model",
+            "type": "string"
+          },
+          "user": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User"
+          }
+        },
+        "required": [
+          "model",
+          "input"
+        ],
+        "title": "ModerationRequest",
+        "type": "object"
+      },
+      "ModerationResponse": {
+        "description": "Normalized moderation response across providers.",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "model": {
+            "title": "Model",
+            "type": "string"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/ModerationResult"
+            },
+            "title": "Results",
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "model",
+          "results"
+        ],
+        "title": "ModerationResponse",
+        "type": "object"
+      },
+      "ModerationResult": {
+        "description": "A single moderation decision, typically one per input item.",
+        "properties": {
+          "categories": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "title": "Categories",
+            "type": "object"
+          },
+          "category_applied_input_types": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category Applied Input Types"
+          },
+          "category_scores": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "title": "Category Scores",
+            "type": "object"
+          },
+          "flagged": {
+            "title": "Flagged",
+            "type": "boolean"
+          },
+          "provider_raw": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider Raw"
+          }
+        },
+        "required": [
+          "flagged"
+        ],
+        "title": "ModerationResult",
+        "type": "object"
+      },
       "PricingResponse": {
         "description": "Response model for model pricing.",
         "properties": {
@@ -1227,6 +1359,75 @@
           "updated_at"
         ],
         "title": "PricingResponse",
+        "type": "object"
+      },
+      "RerankRequest": {
+        "description": "Rerank request.",
+        "properties": {
+          "documents": {
+            "description": "List of document strings to rerank",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Documents",
+            "type": "array"
+          },
+          "max_tokens_per_doc": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-document truncation limit",
+            "title": "Max Tokens Per Doc"
+          },
+          "model": {
+            "description": "Provider-prefixed model ID, e.g. 'cohere:rerank-v3.5'",
+            "title": "Model",
+            "type": "string"
+          },
+          "query": {
+            "description": "The search query to rerank documents against",
+            "title": "Query",
+            "type": "string"
+          },
+          "top_n": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Maximum number of results to return",
+            "title": "Top N"
+          },
+          "user": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "User ID for usage attribution",
+            "title": "User"
+          }
+        },
+        "required": [
+          "model",
+          "query",
+          "documents"
+        ],
+        "title": "RerankRequest",
         "type": "object"
       },
       "ResponsesRequest": {
@@ -3008,6 +3209,60 @@
         ]
       }
     },
+    "/v1/moderations": {
+      "post": {
+        "description": "OpenAI-compatible moderations endpoint.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
+        "operationId": "create_moderation_v1_moderations_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "include_raw",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Raw",
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModerationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModerationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Moderation",
+        "tags": [
+          "moderations"
+        ]
+      }
+    },
     "/v1/pricing": {
       "get": {
         "description": "List all model pricing.",
@@ -3268,6 +3523,46 @@
         "summary": "Get Pricing History",
         "tags": [
           "pricing"
+        ]
+      }
+    },
+    "/v1/rerank": {
+      "post": {
+        "description": "Rerank documents by relevance to a query.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
+        "operationId": "create_rerank_v1_rerank_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RerankRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Rerank",
+        "tags": [
+          "rerank"
         ]
       }
     },

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -20,7 +20,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db_if_needed, get_log_writer, verify_api_key_or_master_key
 from gateway.api.routes._helpers import resolve_user_id
-from gateway.auth.vertex_auth import setup_vertex_environment
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.metrics import record_cost, record_tokens
@@ -39,6 +38,7 @@ from gateway.services.mcp_loop import (
     mcp_tool_loop_stream,
 )
 from gateway.services.pricing_service import find_model_pricing
+from gateway.services.provider_kwargs import get_provider_kwargs as get_provider_kwargs  # noqa: F401
 from gateway.services.sandbox_backend import SandboxBackend, SandboxNotReachableError
 from gateway.services.web_search_backend import WebSearchBackend, WebSearchNotReachableError
 from gateway.streaming import (
@@ -298,46 +298,6 @@ class ChatCompletionRequest(BaseModel):
         ),
     )
     max_tool_iterations: int | None = Field(default=None, ge=1, le=MAX_TOOL_ITERATIONS_CAP)
-
-
-def get_provider_kwargs(
-    config: GatewayConfig,
-    provider: LLMProvider,
-) -> dict[str, Any]:
-    """Get provider kwargs from config for acompletion calls.
-
-    Args:
-        config: Gateway configuration
-        provider: Provider name
-
-    Returns:
-        Dictionary of provider kwargs (credentials, client_args, etc.)
-
-    """
-    kwargs: dict[str, Any] = {}
-    if provider.value in config.providers:
-        provider_config = config.providers[provider.value]
-
-        if provider == LLMProvider.VERTEXAI:
-            vertex_creds = provider_config.get("credentials")
-            vertex_project = provider_config.get("project")
-            vertex_location = provider_config.get("location")
-
-            kwargs.update(
-                setup_vertex_environment(
-                    credentials=vertex_creds,
-                    project=vertex_project,
-                    location=vertex_location,
-                )
-            )
-            if "client_args" in provider_config:
-                kwargs["client_args"] = provider_config["client_args"]
-        else:
-            kwargs = {k: v for k, v in provider_config.items() if k != "client_args"}
-            if "client_args" in provider_config:
-                kwargs["client_args"] = provider_config["client_args"]
-
-    return kwargs
 
 
 async def log_usage(

--- a/src/gateway/api/routes/models.py
+++ b/src/gateway/api/routes/models.py
@@ -148,20 +148,21 @@ async def get_model(
     pricing = (await db.execute(stmt)).scalar_one_or_none()
 
     # Check the discovery cache for this model (respecting TTL).
+    # Parse provider from model_id ("provider:model_name") for a targeted lookup
+    # instead of scanning all cached providers.
     discovered_model = None
     discovered_provider = None
-    if config.model_discovery:
+    if config.model_discovery and ":" in model_id:
+        provider_prefix, model_name = model_id.split(":", 1)
         cache = get_model_cache()
         ttl = config.model_cache_ttl_seconds
-        for provider_name, models in cache.get_all_cached(ttl=ttl).items():
-            for model in models:
-                cache_key = f"{provider_name}:{model.id}"
-                if cache_key == model_id:
+        cached_models = cache.get(provider_prefix, ttl)
+        if cached_models is not None:
+            for model in cached_models:
+                if model.id == model_name:
                     discovered_model = model
-                    discovered_provider = provider_name
+                    discovered_provider = provider_prefix
                     break
-            if discovered_model:
-                break
 
     if not pricing and not discovered_model:
         raise HTTPException(

--- a/src/gateway/api/routes/models.py
+++ b/src/gateway/api/routes/models.py
@@ -107,13 +107,13 @@ async def list_models(
             logger.exception("Model discovery failed unexpectedly")
             discovered = []
 
-        for model in discovered:
-            model_key = f"{model.owned_by}:{model.id}" if ":" not in model.id else model.id
+        for provider_name, model in discovered:
+            model_key = f"{provider_name}:{model.id}"
             pricing = pricing_map.pop(model_key, None)
             merged[model_key] = ModelObject(
                 id=model_key,
                 created=model.created,
-                owned_by=model.owned_by,
+                owned_by=provider_name,
                 pricing=ModelPricingInfo(
                     input_price_per_million=pricing.input_price_per_million,
                     output_price_per_million=pricing.output_price_per_million,
@@ -147,15 +147,18 @@ async def get_model(
     )
     pricing = (await db.execute(stmt)).scalar_one_or_none()
 
-    # Check the discovery cache for this model.
+    # Check the discovery cache for this model (respecting TTL).
     discovered_model = None
+    discovered_provider = None
     if config.model_discovery:
         cache = get_model_cache()
-        for models in cache.get_all_cached().values():
+        ttl = config.model_cache_ttl_seconds
+        for provider_name, models in cache.get_all_cached(ttl=ttl).items():
             for model in models:
-                cache_key = f"{model.owned_by}:{model.id}" if ":" not in model.id else model.id
+                cache_key = f"{provider_name}:{model.id}"
                 if cache_key == model_id:
                     discovered_model = model
+                    discovered_provider = provider_name
                     break
             if discovered_model:
                 break
@@ -168,15 +171,12 @@ async def get_model(
 
     # Build the response, merging both sources.
     if discovered_model:
-        model_key = (
-            f"{discovered_model.owned_by}:{discovered_model.id}"
-            if ":" not in discovered_model.id
-            else discovered_model.id
-        )
+        assert discovered_provider is not None
+        model_key = f"{discovered_provider}:{discovered_model.id}"
         return ModelObject(
             id=model_key,
             created=discovered_model.created,
-            owned_by=discovered_model.owned_by,
+            owned_by=discovered_provider,
             pricing=ModelPricingInfo(
                 input_price_per_million=pricing.input_price_per_million,
                 output_price_per_million=pricing.output_price_per_million,

--- a/src/gateway/api/routes/models.py
+++ b/src/gateway/api/routes/models.py
@@ -1,17 +1,27 @@
-"""OpenAI-compatible models listing endpoint."""
+"""OpenAI-compatible models listing endpoint with auto-discovery."""
 
 import calendar
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.api.deps import get_db, verify_api_key_or_master_key
+from gateway.api.deps import get_config, get_db, verify_api_key_or_master_key
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger
 from gateway.models.entities import ModelPricing
+from gateway.services.model_discovery_service import discover_all_models, get_model_cache
 
 router = APIRouter(prefix="/v1", tags=["models"])
+
+
+class ModelPricingInfo(BaseModel):
+    """Pricing information for a model."""
+
+    input_price_per_million: float
+    output_price_per_million: float
 
 
 class ModelObject(BaseModel):
@@ -21,6 +31,7 @@ class ModelObject(BaseModel):
     object: str = "model"
     created: int
     owned_by: str
+    pricing: ModelPricingInfo | None = None
 
 
 class ModelListResponse(BaseModel):
@@ -39,18 +50,15 @@ def _model_from_pricing(pricing: ModelPricing) -> ModelObject:
         id=pricing.model_key,
         created=created,
         owned_by=owned_by,
+        pricing=ModelPricingInfo(
+            input_price_per_million=pricing.input_price_per_million,
+            output_price_per_million=pricing.output_price_per_million,
+        ),
     )
 
 
-@router.get("/models", dependencies=[Depends(verify_api_key_or_master_key)])
-async def list_models(
-    db: Annotated[AsyncSession, Depends(get_db)],
-) -> ModelListResponse:
-    """List all available models.
-
-    Returns models derived from the model_pricing table in an
-    OpenAI-compatible format.
-    """
+async def _get_pricing_map(db: AsyncSession, provider_filter: str | None = None) -> dict[str, ModelPricing]:
+    """Load latest pricing per model_key, optionally filtered by provider prefix."""
     latest_effective = (
         select(
             ModelPricing.model_key.label("model_key"),
@@ -60,26 +68,77 @@ async def list_models(
         .subquery()
     )
 
-    stmt = (
-        select(ModelPricing)
-        .join(
-            latest_effective,
-            (ModelPricing.model_key == latest_effective.c.model_key)
-            & (ModelPricing.effective_at == latest_effective.c.effective_at),
-        )
-        .order_by(ModelPricing.model_key)
+    stmt = select(ModelPricing).join(
+        latest_effective,
+        (ModelPricing.model_key == latest_effective.c.model_key)
+        & (ModelPricing.effective_at == latest_effective.c.effective_at),
     )
+
+    if provider_filter:
+        stmt = stmt.where(ModelPricing.model_key.startswith(f"{provider_filter}:"))
+
+    stmt = stmt.order_by(ModelPricing.model_key)
     result = await db.execute(stmt)
     pricings = result.scalars().all()
-    return ModelListResponse(data=[_model_from_pricing(p) for p in pricings])
+    return {p.model_key: p for p in pricings}
+
+
+@router.get("/models", dependencies=[Depends(verify_api_key_or_master_key)])
+async def list_models(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    provider: Annotated[str | None, Query(description="Filter models by provider name")] = None,
+) -> ModelListResponse:
+    """List all available models.
+
+    Returns models auto-discovered from configured providers, enriched with
+    pricing data from the model_pricing table when available. Models that only
+    exist in the pricing table are also included for backward compatibility.
+    """
+    pricing_map = await _get_pricing_map(db, provider_filter=provider)
+
+    merged: dict[str, ModelObject] = {}
+
+    # Phase 1: auto-discovered models from upstream providers.
+    if config.model_discovery:
+        try:
+            discovered = await discover_all_models(config, provider_filter=provider)
+        except Exception:
+            logger.exception("Model discovery failed unexpectedly")
+            discovered = []
+
+        for model in discovered:
+            model_key = f"{model.owned_by}:{model.id}" if ":" not in model.id else model.id
+            pricing = pricing_map.pop(model_key, None)
+            merged[model_key] = ModelObject(
+                id=model_key,
+                created=model.created,
+                owned_by=model.owned_by,
+                pricing=ModelPricingInfo(
+                    input_price_per_million=pricing.input_price_per_million,
+                    output_price_per_million=pricing.output_price_per_million,
+                )
+                if pricing
+                else None,
+            )
+
+    # Phase 2: pricing-only models (not discovered but have pricing entries).
+    for model_key, pricing in pricing_map.items():
+        if model_key not in merged:
+            merged[model_key] = _model_from_pricing(pricing)
+
+    sorted_models = sorted(merged.values(), key=lambda m: m.id)
+    return ModelListResponse(data=sorted_models)
 
 
 @router.get("/models/{model_id:path}", dependencies=[Depends(verify_api_key_or_master_key)])
 async def get_model(
     model_id: str,
     db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> ModelObject:
     """Get details for a specific model."""
+    # Check the pricing table first.
     stmt = (
         select(ModelPricing)
         .where(ModelPricing.model_key == model_id)
@@ -88,10 +147,44 @@ async def get_model(
     )
     pricing = (await db.execute(stmt)).scalar_one_or_none()
 
-    if not pricing:
+    # Check the discovery cache for this model.
+    discovered_model = None
+    if config.model_discovery:
+        cache = get_model_cache()
+        for models in cache.get_all_cached().values():
+            for model in models:
+                cache_key = f"{model.owned_by}:{model.id}" if ":" not in model.id else model.id
+                if cache_key == model_id:
+                    discovered_model = model
+                    break
+            if discovered_model:
+                break
+
+    if not pricing and not discovered_model:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Model '{model_id}' not found",
         )
 
+    # Build the response, merging both sources.
+    if discovered_model:
+        model_key = (
+            f"{discovered_model.owned_by}:{discovered_model.id}"
+            if ":" not in discovered_model.id
+            else discovered_model.id
+        )
+        return ModelObject(
+            id=model_key,
+            created=discovered_model.created,
+            owned_by=discovered_model.owned_by,
+            pricing=ModelPricingInfo(
+                input_price_per_million=pricing.input_price_per_million,
+                output_price_per_million=pricing.output_price_per_million,
+            )
+            if pricing
+            else None,
+        )
+
+    # Pricing-only model (no discovery data).
+    assert pricing is not None
     return _model_from_pricing(pricing)

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -99,6 +99,15 @@ class GatewayConfig(BaseSettings):
         default="for_update",
         description="Budget validation strategy: 'for_update' (default), 'cas' (lock-free), or 'disabled'.",
     )
+    model_discovery: bool = Field(
+        default=True,
+        description="Enable auto-discovery of models from configured providers via GET /v1/models",
+    )
+    model_cache_ttl_seconds: int = Field(
+        default=300,
+        ge=0,
+        description="TTL in seconds for the in-memory model discovery cache (0 disables caching)",
+    )
     mode: str = Field(default="standalone", description="Gateway operating mode: standalone or platform")
     platform: dict[str, Any] = Field(default_factory=dict, description="Platform integration settings")
 

--- a/src/gateway/services/model_discovery_service.py
+++ b/src/gateway/services/model_discovery_service.py
@@ -8,9 +8,9 @@ from dataclasses import dataclass, field
 from any_llm import AnyLLM, LLMProvider, alist_models
 from any_llm.types.model import Model
 
-from gateway.api.routes.chat import get_provider_kwargs
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
+from gateway.services.provider_kwargs import get_provider_kwargs
 
 
 @dataclass
@@ -57,7 +57,7 @@ class ModelCache:
         """
         result: dict[str, list[Model]] = {}
         now = time.monotonic()
-        for provider, entry in self._store.items():
+        for provider, entry in list(self._store.items()):
             if ttl is not None:
                 elapsed = now - entry.cached_at
                 if ttl <= 0 or elapsed >= ttl:

--- a/src/gateway/services/model_discovery_service.py
+++ b/src/gateway/services/model_discovery_service.py
@@ -29,7 +29,10 @@ class ModelCache:
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
     def get(self, provider: str, ttl: int) -> list[Model] | None:
-        """Return cached models if still valid, otherwise None."""
+        """Return cached models if still valid, otherwise None.
+
+        Returns a shallow copy so callers cannot mutate the internal cache.
+        """
         entry = self._store.get(provider)
         if entry is None:
             return None
@@ -38,15 +41,29 @@ class ModelCache:
         elapsed = time.monotonic() - entry.cached_at
         if elapsed >= ttl:
             return None
-        return entry.models
+        return list(entry.models)
 
     def set(self, provider: str, models: list[Model]) -> None:
         """Store a provider's model list with the current timestamp."""
         self._store[provider] = _CacheEntry(models=list(models), cached_at=time.monotonic())
 
-    def get_all_cached(self) -> dict[str, list[Model]]:
-        """Return all currently stored entries (regardless of TTL)."""
-        return {provider: entry.models for provider, entry in self._store.items()}
+    def get_all_cached(self, ttl: int | None = None) -> dict[str, list[Model]]:
+        """Return stored entries, optionally filtering by TTL.
+
+        Returns shallow copies so callers cannot mutate the internal cache.
+
+        Args:
+            ttl: If set, only return entries that are still valid. If None, return all.
+        """
+        result: dict[str, list[Model]] = {}
+        now = time.monotonic()
+        for provider, entry in self._store.items():
+            if ttl is not None:
+                elapsed = now - entry.cached_at
+                if ttl <= 0 or elapsed >= ttl:
+                    continue
+            result[provider] = list(entry.models)
+        return result
 
     def clear(self, provider: str | None = None) -> None:
         """Invalidate one or all providers."""
@@ -100,7 +117,7 @@ async def _discover_for_provider(
 async def discover_all_models(
     config: GatewayConfig,
     provider_filter: str | None = None,
-) -> list[Model]:
+) -> list[tuple[str, Model]]:
     """Discover models from configured providers with caching.
 
     Args:
@@ -108,7 +125,8 @@ async def discover_all_models(
         provider_filter: If set, only discover models for this provider.
 
     Returns:
-        Combined list of Model objects from all eligible providers.
+        List of (provider_name, Model) tuples so callers can build model_key
+        from the configured provider key rather than relying on ``owned_by``.
 
     """
     cache = get_model_cache()
@@ -120,13 +138,13 @@ async def discover_all_models(
         providers_to_query = list(config.providers.keys())
 
     # Separate providers into cache-hit and cache-miss groups.
-    result_models: list[Model] = []
+    result_models: list[tuple[str, Model]] = []
     providers_needing_fetch: list[str] = []
 
     for provider_name in providers_to_query:
         cached = cache.get(provider_name, ttl)
         if cached is not None:
-            result_models.extend(cached)
+            result_models.extend((provider_name, m) for m in cached)
         else:
             if _supports_list_models(provider_name):
                 providers_needing_fetch.append(provider_name)
@@ -143,7 +161,7 @@ async def discover_all_models(
         for provider_name in providers_needing_fetch:
             cached = cache.get(provider_name, ttl)
             if cached is not None:
-                result_models.extend(cached)
+                result_models.extend((provider_name, m) for m in cached)
             else:
                 still_needed.append(provider_name)
 
@@ -162,6 +180,6 @@ async def discover_all_models(
                     continue
                 _, models = result
                 cache.set(provider_name, models)
-                result_models.extend(models)
+                result_models.extend((provider_name, m) for m in models)
 
     return result_models

--- a/src/gateway/services/model_discovery_service.py
+++ b/src/gateway/services/model_discovery_service.py
@@ -1,0 +1,167 @@
+"""Auto-discovery of models from configured providers with in-memory TTL caching."""
+
+import asyncio
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+from any_llm import AnyLLM, LLMProvider, alist_models
+from any_llm.types.model import Model
+
+from gateway.api.routes.chat import get_provider_kwargs
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger
+
+
+@dataclass
+class _CacheEntry:
+    """A single provider's cached model list."""
+
+    models: list[Model]
+    cached_at: float  # time.monotonic()
+
+
+@dataclass
+class ModelCache:
+    """In-memory TTL cache for discovered models, keyed by provider name."""
+
+    _store: dict[str, _CacheEntry] = field(default_factory=dict)
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    def get(self, provider: str, ttl: int) -> list[Model] | None:
+        """Return cached models if still valid, otherwise None."""
+        entry = self._store.get(provider)
+        if entry is None:
+            return None
+        if ttl <= 0:
+            return None
+        elapsed = time.monotonic() - entry.cached_at
+        if elapsed >= ttl:
+            return None
+        return entry.models
+
+    def set(self, provider: str, models: list[Model]) -> None:
+        """Store a provider's model list with the current timestamp."""
+        self._store[provider] = _CacheEntry(models=list(models), cached_at=time.monotonic())
+
+    def get_all_cached(self) -> dict[str, list[Model]]:
+        """Return all currently stored entries (regardless of TTL)."""
+        return {provider: entry.models for provider, entry in self._store.items()}
+
+    def clear(self, provider: str | None = None) -> None:
+        """Invalidate one or all providers."""
+        if provider is None:
+            self._store.clear()
+        else:
+            self._store.pop(provider, None)
+
+
+# Module-level singleton shared across requests within a worker process.
+_model_cache = ModelCache()
+
+
+def get_model_cache() -> ModelCache:
+    """Return the module-level model cache singleton."""
+    return _model_cache
+
+
+def _supports_list_models(provider_name: str) -> bool:
+    """Check whether a provider supports model listing without instantiating it."""
+    try:
+        provider_class = AnyLLM.get_provider_class(provider_name)
+        metadata = provider_class.get_provider_metadata()
+        return metadata.list_models
+    except (ImportError, AttributeError, Exception):
+        return False
+
+
+async def _discover_for_provider(
+    provider_name: str,
+    config: GatewayConfig,
+) -> tuple[str, list[Model]]:
+    """Discover models for a single provider. Returns (provider_name, models)."""
+    provider_enum = LLMProvider(provider_name)
+    kwargs = get_provider_kwargs(config, provider_enum)
+
+    api_key = kwargs.pop("api_key", None)
+    api_base = kwargs.pop("api_base", None)
+    client_args = kwargs.pop("client_args", None)
+
+    models: Sequence[Model] = await alist_models(
+        provider=provider_enum,
+        api_key=api_key,
+        api_base=api_base,
+        client_args=client_args,
+        **kwargs,
+    )
+    return provider_name, list(models)
+
+
+async def discover_all_models(
+    config: GatewayConfig,
+    provider_filter: str | None = None,
+) -> list[Model]:
+    """Discover models from configured providers with caching.
+
+    Args:
+        config: Gateway configuration with provider credentials.
+        provider_filter: If set, only discover models for this provider.
+
+    Returns:
+        Combined list of Model objects from all eligible providers.
+
+    """
+    cache = get_model_cache()
+    ttl = config.model_cache_ttl_seconds
+
+    if provider_filter:
+        providers_to_query = [provider_filter] if provider_filter in config.providers else []
+    else:
+        providers_to_query = list(config.providers.keys())
+
+    # Separate providers into cache-hit and cache-miss groups.
+    result_models: list[Model] = []
+    providers_needing_fetch: list[str] = []
+
+    for provider_name in providers_to_query:
+        cached = cache.get(provider_name, ttl)
+        if cached is not None:
+            result_models.extend(cached)
+        else:
+            if _supports_list_models(provider_name):
+                providers_needing_fetch.append(provider_name)
+            else:
+                logger.debug("Provider '%s' does not support model listing, skipping", provider_name)
+
+    if not providers_needing_fetch:
+        return result_models
+
+    # Fetch all cache-miss providers concurrently.
+    async with cache._lock:
+        # Double-check cache under lock to prevent thundering herd.
+        still_needed: list[str] = []
+        for provider_name in providers_needing_fetch:
+            cached = cache.get(provider_name, ttl)
+            if cached is not None:
+                result_models.extend(cached)
+            else:
+                still_needed.append(provider_name)
+
+        if still_needed:
+            tasks = [_discover_for_provider(name, config) for name in still_needed]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+
+            for i, result in enumerate(results):
+                provider_name = still_needed[i]
+                if isinstance(result, BaseException):
+                    logger.warning(
+                        "Model discovery failed for provider '%s': %s",
+                        provider_name,
+                        result,
+                    )
+                    continue
+                _, models = result
+                cache.set(provider_name, models)
+                result_models.extend(models)
+
+    return result_models

--- a/src/gateway/services/provider_kwargs.py
+++ b/src/gateway/services/provider_kwargs.py
@@ -1,0 +1,48 @@
+"""Shared helper for building provider kwargs from gateway configuration."""
+
+from typing import Any
+
+from any_llm import LLMProvider
+
+from gateway.auth.vertex_auth import setup_vertex_environment
+from gateway.core.config import GatewayConfig
+
+
+def get_provider_kwargs(
+    config: GatewayConfig,
+    provider: LLMProvider,
+) -> dict[str, Any]:
+    """Get provider kwargs from config for acompletion calls.
+
+    Args:
+        config: Gateway configuration
+        provider: Provider name
+
+    Returns:
+        Dictionary of provider kwargs (credentials, client_args, etc.)
+
+    """
+    kwargs: dict[str, Any] = {}
+    if provider.value in config.providers:
+        provider_config = config.providers[provider.value]
+
+        if provider == LLMProvider.VERTEXAI:
+            vertex_creds = provider_config.get("credentials")
+            vertex_project = provider_config.get("project")
+            vertex_location = provider_config.get("location")
+
+            kwargs.update(
+                setup_vertex_environment(
+                    credentials=vertex_creds,
+                    project=vertex_project,
+                    location=vertex_location,
+                )
+            )
+            if "client_args" in provider_config:
+                kwargs["client_args"] = provider_config["client_args"]
+        else:
+            kwargs = {k: v for k, v in provider_config.items() if k != "client_args"}
+            if "client_args" in provider_config:
+                kwargs["client_args"] = provider_config["client_args"]
+
+    return kwargs

--- a/tests/integration/test_model_discovery.py
+++ b/tests/integration/test_model_discovery.py
@@ -1,5 +1,6 @@
 """Integration tests for model auto-discovery in the GET /v1/models endpoint."""
 
+import asyncio
 from collections.abc import AsyncGenerator, Generator
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -70,10 +71,13 @@ def _make_client(config: GatewayConfig) -> Generator[TestClient]:
         with TestClient(app) as test_client:
             yield test_client
     finally:
+        # Dispose the async engine to avoid leaking connections/tasks.
+        asyncio.run(async_engine.dispose())
         Base.metadata.drop_all(bind=engine)
         with engine.connect() as conn:
             conn.execute(text("DROP TABLE IF EXISTS alembic_version CASCADE"))
             conn.commit()
+        engine.dispose()
 
 
 @pytest.fixture

--- a/tests/integration/test_model_discovery.py
+++ b/tests/integration/test_model_discovery.py
@@ -1,0 +1,374 @@
+"""Integration tests for model auto-discovery in the GET /v1/models endpoint."""
+
+from collections.abc import AsyncGenerator, Generator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from gateway.core.config import API_KEY_HEADER, GatewayConfig
+from gateway.db import Base, get_db
+from gateway.main import create_app
+from gateway.services.model_discovery_service import get_model_cache
+
+from .conftest import _run_alembic_migrations, _to_async_url
+
+
+def _make_openai_model(model_id: str, owned_by: str = "openai", created: int = 1700000000) -> dict[str, Any]:
+    """Build a dict that Model.model_validate accepts."""
+    return {"id": model_id, "object": "model", "created": created, "owned_by": owned_by}
+
+
+@pytest.fixture
+def discovery_config(postgres_url: str) -> GatewayConfig:
+    """Config with a fake openai provider and discovery enabled."""
+    return GatewayConfig(
+        database_url=postgres_url,
+        master_key="test-master-key",
+        host="127.0.0.1",
+        port=8000,
+        auto_migrate=False,
+        model_discovery=True,
+        model_cache_ttl_seconds=300,
+        providers={"openai": {"api_key": "sk-fake-for-test"}},
+    )
+
+
+@pytest.fixture
+def no_discovery_config(postgres_url: str) -> GatewayConfig:
+    """Config with discovery disabled."""
+    return GatewayConfig(
+        database_url=postgres_url,
+        master_key="test-master-key",
+        host="127.0.0.1",
+        port=8000,
+        auto_migrate=False,
+        model_discovery=False,
+        providers={"openai": {"api_key": "sk-fake-for-test"}},
+    )
+
+
+def _make_client(config: GatewayConfig) -> Generator[TestClient]:
+    _run_alembic_migrations(config.database_url)
+
+    from sqlalchemy import create_engine, text
+
+    engine = create_engine(config.database_url, pool_pre_ping=True)
+    async_engine = create_async_engine(_to_async_url(config.database_url), pool_pre_ping=True)
+    async_session_factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    app = create_app(config)
+
+    async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
+        async with async_session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    try:
+        with TestClient(app) as test_client:
+            yield test_client
+    finally:
+        Base.metadata.drop_all(bind=engine)
+        with engine.connect() as conn:
+            conn.execute(text("DROP TABLE IF EXISTS alembic_version CASCADE"))
+            conn.commit()
+
+
+@pytest.fixture
+def discovery_client(discovery_config: GatewayConfig) -> Generator[TestClient]:
+    """Test client with model discovery enabled."""
+    # Clear the module-level model cache before each test.
+    get_model_cache().clear()
+    yield from _make_client(discovery_config)
+
+
+@pytest.fixture
+def no_discovery_client(no_discovery_config: GatewayConfig) -> Generator[TestClient]:
+    """Test client with model discovery disabled."""
+    get_model_cache().clear()
+    yield from _make_client(no_discovery_config)
+
+
+@pytest.fixture
+def discovery_master_header() -> dict[str, str]:
+    return {API_KEY_HEADER: "Bearer test-master-key"}
+
+
+# ---------------------------------------------------------------------------
+# Discovery tests
+# ---------------------------------------------------------------------------
+
+
+def test_list_models_with_discovery(
+    discovery_client: TestClient,
+    discovery_master_header: dict[str, str],
+) -> None:
+    """Discovered models appear in GET /v1/models."""
+    from any_llm.types.model import Model
+
+    fake_models = [
+        Model(**_make_openai_model("gpt-4o")),
+        Model(**_make_openai_model("gpt-4o-mini")),
+    ]
+
+    with (
+        patch(
+            "gateway.services.model_discovery_service._supports_list_models",
+            return_value=True,
+        ),
+        patch(
+            "gateway.services.model_discovery_service.alist_models",
+            new_callable=AsyncMock,
+            return_value=fake_models,
+        ),
+    ):
+        resp = discovery_client.get("/v1/models", headers=discovery_master_header)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["object"] == "list"
+    ids = [m["id"] for m in data["data"]]
+    assert "openai:gpt-4o" in ids
+    assert "openai:gpt-4o-mini" in ids
+
+
+def test_list_models_discovery_disabled(
+    no_discovery_client: TestClient,
+    discovery_master_header: dict[str, str],
+) -> None:
+    """When discovery is disabled, only pricing-table models appear."""
+    resp = no_discovery_client.get("/v1/models", headers=discovery_master_header)
+    assert resp.status_code == 200
+    assert resp.json()["data"] == []
+
+
+def test_list_models_pricing_enrichment(
+    discovery_client: TestClient,
+    discovery_master_header: dict[str, str],
+) -> None:
+    """Discovered models are enriched with pricing data when available."""
+    from any_llm.types.model import Model
+
+    fake_models = [Model(**_make_openai_model("gpt-4o"))]
+
+    # First, set pricing for this model.
+    resp = discovery_client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "openai:gpt-4o",
+            "input_price_per_million": 2.5,
+            "output_price_per_million": 10.0,
+        },
+        headers=discovery_master_header,
+    )
+    assert resp.status_code == 200
+
+    with (
+        patch(
+            "gateway.services.model_discovery_service._supports_list_models",
+            return_value=True,
+        ),
+        patch(
+            "gateway.services.model_discovery_service.alist_models",
+            new_callable=AsyncMock,
+            return_value=fake_models,
+        ),
+    ):
+        resp = discovery_client.get("/v1/models", headers=discovery_master_header)
+
+    assert resp.status_code == 200
+    models = resp.json()["data"]
+    gpt4 = next(m for m in models if m["id"] == "openai:gpt-4o")
+    assert gpt4["pricing"] is not None
+    assert gpt4["pricing"]["input_price_per_million"] == 2.5
+    assert gpt4["pricing"]["output_price_per_million"] == 10.0
+
+
+def test_list_models_no_pricing_returns_null(
+    discovery_client: TestClient,
+    discovery_master_header: dict[str, str],
+) -> None:
+    """Discovered models without pricing have pricing=None."""
+    from any_llm.types.model import Model
+
+    fake_models = [Model(**_make_openai_model("gpt-4o-mini"))]
+
+    with (
+        patch(
+            "gateway.services.model_discovery_service._supports_list_models",
+            return_value=True,
+        ),
+        patch(
+            "gateway.services.model_discovery_service.alist_models",
+            new_callable=AsyncMock,
+            return_value=fake_models,
+        ),
+    ):
+        resp = discovery_client.get("/v1/models", headers=discovery_master_header)
+
+    assert resp.status_code == 200
+    models = resp.json()["data"]
+    gpt4_mini = next(m for m in models if m["id"] == "openai:gpt-4o-mini")
+    assert gpt4_mini["pricing"] is None
+
+
+def test_list_models_pricing_only_still_appears(
+    discovery_client: TestClient,
+    discovery_master_header: dict[str, str],
+) -> None:
+    """Models only in the pricing table still appear even when discovery returns nothing."""
+    # Add a pricing-only model (for a provider not in config.providers).
+    resp = discovery_client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "openai:legacy-model",
+            "input_price_per_million": 1.0,
+            "output_price_per_million": 2.0,
+        },
+        headers=discovery_master_header,
+    )
+    assert resp.status_code == 200
+
+    with (
+        patch(
+            "gateway.services.model_discovery_service._supports_list_models",
+            return_value=True,
+        ),
+        patch(
+            "gateway.services.model_discovery_service.alist_models",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+    ):
+        resp = discovery_client.get("/v1/models", headers=discovery_master_header)
+
+    assert resp.status_code == 200
+    ids = [m["id"] for m in resp.json()["data"]]
+    assert "openai:legacy-model" in ids
+
+
+def test_list_models_provider_filter(
+    discovery_client: TestClient,
+    discovery_master_header: dict[str, str],
+) -> None:
+    """The ?provider= query param filters results to a single provider."""
+    from any_llm.types.model import Model
+
+    fake_models = [Model(**_make_openai_model("gpt-4o"))]
+
+    # Add a pricing entry for a different provider.
+    discovery_client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "anthropic:claude-3-opus",
+            "input_price_per_million": 15.0,
+            "output_price_per_million": 75.0,
+        },
+        headers=discovery_master_header,
+    )
+
+    with (
+        patch(
+            "gateway.services.model_discovery_service._supports_list_models",
+            return_value=True,
+        ),
+        patch(
+            "gateway.services.model_discovery_service.alist_models",
+            new_callable=AsyncMock,
+            return_value=fake_models,
+        ),
+    ):
+        resp = discovery_client.get("/v1/models?provider=openai", headers=discovery_master_header)
+
+    assert resp.status_code == 200
+    ids = [m["id"] for m in resp.json()["data"]]
+    # OpenAI models should appear; Anthropic should not.
+    assert "openai:gpt-4o" in ids
+    assert all("anthropic:" not in mid for mid in ids)
+
+
+def test_list_models_discovery_error_graceful(
+    discovery_client: TestClient,
+    discovery_master_header: dict[str, str],
+) -> None:
+    """When discovery fails for a provider, the endpoint still succeeds."""
+    with (
+        patch(
+            "gateway.services.model_discovery_service._supports_list_models",
+            return_value=True,
+        ),
+        patch(
+            "gateway.services.model_discovery_service.alist_models",
+            new_callable=AsyncMock,
+            side_effect=ConnectionError("upstream unreachable"),
+        ),
+    ):
+        resp = discovery_client.get("/v1/models", headers=discovery_master_header)
+
+    assert resp.status_code == 200
+    assert resp.json()["object"] == "list"
+
+
+def test_get_model_from_discovery_cache(
+    discovery_client: TestClient,
+    discovery_master_header: dict[str, str],
+) -> None:
+    """GET /v1/models/{id} finds a model that exists only in the discovery cache."""
+    from any_llm.types.model import Model
+
+    fake_models = [Model(**_make_openai_model("gpt-4o"))]
+
+    # Pre-populate the discovery cache.
+    cache = get_model_cache()
+    cache.set("openai", fake_models)
+
+    resp = discovery_client.get("/v1/models/openai:gpt-4o", headers=discovery_master_header)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == "openai:gpt-4o"
+    assert data["owned_by"] == "openai"
+
+
+def test_get_model_not_found_with_discovery(
+    discovery_client: TestClient,
+    discovery_master_header: dict[str, str],
+) -> None:
+    """GET /v1/models/{id} returns 404 when not in cache or pricing table."""
+    resp = discovery_client.get(
+        "/v1/models/openai:nonexistent-model",
+        headers=discovery_master_header,
+    )
+    assert resp.status_code == 404
+
+
+def test_list_models_sorted(
+    discovery_client: TestClient,
+    discovery_master_header: dict[str, str],
+) -> None:
+    """Discovered models are sorted alphabetically by id."""
+    from any_llm.types.model import Model
+
+    fake_models = [
+        Model(**_make_openai_model("gpt-4o")),
+        Model(**_make_openai_model("dall-e-3")),
+        Model(**_make_openai_model("gpt-3.5-turbo")),
+    ]
+
+    with (
+        patch(
+            "gateway.services.model_discovery_service._supports_list_models",
+            return_value=True,
+        ),
+        patch(
+            "gateway.services.model_discovery_service.alist_models",
+            new_callable=AsyncMock,
+            return_value=fake_models,
+        ),
+    ):
+        resp = discovery_client.get("/v1/models", headers=discovery_master_header)
+
+    assert resp.status_code == 200
+    ids = [m["id"] for m in resp.json()["data"]]
+    assert ids == sorted(ids)

--- a/tests/unit/test_gateway_model_discovery.py
+++ b/tests/unit/test_gateway_model_discovery.py
@@ -1,6 +1,7 @@
 """Unit tests for the model discovery cache and service."""
 
 import time
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -141,7 +142,9 @@ class TestSupportsListModels:
 
 
 class TestDiscoverAllModels:
-    def _make_config(self, providers: dict | None = None, discovery: bool = True, ttl: int = 300) -> GatewayConfig:
+    def _make_config(
+        self, providers: dict[str, Any] | None = None, discovery: bool = True, ttl: int = 300
+    ) -> GatewayConfig:
         return GatewayConfig(
             providers=providers or {},
             model_discovery=discovery,
@@ -224,7 +227,7 @@ class TestDiscoverAllModels:
 
         openai_models = [_make_model("gpt-4o")]
 
-        async def mock_alist(provider, **kwargs):
+        async def mock_alist(provider: Any, **kwargs: Any) -> list[Model]:
             if provider.value == "openai":
                 return openai_models
             raise ConnectionError("upstream unreachable")

--- a/tests/unit/test_gateway_model_discovery.py
+++ b/tests/unit/test_gateway_model_discovery.py
@@ -92,6 +92,42 @@ class TestModelCache:
         assert len(all_cached["openai"]) == 1
         assert len(all_cached["anthropic"]) == 1
 
+    def test_get_all_cached_respects_ttl(self) -> None:
+        """get_all_cached with ttl filters out expired entries."""
+        cache = ModelCache()
+        cache.set("openai", [_make_model("gpt-4o")])
+        cache.set("anthropic", [_make_model("claude-3-opus")])
+
+        # Backdate the openai entry so it appears expired.
+        cache._store["openai"].cached_at = time.monotonic() - 400
+
+        all_cached = cache.get_all_cached(ttl=300)
+        assert "openai" not in all_cached
+        assert "anthropic" in all_cached
+
+    def test_get_all_cached_returns_shallow_copy(self) -> None:
+        """Mutating the returned list should not affect the cache."""
+        cache = ModelCache()
+        cache.set("openai", [_make_model("gpt-4o")])
+
+        returned = cache.get_all_cached()
+        returned["openai"].append(_make_model("gpt-3.5"))
+
+        # Internal cache should still have only 1 model.
+        assert len(cache._store["openai"].models) == 1
+
+    def test_get_returns_shallow_copy(self) -> None:
+        """Mutating the returned list should not affect the cache."""
+        cache = ModelCache()
+        cache.set("openai", [_make_model("gpt-4o")])
+
+        returned = cache.get("openai", ttl=300)
+        assert returned is not None
+        returned.append(_make_model("gpt-3.5"))
+
+        # Internal cache should still have only 1 model.
+        assert len(cache._store["openai"].models) == 1
+
     def test_set_copies_list(self) -> None:
         """Mutating the original list should not affect the cached copy."""
         cache = ModelCache()
@@ -160,6 +196,31 @@ class TestDiscoverAllModels:
         assert result == []
 
     @pytest.mark.asyncio
+    async def test_returns_provider_qualified_tuples(self) -> None:
+        """discover_all_models returns (provider_name, Model) tuples."""
+        config = self._make_config(providers={"openai": {"api_key": "sk-test"}})
+        expected_models = [_make_model("gpt-4o")]
+
+        with (
+            patch("gateway.services.model_discovery_service.get_model_cache") as mock_cache_fn,
+            patch("gateway.services.model_discovery_service._supports_list_models", return_value=True),
+            patch(
+                "gateway.services.model_discovery_service.alist_models",
+                new_callable=AsyncMock,
+                return_value=expected_models,
+            ),
+            patch("gateway.services.model_discovery_service.get_provider_kwargs", return_value={"api_key": "sk-test"}),
+        ):
+            cache = ModelCache()
+            mock_cache_fn.return_value = cache
+            result = await discover_all_models(config)
+
+        assert len(result) == 1
+        provider_name, model = result[0]
+        assert provider_name == "openai"
+        assert model.id == "gpt-4o"
+
+    @pytest.mark.asyncio
     async def test_discovers_models_from_provider(self) -> None:
         config = self._make_config(providers={"openai": {"api_key": "sk-test"}})
         expected_models = [_make_model("gpt-4o"), _make_model("gpt-4o-mini")]
@@ -179,7 +240,8 @@ class TestDiscoverAllModels:
             result = await discover_all_models(config)
 
         assert len(result) == 2
-        assert result[0].id == "gpt-4o"
+        assert result[0][0] == "openai"
+        assert result[0][1].id == "gpt-4o"
 
     @pytest.mark.asyncio
     async def test_uses_cache_on_hit(self) -> None:
@@ -197,7 +259,8 @@ class TestDiscoverAllModels:
             result = await discover_all_models(config)
 
         assert len(result) == 1
-        assert result[0].id == "gpt-4o"
+        assert result[0][0] == "openai"
+        assert result[0][1].id == "gpt-4o"
         mock_supports.assert_not_called()
         mock_alist.assert_not_called()
 
@@ -246,7 +309,8 @@ class TestDiscoverAllModels:
 
         # Only openai models should be returned; mistral failure is swallowed.
         assert len(result) == 1
-        assert result[0].id == "gpt-4o"
+        assert result[0][0] == "openai"
+        assert result[0][1].id == "gpt-4o"
 
     @pytest.mark.asyncio
     async def test_provider_filter_limits_query(self) -> None:

--- a/tests/unit/test_gateway_model_discovery.py
+++ b/tests/unit/test_gateway_model_discovery.py
@@ -1,0 +1,283 @@
+"""Unit tests for the model discovery cache and service."""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from any_llm.types.model import Model
+
+from gateway.core.config import GatewayConfig
+from gateway.services.model_discovery_service import (
+    ModelCache,
+    _supports_list_models,
+    discover_all_models,
+)
+
+
+def _make_model(model_id: str, owned_by: str = "openai", created: int = 1700000000) -> Model:
+    """Create a minimal Model instance for testing."""
+    return Model(id=model_id, object="model", created=created, owned_by=owned_by)
+
+
+# ---------------------------------------------------------------------------
+# ModelCache tests
+# ---------------------------------------------------------------------------
+
+
+class TestModelCache:
+    def test_get_returns_none_on_empty_cache(self) -> None:
+        cache = ModelCache()
+        assert cache.get("openai", ttl=300) is None
+
+    def test_set_and_get_returns_cached_models(self) -> None:
+        cache = ModelCache()
+        models = [_make_model("gpt-4o"), _make_model("gpt-4o-mini")]
+        cache.set("openai", models)
+
+        result = cache.get("openai", ttl=300)
+        assert result is not None
+        assert len(result) == 2
+        assert result[0].id == "gpt-4o"
+
+    def test_get_returns_none_when_ttl_zero(self) -> None:
+        cache = ModelCache()
+        cache.set("openai", [_make_model("gpt-4o")])
+        assert cache.get("openai", ttl=0) is None
+
+    def test_cache_expires_after_ttl(self) -> None:
+        cache = ModelCache()
+        cache.set("openai", [_make_model("gpt-4o")])
+
+        # Manually backdate the cached_at timestamp.
+        entry = cache._store["openai"]
+        entry.cached_at = time.monotonic() - 400
+
+        assert cache.get("openai", ttl=300) is None
+
+    def test_cache_still_valid_before_ttl(self) -> None:
+        cache = ModelCache()
+        cache.set("openai", [_make_model("gpt-4o")])
+
+        result = cache.get("openai", ttl=300)
+        assert result is not None
+        assert len(result) == 1
+
+    def test_clear_specific_provider(self) -> None:
+        cache = ModelCache()
+        cache.set("openai", [_make_model("gpt-4o")])
+        cache.set("anthropic", [_make_model("claude-3-opus")])
+
+        cache.clear("openai")
+        assert cache.get("openai", ttl=300) is None
+        assert cache.get("anthropic", ttl=300) is not None
+
+    def test_clear_all_providers(self) -> None:
+        cache = ModelCache()
+        cache.set("openai", [_make_model("gpt-4o")])
+        cache.set("anthropic", [_make_model("claude-3-opus")])
+
+        cache.clear()
+        assert cache.get("openai", ttl=300) is None
+        assert cache.get("anthropic", ttl=300) is None
+
+    def test_get_all_cached(self) -> None:
+        cache = ModelCache()
+        cache.set("openai", [_make_model("gpt-4o")])
+        cache.set("anthropic", [_make_model("claude-3-opus")])
+
+        all_cached = cache.get_all_cached()
+        assert "openai" in all_cached
+        assert "anthropic" in all_cached
+        assert len(all_cached["openai"]) == 1
+        assert len(all_cached["anthropic"]) == 1
+
+    def test_set_copies_list(self) -> None:
+        """Mutating the original list should not affect the cached copy."""
+        cache = ModelCache()
+        models = [_make_model("gpt-4o")]
+        cache.set("openai", models)
+        models.append(_make_model("gpt-3.5"))
+
+        cached = cache.get("openai", ttl=300)
+        assert cached is not None
+        assert len(cached) == 1
+
+
+# ---------------------------------------------------------------------------
+# _supports_list_models tests
+# ---------------------------------------------------------------------------
+
+
+class TestSupportsListModels:
+    def test_returns_true_for_supported_provider(self) -> None:
+        metadata = MagicMock()
+        metadata.list_models = True
+        provider_class = MagicMock()
+        provider_class.get_provider_metadata.return_value = metadata
+
+        with patch("gateway.services.model_discovery_service.AnyLLM") as mock_any:
+            mock_any.get_provider_class.return_value = provider_class
+            assert _supports_list_models("openai") is True
+
+    def test_returns_false_for_unsupported_provider(self) -> None:
+        metadata = MagicMock()
+        metadata.list_models = False
+        provider_class = MagicMock()
+        provider_class.get_provider_metadata.return_value = metadata
+
+        with patch("gateway.services.model_discovery_service.AnyLLM") as mock_any:
+            mock_any.get_provider_class.return_value = provider_class
+            assert _supports_list_models("sagemaker") is False
+
+    def test_returns_false_on_import_error(self) -> None:
+        with patch("gateway.services.model_discovery_service.AnyLLM") as mock_any:
+            mock_any.get_provider_class.side_effect = ImportError("no such provider")
+            assert _supports_list_models("nonexistent") is False
+
+
+# ---------------------------------------------------------------------------
+# discover_all_models tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverAllModels:
+    def _make_config(self, providers: dict | None = None, discovery: bool = True, ttl: int = 300) -> GatewayConfig:
+        return GatewayConfig(
+            providers=providers or {},
+            model_discovery=discovery,
+            model_cache_ttl_seconds=ttl,
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_providers(self) -> None:
+        config = self._make_config()
+        with patch("gateway.services.model_discovery_service.get_model_cache") as mock_cache:
+            mock_cache.return_value = ModelCache()
+            result = await discover_all_models(config)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_discovers_models_from_provider(self) -> None:
+        config = self._make_config(providers={"openai": {"api_key": "sk-test"}})
+        expected_models = [_make_model("gpt-4o"), _make_model("gpt-4o-mini")]
+
+        with (
+            patch("gateway.services.model_discovery_service.get_model_cache") as mock_cache_fn,
+            patch("gateway.services.model_discovery_service._supports_list_models", return_value=True),
+            patch(
+                "gateway.services.model_discovery_service.alist_models",
+                new_callable=AsyncMock,
+                return_value=expected_models,
+            ),
+            patch("gateway.services.model_discovery_service.get_provider_kwargs", return_value={"api_key": "sk-test"}),
+        ):
+            cache = ModelCache()
+            mock_cache_fn.return_value = cache
+            result = await discover_all_models(config)
+
+        assert len(result) == 2
+        assert result[0].id == "gpt-4o"
+
+    @pytest.mark.asyncio
+    async def test_uses_cache_on_hit(self) -> None:
+        config = self._make_config(providers={"openai": {"api_key": "sk-test"}})
+        cached_models = [_make_model("gpt-4o")]
+
+        cache = ModelCache()
+        cache.set("openai", cached_models)
+
+        with (
+            patch("gateway.services.model_discovery_service.get_model_cache", return_value=cache),
+            patch("gateway.services.model_discovery_service._supports_list_models") as mock_supports,
+            patch("gateway.services.model_discovery_service.alist_models") as mock_alist,
+        ):
+            result = await discover_all_models(config)
+
+        assert len(result) == 1
+        assert result[0].id == "gpt-4o"
+        mock_supports.assert_not_called()
+        mock_alist.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_unsupported_providers(self) -> None:
+        config = self._make_config(providers={"sagemaker": {"region": "us-east-1"}})
+
+        with (
+            patch("gateway.services.model_discovery_service.get_model_cache") as mock_cache_fn,
+            patch("gateway.services.model_discovery_service._supports_list_models", return_value=False),
+            patch("gateway.services.model_discovery_service.alist_models") as mock_alist,
+        ):
+            mock_cache_fn.return_value = ModelCache()
+            result = await discover_all_models(config)
+
+        assert result == []
+        mock_alist.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handles_provider_failure_gracefully(self) -> None:
+        config = self._make_config(
+            providers={
+                "openai": {"api_key": "sk-test"},
+                "mistral": {"api_key": "mk-test"},
+            }
+        )
+
+        openai_models = [_make_model("gpt-4o")]
+
+        async def mock_alist(provider, **kwargs):
+            if provider.value == "openai":
+                return openai_models
+            raise ConnectionError("upstream unreachable")
+
+        with (
+            patch("gateway.services.model_discovery_service.get_model_cache") as mock_cache_fn,
+            patch("gateway.services.model_discovery_service._supports_list_models", return_value=True),
+            patch("gateway.services.model_discovery_service.alist_models", side_effect=mock_alist),
+            patch(
+                "gateway.services.model_discovery_service.get_provider_kwargs",
+                return_value={"api_key": "test"},
+            ),
+        ):
+            mock_cache_fn.return_value = ModelCache()
+            result = await discover_all_models(config)
+
+        # Only openai models should be returned; mistral failure is swallowed.
+        assert len(result) == 1
+        assert result[0].id == "gpt-4o"
+
+    @pytest.mark.asyncio
+    async def test_provider_filter_limits_query(self) -> None:
+        config = self._make_config(
+            providers={
+                "openai": {"api_key": "sk-test"},
+                "anthropic": {"api_key": "ak-test"},
+            }
+        )
+        openai_models = [_make_model("gpt-4o")]
+
+        with (
+            patch("gateway.services.model_discovery_service.get_model_cache") as mock_cache_fn,
+            patch("gateway.services.model_discovery_service._supports_list_models", return_value=True),
+            patch(
+                "gateway.services.model_discovery_service.alist_models",
+                new_callable=AsyncMock,
+                return_value=openai_models,
+            ) as mock_alist,
+            patch("gateway.services.model_discovery_service.get_provider_kwargs", return_value={"api_key": "test"}),
+        ):
+            mock_cache_fn.return_value = ModelCache()
+            result = await discover_all_models(config, provider_filter="openai")
+
+        assert len(result) == 1
+        # alist_models should only be called once (for openai).
+        assert mock_alist.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_provider_filter_nonexistent_returns_empty(self) -> None:
+        config = self._make_config(providers={"openai": {"api_key": "sk-test"}})
+
+        with patch("gateway.services.model_discovery_service.get_model_cache") as mock_cache_fn:
+            mock_cache_fn.return_value = ModelCache()
+            result = await discover_all_models(config, provider_filter="nonexistent")
+
+        assert result == []


### PR DESCRIPTION
## Summary

Closes #69

When `GET /v1/models` is called in standalone mode, the gateway now queries each configured provider's upstream API for available models via `any_llm.alist_models()`, merges the results with existing `model_pricing` entries, and returns the combined list in OpenAI-compatible format.

## Problem

Previously, `/v1/models` only returned models with manually configured pricing entries in the database. This was confusing for users and broke tools (OpenCode, Continue, etc.) that rely on the OpenAI-compatible `/v1/models` endpoint to discover available models — even though chat completions worked fine for any model with configured provider credentials.

## Changes

### New files
- **`src/gateway/services/model_discovery_service.py`** — Model discovery service with in-memory TTL cache
  - `ModelCache` class: per-provider caching with configurable TTL (default 5 min)
  - `discover_all_models()`: parallel async querying of all configured providers
  - Graceful error handling: failed providers are logged and skipped
  - Uses `AnyLLM.get_provider_metadata().list_models` to check provider support before querying

### Modified files
- **`src/gateway/core/config.py`** — Two new config fields:
  - `model_discovery: bool` (default `true`) — global toggle for auto-discovery
  - `model_cache_ttl_seconds: int` (default `300`) — TTL for the model list cache
- **`src/gateway/api/routes/models.py`** — Updated endpoints:
  - `GET /v1/models` now merges discovered + pricing-table models
  - New optional `?provider=` query param to filter by provider
  - New `ModelPricingInfo` schema with optional pricing enrichment
  - `GET /v1/models/{id}` also checks the discovery cache
- **`docs/public/openapi.json`** — Regenerated

### New tests
- **`tests/unit/test_gateway_model_discovery.py`** — 19 unit tests for cache behavior, provider support checks, and discovery logic
- **`tests/integration/test_model_discovery.py`** — 10 integration tests for the full endpoint behavior with mocked upstream providers

## Design Decisions

1. **Cache keyed by provider** — each provider's model list is cached independently with TTL-based expiration
2. **Pricing enrichment** — discovered models include `pricing` field only when pricing data exists in `model_pricing` table; `null` otherwise
3. **Backward compatible** — models that only exist in the pricing table (no discovery) still appear in the listing
4. **Graceful degradation** — if a provider's `alist_models` fails, the endpoint still succeeds with results from other providers
5. **Platform mode** — out of scope for this PR (no platform models endpoint exists yet)

## Configuration

```yaml
# config.yml
model_discovery: true          # Enable/disable auto-discovery (default: true)
model_cache_ttl_seconds: 300   # Cache TTL in seconds (default: 300, 0 disables caching)
```

Or via environment variables:
```
GATEWAY_MODEL_DISCOVERY=true
GATEWAY_MODEL_CACHE_TTL_SECONDS=300
```

## Test Results

All 459 tests pass (including 29 new tests), 0 failures. Lint clean.