### PR TITLE
feat(responses): PR 3/4 — MCP / sandbox / web_search on /v1/responses

### DIFF
--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -1,7 +1,10 @@
+import os
+from collections.abc import AsyncIterator
 from typing import Annotated, Any
 
 from any_llm import AnyLLM, aresponses
 from any_llm.types.completion import CompletionUsage
+from any_llm.types.responses import Response as ResponsesResponse
 from any_llm.types.responses import ResponseStreamEvent
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi import Response as FastAPIResponse
@@ -13,13 +16,32 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
 from gateway.api.routes._helpers import resolve_user_id
+from gateway.api.routes._tools import (
+    _build_web_search_backend,
+    _extract_code_execution_tool,
+    _extract_web_search_tool,
+    _resolve_sandbox_purpose_hint,
+    _strip_gateway_fields,
+)
 from gateway.api.routes.chat import get_provider_kwargs, log_usage, rate_limit_headers
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import APIKey
+from gateway.models.mcp import McpServerConfig
 from gateway.rate_limit import check_rate_limit
 from gateway.services.budget_service import validate_user_budget
 from gateway.services.log_writer import LogWriter
+from gateway.services.mcp_client import MCPClientPool
+from gateway.services.mcp_loop_responses import (
+    DEFAULT_MAX_TOOL_ITERATIONS,
+    MAX_TOOL_ITERATIONS_CAP,
+    MaxToolIterationsExceeded,
+    responses_tool_loop,
+    responses_tool_loop_stream,
+)
+from gateway.services.sandbox_backend import SandboxBackend, SandboxNotReachableError
+from gateway.services.tool_format import inject_purpose_hints_responses, openai_to_responses_tools
+from gateway.services.web_search_backend import WebSearchNotReachableError
 from gateway.streaming import RESPONSES_STREAM_FORMAT, streaming_generator
 
 router = APIRouter(prefix="/v1", tags=["responses"])
@@ -30,7 +52,13 @@ _API_KEY_NO_USER = "API key has no associated user"
 
 
 class ResponsesRequest(BaseModel):
-    """OpenAI Responses API-compatible request."""
+    """OpenAI Responses API-compatible request.
+
+    Gateway-internal fields (``mcp_servers``, ``tools_header``,
+    ``max_tool_iterations``) opt the request into gateway-managed MCP /
+    sandbox / web_search without changing the upstream wire shape. They're
+    stripped before the request is forwarded.
+    """
 
     model_config = ConfigDict(extra="allow")
 
@@ -38,6 +66,13 @@ class ResponsesRequest(BaseModel):
     input: Any
     stream: bool = False
     user: str | None = None
+    tools: list[dict[str, Any]] | None = None
+
+    # Gateway-internal — same semantics as ChatCompletionRequest /
+    # MessagesRequest. Stripped from upstream call_kwargs at the boundary.
+    mcp_servers: list[McpServerConfig] | None = None
+    tools_header: str | None = None
+    max_tool_iterations: int | None = None
 
 
 def _usage_to_completion_usage(
@@ -62,7 +97,12 @@ async def create_response(
     config: Annotated[GatewayConfig, Depends(get_config)],
     log_writer: Annotated[LogWriter, Depends(get_log_writer)],
 ) -> dict[str, Any] | StreamingResponse:
-    """OpenAI-compatible Responses endpoint."""
+    """OpenAI-compatible Responses endpoint.
+
+    Supports gateway-managed MCP tool-use loops, sandboxed code execution,
+    and SearXNG web_search on the standalone path. Platform-mode
+    multi-attempt fallback is handled in a follow-up PR.
+    """
 
     api_key, is_master_key = auth_result
     api_key_id = api_key.id if api_key else None
@@ -101,7 +141,68 @@ async def create_response(
 
     provider_kwargs = get_provider_kwargs(config, provider)
 
-    request_fields = request_body.model_dump(exclude_none=True)
+    # Tool extraction mirrors chat.py / messages.py.
+    sandbox_tool_entry, tools_after_sandbox = _extract_code_execution_tool(request_body.tools)
+    sandbox_url: str | None = os.environ.get("GATEWAY_SANDBOX_URL") or None
+    use_sandbox = False
+    if sandbox_tool_entry is not None:
+        if sandbox_url is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "code_execution tool requested but no sandbox is configured on this gateway. "
+                    "Set GATEWAY_SANDBOX_URL on the gateway, or remove code_execution from `tools`."
+                ),
+            )
+        if request_body.mcp_servers:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "code_execution and mcp_servers cannot be combined in the same request yet; "
+                    "pick one. Multi-backend dispatch is a planned refinement."
+                ),
+            )
+        use_sandbox = True
+
+    web_search_tool_entry, remaining_user_tools = _extract_web_search_tool(tools_after_sandbox)
+    web_search_url: str | None = os.environ.get("GATEWAY_WEB_SEARCH_URL") or None
+    use_web_search = False
+    if web_search_tool_entry is not None:
+        if web_search_url is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "web_search tool requested but no search backend is configured on this gateway. "
+                    "Set GATEWAY_WEB_SEARCH_URL on the gateway, or remove web_search from `tools`."
+                ),
+            )
+        if use_sandbox or request_body.mcp_servers:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "web_search cannot be combined with code_execution or mcp_servers in the same "
+                    "request yet; pick one."
+                ),
+            )
+        use_web_search = True
+
+    mcp_server_configs = request_body.mcp_servers
+    max_tool_iterations = min(
+        request_body.max_tool_iterations or DEFAULT_MAX_TOOL_ITERATIONS,
+        MAX_TOOL_ITERATIONS_CAP,
+    )
+
+    request_fields = _strip_gateway_fields(
+        request_body.model_dump(exclude_none=True),
+        tools_extracted=sandbox_tool_entry is not None or web_search_tool_entry is not None,
+        remaining_user_tools=remaining_user_tools,
+    )
+    # Caller-supplied function tools are still in OpenAI Chat-Completions
+    # nested shape; convert to Responses flat shape so the upstream call
+    # accepts them.
+    if request_fields.get("tools"):
+        request_fields["tools"] = openai_to_responses_tools(request_fields["tools"])
+
     input_payload = request_fields.pop("input")
     stream = bool(request_fields.pop("stream", False))
     request_fields.pop("model", None)
