### PR TITLE
ci: upgrade Node.js 20 actions to Node 24

### DIFF
--- a/.github/workflows/gateway-docker.yml
+++ b/.github/workflows/gateway-docker.yml
@@ -42,7 +42,7 @@ jobs:
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to the Container registry
         uses: docker/login-action@v4
@@ -108,7 +108,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Upgrade two GitHub Actions in `gateway-docker.yml` that still use the Node.js 20 runtime to versions that use Node.js 24:

| Action | Before | After | Node Runtime |
|--------|--------|-------|-------------|
| `docker/setup-buildx-action` | `@v3` (node20) | `@v4` (node24) | node20 -> node24 |
| `peter-evans/dockerhub-description` | `@v4` (node20) | `@v5` (node24) | node20 -> node24 |

## Why

GitHub is deprecating Node.js 20 for Actions:
- **June 2, 2026**: Node.js 20 actions will be forced to run on Node.js 24
- **September 16, 2026**: Node.js 20 runtime will be fully removed

All other actions in the repository are already on Node.js 24 or use composite (shell-based) runners not affected by this deprecation.

## Verification

- `docker/setup-buildx-action@v3` is used with no `with:` inputs, so the v4 upgrade (which removed some deprecated inputs) has no breaking impact
- `peter-evans/dockerhub-description@v5` is a straightforward Node runtime upgrade; the `with:` inputs (`username`, `password`, `repository`, `readme-filepath`) are unchanged between v4 and v5
- No self-hosted runners are used, so the Actions Runner version requirement for v5 does not apply