### PR TITLE
Support gw_ API key prefix alongside gw-

### DIFF
--- a/src/gateway/auth/models.py
+++ b/src/gateway/auth/models.py
@@ -38,16 +38,16 @@ def validate_api_key_format(api_key: str) -> None:
         msg = f"API key must be a string, got {type(api_key).__name__}"
         raise ValueError(msg)
 
-    if not api_key.startswith("gw-"):
-        msg = "API key must start with 'gw-' prefix"
+    if not (api_key.startswith("gw-") or api_key.startswith("gw_")):
+        msg = "API key must start with 'gw-' or 'gw_' prefix"
         raise ValueError(msg)
 
     if len(api_key) < 50:
         msg = f"API key is too short. Expected at least 50 characters, got {len(api_key)}"
         raise ValueError(msg)
 
-    if not re.match(r"^gw-[A-Za-z0-9_-]+$", api_key):
-        msg = "API key contains invalid characters. Must match pattern: gw-[A-Za-z0-9_-]+"
+    if not re.match(r"^gw[-_][A-Za-z0-9_-]+$", api_key):
+        msg = "API key contains invalid characters. Must match pattern: gw[-_][A-Za-z0-9_-]+"
         raise ValueError(msg)
 
 

--- a/tests/unit/test_auth_models.py
+++ b/tests/unit/test_auth_models.py
@@ -1,0 +1,33 @@
+import pytest
+
+from gateway.auth.models import hash_key, validate_api_key_format
+
+
+@pytest.mark.parametrize(
+    "api_key",
+    [
+        "gw-" + "a" * 48,
+        "gw_" + "a" * 48,
+    ],
+)
+def test_validate_api_key_format_accepts_supported_prefixes(api_key: str) -> None:
+    validate_api_key_format(api_key)
+
+
+@pytest.mark.parametrize(
+    "api_key",
+    [
+        "gw" + "a" * 49,
+        "gx-" + "a" * 48,
+        "gw." + "a" * 48,
+    ],
+)
+def test_validate_api_key_format_rejects_invalid_prefixes(api_key: str) -> None:
+    with pytest.raises(ValueError, match="prefix"):
+        validate_api_key_format(api_key)
+
+
+def test_hash_key_accepts_gw_underscore_prefix() -> None:
+    digest = hash_key("gw_" + "a" * 48)
+
+    assert len(digest) == 64


### PR DESCRIPTION
## What
- accept both gw- and gw_ prefixes in API key format validation
- update invalid-prefix error message to mention both supported prefixes
- add unit tests covering accepted/rejected prefixes and hashing for gw_ keys

## Why
Some otari-issued keys use the gw_ prefix. Local gateway validation rejected these keys in standalone auth flows.

## Verification
- uv run pytest tests/unit/test_auth_models.py tests/unit/test_extract_bearer_token.py -v