### PR TITLE
feat(messages): PR 2/4 — MCP / sandbox / web_search on /v1/messages

### DIFF
--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -76,7 +76,7 @@ class MessagesRequest(BaseModel):
     # Gateway-internal: identical semantics to ChatCompletionRequest.
     mcp_servers: list[McpServerConfig] | None = None
     tools_header: str | None = None
-    max_tool_iterations: int | None = None
+    max_tool_iterations: int | None = Field(default=None, ge=1, le=MAX_TOOL_ITERATIONS_CAP)
 
 
 def _anthropic_error(error_type: str, message: str, status_code: int) -> HTTPException:
@@ -535,9 +535,19 @@ async def _open_tool_loop_stream(
     web_search_url: str | None,
     max_tool_iterations: int,
 ) -> AsyncIterator[MessageStreamEvent]:
-    """Open the right backend, eagerly enter it (so connection failures
-    surface as HTTP errors, not as in-band SSE errors after a 200 OK), and
-    return an async iterator that yields all events for the entire tool loop.
+    """Return an async iterator that yields events for the entire tool loop.
+
+    For the sandbox and web_search paths the backend is opened **eagerly**
+    (the ``await ... __aenter__()`` runs before the iterator is returned), so
+    a backend-unreachable error surfaces as an HTTP 502 rather than landing
+    in the SSE channel after the response has already committed to 200 OK.
+
+    The MCP path is different: ``MCPClientPool`` is entered lazily inside the
+    iterator's ``async with`` block. An ``MCPClientPool`` dial failure surfaces
+    once the client starts pulling events. A future improvement would
+    AsyncExitStack-share the pool across attempts and eager-open it for the
+    same UX as the other two backends; for now MCP keeps the simpler
+    enter-inside-generator pattern.
     """
     if mcp_server_configs:
         pool_cfgs = mcp_server_configs

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -471,22 +471,40 @@ async def _stream_messages(
             error=error,
         )
 
-    if not use_tool_loop:
-        msg_stream = await amessages(**call_kwargs)
-        msg_stream_typed: AsyncIterator[MessageStreamEvent] = msg_stream  # type: ignore[assignment]
-    else:
-        msg_stream_typed = await _open_tool_loop_stream(
-            call_kwargs=call_kwargs,
-            tools_header=request.tools_header,
-            mcp_server_configs=mcp_server_configs,
-            use_sandbox=use_sandbox,
-            sandbox_tool_entry=sandbox_tool_entry,
-            sandbox_url=sandbox_url,
-            use_web_search=use_web_search,
-            web_search_tool_entry=web_search_tool_entry,
-            web_search_url=web_search_url,
-            max_tool_iterations=max_tool_iterations,
-        )
+    try:
+        if not use_tool_loop:
+            msg_stream = await amessages(**call_kwargs)
+            msg_stream_typed: AsyncIterator[MessageStreamEvent] = msg_stream  # type: ignore[assignment]
+        else:
+            msg_stream_typed = await _open_tool_loop_stream(
+                call_kwargs=call_kwargs,
+                tools_header=request.tools_header,
+                mcp_server_configs=mcp_server_configs,
+                use_sandbox=use_sandbox,
+                sandbox_tool_entry=sandbox_tool_entry,
+                sandbox_url=sandbox_url,
+                use_web_search=use_web_search,
+                web_search_tool_entry=web_search_tool_entry,
+                web_search_url=web_search_url,
+                max_tool_iterations=max_tool_iterations,
+            )
+    except SandboxNotReachableError as exc:
+        # Surfaced here (rather than from the in-band SSE channel) because the
+        # backend is opened eagerly — see ``_open_tool_loop_stream``'s
+        # docstring. Mirrors the non-streaming error mapping.
+        logger.error("Sandbox unreachable for %s:%s: %s", provider, model, exc)
+        raise _anthropic_error(
+            _ERR_API,
+            "code_execution sandbox unreachable — check GATEWAY_SANDBOX_URL",
+            status.HTTP_502_BAD_GATEWAY,
+        ) from exc
+    except WebSearchNotReachableError as exc:
+        logger.error("Web search backend unreachable for %s:%s: %s", provider, model, exc)
+        raise _anthropic_error(
+            _ERR_API,
+            "web_search backend unreachable — check GATEWAY_WEB_SEARCH_URL",
+            status.HTTP_502_BAD_GATEWAY,
+        ) from exc
 
     rl_headers = rate_limit_headers(rate_limit_info) if rate_limit_info else {}
     return StreamingResponse(

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -1,3 +1,5 @@
+import os
+from collections.abc import AsyncIterator
 from typing import Annotated, Any
 
 from any_llm import AnyLLM, amessages
@@ -15,20 +17,46 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
 from gateway.api.routes._helpers import resolve_user_id
+from gateway.api.routes._tools import (
+    _build_web_search_backend,
+    _extract_code_execution_tool,
+    _extract_web_search_tool,
+    _resolve_sandbox_purpose_hint,
+    _strip_gateway_fields,
+)
 from gateway.api.routes.chat import get_provider_kwargs, log_usage, rate_limit_headers
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import APIKey
+from gateway.models.mcp import McpServerConfig
 from gateway.rate_limit import check_rate_limit
 from gateway.services.budget_service import validate_user_budget
 from gateway.services.log_writer import LogWriter
+from gateway.services.mcp_client import MCPClientPool
+from gateway.services.mcp_loop_messages import (
+    DEFAULT_MAX_TOOL_ITERATIONS,
+    MAX_TOOL_ITERATIONS_CAP,
+    MaxToolIterationsExceeded,
+    anthropic_tool_loop,
+    anthropic_tool_loop_stream,
+)
+from gateway.services.sandbox_backend import SandboxBackend, SandboxNotReachableError
+from gateway.services.tool_format import inject_purpose_hints_anthropic, openai_to_anthropic_tools
+from gateway.services.web_search_backend import WebSearchNotReachableError
 from gateway.streaming import ANTHROPIC_STREAM_FORMAT, streaming_generator
 
 router = APIRouter(prefix="/v1", tags=["messages"])
 
 
 class MessagesRequest(BaseModel):
-    """Anthropic Messages API-compatible request."""
+    """Anthropic Messages API-compatible request.
+
+    Gateway-internal fields (``mcp_servers``, ``tools_header``,
+    ``max_tool_iterations``) are accepted on top of the Anthropic wire shape
+    so the same client can opt into gateway-managed MCP / sandbox / web_search
+    without abandoning the Messages API. These fields are stripped before the
+    request is forwarded upstream.
+    """
 
     model: str
     messages: list[dict[str, Any]] = Field(min_length=1)
@@ -44,6 +72,11 @@ class MessagesRequest(BaseModel):
     metadata: dict[str, Any] | None = None
     thinking: dict[str, Any] | None = None
     cache_control: dict[str, Any] | None = None
+
+    # Gateway-internal: identical semantics to ChatCompletionRequest.
+    mcp_servers: list[McpServerConfig] | None = None
+    tools_header: str | None = None
+    max_tool_iterations: int | None = None
 
 
 def _anthropic_error(error_type: str, message: str, status_code: int) -> HTTPException:
@@ -72,7 +105,13 @@ async def create_message(
     config: Annotated[GatewayConfig, Depends(get_config)],
     log_writer: Annotated[LogWriter, Depends(get_log_writer)],
 ) -> dict[str, Any] | StreamingResponse:
-    """Anthropic Messages API-compatible endpoint."""
+    """Anthropic Messages API-compatible endpoint.
+
+    Supports MCP tool-use loops, sandboxed code execution, and SearXNG
+    web_search on the standalone-mode path. Platform-mode multi-attempt
+    fallback is not wired here yet (handled by a follow-up PR); requests in
+    platform mode currently pass through to the upstream provider unchanged.
+    """
     api_key, is_master_key = auth_result
     api_key_id = api_key.id if api_key else None
     user_from_metadata = request.metadata.get("user_id") if request.metadata else None
@@ -104,80 +143,113 @@ async def create_message(
         await db.rollback()
 
     provider, model = AnyLLM.split_model_provider(request.model)
-
     provider_kwargs = get_provider_kwargs(config, provider)
 
-    # Request fields take precedence over provider config defaults
-    request_fields = request.model_dump(exclude_unset=True)
+    # Tool extraction mirrors chat.py: sandbox / web_search / mcp_servers are
+    # mutually exclusive for now (multi-backend dispatch is a follow-up).
+    sandbox_tool_entry, tools_after_sandbox = _extract_code_execution_tool(request.tools)
+    sandbox_url: str | None = os.environ.get("GATEWAY_SANDBOX_URL") or None
+    use_sandbox = False
+    if sandbox_tool_entry is not None:
+        if sandbox_url is None:
+            raise _anthropic_error(
+                _ERR_INVALID_REQUEST,
+                (
+                    "code_execution tool requested but no sandbox is configured on this gateway. "
+                    "Set GATEWAY_SANDBOX_URL on the gateway, or remove code_execution from `tools`."
+                ),
+                status.HTTP_400_BAD_REQUEST,
+            )
+        if request.mcp_servers:
+            raise _anthropic_error(
+                _ERR_INVALID_REQUEST,
+                (
+                    "code_execution and mcp_servers cannot be combined in the same request yet; "
+                    "pick one. Multi-backend dispatch is a planned refinement."
+                ),
+                status.HTTP_400_BAD_REQUEST,
+            )
+        use_sandbox = True
+
+    web_search_tool_entry, remaining_user_tools = _extract_web_search_tool(tools_after_sandbox)
+    web_search_url: str | None = os.environ.get("GATEWAY_WEB_SEARCH_URL") or None
+    use_web_search = False
+    if web_search_tool_entry is not None:
+        if web_search_url is None:
+            raise _anthropic_error(
+                _ERR_INVALID_REQUEST,
+                (
+                    "web_search tool requested but no search backend is configured on this gateway. "
+                    "Set GATEWAY_WEB_SEARCH_URL on the gateway, or remove web_search from `tools`."
+                ),
+                status.HTTP_400_BAD_REQUEST,
+            )
+        if use_sandbox or request.mcp_servers:
+            raise _anthropic_error(
+                _ERR_INVALID_REQUEST,
+                (
+                    "web_search cannot be combined with code_execution or mcp_servers in the same "
+                    "request yet; pick one."
+                ),
+                status.HTTP_400_BAD_REQUEST,
+            )
+        use_web_search = True
+
+    mcp_server_configs = request.mcp_servers
+    max_tool_iterations = min(
+        request.max_tool_iterations or DEFAULT_MAX_TOOL_ITERATIONS,
+        MAX_TOOL_ITERATIONS_CAP,
+    )
+
+    # Strip gateway-internal fields, convert any caller-supplied OpenAI-shaped
+    # tools to Anthropic shape so a mixed list works, and rebuild kwargs.
+    request_fields = _strip_gateway_fields(
+        request.model_dump(exclude_unset=True),
+        tools_extracted=sandbox_tool_entry is not None or web_search_tool_entry is not None,
+        remaining_user_tools=remaining_user_tools,
+    )
+    if request_fields.get("tools"):
+        request_fields["tools"] = openai_to_anthropic_tools(request_fields["tools"])
     call_kwargs: dict[str, Any] = {**provider_kwargs, **request_fields}
 
+    use_tool_loop = bool(mcp_server_configs) or use_sandbox or use_web_search
+
+    if request.stream:
+        return await _stream_messages(
+            call_kwargs=call_kwargs,
+            request=request,
+            db=db,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            user_id=user_id,
+            provider=provider,
+            model=model,
+            rate_limit_info=rate_limit_info,
+            use_tool_loop=use_tool_loop,
+            mcp_server_configs=mcp_server_configs,
+            use_sandbox=use_sandbox,
+            sandbox_tool_entry=sandbox_tool_entry,
+            sandbox_url=sandbox_url,
+            use_web_search=use_web_search,
+            web_search_tool_entry=web_search_tool_entry,
+            web_search_url=web_search_url,
+            max_tool_iterations=max_tool_iterations,
+        )
+
     try:
-        if request.stream:
-            call_kwargs["stream"] = True
-
-            def _format_chunk(event: MessageStreamEvent) -> str:
-                return f"event: {event.type}\ndata: {event.model_dump_json(exclude_none=True)}\n\n"
-
-            def _extract_usage(event: MessageStreamEvent) -> CompletionUsage | None:
-                if isinstance(event, MessageDeltaEvent):
-                    input_tokens = event.usage.input_tokens or 0
-                    output_tokens = event.usage.output_tokens or 0
-                    return CompletionUsage(
-                        prompt_tokens=input_tokens,
-                        completion_tokens=output_tokens,
-                        total_tokens=input_tokens + output_tokens,
-                    )
-                if isinstance(event, MessageStartEvent):
-                    input_tokens = event.message.usage.input_tokens or 0
-                    if input_tokens:
-                        return CompletionUsage(
-                            prompt_tokens=input_tokens,
-                            completion_tokens=0,
-                            total_tokens=input_tokens,
-                        )
-                return None
-
-            async def _on_complete(usage_data: CompletionUsage) -> None:
-                await log_usage(
-                    db=db,
-                    log_writer=log_writer,
-                    api_key_id=api_key_id,
-                    model=model,
-                    provider=provider,
-                    endpoint="/v1/messages",
-                    user_id=user_id,
-                    usage_override=usage_data,
-                )
-
-            async def _on_error(error: str) -> None:
-                await log_usage(
-                    db=db,
-                    log_writer=log_writer,
-                    api_key_id=api_key_id,
-                    model=model,
-                    provider=provider,
-                    endpoint="/v1/messages",
-                    user_id=user_id,
-                    error=error,
-                )
-
-            msg_stream = await amessages(**call_kwargs)
-            rl_headers = rate_limit_headers(rate_limit_info) if rate_limit_info else {}
-            return StreamingResponse(
-                streaming_generator(
-                    stream=msg_stream,  # type: ignore[arg-type]
-                    format_chunk=_format_chunk,
-                    extract_usage=_extract_usage,
-                    fmt=ANTHROPIC_STREAM_FORMAT,
-                    on_complete=_on_complete,
-                    on_error=_on_error,
-                    label=f"{provider}:{model}",
-                ),
-                media_type="text/event-stream",
-                headers=rl_headers,
-            )
-
-        result: MessageResponse = await amessages(**call_kwargs)  # type: ignore[assignment]
+        result = await _run_messages_non_stream(
+            call_kwargs=call_kwargs,
+            tools_header=request.tools_header,
+            use_tool_loop=use_tool_loop,
+            mcp_server_configs=mcp_server_configs,
+            use_sandbox=use_sandbox,
+            sandbox_tool_entry=sandbox_tool_entry,
+            sandbox_url=sandbox_url,
+            use_web_search=use_web_search,
+            web_search_tool_entry=web_search_tool_entry,
+            web_search_url=web_search_url,
+            max_tool_iterations=max_tool_iterations,
+        )
 
         if result.usage:
             usage_data = CompletionUsage(
@@ -198,6 +270,35 @@ async def create_message(
 
     except HTTPException:
         raise
+    except MaxToolIterationsExceeded as e:
+        # Gateway-side cap hit, not an upstream failure. 422 keeps the same
+        # semantics as the chat endpoint so callers can tell a runaway tool
+        # loop from a provider outage.
+        await log_usage(
+            db=db,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            model=model,
+            provider=provider,
+            endpoint="/v1/messages",
+            user_id=user_id,
+            error=str(e),
+        )
+        raise _anthropic_error(_ERR_INVALID_REQUEST, str(e), status.HTTP_422_UNPROCESSABLE_ENTITY) from e
+    except SandboxNotReachableError as e:
+        logger.error("Sandbox unreachable for %s:%s: %s", provider, model, e)
+        raise _anthropic_error(
+            _ERR_API,
+            "code_execution sandbox unreachable — check GATEWAY_SANDBOX_URL",
+            status.HTTP_502_BAD_GATEWAY,
+        ) from e
+    except WebSearchNotReachableError as e:
+        logger.error("Web search backend unreachable for %s:%s: %s", provider, model, e)
+        raise _anthropic_error(
+            _ERR_API,
+            "web_search backend unreachable — check GATEWAY_WEB_SEARCH_URL",
+            status.HTTP_502_BAD_GATEWAY,
+        ) from e
     except Exception as e:
         await log_usage(
             db=db,
@@ -221,3 +322,271 @@ async def create_message(
             response.headers[key] = value
 
     return result.model_dump(exclude_none=True)
+
+
+async def _run_messages_non_stream(
+    *,
+    call_kwargs: dict[str, Any],
+    tools_header: str | None,
+    use_tool_loop: bool,
+    mcp_server_configs: list[McpServerConfig] | None,
+    use_sandbox: bool,
+    sandbox_tool_entry: dict[str, Any] | None,
+    sandbox_url: str | None,
+    use_web_search: bool,
+    web_search_tool_entry: dict[str, Any] | None,
+    web_search_url: str | None,
+    max_tool_iterations: int,
+) -> MessageResponse:
+    """Dispatch the non-streaming Anthropic call.
+
+    Plain ``amessages`` when no gateway tools are in play. Otherwise the
+    appropriate backend is opened (MCP pool, sandbox, or web_search) and
+    ``anthropic_tool_loop`` drives the tool round-trips.
+    """
+    if not use_tool_loop:
+        return await amessages(**call_kwargs)  # type: ignore[return-value]
+
+    if mcp_server_configs:
+        async with MCPClientPool(mcp_server_configs) as pool:
+            kwargs = inject_purpose_hints_anthropic(
+                {**call_kwargs},
+                pool.purpose_hints(),
+                header=tools_header,
+            )
+            return await anthropic_tool_loop(
+                completion_kwargs=kwargs,
+                pool=pool,
+                max_iterations=max_tool_iterations,
+            )
+
+    if use_sandbox:
+        assert sandbox_url is not None
+        sandbox_hint = _resolve_sandbox_purpose_hint(sandbox_tool_entry)
+        async with SandboxBackend(sandbox_url=sandbox_url, purpose_hint=sandbox_hint) as backend:
+            kwargs = inject_purpose_hints_anthropic(
+                {**call_kwargs},
+                backend.purpose_hints(),
+                header=tools_header,
+            )
+            return await anthropic_tool_loop(
+                completion_kwargs=kwargs,
+                pool=backend,  # type: ignore[arg-type]
+                max_iterations=max_tool_iterations,
+            )
+
+    assert use_web_search
+    assert web_search_url is not None
+    assert web_search_tool_entry is not None
+    async with _build_web_search_backend(
+        base_url=web_search_url,
+        tool_entry=web_search_tool_entry,
+    ) as web_backend:
+        kwargs = inject_purpose_hints_anthropic(
+            {**call_kwargs},
+            web_backend.purpose_hints(),
+            header=tools_header,
+        )
+        return await anthropic_tool_loop(
+            completion_kwargs=kwargs,
+            pool=web_backend,  # type: ignore[arg-type]
+            max_iterations=max_tool_iterations,
+        )
+
+
+async def _stream_messages(
+    *,
+    call_kwargs: dict[str, Any],
+    request: MessagesRequest,
+    db: AsyncSession,
+    log_writer: LogWriter,
+    api_key_id: str | None,
+    user_id: str,
+    provider: Any,
+    model: str,
+    rate_limit_info: Any,
+    use_tool_loop: bool,
+    mcp_server_configs: list[McpServerConfig] | None,
+    use_sandbox: bool,
+    sandbox_tool_entry: dict[str, Any] | None,
+    sandbox_url: str | None,
+    use_web_search: bool,
+    web_search_tool_entry: dict[str, Any] | None,
+    web_search_url: str | None,
+    max_tool_iterations: int,
+) -> StreamingResponse:
+    """Streaming Anthropic endpoint dispatch.
+
+    Plain ``amessages(stream=True)`` when no gateway tools are in play.
+    Otherwise the backend is opened **eagerly** (before the StreamingResponse
+    is constructed) so a backend-unreachable error surfaces as an HTTP error
+    rather than a 200 OK followed by an in-band SSE error. Same rationale as
+    the chat.py sandbox/web_search streaming paths.
+    """
+    call_kwargs["stream"] = True
+
+    def _format_chunk(event: MessageStreamEvent) -> str:
+        return f"event: {event.type}\ndata: {event.model_dump_json(exclude_none=True)}\n\n"
+
+    def _extract_usage(event: MessageStreamEvent) -> CompletionUsage | None:
+        if isinstance(event, MessageDeltaEvent):
+            input_tokens = event.usage.input_tokens or 0
+            output_tokens = event.usage.output_tokens or 0
+            return CompletionUsage(
+                prompt_tokens=input_tokens,
+                completion_tokens=output_tokens,
+                total_tokens=input_tokens + output_tokens,
+            )
+        if isinstance(event, MessageStartEvent):
+            input_tokens = event.message.usage.input_tokens or 0
+            if input_tokens:
+                return CompletionUsage(
+                    prompt_tokens=input_tokens,
+                    completion_tokens=0,
+                    total_tokens=input_tokens,
+                )
+        return None
+
+    async def _on_complete(usage_data: CompletionUsage) -> None:
+        await log_usage(
+            db=db,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            model=model,
+            provider=provider,
+            endpoint="/v1/messages",
+            user_id=user_id,
+            usage_override=usage_data,
+        )
+
+    async def _on_error(error: str) -> None:
+        await log_usage(
+            db=db,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            model=model,
+            provider=provider,
+            endpoint="/v1/messages",
+            user_id=user_id,
+            error=error,
+        )
+
+    if not use_tool_loop:
+        msg_stream = await amessages(**call_kwargs)
+        msg_stream_typed: AsyncIterator[MessageStreamEvent] = msg_stream  # type: ignore[assignment]
+    else:
+        msg_stream_typed = await _open_tool_loop_stream(
+            call_kwargs=call_kwargs,
+            tools_header=request.tools_header,
+            mcp_server_configs=mcp_server_configs,
+            use_sandbox=use_sandbox,
+            sandbox_tool_entry=sandbox_tool_entry,
+            sandbox_url=sandbox_url,
+            use_web_search=use_web_search,
+            web_search_tool_entry=web_search_tool_entry,
+            web_search_url=web_search_url,
+            max_tool_iterations=max_tool_iterations,
+        )
+
+    rl_headers = rate_limit_headers(rate_limit_info) if rate_limit_info else {}
+    return StreamingResponse(
+        streaming_generator(
+            stream=msg_stream_typed,
+            format_chunk=_format_chunk,
+            extract_usage=_extract_usage,
+            fmt=ANTHROPIC_STREAM_FORMAT,
+            on_complete=_on_complete,
+            on_error=_on_error,
+            label=f"{provider}:{model}",
+        ),
+        media_type="text/event-stream",
+        headers=rl_headers,
+    )
+
+
+async def _open_tool_loop_stream(
+    *,
+    call_kwargs: dict[str, Any],
+    tools_header: str | None,
+    mcp_server_configs: list[McpServerConfig] | None,
+    use_sandbox: bool,
+    sandbox_tool_entry: dict[str, Any] | None,
+    sandbox_url: str | None,
+    use_web_search: bool,
+    web_search_tool_entry: dict[str, Any] | None,
+    web_search_url: str | None,
+    max_tool_iterations: int,
+) -> AsyncIterator[MessageStreamEvent]:
+    """Open the right backend, eagerly enter it (so connection failures
+    surface as HTTP errors, not as in-band SSE errors after a 200 OK), and
+    return an async iterator that yields all events for the entire tool loop.
+    """
+    if mcp_server_configs:
+        pool_cfgs = mcp_server_configs
+
+        async def _mcp_iter() -> AsyncIterator[MessageStreamEvent]:
+            async with MCPClientPool(pool_cfgs) as pool:
+                kwargs = inject_purpose_hints_anthropic(
+                    {**call_kwargs},
+                    pool.purpose_hints(),
+                    header=tools_header,
+                )
+                async for event in anthropic_tool_loop_stream(
+                    completion_kwargs=kwargs,
+                    pool=pool,
+                    max_iterations=max_tool_iterations,
+                ):
+                    yield event
+
+        return _mcp_iter()
+
+    if use_sandbox:
+        assert sandbox_url is not None
+        sandbox_hint = _resolve_sandbox_purpose_hint(sandbox_tool_entry)
+        sandbox_backend = SandboxBackend(sandbox_url=sandbox_url, purpose_hint=sandbox_hint)
+        await sandbox_backend.__aenter__()  # eager-open: may raise SandboxNotReachableError
+
+        async def _sandbox_iter() -> AsyncIterator[MessageStreamEvent]:
+            try:
+                kwargs = inject_purpose_hints_anthropic(
+                    {**call_kwargs},
+                    sandbox_backend.purpose_hints(),
+                    header=tools_header,
+                )
+                async for event in anthropic_tool_loop_stream(
+                    completion_kwargs=kwargs,
+                    pool=sandbox_backend,  # type: ignore[arg-type]
+                    max_iterations=max_tool_iterations,
+                ):
+                    yield event
+            finally:
+                await sandbox_backend.__aexit__(None, None, None)
+
+        return _sandbox_iter()
+
+    assert use_web_search
+    assert web_search_url is not None
+    assert web_search_tool_entry is not None
+    web_search_backend = _build_web_search_backend(
+        base_url=web_search_url,
+        tool_entry=web_search_tool_entry,
+    )
+    await web_search_backend.__aenter__()  # eager-open
+
+    async def _web_search_iter() -> AsyncIterator[MessageStreamEvent]:
+        try:
+            kwargs = inject_purpose_hints_anthropic(
+                {**call_kwargs},
+                web_search_backend.purpose_hints(),
+                header=tools_header,
+            )
+            async for event in anthropic_tool_loop_stream(
+                completion_kwargs=kwargs,
+                pool=web_search_backend,  # type: ignore[arg-type]
+                max_iterations=max_tool_iterations,
+            ):
+                yield event
+        finally:
+            await web_search_backend.__aexit__(None, None, None)
+
+    return _web_search_iter()

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -251,6 +251,12 @@ async def anthropic_tool_loop_stream(
     base = {k: v for k, v in completion_kwargs.items() if k not in {"messages", "tools"}}
     base["stream"] = True
 
+    # Accumulator for output_tokens from dropped intermediate ``message_delta``
+    # events. The final iteration's forwarded ``message_delta`` is modified to
+    # carry the cumulative total so streaming usage reporting downstream sees
+    # the full tool-loop output, not just the final round's tokens.
+    acc_output_tokens = 0
+
     for _ in range(max_iterations):
         kwargs: dict[str, Any] = {**base, "messages": messages}
         if merged_tools:
@@ -258,8 +264,16 @@ async def anthropic_tool_loop_stream(
 
         stream: AsyncIterator[MessageStreamEvent] = await amessages(**kwargs)  # type: ignore[assignment]
 
-        tool_use_blocks: dict[int, dict[str, Any]] = {}  # index -> {"id", "name", "json_buf"}
-        text_buffers: dict[int, list[str]] = {}  # index -> running text fragments
+        # All blocks (text, tool_use, thinking, redacted_thinking, …) tracked
+        # by their original ``content_block_start.index`` so the assistant
+        # message we feed back into the next round preserves the model's
+        # original ordering and doesn't silently drop non-text / non-tool_use
+        # block types.
+        blocks_by_index: dict[int, dict[str, Any]] = {}
+        # Per-tool_use JSON-arg buffer, keyed by index. Stored separately from
+        # ``blocks_by_index`` so we don't have to strip an internal field
+        # before serializing the assistant message.
+        tool_use_json_bufs: dict[int, str] = {}
         stop_reason: str | None = None
         deferred_terminal: list[MessageStreamEvent] = []
 
@@ -269,24 +283,32 @@ async def anthropic_tool_loop_stream(
             if event_type == "content_block_start":
                 block = event.content_block  # type: ignore[union-attr]
                 idx = event.index  # type: ignore[union-attr]
-                btype = getattr(block, "type", None)
-                if btype == "tool_use":
-                    tool_use_blocks[idx] = {
-                        "id": getattr(block, "id", ""),
-                        "name": getattr(block, "name", ""),
-                        "json_buf": "",
-                    }
-                elif btype == "text":
-                    text_buffers[idx] = [getattr(block, "text", "") or ""]
+                if hasattr(block, "model_dump"):
+                    blocks_by_index[idx] = block.model_dump(exclude_none=True)
+                else:
+                    blocks_by_index[idx] = dict(block) if isinstance(block, dict) else {}
+                if blocks_by_index[idx].get("type") == "tool_use":
+                    tool_use_json_bufs[idx] = ""
 
             elif event_type == "content_block_delta":
                 idx = event.index  # type: ignore[union-attr]
                 delta = event.delta  # type: ignore[union-attr]
                 dtype = getattr(delta, "type", None)
-                if dtype == "input_json_delta" and idx in tool_use_blocks:
-                    tool_use_blocks[idx]["json_buf"] += getattr(delta, "partial_json", "") or ""
-                elif dtype == "text_delta" and idx in text_buffers:
-                    text_buffers[idx].append(getattr(delta, "text", "") or "")
+                block_dict = blocks_by_index.get(idx)
+                if block_dict is None:
+                    pass  # delta for an unknown index — defensive no-op
+                elif dtype == "input_json_delta" and idx in tool_use_json_bufs:
+                    tool_use_json_bufs[idx] += getattr(delta, "partial_json", "") or ""
+                elif dtype == "text_delta":
+                    block_dict["text"] = (block_dict.get("text") or "") + (getattr(delta, "text", "") or "")
+                elif dtype == "thinking_delta":
+                    block_dict["thinking"] = (block_dict.get("thinking") or "") + (
+                        getattr(delta, "thinking", "") or ""
+                    )
+                elif dtype == "signature_delta":
+                    block_dict["signature"] = (block_dict.get("signature") or "") + (
+                        getattr(delta, "signature", "") or ""
+                    )
 
             elif event_type == "message_delta":
                 stop_reason = getattr(event.delta, "stop_reason", None) or stop_reason  # type: ignore[union-attr]
@@ -301,52 +323,56 @@ async def anthropic_tool_loop_stream(
             yield event
 
         # Decide whether to loop or exit.
-        if not tool_use_blocks or stop_reason != "tool_use":
-            for term in deferred_terminal:
-                yield term
-            return
-
-        # Build owned/foreign blocks for execution. We don't have the full
-        # pydantic ToolUseBlock; we only need .id / .name / .input.
         owned_specs: list[dict[str, Any]] = []
         has_foreign = False
-        for idx in sorted(tool_use_blocks):
-            spec = tool_use_blocks[idx]
-            name = spec["name"]
-            if pool.owns_tool(name):
-                owned_specs.append(spec)
+        for idx in sorted(blocks_by_index):
+            block_dict = blocks_by_index[idx]
+            if block_dict.get("type") != "tool_use":
+                continue
+            if pool.owns_tool(block_dict.get("name", "")):
+                owned_specs.append({"index": idx, **block_dict})
             else:
                 has_foreign = True
 
-        if has_foreign or not owned_specs:
-            # Caller dispatches the foreign blocks (or there's nothing to do
-            # internally). Forward terminal events and exit. Mixed (owned +
-            # foreign) is handled the same way as all-foreign in streaming
-            # mode — rewriting deltas mid-stream to remove the owned blocks
-            # would be too invasive; the client sees the full set.
+        # Loop exits when: no tool_use blocks, stop_reason isn't tool_use,
+        # the batch is mixed/foreign, or nothing owned. In all of those cases
+        # the deferred terminal events get forwarded (and the message_delta
+        # is rewritten to carry cumulative output_tokens from any prior
+        # dropped iterations).
+        exiting = not owned_specs or has_foreign or stop_reason != "tool_use"
+        if exiting:
             for term in deferred_terminal:
-                yield term
+                yield _maybe_fold_message_delta_usage(term, acc_output_tokens)
             return
 
-        # All-owned: execute and continue the loop. Drop the deferred terminal
-        # events so the client doesn't see a premature "message ended" signal.
-        assistant_content: list[dict[str, Any]] = []
-        for idx in sorted(text_buffers):
-            assistant_content.append({"type": "text", "text": "".join(text_buffers[idx])})
-        for spec in owned_specs:
-            try:
-                parsed_input = json.loads(spec["json_buf"] or "{}")
-            except json.JSONDecodeError:
-                parsed_input = {}
-            assistant_content.append(
-                {"type": "tool_use", "id": spec["id"], "name": spec["name"], "input": parsed_input}
-            )
+        # All-owned: continue the loop. Accumulate this iteration's
+        # output_tokens (from the dropped terminal) for the next final-fold.
+        for term in deferred_terminal:
+            if getattr(term, "type", None) == "message_delta":
+                usage = getattr(term, "usage", None)
+                if usage is not None:
+                    acc_output_tokens += getattr(usage, "output_tokens", 0) or 0
 
-        # Execute and build tool_result blocks for the next user message.
+        # Assistant message for the next round — preserve original block
+        # ordering. tool_use blocks pick up the parsed input from their
+        # JSON buffer.
+        assistant_content: list[dict[str, Any]] = []
+        for idx in sorted(blocks_by_index):
+            block_dict = blocks_by_index[idx]
+            if block_dict.get("type") == "tool_use":
+                try:
+                    parsed_input = json.loads(tool_use_json_bufs.get(idx, "") or "{}")
+                except json.JSONDecodeError:
+                    parsed_input = {}
+                block_dict = {**block_dict, "input": parsed_input}
+            assistant_content.append(block_dict)
+
+        # Execute owned tool_use blocks and build tool_result blocks for the
+        # next user message.
         tool_results: list[dict[str, Any]] = []
         for spec in owned_specs:
             try:
-                parsed_input = json.loads(spec["json_buf"] or "{}")
+                parsed_input = json.loads(tool_use_json_bufs.get(spec["index"], "") or "{}")
             except json.JSONDecodeError:
                 parsed_input = {}
             try:
@@ -360,3 +386,25 @@ async def anthropic_tool_loop_stream(
         messages.append({"role": "user", "content": tool_results})
 
     raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")
+
+
+def _maybe_fold_message_delta_usage(event: Any, acc_output_tokens: int) -> Any:
+    """Return ``event`` with cumulative output_tokens folded in.
+
+    Pass-through for any event type other than ``message_delta``. For a
+    ``message_delta`` carrying a usage block, replaces ``output_tokens`` with
+    ``current + acc_output_tokens`` so the stream consumer sees the full
+    tool-loop output count instead of only the final iteration's. No-op when
+    ``acc_output_tokens`` is zero (single-iteration streams stay byte-exact).
+    """
+    if acc_output_tokens <= 0:
+        return event
+    if getattr(event, "type", None) != "message_delta":
+        return event
+    usage = getattr(event, "usage", None)
+    if usage is None or not hasattr(usage, "model_copy"):
+        return event
+    new_usage = usage.model_copy(
+        update={"output_tokens": (getattr(usage, "output_tokens", 0) or 0) + acc_output_tokens}
+    )
+    return event.model_copy(update={"usage": new_usage})

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -12,7 +12,7 @@ The duck-typed pool interface (``owns_tool`` / ``call_tool`` /
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import TYPE_CHECKING, Any
 
 from any_llm import amessages
@@ -113,6 +113,7 @@ async def anthropic_tool_loop(
     completion_kwargs: dict[str, Any],
     pool: MCPClientPool,
     max_iterations: int,
+    on_first_response: Callable[[], None] | None = None,
 ) -> MessageResponse:
     """Non-streaming Anthropic Messages tool-use loop.
 
