### PR TITLE
feat(chat): pre-lock-in fallback for tool-loop requests

### DIFF
--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -3,6 +3,7 @@ import os
 import time
 import uuid
 from collections.abc import AsyncIterator, Callable
+from contextlib import AsyncExitStack
 from datetime import UTC, datetime
 from typing import Annotated, Any, NamedTuple
 
@@ -51,6 +52,16 @@ from gateway.streaming import (
 router = APIRouter(prefix="/v1/chat", tags=["chat"])
 
 _USAGE_NON_RETRYABLE_STATUS_CODES = {401, 404, 409, 422}
+
+# Streaming first-chunk timeouts (platform-mode fallback). Plain LLM streams
+# rarely take long to produce a first token, so a tight cap keeps failed-
+# attempt latency low. Tool-loop streams may reason before emitting tokens
+# or a tool_call (especially with extended thinking), so they get more
+# headroom. Both are operator-tunable via `config.platform`.
+_DEFAULT_STREAM_FIRST_CHUNK_TIMEOUT_MS = 2000
+_DEFAULT_STREAM_FIRST_CHUNK_TIMEOUT_MS_TOOL_LOOP = 30000
+_STREAM_FIRST_CHUNK_TIMEOUT_MS_KEY = "streaming_first_chunk_timeout_ms"
+_STREAM_FIRST_CHUNK_TIMEOUT_MS_TOOL_LOOP_KEY = "streaming_first_chunk_timeout_ms_tool_loop"
 
 
 def rate_limit_headers(info: RateLimitInfo) -> dict[str, str]:
@@ -916,10 +927,10 @@ async def chat_completions(
     # Errors after first chunk propagate to the client.
     # ------------------------------------------------------------------
     if request.stream:
-        # Sandbox / web_search paths collapse to the standalone streaming block
-        # below so the tool loop sees a single set of credentials; multi-attempt
-        # fallback is intentionally not layered around them (see comment above).
-        if platform_mode and not use_sandbox and not use_web_search:
+        # Platform-mode streaming — tool modes (sandbox / web_search / MCP)
+        # also flow through here so they get per-attempt fallback up to the
+        # lock-in point (first chunk = first assistant message).
+        if platform_mode:
             if route is None or not route.attempts:
                 if route is not None:
                     logger.error(
@@ -930,6 +941,11 @@ async def chat_completions(
                     status_code=status.HTTP_502_BAD_GATEWAY,
                     detail="Authorization service returned no resolvable provider",
                 )
+            stream_mcp_configs = request.mcp_servers
+            stream_max_tool_iterations = min(
+                request.max_tool_iterations or DEFAULT_MAX_TOOL_ITERATIONS,
+                MAX_TOOL_ITERATIONS_CAP,
+            )
             try:
                 return await _run_streaming_with_fallback(
                     route=route,
@@ -938,9 +954,31 @@ async def chat_completions(
                     config=config,
                     background_tasks=background_tasks,
                     rate_limit_info=rate_limit_info,
+                    mcp_server_configs=stream_mcp_configs,
+                    use_sandbox=use_sandbox,
+                    sandbox_url=sandbox_url,
+                    sandbox_tool_entry=sandbox_tool_entry,
+                    use_web_search=use_web_search,
+                    web_search_url=web_search_url,
+                    web_search_tool_entry=web_search_tool_entry,
+                    remaining_user_tools=remaining_user_tools,
+                    tools_extracted=sandbox_tool_entry is not None or web_search_tool_entry is not None,
+                    max_tool_iterations=stream_max_tool_iterations,
                 )
             except HTTPException:
                 raise
+            except SandboxNotReachableError as exc:
+                logger.error("Sandbox unreachable request_id=%s: %s", route.request_id, exc)
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail="code_execution sandbox unreachable — check GATEWAY_SANDBOX_URL",
+                ) from exc
+            except WebSearchNotReachableError as exc:
+                logger.error("Web search backend unreachable request_id=%s: %s", route.request_id, exc)
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail="web_search backend unreachable — check GATEWAY_WEB_SEARCH_URL",
+                ) from exc
             except Exception as exc:
                 # Every attempt failed before any bytes were flushed.
                 logger.error(
@@ -960,15 +998,13 @@ async def chat_completions(
                     detail=("LLM provider error" if len(route.attempts) <= 1 else "All upstream providers failed"),
                 ) from exc
 
-        # Standalone path: single attempt, no fallback (unchanged from v1.0).
+        # Standalone path: single attempt, no fallback (no `route.attempts`).
+        # Platform-mode requests (including tool modes) take the multi-attempt
+        # branch above; this block runs only when `model` is a literal
+        # ``provider:model`` selector and no routing policy applies.
         provider, model = AnyLLM.split_model_provider(request.model)
         provider_kwargs = get_provider_kwargs(config, provider)
 
-        # Standalone streaming path: single attempt, optionally wrapped in
-        # the MCP tool-use loop. When `mcp_servers` is set the tool loop owns
-        # the stream and re-emits chunks; the multi-attempt fallback
-        # (`_run_streaming_with_fallback`) is intentionally not used because
-        # an MCP-driven request shouldn't silently swap providers mid-loop.
         mcp_server_configs = request.mcp_servers
         max_tool_iterations = min(
             request.max_tool_iterations or DEFAULT_MAX_TOOL_ITERATIONS,
@@ -1131,11 +1167,12 @@ async def chat_completions(
         )
 
     # ------------------------------------------------------------------
-    # Non-streaming path. Routing-policy fallback (`route.attempts`) and MCP
-    # tool-use loops are mutually exclusive: when `mcp_servers` is set we run
-    # a single MCP loop against the primary attempt's credentials and skip
-    # the per-attempt retry walk (see PR design note — an MCP-driven request
-    # shouldn't silently swap providers between tool-use rounds).
+    # Non-streaming path. Iterates `route.attempts` with pre-lock-in
+    # fallback semantics: if a tool-loop attempt fails *before* the model
+    # has returned its first assistant message, we fall through to the
+    # next attempt. Once locked in (first assistant message received),
+    # subsequent failures terminate the request — we never swap providers
+    # between tool-use rounds.
     # ------------------------------------------------------------------
     mcp_server_configs = request.mcp_servers
     max_tool_iterations = min(
@@ -1160,11 +1197,6 @@ async def chat_completions(
                 status_code=status.HTTP_502_BAD_GATEWAY,
                 detail="Authorization service returned no resolvable provider",
             )
-        # MCP / sandbox / web_search modes: collapse to the primary attempt,
-        # no per-attempt fallback (a tool-use loop shouldn't silently swap
-        # providers between rounds).
-        if mcp_server_configs or use_sandbox or use_web_search:
-            attempts_to_try = attempts_to_try[:1]
     else:
         provider, model = AnyLLM.split_model_provider(request.model)
         provider_kwargs = get_provider_kwargs(config, provider)
@@ -1198,6 +1230,24 @@ async def chat_completions(
                 "model": f"{attempt_provider.value}:{attempt_model}",
             }
 
+            # Per-attempt lock-in flag. Flipped the moment the upstream
+            # returns its first assistant message. After that, any failure
+            # terminates the request — fallback would replay a provider-
+            # specific transcript on a different provider, which has
+            # undefined semantics.
+            locked_in = False
+
+            def _mark_locked_in(_pos: int = attempt.position) -> None:
+                nonlocal locked_in
+                locked_in = True
+                logger.info(
+                    "Tool-loop lock-in request_id=%s position=%d provider=%s model=%s",
+                    platform_route.request_id,
+                    _pos,
+                    attempt.provider,
+                    attempt.model,
+                )
+
             try:
                 if mcp_server_configs:
                     async with MCPClientPool(mcp_server_configs) as pool:
@@ -1213,6 +1263,7 @@ async def chat_completions(
                             completion_kwargs=mcp_kwargs,
                             pool=pool,
                             max_iterations=max_tool_iterations,
+                            on_first_response=_mark_locked_in,
                         )
                 elif use_sandbox:
                     assert sandbox_url is not None
@@ -1230,6 +1281,7 @@ async def chat_completions(
                             completion_kwargs=sandbox_kwargs,
                             pool=backend,  # type: ignore[arg-type]
                             max_iterations=max_tool_iterations,
+                            on_first_response=_mark_locked_in,
                         )
                 elif use_web_search:
                     assert web_search_url is not None
@@ -1250,6 +1302,7 @@ async def chat_completions(
                             completion_kwargs=web_kwargs,
                             pool=web_backend,  # type: ignore[arg-type]
                             max_iterations=max_tool_iterations,
+                            on_first_response=_mark_locked_in,
                         )
                 else:
                     completion = await acompletion(**completion_kwargs)  # type: ignore[assignment]
@@ -1280,15 +1333,27 @@ async def chat_completions(
                     error_class,
                 )
                 logger.warning(
-                    "Provider call failed request_id=%s position=%d provider=%s model=%s error=%s retryable=%s",
+                    "Provider call failed request_id=%s position=%d provider=%s model=%s "
+                    "error=%s retryable=%s locked_in=%s",
                     platform_route.request_id,
                     attempt.position,
                     attempt.provider,
                     attempt.model,
                     error_class,
                     retryable,
+                    locked_in,
                 )
                 last_exc = exc
+                # Locked-in: at least one tool-loop round produced an
+                # assistant message on this attempt. Subsequent failures
+                # cannot be transparently retried on another provider — the
+                # conversation now contains provider-specific tool_call ids
+                # and reasoning blocks. Surface immediately.
+                if locked_in:
+                    raise HTTPException(
+                        status_code=status.HTTP_502_BAD_GATEWAY,
+                        detail="LLM provider error",
+                    ) from exc
                 if not retryable:
                     raise HTTPException(
                         status_code=status.HTTP_502_BAD_GATEWAY,
@@ -1587,18 +1652,95 @@ async def _run_streaming_with_fallback(
     config: GatewayConfig,
     background_tasks: BackgroundTasks,
     rate_limit_info: RateLimitInfo | None,
+    mcp_server_configs: list[McpServerConfig] | None = None,
+    use_sandbox: bool = False,
+    sandbox_url: str | None = None,
+    sandbox_tool_entry: dict[str, Any] | None = None,
+    use_web_search: bool = False,
+    web_search_url: str | None = None,
+    web_search_tool_entry: dict[str, Any] | None = None,
+    remaining_user_tools: list[dict[str, Any]] | None = None,
+    tools_extracted: bool = False,
+    max_tool_iterations: int = DEFAULT_MAX_TOOL_ITERATIONS,
 ) -> StreamingResponse:
     """Iterate route.attempts for a streaming request, falling through on any
     attempt that fails before its first chunk arrives.
 
-    Once an attempt yields its first chunk, we commit and start flushing to the
-    client — errors past that point propagate to the SSE channel as today.
+    Once an attempt yields its first chunk, we commit and start flushing to
+    the client — errors past that point propagate to the SSE channel as
+    today. This is the streaming analogue of the non-streaming
+    pre-lock-in-fallback flow in the request handler above.
+
+    Tool-loop modes (sandbox / web_search / MCP) are layered on top using
+    the same pre-first-chunk fallback semantics: the upstream
+    ``acompletion(stream=True)`` call inside ``mcp_tool_loop_stream`` runs
+    lazily when ``iterate_streaming_attempts`` pulls the first chunk; if
+    that call fails (or any retryable error fires before a chunk arrives)
+    we move to the next attempt with a clean conversation slate.
     """
-    # Strip gateway-internal fields the upstream SDKs don't accept (Anthropic
-    # in particular rejects unknown kwargs). This path runs in platform mode
-    # with neither MCP nor sandbox, so we don't pass remaining_user_tools.
-    base_request_fields = _strip_gateway_fields(request.model_dump(exclude_unset=True))
-    first_chunk_timeout_seconds = int(config.platform.get("streaming_first_chunk_timeout_ms", 2000)) / 1000
+    tool_mode = bool(mcp_server_configs) or use_sandbox or use_web_search
+
+    base_request_fields = _strip_gateway_fields(
+        request.model_dump(exclude_unset=True),
+        tools_extracted=tools_extracted,
+        remaining_user_tools=remaining_user_tools,
+    )
+
+    # Tool-mode streams need more headroom on first-chunk wait: the model
+    # may reason briefly before emitting tokens or a tool_call, especially
+    # with extended thinking. Keep the existing tight default for plain
+    # streams so failed-attempt latency stays low when no tools are in play.
+    if tool_mode:
+        first_chunk_timeout_seconds = (
+            int(
+                config.platform.get(
+                    _STREAM_FIRST_CHUNK_TIMEOUT_MS_TOOL_LOOP_KEY,
+                    _DEFAULT_STREAM_FIRST_CHUNK_TIMEOUT_MS_TOOL_LOOP,
+                )
+            )
+            / 1000
+        )
+    else:
+        first_chunk_timeout_seconds = (
+            int(
+                config.platform.get(
+                    _STREAM_FIRST_CHUNK_TIMEOUT_MS_KEY,
+                    _DEFAULT_STREAM_FIRST_CHUNK_TIMEOUT_MS,
+                )
+            )
+            / 1000
+        )
+
+    # Open the tool backend(s) once before iterating attempts. Eager open
+    # lets gateway-side dependency failures (sandbox unreachable, web
+    # search backend unreachable) surface as a normal HTTP error instead
+    # of as a mid-SSE error event after the 200 OK header. The exit stack
+    # is closed when streaming completes (success or error path inside
+    # the wrapped iterator) or, if no attempt commits, in the outer
+    # except handler below.
+    backend_stack = AsyncExitStack()
+    pool_for_loop: Any = None
+    try:
+        if mcp_server_configs is not None:
+            pool_for_loop = await backend_stack.enter_async_context(MCPClientPool(mcp_server_configs))
+        elif use_sandbox:
+            assert sandbox_url is not None
+            sandbox_hint = _resolve_sandbox_purpose_hint(sandbox_tool_entry)
+            pool_for_loop = await backend_stack.enter_async_context(
+                SandboxBackend(sandbox_url=sandbox_url, purpose_hint=sandbox_hint),
+            )
+        elif use_web_search:
+            assert web_search_url is not None
+            assert web_search_tool_entry is not None
+            pool_for_loop = await backend_stack.enter_async_context(
+                _build_web_search_backend(base_url=web_search_url, tool_entry=web_search_tool_entry),
+            )
+    except BaseException:
+        # Eager-open failure (e.g. SandboxNotReachableError) — propagate so
+        # the route handler maps it to the existing HTTP status. Nothing to
+        # clean up on the stack yet because the entry failed.
+        await backend_stack.aclose()
+        raise
 
     async def _build_for_attempt(
         attempt: ResolvedAttempt,
@@ -1614,7 +1756,21 @@ async def _run_streaming_with_fallback(
         }
         if completion_kwargs.get("stream_options") is None:
             completion_kwargs["stream_options"] = {"include_usage": True}
-        return await acompletion(**completion_kwargs)  # type: ignore[return-value]
+        if pool_for_loop is None:
+            return await acompletion(**completion_kwargs)  # type: ignore[return-value]
+        kwargs = {
+            **completion_kwargs,
+            "messages": inject_purpose_hints(
+                completion_kwargs["messages"],
+                pool_for_loop.purpose_hints(),
+                header=request.tools_header,
+            ),
+        }
+        return mcp_tool_loop_stream(
+            completion_kwargs=kwargs,
+            pool=pool_for_loop,
+            max_iterations=max_tool_iterations,
+        )
 
     async def _on_attempt_failed(attempt: ResolvedAttempt, failure: StreamingAttemptFailure) -> None:
         background_tasks.add_task(
@@ -1634,16 +1790,43 @@ async def _run_streaming_with_fallback(
             failure.error_class,
         )
 
-    chosen, stream = await iterate_streaming_attempts(
-        attempts=route.attempts,
-        build_stream=_build_for_attempt,
-        classify_error=_classify_upstream_error,
-        on_attempt_failed=_on_attempt_failed,
-        first_chunk_timeout_seconds=first_chunk_timeout_seconds,
-    )
+    try:
+        chosen, stream = await iterate_streaming_attempts(
+            attempts=route.attempts,
+            build_stream=_build_for_attempt,
+            classify_error=_classify_upstream_error,
+            on_attempt_failed=_on_attempt_failed,
+            first_chunk_timeout_seconds=first_chunk_timeout_seconds,
+        )
+    except BaseException:
+        # No attempt yielded a first chunk — close the tool backend before
+        # propagating the failure. The route handler maps it to HTTP.
+        await backend_stack.aclose()
+        raise
+
+    if tool_mode:
+        logger.info(
+            "Tool-loop streaming lock-in request_id=%s position=%d provider=%s model=%s",
+            route.request_id,
+            chosen.position,
+            chosen.provider,
+            chosen.model,
+        )
+
+    if pool_for_loop is not None:
+        async def _stream_with_backend_cleanup() -> AsyncIterator[ChatCompletionChunk]:
+            try:
+                async for chunk in stream:
+                    yield chunk
+            finally:
+                await backend_stack.aclose()
+
+        stream_to_return: AsyncIterator[ChatCompletionChunk] = _stream_with_backend_cleanup()
+    else:
+        stream_to_return = stream
 
     return _build_streaming_response(
-        stream=stream,
+        stream=stream_to_return,
         provider=LLMProvider(chosen.provider),
         model=chosen.model,
         platform_mode=True,

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -1721,7 +1721,7 @@ async def _run_streaming_with_fallback(
     backend_stack = AsyncExitStack()
     pool_for_loop: Any = None
     try:
-        if mcp_server_configs is not None:
+        if mcp_server_configs:
             pool_for_loop = await backend_stack.enter_async_context(MCPClientPool(mcp_server_configs))
         elif use_sandbox:
             assert sandbox_url is not None

--- a/src/gateway/services/mcp_loop.py
+++ b/src/gateway/services/mcp_loop.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import TYPE_CHECKING, Any
 
 from any_llm import acompletion
@@ -222,8 +222,17 @@ async def mcp_tool_loop(
     completion_kwargs: dict[str, Any],
     pool: MCPClientPool,
     max_iterations: int,
+    on_first_response: Callable[[], None] | None = None,
 ) -> ChatCompletion:
-    """Non-streaming variant. Accumulates usage across iterations into the returned completion."""
+    """Non-streaming variant. Accumulates usage across iterations into the returned completion.
+
+    ``on_first_response`` is invoked exactly once, right after the first
+    upstream ``acompletion`` call returns successfully. Callers use it to lock
+    in the chosen provider — once the model has produced *any* assistant
+    message, the conversation state is provider-specific and subsequent
+    failures must not silently swap providers. See the platform-mode attempt
+    loop in :mod:`gateway.api.routes.chat` for the consumer.
+    """
     messages = list(completion_kwargs.get("messages") or [])
     user_tools = list(completion_kwargs.get("tools") or [])
     merged_tools = user_tools + pool.openai_tools
@@ -232,6 +241,7 @@ async def mcp_tool_loop(
 
     acc_prompt = 0
     acc_completion = 0
+    first_response_signaled = False
 
     for _ in range(max_iterations):
         kwargs: dict[str, Any] = {**base, "messages": messages, "stream": False}
@@ -239,6 +249,10 @@ async def mcp_tool_loop(
             kwargs["tools"] = merged_tools
 
         completion: ChatCompletion = await acompletion(**kwargs)  # type: ignore[assignment]
+        if not first_response_signaled:
+            first_response_signaled = True
+            if on_first_response is not None:
+                on_first_response()
         if completion.usage:
             acc_prompt += completion.usage.prompt_tokens or 0
             acc_completion += completion.usage.completion_tokens or 0

--- a/tests/integration/test_platform_mode_chat.py
+++ b/tests/integration/test_platform_mode_chat.py
@@ -565,3 +565,290 @@ def test_platform_mode_streaming_returns_502_when_all_attempts_fail(
 
     assert response.status_code == 502
     assert response.json() == {"detail": "All upstream providers failed"}
+
+
+# ---------------------------------------------------------------------------
+# Tool-loop fallback (pre-lock-in)
+# ---------------------------------------------------------------------------
+#
+# Contract: when a request uses an inline tool backend (mcp_servers /
+# sandbox / web_search), per-attempt fallback still applies as long as the
+# chosen attempt has not yet returned its first assistant message. Once it
+# has — i.e. the tool loop has "locked in" — subsequent upstream failures
+# terminate the request; we never silently swap providers between tool-use
+# rounds.
+
+
+class _FakeMcpPool:
+    """Minimal MCPClientPool duck-type for the fallback-flow tests. We don't
+    actually want to dial out to an MCP server here — only to exercise the
+    chat route's per-attempt iteration around the tool loop."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> "_FakeMcpPool":
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    @property
+    def openai_tools(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "type": "function",
+                "function": {"name": "remote_search", "description": "", "parameters": {}},
+            }
+        ]
+
+    def owns_tool(self, name: str) -> bool:
+        return name == "remote_search"
+
+    def purpose_hints(self) -> list[tuple[str, str]]:
+        return []
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+        return "tool ran"
+
+
+def _two_attempt_resolve_response(*, request_id: str) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "request_id": request_id,
+            "fallback_enabled": True,
+            "attempts": [
+                {
+                    "attempt_id": "tool-att-anthropic",
+                    "position": 0,
+                    "provider": "anthropic",
+                    "model": "claude-haiku-4-5",
+                    "api_key": "sk-ant-broken",
+                    "api_base": None,
+                    "managed": False,
+                },
+                {
+                    "attempt_id": "tool-att-openai",
+                    "position": 1,
+                    "provider": "openai",
+                    "model": "gpt-4o-mini",
+                    "api_key": "sk-openai-real",
+                    "api_base": "https://api.openai.com/v1",
+                    "managed": False,
+                },
+            ],
+        },
+    )
+
+
+def test_platform_mode_tool_loop_falls_through_pre_lock_in(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-streaming MCP request: first attempt errors before any tool round
+    completes → the gateway falls through to the second attempt and returns
+    its successful completion."""
+
+    usage_reports: list[dict[str, Any]] = []
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _two_attempt_resolve_response(request_id="tool-req-1")
+        usage_reports.append(body)
+        return httpx.Response(204)
+
+    calls: list[str] = []
+
+    class _FakeAuthError(Exception):
+        status_code = 401
+
+    async def fake_loop_acompletion(**kwargs: Any) -> ChatCompletion:
+        model = kwargs.get("model", "")
+        calls.append(model)
+        if "anthropic" in model:
+            raise _FakeAuthError("simulated upstream 401 on anthropic")
+        return ChatCompletion(
+            id="cmpl-1",
+            object="chat.completion",
+            created=0,
+            model="openai:gpt-4o-mini",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="hello from openai"),
+                )
+            ],
+            usage=CompletionUsage(prompt_tokens=3, completion_tokens=2, total_tokens=5),
+        )
+
+    monkeypatch.setattr("gateway.api.routes.chat._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.MCPClientPool", _FakeMcpPool)
+    monkeypatch.setattr("gateway.services.mcp_loop.acompletion", fake_loop_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            "mcp_servers": [{"name": "test", "url": "http://127.0.0.1:18080/mcp"}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["X-Correlation-ID"] == "tool-att-openai"
+    body = response.json()
+    assert body["choices"][0]["message"]["content"] == "hello from openai"
+    # Both attempts were tried in order — confirms the [:1] collapse is gone.
+    assert calls == ["anthropic:claude-haiku-4-5", "openai:gpt-4o-mini"]
+    # The first attempt's failure was reported to the platform as `error`.
+    error_reports = [r for r in usage_reports if r.get("status") == "error"]
+    assert len(error_reports) == 1
+    assert error_reports[0]["correlation_id"] == "tool-att-anthropic"
+
+
+def test_platform_mode_tool_loop_no_fallback_after_lock_in(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-streaming MCP request: first attempt returns a tool_call (lock-in
+    fires), then upstream dies on round 2. The gateway must NOT try the
+    second attempt — that would replay a provider-specific transcript on a
+    different provider."""
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _two_attempt_resolve_response(request_id="tool-req-2")
+        return httpx.Response(204)
+
+    calls: list[str] = []
+    state = {"round": 0}
+
+    async def fake_loop_acompletion(**kwargs: Any) -> ChatCompletion:
+        calls.append(kwargs.get("model", ""))
+        state["round"] += 1
+        if state["round"] == 1:
+            return ChatCompletion(
+                id="cmpl-round1",
+                object="chat.completion",
+                created=0,
+                model="anthropic:claude-haiku-4-5",
+                choices=[
+                    Choice(
+                        finish_reason="tool_calls",
+                        index=0,
+                        message=ChatCompletionMessage(
+                            role="assistant",
+                            content=None,
+                            tool_calls=[
+                                {  # type: ignore[list-item]
+                                    "id": "call_1",
+                                    "type": "function",
+                                    "function": {"name": "remote_search", "arguments": "{}"},
+                                }
+                            ],
+                        ),
+                    )
+                ],
+                usage=CompletionUsage(prompt_tokens=3, completion_tokens=2, total_tokens=5),
+            )
+        # Round 2 (still on attempt 1 — lock-in is in effect) — upstream dies.
+        raise RuntimeError("simulated upstream 5xx on round 2")
+
+    monkeypatch.setattr("gateway.api.routes.chat._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.MCPClientPool", _FakeMcpPool)
+    monkeypatch.setattr("gateway.services.mcp_loop.acompletion", fake_loop_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            "mcp_servers": [{"name": "test", "url": "http://127.0.0.1:18080/mcp"}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 502
+    # Both calls were to attempt 1 (rounds 1 and 2 of the tool loop). The
+    # second attempt (openai) is never tried because lock-in fired on round 1.
+    assert calls == ["anthropic:claude-haiku-4-5", "anthropic:claude-haiku-4-5"]
+
+
+def test_platform_mode_tool_loop_streaming_falls_through_pre_lock_in(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Streaming MCP request: first attempt errors before yielding any
+    chunk → gateway falls through to the second attempt and streams its
+    response. Same pre-lock-in semantics as the non-streaming case."""
+    from collections.abc import AsyncIterator
+
+    from any_llm.types.completion import ChatCompletionChunk
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _two_attempt_resolve_response(request_id="tool-stream-req-1")
+        return httpx.Response(204)
+
+    calls: list[str] = []
+
+    class _FakeAuthError(Exception):
+        status_code = 401
+
+    async def fake_loop_acompletion(**kwargs: Any) -> Any:
+        model = kwargs.get("model", "")
+        calls.append(model)
+        if "anthropic" in model:
+            raise _FakeAuthError("simulated upstream 401")
+
+        async def _stream() -> AsyncIterator[ChatCompletionChunk]:
+            yield ChatCompletionChunk.model_validate(
+                {
+                    "id": "chunk-1",
+                    "object": "chat.completion.chunk",
+                    "created": 1700000000,
+                    "model": "openai:gpt-4o-mini",
+                    "choices": [{"index": 0, "delta": {"content": "hello"}, "finish_reason": None}],
+                }
+            )
+            yield ChatCompletionChunk.model_validate(
+                {
+                    "id": "chunk-2",
+                    "object": "chat.completion.chunk",
+                    "created": 1700000000,
+                    "model": "openai:gpt-4o-mini",
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 3, "completion_tokens": 1, "total_tokens": 4},
+                }
+            )
+
+        return _stream()
+
+    monkeypatch.setattr("gateway.api.routes.chat._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.MCPClientPool", _FakeMcpPool)
+    monkeypatch.setattr("gateway.services.mcp_loop.acompletion", fake_loop_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+            "mcp_servers": [{"name": "test", "url": "http://127.0.0.1:18080/mcp"}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["X-Correlation-ID"] == "tool-att-openai"
+    assert calls == ["anthropic:claude-haiku-4-5", "openai:gpt-4o-mini"]
+    assert "hello" in response.text

--- a/tests/unit/test_mcp_loop.py
+++ b/tests/unit/test_mcp_loop.py
@@ -501,3 +501,127 @@ async def test_loop_mixed_tools_executes_mcp_and_returns_only_foreign(
     remaining = out.choices[0].message.tool_calls or []
     remaining_names = [tc.function.name for tc in remaining if hasattr(tc, "function")]
     assert remaining_names == ["user_tool"]
+
+
+# ---------- on_first_response lock-in signal ----------
+#
+# These tests pin the contract used by the platform-mode attempt loop in
+# chat.py to decide when a tool-loop attempt has "committed" to a provider.
+# The route handler MUST be able to tell apart:
+#   * the first upstream acompletion raised → free to fall back to the next
+#     attempt with a clean conversation slate
+#   * the first upstream acompletion returned → request is locked in;
+#     downstream failures must surface, not swap providers
+
+
+@pytest.mark.asyncio
+async def test_loop_on_first_response_fires_once_after_first_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Callback fires exactly once, immediately after the first acompletion
+    returns — before MCP execution, before later rounds. Multi-round loops
+    must not double-fire."""
+    responses = iter(
+        [
+            _completion(finish="tool_calls", tool_calls=[("c1", "fetch_url", "{}")]),
+            _completion(finish="stop", content="done"),
+        ]
+    )
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        return next(responses)
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    invocations: list[int] = []
+
+    def _on_first() -> None:
+        invocations.append(1)
+
+    await mcp_tool_loop(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+        pool=_FakePool(tool_names=["fetch_url"]),  # type: ignore[arg-type]
+        max_iterations=5,
+        on_first_response=_on_first,
+    )
+    # Two rounds (tool_calls then stop) — callback must still only fire on round 1.
+    assert invocations == [1]
+
+
+@pytest.mark.asyncio
+async def test_loop_on_first_response_not_called_when_first_acompletion_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the first acompletion raises (auth, billing, network), the callback
+    must NOT fire — the route handler relies on this to decide whether
+    fallback to the next attempt is safe."""
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        raise RuntimeError("simulated upstream auth error")
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    invocations: list[int] = []
+
+    def _on_first() -> None:
+        invocations.append(1)
+
+    with pytest.raises(RuntimeError):
+        await mcp_tool_loop(
+            completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+            pool=_FakePool(tool_names=["fetch_url"]),  # type: ignore[arg-type]
+            max_iterations=5,
+            on_first_response=_on_first,
+        )
+    assert invocations == []
+
+
+@pytest.mark.asyncio
+async def test_loop_on_first_response_fires_before_second_round_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If round 1 succeeds and round 2 raises, callback fired on round 1.
+    The route handler sees ``locked_in=True`` and surfaces the round-2
+    failure as an error rather than falling back — that's the "no silent
+    swap mid-loop" guarantee."""
+    state = {"round": 0}
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        state["round"] += 1
+        if state["round"] == 1:
+            return _completion(finish="tool_calls", tool_calls=[("c1", "fetch_url", "{}")])
+        raise RuntimeError("simulated upstream 5xx on round 2")
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    invocations: list[int] = []
+
+    def _on_first() -> None:
+        invocations.append(1)
+
+    with pytest.raises(RuntimeError):
+        await mcp_tool_loop(
+            completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+            pool=_FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"}),  # type: ignore[arg-type]
+            max_iterations=5,
+            on_first_response=_on_first,
+        )
+    # Callback fired exactly once on round 1, even though round 2 failed.
+    assert invocations == [1]
+
+
+@pytest.mark.asyncio
+async def test_loop_omitting_on_first_response_is_backward_compatible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing callers that don't pass on_first_response continue to work."""
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        return _completion(finish="stop", content="ok")
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    out = await mcp_tool_loop(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+        pool=_FakePool(tool_names=["fetch_url"]),  # type: ignore[arg-type]
+        max_iterations=5,
+    )
+    assert out.choices[0].message.content == "ok"


### PR DESCRIPTION
## Summary

Stacked on top of #72.

Tool-loop requests (`code_execution` / `mcp_servers` / `web_search`) used to collapse to a single attempt and skip routing-policy fallback entirely. A bad or expired primary key would fail the whole request even when a healthy fallback provider was configured.

This PR iterates the full attempt list and falls through on any failure that lands *before* the model returns its first assistant message. Once a tool round has produced an assistant message (content or `tool_call`), the request locks in to that provider — subsequent failures terminate the request, so we never replay a provider-specific transcript on a different provider.

## Why

A user with Anthropic primary + OpenAI fallback enabled and `code_execution` in `tools` would hit a `502` the moment their Anthropic key expired — fallback was silently disabled because tools were in play. The original `[:1]` collapse over-applied a sensible rule ("don't swap providers mid-loop") to a case that didn't need it (the loop hadn't started yet).

## What changed

- `mcp_tool_loop` gains an optional `on_first_response` callback fired once after the first upstream `acompletion` succeeds. The route handler uses it to flip a per-attempt `locked_in` flag.
- The `attempts_to_try[:1]` collapse for `mcp_servers / use_sandbox / use_web_search` is removed. In the `except BaseException` handler, the request raises unconditionally when `locked_in=True`; otherwise the existing retryable/continue path runs.
- `_run_streaming_with_fallback` accepts tool-mode parameters and now drives platform-mode streaming tool requests. The tool backend is opened once via `AsyncExitStack` and shared across attempts; eager-open preserves the "gateway-side dependency failure → HTTP error, not mid-SSE error" UX.
- Tool-mode streams use a longer first-chunk timeout (default 30s) — configurable via `streaming_first_chunk_timeout_ms_tool_loop` on `config.platform`. Reason: the model may reason before emitting tokens or a `tool_call`.

## What didn't change

- Resolver contract with otari-ai (`/gateway/provider-keys/resolve`).
- Tool definition shapes — still OpenAI-style function tools for `code_execution`, `web_search`, and MCP-derived tools.
- The "no silent mid-loop swap" invariant — still holds, just enforced precisely at the lock-in point instead of by disabling fallback up front.
- Standalone mode (no `route.attempts`).
- Mutual exclusivity between sandbox / MCP / web_search at request time.

## Test plan

- [x] **Regression tests pass on this branch, fail on `main`.** Verified by reverting just the production changes and re-running with the test changes applied: 2 integration tests and 3 unit tests fail; with the production changes restored, all pass.
- [x] `uv run pytest tests/unit/test_mcp_loop.py` — 20 tests, including 4 new ones pinning the `on_first_response` contract (fires once, not on first-call failure, fires before round-2 failure, backward-compat when omitted).
- [x] `uv run pytest tests/integration/test_platform_mode_chat.py` — 13 tests, including 3 new ones: pre-lock-in fallback (non-streaming + streaming), no-fallback-after-lock-in.
- [x] `uv run mypy src tests scripts` — clean, 130 source files, strict mode.
- [x] `uv run ruff check` — clean.
- [ ] **Manual end-to-end against a real Anthropic + OpenAI route would be valuable before un-drafting** — happy to walk through it together.

## Follow-ups (not in this PR)

Code review surfaced several worthwhile refactors that I deliberately deferred to keep this PR focused:

- Collapse the 10 tool-mode kwargs on `_run_streaming_with_fallback` into a `ToolMode` dataclass (tagged union over `mcp` / `sandbox` / `web_search`).
- Extract a `_open_tool_backend(stack, tool_mode)` helper to dedupe the 3 near-identical tool-mode branches in the non-streaming attempt loop.
- Extract per-attempt body into `_run_one_attempt(attempt) -> tuple[ChatCompletion, bool]` to localize the `locked_in` flag and remove the `nonlocal` pattern.
- Mirror the eager-open-once pattern in the non-streaming path (currently opens the backend per-attempt — wasted work on retried attempts).
- Promote `_FakeMcpPool` / `_FakePool` to a shared `conftest.py` fixture and fold the new `_two_attempt_resolve_response` helper into the existing inline copies.
- `asyncio.gather` the MCP server dials in `MCPClientPool.__aenter__` — pre-existing, but more impactful now that the streaming path opens before the first attempt.
- Document `streaming_first_chunk_timeout_ms_tool_loop` and consider a request-wide deadline cap on streaming tool-loop fallback (currently bounded by per-attempt timeout × N attempts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)