### PR TITLE
fix(budget): close cross-user IDOR, overspend race, and unmetered-usage bypasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to this project are documented here. This project adheres to
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Security
+
+Fixes for four budget/billing vulnerabilities. **Standalone (self-hosted) mode
+only** — platform mode resolves budgets/pricing upstream and is unaffected.
+
+- **Cross-user budget charging / impersonation via the `user` field (IDOR).** A
+  non-master API key could set `"user"` to another user and charge spend to, and
+  exhaust the budget of, that user. Non-master keys are now bound to their own
+  user (see breaking change below).
+- **Budget overspend race (TOCTOU).** Concurrent requests could all pass the
+  budget check against stale spend and collectively exceed `max_budget`. Budgets
+  are now enforced with atomic pre-debit reservations.
+- **Unpriced models served free and unmetered.** A model with no pricing was
+  served and charged $0, bypassing the budget cap. Now rejected by default (see
+  breaking change below).
+- **Streaming responses without usage data were not billed.** Now metered per a
+  configurable policy.
+
+### Added
+
+- `users.reserved` column (migration `b2f4c6d8e0a1`) holding in-flight budget
+  reservations; spend reconciles to actual cost on completion.
+- Config `require_pricing` (default `true`), `stream_missing_usage_policy`
+  (`estimate` | `fail` | `allow_free`, default `estimate`),
+  `reject_user_mismatch` (default `true`), and
+  `budget_estimate_default_output_tokens`.
+- Startup warning when `require_pricing` is enabled but no pricing is configured.
+- `SECURITY.md`.
+
+### Changed (BREAKING — standalone mode)
+
+- **`require_pricing` defaults to `true`:** requests for models with no pricing
+  row are rejected with **HTTP 402**. Operators running genuinely free or
+  self-hosted models must add an explicit `$0` pricing entry, or set
+  `require_pricing=false`. Audio and moderation endpoints are exempt.
+- **The client `user` field is no longer trusted for non-master keys:** a
+  request naming a user other than the key's own is rejected with **HTTP 403**.
+  Set `reject_user_mismatch=false` to instead bind spend to the key's own user
+  while still forwarding `user` to the provider (OpenAI-style end-user tag) — use
+  this if clients send arbitrary `user` values for abuse tracking. The master key
+  may still bill an arbitrary user.
+- **`stream_missing_usage_policy` defaults to `estimate`:** a streamed response
+  that completes without provider usage data is billed an estimated cost rather
+  than served free. Set to `allow_free` for the previous behavior.
+- The usage-log writer no longer updates `users.spend`; reconciliation of the
+  budget reservation is now the sole authority for spend.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take the security of otari seriously. If you believe you have found a
+security vulnerability, please report it to us privately.
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, please use one of the following channels:
+
+- Open a private [GitHub Security Advisory](https://github.com/mozilla-ai/otari/security/advisories/new)
+  on this repository, or
+- Email **security@mozilla.ai** with the details.
+
+Please include as much of the following as you can:
+
+- The type of issue (e.g. budget bypass, authentication/authorization flaw,
+  injection, SSRF, etc.).
+- The affected component and version/commit.
+- Step-by-step instructions to reproduce, and a proof-of-concept if available.
+- The impact of the issue, including how an attacker might exploit it.
+
+Test only against your own self-hosted instance. Do not run scans or send
+exploit traffic against any mozilla.ai-operated infrastructure.
+
+## Disclosure Process
+
+- We will acknowledge receipt of your report within a few business days.
+- We will investigate and keep you informed of our progress.
+- Once a fix is available, we will coordinate a disclosure timeline with you and
+  credit you in the advisory (unless you prefer to remain anonymous).
+
+## Scope Notes for Operators
+
+otari is a self-hosted LLM gateway; several controls are configuration-dependent:
+
+- **Pricing is required by default.** `require_pricing` defaults to `true`:
+  requests for models with no configured pricing are rejected (HTTP 402) so an
+  unpriced model cannot be served free and unmetered. Operators running
+  genuinely free / self-hosted models must add an explicit `$0` pricing entry,
+  or set `require_pricing=false` to opt out.
+- **Budgets are enforced via atomic pre-debit reservations.** Concurrent
+  requests cannot collectively exceed `max_budget`.
+- **The client `user` field is not trusted for non-master keys.** Spend is bound
+  to the API key's own user; only the master key may bill on behalf of an
+  arbitrary user. By default a non-master key naming a different user is rejected
+  (403); set `reject_user_mismatch=false` to instead bind to the key's own user
+  while still forwarding `user` to the provider as an end-user tag.
+- **Audio and moderation endpoints** have no token-based pricing model and are
+  exempt from `require_pricing` (treated as $0 when unpriced).

--- a/alembic/versions/b2f4c6d8e0a1_add_user_reserved_budget.py
+++ b/alembic/versions/b2f4c6d8e0a1_add_user_reserved_budget.py
@@ -1,0 +1,31 @@
+"""Add users.reserved column for in-flight budget reservations.
+
+Revision ID: b2f4c6d8e0a1
+Revises: a1b2c3d4e5f6
+Create Date: 2026-06-01 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b2f4c6d8e0a1"
+down_revision: str | Sequence[str] | None = "a1b2c3d4e5f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "users",
+        sa.Column("reserved", sa.Float(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("users", "reserved")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,10 @@ pricing:
 | `bootstrap_api_key` | bool | `true` | Create a first-use API key on startup when none exist |
 | `log_writer_strategy` | string | `"single"` | Usage log writing: `"single"` (inline) or `"batch"` (background) |
 | `budget_strategy` | string | `"for_update"` | Budget validation: `"for_update"`, `"cas"`, or `"disabled"` |
+| `require_pricing` | bool | `true` | Reject requests for models with no configured pricing (HTTP 402, fail-closed). When `false`, unpriced models are served and logged without cost. Audio and moderation endpoints are always exempt. |
+| `reject_user_mismatch` | bool | `true` | When `true`, a non-master key whose request names a `user` other than its own is rejected (HTTP 403). When `false`, the client `user` is still forwarded to the provider but spend is always bound to the key's own user. The master key may always bill an arbitrary user. |
+| `stream_missing_usage_policy` | string | `"estimate"` | How to bill a streamed response that completes with no provider usage data: `"estimate"` (charge the up-front estimate), `"fail"` (charge estimate and mark errored), or `"allow_free"` (don't bill). |
+| `budget_estimate_default_output_tokens` | int | `1024` | Output-token count assumed when reserving budget for a request with no declared max output; reconciled to actual usage on completion. |
 | `mode` | string | `"standalone"` | Configured mode (`"standalone"` or `"platform"`). Effective behavior is driven by presence of `OTARI_AI_TOKEN`. |
 | `platform` | dict | `{}` | otari.ai integration settings (`base_url`, timeouts, retries) |
 
@@ -159,3 +163,9 @@ pricing:
 ```
 
 Config pricing sets initial values. Pricing set via the `/v1/pricing` API takes precedence.
+
+> **Fail-closed by default.** With `require_pricing: true` (the default), a request for a model
+> that has no pricing entry is rejected with HTTP 402 rather than served free and unmetered — an
+> unpriced model would otherwise bypass the budget cap. To run genuinely free or self-hosted
+> models, add an explicit `$0` pricing entry, or set `require_pricing: false`. Audio and moderation
+> endpoints are exempt. A startup warning is logged if `require_pricing` is on with no pricing configured.

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -2084,6 +2084,10 @@
             ],
             "title": "Next Budget Reset At"
           },
+          "reserved": {
+            "title": "Reserved",
+            "type": "number"
+          },
           "spend": {
             "title": "Spend",
             "type": "number"
@@ -2101,6 +2105,7 @@
           "user_id",
           "alias",
           "spend",
+          "reserved",
           "budget_id",
           "budget_started_at",
           "next_budget_reset_at",

--- a/src/gateway/api/routes/_helpers.py
+++ b/src/gateway/api/routes/_helpers.py
@@ -16,13 +16,18 @@ def resolve_user_id(
     master_key_error: HTTPException,
     no_api_key_error: HTTPException,
     no_user_error: HTTPException,
+    forbidden_user_error: HTTPException,
+    reject_mismatch: bool = True,
 ) -> str:
     """Resolve the effective user_id from request context.
 
     The resolution order is:
-    1. If master key is used, the request *must* supply a user_id.
-    2. If the request supplies a user_id, use it.
-    3. Fall back to the user_id associated with the API key.
+    1. If master key is used, the request *must* supply a user_id, and may
+       name any user (the master key is trusted to act on behalf of others).
+    2. For a non-master key, spend is *always* bound to the key's own user.
+       The request may echo the same user_id (e.g. OpenAI's ``user`` field for
+       tracking), but naming a *different* user is rejected — otherwise any key
+       could charge spend to, and exhaust the budget of, another user.
 
     Args:
         user_id_from_request: User identifier extracted from the request body
@@ -31,6 +36,13 @@ def resolve_user_id(
         master_key_error: Raised when master key is used but no user_id is provided
         no_api_key_error: Raised when no API key is available
         no_user_error: Raised when the API key has no associated user
+        forbidden_user_error: Raised when a non-master key names a user other
+            than its own (only when ``reject_mismatch`` is True)
+        reject_mismatch: When True (default), a non-master key naming a different
+            user is rejected. When False, the mismatch is ignored and spend is
+            still bound to the key's own user (the client ``user`` is treated as
+            a provider-side tag only). Spend is bound to the key's user either
+            way — leniency never lets a key charge another user.
 
     Returns:
         Resolved user_id string
@@ -41,11 +53,16 @@ def resolve_user_id(
             raise master_key_error
         return user_id_from_request
 
-    if user_id_from_request:
-        return user_id_from_request
-
     if api_key is None:
         raise no_api_key_error
     if not api_key.user_id:
         raise no_user_error
-    return str(api_key.user_id)
+    key_user_id = str(api_key.user_id)
+
+    # A non-master key is bound to its own user. Allow the request to echo that
+    # same id; a different id is rejected (strict) or ignored (lenient) — either
+    # way spend binds to key_user_id, so a key can never charge another user.
+    if reject_mismatch and user_id_from_request and user_id_from_request != key_user_id:
+        raise forbidden_user_error
+
+    return key_user_id

--- a/src/gateway/api/routes/audio.py
+++ b/src/gateway/api/routes/audio.py
@@ -18,7 +18,11 @@ from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import APIKey, UsageLog
 from gateway.rate_limit import check_rate_limit
-from gateway.services.budget_service import validate_user_budget
+from gateway.services.budget_service import (
+    reconcile_reservation,
+    refund_reservation,
+    reserve_budget,
+)
 from gateway.services.log_writer import LogWriter
 
 router = APIRouter(prefix="/v1", tags=["audio"])
@@ -80,13 +84,19 @@ async def create_transcription(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="API key has no associated user",
         ),
+        forbidden_user_error=HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="'user' field does not match the authenticated API key's user",
+        ),
+        reject_mismatch=config.reject_user_mismatch,
     )
 
     rate_limit_info = check_rate_limit(raw_request, user_id)
 
-    _ = await validate_user_budget(db, user_id, model, strategy=config.budget_strategy)
-    if config.budget_strategy == "for_update":
-        await db.rollback()
+    # Audio is exempt from require_pricing and has no measurable cost unit yet,
+    # so the reservation estimate is 0 — it still enforces existing per-user
+    # state (user exists, not blocked, not already over budget).
+    reservation = await reserve_budget(db, user_id, 0.0, model=model, strategy=config.budget_strategy)
 
     provider, model_name = AnyLLM.split_model_provider(model)
 