@@ -130,6 +131,13 @@ async def anthropic_tool_loop(
         the caller only sees what it can dispatch.
 
     Accumulates usage across iterations into the returned ``MessageResponse``.
+
+    ``on_first_response`` is invoked exactly once, right after the first
+    upstream ``amessages`` call returns successfully. Mirrors the contract on
+    :func:`gateway.services.mcp_loop.mcp_tool_loop` so platform-mode callers
+    can lock in to the chosen provider — once the model has produced any
+    assistant content, the conversation state is provider-specific and
+    subsequent failures must not silently swap providers.
     """
     messages = list(completion_kwargs.get("messages") or [])
     user_tools = list(completion_kwargs.get("tools") or [])
@@ -139,6 +147,7 @@ async def anthropic_tool_loop(
 
     acc_input = 0
     acc_output = 0
+    first_response_signaled = False
 
     for _ in range(max_iterations):
         kwargs: dict[str, Any] = {**base, "messages": messages, "stream": False}
@@ -146,6 +155,10 @@ async def anthropic_tool_loop(
             kwargs["tools"] = merged_tools
 
         result: MessageResponse = await amessages(**kwargs)  # type: ignore[assignment]
+        if not first_response_signaled:
+            first_response_signaled = True
+            if on_first_response is not None:
+                on_first_response()
         if result.usage:
             acc_input += result.usage.input_tokens or 0
             acc_output += result.usage.output_tokens or 0

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -1,0 +1,349 @@
+"""Anthropic Messages API variant of the MCP tool-use loop.
+
+Mirrors :mod:`gateway.services.mcp_loop` but speaks the Anthropic wire shape:
+``content`` blocks instead of ``tool_calls``, ``tool_use`` / ``tool_result``
+blocks, ``stop_reason == "tool_use"`` as the round-continuation signal.
+
+The duck-typed pool interface (``owns_tool`` / ``call_tool`` /
+``openai_tools`` / ``purpose_hints``) is reused unchanged; the
+``openai_tools`` shape is converted at the boundary in :mod:`tool_format`.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
+
+from any_llm import amessages
+
+from gateway.log_config import logger
+from gateway.services.mcp_loop import (
+    DEFAULT_MAX_TOOL_ITERATIONS,
+    MAX_TOOL_ITERATIONS_CAP,
+    MaxToolIterationsExceeded,
+)
+from gateway.services.tool_format import openai_to_anthropic_tools
+
+if TYPE_CHECKING:
+    from any_llm.types.messages import (
+        MessageResponse,
+        MessageStreamEvent,
+    )
+
+    from gateway.services.mcp_client import MCPClientPool
+
+# Re-export so callers in routes/messages.py have a single import surface.
+__all__ = [
+    "DEFAULT_MAX_TOOL_ITERATIONS",
+    "MAX_TOOL_ITERATIONS_CAP",
+    "MaxToolIterationsExceeded",
+    "anthropic_tool_loop",
+    "anthropic_tool_loop_stream",
+]
+
+
+def _split_tool_uses(
+    content: list[Any],
+    pool: MCPClientPool,
+) -> tuple[list[Any], bool]:
+    """Return (owned_tool_use_blocks, has_foreign).
+
+    Walks ``content`` for blocks with ``type == "tool_use"`` and partitions
+    them by ``pool.owns_tool(block.name)``. Foreign = caller-supplied tool the
+    gateway can't execute itself; the caller dispatches it.
+    """
+    owned: list[Any] = []
+    has_foreign = False
+    for block in content:
+        if getattr(block, "type", None) != "tool_use":
+            continue
+        if pool.owns_tool(block.name):
+            owned.append(block)
+        else:
+            has_foreign = True
+    return owned, has_foreign
+
+
+async def _execute_tool_uses(
+    pool: MCPClientPool,
+    blocks: list[Any],
+) -> list[dict[str, Any]]:
+    """Run each owned tool_use block and return the Anthropic tool_result blocks.
+
+    Tool failures convert to a ``[tool error] …`` string in the result so the
+    model can recover. Only cancellation-class exceptions
+    (``asyncio.CancelledError``, ``KeyboardInterrupt``) escape — they inherit
+    from ``BaseException`` and skip the ``Exception`` clause. Same idiom as
+    :func:`gateway.services.mcp_loop._execute_mcp_calls`.
+    """
+    out: list[dict[str, Any]] = []
+    for block in blocks:
+        try:
+            text = await pool.call_tool(block.name, dict(block.input or {}))
+        except Exception as exc:  # noqa: BLE001 — see docstring
+            logger.warning("MCP tool %s execution failed: %s", block.name, exc)
+            text = f"[tool error] {exc}"
+        out.append({"type": "tool_result", "tool_use_id": block.id, "content": text})
+    return out
+
+
+def _content_to_dicts(content: list[Any]) -> list[dict[str, Any]]:
+    """Serialize a list of Anthropic content blocks back to wire shape.
+
+    The model returned them as pydantic objects (TextBlock, ToolUseBlock,
+    ThinkingBlock, …); when we feed them back as an assistant message on the
+    next turn, Anthropic expects plain dicts.
+    """
+    out: list[dict[str, Any]] = []
+    for block in content:
+        if hasattr(block, "model_dump"):
+            out.append(block.model_dump(exclude_none=True))
+        elif isinstance(block, dict):
+            out.append(block)
+        else:
+            # Defensive: any_llm should always hand us pydantic models, but
+            # if a provider adapter returns a raw dict-like, accept it.
+            out.append(dict(block))
+    return out
+
+
+async def anthropic_tool_loop(
+    *,
+    completion_kwargs: dict[str, Any],
+    pool: MCPClientPool,
+    max_iterations: int,
+) -> MessageResponse:
+    """Non-streaming Anthropic Messages tool-use loop.
+
+    Each iteration calls ``amessages``, walks the response's content blocks for
+    ``tool_use`` entries, and if any are gateway-owned, executes them and
+    appends the assistant + tool_result messages for the next round.
+
+    Loop terminates when:
+      * the response has no ``tool_use`` blocks (final answer);
+      * ``stop_reason != "tool_use"`` (model decided to stop);
+      * the response contains foreign ``tool_use`` blocks — those are returned
+        to the caller for client-side dispatch. If the batch is mixed
+        (owned + foreign), the owned subset is executed for its side effects
+        but the response is returned with the owned blocks filtered out so
+        the caller only sees what it can dispatch.
+
+    Accumulates usage across iterations into the returned ``MessageResponse``.
+    """
+    messages = list(completion_kwargs.get("messages") or [])
+    user_tools = list(completion_kwargs.get("tools") or [])
+    merged_tools = user_tools + openai_to_anthropic_tools(pool.openai_tools)
+
+    base = {k: v for k, v in completion_kwargs.items() if k not in {"messages", "tools", "stream"}}
+
+    acc_input = 0
+    acc_output = 0
+
+    for _ in range(max_iterations):
+        kwargs: dict[str, Any] = {**base, "messages": messages, "stream": False}
+        if merged_tools:
+            kwargs["tools"] = merged_tools
+
+        result: MessageResponse = await amessages(**kwargs)  # type: ignore[assignment]
+        if result.usage:
+            acc_input += result.usage.input_tokens or 0
+            acc_output += result.usage.output_tokens or 0
+
+        content = list(result.content or [])
+        owned, has_foreign = _split_tool_uses(content, pool)
+
+        if has_foreign:
+            # Mixed batch: execute owned subset for its side effects, then
+            # filter from the returned content so the caller only sees blocks
+            # it can dispatch. Mirrors the chat-completions mixed-batch
+            # handling in mcp_loop._mcp_tool_loop.
+            if owned:
+                await _execute_tool_uses(pool, owned)
+                owned_ids = {b.id for b in owned}
+                try:
+                    result.content = [
+                        b
+                        for b in content
+                        if not (getattr(b, "type", None) == "tool_use" and getattr(b, "id", None) in owned_ids)
+                    ]
+                except (AttributeError, TypeError):
+                    logger.warning(
+                        "Anthropic-mixed: could not filter content on response; client will see tool_use "
+                        "blocks the gateway already executed (no-op on the client side).",
+                    )
+            _fold_usage(result, acc_input, acc_output)
+            return result
+
+        if not owned or result.stop_reason != "tool_use":
+            _fold_usage(result, acc_input, acc_output)
+            return result
+
+        # All-owned: continue the loop. Append the assistant turn (so the model
+        # sees its own tool_use blocks) and a user turn carrying tool_result.
+        messages.append({"role": "assistant", "content": _content_to_dicts(content)})
+        messages.append({"role": "user", "content": await _execute_tool_uses(pool, owned)})
+
+    raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")
+
+
+def _fold_usage(result: MessageResponse, input_total: int, output_total: int) -> None:
+    """Replace ``result.usage`` token counts with the loop's running totals.
+
+    Mirrors :func:`gateway.services.mcp_loop._fold_usage` but in Anthropic
+    field naming (``input_tokens`` / ``output_tokens`` instead of
+    ``prompt_tokens`` / ``completion_tokens``).
+    """
+    if result.usage is None:
+        return
+    result.usage.input_tokens = input_total
+    result.usage.output_tokens = output_total
+
+
+async def anthropic_tool_loop_stream(
+    *,
+    completion_kwargs: dict[str, Any],
+    pool: MCPClientPool,
+    max_iterations: int,
+) -> AsyncIterator[MessageStreamEvent]:
+    """Streaming Anthropic Messages tool-use loop.
+
+    Forwards every Anthropic event downstream **except** the terminal
+    ``message_delta`` / ``message_stop`` of an iteration that's about to
+    continue (a new ``message_start`` after the client thought the message
+    ended would confuse most SDK consumers).
+
+    Per iteration:
+      1. Set ``stream=True`` on ``amessages`` and iterate the event stream.
+      2. Track tool_use content blocks by ``index`` from ``content_block_start``
+         (when ``content_block.type == "tool_use"``). Buffer their
+         ``input_json_delta`` chunks until ``content_block_stop``.
+      3. Yield every event as it arrives (including the tool_use events — the
+         client sees the model's tool intent even mid-loop). Defer
+         ``message_delta`` and ``message_stop`` until we know whether the loop
+         will continue.
+      4. On ``message_stop``: if any buffered tool_use blocks exist AND all
+         owned by the pool, execute them, append messages, drop the terminal
+         events, and continue. If foreign blocks exist OR no tool_use blocks
+         were buffered, forward the terminal events and exit.
+
+    Re-emitting a synthetic ``message_start`` for the next iteration is not
+    needed because ``amessages`` produces a fresh stream — the next call's
+    natural ``message_start`` arrives downstream as if nothing had happened.
+    """
+    messages = list(completion_kwargs.get("messages") or [])
+    user_tools = list(completion_kwargs.get("tools") or [])
+    merged_tools = user_tools + openai_to_anthropic_tools(pool.openai_tools)
+
+    base = {k: v for k, v in completion_kwargs.items() if k not in {"messages", "tools"}}
+    base["stream"] = True
+
+    for _ in range(max_iterations):
+        kwargs: dict[str, Any] = {**base, "messages": messages}
+        if merged_tools:
+            kwargs["tools"] = merged_tools
+
+        stream: AsyncIterator[MessageStreamEvent] = await amessages(**kwargs)  # type: ignore[assignment]
+
+        tool_use_blocks: dict[int, dict[str, Any]] = {}  # index -> {"id", "name", "json_buf"}
+        text_buffers: dict[int, list[str]] = {}  # index -> running text fragments
+        stop_reason: str | None = None
+        deferred_terminal: list[MessageStreamEvent] = []
+
+        async for event in stream:
+            event_type = getattr(event, "type", None)
+
+            if event_type == "content_block_start":
+                block = event.content_block  # type: ignore[union-attr]
+                idx = event.index  # type: ignore[union-attr]
+                btype = getattr(block, "type", None)
+                if btype == "tool_use":
+                    tool_use_blocks[idx] = {
+                        "id": getattr(block, "id", ""),
+                        "name": getattr(block, "name", ""),
+                        "json_buf": "",
+                    }
+                elif btype == "text":
+                    text_buffers[idx] = [getattr(block, "text", "") or ""]
+
+            elif event_type == "content_block_delta":
+                idx = event.index  # type: ignore[union-attr]
+                delta = event.delta  # type: ignore[union-attr]
+                dtype = getattr(delta, "type", None)
+                if dtype == "input_json_delta" and idx in tool_use_blocks:
+                    tool_use_blocks[idx]["json_buf"] += getattr(delta, "partial_json", "") or ""
+                elif dtype == "text_delta" and idx in text_buffers:
+                    text_buffers[idx].append(getattr(delta, "text", "") or "")
+
+            elif event_type == "message_delta":
+                stop_reason = getattr(event.delta, "stop_reason", None) or stop_reason  # type: ignore[union-attr]
+                deferred_terminal.append(event)
+                continue
+
+            elif event_type == "message_stop":
+                deferred_terminal.append(event)
+                # Fall through to the post-stream decision below.
+                break
+
+            yield event
+
+        # Decide whether to loop or exit.
+        if not tool_use_blocks or stop_reason != "tool_use":
+            for term in deferred_terminal:
+                yield term
+            return
+
+        # Build owned/foreign blocks for execution. We don't have the full
+        # pydantic ToolUseBlock; we only need .id / .name / .input.
+        owned_specs: list[dict[str, Any]] = []
+        has_foreign = False
+        for idx in sorted(tool_use_blocks):
+            spec = tool_use_blocks[idx]
+            name = spec["name"]
+            if pool.owns_tool(name):
+                owned_specs.append(spec)
+            else:
+                has_foreign = True
+
+        if has_foreign or not owned_specs:
+            # Caller dispatches the foreign blocks (or there's nothing to do
+            # internally). Forward terminal events and exit. Mixed (owned +
+            # foreign) is handled the same way as all-foreign in streaming
+            # mode — rewriting deltas mid-stream to remove the owned blocks
+            # would be too invasive; the client sees the full set.
+            for term in deferred_terminal:
+                yield term
+            return
+
+        # All-owned: execute and continue the loop. Drop the deferred terminal
+        # events so the client doesn't see a premature "message ended" signal.
+        assistant_content: list[dict[str, Any]] = []
+        for idx in sorted(text_buffers):
+            assistant_content.append({"type": "text", "text": "".join(text_buffers[idx])})
+        for spec in owned_specs:
+            try:
+                parsed_input = json.loads(spec["json_buf"] or "{}")
+            except json.JSONDecodeError:
+                parsed_input = {}
+            assistant_content.append(
+                {"type": "tool_use", "id": spec["id"], "name": spec["name"], "input": parsed_input}
+            )
+
+        # Execute and build tool_result blocks for the next user message.
+        tool_results: list[dict[str, Any]] = []
+        for spec in owned_specs:
+            try:
+                parsed_input = json.loads(spec["json_buf"] or "{}")
+            except json.JSONDecodeError:
+                parsed_input = {}
+            try:
+                text = await pool.call_tool(spec["name"], parsed_input)
+            except Exception as exc:  # noqa: BLE001 — same tool-error-as-message idiom as the non-stream loop
+                logger.warning("MCP tool %s execution failed: %s", spec["name"], exc)
+                text = f"[tool error] {exc}"
+            tool_results.append({"type": "tool_result", "tool_use_id": spec["id"], "content": text})
+
+        messages.append({"role": "assistant", "content": assistant_content})
+        messages.append({"role": "user", "content": tool_results})
+
+    raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")

--- a/src/gateway/services/tool_format.py
+++ b/src/gateway/services/tool_format.py
@@ -1,0 +1,106 @@
+"""Tool-definition format conversion + per-format purpose-hint injection.
+
+The duck-typed pool interface (``MCPClientPool`` / ``SandboxBackend`` /
+``WebSearchBackend``) exposes ``openai_tools`` in the OpenAI Chat-Completions
+shape::
+
+    [{"type": "function", "function": {"name", "description", "parameters"}}]
+
+The Anthropic Messages API and OpenAI Responses API expect different shapes.
+Rather than push per-format properties down into the backends, we convert at
+the boundary — each route handler converts the pool's OpenAI shape into the
+shape its endpoint accepts. Backends stay format-agnostic.
+
+For purpose-hint injection, the chat-completions helper
+(:func:`gateway.services.mcp_loop.inject_purpose_hints`) merges hints into the
+``messages`` system role. Anthropic and Responses both surface "system" as a
+separate top-level field, so they get their own per-format helpers here.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from gateway.services.mcp_loop import PURPOSE_HINT_HEADER
+
+
+def openai_to_anthropic_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert OpenAI-shape function tools into Anthropic Messages shape.
+
+    Input::
+
+        [{"type": "function", "function": {"name": ..., "description": ..., "parameters": {...}}}]
+
+    Output::
+
+        [{"name": ..., "description": ..., "input_schema": {...}}]
+
+    Entries that aren't OpenAI function tools (e.g. already-Anthropic shape, or
+    a custom tool type the pool happens to expose) pass through unchanged so
+    that mixed lists don't break.
+    """
+    out: list[dict[str, Any]] = []
+    for tool in tools:
+        if tool.get("type") == "function" and isinstance(tool.get("function"), dict):
+            fn = tool["function"]
+            converted: dict[str, Any] = {"name": fn.get("name", "")}
+            if "description" in fn:
+                converted["description"] = fn["description"]
+            if "parameters" in fn:
+                converted["input_schema"] = fn["parameters"]
+            else:
+                # Anthropic requires input_schema even when no parameters.
+                converted["input_schema"] = {"type": "object", "properties": {}}
+            out.append(converted)
+        else:
+            out.append(tool)
+    return out
+
+
+def _resolve_header(header: str | None) -> str:
+    """Pick the effective purpose-hint preamble header.
+
+    Priority: ``header`` arg → ``GATEWAY_TOOLS_HEADER`` env → built-in default.
+    Mirrors :func:`gateway.services.mcp_loop.inject_purpose_hints`.
+    """
+    return header or os.environ.get("GATEWAY_TOOLS_HEADER") or PURPOSE_HINT_HEADER
+
+
+def _build_hint_block(hints: list[tuple[str, str]], header: str | None) -> str:
+    lines = [_resolve_header(header)]
+    for name, hint in hints:
+        lines.append(f"- {name}: {hint}")
+    return "\n".join(lines)
+
+
+def inject_purpose_hints_anthropic(
+    call_kwargs: dict[str, Any],
+    hints: list[tuple[str, str]],
+    *,
+    header: str | None = None,
+) -> dict[str, Any]:
+    """Prepend per-tool purpose hints to the Anthropic ``system`` field.
+
+    ``system`` may be a plain string or a list of content-block dicts (used for
+    cache_control). The hint block is prepended in both cases — a string
+    becomes ``"<hint>\\n\\n<existing>"``, a list gets a leading text block.
+
+    Mutates ``call_kwargs`` in place and returns it for chaining. No-op when
+    ``hints`` is empty so the caller can always wrap.
+    """
+    if not hints:
+        return call_kwargs
+
+    block = _build_hint_block(hints, header)
+    existing = call_kwargs.get("system")
+
+    if existing is None:
+        call_kwargs["system"] = block
+    elif isinstance(existing, str):
+        call_kwargs["system"] = f"{block}\n\n{existing}" if existing else block
+    elif isinstance(existing, list):
+        call_kwargs["system"] = [{"type": "text", "text": block}, *existing]
+    else:
+        call_kwargs["system"] = block
+    return call_kwargs

--- a/tests/integration/test_messages_route_dispatch.py
+++ b/tests/integration/test_messages_route_dispatch.py
@@ -8,14 +8,23 @@ Anthropic shape, and the per-tool dispatch into the right backend.
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from any_llm.types.messages import (
+    ContentBlockDeltaEvent,
+    MessageDelta,
+    MessageDeltaEvent,
+    MessageDeltaUsage,
     MessageResponse,
+    MessageStartEvent,
+    MessageStopEvent,
+    MessageStreamEvent,
     MessageUsage,
     TextBlock,
+    TextDelta,
 )
 from fastapi.testclient import TestClient
 
@@ -446,6 +455,216 @@ def test_sandbox_unreachable_returns_502_anthropic_body(
                 "model": "anthropic:claude-3-5-sonnet-20241022",
                 "messages": [{"role": "user", "content": "go"}],
                 "max_tokens": 100,
+                "tools": [{"type": "code_execution_20250825"}],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 502
+    _assert_anthropic_error(resp.json(), error_type="api_error", message_substr="sandbox unreachable")
+
+
+# ---------- streaming dispatch ----------
+
+
+def _stream_message_start() -> MessageStartEvent:
+    return MessageStartEvent(
+        type="message_start",
+        message=cast(Any, _text_response("")),
+    )
+
+
+def _stream_text_delta(text: str) -> ContentBlockDeltaEvent:
+    return ContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=0,
+        delta=cast(Any, TextDelta(type="text_delta", text=text)),
+    )
+
+
+def _stream_message_delta() -> MessageDeltaEvent:
+    return MessageDeltaEvent(
+        type="message_delta",
+        delta=MessageDelta(stop_reason=cast(Any, "end_turn"), stop_sequence=None),
+        usage=MessageDeltaUsage(
+            input_tokens=None,
+            output_tokens=1,
+            cache_creation_input_tokens=None,
+            cache_read_input_tokens=None,
+            server_tool_use=None,
+        ),
+    )
+
+
+def _stream_message_stop() -> MessageStopEvent:
+    return MessageStopEvent(type="message_stop")
+
+
+async def _stream_iter(*events: MessageStreamEvent) -> AsyncIterator[MessageStreamEvent]:
+    for event in events:
+        yield event
+
+
+def test_stream_no_tools_returns_sse_response(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """``stream: true`` with no gateway tools wraps the upstream stream in an
+    SSE response. The route should NOT call the tool loop.
+    """
+
+    async def fake_amessages(**_kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        return _stream_iter(_stream_message_start(), _stream_message_stop())
+
+    tool_loop_called = False
+
+    async def fake_loop_stream(**_kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        nonlocal tool_loop_called
+        tool_loop_called = True
+        # Async-generator shape to match anthropic_tool_loop_stream.
+        return
+        yield  # noqa: F811 — needed to classify this as an async generator
+
+    with (
+        patch("gateway.api.routes.messages.amessages", new=fake_amessages),
+        patch("gateway.api.routes.messages.anthropic_tool_loop_stream", new=fake_loop_stream),
+    ):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "anthropic:claude-3-5-sonnet-20241022",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 100,
+                "stream": True,
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert tool_loop_called is False
+
+
+def test_stream_mcp_servers_dispatches_through_tool_loop_stream(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """``stream: true`` with ``mcp_servers`` routes through
+    ``anthropic_tool_loop_stream`` rather than calling ``amessages`` directly.
+    """
+    seen: dict[str, Any] = {}
+
+    async def fake_loop_stream(
+        *, completion_kwargs: Any, pool: Any, max_iterations: int
+    ) -> AsyncIterator[MessageStreamEvent]:
+        seen["pool"] = pool
+        seen["max_iterations"] = max_iterations
+        yield _stream_message_stop()
+
+    plain_amessages_called = False
+
+    async def fake_amessages(**_kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        nonlocal plain_amessages_called
+        plain_amessages_called = True
+        return _stream_iter()
+
+    with (
+        patch("gateway.api.routes.messages.anthropic_tool_loop_stream", new=fake_loop_stream),
+        patch("gateway.api.routes.messages.amessages", new=fake_amessages),
+        patch(
+            "gateway.services.mcp_client.MCPClientPool.__aenter__",
+            new=AsyncMock(return_value=AsyncMock(purpose_hints=lambda: [])),
+        ),
+        patch("gateway.services.mcp_client.MCPClientPool.__aexit__", new=AsyncMock(return_value=None)),
+    ):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "anthropic:claude-3-5-sonnet-20241022",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 100,
+                "stream": True,
+                "mcp_servers": [{"name": "test", "url": "http://127.0.0.1:9999/mcp"}],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert seen.get("pool") is not None, "anthropic_tool_loop_stream was not invoked"
+    assert plain_amessages_called is False
+
+
+def test_stream_code_execution_dispatches_through_sandbox(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``stream: true`` with ``code_execution_*`` opens the sandbox backend
+    and feeds it to ``anthropic_tool_loop_stream``.
+    """
+    monkeypatch.setenv("GATEWAY_SANDBOX_URL", "http://127.0.0.1:9999/sandbox")
+
+    pool_seen: list[Any] = []
+
+    async def fake_loop_stream(
+        *, completion_kwargs: Any, pool: Any, max_iterations: int
+    ) -> AsyncIterator[MessageStreamEvent]:
+        pool_seen.append(pool)
+        yield _stream_message_stop()
+
+    fake_backend = AsyncMock()
+    fake_backend.purpose_hints = lambda: []
+    fake_backend.__aenter__ = AsyncMock(return_value=fake_backend)
+    fake_backend.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("gateway.api.routes.messages.anthropic_tool_loop_stream", new=fake_loop_stream),
+        patch("gateway.api.routes.messages.SandboxBackend", return_value=fake_backend),
+    ):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "anthropic:claude-3-5-sonnet-20241022",
+                "messages": [{"role": "user", "content": "compute"}],
+                "max_tokens": 100,
+                "stream": True,
+                "tools": [{"type": "code_execution_20250825"}],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert pool_seen == [fake_backend], "tool loop didn't receive the SandboxBackend"
+
+
+def test_stream_sandbox_unreachable_returns_502_anthropic_body(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test for the eager-open error mapping bug: when the
+    streaming sandbox eager-open fails, the route must return a 502 with the
+    Anthropic error envelope rather than a 500 (which is what would happen
+    if the streaming dispatch wasn't wrapped in the error-mapping
+    try/except).
+    """
+    monkeypatch.setenv("GATEWAY_SANDBOX_URL", "http://127.0.0.1:9999/sandbox")
+
+    from gateway.services.sandbox_backend import SandboxNotReachableError
+
+    with patch(
+        "gateway.api.routes.messages.SandboxBackend",
+        return_value=AsyncMock(__aenter__=AsyncMock(side_effect=SandboxNotReachableError("boom"))),
+    ):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "anthropic:claude-3-5-sonnet-20241022",
+                "messages": [{"role": "user", "content": "go"}],
+                "max_tokens": 100,
+                "stream": True,
                 "tools": [{"type": "code_execution_20250825"}],
             },
             headers=api_key_header,

--- a/tests/integration/test_messages_route_dispatch.py
+++ b/tests/integration/test_messages_route_dispatch.py
@@ -1,0 +1,455 @@
+"""Route-level tests for the /v1/messages endpoint wiring.
+
+These complement :mod:`tests.unit.test_mcp_loop_messages` (which tests the
+Anthropic tool loop in isolation) by exercising the FastAPI route handler:
+tool extraction, mutual-exclusivity validation, error-body mapping to the
+Anthropic shape, and the per-tool dispatch into the right backend.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from any_llm.types.messages import (
+    MessageResponse,
+    MessageUsage,
+    TextBlock,
+)
+from fastapi.testclient import TestClient
+
+
+def _text_response(text: str = "ok") -> MessageResponse:
+    return MessageResponse(
+        id="msg_test",
+        type="message",
+        role="assistant",
+        model="claude-3-5-sonnet-20241022",
+        content=[TextBlock(type="text", text=text, citations=None)],
+        stop_reason=cast(Any, "end_turn"),
+        stop_sequence=None,
+        usage=MessageUsage(
+            input_tokens=5,
+            output_tokens=2,
+            cache_creation_input_tokens=None,
+            cache_read_input_tokens=None,
+            cache_creation=None,
+            server_tool_use=None,
+            service_tier=None,
+        ),
+        container=None,
+    )
+
+
+# ---------- plain amessages (no gateway tools) ----------
+
+
+def test_no_tools_falls_through_to_plain_amessages(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """A vanilla request with no gateway-managed tools hits ``amessages`` directly,
+    bypassing the tool loop entirely.
+    """
+    captured: dict[str, Any] = {}
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        captured.update(kwargs)
+        return _text_response("hi")
+
+    with patch("gateway.api.routes.messages.amessages", new=fake_amessages):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "anthropic:claude-3-5-sonnet-20241022",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 100,
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["content"][0]["text"] == "hi"
+    # Direct amessages call: tool-loop-only fields shouldn't appear.
+    assert "tools" not in captured
+
+
+def test_gateway_internal_fields_are_stripped_from_upstream_kwargs(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """``mcp_servers`` / ``tools_header`` / ``max_tool_iterations`` are gateway-
+    only knobs; Anthropic rejects unknown kwargs with a 400. Stripping must
+    happen at the boundary so they never reach ``amessages``.
+    """
+    captured: dict[str, Any] = {}
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        captured.update(kwargs)
+        return _text_response()
+
+    with patch("gateway.api.routes.messages.amessages", new=fake_amessages):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "anthropic:claude-3-5-sonnet-20241022",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 100,
+                "tools_header": "Tools available:",
+                "max_tool_iterations": 3,
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200
+    for field in ("mcp_servers", "mcp_server_ids", "tools_header", "max_tool_iterations", "user"):
+        assert field not in captured, f"gateway-internal field {field!r} leaked to upstream"
+
+
+def test_user_supplied_openai_shape_tools_get_converted_to_anthropic(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """A caller can mix gateway-managed tools and their own function tools; the
+    OpenAI-shape ones must be converted to ``{name, description, input_schema}``
+    before the call reaches Anthropic.
+    """
+    captured: dict[str, Any] = {}
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        captured.update(kwargs)
+        return _text_response()
+
+    with patch("gateway.api.routes.messages.amessages", new=fake_amessages):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "anthropic:claude-3-5-sonnet-20241022",
+                "messages": [{"role": "user", "content": "do it"}],
+                "max_tokens": 100,
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "description": "look stuff up",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200
+    forwarded_tools = captured.get("tools")
+    assert forwarded_tools is not None
+    assert forwarded_tools[0]["name"] == "lookup"
+    assert forwarded_tools[0]["input_schema"] == {"type": "object", "properties": {}}
+    # The OpenAI wrapper keys must be gone.
+    assert "function" not in forwarded_tools[0]
+    assert forwarded_tools[0].get("type") != "function"
+
+
+# ---------- gateway tool dispatch ----------
+
+
+def test_mcp_servers_dispatches_through_anthropic_tool_loop(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """A request with ``mcp_servers`` routes through ``anthropic_tool_loop`` rather
+    than calling ``amessages`` directly. Catches regressions where the dispatch
+    if/elif chain silently falls through to the plain path.
+    """
+    seen: dict[str, Any] = {}
+
+    async def fake_loop(*, completion_kwargs: Any, pool: Any, max_iterations: int) -> MessageResponse:
+        seen["completion_kwargs"] = completion_kwargs
+        seen["pool"] = pool
+        seen["max_iterations"] = max_iterations
+        return _text_response("via-mcp-loop")
+
+    plain_amessages_called = False
+
+    async def fake_amessages(**_kwargs: Any) -> MessageResponse:
+        nonlocal plain_amessages_called
+        plain_amessages_called = True
+        return _text_response()
+
+    with (
+        patch("gateway.api.routes.messages.anthropic_tool_loop", new=fake_loop),
+        patch("gateway.api.routes.messages.amessages", new=fake_amessages),
+        patch(
+            "gateway.services.mcp_client.MCPClientPool.__aenter__",
+            new=AsyncMock(return_value=AsyncMock(purpose_hints=lambda: [])),
+        ),
+        patch("gateway.services.mcp_client.MCPClientPool.__aexit__", new=AsyncMock(return_value=None)),
+    ):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "anthropic:claude-3-5-sonnet-20241022",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 100,
+                "mcp_servers": [
+                    {"name": "test", "url": "http://127.0.0.1:9999/mcp"},
+                ],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["content"][0]["text"] == "via-mcp-loop"
+    assert "completion_kwargs" in seen, "anthropic_tool_loop was not invoked"
+    assert plain_amessages_called is False
+
+
+def test_code_execution_dispatches_through_sandbox_backend(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``tools: [{"type": "code_execution_*"}]`` routes through ``SandboxBackend``."""
+    monkeypatch.setenv("GATEWAY_SANDBOX_URL", "http://127.0.0.1:9999/sandbox")
+
+    pool_seen: list[Any] = []
+
+    async def fake_loop(*, completion_kwargs: Any, pool: Any, max_iterations: int) -> MessageResponse:
+        pool_seen.append(pool)
+        return _text_response("via-sandbox-loop")
+
+    fake_backend = AsyncMock()
+    fake_backend.purpose_hints = lambda: []
+
+    with (
+        patch("gateway.api.routes.messages.anthropic_tool_loop", new=fake_loop),
+        patch(
+            "gateway.api.routes.messages.SandboxBackend",
+            return_value=AsyncMock(
+                __aenter__=AsyncMock(return_value=fake_backend),
+                __aexit__=AsyncMock(return_value=None),
+            ),
+        ),
+    ):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "anthropic:claude-3-5-sonnet-20241022",
+                "messages": [{"role": "user", "content": "compute"}],
+                "max_tokens": 100,
+                "tools": [{"type": "code_execution_20250825"}],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["content"][0]["text"] == "via-sandbox-loop"
+    assert pool_seen == [fake_backend], "loop didn't receive the SandboxBackend"
+
+
+def test_web_search_dispatches_through_web_search_backend(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``tools: [{"type": "web_search_*"}]`` routes through ``WebSearchBackend``."""
+    monkeypatch.setenv("GATEWAY_WEB_SEARCH_URL", "http://127.0.0.1:9999/search")
+
+    pool_seen: list[Any] = []
+
+    async def fake_loop(*, completion_kwargs: Any, pool: Any, max_iterations: int) -> MessageResponse:
+        pool_seen.append(pool)
+        return _text_response("via-web-search-loop")
+
+    fake_backend = AsyncMock()
+    fake_backend.purpose_hints = lambda: []
+
+    fake_builder_result = AsyncMock(
+        __aenter__=AsyncMock(return_value=fake_backend),
+        __aexit__=AsyncMock(return_value=None),
+    )
+
+    with (
+        patch("gateway.api.routes.messages.anthropic_tool_loop", new=fake_loop),
+        patch("gateway.api.routes.messages._build_web_search_backend", return_value=fake_builder_result),
+    ):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "anthropic:claude-3-5-sonnet-20241022",
+                "messages": [{"role": "user", "content": "search"}],
+                "max_tokens": 100,
+                "tools": [{"type": "web_search_20250305"}],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["content"][0]["text"] == "via-web-search-loop"
+    assert pool_seen == [fake_backend], "loop didn't receive the WebSearchBackend"
+
+
+# ---------- validation errors (Anthropic-shaped 400) ----------
+
+
+def _assert_anthropic_error(body: dict[str, Any], *, error_type: str, message_substr: str) -> None:
+    assert "detail" in body, body
+    detail = body["detail"]
+    assert detail["type"] == "error"
+    assert detail["error"]["type"] == error_type
+    assert message_substr in detail["error"]["message"]
+
+
+def test_code_execution_without_sandbox_env_returns_400_anthropic_body(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GATEWAY_SANDBOX_URL", raising=False)
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "anthropic:claude-3-5-sonnet-20241022",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+            "tools": [{"type": "code_execution_20250825"}],
+        },
+        headers=api_key_header,
+    )
+    assert resp.status_code == 400
+    _assert_anthropic_error(resp.json(), error_type="invalid_request_error", message_substr="GATEWAY_SANDBOX_URL")
+
+
+def test_code_execution_combined_with_mcp_servers_returns_400(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GATEWAY_SANDBOX_URL", "http://127.0.0.1:9999/sandbox")
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "anthropic:claude-3-5-sonnet-20241022",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+            "tools": [{"type": "code_execution_20250825"}],
+            "mcp_servers": [{"name": "x", "url": "http://127.0.0.1:9999/mcp"}],
+        },
+        headers=api_key_header,
+    )
+    assert resp.status_code == 400
+    _assert_anthropic_error(
+        resp.json(),
+        error_type="invalid_request_error",
+        message_substr="code_execution and mcp_servers cannot be combined",
+    )
+
+
+def test_web_search_combined_with_sandbox_returns_400(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GATEWAY_SANDBOX_URL", "http://127.0.0.1:9999/sandbox")
+    monkeypatch.setenv("GATEWAY_WEB_SEARCH_URL", "http://127.0.0.1:9999/search")
+    resp = client.post(
+        "/v1/messages",
+        json={
+            "model": "anthropic:claude-3-5-sonnet-20241022",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+            "tools": [
+                {"type": "code_execution_20250825"},
+                {"type": "web_search_20250305"},
+            ],
+        },
+        headers=api_key_header,
+    )
+    assert resp.status_code == 400
+    _assert_anthropic_error(
+        resp.json(),
+        error_type="invalid_request_error",
+        message_substr="web_search cannot be combined",
+    )
+
+
+# ---------- gateway-side runtime errors ----------
+
+
+def test_max_tool_iterations_exceeded_returns_422_anthropic_body(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The gateway's own iteration cap is distinct from a provider outage —
+    422 with the Anthropic error envelope lets callers tell them apart.
+    """
+    monkeypatch.setenv("GATEWAY_SANDBOX_URL", "http://127.0.0.1:9999/sandbox")
+
+    from gateway.services.mcp_loop_messages import MaxToolIterationsExceeded
+
+    async def fake_loop(*, completion_kwargs: Any, pool: Any, max_iterations: int) -> MessageResponse:
+        raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")
+
+    fake_backend = AsyncMock()
+    fake_backend.purpose_hints = lambda: []
+
+    with (
+        patch("gateway.api.routes.messages.anthropic_tool_loop", new=fake_loop),
+        patch(
+            "gateway.api.routes.messages.SandboxBackend",
+            return_value=AsyncMock(
+                __aenter__=AsyncMock(return_value=fake_backend),
+                __aexit__=AsyncMock(return_value=None),
+            ),
+        ),
+    ):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "anthropic:claude-3-5-sonnet-20241022",
+                "messages": [{"role": "user", "content": "go"}],
+                "max_tokens": 100,
+                "tools": [{"type": "code_execution_20250825"}],
+                "max_tool_iterations": 1,
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 422
+    _assert_anthropic_error(
+        resp.json(),
+        error_type="invalid_request_error",
+        message_substr="max_tool_iterations",
+    )
+
+
+def test_sandbox_unreachable_returns_502_anthropic_body(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GATEWAY_SANDBOX_URL", "http://127.0.0.1:9999/sandbox")
+
+    from gateway.services.sandbox_backend import SandboxNotReachableError
+
+    with patch(
+        "gateway.api.routes.messages.SandboxBackend",
+        return_value=AsyncMock(__aenter__=AsyncMock(side_effect=SandboxNotReachableError("boom"))),
+    ):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "anthropic:claude-3-5-sonnet-20241022",
+                "messages": [{"role": "user", "content": "go"}],
+                "max_tokens": 100,
+                "tools": [{"type": "code_execution_20250825"}],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 502
+    _assert_anthropic_error(resp.json(), error_type="api_error", message_substr="sandbox unreachable")

--- a/tests/unit/test_mcp_loop_messages.py
+++ b/tests/unit/test_mcp_loop_messages.py
@@ -1,0 +1,629 @@
+"""Unit tests for the Anthropic-shaped MCP tool-use loop and tool-format helpers.
+
+Mirrors :mod:`tests.unit.test_mcp_loop` semantically: same scenarios, expressed
+in Anthropic content-block / streaming-event shape.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any, cast
+
+import pytest
+from any_llm.types.messages import (
+    ContentBlockDeltaEvent,
+    ContentBlockStartEvent,
+    ContentBlockStopEvent,
+    InputJSONDelta,
+    MessageDelta,
+    MessageDeltaEvent,
+    MessageDeltaUsage,
+    MessageResponse,
+    MessageStartEvent,
+    MessageStopEvent,
+    MessageStreamEvent,
+    MessageUsage,
+    TextBlock,
+    TextDelta,
+    ToolUseBlock,
+)
+
+from gateway.services import mcp_loop_messages as messages_loop_module
+from gateway.services.mcp_loop_messages import (
+    MaxToolIterationsExceeded,
+    anthropic_tool_loop,
+    anthropic_tool_loop_stream,
+)
+from gateway.services.tool_format import (
+    inject_purpose_hints_anthropic,
+    openai_to_anthropic_tools,
+)
+
+
+class _FakePool:
+    """Stand-in for MCPClientPool that satisfies the loop's protocol.
+
+    Duck-types the same surface as :class:`tests.unit.test_mcp_loop._FakePool`
+    so the same scenarios apply.
+    """
+
+    def __init__(
+        self,
+        tool_names: list[str],
+        purpose_hints: list[tuple[str, str]] | None = None,
+        results: dict[str, str] | None = None,
+    ):
+        self._tool_names = set(tool_names)
+        self._hints = purpose_hints or []
+        self._results = results or {}
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    @property
+    def openai_tools(self) -> list[dict[str, Any]]:
+        return [
+            {"type": "function", "function": {"name": n, "description": "", "parameters": {}}}
+            for n in sorted(self._tool_names)
+        ]
+
+    def owns_tool(self, name: str) -> bool:
+        return name in self._tool_names
+
+    def purpose_hints(self) -> list[tuple[str, str]]:
+        return list(self._hints)
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+        self.calls.append((name, arguments))
+        if name not in self._results:
+            return f"ran {name}"
+        return self._results[name]
+
+
+def _text_block(text: str) -> TextBlock:
+    return TextBlock(type="text", text=text, citations=None)
+
+
+def _tool_use(id: str, name: str, input: dict[str, Any]) -> ToolUseBlock:
+    return ToolUseBlock(type="tool_use", id=id, name=name, input=input)
+
+
+def _message_response(
+    *,
+    stop_reason: str,
+    content: list[Any] | None = None,
+    input_tokens: int = 1,
+    output_tokens: int = 1,
+) -> MessageResponse:
+    return MessageResponse(
+        id="msg_1",
+        type="message",
+        role="assistant",
+        model="fake",
+        content=content or [],
+        stop_reason=cast(Any, stop_reason),
+        stop_sequence=None,
+        usage=MessageUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_creation_input_tokens=None,
+            cache_read_input_tokens=None,
+            cache_creation=None,
+            server_tool_use=None,
+            service_tier=None,
+        ),
+        container=None,
+    )
+
+
+# ---------- pure helpers ----------
+
+
+def test_openai_to_anthropic_tools_converts_function_shape() -> None:
+    out = openai_to_anthropic_tools(
+        [{"type": "function", "function": {"name": "fetch", "description": "d", "parameters": {"type": "object"}}}]
+    )
+    assert out == [{"name": "fetch", "description": "d", "input_schema": {"type": "object"}}]
+
+
+def test_openai_to_anthropic_tools_supplies_empty_schema_when_parameters_missing() -> None:
+    out = openai_to_anthropic_tools([{"type": "function", "function": {"name": "noop"}}])
+    assert out == [{"name": "noop", "input_schema": {"type": "object", "properties": {}}}]
+
+
+def test_openai_to_anthropic_tools_passes_unknown_shapes_through() -> None:
+    odd = {"type": "custom", "spec": {"foo": "bar"}}
+    out = openai_to_anthropic_tools([odd])
+    assert out == [odd]
+
+
+def test_inject_purpose_hints_anthropic_no_hints_returns_unchanged() -> None:
+    kwargs: dict[str, Any] = {"system": "be helpful"}
+    out = inject_purpose_hints_anthropic(kwargs, [])
+    assert out["system"] == "be helpful"
+
+
+def test_inject_purpose_hints_anthropic_inserts_when_no_system() -> None:
+    kwargs: dict[str, Any] = {}
+    out = inject_purpose_hints_anthropic(kwargs, [("calendar", "for scheduling")])
+    assert "calendar" in out["system"]
+    assert "for scheduling" in out["system"]
+
+
+def test_inject_purpose_hints_anthropic_prepends_existing_string_system() -> None:
+    kwargs: dict[str, Any] = {"system": "be helpful"}
+    out = inject_purpose_hints_anthropic(kwargs, [("cal", "use it")])
+    assert "cal" in out["system"]
+    assert "be helpful" in out["system"]
+    assert out["system"].index("cal") < out["system"].index("be helpful")
+
+
+def test_inject_purpose_hints_anthropic_prepends_existing_list_system() -> None:
+    kwargs: dict[str, Any] = {
+        "system": [{"type": "text", "text": "be helpful", "cache_control": {"type": "ephemeral"}}]
+    }
+    out = inject_purpose_hints_anthropic(kwargs, [("cal", "use it")])
+    assert isinstance(out["system"], list)
+    assert out["system"][0]["type"] == "text"
+    assert "cal" in out["system"][0]["text"]
+    # The original list entry is preserved after the prepended hint block.
+    assert out["system"][1]["cache_control"] == {"type": "ephemeral"}
+
+
+# ---------- non-streaming loop ----------
+
+
+@pytest.mark.asyncio
+async def test_loop_returns_immediately_when_model_returns_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        calls.append(kwargs)
+        return _message_response(stop_reason="end_turn", content=[_text_block("hi there")])
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    pool = _FakePool(tool_names=["fetch_url"])
+    out = await anthropic_tool_loop(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 100},
+        pool=cast(Any, pool),
+        max_iterations=5,
+    )
+    assert isinstance(out.content[0], TextBlock)
+    assert out.content[0].text == "hi there"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_loop_executes_owned_tool_and_completes(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = iter(
+        [
+            _message_response(
+                stop_reason="tool_use",
+                content=[_tool_use("tu_1", "fetch_url", {"u": "x"})],
+            ),
+            _message_response(stop_reason="end_turn", content=[_text_block("fetched: ok")]),
+        ]
+    )
+    captured_messages: list[list[dict[str, Any]]] = []
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        captured_messages.append(kwargs["messages"])
+        return next(responses)
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    pool = _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})
+    out = await anthropic_tool_loop(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "fetch x"}], "max_tokens": 100},
+        pool=cast(Any, pool),
+        max_iterations=5,
+    )
+
+    assert out.stop_reason == "end_turn"
+    assert pool.calls == [("fetch_url", {"u": "x"})]
+    # second call should have assistant tool_use msg and user tool_result msg appended
+    second_msgs = captured_messages[1]
+    assert second_msgs[-2]["role"] == "assistant"
+    assert any(block.get("type") == "tool_use" for block in second_msgs[-2]["content"])
+    assert second_msgs[-1]["role"] == "user"
+    assert second_msgs[-1]["content"][0]["type"] == "tool_result"
+    assert second_msgs[-1]["content"][0]["tool_use_id"] == "tu_1"
+    assert second_msgs[-1]["content"][0]["content"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_loop_accumulates_usage_across_iterations(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = iter(
+        [
+            _message_response(
+                stop_reason="tool_use",
+                content=[_tool_use("tu_1", "fetch_url", {})],
+                input_tokens=10,
+                output_tokens=2,
+            ),
+            _message_response(
+                stop_reason="end_turn",
+                content=[_text_block("done")],
+                input_tokens=12,
+                output_tokens=3,
+            ),
+        ]
+    )
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        return next(responses)
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    out = await anthropic_tool_loop(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}], "max_tokens": 100},
+        pool=cast(Any, _FakePool(tool_names=["fetch_url"])),
+        max_iterations=5,
+    )
+    assert out.usage is not None
+    assert out.usage.input_tokens == 22
+    assert out.usage.output_tokens == 5
+
+
+@pytest.mark.asyncio
+async def test_loop_max_iter_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        return _message_response(stop_reason="tool_use", content=[_tool_use("tu", "fetch_url", {})])
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    with pytest.raises(MaxToolIterationsExceeded):
+        await anthropic_tool_loop(
+            completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}], "max_tokens": 100},
+            pool=cast(Any, _FakePool(tool_names=["fetch_url"])),
+            max_iterations=2,
+        )
+
+
+@pytest.mark.asyncio
+async def test_loop_foreign_tool_returns_to_caller_without_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        return _message_response(stop_reason="tool_use", content=[_tool_use("tu", "user_tool", {})])
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    pool = _FakePool(tool_names=["fetch_url"])  # doesn't own user_tool
+    out = await anthropic_tool_loop(
+        completion_kwargs={
+            "model": "fake",
+            "messages": [{"role": "user", "content": "go"}],
+            "max_tokens": 100,
+            "tools": [{"name": "user_tool", "input_schema": {"type": "object"}}],
+        },
+        pool=cast(Any, pool),
+        max_iterations=5,
+    )
+    assert out.stop_reason == "tool_use"
+    assert pool.calls == []
+    assert any(getattr(block, "type", None) == "tool_use" for block in out.content)
+
+
+@pytest.mark.asyncio
+async def test_loop_mixed_tools_executes_owned_and_returns_only_foreign(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mixed batch: gateway executes the owned subset and filters it from the
+    returned content. The client only sees what it can dispatch itself.
+    """
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        return _message_response(
+            stop_reason="tool_use",
+            content=[
+                _tool_use("owned_id", "fetch_url", {}),
+                _tool_use("foreign_id", "user_tool", {}),
+            ],
+        )
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    pool = _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})
+    out = await anthropic_tool_loop(
+        completion_kwargs={
+            "model": "fake",
+            "messages": [{"role": "user", "content": "go"}],
+            "max_tokens": 100,
+            "tools": [{"name": "user_tool", "input_schema": {"type": "object"}}],
+        },
+        pool=cast(Any, pool),
+        max_iterations=5,
+    )
+    # Owned tool was executed internally.
+    assert pool.calls == [("fetch_url", {})]
+    # Returned content only carries the foreign tool_use.
+    tool_use_blocks = [b for b in out.content if getattr(b, "type", None) == "tool_use"]
+    tool_use_ids = [getattr(b, "id", None) for b in tool_use_blocks]
+    assert tool_use_ids == ["foreign_id"]
+
+
+@pytest.mark.asyncio
+async def test_loop_tool_execution_failure_appears_as_tool_result_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = iter(
+        [
+            _message_response(stop_reason="tool_use", content=[_tool_use("tu", "fetch_url", {})]),
+            _message_response(stop_reason="end_turn", content=[_text_block("recovered")]),
+        ]
+    )
+    captured: list[list[dict[str, Any]]] = []
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        captured.append(kwargs["messages"])
+        return next(responses)
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    class FailingPool(_FakePool):
+        async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+            raise RuntimeError("upstream down")
+
+    pool = FailingPool(tool_names=["fetch_url"])
+    out = await anthropic_tool_loop(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}], "max_tokens": 100},
+        pool=cast(Any, pool),
+        max_iterations=5,
+    )
+    assert isinstance(out.content[0], TextBlock)
+    assert out.content[0].text == "recovered"
+    tool_result_msg = captured[1][-1]
+    assert tool_result_msg["role"] == "user"
+    assert tool_result_msg["content"][0]["type"] == "tool_result"
+    assert "tool error" in tool_result_msg["content"][0]["content"]
+    assert "upstream down" in tool_result_msg["content"][0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_loop_exits_when_stop_reason_isnt_tool_use_even_with_tool_use_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the model emits tool_use blocks but stops with a non-``tool_use`` reason
+    (e.g. ``end_turn`` because ``max_tokens`` was hit mid-tool-call), the loop
+    must exit rather than try to execute them.
+    """
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        return _message_response(stop_reason="end_turn", content=[_tool_use("tu", "fetch_url", {})])
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    pool = _FakePool(tool_names=["fetch_url"])
+    out = await anthropic_tool_loop(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}], "max_tokens": 100},
+        pool=cast(Any, pool),
+        max_iterations=5,
+    )
+    assert out.stop_reason == "end_turn"
+    assert pool.calls == []  # never executed
+
+
+# ---------- streaming loop ----------
+
+
+async def _async_iter(*events: MessageStreamEvent) -> AsyncIterator[MessageStreamEvent]:
+    for e in events:
+        yield e
+
+
+def _msg_start_event() -> MessageStartEvent:
+    return MessageStartEvent(
+        type="message_start",
+        message=cast(
+            Any,
+            _message_response(stop_reason="end_turn", content=[], input_tokens=1, output_tokens=0),
+        ),
+    )
+
+
+def _msg_delta_event(stop_reason: str, output_tokens: int = 1) -> MessageDeltaEvent:
+    return MessageDeltaEvent(
+        type="message_delta",
+        delta=MessageDelta(stop_reason=cast(Any, stop_reason), stop_sequence=None),
+        usage=MessageDeltaUsage(
+            input_tokens=None,
+            output_tokens=output_tokens,
+            cache_creation_input_tokens=None,
+            cache_read_input_tokens=None,
+            server_tool_use=None,
+        ),
+    )
+
+
+def _msg_stop_event() -> MessageStopEvent:
+    return MessageStopEvent(type="message_stop")
+
+
+def _text_block_start(index: int, text: str = "") -> ContentBlockStartEvent:
+    return ContentBlockStartEvent(
+        type="content_block_start",
+        index=index,
+        content_block=cast(Any, TextBlock(type="text", text=text, citations=None)),
+    )
+
+
+def _text_delta(index: int, text: str) -> ContentBlockDeltaEvent:
+    return ContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=index,
+        delta=cast(Any, TextDelta(type="text_delta", text=text)),
+    )
+
+
+def _content_block_stop(index: int) -> ContentBlockStopEvent:
+    return ContentBlockStopEvent(type="content_block_stop", index=index)
+
+
+def _tool_use_block_start(index: int, tool_id: str, name: str) -> ContentBlockStartEvent:
+    return ContentBlockStartEvent(
+        type="content_block_start",
+        index=index,
+        content_block=cast(Any, ToolUseBlock(type="tool_use", id=tool_id, name=name, input={})),
+    )
+
+
+def _input_json_delta(index: int, partial: str) -> ContentBlockDeltaEvent:
+    return ContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=index,
+        delta=cast(Any, InputJSONDelta(type="input_json_delta", partial_json=partial)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_passes_text_events_through_and_terminates(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_amessages(**kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        return _async_iter(
+            _msg_start_event(),
+            _text_block_start(0),
+            _text_delta(0, "hi"),
+            _text_delta(0, " there"),
+            _content_block_stop(0),
+            _msg_delta_event("end_turn"),
+            _msg_stop_event(),
+        )
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    types: list[str] = []
+    async for event in anthropic_tool_loop_stream(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 100},
+        pool=cast(Any, _FakePool(tool_names=[])),
+        max_iterations=3,
+    ):
+        types.append(event.type)
+    # All events forwarded — single-iteration path, terminal events included.
+    assert types == [
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_runs_owned_tool_and_continues(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Iteration 1 emits a tool_use block; the loop executes it server-side and
+    drops the intermediate ``message_delta`` / ``message_stop``. Iteration 2 runs
+    and its terminal events ARE forwarded.
+    """
+    iter_streams = iter(
+        [
+            _async_iter(
+                _msg_start_event(),
+                _tool_use_block_start(0, "tu_1", "fetch_url"),
+                _input_json_delta(0, '{"u":'),
+                _input_json_delta(0, ' "x"}'),
+                _content_block_stop(0),
+                _msg_delta_event("tool_use"),
+                _msg_stop_event(),
+            ),
+            _async_iter(
+                _msg_start_event(),
+                _text_block_start(0),
+                _text_delta(0, "done"),
+                _content_block_stop(0),
+                _msg_delta_event("end_turn"),
+                _msg_stop_event(),
+            ),
+        ]
+    )
+
+    async def fake_amessages(**kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        return next(iter_streams)
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    pool = _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})
+    terminal_types: list[str] = []
+    async for event in anthropic_tool_loop_stream(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}], "max_tokens": 100},
+        pool=cast(Any, pool),
+        max_iterations=5,
+    ):
+        if event.type in {"message_delta", "message_stop"}:
+            terminal_types.append(event.type)
+    # Only the FINAL iteration's terminal events are forwarded. The intermediate
+    # ``tool_use`` iteration's terminal events are dropped.
+    assert terminal_types == ["message_delta", "message_stop"]
+    assert pool.calls == [("fetch_url", {"u": "x"})]
+
+
+@pytest.mark.asyncio
+async def test_stream_forwards_terminal_when_model_emits_foreign_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the model asks for a foreign tool, the loop terminates and the
+    terminal events MUST reach the client so it knows to dispatch.
+    """
+    iter_streams = iter(
+        [
+            _async_iter(
+                _msg_start_event(),
+                _tool_use_block_start(0, "tu", "user_tool"),
+                _content_block_stop(0),
+                _msg_delta_event("tool_use"),
+                _msg_stop_event(),
+            ),
+        ]
+    )
+
+    async def fake_amessages(**kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        return next(iter_streams)
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    pool = _FakePool(tool_names=["fetch_url"])  # doesn't own user_tool
+    terminal_types: list[str] = []
+    async for event in anthropic_tool_loop_stream(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}], "max_tokens": 100},
+        pool=cast(Any, pool),
+        max_iterations=5,
+    ):
+        if event.type in {"message_delta", "message_stop"}:
+            terminal_types.append(event.type)
+    assert terminal_types == ["message_delta", "message_stop"]
+    assert pool.calls == []
+
+
+@pytest.mark.asyncio
+async def test_stream_input_json_delta_accumulates_across_chunks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The streaming loop must concatenate partial_json across multiple
+    input_json_delta events before parsing the tool input.
+    """
+    iter_streams = iter(
+        [
+            _async_iter(
+                _msg_start_event(),
+                _tool_use_block_start(0, "tu_1", "fetch_url"),
+                _input_json_delta(0, '{"u":'),
+                _input_json_delta(0, ' "x",'),
+                _input_json_delta(0, ' "n": 3}'),
+                _content_block_stop(0),
+                _msg_delta_event("tool_use"),
+                _msg_stop_event(),
+            ),
+            _async_iter(
+                _msg_start_event(),
+                _text_block_start(0),
+                _text_delta(0, "done"),
+                _content_block_stop(0),
+                _msg_delta_event("end_turn"),
+                _msg_stop_event(),
+            ),
+        ]
+    )
+
+    async def fake_amessages(**kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        return next(iter_streams)
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    pool = _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})
+    async for _event in anthropic_tool_loop_stream(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}], "max_tokens": 100},
+        pool=cast(Any, pool),
+        max_iterations=5,
+    ):
+        pass
+    assert pool.calls == [("fetch_url", {"u": "x", "n": 3})]