@@ -114,60 +215,44 @@ async def create_response(
     call_kwargs["provider"] = provider
     call_kwargs["input_data"] = input_payload
 
+    use_tool_loop = bool(mcp_server_configs) or use_sandbox or use_web_search
+
+    if stream:
+        return await _stream_responses(
+            call_kwargs=call_kwargs,
+            tools_header=request_body.tools_header,
+            db=db,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            user_id=user_id,
+            provider=provider,
+            model=model,
+            rate_limit_info=rate_limit_info,
+            use_tool_loop=use_tool_loop,
+            mcp_server_configs=mcp_server_configs,
+            use_sandbox=use_sandbox,
+            sandbox_tool_entry=sandbox_tool_entry,
+            sandbox_url=sandbox_url,
+            use_web_search=use_web_search,
+            web_search_tool_entry=web_search_tool_entry,
+            web_search_url=web_search_url,
+            max_tool_iterations=max_tool_iterations,
+        )
+
     try:
-        if stream:
-            call_kwargs["stream"] = True
-
-            def _format_chunk(event: ResponseStreamEvent) -> str:
-                return f"event: {event.type}\ndata: {event.model_dump_json(exclude_none=True)}\n\n"
-
-            def _extract_usage(event: ResponseStreamEvent) -> CompletionUsage | None:
-                response_obj = getattr(event, "response", None)
-                if response_obj and getattr(response_obj, "usage", None):
-                    return _usage_to_completion_usage(response_obj.usage)
-                return None
-
-            async def _on_complete(usage_data: CompletionUsage) -> None:
-                await log_usage(
-                    db=db,
-                    log_writer=log_writer,
-                    api_key_id=api_key_id,
-                    model=model,
-                    provider=provider,
-                    endpoint="/v1/responses",
-                    user_id=user_id,
-                    usage_override=usage_data,
-                )
-
-            async def _on_error(error: str) -> None:
-                await log_usage(
-                    db=db,
-                    log_writer=log_writer,
-                    api_key_id=api_key_id,
-                    model=model,
-                    provider=provider,
-                    endpoint="/v1/responses",
-                    user_id=user_id,
-                    error=error,
-                )
-
-            stream_result = await aresponses(**call_kwargs)
-            rl_headers = rate_limit_headers(rate_limit_info) if rate_limit_info else {}
-            return StreamingResponse(
-                streaming_generator(
-                    stream=stream_result,  # type: ignore[arg-type]
-                    format_chunk=_format_chunk,
-                    extract_usage=_extract_usage,
-                    fmt=RESPONSES_STREAM_FORMAT,
-                    on_complete=_on_complete,
-                    on_error=_on_error,
-                    label=f"{provider}:{model}",
-                ),
-                media_type="text/event-stream",
-                headers=rl_headers,
-            )
-
-        result = await aresponses(**call_kwargs)
+        result = await _run_responses_non_stream(
+            call_kwargs=call_kwargs,
+            tools_header=request_body.tools_header,
+            use_tool_loop=use_tool_loop,
+            mcp_server_configs=mcp_server_configs,
+            use_sandbox=use_sandbox,
+            sandbox_tool_entry=sandbox_tool_entry,
+            sandbox_url=sandbox_url,
+            use_web_search=use_web_search,
+            web_search_tool_entry=web_search_tool_entry,
+            web_search_url=web_search_url,
+            max_tool_iterations=max_tool_iterations,
+        )
         usage_data = _usage_to_completion_usage(getattr(result, "usage", None))
         await log_usage(
             db=db,
@@ -182,6 +267,35 @@ async def create_response(
 
     except HTTPException:
         raise
+    except MaxToolIterationsExceeded as e:
+        # Gateway-side cap hit, not an upstream failure. 422 lets callers
+        # distinguish a runaway tool loop from a provider outage.
+        await log_usage(
+            db=db,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            model=model,
+            provider=provider,
+            endpoint="/v1/responses",
+            user_id=user_id,
+            error=str(e),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(e),
+        ) from e
+    except SandboxNotReachableError as e:
+        logger.error("Sandbox unreachable for %s:%s: %s", provider, model, e)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="code_execution sandbox unreachable — check GATEWAY_SANDBOX_URL",
+        ) from e
+    except WebSearchNotReachableError as e:
+        logger.error("Web search backend unreachable for %s:%s: %s", provider, model, e)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="web_search backend unreachable — check GATEWAY_WEB_SEARCH_URL",
+        ) from e
     except Exception as e:
         await log_usage(
             db=db,
@@ -203,4 +317,257 @@ async def create_response(
         for key, value in rate_limit_headers(rate_limit_info).items():
             response.headers[key] = value
 
-    return result.model_dump(exclude_none=True)  # type: ignore[union-attr]
+    return result.model_dump(exclude_none=True)
+
+
+async def _run_responses_non_stream(
+    *,
+    call_kwargs: dict[str, Any],
+    tools_header: str | None,
+    use_tool_loop: bool,
+    mcp_server_configs: list[McpServerConfig] | None,
+    use_sandbox: bool,
+    sandbox_tool_entry: dict[str, Any] | None,
+    sandbox_url: str | None,
+    use_web_search: bool,
+    web_search_tool_entry: dict[str, Any] | None,
+    web_search_url: str | None,
+    max_tool_iterations: int,
+) -> ResponsesResponse:
+    """Dispatch the non-streaming Responses call.
+
+    Plain ``aresponses`` when no gateway tools are in play. Otherwise the
+    appropriate backend is opened and ``responses_tool_loop`` drives the tool
+    round-trips.
+    """
+    if not use_tool_loop:
+        return await aresponses(**call_kwargs)  # type: ignore[return-value]
+
+    if mcp_server_configs:
+        async with MCPClientPool(mcp_server_configs) as pool:
+            kwargs = inject_purpose_hints_responses(
+                {**call_kwargs},
+                pool.purpose_hints(),
+                header=tools_header,
+            )
+            return await responses_tool_loop(
+                completion_kwargs=kwargs,
+                pool=pool,
+                max_iterations=max_tool_iterations,
+            )
+
+    if use_sandbox:
+        assert sandbox_url is not None
+        sandbox_hint = _resolve_sandbox_purpose_hint(sandbox_tool_entry)
+        async with SandboxBackend(sandbox_url=sandbox_url, purpose_hint=sandbox_hint) as backend:
+            kwargs = inject_purpose_hints_responses(
+                {**call_kwargs},
+                backend.purpose_hints(),
+                header=tools_header,
+            )
+            return await responses_tool_loop(
+                completion_kwargs=kwargs,
+                pool=backend,  # type: ignore[arg-type]
+                max_iterations=max_tool_iterations,
+            )
+
+    assert use_web_search
+    assert web_search_url is not None
+    assert web_search_tool_entry is not None
+    async with _build_web_search_backend(
+        base_url=web_search_url,
+        tool_entry=web_search_tool_entry,
+    ) as web_backend:
+        kwargs = inject_purpose_hints_responses(
+            {**call_kwargs},
+            web_backend.purpose_hints(),
+            header=tools_header,
+        )
+        return await responses_tool_loop(
+            completion_kwargs=kwargs,
+            pool=web_backend,  # type: ignore[arg-type]
+            max_iterations=max_tool_iterations,
+        )
+
+
+async def _stream_responses(
+    *,
+    call_kwargs: dict[str, Any],
+    tools_header: str | None,
+    db: AsyncSession,
+    log_writer: LogWriter,
+    api_key_id: str | None,
+    user_id: str,
+    provider: Any,
+    model: str,
+    rate_limit_info: Any,
+    use_tool_loop: bool,
+    mcp_server_configs: list[McpServerConfig] | None,
+    use_sandbox: bool,
+    sandbox_tool_entry: dict[str, Any] | None,
+    sandbox_url: str | None,
+    use_web_search: bool,
+    web_search_tool_entry: dict[str, Any] | None,
+    web_search_url: str | None,
+    max_tool_iterations: int,
+) -> StreamingResponse:
+    """Streaming Responses dispatch.
+
+    Plain ``aresponses(stream=True)`` when no gateway tools are in play.
+    Otherwise the backend is opened eagerly so a backend-unreachable failure
+    surfaces as an HTTP error rather than a 200 + in-band SSE error. Same
+    rationale as the chat.py / messages.py streaming paths.
+    """
+    call_kwargs["stream"] = True
+
+    def _format_chunk(event: ResponseStreamEvent) -> str:
+        return f"event: {event.type}\ndata: {event.model_dump_json(exclude_none=True)}\n\n"
+
+    def _extract_usage(event: ResponseStreamEvent) -> CompletionUsage | None:
+        response_obj = getattr(event, "response", None)
+        if response_obj and getattr(response_obj, "usage", None):
+            return _usage_to_completion_usage(response_obj.usage)
+        return None
+
+    async def _on_complete(usage_data: CompletionUsage) -> None:
+        await log_usage(
+            db=db,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            model=model,
+            provider=provider,
+            endpoint="/v1/responses",
+            user_id=user_id,
+            usage_override=usage_data,
+        )
+
+    async def _on_error(error: str) -> None:
+        await log_usage(
+            db=db,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            model=model,
+            provider=provider,
+            endpoint="/v1/responses",
+            user_id=user_id,
+            error=error,
+        )
+
+    if not use_tool_loop:
+        stream_result = await aresponses(**call_kwargs)
+        stream_iter: AsyncIterator[ResponseStreamEvent] = stream_result  # type: ignore[assignment]
+    else:
+        stream_iter = await _open_tool_loop_stream(
+            call_kwargs=call_kwargs,
+            tools_header=tools_header,
+            mcp_server_configs=mcp_server_configs,
+            use_sandbox=use_sandbox,
+            sandbox_tool_entry=sandbox_tool_entry,
+            sandbox_url=sandbox_url,
+            use_web_search=use_web_search,
+            web_search_tool_entry=web_search_tool_entry,
+            web_search_url=web_search_url,
+            max_tool_iterations=max_tool_iterations,
+        )
+
+    rl_headers = rate_limit_headers(rate_limit_info) if rate_limit_info else {}
+    return StreamingResponse(
+        streaming_generator(
+            stream=stream_iter,
+            format_chunk=_format_chunk,
+            extract_usage=_extract_usage,
+            fmt=RESPONSES_STREAM_FORMAT,
+            on_complete=_on_complete,
+            on_error=_on_error,
+            label=f"{provider}:{model}",
+        ),
+        media_type="text/event-stream",
+        headers=rl_headers,
+    )
+
+
+async def _open_tool_loop_stream(
+    *,
+    call_kwargs: dict[str, Any],
+    tools_header: str | None,
+    mcp_server_configs: list[McpServerConfig] | None,
+    use_sandbox: bool,
+    sandbox_tool_entry: dict[str, Any] | None,
+    sandbox_url: str | None,
+    use_web_search: bool,
+    web_search_tool_entry: dict[str, Any] | None,
+    web_search_url: str | None,
+    max_tool_iterations: int,
+) -> AsyncIterator[ResponseStreamEvent]:
+    """Open the right backend, eagerly enter it, and return an iterator that
+    yields all events for the entire tool loop.
+    """
+    if mcp_server_configs:
+        pool_cfgs = mcp_server_configs
+
+        async def _mcp_iter() -> AsyncIterator[ResponseStreamEvent]:
+            async with MCPClientPool(pool_cfgs) as pool:
+                kwargs = inject_purpose_hints_responses(
+                    {**call_kwargs},
+                    pool.purpose_hints(),
+                    header=tools_header,
+                )
+                async for event in responses_tool_loop_stream(
+                    completion_kwargs=kwargs,
+                    pool=pool,
+                    max_iterations=max_tool_iterations,
+                ):
+                    yield event
+
+        return _mcp_iter()
+
+    if use_sandbox:
+        assert sandbox_url is not None
+        sandbox_hint = _resolve_sandbox_purpose_hint(sandbox_tool_entry)
+        sandbox_backend = SandboxBackend(sandbox_url=sandbox_url, purpose_hint=sandbox_hint)
+        await sandbox_backend.__aenter__()  # eager-open
+
+        async def _sandbox_iter() -> AsyncIterator[ResponseStreamEvent]:
+            try:
+                kwargs = inject_purpose_hints_responses(
+                    {**call_kwargs},
+                    sandbox_backend.purpose_hints(),
+                    header=tools_header,
+                )
+                async for event in responses_tool_loop_stream(
+                    completion_kwargs=kwargs,
+                    pool=sandbox_backend,  # type: ignore[arg-type]
+                    max_iterations=max_tool_iterations,
+                ):
+                    yield event
+            finally:
+                await sandbox_backend.__aexit__(None, None, None)
+
+        return _sandbox_iter()
+
+    assert use_web_search
+    assert web_search_url is not None
+    assert web_search_tool_entry is not None
+    web_search_backend = _build_web_search_backend(
+        base_url=web_search_url,
+        tool_entry=web_search_tool_entry,
+    )
+    await web_search_backend.__aenter__()  # eager-open
+
+    async def _web_search_iter() -> AsyncIterator[ResponseStreamEvent]:
+        try:
+            kwargs = inject_purpose_hints_responses(
+                {**call_kwargs},
+                web_search_backend.purpose_hints(),
+                header=tools_header,
+            )
+            async for event in responses_tool_loop_stream(
+                completion_kwargs=kwargs,
+                pool=web_search_backend,  # type: ignore[arg-type]
+                max_iterations=max_tool_iterations,
+            ):
+                yield event
+        finally:
+            await web_search_backend.__aexit__(None, None, None)
+
+    return _web_search_iter()

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -453,22 +453,38 @@ async def _stream_responses(
             error=error,
         )
 
-    if not use_tool_loop:
-        stream_result = await aresponses(**call_kwargs)
-        stream_iter: AsyncIterator[ResponseStreamEvent] = stream_result  # type: ignore[assignment]
-    else:
-        stream_iter = await _open_tool_loop_stream(
-            call_kwargs=call_kwargs,
-            tools_header=tools_header,
-            mcp_server_configs=mcp_server_configs,
-            use_sandbox=use_sandbox,
-            sandbox_tool_entry=sandbox_tool_entry,
-            sandbox_url=sandbox_url,
-            use_web_search=use_web_search,
-            web_search_tool_entry=web_search_tool_entry,
-            web_search_url=web_search_url,
-            max_tool_iterations=max_tool_iterations,
-        )
+    try:
+        if not use_tool_loop:
+            stream_result = await aresponses(**call_kwargs)
+            stream_iter: AsyncIterator[ResponseStreamEvent] = stream_result  # type: ignore[assignment]
+        else:
+            stream_iter = await _open_tool_loop_stream(
+                call_kwargs=call_kwargs,
+                tools_header=tools_header,
+                mcp_server_configs=mcp_server_configs,
+                use_sandbox=use_sandbox,
+                sandbox_tool_entry=sandbox_tool_entry,
+                sandbox_url=sandbox_url,
+                use_web_search=use_web_search,
+                web_search_tool_entry=web_search_tool_entry,
+                web_search_url=web_search_url,
+                max_tool_iterations=max_tool_iterations,
+            )
+    except SandboxNotReachableError as exc:
+        # Surfaced here (rather than from the in-band SSE channel) because the
+        # backend is opened eagerly — see ``_open_tool_loop_stream``'s
+        # docstring. Mirrors the non-streaming error mapping.
+        logger.error("Sandbox unreachable for %s:%s: %s", provider, model, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="code_execution sandbox unreachable — check GATEWAY_SANDBOX_URL",
+        ) from exc
+    except WebSearchNotReachableError as exc:
+        logger.error("Web search backend unreachable for %s:%s: %s", provider, model, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="web_search backend unreachable — check GATEWAY_WEB_SEARCH_URL",
+        ) from exc
 
     rl_headers = rate_limit_headers(rate_limit_info) if rate_limit_info else {}
     return StreamingResponse(

--- a/src/gateway/services/mcp_loop_responses.py
+++ b/src/gateway/services/mcp_loop_responses.py
@@ -238,19 +238,28 @@ async def responses_tool_loop_stream(
 
     Forwards every event downstream and tracks ``function_call`` output items
     by buffering ``response.function_call_arguments.delta`` chunks per
-    ``output_index`` until ``response.output_item.done`` for that item.
+    ``output_index``. ``response.function_call_arguments.done``, if present,
+    overrides the running buffer with the terminal argument string.
 
-    On ``response.completed``: if any buffered function_call items exist AND
-    all owned by the pool, execute them, append the originals plus the
-    ``function_call_output`` items to ``input_data``, drop the terminal
-    ``response.completed`` event, and start the next round. If any foreign
-    function_call is present (or none at all), forward ``response.completed``
-    and exit.
+    Loop continuation is decided on ``response.completed``: if any buffered
+    function_call items exist AND all are owned by the pool, execute them,
+    append the originals plus the ``function_call_output`` items to
+    ``input_data``, drop the terminal ``response.completed`` event, and start
+    the next round. If any foreign function_call is present (or none at all),
+    forward ``response.completed`` and exit.
 
     Mixed batches in streaming mode forward everything as-is (rewriting the
     output_items mid-stream to remove owned ones would be too invasive); the
     client sees what it sees and the loop exits. Same trade-off as the
     Anthropic streaming variant.
+
+    Cumulative usage across iterations: each iteration's
+    ``response.completed`` carries that iteration's usage on ``event.response.usage``.
+    When the loop continues, that event is dropped and its usage would be
+    lost from streaming token reporting. We accumulate the per-iteration
+    ``output_tokens`` and fold the running total into the final forwarded
+    ``response.completed`` so downstream usage logging sees the full
+    tool-loop output count.
     """
     input_items = _coerce_input_to_list(completion_kwargs.get("input_data"))
     user_tools = list(completion_kwargs.get("tools") or [])
@@ -258,6 +267,8 @@ async def responses_tool_loop_stream(
 
     base = {k: v for k, v in completion_kwargs.items() if k not in {"input_data", "tools"}}
     base["stream"] = True
+
+    acc_output_tokens = 0  # see usage-accumulation note in the docstring.
 
     for _ in range(max_iterations):
         kwargs: dict[str, Any] = {**base, "input_data": input_items}
@@ -313,7 +324,7 @@ async def responses_tool_loop_stream(
         # Decide whether to loop or exit.
         if not function_calls:
             if deferred_completed is not None:
-                yield deferred_completed
+                yield _maybe_fold_response_completed_usage(deferred_completed, acc_output_tokens)
             return
 
         owned_specs: list[dict[str, Any]] = []
@@ -328,10 +339,17 @@ async def responses_tool_loop_stream(
         if has_foreign or not owned_specs:
             # Caller dispatches the foreign calls; or there's nothing to do.
             if deferred_completed is not None:
-                yield deferred_completed
+                yield _maybe_fold_response_completed_usage(deferred_completed, acc_output_tokens)
             return
 
-        # All-owned: execute, append to input, continue. Drop the terminal.
+        # All-owned: accumulate this iteration's output_tokens from the
+        # dropped ``response.completed`` event (so the next final-fold sees
+        # the running total), then execute, append to input, and continue.
+        if deferred_completed is not None:
+            iter_response = getattr(deferred_completed, "response", None)
+            iter_usage = getattr(iter_response, "usage", None) if iter_response is not None else None
+            if iter_usage is not None:
+                acc_output_tokens += getattr(iter_usage, "output_tokens", 0) or 0
         for spec in owned_specs:
             input_items.append(
                 {
@@ -355,3 +373,27 @@ async def responses_tool_loop_stream(
             input_items.append({"type": "function_call_output", "call_id": spec["call_id"], "output": text})
 
     raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")
+
+
+def _maybe_fold_response_completed_usage(event: Any, acc_output_tokens: int) -> Any:
+    """Return a ``response.completed`` event with cumulative output_tokens folded in.
+
+    Pass-through for any other event type or when ``acc_output_tokens`` is
+    zero. The Responses streaming usage report is read off
+    ``event.response.usage``; we ``model_copy`` the Response with an updated
+    Usage so consumers (``streaming_generator``) see the full tool-loop
+    output count instead of only the final iteration's.
+    """
+    if acc_output_tokens <= 0:
+        return event
+    if getattr(event, "type", None) != "response.completed":
+        return event
+    response_obj = getattr(event, "response", None)
+    usage = getattr(response_obj, "usage", None) if response_obj is not None else None
+    if usage is None or not hasattr(usage, "model_copy") or response_obj is None:
+        return event
+    new_output = (getattr(usage, "output_tokens", 0) or 0) + acc_output_tokens
+    new_total = (getattr(usage, "total_tokens", 0) or 0) + acc_output_tokens
+    new_usage = usage.model_copy(update={"output_tokens": new_output, "total_tokens": new_total})
+    new_response = response_obj.model_copy(update={"usage": new_usage})
+    return event.model_copy(update={"response": new_response})

--- a/src/gateway/services/mcp_loop_responses.py
+++ b/src/gateway/services/mcp_loop_responses.py
@@ -1,0 +1,343 @@
+"""OpenAI Responses API variant of the MCP tool-use loop.
+
+Mirrors :mod:`gateway.services.mcp_loop` and
+:mod:`gateway.services.mcp_loop_messages` but speaks the OpenAI Responses wire
+shape: ``Response.output`` items (``function_call`` entries) instead of
+``tool_calls``; ``function_call_output`` input items as tool results;
+``response.output_item.*`` / ``response.function_call_arguments.*`` /
+``response.completed`` stream events.
+
+The duck-typed pool interface (``owns_tool`` / ``call_tool`` /
+``openai_tools`` / ``purpose_hints``) is reused unchanged; the
+``openai_tools`` shape is converted at the boundary in :mod:`tool_format`.
+
+Native server-managed tools that the Responses API can run upstream
+(``web_search_call``, ``code_interpreter_call``, ``mcp_call``, etc.) are not
+intercepted here — those output items belong to the provider's own tool
+execution path and the gateway has nothing to dispatch against.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
+
+from any_llm import aresponses
+
+from gateway.log_config import logger
+from gateway.services.mcp_loop import (
+    DEFAULT_MAX_TOOL_ITERATIONS,
+    MAX_TOOL_ITERATIONS_CAP,
+    MaxToolIterationsExceeded,
+)
+from gateway.services.tool_format import openai_to_responses_tools
+
+if TYPE_CHECKING:
+    from any_llm.types.responses import Response, ResponseStreamEvent
+
+    from gateway.services.mcp_client import MCPClientPool
+
+__all__ = [
+    "DEFAULT_MAX_TOOL_ITERATIONS",
+    "MAX_TOOL_ITERATIONS_CAP",
+    "MaxToolIterationsExceeded",
+    "responses_tool_loop",
+    "responses_tool_loop_stream",
+]
+
+
+def _split_function_calls(
+    output: list[Any],
+    pool: MCPClientPool,
+) -> tuple[list[Any], bool]:
+    """Return (owned_function_call_items, has_foreign).
+
+    Walks ``output`` for items with ``type == "function_call"`` and partitions
+    by ``pool.owns_tool(item.name)``. Non-function-call items (text messages,
+    web_search_call, code_interpreter_call, mcp_call, …) are ignored — they're
+    not gateway-managed tool dispatch.
+    """
+    owned: list[Any] = []
+    has_foreign = False
+    for item in output:
+        if getattr(item, "type", None) != "function_call":
+            continue
+        if pool.owns_tool(item.name):
+            owned.append(item)
+        else:
+            has_foreign = True
+    return owned, has_foreign
+
+
+async def _execute_function_calls(
+    pool: MCPClientPool,
+    items: list[Any],
+) -> list[dict[str, Any]]:
+    """Run each owned function_call and return the Responses function_call_output items.
+
+    Tool failures convert to a ``[tool error] …`` string in the output so the
+    model can recover. Only cancellation-class exceptions escape — same idiom
+    as :func:`gateway.services.mcp_loop._execute_mcp_calls`.
+    """
+    out: list[dict[str, Any]] = []
+    for item in items:
+        try:
+            args = json.loads(item.arguments or "{}")
+        except json.JSONDecodeError:
+            args = {}
+        try:
+            text = await pool.call_tool(item.name, args)
+        except Exception as exc:  # noqa: BLE001 — see docstring
+            logger.warning("MCP tool %s execution failed: %s", item.name, exc)
+            text = f"[tool error] {exc}"
+        out.append({"type": "function_call_output", "call_id": item.call_id, "output": text})
+    return out
+
+
+def _items_to_dicts(items: list[Any]) -> list[dict[str, Any]]:
+    """Serialize Response output items back to wire shape for the next round's input."""
+    out: list[dict[str, Any]] = []
+    for item in items:
+        if hasattr(item, "model_dump"):
+            out.append(item.model_dump(exclude_none=True))
+        elif isinstance(item, dict):
+            out.append(item)
+        else:
+            out.append(dict(item))
+    return out
+
+
+def _coerce_input_to_list(input_data: Any) -> list[Any]:
+    """Normalize ``input_data`` to a list so the tool loop can append items.
+
+    The Responses API accepts ``input`` as either a string (treated as a single
+    user message) or a list of input items. To continue the conversation after
+    a tool round we have to append items, which requires the list form.
+    """
+    if input_data is None:
+        return []
+    if isinstance(input_data, list):
+        return list(input_data)
+    if isinstance(input_data, str):
+        return [{"role": "user", "content": input_data}]
+    return [input_data]
+
+
+async def responses_tool_loop(
+    *,
+    completion_kwargs: dict[str, Any],
+    pool: MCPClientPool,
+    max_iterations: int,
+) -> Response:
+    """Non-streaming OpenAI Responses tool-use loop.
+
+    Each iteration calls ``aresponses``, walks ``result.output`` for owned
+    ``function_call`` items, executes them, and appends the originals plus
+    matching ``function_call_output`` items to ``input_data`` for the next
+    round. Loop terminates when:
+
+    - the response has no owned ``function_call`` items (final answer);
+    - the response includes foreign ``function_call`` items — those are
+      returned to the caller for client-side dispatch. Mixed batches execute
+      the owned subset for its side effects and filter those out of the
+      returned ``output`` so the caller only sees the foreign ones.
+
+    Accumulates ``input_tokens`` / ``output_tokens`` / ``total_tokens`` across
+    iterations into the returned ``Response``.
+    """
+    input_items = _coerce_input_to_list(completion_kwargs.get("input_data"))
+    user_tools = list(completion_kwargs.get("tools") or [])
+    merged_tools = user_tools + openai_to_responses_tools(pool.openai_tools)
+
+    base = {k: v for k, v in completion_kwargs.items() if k not in {"input_data", "tools", "stream"}}
+
+    acc_input = 0
+    acc_output = 0
+    acc_total = 0
+
+    for _ in range(max_iterations):
+        kwargs: dict[str, Any] = {**base, "input_data": input_items, "stream": False}
+        if merged_tools:
+            kwargs["tools"] = merged_tools
+
+        result: Response = await aresponses(**kwargs)  # type: ignore[assignment]
+        if result.usage:
+            acc_input += result.usage.input_tokens or 0
+            acc_output += result.usage.output_tokens or 0
+            acc_total += result.usage.total_tokens or 0
+
+        output = list(result.output or [])
+        owned, has_foreign = _split_function_calls(output, pool)
+
+        if has_foreign:
+            # Mixed batch: execute owned for side effects, filter from output.
+            if owned:
+                await _execute_function_calls(pool, owned)
+                owned_call_ids = {item.call_id for item in owned}
+                try:
+                    result.output = [
+                        item
+                        for item in output
+                        if not (
+                            getattr(item, "type", None) == "function_call"
+                            and getattr(item, "call_id", None) in owned_call_ids
+                        )
+                    ]
+                except (AttributeError, TypeError):
+                    logger.warning(
+                        "Responses-mixed: could not filter output on response; client will see function_call "
+                        "items the gateway already executed (no-op on the client side).",
+                    )
+            _fold_usage(result, acc_input, acc_output, acc_total)
+            return result
+
+        if not owned:
+            _fold_usage(result, acc_input, acc_output, acc_total)
+            return result
+
+        # All-owned: continue. Append the assistant's function_call items AND
+        # the matching function_call_output items so the next call's input has
+        # the full transcript.
+        input_items.extend(_items_to_dicts(owned))
+        input_items.extend(await _execute_function_calls(pool, owned))
+
+    raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")
+
+
+def _fold_usage(result: Response, input_total: int, output_total: int, total_total: int) -> None:
+    """Replace ``result.usage`` token counts with the loop's running totals."""
+    if result.usage is None:
+        return
+    result.usage.input_tokens = input_total
+    result.usage.output_tokens = output_total
+    result.usage.total_tokens = total_total
+
+
+async def responses_tool_loop_stream(
+    *,
+    completion_kwargs: dict[str, Any],
+    pool: MCPClientPool,
+    max_iterations: int,
+) -> AsyncIterator[ResponseStreamEvent]:
+    """Streaming OpenAI Responses tool-use loop.
+
+    Forwards every event downstream and tracks ``function_call`` output items
+    by buffering ``response.function_call_arguments.delta`` chunks per
+    ``output_index`` until ``response.output_item.done`` for that item.
+
+    On ``response.completed``: if any buffered function_call items exist AND
+    all owned by the pool, execute them, append the originals plus the
+    ``function_call_output`` items to ``input_data``, drop the terminal
+    ``response.completed`` event, and start the next round. If any foreign
+    function_call is present (or none at all), forward ``response.completed``
+    and exit.
+
+    Mixed batches in streaming mode forward everything as-is (rewriting the
+    output_items mid-stream to remove owned ones would be too invasive); the
+    client sees what it sees and the loop exits. Same trade-off as the
+    Anthropic streaming variant.
+    """
+    input_items = _coerce_input_to_list(completion_kwargs.get("input_data"))
+    user_tools = list(completion_kwargs.get("tools") or [])
+    merged_tools = user_tools + openai_to_responses_tools(pool.openai_tools)
+
+    base = {k: v for k, v in completion_kwargs.items() if k not in {"input_data", "tools"}}
+    base["stream"] = True
+
+    for _ in range(max_iterations):
+        kwargs: dict[str, Any] = {**base, "input_data": input_items}
+        if merged_tools:
+            kwargs["tools"] = merged_tools
+
+        stream: AsyncIterator[ResponseStreamEvent] = await aresponses(**kwargs)  # type: ignore[assignment]
+
+        # Per-iteration state.
+        function_calls: dict[int, dict[str, Any]] = {}  # output_index -> {"call_id", "name", "arguments"}
+        deferred_completed: ResponseStreamEvent | None = None
+
+        async for event in stream:
+            etype = getattr(event, "type", None)
+
+            if etype == "response.output_item.added":
+                item = getattr(event, "item", None)
+                output_index = getattr(event, "output_index", None)
+                if item is not None and output_index is not None and getattr(item, "type", None) == "function_call":
+                    function_calls[output_index] = {
+                        "call_id": getattr(item, "call_id", ""),
+                        "name": getattr(item, "name", ""),
+                        "arguments": getattr(item, "arguments", "") or "",
+                    }
+
+            elif etype == "response.function_call_arguments.delta":
+                idx = getattr(event, "output_index", None)
+                if idx is not None and idx in function_calls:
+                    function_calls[idx]["arguments"] += getattr(event, "delta", "") or ""
+
+            elif etype == "response.function_call_arguments.done":
+                # The terminal arguments value overrides the running buffer —
+                # the SDK uses this event for completeness even when the
+                # deltas already concatenate cleanly.
+                idx = getattr(event, "output_index", None)
+                if idx is not None and idx in function_calls:
+                    final_args = getattr(event, "arguments", None)
+                    if final_args:
+                        function_calls[idx]["arguments"] = final_args
+                    final_name = getattr(event, "name", None)
+                    if final_name:
+                        function_calls[idx]["name"] = final_name
+
+            elif etype == "response.completed":
+                # Defer — we'll decide whether to forward or drop after the
+                # tool-call accounting below. Break out so the `yield event`
+                # below this if/elif chain is skipped.
+                deferred_completed = event
+                break
+
+            yield event
+
+        # Decide whether to loop or exit.
+        if not function_calls:
+            if deferred_completed is not None:
+                yield deferred_completed
+            return
+
+        owned_specs: list[dict[str, Any]] = []
+        has_foreign = False
+        for idx in sorted(function_calls):
+            spec = function_calls[idx]
+            if pool.owns_tool(spec["name"]):
+                owned_specs.append(spec)
+            else:
+                has_foreign = True
+
+        if has_foreign or not owned_specs:
+            # Caller dispatches the foreign calls; or there's nothing to do.
+            if deferred_completed is not None:
+                yield deferred_completed
+            return
+
+        # All-owned: execute, append to input, continue. Drop the terminal.
+        for spec in owned_specs:
+            input_items.append(
+                {
+                    "type": "function_call",
+                    "call_id": spec["call_id"],
+                    "name": spec["name"],
+                    "arguments": spec["arguments"] or "{}",
+                }
+            )
+
+        for spec in owned_specs:
+            try:
+                parsed_args = json.loads(spec["arguments"] or "{}")
+            except json.JSONDecodeError:
+                parsed_args = {}
+            try:
+                text = await pool.call_tool(spec["name"], parsed_args)
+            except Exception as exc:  # noqa: BLE001 — same tool-error-as-message idiom as the non-stream loop
+                logger.warning("MCP tool %s execution failed: %s", spec["name"], exc)
+                text = f"[tool error] {exc}"
+            input_items.append({"type": "function_call_output", "call_id": spec["call_id"], "output": text})
+
+    raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")

--- a/src/gateway/services/mcp_loop_responses.py
+++ b/src/gateway/services/mcp_loop_responses.py
@@ -20,7 +20,7 @@ execution path and the gateway has nothing to dispatch against.
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import TYPE_CHECKING, Any
 
 from any_llm import aresponses
@@ -129,6 +129,7 @@ async def responses_tool_loop(
     completion_kwargs: dict[str, Any],
     pool: MCPClientPool,
     max_iterations: int,
+    on_first_response: Callable[[], None] | None = None,
 ) -> Response:
     """Non-streaming OpenAI Responses tool-use loop.
 
@@ -145,6 +146,14 @@ async def responses_tool_loop(
 
     Accumulates ``input_tokens`` / ``output_tokens`` / ``total_tokens`` across
     iterations into the returned ``Response``.
+
+    ``on_first_response`` is invoked exactly once, right after the first
+    upstream ``aresponses`` call returns successfully. Mirrors the contract
+    on :func:`gateway.services.mcp_loop.mcp_tool_loop` so platform-mode
+    callers can lock in to the chosen provider once an assistant turn has
+    materialized — subsequent failures terminate the request instead of
+    silently swapping providers (a Responses transcript carries
+    provider-specific call_ids and reasoning items that can't be replayed).
     """
     input_items = _coerce_input_to_list(completion_kwargs.get("input_data"))
     user_tools = list(completion_kwargs.get("tools") or [])
@@ -155,6 +164,7 @@ async def responses_tool_loop(
     acc_input = 0
     acc_output = 0
     acc_total = 0
+    first_response_signaled = False
 
     for _ in range(max_iterations):
         kwargs: dict[str, Any] = {**base, "input_data": input_items, "stream": False}
@@ -162,6 +172,10 @@ async def responses_tool_loop(
             kwargs["tools"] = merged_tools
 
         result: Response = await aresponses(**kwargs)  # type: ignore[assignment]
+        if not first_response_signaled:
+            first_response_signaled = True
+            if on_first_response is not None:
+                on_first_response()
         if result.usage:
             acc_input += result.usage.input_tokens or 0
             acc_output += result.usage.output_tokens or 0

--- a/src/gateway/services/tool_format.py
+++ b/src/gateway/services/tool_format.py
@@ -104,3 +104,62 @@ def inject_purpose_hints_anthropic(
     else:
         call_kwargs["system"] = block
     return call_kwargs
+
+
+def openai_to_responses_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert OpenAI Chat-Completions function tools to OpenAI Responses shape.
+
+    Input (Chat Completions, nested)::
+
+        [{"type": "function", "function": {"name", "description", "parameters"}}]
+
+    Output (Responses, flat)::
+
+        [{"type": "function", "name", "description", "parameters"}]
+
+    Entries already in flat shape (no nested ``function`` dict) pass through
+    unchanged, so a mixed list works.
+    """
+    out: list[dict[str, Any]] = []
+    for tool in tools:
+        if tool.get("type") == "function" and isinstance(tool.get("function"), dict):
+            fn = tool["function"]
+            converted: dict[str, Any] = {"type": "function", "name": fn.get("name", "")}
+            if "description" in fn:
+                converted["description"] = fn["description"]
+            if "parameters" in fn:
+                converted["parameters"] = fn["parameters"]
+            out.append(converted)
+        else:
+            out.append(tool)
+    return out
+
+
+def inject_purpose_hints_responses(
+    call_kwargs: dict[str, Any],
+    hints: list[tuple[str, str]],
+    *,
+    header: str | None = None,
+) -> dict[str, Any]:
+    """Prepend per-tool purpose hints to the Responses API ``instructions`` field.
+
+    Mutates ``call_kwargs`` in place. No-op when ``hints`` is empty.
+    The Responses ``instructions`` field is a plain string (no content-block
+    list form), so the handling is simpler than the Anthropic case.
+    """
+    if not hints:
+        return call_kwargs
+
+    block = _build_hint_block(hints, header)
+    existing = call_kwargs.get("instructions")
+
+    if not existing:
+        call_kwargs["instructions"] = block
+    elif isinstance(existing, str):
+        call_kwargs["instructions"] = f"{block}\n\n{existing}"
+    else:
+        # Defensive: Responses spec types it as `str | None`, but if a future
+        # version of the SDK widens it, fall back to a string replacement
+        # rather than silently dropping the hints.
+        call_kwargs["instructions"] = block
+    return call_kwargs

--- a/tests/integration/test_responses_route_dispatch.py
+++ b/tests/integration/test_responses_route_dispatch.py
@@ -8,13 +8,14 @@ string — the Responses API doesn't use the Anthropic-style error envelope).
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from any_llm.types.responses import Response
+from any_llm.types.responses import Response, ResponseStreamEvent
 from fastapi.testclient import TestClient
-from openai.types.responses import ResponseUsage
+from openai.types.responses import ResponseCompletedEvent, ResponseTextDeltaEvent, ResponseUsage
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
 _MODEL = "openai:gpt-4o-mini"
@@ -396,6 +397,209 @@ def test_sandbox_unreachable_returns_502(
             json={
                 "model": _MODEL,
                 "input": "go",
+                "tools": [{"type": "code_execution_20250825"}],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 502
+    assert "sandbox unreachable" in resp.json()["detail"]
+
+
+# ---------- streaming dispatch ----------
+
+
+def _stream_text_event(delta: str) -> ResponseTextDeltaEvent:
+    return ResponseTextDeltaEvent(
+        type="response.output_text.delta",
+        item_id="msg_1",
+        output_index=0,
+        content_index=0,
+        delta=delta,
+        sequence_number=0,
+        logprobs=[],
+    )
+
+
+def _stream_completed_event() -> ResponseCompletedEvent:
+    return ResponseCompletedEvent(
+        type="response.completed",
+        response=_response(),
+        sequence_number=0,
+    )
+
+
+async def _stream_iter(*events: ResponseStreamEvent) -> AsyncIterator[ResponseStreamEvent]:
+    for event in events:
+        yield event
+
+
+def test_stream_no_tools_returns_sse_response(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """``stream: true`` with no gateway tools wraps the upstream stream in an
+    SSE response. The route should NOT call the tool loop — this is the plain
+    ``aresponses(stream=True)`` path.
+
+    ``aresponses`` is a coroutine that returns the stream, so the fake is an
+    ``async def`` returning an async iterator. The tool loop is an async
+    generator, so its fake must use ``yield`` (and is a separate shape).
+    """
+
+    async def fake_aresponses(**_kwargs: Any) -> AsyncIterator[ResponseStreamEvent]:
+        return _stream_iter(_stream_text_event("hi"), _stream_completed_event())
+
+    tool_loop_called = False
+
+    async def fake_loop_stream(**_kwargs: Any) -> AsyncIterator[ResponseStreamEvent]:
+        nonlocal tool_loop_called
+        tool_loop_called = True
+        # Match the async-generator shape of responses_tool_loop_stream. The
+        # yield is unreachable but tells Python this is an async generator
+        # (not an async function returning an iterator) — that's what the
+        # route's ``async for`` expects.
+        return
+        yield  # noqa: F811 — needed to flag this as an async generator
+
+    with (
+        patch("gateway.api.routes.responses.aresponses", new=fake_aresponses),
+        patch("gateway.api.routes.responses.responses_tool_loop_stream", new=fake_loop_stream),
+    ):
+        resp = client.post(
+            "/v1/responses",
+            json={"model": _MODEL, "input": "hi", "stream": True},
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert tool_loop_called is False
+
+
+def test_stream_mcp_servers_dispatches_through_tool_loop_stream(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """``stream: true`` with ``mcp_servers`` routes through
+    ``responses_tool_loop_stream`` rather than calling ``aresponses`` directly.
+    Catches regressions where the streaming dispatch silently falls through.
+    """
+    seen: dict[str, Any] = {}
+
+    async def fake_loop_stream(
+        *, completion_kwargs: Any, pool: Any, max_iterations: int
+    ) -> AsyncIterator[ResponseStreamEvent]:
+        seen["pool"] = pool
+        seen["max_iterations"] = max_iterations
+        yield _stream_completed_event()
+
+    plain_aresponses_called = False
+
+    async def fake_aresponses(**_kwargs: Any) -> AsyncIterator[ResponseStreamEvent]:
+        nonlocal plain_aresponses_called
+        plain_aresponses_called = True
+        return _stream_iter()
+
+    with (
+        patch("gateway.api.routes.responses.responses_tool_loop_stream", new=fake_loop_stream),
+        patch("gateway.api.routes.responses.aresponses", new=fake_aresponses),
+        patch(
+            "gateway.services.mcp_client.MCPClientPool.__aenter__",
+            new=AsyncMock(return_value=AsyncMock(purpose_hints=lambda: [])),
+        ),
+        patch("gateway.services.mcp_client.MCPClientPool.__aexit__", new=AsyncMock(return_value=None)),
+    ):
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": _MODEL,
+                "input": "hi",
+                "stream": True,
+                "mcp_servers": [{"name": "test", "url": "http://127.0.0.1:9999/mcp"}],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert seen.get("pool") is not None, "responses_tool_loop_stream was not invoked"
+    assert plain_aresponses_called is False
+
+
+def test_stream_code_execution_dispatches_through_sandbox(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``stream: true`` with ``code_execution_*`` opens the sandbox backend and
+    feeds it to ``responses_tool_loop_stream``.
+
+    Note: the streaming path uses the ``sandbox_backend`` instance itself
+    (not the value ``__aenter__`` returns) for ``purpose_hints()`` and as
+    the ``pool`` argument — matching how real ``SandboxBackend.__aenter__``
+    returns ``self``. The fake here mirrors that by having ``__aenter__``
+    return the same outer mock and exposing ``purpose_hints`` on it.
+    """
+    monkeypatch.setenv("GATEWAY_SANDBOX_URL", "http://127.0.0.1:9999/sandbox")
+
+    pool_seen: list[Any] = []
+
+    async def fake_loop_stream(
+        *, completion_kwargs: Any, pool: Any, max_iterations: int
+    ) -> AsyncIterator[ResponseStreamEvent]:
+        pool_seen.append(pool)
+        yield _stream_completed_event()
+
+    fake_backend = AsyncMock()
+    fake_backend.purpose_hints = lambda: []
+    fake_backend.__aenter__ = AsyncMock(return_value=fake_backend)
+    fake_backend.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("gateway.api.routes.responses.responses_tool_loop_stream", new=fake_loop_stream),
+        patch("gateway.api.routes.responses.SandboxBackend", return_value=fake_backend),
+    ):
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": _MODEL,
+                "input": "compute",
+                "stream": True,
+                "tools": [{"type": "code_execution_20250825"}],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert pool_seen == [fake_backend], "tool loop didn't receive the SandboxBackend"
+
+
+def test_stream_sandbox_unreachable_returns_502(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test for the eager-open error mapping bug: when the
+    streaming sandbox eager-open fails, the route must return a 502 with the
+    documented detail rather than a 500 (which is what would happen if the
+    streaming dispatch wasn't wrapped in the error-mapping try/except).
+    """
+    monkeypatch.setenv("GATEWAY_SANDBOX_URL", "http://127.0.0.1:9999/sandbox")
+
+    from gateway.services.sandbox_backend import SandboxNotReachableError
+
+    with patch(
+        "gateway.api.routes.responses.SandboxBackend",
+        return_value=AsyncMock(__aenter__=AsyncMock(side_effect=SandboxNotReachableError("boom"))),
+    ):
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": _MODEL,
+                "input": "go",
+                "stream": True,
                 "tools": [{"type": "code_execution_20250825"}],
             },
             headers=api_key_header,

--- a/tests/integration/test_responses_route_dispatch.py
+++ b/tests/integration/test_responses_route_dispatch.py
@@ -1,0 +1,425 @@
+"""Route-level tests for the /v1/responses endpoint wiring.
+
+Mirror of :mod:`tests.integration.test_messages_route_dispatch` for the OpenAI
+Responses API surface: tool extraction, mutual-exclusivity validation,
+per-backend dispatch, and error mapping (plain HTTPException with a ``detail``
+string — the Responses API doesn't use the Anthropic-style error envelope).
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from any_llm.types.responses import Response
+from fastapi.testclient import TestClient
+from openai.types.responses import ResponseUsage
+from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+
+_MODEL = "openai:gpt-4o-mini"
+
+
+def _response(*, output: list[Any] | None = None, status: str = "completed") -> Response:
+    return Response(
+        id="resp_test",
+        created_at=0.0,
+        model="fake",
+        object="response",
+        status=cast(Any, status),
+        output=output or [],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+        usage=ResponseUsage(
+            input_tokens=5,
+            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            output_tokens=2,
+            output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+            total_tokens=7,
+        ),
+        error=None,
+        incomplete_details=None,
+        instructions=None,
+        metadata=None,
+        temperature=None,
+        top_p=None,
+    )
+
+
+# ---------- plain aresponses (no gateway tools) ----------
+
+
+def test_no_tools_falls_through_to_plain_aresponses(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        captured.update(kwargs)
+        return _response()
+
+    with patch("gateway.api.routes.responses.aresponses", new=fake_aresponses):
+        resp = client.post(
+            "/v1/responses",
+            json={"model": _MODEL, "input": "hi"},
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    # No tools in the upstream kwargs since none were requested.
+    assert "tools" not in captured
+
+
+def test_gateway_internal_fields_are_stripped_from_upstream_kwargs(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """``mcp_servers`` / ``tools_header`` / ``max_tool_iterations`` are
+    gateway-only knobs. They must not be forwarded to ``aresponses``.
+    """
+    captured: dict[str, Any] = {}
+
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        captured.update(kwargs)
+        return _response()
+
+    with patch("gateway.api.routes.responses.aresponses", new=fake_aresponses):
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": _MODEL,
+                "input": "hi",
+                "tools_header": "Tools available:",
+                "max_tool_iterations": 3,
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    for field in ("mcp_servers", "mcp_server_ids", "tools_header", "max_tool_iterations"):
+        assert field not in captured, f"gateway-internal field {field!r} leaked to upstream"
+
+
+def test_user_supplied_chat_shape_tools_get_flattened_to_responses_shape(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """Callers may pass tools in OpenAI Chat-Completions nested shape; they
+    must be flattened to the Responses API's flat shape before forwarding.
+    """
+    captured: dict[str, Any] = {}
+
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        captured.update(kwargs)
+        return _response()
+
+    with patch("gateway.api.routes.responses.aresponses", new=fake_aresponses):
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": _MODEL,
+                "input": "do it",
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "description": "look stuff up",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    forwarded_tools = captured.get("tools")
+    assert forwarded_tools is not None
+    assert forwarded_tools[0]["type"] == "function"
+    assert forwarded_tools[0]["name"] == "lookup"
+    assert forwarded_tools[0]["parameters"] == {"type": "object", "properties": {}}
+    # No nested function key — that's Chat-Completions shape, not Responses.
+    assert "function" not in forwarded_tools[0]
+
+
+# ---------- gateway tool dispatch ----------
+
+
+def test_mcp_servers_dispatches_through_responses_tool_loop(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    seen: dict[str, Any] = {}
+
+    async def fake_loop(*, completion_kwargs: Any, pool: Any, max_iterations: int) -> Response:
+        seen["completion_kwargs"] = completion_kwargs
+        seen["pool"] = pool
+        seen["max_iterations"] = max_iterations
+        return _response()
+
+    plain_aresponses_called = False
+
+    async def fake_aresponses(**_kwargs: Any) -> Response:
+        nonlocal plain_aresponses_called
+        plain_aresponses_called = True
+        return _response()
+
+    with (
+        patch("gateway.api.routes.responses.responses_tool_loop", new=fake_loop),
+        patch("gateway.api.routes.responses.aresponses", new=fake_aresponses),
+        patch(
+            "gateway.services.mcp_client.MCPClientPool.__aenter__",
+            new=AsyncMock(return_value=AsyncMock(purpose_hints=lambda: [])),
+        ),
+        patch("gateway.services.mcp_client.MCPClientPool.__aexit__", new=AsyncMock(return_value=None)),
+    ):
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": _MODEL,
+                "input": "hi",
+                "mcp_servers": [{"name": "test", "url": "http://127.0.0.1:9999/mcp"}],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert "completion_kwargs" in seen, "responses_tool_loop was not invoked"
+    assert plain_aresponses_called is False
+
+
+def test_code_execution_dispatches_through_sandbox_backend(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GATEWAY_SANDBOX_URL", "http://127.0.0.1:9999/sandbox")
+
+    pool_seen: list[Any] = []
+
+    async def fake_loop(*, completion_kwargs: Any, pool: Any, max_iterations: int) -> Response:
+        pool_seen.append(pool)
+        return _response()
+
+    fake_backend = AsyncMock()
+    fake_backend.purpose_hints = lambda: []
+
+    with (
+        patch("gateway.api.routes.responses.responses_tool_loop", new=fake_loop),
+        patch(
+            "gateway.api.routes.responses.SandboxBackend",
+            return_value=AsyncMock(
+                __aenter__=AsyncMock(return_value=fake_backend),
+                __aexit__=AsyncMock(return_value=None),
+            ),
+        ),
+    ):
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": _MODEL,
+                "input": "compute",
+                "tools": [{"type": "code_execution_20250825"}],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert pool_seen == [fake_backend]
+
+
+def test_web_search_dispatches_through_web_search_backend(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GATEWAY_WEB_SEARCH_URL", "http://127.0.0.1:9999/search")
+
+    pool_seen: list[Any] = []
+
+    async def fake_loop(*, completion_kwargs: Any, pool: Any, max_iterations: int) -> Response:
+        pool_seen.append(pool)
+        return _response()
+
+    fake_backend = AsyncMock()
+    fake_backend.purpose_hints = lambda: []
+
+    fake_builder_result = AsyncMock(
+        __aenter__=AsyncMock(return_value=fake_backend),
+        __aexit__=AsyncMock(return_value=None),
+    )
+
+    with (
+        patch("gateway.api.routes.responses.responses_tool_loop", new=fake_loop),
+        patch("gateway.api.routes.responses._build_web_search_backend", return_value=fake_builder_result),
+    ):
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": _MODEL,
+                "input": "search",
+                "tools": [{"type": "web_search_20250305"}],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert pool_seen == [fake_backend]
+
+
+# ---------- validation errors ----------
+
+
+def test_code_execution_without_sandbox_env_returns_400(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GATEWAY_SANDBOX_URL", raising=False)
+    resp = client.post(
+        "/v1/responses",
+        json={
+            "model": _MODEL,
+            "input": "hi",
+            "tools": [{"type": "code_execution_20250825"}],
+        },
+        headers=api_key_header,
+    )
+    assert resp.status_code == 400
+    assert "GATEWAY_SANDBOX_URL" in resp.json()["detail"]
+
+
+def test_code_execution_combined_with_mcp_servers_returns_400(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GATEWAY_SANDBOX_URL", "http://127.0.0.1:9999/sandbox")
+    resp = client.post(
+        "/v1/responses",
+        json={
+            "model": _MODEL,
+            "input": "hi",
+            "tools": [{"type": "code_execution_20250825"}],
+            "mcp_servers": [{"name": "x", "url": "http://127.0.0.1:9999/mcp"}],
+        },
+        headers=api_key_header,
+    )
+    assert resp.status_code == 400
+    assert "code_execution and mcp_servers" in resp.json()["detail"]
+
+
+def test_web_search_combined_with_sandbox_returns_400(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GATEWAY_SANDBOX_URL", "http://127.0.0.1:9999/sandbox")
+    monkeypatch.setenv("GATEWAY_WEB_SEARCH_URL", "http://127.0.0.1:9999/search")
+    resp = client.post(
+        "/v1/responses",
+        json={
+            "model": _MODEL,
+            "input": "hi",
+            "tools": [
+                {"type": "code_execution_20250825"},
+                {"type": "web_search_20250305"},
+            ],
+        },
+        headers=api_key_header,
+    )
+    assert resp.status_code == 400
+    assert "web_search cannot be combined" in resp.json()["detail"]
+
+
+# ---------- gateway-side runtime errors ----------
+
+
+def test_max_tool_iterations_exceeded_returns_422(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GATEWAY_SANDBOX_URL", "http://127.0.0.1:9999/sandbox")
+
+    from gateway.services.mcp_loop_responses import MaxToolIterationsExceeded
+
+    async def fake_loop(*, completion_kwargs: Any, pool: Any, max_iterations: int) -> Response:
+        raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")
+
+    fake_backend = AsyncMock()
+    fake_backend.purpose_hints = lambda: []
+
+    with (
+        patch("gateway.api.routes.responses.responses_tool_loop", new=fake_loop),
+        patch(
+            "gateway.api.routes.responses.SandboxBackend",
+            return_value=AsyncMock(
+                __aenter__=AsyncMock(return_value=fake_backend),
+                __aexit__=AsyncMock(return_value=None),
+            ),
+        ),
+    ):
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": _MODEL,
+                "input": "go",
+                "tools": [{"type": "code_execution_20250825"}],
+                "max_tool_iterations": 1,
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 422
+    assert "max_tool_iterations" in resp.json()["detail"]
+
+
+def test_sandbox_unreachable_returns_502(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GATEWAY_SANDBOX_URL", "http://127.0.0.1:9999/sandbox")
+
+    from gateway.services.sandbox_backend import SandboxNotReachableError
+
+    with patch(
+        "gateway.api.routes.responses.SandboxBackend",
+        return_value=AsyncMock(__aenter__=AsyncMock(side_effect=SandboxNotReachableError("boom"))),
+    ):
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": _MODEL,
+                "input": "go",
+                "tools": [{"type": "code_execution_20250825"}],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 502
+    assert "sandbox unreachable" in resp.json()["detail"]
+
+
+# ---------- provider-support guard (pre-existing behavior) ----------
+
+
+def test_provider_without_responses_support_returns_400(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """The pre-existing SUPPORTS_RESPONSES check still works after the
+    wiring changes. Catches regressions where the provider-support guard
+    might be bypassed by the tool dispatch path.
+    """
+    resp = client.post(
+        "/v1/responses",
+        json={"model": "anthropic:claude-3-5-sonnet-20241022", "input": "hi"},
+        headers=api_key_header,
+    )
+    assert resp.status_code == 400
+    assert "does not support the Responses API" in resp.json()["detail"]

--- a/tests/unit/test_mcp_loop_responses.py
+++ b/tests/unit/test_mcp_loop_responses.py
@@ -1,0 +1,610 @@
+"""Unit tests for the Responses API MCP tool-use loop and tool-format helpers.
+
+Mirrors :mod:`tests.unit.test_mcp_loop` and
+:mod:`tests.unit.test_mcp_loop_messages` semantically — same scenarios
+expressed in the Responses API ``output`` items + ``function_call_output``
+input items shape.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any, cast
+
+import pytest
+from any_llm.types.responses import Response, ResponseStreamEvent
+from openai.types.responses import (
+    ResponseCompletedEvent,
+    ResponseFunctionCallArgumentsDeltaEvent,
+    ResponseFunctionCallArgumentsDoneEvent,
+    ResponseFunctionToolCall,
+    ResponseOutputItemAddedEvent,
+    ResponseOutputItemDoneEvent,
+    ResponseTextDeltaEvent,
+    ResponseUsage,
+)
+from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+
+from gateway.services import mcp_loop_responses as responses_loop_module
+from gateway.services.mcp_loop_responses import (
+    MaxToolIterationsExceeded,
+    responses_tool_loop,
+    responses_tool_loop_stream,
+)
+from gateway.services.tool_format import (
+    inject_purpose_hints_responses,
+    openai_to_responses_tools,
+)
+
+
+class _FakePool:
+    """Stand-in for MCPClientPool — same duck-typed surface as the other tests' _FakePool."""
+
+    def __init__(
+        self,
+        tool_names: list[str],
+        purpose_hints: list[tuple[str, str]] | None = None,
+        results: dict[str, str] | None = None,
+    ):
+        self._tool_names = set(tool_names)
+        self._hints = purpose_hints or []
+        self._results = results or {}
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    @property
+    def openai_tools(self) -> list[dict[str, Any]]:
+        return [
+            {"type": "function", "function": {"name": n, "description": "", "parameters": {}}}
+            for n in sorted(self._tool_names)
+        ]
+
+    def owns_tool(self, name: str) -> bool:
+        return name in self._tool_names
+
+    def purpose_hints(self) -> list[tuple[str, str]]:
+        return list(self._hints)
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+        self.calls.append((name, arguments))
+        if name not in self._results:
+            return f"ran {name}"
+        return self._results[name]
+
+
+def _function_call(
+    call_id: str,
+    name: str,
+    arguments: str,
+) -> ResponseFunctionToolCall:
+    return ResponseFunctionToolCall(
+        type="function_call",
+        call_id=call_id,
+        name=name,
+        arguments=arguments,
+    )
+
+
+def _response(
+    *,
+    output: list[Any] | None = None,
+    status: str = "completed",
+    input_tokens: int = 1,
+    output_tokens: int = 1,
+) -> Response:
+    """Build a minimal Response. Many required fields are filled with neutral defaults."""
+    return Response(
+        id="resp_test",
+        created_at=0.0,
+        model="fake",
+        object="response",
+        status=cast(Any, status),
+        output=output or [],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+        usage=ResponseUsage(
+            input_tokens=input_tokens,
+            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            output_tokens=output_tokens,
+            output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+            total_tokens=input_tokens + output_tokens,
+        ),
+        error=None,
+        incomplete_details=None,
+        instructions=None,
+        metadata=None,
+        temperature=None,
+        top_p=None,
+    )
+
+
+# ---------- pure helpers ----------
+
+
+def test_openai_to_responses_tools_flattens_function_shape() -> None:
+    out = openai_to_responses_tools(
+        [{"type": "function", "function": {"name": "fetch", "description": "d", "parameters": {"type": "object"}}}]
+    )
+    assert out == [{"type": "function", "name": "fetch", "description": "d", "parameters": {"type": "object"}}]
+
+
+def test_openai_to_responses_tools_omits_missing_optional_fields() -> None:
+    out = openai_to_responses_tools([{"type": "function", "function": {"name": "noop"}}])
+    assert out == [{"type": "function", "name": "noop"}]
+
+
+def test_openai_to_responses_tools_passes_already_flat_shapes_through() -> None:
+    flat = {"type": "function", "name": "lookup", "parameters": {"type": "object"}}
+    out = openai_to_responses_tools([flat])
+    assert out == [flat]
+
+
+def test_inject_purpose_hints_responses_no_hints_returns_unchanged() -> None:
+    kwargs: dict[str, Any] = {"instructions": "be helpful"}
+    assert inject_purpose_hints_responses(kwargs, [])["instructions"] == "be helpful"
+
+
+def test_inject_purpose_hints_responses_inserts_when_no_instructions() -> None:
+    kwargs: dict[str, Any] = {}
+    out = inject_purpose_hints_responses(kwargs, [("calendar", "for scheduling")])
+    assert "calendar" in out["instructions"]
+    assert "for scheduling" in out["instructions"]
+
+
+def test_inject_purpose_hints_responses_prepends_existing_instructions() -> None:
+    kwargs: dict[str, Any] = {"instructions": "be helpful"}
+    out = inject_purpose_hints_responses(kwargs, [("cal", "use it")])
+    assert "cal" in out["instructions"]
+    assert "be helpful" in out["instructions"]
+    assert out["instructions"].index("cal") < out["instructions"].index("be helpful")
+
+
+# ---------- non-streaming loop ----------
+
+
+@pytest.mark.asyncio
+async def test_loop_returns_immediately_when_no_function_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        calls.append(kwargs)
+        return _response(output=[], status="completed")
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    pool = _FakePool(tool_names=["fetch_url"])
+    out = await responses_tool_loop(
+        completion_kwargs={"model": "fake", "input_data": [{"role": "user", "content": "hi"}]},
+        pool=cast(Any, pool),
+        max_iterations=5,
+    )
+    assert out.status == "completed"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_loop_executes_owned_function_call_and_completes(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = iter(
+        [
+            _response(output=[_function_call("call_1", "fetch_url", '{"u":"x"}')]),
+            _response(output=[], status="completed"),
+        ]
+    )
+    captured_inputs: list[Any] = []
+
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        # Snapshot the input list — the loop mutates it across iterations.
+        captured_inputs.append(list(kwargs["input_data"]))
+        return next(responses)
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    pool = _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})
+    out = await responses_tool_loop(
+        completion_kwargs={"model": "fake", "input_data": [{"role": "user", "content": "fetch x"}]},
+        pool=cast(Any, pool),
+        max_iterations=5,
+    )
+
+    assert pool.calls == [("fetch_url", {"u": "x"})]
+    # Second call's input must include the function_call item + the
+    # matching function_call_output item appended to the running list.
+    second_input = captured_inputs[1]
+    types = [item.get("type") for item in second_input if isinstance(item, dict)]
+    assert "function_call" in types
+    assert "function_call_output" in types
+    output_item = next(
+        item
+        for item in second_input
+        if isinstance(item, dict) and item.get("type") == "function_call_output"
+    )
+    assert output_item["call_id"] == "call_1"
+    assert output_item["output"] == "ok"
+    assert out.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_loop_accumulates_usage_across_iterations(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = iter(
+        [
+            _response(output=[_function_call("c1", "fetch_url", "{}")], input_tokens=10, output_tokens=2),
+            _response(output=[], status="completed", input_tokens=12, output_tokens=3),
+        ]
+    )
+
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        return next(responses)
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    out = await responses_tool_loop(
+        completion_kwargs={"model": "fake", "input_data": "go"},
+        pool=cast(Any, _FakePool(tool_names=["fetch_url"])),
+        max_iterations=5,
+    )
+    assert out.usage is not None
+    assert out.usage.input_tokens == 22
+    assert out.usage.output_tokens == 5
+    assert out.usage.total_tokens == 27
+
+
+@pytest.mark.asyncio
+async def test_loop_max_iter_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        return _response(output=[_function_call("c", "fetch_url", "{}")])
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    with pytest.raises(MaxToolIterationsExceeded):
+        await responses_tool_loop(
+            completion_kwargs={"model": "fake", "input_data": "go"},
+            pool=cast(Any, _FakePool(tool_names=["fetch_url"])),
+            max_iterations=2,
+        )
+
+
+@pytest.mark.asyncio
+async def test_loop_foreign_function_call_returns_to_caller_without_execution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        return _response(output=[_function_call("c", "user_tool", "{}")])
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    pool = _FakePool(tool_names=["fetch_url"])  # doesn't own user_tool
+    out = await responses_tool_loop(
+        completion_kwargs={
+            "model": "fake",
+            "input_data": "go",
+            "tools": [{"type": "function", "name": "user_tool", "parameters": {}}],
+        },
+        pool=cast(Any, pool),
+        max_iterations=5,
+    )
+    assert pool.calls == []
+    types = [getattr(item, "type", None) for item in out.output]
+    assert "function_call" in types
+
+
+@pytest.mark.asyncio
+async def test_loop_mixed_calls_executes_owned_and_returns_only_foreign(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        return _response(
+            output=[
+                _function_call("owned_id", "fetch_url", "{}"),
+                _function_call("foreign_id", "user_tool", "{}"),
+            ],
+        )
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    pool = _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})
+    out = await responses_tool_loop(
+        completion_kwargs={
+            "model": "fake",
+            "input_data": "go",
+            "tools": [{"type": "function", "name": "user_tool", "parameters": {}}],
+        },
+        pool=cast(Any, pool),
+        max_iterations=5,
+    )
+    assert pool.calls == [("fetch_url", {})]
+    remaining_call_ids = [
+        getattr(item, "call_id", None)
+        for item in out.output
+        if getattr(item, "type", None) == "function_call"
+    ]
+    assert remaining_call_ids == ["foreign_id"]
+
+
+@pytest.mark.asyncio
+async def test_loop_tool_failure_appears_as_function_call_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = iter(
+        [
+            _response(output=[_function_call("c", "fetch_url", "{}")]),
+            _response(output=[], status="completed"),
+        ]
+    )
+    captured_inputs: list[Any] = []
+
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        # Snapshot the input list — the loop mutates it across iterations.
+        captured_inputs.append(list(kwargs["input_data"]))
+        return next(responses)
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    class FailingPool(_FakePool):
+        async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+            raise RuntimeError("upstream down")
+
+    pool = FailingPool(tool_names=["fetch_url"])
+    await responses_tool_loop(
+        completion_kwargs={"model": "fake", "input_data": "go"},
+        pool=cast(Any, pool),
+        max_iterations=5,
+    )
+    second_input = captured_inputs[1]
+    output_item = next(
+        item
+        for item in second_input
+        if isinstance(item, dict) and item.get("type") == "function_call_output"
+    )
+    assert "tool error" in output_item["output"]
+    assert "upstream down" in output_item["output"]
+
+
+@pytest.mark.asyncio
+async def test_loop_coerces_string_input_into_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Responses API accepts a string as ``input`` (treated as a single user
+    message). To continue past a tool round we need a list; the loop must
+    normalise on entry so the next call sees the full appended transcript.
+    """
+    responses = iter(
+        [
+            _response(output=[_function_call("c1", "fetch_url", "{}")]),
+            _response(output=[], status="completed"),
+        ]
+    )
+    captured_inputs: list[Any] = []
+
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        # Snapshot via list() — the loop reuses the same input_items list
+        # across iterations, so capturing the reference would show only the
+        # final state.
+        captured_inputs.append(list(kwargs["input_data"]))
+        return next(responses)
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    pool = _FakePool(tool_names=["fetch_url"])
+    await responses_tool_loop(
+        completion_kwargs={"model": "fake", "input_data": "hi"},
+        pool=cast(Any, pool),
+        max_iterations=5,
+    )
+    # First call was normalised to a list with just the user message.
+    assert isinstance(captured_inputs[0], list)
+    assert len(captured_inputs[0]) == 1
+    assert captured_inputs[0][0]["role"] == "user"
+    # Second call has the function_call + function_call_output appended.
+    assert len(captured_inputs[1]) > len(captured_inputs[0])
+
+
+# ---------- streaming loop ----------
+
+
+async def _async_iter(*events: ResponseStreamEvent) -> AsyncIterator[ResponseStreamEvent]:
+    for e in events:
+        yield e
+
+
+def _output_item_added(output_index: int, item: Any, seq: int = 0) -> ResponseOutputItemAddedEvent:
+    return ResponseOutputItemAddedEvent(
+        type="response.output_item.added",
+        item=item,
+        output_index=output_index,
+        sequence_number=seq,
+    )
+
+
+def _output_item_done(output_index: int, item: Any, seq: int = 0) -> ResponseOutputItemDoneEvent:
+    return ResponseOutputItemDoneEvent(
+        type="response.output_item.done",
+        item=item,
+        output_index=output_index,
+        sequence_number=seq,
+    )
+
+
+def _function_call_args_delta(
+    output_index: int, item_id: str, delta: str, seq: int = 0
+) -> ResponseFunctionCallArgumentsDeltaEvent:
+    return ResponseFunctionCallArgumentsDeltaEvent(
+        type="response.function_call_arguments.delta",
+        item_id=item_id,
+        output_index=output_index,
+        delta=delta,
+        sequence_number=seq,
+    )
+
+
+def _function_call_args_done(
+    output_index: int, item_id: str, name: str, arguments: str, seq: int = 0
+) -> ResponseFunctionCallArgumentsDoneEvent:
+    return ResponseFunctionCallArgumentsDoneEvent(
+        type="response.function_call_arguments.done",
+        item_id=item_id,
+        output_index=output_index,
+        name=name,
+        arguments=arguments,
+        sequence_number=seq,
+    )
+
+
+def _text_delta(item_id: str, output_index: int, delta: str, seq: int = 0) -> ResponseTextDeltaEvent:
+    return ResponseTextDeltaEvent(
+        type="response.output_text.delta",
+        item_id=item_id,
+        output_index=output_index,
+        content_index=0,
+        delta=delta,
+        sequence_number=seq,
+        logprobs=[],
+    )
+
+
+def _response_completed(seq: int = 0) -> ResponseCompletedEvent:
+    return ResponseCompletedEvent(
+        type="response.completed",
+        response=_response(output=[], status="completed"),
+        sequence_number=seq,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_passes_text_events_through_and_terminates(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_aresponses(**kwargs: Any) -> AsyncIterator[ResponseStreamEvent]:
+        return _async_iter(
+            _text_delta("msg_1", 0, "hi"),
+            _text_delta("msg_1", 0, " there"),
+            _response_completed(),
+        )
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    types: list[str] = []
+    async for event in responses_tool_loop_stream(
+        completion_kwargs={"model": "fake", "input_data": "hi"},
+        pool=cast(Any, _FakePool(tool_names=[])),
+        max_iterations=3,
+    ):
+        types.append(event.type)
+    assert types == [
+        "response.output_text.delta",
+        "response.output_text.delta",
+        "response.completed",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_runs_owned_function_call_and_continues(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Iteration 1 emits a function_call output item; the loop executes it and
+    drops the intermediate response.completed. Iteration 2 runs and its
+    terminal response.completed IS forwarded.
+    """
+    fc = _function_call("call_1", "fetch_url", "")
+    iter_streams = iter(
+        [
+            _async_iter(
+                _output_item_added(0, fc),
+                _function_call_args_delta(0, "fc_item_1", '{"u":'),
+                _function_call_args_delta(0, "fc_item_1", ' "x"}'),
+                _function_call_args_done(0, "fc_item_1", "fetch_url", '{"u": "x"}'),
+                _output_item_done(0, _function_call("call_1", "fetch_url", '{"u": "x"}')),
+                _response_completed(),
+            ),
+            _async_iter(
+                _text_delta("msg_1", 0, "done"),
+                _response_completed(),
+            ),
+        ]
+    )
+
+    async def fake_aresponses(**kwargs: Any) -> AsyncIterator[ResponseStreamEvent]:
+        return next(iter_streams)
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    pool = _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})
+    completed_count = 0
+    async for event in responses_tool_loop_stream(
+        completion_kwargs={"model": "fake", "input_data": "go"},
+        pool=cast(Any, pool),
+        max_iterations=5,
+    ):
+        if event.type == "response.completed":
+            completed_count += 1
+    # Only the final iteration's response.completed is forwarded — the
+    # intermediate one is dropped because the loop kept iterating.
+    assert completed_count == 1
+    assert pool.calls == [("fetch_url", {"u": "x"})]
+
+
+@pytest.mark.asyncio
+async def test_stream_foreign_function_call_forwards_terminal_and_exits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the model emits a function_call for a foreign tool, the loop must
+    forward response.completed so the client knows to dispatch.
+    """
+    fc = _function_call("call_1", "user_tool", "")
+    iter_streams = iter(
+        [
+            _async_iter(
+                _output_item_added(0, fc),
+                _function_call_args_done(0, "fc_item_1", "user_tool", "{}"),
+                _response_completed(),
+            ),
+        ]
+    )
+
+    async def fake_aresponses(**kwargs: Any) -> AsyncIterator[ResponseStreamEvent]:
+        return next(iter_streams)
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    pool = _FakePool(tool_names=["fetch_url"])  # doesn't own user_tool
+    types: list[str] = []
+    async for event in responses_tool_loop_stream(
+        completion_kwargs={"model": "fake", "input_data": "go"},
+        pool=cast(Any, pool),
+        max_iterations=5,
+    ):
+        types.append(event.type)
+    assert "response.completed" in types
+    assert pool.calls == []
+
+
+@pytest.mark.asyncio
+async def test_stream_function_call_arguments_accumulate_across_deltas(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Partial ``arguments`` deltas across multiple events must concatenate
+    before the tool input is parsed.
+    """
+    fc = _function_call("call_1", "fetch_url", "")
+    iter_streams = iter(
+        [
+            _async_iter(
+                _output_item_added(0, fc),
+                _function_call_args_delta(0, "fc_item_1", '{"u":'),
+                _function_call_args_delta(0, "fc_item_1", ' "x",'),
+                _function_call_args_delta(0, "fc_item_1", ' "n": 3}'),
+                # Deliberately omit the done event to confirm the loop can
+                # work off the accumulated deltas alone.
+                _response_completed(),
+            ),
+            _async_iter(
+                _text_delta("msg_1", 0, "done"),
+                _response_completed(),
+            ),
+        ]
+    )
+
+    async def fake_aresponses(**kwargs: Any) -> AsyncIterator[ResponseStreamEvent]:
+        return next(iter_streams)
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    pool = _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})
+    async for _event in responses_tool_loop_stream(
+        completion_kwargs={"model": "fake", "input_data": "go"},
+        pool=cast(Any, pool),
+        max_iterations=5,
+    ):
+        pass
+    assert pool.calls == [("fetch_url", {"u": "x", "n": 3})]

--- a/tests/unit/test_mcp_loop_responses.py
+++ b/tests/unit/test_mcp_loop_responses.py
@@ -394,6 +394,90 @@ async def test_loop_coerces_string_input_into_list(monkeypatch: pytest.MonkeyPat
     assert len(captured_inputs[1]) > len(captured_inputs[0])
 
 
+# ---------- on_first_response (lock-in callback) ----------
+
+
+@pytest.mark.asyncio
+async def test_loop_fires_on_first_response_after_first_aresponses_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``on_first_response`` is invoked exactly once, right after the first
+    upstream call returns successfully.
+    """
+    responses = iter(
+        [
+            _response(output=[_function_call("c1", "fetch_url", "{}")]),
+            _response(output=[], status="completed"),
+        ]
+    )
+    fire_order: list[str] = []
+
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        fire_order.append("aresponses")
+        return next(responses)
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    def _on_first() -> None:
+        fire_order.append("on_first_response")
+
+    await responses_tool_loop(
+        completion_kwargs={"model": "fake", "input_data": "go"},
+        pool=cast(Any, _FakePool(tool_names=["fetch_url"])),
+        max_iterations=5,
+        on_first_response=_on_first,
+    )
+    assert fire_order[0] == "aresponses"
+    assert fire_order[1] == "on_first_response"
+    assert fire_order.count("on_first_response") == 1
+
+
+@pytest.mark.asyncio
+async def test_loop_does_not_fire_on_first_response_when_initial_call_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fired = False
+
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        raise RuntimeError("upstream 500")
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    def _on_first() -> None:
+        nonlocal fired
+        fired = True
+
+    with pytest.raises(RuntimeError, match="upstream 500"):
+        await responses_tool_loop(
+            completion_kwargs={"model": "fake", "input_data": "go"},
+            pool=cast(Any, _FakePool(tool_names=["fetch_url"])),
+            max_iterations=5,
+            on_first_response=_on_first,
+        )
+    assert fired is False
+
+
+@pytest.mark.asyncio
+async def test_loop_is_backward_compatible_without_on_first_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The callback is optional — callers that don't need lock-in (standalone
+    mode) can omit it without changing behavior.
+    """
+
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        return _response(output=[], status="completed")
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    out = await responses_tool_loop(
+        completion_kwargs={"model": "fake", "input_data": "hi"},
+        pool=cast(Any, _FakePool(tool_names=[])),
+        max_iterations=5,
+    )
+    assert out.status == "completed"
+
+
 # ---------- streaming loop ----------
 
 


### PR DESCRIPTION
> **PR 3 of 4** in the messages/responses parity series. Stacked on #77 (PR 2).
>
> See #76 for the multi-PR plan rationale.

## What this PR does

Wires all three gateway-managed tool modes into the OpenAI Responses endpoint for both streaming and non-streaming, standalone-mode only. Symmetric with PR 2 for `/v1/messages`. Platform-mode is PR 4.

## Files

**New:**
- `src/gateway/services/mcp_loop_responses.py` — `responses_tool_loop` and `responses_tool_loop_stream`. Speaks the Responses wire shape: walks `Response.output` for `function_call` items, appends `function_call_output` items + original `function_call` items to `input_data` between rounds, accumulates `input_tokens` / `output_tokens` / `total_tokens`. Mirrors the `on_first_response` lock-in callback from `mcp_tool_loop`.
- `tests/unit/test_mcp_loop_responses.py` — 21 unit tests on the loop, including 3 for `on_first_response`.
- `tests/integration/test_responses_route_dispatch.py` — 16 FastAPI TestClient tests.

**Modified:**
- `src/gateway/services/tool_format.py` — extended with `openai_to_responses_tools` (flat shape) and `inject_purpose_hints_responses` (prepends to `instructions`).
- `src/gateway/api/routes/responses.py` — adds explicit `mcp_servers` / `tools_header` / `max_tool_iterations` / `tools` fields to `ResponsesRequest` (extra="allow" preserved), extracts code_execution / web_search, dispatches to the new loops. Same three-way mutual-exclusivity rule. `MaxToolIterationsExceeded` → 422, backend unreachable → 502 (plain detail, not Anthropic envelope — Responses uses standard FastAPI error shape).

## What this PR explicitly doesn't intercept

OpenAI Responses can run `web_search_call`, `code_interpreter_call`, `mcp_call` server-side (provider-managed). The loop deliberately does not intercept those output items — they belong to the provider's own dispatch path. Only items with `type == "function_call"` are considered for gateway-side execution.

## Test plan

- [x] `make lint` — clean.
- [x] `make typecheck` — clean (144 files).
- [x] `uv run pytest tests/unit` — 243 passed (+21 in `test_mcp_loop_responses.py`).
- [x] `uv run pytest tests/integration/test_responses_route_dispatch.py` — 16 passed.
- [x] `uv run pytest tests/integration/test_messages_route_dispatch.py tests/integration/test_platform_mode_chat.py tests/integration/test_platform_mode_surface.py` — 33 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)