@@ -135,8 +145,10 @@ async def create_transcription(
         # so cost is left unset until a dedicated pricing metric is available.
 
         await log_writer.put(usage_log)
+        await reconcile_reservation(db, reservation, 0.0)
 
     except HTTPException:
+        await refund_reservation(db, reservation)
         raise
     except Exception as e:
         error_log = UsageLog(
@@ -151,6 +163,7 @@ async def create_transcription(
             error_message=str(e),
         )
         await log_writer.put(error_log)
+        await refund_reservation(db, reservation)
 
         logger.error("Provider call failed for %s:%s: %s", provider, model_name, e)
         raise HTTPException(
@@ -229,13 +242,19 @@ async def create_speech(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="API key has no associated user",
         ),
+        forbidden_user_error=HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="'user' field does not match the authenticated API key's user",
+        ),
+        reject_mismatch=config.reject_user_mismatch,
     )
 
     rate_limit_info = check_rate_limit(raw_request, user_id)
 
-    _ = await validate_user_budget(db, user_id, request.model, strategy=config.budget_strategy)
-    if config.budget_strategy == "for_update":
-        await db.rollback()
+    # Audio is exempt from require_pricing and has no measurable cost unit yet,
+    # so the reservation estimate is 0 — it still enforces existing per-user
+    # state (user exists, not blocked, not already over budget).
+    reservation = await reserve_budget(db, user_id, 0.0, model=request.model, strategy=config.budget_strategy)
 
     provider, model_name = AnyLLM.split_model_provider(request.model)
 
@@ -276,8 +295,10 @@ async def create_speech(
         # so cost is left unset until a dedicated pricing metric is available.
 
         await log_writer.put(usage_log)
+        await reconcile_reservation(db, reservation, 0.0)
 
     except HTTPException:
+        await refund_reservation(db, reservation)
         raise
     except Exception as e:
         error_log = UsageLog(
@@ -292,6 +313,7 @@ async def create_speech(
             error_message=str(e),
         )
         await log_writer.put(error_log)
+        await refund_reservation(db, reservation)
 
         logger.error("Provider call failed for %s:%s: %s", provider, model_name, e)
         raise HTTPException(

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -9,6 +9,7 @@ from typing import Annotated, Any
 
 import httpx
 from any_llm import AnyLLM, LLMProvider, acompletion
+from any_llm.exceptions import AnyLLMError
 from any_llm.types.completion import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -48,7 +49,13 @@ from gateway.metrics import record_cost, record_tokens
 from gateway.models.entities import APIKey, UsageLog
 from gateway.models.mcp import McpServerConfig
 from gateway.rate_limit import RateLimitInfo, check_rate_limit
-from gateway.services.budget_service import validate_user_budget
+from gateway.services.budget_service import (
+    ReservationHandle,
+    estimate_cost,
+    reconcile_reservation,
+    refund_reservation,
+    reserve_budget,
+)
 from gateway.services.log_writer import LogWriter
 from gateway.services.mcp_client import MCPClientPool
 from gateway.services.mcp_loop import (
@@ -59,7 +66,7 @@ from gateway.services.mcp_loop import (
     mcp_tool_loop,
     mcp_tool_loop_stream,
 )
-from gateway.services.pricing_service import find_model_pricing
+from gateway.services.pricing_service import find_model_pricing, pricing_required_but_missing
 from gateway.services.provider_kwargs import get_provider_kwargs as get_provider_kwargs  # noqa: F401
 from gateway.services.sandbox_backend import SandboxBackend, SandboxNotReachableError
 from gateway.services.web_search_backend import WebSearchNotReachableError
@@ -130,8 +137,12 @@ async def log_usage(
     response: ChatCompletion | AsyncIterator[ChatCompletionChunk] | None = None,
     usage_override: CompletionUsage | None = None,
     error: str | None = None,
-) -> None:
-    """Log API usage to database and update user spend.
+) -> float | None:
+    """Log API usage to the database and return the computed cost.
+
+    Spend is no longer written here — the budget reservation reconcile path owns
+    ``users.spend``. This returns the cost it computed so the caller can reconcile
+    the reservation with the actual amount.
 
     Args:
         db: Database session
@@ -143,6 +154,9 @@ async def log_usage(
         response: Response object (if successful)
         usage_override: Usage data for streaming requests
         error: Error message (if failed)
+
+    Returns:
+        The computed cost for this request, or None when usage/pricing is absent.
 
     """
     usage_log = UsageLog(
@@ -185,6 +199,7 @@ async def log_usage(
             logger.warning(f"No pricing configured for '{model_ref}'. Usage will be tracked without cost.")
 
     await log_writer.put(usage_log)
+    return usage_log.cost
 
 
 
@@ -222,6 +237,10 @@ async def chat_completions(
     platform_mode = config.is_platform_mode
     route: ResolvedRoute | None = None
     user_token: str | None = None  # set inside the platform_mode branch; referenced again later
+    # Budget pre-debit for the standalone (local-DB) path only; platform mode
+    # reports usage upstream instead. Settled (reconciled/refunded) at every
+    # completion and error hook below.
+    reservation: ReservationHandle | None = None
 
     if platform_mode:
         user_token = _extract_platform_user_token(raw_request)
@@ -265,12 +284,41 @@ async def chat_completions(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="API key has no associated user",
             ),
+            forbidden_user_error=HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="'user' field does not match the authenticated API key's user",
+            ),
+            reject_mismatch=config.reject_user_mismatch,
         )
 
         rate_limit_info = check_rate_limit(raw_request, user_id)
-        _ = await validate_user_budget(db, user_id, request.model, strategy=config.budget_strategy)
-        if config.budget_strategy == "for_update":
-            await db.rollback()
+
+        # Tolerate an unparseable / unknown-provider selector here — the budget
+        # check below and the downstream provider call surface those with their
+        # own status codes. A model we can't parse simply has no pricing.
+        try:
+            gate_provider, gate_model = AnyLLM.split_model_provider(request.model)
+        except (ValueError, AnyLLMError):
+            gate_provider, gate_model = None, request.model
+        gate_pricing = await find_model_pricing(db, gate_provider, gate_model)
+        estimate = estimate_cost(
+            gate_pricing,
+            prompt_chars=len(str(request.messages)),
+            max_output_tokens=request.max_tokens or request.max_completion_tokens,
+            default_output_tokens=config.budget_estimate_default_output_tokens,
+        )
+        # Reserve first so user/blocked/budget rejections (404/403) take
+        # precedence over the missing-pricing rejection (402); refund if we then
+        # reject for missing pricing.
+        reservation = await reserve_budget(
+            db, user_id, estimate, model=request.model, strategy=config.budget_strategy
+        )
+        if pricing_required_but_missing(gate_pricing, require_pricing=config.require_pricing):
+            await refund_reservation(db, reservation)
+            raise HTTPException(
+                status_code=status.HTTP_402_PAYMENT_REQUIRED,
+                detail=f"No pricing configured for model '{request.model}'",
+            )
 
     # Workspace-scoped MCP server references (platform mode only). Callers
     # pass `mcp_server_ids: [uuid, ...]` instead of inlining each config; we
@@ -554,12 +602,16 @@ async def chat_completions(
             # a "provider outage" that's actually the sandbox container
             # being down. 502 keeps "upstream dependency failed" semantics.
             logger.error("Sandbox unreachable for %s:%s: %s", provider, model, exc)
+            if db is not None and reservation is not None:
+                await refund_reservation(db, reservation)
             raise HTTPException(
                 status_code=status.HTTP_502_BAD_GATEWAY,
                 detail="code_execution sandbox unreachable — check GATEWAY_SANDBOX_URL",
             ) from exc
         except WebSearchNotReachableError as exc:
             logger.error("Web search backend unreachable for %s:%s: %s", provider, model, exc)
+            if db is not None and reservation is not None:
+                await refund_reservation(db, reservation)
             raise HTTPException(
                 status_code=status.HTTP_502_BAD_GATEWAY,
                 detail="web_search backend unreachable — check GATEWAY_WEB_SEARCH_URL",
@@ -576,6 +628,8 @@ async def chat_completions(
                     user_id=user_id,
                     error=str(exc),
                 )
+                if reservation is not None:
+                    await refund_reservation(db, reservation)
             logger.error("Stream creation failed for %s:%s: %s", provider, model, exc)
             if isinstance(exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
                 raise HTTPException(
@@ -600,6 +654,7 @@ async def chat_completions(
             api_key_id=api_key_id,
             user_id=user_id,
             rate_limit_info=rate_limit_info,
+            reservation=reservation,
         )
 
     # ------------------------------------------------------------------
@@ -807,7 +862,7 @@ async def chat_completions(
         else:
             completion = await acompletion(**completion_kwargs)  # type: ignore[assignment]
         if db is not None:
-            await log_usage(
+            actual_cost = await log_usage(
                 db=db,
                 log_writer=log_writer,
                 api_key_id=api_key_id,
@@ -817,19 +872,27 @@ async def chat_completions(
                 user_id=user_id,
                 response=completion,
             )
+            if reservation is not None:
+                await reconcile_reservation(db, reservation, actual_cost or 0.0)
     except HTTPException:
+        if db is not None and reservation is not None:
+            await refund_reservation(db, reservation)
         raise
     except SandboxNotReachableError as exc:
         # Sandbox is gateway-side infra, not an LLM provider. Clearer detail
         # so operators don't chase a provider outage that's really the
         # sandbox container being down.
         logger.error("Sandbox unreachable for %s:%s: %s", provider, model, exc)
+        if db is not None and reservation is not None:
+            await refund_reservation(db, reservation)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="code_execution sandbox unreachable — check GATEWAY_SANDBOX_URL",
         ) from exc
     except WebSearchNotReachableError as exc:
         logger.error("Web search backend unreachable for %s:%s: %s", provider, model, exc)
+        if db is not None and reservation is not None:
+            await refund_reservation(db, reservation)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="web_search backend unreachable — check GATEWAY_WEB_SEARCH_URL",
@@ -849,6 +912,8 @@ async def chat_completions(
                 user_id=user_id,
                 error=str(e),
             )
+            if reservation is not None:
+                await refund_reservation(db, reservation)
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=str(e),
@@ -865,6 +930,8 @@ async def chat_completions(
                 user_id=user_id,
                 error=str(e),
             )
+            if reservation is not None:
+                await refund_reservation(db, reservation)
 
         logger.error("Provider call failed for %s:%s: %s", provider, model, e)
         if isinstance(e, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
@@ -898,6 +965,7 @@ def _build_streaming_response(
     api_key_id: str | None,
     user_id: str | None,
     rate_limit_info: RateLimitInfo | None,
+    reservation: ReservationHandle | None = None,
 ) -> StreamingResponse:
     """Wrap an already-opened upstream stream in an SSE response."""
 
@@ -926,7 +994,7 @@ def _build_streaming_response(
             return
         if db is None or log_writer is None:
             return
-        await log_usage(
+        actual_cost = await log_usage(
             db=db,
             log_writer=log_writer,
             api_key_id=api_key_id,
@@ -936,6 +1004,40 @@ def _build_streaming_response(
             user_id=user_id,
             usage_override=usage_data,
         )
+        if reservation is not None:
+            await reconcile_reservation(db, reservation, actual_cost or 0.0)
+
+    async def _on_no_usage() -> None:
+        # Stream completed but the provider sent no usage data. Settle the
+        # reservation per stream_missing_usage_policy instead of billing $0.
+        if db is None or log_writer is None or reservation is None:
+            return
+        policy = config.stream_missing_usage_policy
+        if policy == "allow_free":
+            await log_usage(
+                db=db,
+                log_writer=log_writer,
+                api_key_id=api_key_id,
+                model=model,
+                provider=provider,
+                endpoint="/v1/chat/completions",
+                user_id=user_id,
+            )
+            await refund_reservation(db, reservation)
+            return
+        # 'estimate' and 'fail' both charge the up-front estimate; 'fail' also
+        # records the request as errored.
+        await log_usage(
+            db=db,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            model=model,
+            provider=provider,
+            endpoint="/v1/chat/completions",
+            user_id=user_id,
+            error="stream completed without usage data" if policy == "fail" else None,
+        )
+        await reconcile_reservation(db, reservation, reservation.estimate)
 
     async def _on_error(error: str) -> None:
         if platform_mode and correlation_id:
@@ -960,6 +1062,14 @@ def _build_streaming_response(
             user_id=user_id,
             error=error,
         )
+        if reservation is not None:
+            await refund_reservation(db, reservation)
+
+    async def _on_incomplete() -> None:
+        # Client disconnected mid-stream — release the reservation.
+        if db is None or reservation is None:
+            return
+        await refund_reservation(db, reservation)
 
     rl_headers = rate_limit_headers(rate_limit_info) if rate_limit_info else {}
     # StreamingResponse builds its own response object, so headers we want on
@@ -979,6 +1089,8 @@ def _build_streaming_response(
             on_complete=_on_complete,
             on_error=_on_error,
             label=f"{provider}:{model}",
+            on_no_usage=_on_no_usage,
+            on_incomplete=_on_incomplete,
         ),
         media_type="text/event-stream",
         headers=headers,

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -137,6 +137,7 @@ async def log_usage(
     response: ChatCompletion | AsyncIterator[ChatCompletionChunk] | None = None,
     usage_override: CompletionUsage | None = None,
     error: str | None = None,
+    cost_override: float | None = None,
 ) -> float | None:
     """Log API usage to the database and return the computed cost.
 
@@ -197,6 +198,12 @@ async def log_usage(
         else:
             model_ref = f"{provider}:{model}" if provider else model
             logger.warning(f"No pricing configured for '{model_ref}'. Usage will be tracked without cost.")
+
+    # When the caller bills a fixed amount without provider usage (e.g. the
+    # stream-missing-usage estimate policy), record that amount on the log row so
+    # usage_logs.cost stays consistent with the spend that was reconciled.
+    if cost_override is not None:
+        usage_log.cost = cost_override
 
     await log_writer.put(usage_log)
     return usage_log.cost
@@ -304,7 +311,7 @@ async def chat_completions(
         estimate = estimate_cost(
             gate_pricing,
             prompt_chars=len(str(request.messages)),
-            max_output_tokens=request.max_tokens or request.max_completion_tokens,
+            max_output_tokens=request.max_tokens if request.max_tokens is not None else request.max_completion_tokens,
             default_output_tokens=config.budget_estimate_default_output_tokens,
         )
         # Reserve first so user/blocked/budget rejections (404/403) take
@@ -1036,6 +1043,7 @@ def _build_streaming_response(
             endpoint="/v1/chat/completions",
             user_id=user_id,
             error="stream completed without usage data" if policy == "fail" else None,
+            cost_override=reservation.estimate,
         )
         await reconcile_reservation(db, reservation, reservation.estimate)
 

--- a/src/gateway/api/routes/embeddings.py
+++ b/src/gateway/api/routes/embeddings.py
@@ -17,9 +17,14 @@ from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import APIKey, UsageLog
 from gateway.rate_limit import check_rate_limit
-from gateway.services.budget_service import validate_user_budget
+from gateway.services.budget_service import (
+    estimate_cost,
+    reconcile_reservation,
+    refund_reservation,
+    reserve_budget,
+)
 from gateway.services.log_writer import LogWriter
-from gateway.services.pricing_service import find_model_pricing
+from gateway.services.pricing_service import find_model_pricing, pricing_required_but_missing
 
 router = APIRouter(prefix="/v1", tags=["embeddings"])
 
@@ -70,15 +75,34 @@ async def create_embedding(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="API key has no associated user",
         ),
+        forbidden_user_error=HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="'user' field does not match the authenticated API key's user",
+        ),
+        reject_mismatch=config.reject_user_mismatch,
     )
 
     rate_limit_info = check_rate_limit(raw_request, user_id)
 
-    _ = await validate_user_budget(db, user_id, request.model, strategy=config.budget_strategy)
-    if config.budget_strategy == "for_update":
-        await db.rollback()
-
     provider, model = AnyLLM.split_model_provider(request.model)
+
+    # Resolve pricing for the reservation estimate and the final cost.
+    pricing = await find_model_pricing(db, provider, model)
+
+    # Embeddings have no generated output, so only the prompt contributes cost.
+    prompt_chars = sum(len(s) for s in request.input) if isinstance(request.input, list) else len(request.input)
+    estimate = estimate_cost(pricing, prompt_chars=prompt_chars, max_output_tokens=None, default_output_tokens=0)
+    # Reserve first so user/blocked/budget rejections (404/403) precede the
+    # missing-pricing rejection (402); refund if we then reject for no pricing.
+    reservation = await reserve_budget(
+        db, user_id, estimate, model=request.model, strategy=config.budget_strategy
+    )
+    if pricing_required_but_missing(pricing, require_pricing=config.require_pricing):
+        await refund_reservation(db, reservation)
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail=f"No pricing configured for model '{provider}:{model}'",
+        )
 
     provider_kwargs = get_provider_kwargs(config, provider)
 
@@ -110,18 +134,16 @@ async def create_embedding(
             total_tokens=result.usage.total_tokens if result.usage else None,
         )
 
-        if result.usage:
-            pricing = await find_model_pricing(db, provider, model, as_of=usage_log.timestamp)
-            if pricing:
-                cost = (result.usage.prompt_tokens / 1_000_000) * pricing.input_price_per_million
-                usage_log.cost = cost
-            else:
-                model_ref = f"{provider}:{model}" if provider else model
-                logger.warning(f"No pricing configured for '{model_ref}'. Usage will be tracked without cost.")
+        cost = 0.0
+        if result.usage and pricing:
+            cost = (result.usage.prompt_tokens / 1_000_000) * pricing.input_price_per_million
+            usage_log.cost = cost
 
         await log_writer.put(usage_log)
+        await reconcile_reservation(db, reservation, cost)
 
     except HTTPException:
+        await refund_reservation(db, reservation)
         raise
     except Exception as e:
         error_log = UsageLog(
@@ -136,6 +158,7 @@ async def create_embedding(
             error_message=str(e),
         )
         await log_writer.put(error_log)
+        await refund_reservation(db, reservation)
 
         logger.error("Provider call failed for %s:%s: %s", provider, model, e)
         raise HTTPException(

--- a/src/gateway/api/routes/images.py
+++ b/src/gateway/api/routes/images.py
@@ -92,7 +92,8 @@ async def create_image(
     pricing = await find_model_pricing(db, provider, model)
 
     # Reserve for the requested image count; reconciled to the actual count below.
-    requested_images = request.n or 1
+    # `is None` (not `or`) so an explicit n=0 isn't silently treated as 1.
+    requested_images = request.n if request.n is not None else 1
     estimate = requested_images * pricing.input_price_per_million if pricing else 0.0
     # Reserve first so 404/403 precede the missing-pricing 402; refund on reject.
     reservation = await reserve_budget(
@@ -127,7 +128,7 @@ async def create_image(
     try:
         result: ImagesResponse = await aimage_generation(**image_kwargs)
 
-        n_images = len(result.data) if result.data else (request.n or 1)
+        n_images = len(result.data) if result.data else requested_images
 
         usage_log = UsageLog(
             id=str(uuid.uuid4()),

--- a/src/gateway/api/routes/images.py
+++ b/src/gateway/api/routes/images.py
@@ -17,9 +17,13 @@ from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import APIKey, UsageLog
 from gateway.rate_limit import check_rate_limit
-from gateway.services.budget_service import validate_user_budget
+from gateway.services.budget_service import (
+    reconcile_reservation,
+    refund_reservation,
+    reserve_budget,
+)
 from gateway.services.log_writer import LogWriter
-from gateway.services.pricing_service import find_model_pricing
+from gateway.services.pricing_service import find_model_pricing, pricing_required_but_missing
 
 router = APIRouter(prefix="/v1", tags=["images"])
 
@@ -73,15 +77,33 @@ async def create_image(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="API key has no associated user",
         ),
+        forbidden_user_error=HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="'user' field does not match the authenticated API key's user",
+        ),
+        reject_mismatch=config.reject_user_mismatch,
     )
 
     rate_limit_info = check_rate_limit(raw_request, user_id)
 
-    _ = await validate_user_budget(db, user_id, request.model, strategy=config.budget_strategy)
-    if config.budget_strategy == "for_update":
-        await db.rollback()
-
     provider, model = AnyLLM.split_model_provider(request.model)
+
+    # Image pricing repurposes input_price_per_million as price-per-image.
+    pricing = await find_model_pricing(db, provider, model)
+
+    # Reserve for the requested image count; reconciled to the actual count below.
+    requested_images = request.n or 1
+    estimate = requested_images * pricing.input_price_per_million if pricing else 0.0
+    # Reserve first so 404/403 precede the missing-pricing 402; refund on reject.
+    reservation = await reserve_budget(
+        db, user_id, estimate, model=request.model, strategy=config.budget_strategy
+    )
+    if pricing_required_but_missing(pricing, require_pricing=config.require_pricing):
+        await refund_reservation(db, reservation)
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail=f"No pricing configured for model '{provider}:{model}'",
+        )
 
     provider_kwargs = get_provider_kwargs(config, provider)
 
@@ -122,17 +144,16 @@ async def create_image(
         )
 
         # Image pricing: repurpose input_price_per_million as price-per-image
-        pricing = await find_model_pricing(db, provider, model, as_of=usage_log.timestamp)
+        cost = 0.0
         if pricing:
             cost = n_images * pricing.input_price_per_million
             usage_log.cost = cost
-        else:
-            model_ref = f"{provider}:{model}" if provider else model
-            logger.warning("No pricing configured for '%s'. Usage will be tracked without cost.", model_ref)
 
         await log_writer.put(usage_log)
+        await reconcile_reservation(db, reservation, cost)
 
     except HTTPException:
+        await refund_reservation(db, reservation)
         raise
     except Exception as e:
         error_log = UsageLog(
@@ -147,6 +168,7 @@ async def create_image(
             error_message=str(e),
         )
         await log_writer.put(error_log)
+        await refund_reservation(db, reservation)
 
         logger.error("Provider call failed for %s:%s: %s", provider, model, e)
         raise HTTPException(

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any
 
 import httpx
 from any_llm import AnyLLM, LLMProvider, amessages
+from any_llm.exceptions import AnyLLMError
 from any_llm.types.completion import CompletionUsage
 from any_llm.types.messages import (
     MessageDeltaEvent,
@@ -44,7 +45,13 @@ from gateway.log_config import logger
 from gateway.models.entities import APIKey
 from gateway.models.mcp import McpServerConfig
 from gateway.rate_limit import RateLimitInfo, check_rate_limit
-from gateway.services.budget_service import validate_user_budget
+from gateway.services.budget_service import (
+    ReservationHandle,
+    estimate_cost,
+    reconcile_reservation,
+    refund_reservation,
+    reserve_budget,
+)
 from gateway.services.log_writer import LogWriter
 from gateway.services.mcp_client import MCPClientPool
 from gateway.services.mcp_loop_messages import (
@@ -54,6 +61,7 @@ from gateway.services.mcp_loop_messages import (
     anthropic_tool_loop,
     anthropic_tool_loop_stream,
 )
+from gateway.services.pricing_service import find_model_pricing, pricing_required_but_missing
 from gateway.services.sandbox_backend import SandboxBackend, SandboxNotReachableError
 from gateway.services.tool_format import inject_purpose_hints_anthropic, openai_to_anthropic_tools
 from gateway.services.web_search_backend import WebSearchNotReachableError
@@ -108,9 +116,11 @@ def _anthropic_error(error_type: str, message: str, status_code: int) -> HTTPExc
 
 _ERR_INVALID_REQUEST = "invalid_request_error"
 _ERR_API = "api_error"
+_ERR_PERMISSION = "permission_error"
 _MASTER_KEY_USER_REQUIRED = "When using master key, 'metadata.user_id' is required in request body"
 _API_KEY_VALIDATION_FAILED = "API key validation failed"
 _API_KEY_NO_USER = "API key has no associated user"
+_USER_FORBIDDEN = "'metadata.user_id' does not match the authenticated API key's user"
 _PROVIDER_ERROR = "The request could not be completed by the provider"
 
 
@@ -141,6 +151,10 @@ async def create_message(
     platform_mode = config.is_platform_mode
     route: ResolvedRoute | None = None
     user_token: str | None = None
+    # Budget pre-debit for the standalone (local-DB) path only; platform mode
+    # reports usage upstream instead. Settled (reconciled/refunded) at every
+    # completion and error hook below.
+    reservation: ReservationHandle | None = None
 
     if platform_mode:
         user_token = _extract_platform_user_token(raw_request)
@@ -184,11 +198,39 @@ async def create_message(
                 _API_KEY_NO_USER,
                 status.HTTP_500_INTERNAL_SERVER_ERROR,
             ),
+            forbidden_user_error=_anthropic_error(
+                _ERR_PERMISSION,
+                _USER_FORBIDDEN,
+                status.HTTP_403_FORBIDDEN,
+            ),
+            reject_mismatch=config.reject_user_mismatch,
         )
         rate_limit_info = check_rate_limit(raw_request, user_id)
-        _ = await validate_user_budget(db, user_id, request.model, strategy=config.budget_strategy)
-        if config.budget_strategy == "for_update":
-            await db.rollback()
+        # Tolerate an unparseable selector: the budget gate (404/403) and the
+        # downstream call surface those; an unparseable model simply has no pricing.
+        try:
+            gate_provider, gate_model = AnyLLM.split_model_provider(request.model)
+        except (ValueError, AnyLLMError):
+            gate_provider, gate_model = None, request.model
+        pricing = await find_model_pricing(db, gate_provider, gate_model)
+        estimate = estimate_cost(
+            pricing,
+            prompt_chars=len(str(request.messages)) + len(str(request.system or "")),
+            max_output_tokens=request.max_tokens,
+            default_output_tokens=config.budget_estimate_default_output_tokens,
+        )
+        # Reserve first so user/blocked/budget rejections (404/403) precede the
+        # missing-pricing rejection (402); refund if we then reject for no pricing.
+        reservation = await reserve_budget(
+            db, user_id, estimate, model=request.model, strategy=config.budget_strategy
+        )
+        if pricing_required_but_missing(pricing, require_pricing=config.require_pricing):
+            await refund_reservation(db, reservation)
+            raise _anthropic_error(
+                _ERR_INVALID_REQUEST,
+                f"No pricing configured for model '{gate_provider}:{gate_model}'",
+                status.HTTP_402_PAYMENT_REQUIRED,
+            )
 
     # mcp_server_ids is platform-only — standalone has no platform to
     # resolve them against, so we reject with a 400 rather than silently
@@ -372,9 +414,11 @@ async def create_message(
             web_search_tool_entry=web_search_tool_entry,
             web_search_url=web_search_url,
             max_tool_iterations=max_tool_iterations,
+            config=config,
             platform_correlation_id=platform_correlation_id,
             platform_request_id=platform_request_id,
             platform_config=platform_config,
+            reservation=reservation,
         )
 
     # ------------------------------------------------------------------
@@ -448,24 +492,30 @@ async def create_message(
             max_tool_iterations=max_tool_iterations,
         )
 
-        if db is not None and result.usage:
-            usage_data = CompletionUsage(
-                prompt_tokens=result.usage.input_tokens,
-                completion_tokens=result.usage.output_tokens,
-                total_tokens=result.usage.input_tokens + result.usage.output_tokens,
-            )
-            await log_usage(
-                db=db,
-                log_writer=log_writer,
-                api_key_id=api_key_id,
-                model=model,
-                provider=provider,
-                endpoint="/v1/messages",
-                user_id=user_id,
-                usage_override=usage_data,
-            )
+        if db is not None:
+            actual_cost: float | None = None
+            if result.usage:
+                usage_data = CompletionUsage(
+                    prompt_tokens=result.usage.input_tokens,
+                    completion_tokens=result.usage.output_tokens,
+                    total_tokens=result.usage.input_tokens + result.usage.output_tokens,
+                )
+                actual_cost = await log_usage(
+                    db=db,
+                    log_writer=log_writer,
+                    api_key_id=api_key_id,
+                    model=model,
+                    provider=provider,
+                    endpoint="/v1/messages",
+                    user_id=user_id,
+                    usage_override=usage_data,
+                )
+            if reservation is not None:
+                await reconcile_reservation(db, reservation, actual_cost or 0.0)
 
     except HTTPException:
+        if db is not None and reservation is not None:
+            await refund_reservation(db, reservation)
         raise
     except MaxToolIterationsExceeded as e:
         if db is not None:
@@ -479,9 +529,13 @@ async def create_message(
                 user_id=user_id,
                 error=str(e),
             )
+            if reservation is not None:
+                await refund_reservation(db, reservation)
         raise _anthropic_error(_ERR_INVALID_REQUEST, str(e), status.HTTP_422_UNPROCESSABLE_ENTITY) from e
     except SandboxNotReachableError as e:
         logger.error("Sandbox unreachable for %s:%s: %s", provider, model, e)
+        if db is not None and reservation is not None:
+            await refund_reservation(db, reservation)
         raise _anthropic_error(
             _ERR_API,
             "code_execution sandbox unreachable — check GATEWAY_SANDBOX_URL",
@@ -489,6 +543,8 @@ async def create_message(
         ) from e
     except WebSearchNotReachableError as e:
         logger.error("Web search backend unreachable for %s:%s: %s", provider, model, e)
+        if db is not None and reservation is not None:
+            await refund_reservation(db, reservation)
         raise _anthropic_error(
             _ERR_API,
             "web_search backend unreachable — check GATEWAY_WEB_SEARCH_URL",
@@ -506,6 +562,8 @@ async def create_message(
                 user_id=user_id,
                 error=str(e),
             )
+            if reservation is not None:
+                await refund_reservation(db, reservation)
         logger.error("Provider call failed for %s:%s: %s", provider, model, e)
         raise _anthropic_error(
             _ERR_API,
@@ -731,9 +789,11 @@ async def _stream_messages(
     web_search_tool_entry: dict[str, Any] | None,
     web_search_url: str | None,
     max_tool_iterations: int,
+    config: GatewayConfig,
     platform_correlation_id: str | None = None,
     platform_request_id: str | None = None,
     platform_config: GatewayConfig | None = None,
+    reservation: ReservationHandle | None = None,
 ) -> StreamingResponse:
     """Streaming dispatch for single-attempt requests.
 
@@ -787,7 +847,7 @@ async def _stream_messages(
             return
         if db is None:
             return
-        await log_usage(
+        actual_cost = await log_usage(
             db=db,
             log_writer=log_writer,
             api_key_id=api_key_id,
@@ -797,6 +857,40 @@ async def _stream_messages(
             user_id=user_id,
             usage_override=usage_data,
         )
+        if reservation is not None:
+            await reconcile_reservation(db, reservation, actual_cost or 0.0)
+
+    async def _on_no_usage() -> None:
+        # Stream completed but the provider sent no usage data. Settle the
+        # reservation per stream_missing_usage_policy instead of billing $0.
+        if db is None or log_writer is None or reservation is None:
+            return
+        policy = config.stream_missing_usage_policy
+        if policy == "allow_free":
+            await log_usage(
+                db=db,
+                log_writer=log_writer,
+                api_key_id=api_key_id,
+                model=model,
+                provider=provider,
+                endpoint="/v1/messages",
+                user_id=user_id,
+            )
+            await refund_reservation(db, reservation)
+            return
+        # 'estimate' and 'fail' both charge the up-front estimate; 'fail' also
+        # records the request as errored.
+        await log_usage(
+            db=db,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            model=model,
+            provider=provider,
+            endpoint="/v1/messages",
+            user_id=user_id,
+            error="stream completed without usage data" if policy == "fail" else None,
+        )
+        await reconcile_reservation(db, reservation, reservation.estimate)
 
     async def _on_error(error: str) -> None:
         if platform_mode_active:
@@ -823,6 +917,14 @@ async def _stream_messages(
             user_id=user_id,
             error=error,
         )
+        if reservation is not None:
+            await refund_reservation(db, reservation)
+
+    async def _on_incomplete() -> None:
+        # Client disconnected mid-stream — release the reservation.
+        if db is None or reservation is None:
+            return
+        await refund_reservation(db, reservation)
 
     try:
         if not use_tool_loop:
@@ -896,6 +998,8 @@ async def _stream_messages(
             on_complete=_on_complete,
             on_error=_on_error,
             label=f"{provider}:{model}",
+            on_no_usage=_on_no_usage,
+            on_incomplete=_on_incomplete,
         ),
         media_type="text/event-stream",
         headers=headers,

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -889,6 +889,7 @@ async def _stream_messages(
             endpoint="/v1/messages",
             user_id=user_id,
             error="stream completed without usage data" if policy == "fail" else None,
+            cost_override=reservation.estimate,
         )
         await reconcile_reservation(db, reservation, reservation.estimate)
 

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -228,7 +228,7 @@ async def create_message(
             await refund_reservation(db, reservation)
             raise _anthropic_error(
                 _ERR_INVALID_REQUEST,
-                f"No pricing configured for model '{gate_provider}:{gate_model}'",
+                f"No pricing configured for model '{request.model}'",
                 status.HTTP_402_PAYMENT_REQUIRED,
             )
 

--- a/src/gateway/api/routes/moderations.py
+++ b/src/gateway/api/routes/moderations.py
@@ -16,7 +16,11 @@ from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import APIKey, UsageLog
 from gateway.rate_limit import check_rate_limit
-from gateway.services.budget_service import validate_user_budget
+from gateway.services.budget_service import (
+    reconcile_reservation,
+    refund_reservation,
+    reserve_budget,
+)
 from gateway.services.log_writer import LogWriter
 from gateway.services.pricing_service import find_model_pricing
 from gateway.types.moderation import ModerationResponse
@@ -74,15 +78,25 @@ async def create_moderation(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="API key has no associated user",
         ),
+        forbidden_user_error=HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="'user' field does not match the authenticated API key's user",
+        ),
+        reject_mismatch=config.reject_user_mismatch,
     )
 
     rate_limit_info = check_rate_limit(raw_request, user_id)
 
-    _ = await validate_user_budget(db, user_id, request.model, strategy=config.budget_strategy)
-    if config.budget_strategy == "for_update":
-        await db.rollback()
-
     provider, model = AnyLLM.split_model_provider(request.model)
+
+    # Moderations is exempt from require_pricing: it is free at most providers
+    # and is intentionally treated as $0 when unpriced (see below). Pricing, when
+    # present, is a flat per-request rate stored in input_price_per_million.
+    pricing = await find_model_pricing(db, provider, model)
+    flat_cost = (pricing.input_price_per_million / 1_000_000) if pricing and pricing.input_price_per_million else 0.0
+    reservation = await reserve_budget(
+        db, user_id, flat_cost, model=request.model, strategy=config.budget_strategy
+    )
 
     provider_kwargs = get_provider_kwargs(config, provider)
 
@@ -111,18 +125,15 @@ async def create_moderation(
             total_tokens=None,
         )
 
-        pricing = await find_model_pricing(db, provider, model, as_of=usage_log.timestamp)
-        if pricing and pricing.input_price_per_million:
-            # Flat per-request rate stored as input_price_per_million (moderation has no token usage).
-            usage_log.cost = pricing.input_price_per_million / 1_000_000
-        else:
-            usage_log.cost = 0.0
-            # Intentionally do NOT emit "No pricing configured" warning for
-            # /v1/moderations (free at most providers; keeps logs clean).
+        # Flat per-request rate (moderation has no token usage); intentionally
+        # no "No pricing configured" warning here — free at most providers.
+        usage_log.cost = flat_cost
 
         await log_writer.put(usage_log)
+        await reconcile_reservation(db, reservation, flat_cost)
 
     except HTTPException:
+        await refund_reservation(db, reservation)
         raise
     except NotImplementedError as e:
         error_log = UsageLog(
@@ -137,6 +148,7 @@ async def create_moderation(
             error_message=str(e),
         )
         await log_writer.put(error_log)
+        await refund_reservation(db, reservation)
         if UNSUPPORTED_MODERATION_SUBSTRING in str(e):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -160,6 +172,7 @@ async def create_moderation(
             error_message=str(e),
         )
         await log_writer.put(error_log)
+        await refund_reservation(db, reservation)
 
         logger.error("Provider call failed for %s:%s: %s", provider, model, e)
         raise HTTPException(

--- a/src/gateway/api/routes/rerank.py
+++ b/src/gateway/api/routes/rerank.py
@@ -16,9 +16,14 @@ from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import APIKey, UsageLog
 from gateway.rate_limit import check_rate_limit
-from gateway.services.budget_service import validate_user_budget
+from gateway.services.budget_service import (
+    estimate_cost,
+    reconcile_reservation,
+    refund_reservation,
+    reserve_budget,
+)
 from gateway.services.log_writer import LogWriter
-from gateway.services.pricing_service import find_model_pricing
+from gateway.services.pricing_service import find_model_pricing, pricing_required_but_missing
 
 router = APIRouter(prefix="/v1", tags=["rerank"])
 
@@ -70,15 +75,32 @@ async def create_rerank(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="API key has no associated user",
         ),
+        forbidden_user_error=HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="'user' field does not match the authenticated API key's user",
+        ),
+        reject_mismatch=config.reject_user_mismatch,
     )
 
     rate_limit_info = check_rate_limit(raw_request, user_id)
 
-    _ = await validate_user_budget(db, user_id, request.model, strategy=config.budget_strategy)
-    if config.budget_strategy == "for_update":
-        await db.rollback()
-
     provider, model = AnyLLM.split_model_provider(request.model)
+
+    pricing = await find_model_pricing(db, provider, model)
+
+    # Rerank bills on total tokens (input only). Estimate from query + documents.
+    prompt_chars = len(request.query) + sum(len(doc) for doc in request.documents)
+    estimate = estimate_cost(pricing, prompt_chars=prompt_chars, max_output_tokens=None, default_output_tokens=0)
+    # Reserve first so 404/403 precede the missing-pricing 402; refund on reject.
+    reservation = await reserve_budget(
+        db, user_id, estimate, model=request.model, strategy=config.budget_strategy
+    )
+    if pricing_required_but_missing(pricing, require_pricing=config.require_pricing):
+        await refund_reservation(db, reservation)
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail=f"No pricing configured for model '{provider}:{model}'",
+        )
 
     provider_kwargs = get_provider_kwargs(config, provider)
 
@@ -113,21 +135,16 @@ async def create_rerank(
             total_tokens=total_tokens,
         )
 
-        if result.usage:
-            pricing = await find_model_pricing(db, provider, model, as_of=usage_log.timestamp)
-            if pricing and total_tokens:
-                cost = (total_tokens / 1_000_000) * pricing.input_price_per_million
-                usage_log.cost = cost
-            elif not pricing:
-                model_ref = f"{provider}:{model}" if provider else model
-                logger.warning(
-                    "No pricing configured for '%s'. Usage will be tracked without cost.",
-                    model_ref,
-                )
+        cost = 0.0
+        if result.usage and pricing and total_tokens:
+            cost = (total_tokens / 1_000_000) * pricing.input_price_per_million
+            usage_log.cost = cost
 
         await log_writer.put(usage_log)
+        await reconcile_reservation(db, reservation, cost)
 
     except HTTPException:
+        await refund_reservation(db, reservation)
         raise
     except Exception as e:
         error_log = UsageLog(
@@ -142,6 +159,7 @@ async def create_rerank(
             error_message=str(e),
         )
         await log_writer.put(error_log)
+        await refund_reservation(db, reservation)
 
         logger.error("Provider call failed for %s:%s: %s", provider, model, e)
         raise HTTPException(

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -216,11 +216,15 @@ async def create_response(
         except (ValueError, AnyLLMError):
             gate_provider, gate_model = None, request_body.model
         gate_pricing = await find_model_pricing(db, gate_provider, gate_model)
+        # max_output_tokens comes from an extra="allow" body, so it may be absent,
+        # non-int, or negative — only trust a non-negative int for the estimate.
+        raw_max_output = getattr(request_body, "max_output_tokens", None)
+        max_output_tokens = raw_max_output if isinstance(raw_max_output, int) and raw_max_output >= 0 else None
         estimate = estimate_cost(
             gate_pricing,
             prompt_chars=len(str(request_body.input))
             + len(str(getattr(request_body, "instructions", "") or "")),
-            max_output_tokens=getattr(request_body, "max_output_tokens", None),
+            max_output_tokens=max_output_tokens,
             default_output_tokens=config.budget_estimate_default_output_tokens,
         )
         # Reserve first so user/blocked/budget rejections (404/403) precede the
@@ -888,6 +892,7 @@ async def _stream_responses(
             endpoint="/v1/responses",
             user_id=user_id,
             error="stream completed without usage data" if policy == "fail" else None,
+            cost_override=reservation.estimate,
         )
         await reconcile_reservation(db, reservation, reservation.estimate)
 

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any
 
 import httpx
 from any_llm import AnyLLM, LLMProvider, aresponses
+from any_llm.exceptions import AnyLLMError
 from any_llm.types.completion import CompletionUsage
 from any_llm.types.responses import Response as ResponsesResponse
 from any_llm.types.responses import ResponseStreamEvent
@@ -43,7 +44,13 @@ from gateway.log_config import logger
 from gateway.models.entities import APIKey
 from gateway.models.mcp import McpServerConfig
 from gateway.rate_limit import RateLimitInfo, check_rate_limit
-from gateway.services.budget_service import validate_user_budget
+from gateway.services.budget_service import (
+    ReservationHandle,
+    estimate_cost,
+    reconcile_reservation,
+    refund_reservation,
+    reserve_budget,
+)
 from gateway.services.log_writer import LogWriter
 from gateway.services.mcp_client import MCPClientPool
 from gateway.services.mcp_loop_responses import (
@@ -53,6 +60,7 @@ from gateway.services.mcp_loop_responses import (
     responses_tool_loop,
     responses_tool_loop_stream,
 )
+from gateway.services.pricing_service import find_model_pricing, pricing_required_but_missing
 from gateway.services.sandbox_backend import SandboxBackend, SandboxNotReachableError
 from gateway.services.tool_format import inject_purpose_hints_responses, openai_to_responses_tools
 from gateway.services.web_search_backend import WebSearchNotReachableError
@@ -68,6 +76,7 @@ router = APIRouter(prefix="/v1", tags=["responses"])
 _MASTER_KEY_USER_REQUIRED = "When using master key, 'user' field is required in request body"
 _API_KEY_VALIDATION_FAILED = "API key validation failed"
 _API_KEY_NO_USER = "API key has no associated user"
+_USER_FORBIDDEN = "'user' field does not match the authenticated API key's user"
 
 
 class ResponsesRequest(BaseModel):
@@ -133,6 +142,10 @@ async def create_response(
     platform_mode = config.is_platform_mode
     route: ResolvedRoute | None = None
     user_token: str | None = None
+    # Budget pre-debit for the standalone (local-DB) path only; platform mode
+    # reports usage upstream instead. Settled (reconciled/refunded) at every
+    # completion and error hook below.
+    reservation: ReservationHandle | None = None
 
     if platform_mode:
         user_token = _extract_platform_user_token(raw_request)
@@ -189,11 +202,38 @@ async def create_response(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=_API_KEY_NO_USER,
             ),
+            forbidden_user_error=HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=_USER_FORBIDDEN,
+            ),
+            reject_mismatch=config.reject_user_mismatch,
         )
         rate_limit_info = check_rate_limit(raw_request, user_id)
-        _ = await validate_user_budget(db, user_id, request_body.model, strategy=config.budget_strategy)
-        if config.budget_strategy == "for_update":
-            await db.rollback()
+        # Tolerate an unparseable selector: the budget gate (404/403) and the
+        # downstream call surface those; an unparseable model simply has no pricing.
+        try:
+            gate_provider, gate_model = AnyLLM.split_model_provider(request_body.model)
+        except (ValueError, AnyLLMError):
+            gate_provider, gate_model = None, request_body.model
+        gate_pricing = await find_model_pricing(db, gate_provider, gate_model)
+        estimate = estimate_cost(
+            gate_pricing,
+            prompt_chars=len(str(request_body.input))
+            + len(str(getattr(request_body, "instructions", "") or "")),
+            max_output_tokens=getattr(request_body, "max_output_tokens", None),
+            default_output_tokens=config.budget_estimate_default_output_tokens,
+        )
+        # Reserve first so user/blocked/budget rejections (404/403) precede the
+        # missing-pricing rejection (402); refund if we then reject for no pricing.
+        reservation = await reserve_budget(
+            db, user_id, estimate, model=request_body.model, strategy=config.budget_strategy
+        )
+        if pricing_required_but_missing(gate_pricing, require_pricing=config.require_pricing):
+            await refund_reservation(db, reservation)
+            raise HTTPException(
+                status_code=status.HTTP_402_PAYMENT_REQUIRED,
+                detail=f"No pricing configured for model '{gate_provider}:{gate_model}'",
+            )
         provider, model = AnyLLM.split_model_provider(request_body.model)
         provider_class = AnyLLM.get_provider_class(provider)
         if not getattr(provider_class, "SUPPORTS_RESPONSES", False):
@@ -377,6 +417,7 @@ async def create_response(
         return await _stream_responses(
             call_kwargs=call_kwargs,
             tools_header=request_body.tools_header,
+            config=config,
             db=db,
             log_writer=log_writer,
             api_key_id=api_key_id,
@@ -396,6 +437,7 @@ async def create_response(
             platform_correlation_id=platform_correlation_id,
             platform_request_id=platform_request_id,
             platform_config=platform_config,
+            reservation=reservation,
         )
 
     # ------------------------------------------------------------------
@@ -469,7 +511,7 @@ async def create_response(
         )
         usage_data = _usage_to_completion_usage(getattr(result, "usage", None))
         if db is not None:
-            await log_usage(
+            actual_cost = await log_usage(
                 db=db,
                 log_writer=log_writer,
                 api_key_id=api_key_id,
@@ -479,8 +521,12 @@ async def create_response(
                 user_id=user_id,
                 usage_override=usage_data,
             )
+            if reservation is not None:
+                await reconcile_reservation(db, reservation, actual_cost or 0.0)
 
     except HTTPException:
+        if db is not None and reservation is not None:
+            await refund_reservation(db, reservation)
         raise
     except MaxToolIterationsExceeded as e:
         if db is not None:
@@ -494,18 +540,24 @@ async def create_response(
                 user_id=user_id,
                 error=str(e),
             )
+            if reservation is not None:
+                await refund_reservation(db, reservation)
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=str(e),
         ) from e
     except SandboxNotReachableError as e:
         logger.error("Sandbox unreachable for %s:%s: %s", provider, model, e)
+        if db is not None and reservation is not None:
+            await refund_reservation(db, reservation)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="code_execution sandbox unreachable — check GATEWAY_SANDBOX_URL",
         ) from e
     except WebSearchNotReachableError as e:
         logger.error("Web search backend unreachable for %s:%s: %s", provider, model, e)
+        if db is not None and reservation is not None:
+            await refund_reservation(db, reservation)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="web_search backend unreachable — check GATEWAY_WEB_SEARCH_URL",
@@ -522,6 +574,8 @@ async def create_response(
                 user_id=user_id,
                 error=str(e),
             )
+            if reservation is not None:
+                await refund_reservation(db, reservation)
         logger.error("Provider call failed for %s:%s: %s", provider, model, e)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -731,6 +785,7 @@ async def _stream_responses(
     *,
     call_kwargs: dict[str, Any],
     tools_header: str | None,
+    config: GatewayConfig,
     db: AsyncSession | None,
     log_writer: LogWriter,
     api_key_id: str | None,
@@ -750,6 +805,7 @@ async def _stream_responses(
     platform_correlation_id: str | None = None,
     platform_request_id: str | None = None,
     platform_config: GatewayConfig | None = None,
+    reservation: ReservationHandle | None = None,
 ) -> StreamingResponse:
     """Streaming dispatch for single-attempt requests.
 
@@ -790,7 +846,7 @@ async def _stream_responses(
             return
         if db is None:
             return
-        await log_usage(
+        actual_cost = await log_usage(
             db=db,
             log_writer=log_writer,
             api_key_id=api_key_id,
@@ -800,6 +856,40 @@ async def _stream_responses(
             user_id=user_id,
             usage_override=usage_data,
         )
+        if reservation is not None:
+            await reconcile_reservation(db, reservation, actual_cost or 0.0)
+
+    async def _on_no_usage() -> None:
+        # Stream completed but the provider sent no usage data. Settle the
+        # reservation per stream_missing_usage_policy instead of billing $0.
+        if db is None or log_writer is None or reservation is None:
+            return
+        policy = config.stream_missing_usage_policy
+        if policy == "allow_free":
+            await log_usage(
+                db=db,
+                log_writer=log_writer,
+                api_key_id=api_key_id,
+                model=model,
+                provider=provider,
+                endpoint="/v1/responses",
+                user_id=user_id,
+            )
+            await refund_reservation(db, reservation)
+            return
+        # 'estimate' and 'fail' both charge the up-front estimate; 'fail' also
+        # records the request as errored.
+        await log_usage(
+            db=db,
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            model=model,
+            provider=provider,
+            endpoint="/v1/responses",
+            user_id=user_id,
+            error="stream completed without usage data" if policy == "fail" else None,
+        )
+        await reconcile_reservation(db, reservation, reservation.estimate)
 
     async def _on_error(error: str) -> None:
         if platform_mode_active:
@@ -826,6 +916,14 @@ async def _stream_responses(
             user_id=user_id,
             error=error,
         )
+        if reservation is not None:
+            await refund_reservation(db, reservation)
+
+    async def _on_incomplete() -> None:
+        # Client disconnected mid-stream — release the reservation.
+        if db is None or reservation is None:
+            return
+        await refund_reservation(db, reservation)
 
     try:
         if not use_tool_loop:
@@ -898,6 +996,8 @@ async def _stream_responses(
             on_complete=_on_complete,
             on_error=_on_error,
             label=f"{provider}:{model}",
+            on_no_usage=_on_no_usage,
+            on_incomplete=_on_incomplete,
         ),
         media_type="text/event-stream",
         headers=headers,

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -232,7 +232,7 @@ async def create_response(
             await refund_reservation(db, reservation)
             raise HTTPException(
                 status_code=status.HTTP_402_PAYMENT_REQUIRED,
-                detail=f"No pricing configured for model '{gate_provider}:{gate_model}'",
+                detail=f"No pricing configured for model '{request_body.model}'",
             )
         provider, model = AnyLLM.split_model_provider(request_body.model)
         provider_class = AnyLLM.get_provider_class(provider)

--- a/src/gateway/api/routes/users.py
+++ b/src/gateway/api/routes/users.py
@@ -31,6 +31,7 @@ class UserResponse(BaseModel):
     user_id: str
     alias: str | None
     spend: float
+    reserved: float
     budget_id: str | None
     budget_started_at: str | None
     next_budget_reset_at: str | None
@@ -45,6 +46,9 @@ class UserResponse(BaseModel):
             user_id=user.user_id,
             alias=user.alias,
             spend=float(user.spend),
+            # In-flight budget held by accepted-but-not-yet-settled requests;
+            # the effective committed amount is spend + reserved.
+            reserved=float(user.reserved),
             budget_id=user.budget_id,
             budget_started_at=user.budget_started_at.isoformat() if user.budget_started_at else None,
             next_budget_reset_at=user.next_budget_reset_at.isoformat() if user.next_budget_reset_at else None,

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -126,7 +126,7 @@ class GatewayConfig(BaseSettings):
         description=(
             "Reject requests for models that have no configured pricing (fail-closed, default). "
             "When False, unpriced models are served and logged without cost (legacy behavior). "
-            "Audio endpoints are always exempt — they have no token-based pricing."
+            "Audio and moderation endpoints are always exempt — they have no token-based pricing."
         ),
     )
     reject_user_mismatch: bool = Field(

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import yaml
 from dotenv import load_dotenv
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 API_KEY_HEADER = "Otari-Key"
@@ -121,6 +121,40 @@ class GatewayConfig(BaseSettings):
         default="for_update",
         description="Budget validation strategy: 'for_update' (default), 'cas' (lock-free), or 'disabled'.",
     )
+    require_pricing: bool = Field(
+        default=True,
+        description=(
+            "Reject requests for models that have no configured pricing (fail-closed, default). "
+            "When False, unpriced models are served and logged without cost (legacy behavior). "
+            "Audio endpoints are always exempt — they have no token-based pricing."
+        ),
+    )
+    reject_user_mismatch: bool = Field(
+        default=True,
+        description=(
+            "When True (default), a non-master key whose request names a 'user' other than its own "
+            "is rejected with 403. When False, the client-supplied 'user' is still forwarded to the "
+            "provider (OpenAI-style end-user tag) but spend is always bound to the key's own user — "
+            "use this if clients send arbitrary 'user' values for abuse tracking. The master key may "
+            "always bill an arbitrary user regardless of this setting."
+        ),
+    )
+    budget_estimate_default_output_tokens: int = Field(
+        default=1024,
+        ge=0,
+        description=(
+            "Output-token count assumed when reserving budget for a request whose max output is "
+            "unbounded. Used by the pre-debit estimate; reconciled to actual usage on completion."
+        ),
+    )
+    stream_missing_usage_policy: str = Field(
+        default="estimate",
+        description=(
+            "How to bill a streamed response that completes without provider usage data: "
+            "'estimate' (charge the pre-debit estimate, default), 'fail' (charge estimate and mark "
+            "the request errored), or 'allow_free' (release the reservation, legacy behavior)."
+        ),
+    )
     model_discovery: bool = Field(
         default=True,
         description="Enable auto-discovery of models from configured providers via GET /v1/models",
@@ -146,6 +180,16 @@ class GatewayConfig(BaseSettings):
     @property
     def is_platform_mode(self) -> bool:
         return self.effective_mode == "platform"
+
+    @field_validator("stream_missing_usage_policy")
+    @classmethod
+    def _validate_stream_missing_usage_policy(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        allowed = {"estimate", "fail", "allow_free"}
+        if normalized not in allowed:
+            msg = f"stream_missing_usage_policy must be one of {sorted(allowed)}, got '{value}'"
+            raise ValueError(msg)
+        return normalized
 
     def validate_mode_selection(self) -> None:
         configured_mode = self.mode.strip().lower()

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -15,7 +15,10 @@ from gateway.core.database import create_session, init_db
 from gateway.rate_limit import RateLimiter
 from gateway.services.bootstrap_service import bootstrap_first_api_key
 from gateway.services.log_writer import LogWriter, NoopLogWriter, create_log_writer
-from gateway.services.pricing_init_service import initialize_pricing_from_config
+from gateway.services.pricing_init_service import (
+    initialize_pricing_from_config,
+    warn_if_require_pricing_without_pricing,
+)
 from gateway.version import __version__
 
 _PUBLIC_PREFIXES = ("/health",)
@@ -165,6 +168,7 @@ def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
             async with create_session() as session:
                 await bootstrap_first_api_key(config, session)
                 await initialize_pricing_from_config(config, session)
+                await warn_if_require_pricing_without_pricing(config, session)
             log_writer = create_log_writer(config.log_writer_strategy)
 
         await log_writer.start()

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -80,6 +80,11 @@ class User(Base):
     user_id: Mapped[str] = mapped_column(primary_key=True)
     alias: Mapped[str | None] = mapped_column()
     spend: Mapped[float] = mapped_column(default=0.0)
+    # In-flight budget held by requests that have passed the budget gate but
+    # whose actual cost is not yet known. The effective committed amount is
+    # ``spend + reserved``; reservations are reconciled into ``spend`` (actual
+    # cost) on success or released on failure. See gateway.services.budget_service.
+    reserved: Mapped[float] = mapped_column(default=0.0, server_default="0")
     budget_id: Mapped[str | None] = mapped_column(ForeignKey("budgets.budget_id"))
     budget_started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     next_budget_reset_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
@@ -104,6 +109,7 @@ class User(Base):
             "user_id": self.user_id,
             "alias": self.alias,
             "spend": self.spend,
+            "reserved": self.reserved,
             "budget_id": self.budget_id,
             "budget_started_at": self.budget_started_at.isoformat() if self.budget_started_at else None,
             "next_budget_reset_at": self.next_budget_reset_at.isoformat() if self.next_budget_reset_at else None,

--- a/src/gateway/services/budget_service.py
+++ b/src/gateway/services/budget_service.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
 from any_llm import AnyLLM
 from any_llm.exceptions import AnyLLMError
 from fastapi import HTTPException, status
-from sqlalchemy import select, update
+from sqlalchemy import case, select, update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.log_config import logger
 from gateway.metrics import record_budget_exceeded
-from gateway.models.entities import Budget, BudgetResetLog, User
+from gateway.models.entities import Budget, BudgetResetLog, ModelPricing, User
 from gateway.repositories.users_repository import get_active_user
 from gateway.services.pricing_service import find_model_pricing
 
@@ -197,3 +198,204 @@ async def _is_model_free(db: AsyncSession, model: str) -> bool:
         logger.warning("Failed to determine provider pricing: %s", e)
 
     return False
+
+
+def _normalize_strategy(strategy: str | None) -> str:
+    normalized = (strategy or "for_update").strip().lower()
+    if normalized not in {"for_update", "cas", "disabled"}:
+        return "for_update"
+    return normalized
+
+
+@dataclass
+class ReservationHandle:
+    """Tracks a budget reservation so it can be reconciled or released.
+
+    ``estimate`` is the amount added to ``users.reserved`` at reservation time;
+    ``reserved`` records whether that write actually happened (it is skipped for
+    the ``disabled`` strategy, users without a budget, and free models). The
+    handle is passed to :func:`reconcile_reservation` on success or
+    :func:`refund_reservation` on failure.
+    """
+
+    user_id: str
+    estimate: float
+    reserved: bool
+    strategy: str
+
+
+def estimate_cost(
+    pricing: ModelPricing | None,
+    *,
+    prompt_chars: int,
+    max_output_tokens: int | None,
+    default_output_tokens: int,
+) -> float:
+    """Estimate request cost up front for budget pre-debit.
+
+    There is no tokenizer in the gateway, so prompt tokens are approximated as
+    ``chars / 4`` (a common rough heuristic). Output tokens default to the
+    request's declared max, falling back to ``default_output_tokens`` when the
+    caller leaves the output unbounded. The estimate is intentionally an
+    upper-ish bound; it is reconciled to actual usage on completion.
+    """
+    if pricing is None:
+        return 0.0
+    prompt_tokens = max(prompt_chars, 0) / 4
+    # `is None` rather than falsy: max_output_tokens == 0 is an explicit "no
+    # output" bound and must not fall through to the default cap.
+    output_tokens = max_output_tokens if max_output_tokens is not None else default_output_tokens
+    return (prompt_tokens / 1_000_000) * pricing.input_price_per_million + (
+        output_tokens / 1_000_000
+    ) * pricing.output_price_per_million
+
+
+async def reserve_budget(
+    db: AsyncSession,
+    user_id: str,
+    estimate: float,
+    *,
+    model: str | None = None,
+    strategy: str = "for_update",
+) -> ReservationHandle:
+    """Atomically pre-debit an estimated cost against the user's budget.
+
+    This replaces the old check-then-call pattern (validate, release the lock,
+    call the provider, write spend in a *later* transaction) that allowed
+    concurrent requests to all pass a stale budget check and collectively
+    overspend. Here the estimate is committed to ``users.reserved`` via a single
+    conditional UPDATE: if it would push ``spend + reserved`` past ``max_budget``
+    the row count is zero and we reject with 403. No row lock is held across the
+    provider network call.
+
+    The returned handle must be passed to :func:`reconcile_reservation` (success)
+    or :func:`refund_reservation` (failure) so the reservation does not leak.
+    """
+    normalized = _normalize_strategy(strategy)
+    user = await get_active_user(db, user_id, for_update=False)
+
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"User '{user_id}' not found",
+        )
+    if user.blocked:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"User '{user_id}' is blocked",
+        )
+
+    no_reservation = ReservationHandle(user_id=user_id, estimate=0.0, reserved=False, strategy=normalized)
+
+    if normalized == "disabled" or not user.budget_id:
+        return no_reservation
+
+    budget = await _get_budget(db, user.budget_id)
+    if not budget:
+        return no_reservation
+
+    now = datetime.now(UTC)
+    if user.next_budget_reset_at and now >= user.next_budget_reset_at:
+        # Always reset via the atomic CAS path: reserve_budget never holds a
+        # row lock (see for_update=False above), so the read-modify-write
+        # reset_user_budget would let concurrent requests at the reset boundary
+        # double-reset (duplicate reset logs, clobbered spend).
+        user = await _cas_reset_user_budget(db, user, budget, now)
+
+    # Free models do not consume budget; nothing to reserve. Reconciliation will
+    # add their (zero) cost to spend.
+    if model and await _is_model_free(db, model):
+        return no_reservation
+
+    if budget.max_budget is None:
+        # No cap to enforce, but still reserve so reconciliation math is uniform
+        # and concurrent spend is reflected immediately.
+        await db.execute(
+            update(User)
+            .where(User.user_id == user_id, User.deleted_at.is_(None))
+            .values(reserved=User.reserved + estimate)
+            .execution_options(synchronize_session=False)
+        )
+        await db.commit()
+        return ReservationHandle(user_id=user_id, estimate=estimate, reserved=True, strategy=normalized)
+
+    result = await db.execute(
+        update(User)
+        .where(
+            User.user_id == user_id,
+            User.deleted_at.is_(None),
+            # Already at/over the cap → reject (matches the pre-reservation
+            # `spend >= max_budget` semantics, and also catches zero-estimate
+            # requests like audio for a maxed-out user).
+            User.spend + User.reserved < budget.max_budget,
+            # ...and this request must not push committed spend past the cap.
+            User.spend + User.reserved + estimate <= budget.max_budget,
+        )
+        .values(reserved=User.reserved + estimate)
+        .execution_options(synchronize_session=False)
+    )
+    await db.commit()
+
+    if not getattr(result, "rowcount", 0):
+        record_budget_exceeded()
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"User '{user_id}' has exceeded budget limit",
+        )
+
+    return ReservationHandle(user_id=user_id, estimate=estimate, reserved=True, strategy=normalized)
+
+
+def _release_reserved(estimate: float) -> object:
+    """Column expression that subtracts ``estimate`` from reserved, clamped at 0.
+
+    Uses CASE rather than GREATEST for SQLite compatibility.
+    """
+    return case(
+        (User.reserved - estimate < 0, 0.0),
+        else_=User.reserved - estimate,
+    )
+
+
+async def reconcile_reservation(db: AsyncSession, handle: ReservationHandle, actual_cost: float) -> None:
+    """Settle a reservation: record actual spend and release the held estimate.
+
+    Note: if this UPDATE/commit fails (e.g. a transient DB error after the
+    provider call succeeded), the held estimate is not released and stays in
+    ``users.reserved``. That shrinks the user's effective budget until the next
+    budget reset zeroes it; a future enhancement could add a stale-reservation
+    sweep. This is the cost of fail-closed pre-debit and is rare in practice.
+
+    This is the single authority for writing ``users.spend`` on the billable
+    path — the usage-log writer no longer touches spend, so reconciliation must
+    run for every served request (even when ``actual_cost`` is 0, to release the
+    reservation). Runs inline in the request, not in the (possibly batched) log
+    writer, so the next request's reservation sees fresh totals.
+    """
+    values: dict[str, object] = {}
+    if actual_cost:
+        values["spend"] = User.spend + actual_cost
+    if handle.reserved:
+        values["reserved"] = _release_reserved(handle.estimate)
+    if not values:
+        return
+    await db.execute(
+        update(User)
+        .where(User.user_id == handle.user_id, User.deleted_at.is_(None))
+        .values(**values)
+        .execution_options(synchronize_session=False)
+    )
+    await db.commit()
+
+
+async def refund_reservation(db: AsyncSession, handle: ReservationHandle) -> None:
+    """Release a reservation without recording spend (e.g. provider failure)."""
+    if not handle.reserved:
+        return
+    await db.execute(
+        update(User)
+        .where(User.user_id == handle.user_id, User.deleted_at.is_(None))
+        .values(reserved=_release_reserved(handle.estimate))
+        .execution_options(synchronize_session=False)
+    )
+    await db.commit()

--- a/src/gateway/services/budget_service.py
+++ b/src/gateway/services/budget_service.py
@@ -243,8 +243,10 @@ def estimate_cost(
         return 0.0
     prompt_tokens = max(prompt_chars, 0) / 4
     # `is None` rather than falsy: max_output_tokens == 0 is an explicit "no
-    # output" bound and must not fall through to the default cap.
+    # output" bound and must not fall through to the default cap. Clamp negatives
+    # so a hostile max_output_tokens can't produce a negative estimate.
     output_tokens = max_output_tokens if max_output_tokens is not None else default_output_tokens
+    output_tokens = max(output_tokens, 0)
     return (prompt_tokens / 1_000_000) * pricing.input_price_per_million + (
         output_tokens / 1_000_000
     ) * pricing.output_price_per_million
@@ -271,6 +273,10 @@ async def reserve_budget(
     The returned handle must be passed to :func:`reconcile_reservation` (success)
     or :func:`refund_reservation` (failure) so the reservation does not leak.
     """
+    # Defense-in-depth: estimates derive from client-controlled fields (max
+    # tokens, image count). A negative estimate would *reduce* users.reserved and
+    # weaken the budget gate, so never let one reach the DB.
+    estimate = max(estimate, 0.0)
     normalized = _normalize_strategy(strategy)
     user = await get_active_user(db, user_id, for_update=False)
 
@@ -372,6 +378,8 @@ async def reconcile_reservation(db: AsyncSession, handle: ReservationHandle, act
     reservation). Runs inline in the request, not in the (possibly batched) log
     writer, so the next request's reservation sees fresh totals.
     """
+    # Never let a negative cost reduce recorded spend.
+    actual_cost = max(actual_cost, 0.0)
     values: dict[str, object] = {}
     if actual_cost:
         values["spend"] = User.spend + actual_cost

--- a/src/gateway/services/log_writer.py
+++ b/src/gateway/services/log_writer.py
@@ -6,7 +6,6 @@ import asyncio
 import time
 from typing import Protocol
 
-from sqlalchemy import update
 from sqlalchemy.exc import SQLAlchemyError
 
 from gateway.core.database import create_session
@@ -17,7 +16,7 @@ from gateway.metrics import (
     log_writer_queue_depth,
     log_writer_rows,
 )
-from gateway.models.entities import UsageLog, User
+from gateway.models.entities import UsageLog
 
 
 class LogWriter(Protocol):
@@ -34,13 +33,11 @@ class SingleLogWriter:
     async def put(self, log: UsageLog) -> None:
         async with create_session() as db:
             try:
+                # Spend is owned by the budget reservation reconcile path
+                # (gateway.services.budget_service), not the log writer — the
+                # writer is pure logging. Reconciling here would double-charge
+                # and, under the batch writer, lag the budget gate.
                 db.add(log)
-                if log.cost and log.user_id:
-                    await db.execute(
-                        update(User)
-                        .where(User.user_id == log.user_id, User.deleted_at.is_(None))
-                        .values(spend=User.spend + log.cost)
-                    )
                 await db.commit()
                 log_writer_rows.labels(writer="single", result="written").inc()
             except SQLAlchemyError as e:  # pragma: no cover - defensive logging
@@ -114,14 +111,10 @@ class BatchLogWriter:
         log_writer_batch_size.labels(writer="batch").observe(len(batch))
         try:
             async with create_session() as db:
+                # Spend is reconciled inline via the budget reservation path, not
+                # here — see SingleLogWriter.put. The writer only persists rows.
                 for log in batch:
                     db.add(log)
-                    if log.cost and log.user_id:
-                        await db.execute(
-                            update(User)
-                            .where(User.user_id == log.user_id, User.deleted_at.is_(None))
-                            .values(spend=User.spend + log.cost)
-                        )
                 await db.commit()
                 log_writer_rows.labels(writer="batch", result="written").inc(len(batch))
             log_writer_flush_duration.labels(writer="batch", result="ok").observe(time.monotonic() - start)

--- a/src/gateway/services/pricing_init_service.py
+++ b/src/gateway/services/pricing_init_service.py
@@ -1,7 +1,7 @@
 """Pricing initialization from configuration."""
 
 from any_llm import AnyLLM
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -9,6 +9,25 @@ from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import ModelPricing
 from gateway.services.pricing_service import normalize_effective_at
+
+
+async def warn_if_require_pricing_without_pricing(config: GatewayConfig, db: AsyncSession) -> None:
+    """Warn at startup when require_pricing is on but no pricing is configured.
+
+    With ``require_pricing=True`` (the default), any model lacking a pricing
+    entry is rejected with HTTP 402 — so a deployment with zero pricing rows
+    would reject every billable request. Surface that loudly rather than letting
+    operators discover it via failed traffic.
+    """
+    if not config.require_pricing:
+        return
+    count = (await db.execute(select(func.count()).select_from(ModelPricing))).scalar_one()
+    if count == 0:
+        logger.warning(
+            "require_pricing is enabled but no model pricing is configured: ALL billable requests "
+            "will be rejected with HTTP 402. Add pricing (config `pricing` section or POST /v1/pricing), "
+            "set require_pricing=false, or add explicit $0 pricing for free/self-hosted models."
+        )
 
 
 async def initialize_pricing_from_config(config: GatewayConfig, db: AsyncSession) -> None:

--- a/src/gateway/services/pricing_service.py
+++ b/src/gateway/services/pricing_service.py
@@ -48,3 +48,17 @@ async def find_model_pricing(
 
     legacy_key = f"{provider}/{model}"
     return await _find_by_model_key(db, legacy_key, lookup_time)
+
+
+def pricing_required_but_missing(pricing: ModelPricing | None, *, require_pricing: bool) -> bool:
+    """Return True when the request must be rejected for lacking pricing.
+
+    This is the predicate behind the ``require_pricing`` config: an unpriced
+    model would otherwise be served free and unmetered (the budget cap cannot
+    restrain it). Callers evaluate this *after* reserving budget — so a missing
+    user, a blocked user, or an exhausted budget (404/403) take precedence over
+    the missing-pricing rejection (402) — and refund the reservation before
+    raising. When ``require_pricing`` is False, the legacy behavior is preserved
+    (the request is served and logged without cost).
+    """
+    return pricing is None and require_pricing

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -76,6 +76,8 @@ async def streaming_generator(
     on_complete: Callable[[CompletionUsage], Awaitable[None]],
     on_error: Callable[[str], Awaitable[None]],
     label: str,
+    on_no_usage: Callable[[], Awaitable[None]] | None = None,
+    on_incomplete: Callable[[], Awaitable[None]] | None = None,
 ) -> AsyncIterator[str]:
     """Shared SSE streaming generator with usage tracking and error handling.
 
@@ -84,13 +86,22 @@ async def streaming_generator(
         format_chunk: Formats a chunk into an SSE string
         extract_usage: Extracts usage from a chunk, or returns None if no usage present
         fmt: SSE format configuration (done marker, error payload, etc.)
-        on_complete: Called with aggregated usage after successful streaming
+        on_complete: Called with aggregated usage after successful streaming that
+            included usage data
         on_error: Called with error message on failure
         label: Identifier for error log messages (e.g., "openai:gpt-4")
+        on_no_usage: Called when streaming completes successfully but the provider
+            sent no usage data. Lets the caller bill per ``stream_missing_usage_policy``
+            instead of silently skipping the request. When omitted, a no-usage
+            stream is not billed (legacy behavior).
+        on_incomplete: Called when the stream neither completes nor errors normally
+            (e.g. client disconnect mid-stream). Used to release any budget
+            reservation so it does not leak.
 
     """
     usage = CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
     has_usage = False
+    settled = False
 
     try:
         async for chunk in stream:
@@ -101,17 +112,34 @@ async def streaming_generator(
             yield format_chunk(chunk)
         yield fmt.done_marker
 
-        if has_usage:
-            await on_complete(usage)
+        # Settle on normal completion. Guard the callbacks so a logging failure
+        # can't be mistaken for an incomplete (disconnected) stream.
+        settled = True
+        try:
+            if has_usage:
+                await on_complete(usage)
+            elif on_no_usage is not None:
+                await on_no_usage()
+        except Exception as log_err:
+            logger.error("Failed to log streaming usage for %s: %s", label, log_err)
     except Exception as e:
         yield fmt.error_payload
         if fmt.yield_done_on_error:
             yield fmt.done_marker
+        settled = True
         try:
             await on_error(str(e))
         except Exception as log_err:
             logger.error("Failed to log streaming error usage: %s", log_err)
         logger.error("Streaming error for %s: %s", label, e)
+    finally:
+        if not settled and on_incomplete is not None:
+            # Reached on client disconnect / generator cancellation before the
+            # stream finished — release the reservation so it does not leak.
+            try:
+                await on_incomplete()
+            except Exception as log_err:
+                logger.error("Failed to settle incomplete stream for %s: %s", label, log_err)
 
 
 async def iterate_streaming_attempts(

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import json
-from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any, TypeVar
@@ -78,7 +78,7 @@ async def streaming_generator(
     label: str,
     on_no_usage: Callable[[], Awaitable[None]] | None = None,
     on_incomplete: Callable[[], Awaitable[None]] | None = None,
-) -> AsyncIterator[str]:
+) -> AsyncGenerator[str, None]:
     """Shared SSE streaming generator with usage tracking and error handling.
 
     Args:

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -122,6 +122,16 @@ async def streaming_generator(
                 await on_no_usage()
         except Exception as log_err:
             logger.error("Failed to log streaming usage for %s: %s", label, log_err)
+    except asyncio.CancelledError:
+        # Client disconnect / request cancellation mid-stream. CancelledError is a
+        # BaseException (not caught by `except Exception` below), so handle it
+        # explicitly: settle as incomplete and let cancellation propagate — do not
+        # emit an SSE error payload or call on_error.
+        if not settled and on_incomplete is not None:
+            with suppress(Exception):
+                await on_incomplete()
+        settled = True
+        raise
     except Exception as e:
         yield fmt.error_payload
         if fmt.yield_done_on_error:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -146,6 +146,11 @@ def test_config(postgres_url: str) -> GatewayConfig:
         host="127.0.0.1",
         port=8000,
         auto_migrate=False,
+        # The bulk of the suite predates require_pricing and exercises models
+        # without configuring pricing. Keep the permissive baseline here; the
+        # fail-closed require_pricing=True behavior is covered by dedicated tests
+        # that build their own config (see test_pricing_budget_validation.py).
+        require_pricing=False,
     )
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -149,7 +149,7 @@ def test_config(postgres_url: str) -> GatewayConfig:
         # The bulk of the suite predates require_pricing and exercises models
         # without configuring pricing. Keep the permissive baseline here; the
         # fail-closed require_pricing=True behavior is covered by dedicated tests
-        # that build their own config (see test_pricing_budget_validation.py).
+        # that build their own config (see test_require_pricing.py).
         require_pricing=False,
     )
 

--- a/tests/integration/test_atomic_spend_update.py
+++ b/tests/integration/test_atomic_spend_update.py
@@ -1,102 +1,52 @@
-"""Tests for atomic spend update via SQL expression."""
-
-from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
+"""Tests for atomic spend update via SQL expression in reconcile_reservation."""
 
 import pytest
-from any_llm.types.completion import CompletionUsage
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.api.routes.chat import log_usage
-from gateway.models.entities import ModelPricing, User
-from gateway.services.log_writer import SingleLogWriter
+from gateway.models.entities import User
+from gateway.services.budget_service import ReservationHandle, reconcile_reservation
 
 
 @pytest.mark.asyncio
-async def test_spend_update_uses_sql_expression(async_db: AsyncSession, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that _log_usage updates spend atomically via SQL, not Python read-modify-write."""
+async def test_spend_update_uses_sql_expression(async_db: AsyncSession) -> None:
+    """Test that reconcile_reservation updates spend atomically via SQL, not Python read-modify-write."""
     # Set up user with initial spend
     user = User(user_id="atomic-user", spend=5.0)
     async_db.add(user)
-
-    pricing = ModelPricing(
-        model_key="openai:gpt-4o",
-        input_price_per_million=2.5,
-        output_price_per_million=10.0,
-    )
-    async_db.add(pricing)
     await async_db.commit()
 
-    usage = CompletionUsage(prompt_tokens=1_000_000, completion_tokens=100_000, total_tokens=1_100_000)
-
-    writer = SingleLogWriter()
-
-    @asynccontextmanager
-    async def _session_cm() -> AsyncGenerator[AsyncSession, None]:
-        yield async_db
-
-    monkeypatch.setattr("gateway.services.log_writer.create_session", lambda: _session_cm())
-
-    await log_usage(
-        db=async_db,
-        log_writer=writer,
-        api_key_id=None,
-        model="gpt-4o",
-        provider="openai",
-        endpoint="/v1/chat/completions",
-        user_id="atomic-user",
-        usage_override=usage,
+    # actual_cost equivalent to the old log_usage computation:
+    # (1M / 1M) * 2.5 + (100K / 1M) * 10.0 = 2.5 + 1.0 = 3.5
+    actual_cost = 3.5
+    await reconcile_reservation(
+        async_db,
+        ReservationHandle(user_id="atomic-user", estimate=0.0, reserved=False, strategy="for_update"),
+        actual_cost,
     )
 
     await async_db.refresh(user)
-    updated_user = user
-    assert updated_user is not None
+    assert user is not None
 
-    # Expected cost: (1M / 1M) * 2.5 + (100K / 1M) * 10.0 = 2.5 + 1.0 = 3.5
     expected_new_spend = 5.0 + 3.5
-    assert abs(updated_user.spend - expected_new_spend) < 0.001, (
-        f"Expected spend {expected_new_spend}, got {updated_user.spend}"
-    )
+    assert abs(user.spend - expected_new_spend) < 0.001, f"Expected spend {expected_new_spend}, got {user.spend}"
 
 
 @pytest.mark.asyncio
-async def test_multiple_spend_updates_accumulate(async_db: AsyncSession, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that multiple sequential spend updates accumulate correctly."""
+async def test_multiple_spend_updates_accumulate(async_db: AsyncSession) -> None:
+    """Test that multiple sequential spend updates via reconcile_reservation accumulate correctly."""
     user = User(user_id="multi-spend-user", spend=0.0)
     async_db.add(user)
-
-    pricing = ModelPricing(
-        model_key="openai:gpt-4o",
-        input_price_per_million=10.0,
-        output_price_per_million=10.0,
-    )
-    async_db.add(pricing)
     await async_db.commit()
 
-    writer = SingleLogWriter()
-
-    @asynccontextmanager
-    async def _session_cm() -> AsyncGenerator[AsyncSession, None]:
-        yield async_db
-
-    monkeypatch.setattr("gateway.services.log_writer.create_session", lambda: _session_cm())
-
+    # Each call costs (1M/1M)*10 + (1M/1M)*10 = 20.0, x3 = 60.0
     for _ in range(3):
-        usage = CompletionUsage(prompt_tokens=1_000_000, completion_tokens=1_000_000, total_tokens=2_000_000)
-        await log_usage(
-            db=async_db,
-            log_writer=writer,
-            api_key_id=None,
-            model="gpt-4o",
-            provider="openai",
-            endpoint="/v1/chat/completions",
-            user_id="multi-spend-user",
-            usage_override=usage,
+        await reconcile_reservation(
+            async_db,
+            ReservationHandle(user_id="multi-spend-user", estimate=0.0, reserved=False, strategy="for_update"),
+            20.0,
         )
 
     await async_db.refresh(user)
-    updated_user = user
-    assert updated_user is not None
+    assert user is not None
 
-    # Each call: (1M/1M)*10 + (1M/1M)*10 = 20.0, x3 = 60.0
-    assert abs(updated_user.spend - 60.0) < 0.001, f"Expected spend 60.0, got {updated_user.spend}"
+    assert abs(user.spend - 60.0) < 0.001, f"Expected spend 60.0, got {user.spend}"

--- a/tests/integration/test_budget_race_condition.py
+++ b/tests/integration/test_budget_race_condition.py
@@ -6,9 +6,10 @@ from unittest.mock import patch
 import pytest
 from fastapi import HTTPException
 
-from gateway.models.entities import Budget, User
+from gateway.models.entities import Budget, ModelPricing, User
 from gateway.repositories.users_repository import get_active_user
 from gateway.services.budget_service import (
+    estimate_cost,
     reconcile_reservation,
     refund_reservation,
     reserve_budget,
@@ -140,3 +141,45 @@ async def test_refund_releases_hold_without_charging(async_db: Any) -> None:
     assert user is not None
     assert user.spend == pytest.approx(10.0)  # unchanged
     assert user.reserved == pytest.approx(0.0)
+
+
+def test_estimate_cost_clamps_negative_output_tokens() -> None:
+    """A hostile negative max_output_tokens must not produce a negative estimate."""
+    pricing = ModelPricing(model_key="openai:gpt-4o", input_price_per_million=2.5, output_price_per_million=10.0)
+    est = estimate_cost(pricing, prompt_chars=400, max_output_tokens=-1_000_000, default_output_tokens=1024)
+    # Output term clamped to 0 → only the prompt contributes; never negative.
+    assert est >= 0.0
+    assert est == pytest.approx((400 / 4 / 1_000_000) * 2.5)
+
+
+@pytest.mark.asyncio
+async def test_reserve_budget_clamps_negative_estimate(async_db: Any) -> None:
+    """A negative estimate must not reduce users.reserved (budget-gate bypass)."""
+    async_db.add(Budget(budget_id="neg-budget", max_budget=100.0))
+    async_db.add(User(user_id="neg-user", spend=10.0, reserved=4.0, budget_id="neg-budget"))
+    await async_db.commit()
+
+    await reserve_budget(async_db, "neg-user", -50.0)
+
+    async_db.expire_all()
+    user = await get_active_user(async_db, "neg-user")
+    assert user is not None
+    assert user.reserved == pytest.approx(4.0)  # unchanged — negative clamped to 0
+    assert user.spend == pytest.approx(10.0)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_clamps_negative_cost(async_db: Any) -> None:
+    """A negative actual_cost must not reduce users.spend."""
+    async_db.add(Budget(budget_id="negc-budget", max_budget=100.0))
+    async_db.add(User(user_id="negc-user", spend=10.0, budget_id="negc-budget"))
+    await async_db.commit()
+
+    handle = await reserve_budget(async_db, "negc-user", 5.0)
+    await reconcile_reservation(async_db, handle, -3.0)
+
+    async_db.expire_all()
+    user = await get_active_user(async_db, "negc-user")
+    assert user is not None
+    assert user.spend == pytest.approx(10.0)  # not reduced by the negative cost
+    assert user.reserved == pytest.approx(0.0)  # hold released

--- a/tests/integration/test_budget_race_condition.py
+++ b/tests/integration/test_budget_race_condition.py
@@ -4,10 +4,16 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from fastapi import HTTPException
 
 from gateway.models.entities import Budget, User
 from gateway.repositories.users_repository import get_active_user
-from gateway.services.budget_service import validate_user_budget
+from gateway.services.budget_service import (
+    reconcile_reservation,
+    refund_reservation,
+    reserve_budget,
+    validate_user_budget,
+)
 
 
 @pytest.mark.asyncio
@@ -63,3 +69,74 @@ async def test_budget_check_rejects_at_limit(
     with pytest.raises(HTTPException) as exc_info:
         await validate_user_budget(async_db, "full-user")
     assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_reservation_accumulates_to_prevent_overspend(async_db: Any) -> None:
+    """Two reservations evaluated against the same committed spend cannot both
+    pass — the second sees the first's hold (F2 TOCTOU fix).
+
+    This is the core of the overspend-race fix: before, concurrent requests all
+    read stale ``spend`` and each added its cost afterward, blowing the cap. Now
+    each reservation atomically commits its estimate to ``reserved``, so the
+    second request is rejected even though it was checked against the same
+    starting spend.
+    """
+    async_db.add(Budget(budget_id="resv-budget", max_budget=10.0))
+    async_db.add(User(user_id="resv-user", spend=9.0, budget_id="resv-budget"))
+    await async_db.commit()
+
+    # First reservation fits: 9.0 + 0.8 <= 10.
+    handle = await reserve_budget(async_db, "resv-user", 0.8)
+    assert handle.reserved
+
+    # A naive check against committed spend (9.0) would pass the second request
+    # too; it is rejected because reserved is now held.
+    with pytest.raises(HTTPException) as exc_info:
+        await reserve_budget(async_db, "resv-user", 0.8)
+    assert exc_info.value.status_code == 403
+
+    # expire_all() forces fresh reads — the reservation UPDATEs use
+    # synchronize_session=False and the test session has expire_on_commit=False.
+    async_db.expire_all()
+    user = await get_active_user(async_db, "resv-user")
+    assert user is not None
+    assert user.reserved == pytest.approx(0.8)
+    assert user.spend == pytest.approx(9.0)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_records_actual_cost_and_releases_hold(async_db: Any) -> None:
+    """reconcile_reservation adds the actual cost to spend and frees the estimate."""
+    async_db.add(Budget(budget_id="rec-budget", max_budget=100.0))
+    async_db.add(User(user_id="rec-user", spend=10.0, budget_id="rec-budget"))
+    await async_db.commit()
+
+    handle = await reserve_budget(async_db, "rec-user", 5.0)
+    async_db.expire_all()
+    user = await get_active_user(async_db, "rec-user")
+    assert user is not None and user.reserved == pytest.approx(5.0)
+
+    await reconcile_reservation(async_db, handle, 3.0)
+    async_db.expire_all()
+    user = await get_active_user(async_db, "rec-user")
+    assert user is not None
+    assert user.spend == pytest.approx(13.0)  # 10 + actual 3 (not the 5 estimate)
+    assert user.reserved == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_refund_releases_hold_without_charging(async_db: Any) -> None:
+    """refund_reservation releases the estimate without recording any spend."""
+    async_db.add(Budget(budget_id="ref-budget", max_budget=100.0))
+    async_db.add(User(user_id="ref-user", spend=10.0, budget_id="ref-budget"))
+    await async_db.commit()
+
+    handle = await reserve_budget(async_db, "ref-user", 5.0)
+    await refund_reservation(async_db, handle)
+
+    async_db.expire_all()
+    user = await get_active_user(async_db, "ref-user")
+    assert user is not None
+    assert user.spend == pytest.approx(10.0)  # unchanged
+    assert user.reserved == pytest.approx(0.0)

--- a/tests/integration/test_client_args.py
+++ b/tests/integration/test_client_args.py
@@ -28,6 +28,7 @@ def config_with_client_args(postgres_url: str) -> GatewayConfig:
         host="127.0.0.1",
         port=8000,
         auto_migrate=False,
+        require_pricing=False,
         providers={
             "openai": {
                 "api_key": "test-openai-key",

--- a/tests/integration/test_error_detail_leakage.py
+++ b/tests/integration/test_error_detail_leakage.py
@@ -16,7 +16,6 @@ def test_provider_error_does_not_leak_details(
         json={
             "model": "openai:nonexistent-model-xyz",
             "messages": [{"role": "user", "content": "Hello"}],
-            "user": test_user["user_id"],
         },
         headers=api_key_header,
     )

--- a/tests/integration/test_metrics.py
+++ b/tests/integration/test_metrics.py
@@ -35,6 +35,7 @@ def _make_metrics_client(
         host="127.0.0.1",
         port=8000,
         auto_migrate=False,
+        require_pricing=False,
         enable_metrics=enable_metrics,
         rate_limit_rpm=rate_limit_rpm,
     )

--- a/tests/integration/test_pricing_budget_validation.py
+++ b/tests/integration/test_pricing_budget_validation.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from gateway.core.config import PricingConfig
+from gateway.services.pricing_service import pricing_required_but_missing
 
 
 def test_negative_pricing_rejected(client: TestClient, master_key_header: dict[str, str]) -> None:
@@ -173,3 +174,19 @@ def test_pricing_config_accepts_zero_prices() -> None:
     config = PricingConfig(input_price_per_million=0.0, output_price_per_million=0.0)
     assert config.input_price_per_million == 0.0
     assert config.output_price_per_million == 0.0
+
+
+def test_pricing_required_but_missing_true_when_unpriced_and_required() -> None:
+    """With require_pricing on, a missing pricing row must reject (F3 budget-bypass fix)."""
+    assert pricing_required_but_missing(None, require_pricing=True) is True
+
+
+def test_pricing_required_but_missing_false_when_not_required() -> None:
+    """With require_pricing off, a missing pricing row is allowed (legacy behavior)."""
+    assert pricing_required_but_missing(None, require_pricing=False) is False
+
+
+def test_pricing_required_but_missing_false_when_priced() -> None:
+    """A model that has pricing is never rejected, regardless of require_pricing."""
+    pricing = object()  # any non-None pricing row
+    assert pricing_required_but_missing(pricing, require_pricing=True) is False  # type: ignore[arg-type]

--- a/tests/integration/test_provider_kwargs_override.py
+++ b/tests/integration/test_provider_kwargs_override.py
@@ -30,6 +30,7 @@ def config_with_model_in_provider(postgres_url: str) -> GatewayConfig:
         host="127.0.0.1",
         port=8000,
         auto_migrate=False,
+        require_pricing=False,
         providers={
             "openai": {
                 "api_key": "test-openai-key",
@@ -64,6 +65,7 @@ def test_provider_kwargs_do_not_contain_model() -> None:
     config = GatewayConfig(
         database_url="postgresql://localhost/test",
         master_key="test",
+        require_pricing=False,
         providers={
             "openai": {
                 "api_key": "sk-test-key",

--- a/tests/integration/test_rate_limiting.py
+++ b/tests/integration/test_rate_limiting.py
@@ -29,6 +29,7 @@ def _make_rate_limit_client(
         host="127.0.0.1",
         port=8000,
         auto_migrate=False,
+        require_pricing=False,
         rate_limit_rpm=rate_limit_rpm,
     )
     _run_alembic_migrations(postgres_url)

--- a/tests/integration/test_require_pricing.py
+++ b/tests/integration/test_require_pricing.py
@@ -1,0 +1,103 @@
+"""End-to-end tests for the require_pricing gate (F3) and its precedence.
+
+These build a client with ``require_pricing=True`` (the production default; the
+shared ``client`` fixture turns it off for the legacy suite). They cover the 402
+route branch — exercised nowhere else — and verify that user/blocked/budget
+rejections (404/403) take precedence over the missing-pricing rejection (402),
+i.e. budget is reserved before the pricing gate is enforced.
+"""
+
+import asyncio
+from collections.abc import AsyncGenerator, Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from gateway.core.config import API_KEY_HEADER, GatewayConfig
+from gateway.db import Base, get_db
+from gateway.main import create_app
+
+from .conftest import _run_alembic_migrations, _to_async_url
+
+_MASTER_HEADER = {API_KEY_HEADER: "Bearer test-master-key"}
+_MESSAGES = [{"role": "user", "content": "hi"}]
+
+
+@pytest.fixture
+def strict_pricing_client(postgres_url: str) -> Generator[TestClient]:
+    """TestClient for a gateway with require_pricing=True (fail-closed)."""
+    config = GatewayConfig(
+        database_url=postgres_url,
+        master_key="test-master-key",
+        host="127.0.0.1",
+        port=8000,
+        auto_migrate=False,
+        require_pricing=True,
+    )
+    _run_alembic_migrations(postgres_url)
+    engine = create_engine(postgres_url, pool_pre_ping=True)
+    async_engine = create_async_engine(_to_async_url(postgres_url), pool_pre_ping=True)
+    async_session_factory = async_sessionmaker(async_engine, expire_on_commit=False)
+    app = create_app(config)
+
+    async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
+        async with async_session_factory() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    try:
+        with TestClient(app) as test_client:
+            yield test_client
+    finally:
+        Base.metadata.drop_all(bind=engine)
+        with engine.connect() as conn:
+            conn.execute(text("DROP TABLE IF EXISTS alembic_version CASCADE"))
+            conn.commit()
+        try:
+            asyncio.run(async_engine.dispose())
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            loop.run_until_complete(async_engine.dispose())
+            loop.close()
+
+
+def _chat(client: TestClient, *, model: str, user: str) -> int:
+    resp = client.post(
+        "/v1/chat/completions",
+        json={"model": model, "messages": _MESSAGES, "user": user},
+        headers=_MASTER_HEADER,
+    )
+    return resp.status_code
+
+
+def test_unpriced_model_rejected_with_402(strict_pricing_client: TestClient) -> None:
+    """An unpriced model is rejected with 402 when require_pricing is on (F3)."""
+    strict_pricing_client.post("/v1/users", json={"user_id": "priced-user"}, headers=_MASTER_HEADER)
+    assert _chat(strict_pricing_client, model="openai:gpt-4o", user="priced-user") == 402
+
+
+def test_priced_model_passes_the_gate(strict_pricing_client: TestClient) -> None:
+    """A priced model clears the pricing gate (no 402); any later failure is a provider error."""
+    strict_pricing_client.post("/v1/users", json={"user_id": "priced-user"}, headers=_MASTER_HEADER)
+    strict_pricing_client.post(
+        "/v1/pricing",
+        json={"model_key": "openai:gpt-4o", "input_price_per_million": 2.5, "output_price_per_million": 10.0},
+        headers=_MASTER_HEADER,
+    )
+    assert _chat(strict_pricing_client, model="openai:gpt-4o", user="priced-user") != 402
+
+
+def test_blocked_user_takes_precedence_over_missing_pricing(strict_pricing_client: TestClient) -> None:
+    """A blocked user gets 403, not 402 — budget/state is checked before pricing."""
+    strict_pricing_client.post(
+        "/v1/users", json={"user_id": "blocked-user", "blocked": True}, headers=_MASTER_HEADER
+    )
+    assert _chat(strict_pricing_client, model="openai:gpt-4o", user="blocked-user") == 403
+
+
+def test_missing_user_takes_precedence_over_missing_pricing(strict_pricing_client: TestClient) -> None:
+    """A nonexistent user gets 404, not 402 — user existence is checked before pricing."""
+    assert _chat(strict_pricing_client, model="openai:gpt-4o", user="ghost-user") == 404

--- a/tests/integration/test_responses_endpoint.py
+++ b/tests/integration/test_responses_endpoint.py
@@ -200,12 +200,14 @@ def test_responses_endpoint_bearer_auth(
 
     headers = {API_KEY_HEADER: f"Bearer {api_key_obj['key']}"}
 
+    body = {k: v for k, v in responses_request_body.items() if k != "user"}
+
     with patch(
         "gateway.api.routes.responses.aresponses",
         new_callable=AsyncMock,
         return_value=_FakeResponse({"id": "resp_token"}),
     ):
-        result = client.post("/v1/responses", json=responses_request_body, headers=headers)
+        result = client.post("/v1/responses", json=body, headers=headers)
 
     assert result.status_code == 200
     assert result.json()["id"] == "resp_token"

--- a/tests/integration/test_streaming_error_event.py
+++ b/tests/integration/test_streaming_error_event.py
@@ -21,7 +21,6 @@ def test_streaming_creation_error_returns_http_error(
         json={
             "model": "openai:totally-invalid-model-xyz",
             "messages": [{"role": "user", "content": "Hello"}],
-            "user": test_user["user_id"],
             "stream": True,
         },
         headers=api_key_header,

--- a/tests/integration/test_usage_tracking.py
+++ b/tests/integration/test_usage_tracking.py
@@ -2,8 +2,10 @@ import asyncio
 import json
 import os
 from typing import Any
+from unittest.mock import patch
 
 import pytest
+from any_llm.types.completion import ChatCompletion, ChatCompletionMessage, Choice, CompletionUsage
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -265,7 +267,6 @@ async def test_failed_request_logs_error(
         json={
             "model": "gemini:invalid-model",
             "messages": test_messages,
-            "user": test_user["user_id"],
         },
         headers=api_key_header,
     )
@@ -284,5 +285,61 @@ async def test_failed_request_logs_error(
 
         assert log.status == "error"
         assert log.error_message is not None
+    finally:
+        db.close()
+
+
+def test_spend_incremented_via_reconciliation(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    test_config: GatewayConfig,
+    test_messages: list[dict[str, str]],
+) -> None:
+    """End-to-end: a successful billable request reserves then reconciles, so
+    users.spend increases by the actual cost (the reconcile path is the sole
+    spend authority now that the log writer no longer touches spend)."""
+    client.post("/v1/users", json={"user_id": "spend-user"}, headers=master_key_header)
+    client.post(
+        "/v1/pricing",
+        json={"model_key": MODEL_NAME, "input_price_per_million": 2.5, "output_price_per_million": 10.0},
+        headers=master_key_header,
+    )
+
+    mock_response = ChatCompletion(
+        id="chatcmpl-spend",
+        object="chat.completion",
+        created=0,
+        model=MODEL_NAME,
+        choices=[
+            Choice(
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content="hi"),
+                finish_reason="stop",
+            )
+        ],
+        usage=CompletionUsage(prompt_tokens=1_000_000, completion_tokens=500_000, total_tokens=1_500_000),
+    )
+
+    async def _mock_acompletion(**kwargs: Any) -> ChatCompletion:
+        return mock_response
+
+    with patch("gateway.api.routes.chat.acompletion") as mock_acompletion:
+        mock_acompletion.side_effect = _mock_acompletion
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": MODEL_NAME, "messages": test_messages, "user": "spend-user"},
+            headers=master_key_header,
+        )
+    assert response.status_code == 200
+
+    # Expected cost: 1M/1M * 2.5 + 0.5M/1M * 10 = 2.5 + 5.0 = 7.5
+    engine = create_engine(test_config.database_url)
+    session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = session_local()
+    try:
+        user = db.query(User).filter(User.user_id == "spend-user").first()
+        assert user is not None
+        assert user.spend == pytest.approx(7.5)
+        assert float(user.reserved) == pytest.approx(0.0)  # hold released
     finally:
         db.close()

--- a/tests/integration/test_user_budget.py
+++ b/tests/integration/test_user_budget.py
@@ -193,7 +193,6 @@ def test_user_with_budget(client: TestClient, master_key_header: dict[str, str])
 def test_blocked_user_cannot_make_requests(
     client: TestClient,
     master_key_header: dict[str, str],
-    api_key_header: dict[str, str],
     test_messages: list[dict[str, str]],
 ) -> None:
     """Test that blocked users cannot make completion requests."""
@@ -203,6 +202,8 @@ def test_blocked_user_cannot_make_requests(
         headers=master_key_header,
     )
 
+    # Bill the named user via the master key — a non-master key may only spend
+    # against its own user (see test_api_key_cannot_bill_other_user).
     response = client.post(
         "/v1/chat/completions",
         json={
@@ -210,7 +211,7 @@ def test_blocked_user_cannot_make_requests(
             "messages": test_messages,
             "user": "test-user-1",
         },
-        headers=api_key_header,
+        headers=master_key_header,
     )
     assert response.status_code == 403
     assert "blocked" in response.json()["detail"].lower()
@@ -235,25 +236,37 @@ def test_user_not_found_with_master_key(
     assert "not found" in response.json()["detail"].lower()
 
 
-def test_api_key_requires_existing_user_if_specified(
+def test_api_key_cannot_bill_other_user(
     client: TestClient,
     master_key_header: dict[str, str],
     api_key_header: dict[str, str],
     test_messages: list[dict[str, str]],
 ) -> None:
-    """Test that API key requests require user to exist if user field is specified."""
+    """A non-master key naming a user other than its own is rejected (IDOR fix).
+
+    Previously a user key could set ``user`` to any value and charge spend to
+    that user; the gateway now binds non-master spend to the key's own user.
+    """
+    # Create the would-be victim so this proves the rejection is an ownership
+    # check, not merely a "user not found" path.
+    client.post(
+        "/v1/users",
+        json={"user_id": "victim-user"},
+        headers=master_key_header,
+    )
+
     response = client.post(
         "/v1/chat/completions",
         json={
             "model": "openai:gpt-4o",
             "messages": test_messages,
-            "user": "nonexistent-explicit-user",
+            "user": "victim-user",
         },
         headers=api_key_header,
     )
 
-    assert response.status_code == 404
-    assert "not found" in response.json()["detail"].lower()
+    assert response.status_code == 403
+    assert "does not match" in response.json()["detail"].lower()
 
 
 def test_virtual_key_without_user(
@@ -302,7 +315,6 @@ def test_master_key_requires_user(
 def test_user_exceeded_budget_blocked_on_paid_model(
     client: TestClient,
     master_key_header: dict[str, str],
-    api_key_header: dict[str, str],
     test_messages: list[dict[str, str]],
 ) -> None:
     """Test that users who exceeded budget cannot use paid models."""
@@ -336,7 +348,7 @@ def test_user_exceeded_budget_blocked_on_paid_model(
             "messages": test_messages,
             "user": "test-user-budget",
         },
-        headers=api_key_header,
+        headers=master_key_header,
     )
     assert response.status_code == 403
     assert "budget" in response.json()["detail"].lower()
@@ -345,7 +357,6 @@ def test_user_exceeded_budget_blocked_on_paid_model(
 def test_user_exceeded_budget_allowed_on_free_model(
     client: TestClient,
     master_key_header: dict[str, str],
-    api_key_header: dict[str, str],
     test_messages: list[dict[str, str]],
 ) -> None:
     """Test that users who exceeded budget can still use free models."""
@@ -379,7 +390,7 @@ def test_user_exceeded_budget_allowed_on_free_model(
             "messages": test_messages,
             "user": "test-user-budget",
         },
-        headers=api_key_header,
+        headers=master_key_header,
     )
     assert response.status_code != 403
 
@@ -387,7 +398,6 @@ def test_user_exceeded_budget_allowed_on_free_model(
 def test_user_exceeded_budget_blocked_on_unknown_pricing(
     client: TestClient,
     master_key_header: dict[str, str],
-    api_key_header: dict[str, str],
     test_messages: list[dict[str, str]],
 ) -> None:
     """Test that users who exceeded budget are blocked when model pricing is unknown."""
@@ -411,7 +421,7 @@ def test_user_exceeded_budget_blocked_on_unknown_pricing(
             "messages": test_messages,
             "user": "test-user-budget",
         },
-        headers=api_key_header,
+        headers=master_key_header,
     )
     assert response.status_code == 403
     assert "budget" in response.json()["detail"].lower()

--- a/tests/integration/test_user_delete_preserve_logs.py
+++ b/tests/integration/test_user_delete_preserve_logs.py
@@ -111,7 +111,7 @@ def test_delete_user_preserves_budget_reset_logs(
         client.post(
             "/v1/chat/completions",
             json={"model": MODEL_NAME, "messages": test_messages, "user": "reset-user"},
-            headers=api_key_header,
+            headers=master_key_header,
         )
 
     reset_logs_before = db_session.query(BudgetResetLog).filter(BudgetResetLog.user_id == "reset-user").all()

--- a/tests/unit/test_shared_helpers_pure.py
+++ b/tests/unit/test_shared_helpers_pure.py
@@ -23,6 +23,7 @@ def test_resolve_user_id_master_key_with_user() -> None:
         master_key_error=_make_error("master key requires user"),
         no_api_key_error=_make_error("no api key"),
         no_user_error=_make_error("no user"),
+        forbidden_user_error=_make_error("forbidden user", 403),
     )
     assert user_id == "user-1"
 
@@ -36,22 +37,61 @@ def test_resolve_user_id_master_key_without_user() -> None:
             master_key_error=_make_error("master key requires user"),
             no_api_key_error=_make_error("no api key"),
             no_user_error=_make_error("no user"),
+            forbidden_user_error=_make_error("forbidden user", 403),
         )
     assert exc_info.value.detail == "master key requires user"
 
 
-def test_resolve_user_id_api_key_with_request_user() -> None:
+def test_resolve_user_id_rejects_mismatched_request_user() -> None:
+    """A non-master key naming a *different* user is rejected (IDOR fix)."""
+    api_key = MagicMock()
+    api_key.user_id = "key-user"
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_user_id(
+            user_id_from_request="someone-else",
+            api_key=api_key,
+            is_master_key=False,
+            master_key_error=_make_error("master key requires user"),
+            no_api_key_error=_make_error("no api key"),
+            no_user_error=_make_error("no user"),
+            forbidden_user_error=_make_error("forbidden user", 403),
+        )
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "forbidden user"
+
+
+def test_resolve_user_id_lenient_mode_binds_mismatch_to_key_user() -> None:
+    """With reject_mismatch=False, a foreign user is ignored and bound to the key's user."""
     api_key = MagicMock()
     api_key.user_id = "key-user"
     user_id = resolve_user_id(
-        user_id_from_request="explicit-user",
+        user_id_from_request="someone-else",
         api_key=api_key,
         is_master_key=False,
         master_key_error=_make_error("master key requires user"),
         no_api_key_error=_make_error("no api key"),
         no_user_error=_make_error("no user"),
+        forbidden_user_error=_make_error("forbidden user", 403),
+        reject_mismatch=False,
     )
-    assert user_id == "explicit-user"
+    # Bound to the key's own user — never the foreign one — so no cross-user billing.
+    assert user_id == "key-user"
+
+
+def test_resolve_user_id_allows_matching_request_user() -> None:
+    """Echoing the key's own user id is allowed and binds to that user."""
+    api_key = MagicMock()
+    api_key.user_id = "key-user"
+    user_id = resolve_user_id(
+        user_id_from_request="key-user",
+        api_key=api_key,
+        is_master_key=False,
+        master_key_error=_make_error("master key requires user"),
+        no_api_key_error=_make_error("no api key"),
+        no_user_error=_make_error("no user"),
+        forbidden_user_error=_make_error("forbidden user", 403),
+    )
+    assert user_id == "key-user"
 
 
 def test_resolve_user_id_falls_back_to_api_key() -> None:
@@ -64,6 +104,7 @@ def test_resolve_user_id_falls_back_to_api_key() -> None:
         master_key_error=_make_error("master key requires user"),
         no_api_key_error=_make_error("no api key"),
         no_user_error=_make_error("no user"),
+        forbidden_user_error=_make_error("forbidden user", 403),
     )
     assert user_id == "key-user"
 
@@ -77,6 +118,7 @@ def test_resolve_user_id_no_api_key() -> None:
             master_key_error=_make_error("master key requires user"),
             no_api_key_error=_make_error("no api key", 500),
             no_user_error=_make_error("no user"),
+            forbidden_user_error=_make_error("forbidden user", 403),
         )
     assert exc_info.value.detail == "no api key"
     assert exc_info.value.status_code == 500
@@ -93,6 +135,7 @@ def test_resolve_user_id_api_key_without_user() -> None:
             master_key_error=_make_error("master key requires user"),
             no_api_key_error=_make_error("no api key"),
             no_user_error=_make_error("no user", 500),
+            forbidden_user_error=_make_error("forbidden user", 403),
         )
     assert exc_info.value.detail == "no user"
     assert exc_info.value.status_code == 500
@@ -107,6 +150,7 @@ def test_resolve_user_id_empty_string_treated_as_missing() -> None:
             master_key_error=_make_error("master key requires user"),
             no_api_key_error=_make_error("no api key"),
             no_user_error=_make_error("no user"),
+            forbidden_user_error=_make_error("forbidden user", 403),
         )
     assert exc_info.value.detail == "master key requires user"
 

--- a/tests/unit/test_streaming_generator.py
+++ b/tests/unit/test_streaming_generator.py
@@ -86,6 +86,83 @@ async def test_streaming_generator_no_usage_skips_on_complete() -> None:
 
 
 @pytest.mark.asyncio
+async def test_streaming_generator_no_usage_invokes_on_no_usage() -> None:
+    """When a stream finishes without usage, on_no_usage fires (F4 billing policy hook)."""
+    completed = False
+    no_usage_called = False
+
+    async def on_complete(usage: CompletionUsage) -> None:
+        nonlocal completed
+        completed = True
+
+    async def on_error(error: str) -> None:
+        pytest.fail("on_error should not be called")
+
+    async def on_no_usage() -> None:
+        nonlocal no_usage_called
+        no_usage_called = True
+
+    events: list[str] = []
+    async for event in streaming_generator(
+        stream=_items("hello"),
+        format_chunk=_format_chunk,
+        extract_usage=lambda _: None,
+        fmt=OPENAI_STREAM_FORMAT,
+        on_complete=on_complete,
+        on_error=on_error,
+        label="test:model",
+        on_no_usage=on_no_usage,
+    ):
+        events.append(event)
+
+    assert events == ["data: hello\n\n", "data: [DONE]\n\n"]
+    assert not completed
+    assert no_usage_called
+
+
+@pytest.mark.asyncio
+async def test_streaming_generator_on_incomplete_on_client_disconnect() -> None:
+    """Closing the generator mid-stream (client disconnect) fires on_incomplete, not complete/error."""
+    settled: list[str] = []
+
+    async def on_complete(usage: CompletionUsage) -> None:
+        settled.append("complete")
+
+    async def on_error(error: str) -> None:
+        settled.append("error")
+
+    async def on_no_usage() -> None:
+        settled.append("no_usage")
+
+    async def on_incomplete() -> None:
+        settled.append("incomplete")
+
+    async def _infinite() -> AsyncIterator[str]:
+        i = 0
+        while True:
+            yield f"chunk-{i}"
+            i += 1
+
+    gen = streaming_generator(
+        stream=_infinite(),
+        format_chunk=_format_chunk,
+        extract_usage=lambda _: None,
+        fmt=OPENAI_STREAM_FORMAT,
+        on_complete=on_complete,
+        on_error=on_error,
+        label="test:model",
+        on_no_usage=on_no_usage,
+        on_incomplete=on_incomplete,
+    )
+
+    first = await gen.__anext__()
+    assert first == "data: chunk-0\n\n"
+    await gen.aclose()  # simulate the client hanging up mid-stream
+
+    assert settled == ["incomplete"]
+
+
+@pytest.mark.asyncio
 async def test_streaming_generator_error_openai_format() -> None:
     error_logged: list[str] = []
 


### PR DESCRIPTION
## Summary

Fixes four budget/billing vulnerabilities from a coordinated disclosure. All triaged against the source and reproduced. **Standalone (self-hosted) mode only** — platform mode resolves budgets/pricing upstream via callbacks and is unaffected (verified against `any-llm-platform`: it tracks spend/pricing in its own schema and never reads the gateway's `users` table).

| # | Severity | Issue | Fix |
|---|----------|-------|-----|
| 1 | Critical | **Cross-user IDOR** — a non-master key could set `"user"` to another user and charge/exhaust that user's budget | Spend is bound to the key's own user; a mismatched `user` is rejected (403). Master key keeps the override. |
| 2 | High | **Overspend race (TOCTOU)** — concurrent requests passed a stale budget check and collectively exceeded `max_budget` | Atomic pre-debit **reservations** (new `users.reserved` column): reserve an estimate, reconcile to actual cost on success, refund on failure. |
| 3 | Med/High | **Unpriced models served free & unmetered** (budget bypass) | `require_pricing` (default `true`) → unpriced model returns 402. Audio/moderations exempt. |
| 4 | Med | **Streaming without usage billed $0** | `stream_missing_usage_policy` (`estimate`/`fail`/`allow_free`, default `estimate`). |

The usage-log writer no longer updates `users.spend`; reservation reconciliation is the sole spend authority (avoids double-charging and batch-writer lag).

## ⚠️ Breaking changes (standalone mode)

- **`require_pricing=true` by default** → models with no pricing row return **402**. Operators running free/self-hosted models must add an explicit `$0` pricing entry or set `require_pricing=false`. A startup warning fires if enabled with no pricing configured.
- **The client `user` field is no longer trusted for non-master keys** → naming a different user returns **403**. Set `reject_user_mismatch=false` to instead bind spend to the key's own user while still forwarding `user` to the provider (OpenAI-style end-user tag). The `otari-sdk-*` clients never send a foreign `user`, so this is transparent for them; the flag is for raw OpenAI-SDK clients.
- **`stream_missing_usage_policy=estimate` by default** → a no-usage stream is billed an estimate rather than served free. Set `allow_free` for the prior behavior.

See `CHANGELOG.md`.

## New config
`require_pricing`, `reject_user_mismatch`, `stream_missing_usage_policy`, `budget_estimate_default_output_tokens`.

## Migration
`b2f4c6d8e0a1_add_user_reserved_budget` adds `users.reserved` (default 0).

## Tests
267 unit + 403 integration passing; ruff + mypy clean. New coverage: reservation accumulation (proves the race is closed), reconcile/refund accounting, the `require_pricing` 402 gate + 404/403-before-402 precedence, `streaming_generator` no-usage / client-disconnect refund, lenient `user` binding, and an e2e reserve→reconcile→`spend++`.

## Known tradeoffs (surfaced, not regressions)
- A DB error *during* settlement leaves the held estimate in `users.reserved` until the next budget reset (inherent to fail-closed pre-debit; a stale-reservation sweep could be added later).
- Non-streaming responses lacking provider `usage` still bill $0 (unchanged behavior; the missing-usage policy covers streams, where the issue was reported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)