--- a/tests/unit/test_mcp_loop_messages.py
+++ b/tests/unit/test_mcp_loop_messages.py
@@ -397,6 +397,97 @@ async def test_loop_exits_when_stop_reason_isnt_tool_use_even_with_tool_use_bloc
     assert pool.calls == []  # never executed
 
 
+# ---------- on_first_response (lock-in callback) ----------
+
+
+@pytest.mark.asyncio
+async def test_loop_fires_on_first_response_after_first_amessages_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``on_first_response`` is invoked exactly once, right after the first
+    upstream call returns successfully.
+    """
+    responses = iter(
+        [
+            _message_response(stop_reason="tool_use", content=[_tool_use("tu_1", "fetch_url", {})]),
+            _message_response(stop_reason="end_turn", content=[_text_block("done")]),
+        ]
+    )
+    fire_order: list[str] = []
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        fire_order.append("amessages")
+        return next(responses)
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    def _on_first() -> None:
+        fire_order.append("on_first_response")
+
+    await anthropic_tool_loop(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}], "max_tokens": 100},
+        pool=cast(Any, _FakePool(tool_names=["fetch_url"])),
+        max_iterations=5,
+        on_first_response=_on_first,
+    )
+    # Fires after the first amessages but before any tool-loop continuation.
+    assert fire_order[0] == "amessages"
+    assert fire_order[1] == "on_first_response"
+    # Only ever fires once, even across multiple iterations.
+    assert fire_order.count("on_first_response") == 1
+
+
+@pytest.mark.asyncio
+async def test_loop_does_not_fire_on_first_response_when_initial_call_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the first ``amessages`` call raises before returning, the callback
+    must not fire — callers depend on that to know whether the attempt locked
+    in (and therefore can or can't fall through to a fallback provider).
+    """
+    fired = False
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        raise RuntimeError("upstream 500")
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    def _on_first() -> None:
+        nonlocal fired
+        fired = True
+
+    with pytest.raises(RuntimeError, match="upstream 500"):
+        await anthropic_tool_loop(
+            completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}], "max_tokens": 100},
+            pool=cast(Any, _FakePool(tool_names=["fetch_url"])),
+            max_iterations=5,
+            on_first_response=_on_first,
+        )
+    assert fired is False
+
+
+@pytest.mark.asyncio
+async def test_loop_is_backward_compatible_without_on_first_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The callback is optional — callers that don't need lock-in (standalone
+    mode) can omit it without changing behavior.
+    """
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        return _message_response(stop_reason="end_turn", content=[_text_block("hi")])
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    out = await anthropic_tool_loop(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 100},
+        pool=cast(Any, _FakePool(tool_names=["fetch_url"])),
+        max_iterations=5,
+    )
+    assert isinstance(out.content[0], TextBlock)
+    assert out.content[0].text == "hi"
+
+
 # ---------- streaming loop ----------
 
 


### PR DESCRIPTION
> **PR 2 of 4** in the messages/responses parity series. Stacked on #76 (PR 1).
>
> See #76 for the multi-PR plan rationale.

## What this PR does

Wires all three gateway-managed tool modes into the Anthropic Messages endpoint for both streaming and non-streaming paths — **standalone-mode only**. Platform-mode multi-attempt fallback is PR 4.

Before: `/v1/messages` with `tools: [{"type":"code_execution_20250825"}]` or `mcp_servers: [...]` was a passthrough. After: same behavior as `/v1/chat/completions` for those features.

## Files

**New:**
- `src/gateway/services/tool_format.py` — `openai_to_anthropic_tools` and `inject_purpose_hints_anthropic`.
- `src/gateway/services/mcp_loop_messages.py` — `anthropic_tool_loop` and `anthropic_tool_loop_stream`. Mirrors `mcp_tool_loop`'s signature including the `on_first_response` lock-in callback added in #73; platform-mode callers (PR 4) thread it through to enable pre-lock-in fallback.
- `tests/unit/test_mcp_loop_messages.py` — 22 unit tests on the loop in isolation, including 3 for `on_first_response` (fires once after first call, doesn't fire on first-call failure, optional).
- `tests/integration/test_messages_route_dispatch.py` — 15 FastAPI TestClient tests on the route wiring.

**Modified:**
- `src/gateway/api/routes/messages.py` — adds `MessagesRequest.mcp_servers` / `tools_header` / `max_tool_iterations` fields, extracts code_execution / web_search via the helpers from PR 1, dispatches to the new loops when active, falls back to plain `amessages` otherwise. Same mutual-exclusivity rule as chat.py. Anthropic-shape errors: `MaxToolIterationsExceeded` → 422, sandbox/web_search unreachable → 502.

## Streaming behavior

Per-iteration the stream forwards `message_start`, `content_block_*`, and text/tool_use deltas. The terminal `message_delta` / `message_stop` of an iteration with owned `tool_use` blocks is deferred and dropped if the loop is going to continue. Mixed batches and foreign-tool batches forward terminal events and exit.

## Test plan

- [x] `make lint` — clean.
- [x] `make typecheck` — clean (141 files).
- [x] `uv run pytest tests/unit` — 225 passed.
- [x] `uv run pytest tests/integration/test_messages_route_dispatch.py` — 15 passed.
- [x] `uv run pytest tests/integration/test_platform_mode_chat.py tests/integration/test_platform_mode_surface.py` — 18 passed (confirms PR 1 + main's #73 changes weren't disturbed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)