### PR TITLE
feat(files): file uploads + document understanding for local models

### DIFF
--- a/alembic/versions/c3d5e7f9a1b3_add_file_objects.py
+++ b/alembic/versions/c3d5e7f9a1b3_add_file_objects.py
@@ -1,0 +1,51 @@
+"""add file_objects table
+
+Revision ID: c3d5e7f9a1b3
+Revises: b2f4c6d8e0a1
+Create Date: 2026-06-04 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d5e7f9a1b3"
+down_revision: str | Sequence[str] | None = "b2f4c6d8e0a1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the file_objects table backing the /v1/files API."""
+
+    op.create_table(
+        "file_objects",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("user_id", sa.String(), nullable=False),
+        sa.Column("filename", sa.String(), nullable=False),
+        sa.Column("mime_type", sa.String(), nullable=False),
+        sa.Column("bytes", sa.Integer(), nullable=False),
+        sa.Column("purpose", sa.String(), nullable=False),
+        sa.Column("storage_ref", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("metadata", sa.JSON(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.user_id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_file_objects_user_id", "file_objects", ["user_id"])
+    op.create_index("ix_file_objects_created_at", "file_objects", ["created_at"])
+    op.create_index("ix_file_objects_deleted_at", "file_objects", ["deleted_at"])
+
+
+def downgrade() -> None:
+    """Drop the file_objects table."""
+
+    op.drop_index("ix_file_objects_deleted_at", table_name="file_objects")
+    op.drop_index("ix_file_objects_created_at", table_name="file_objects")
+    op.drop_index("ix_file_objects_user_id", table_name="file_objects")
+    op.drop_table("file_objects")

--- a/config.example.yml
+++ b/config.example.yml
@@ -16,6 +16,34 @@ master_key: YOUR_MASTER_KEY_HERE
 # Prometheus metrics endpoint at /metrics. Set to true to enable.
 # enable_metrics: true
 
+# --- File uploads & document understanding ---------------------------------
+# The /v1/files endpoints accept uploads; the gateway then resolves file/image
+# content blocks in chat requests. For models that natively understand
+# documents/images the blocks pass through unchanged; for text-only local
+# models the gateway extracts the file to text (and captions images) so the
+# model can still "read" the attachment.
+# files_enabled: true
+# files_backend: "local"            # blob backend for raw bytes ('local' only today)
+# files_local_dir: "./otari-files"  # where the local backend stores bytes
+# files_max_bytes: 536870912        # 512 MB upload cap
+# files_retention_hours: 168        # auto-expire files after N hours (omit = keep)
+# file_understanding_enabled: true  # master switch for content normalization
+
+# How images are handled for text-only models: 'describe' (caption via a vision
+# model, falling back to a logged drop), 'ocr' (extract text only), or 'off'.
+# vision_strategy: "describe"
+# vision_describe_model: "ollama:qwen2-vl"   # may be local (free) or frontier
+
+# Per-model capability overrides. any-llm's provider-level flags over-report for
+# text-only models served behind OpenAI-compatible servers (vLLM, llama.cpp,
+# Ollama), so declare the truth here to enable native passthrough where it works.
+# Keys accept either separator: "provider:model" (matching pricing) or
+# "provider/model"; a bare "model" key also matches.
+# model_capabilities:
+#   "ollama:qwen2-vl":
+#     supports_image: true
+#     supports_pdf: false
+
 # Pre-configured provider credentials
 providers:
   vertexai:

--- a/config.example.yml
+++ b/config.example.yml
@@ -34,6 +34,7 @@ master_key: YOUR_MASTER_KEY_HERE
 # model, falling back to a logged drop), 'ocr' (extract text only), or 'off'.
 # vision_strategy: "describe"
 # vision_describe_model: "ollama:qwen2-vl"   # may be local (free) or frontier
+# vision_describe_max_tokens: 1024           # cap per-image caption output (billed to the user)
 
 # Per-model capability overrides. any-llm's provider-level flags over-report for
 # text-only models served behind OpenAI-compatible servers (vLLM, llama.cpp,

--- a/config.example.yml
+++ b/config.example.yml
@@ -26,7 +26,8 @@ master_key: YOUR_MASTER_KEY_HERE
 # files_backend: "local"            # blob backend for raw bytes ('local' only today)
 # files_local_dir: "./otari-files"  # where the local backend stores bytes
 # files_max_bytes: 536870912        # 512 MB upload cap
-# files_retention_hours: 168        # auto-expire files after N hours (omit = keep)
+# files_retention_hours: 168        # stop serving files after N hours; 404 thereafter (omit = keep).
+                                    # Bytes are not auto-reclaimed yet; periodic cleanup is an operator task.
 # file_understanding_enabled: true  # master switch for content normalization
 
 # How images are handled for text-only models: 'describe' (caption via a vision

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -104,6 +104,20 @@ See [Use with Claude Code](use-with-claude-code.md) for a full client setup.
 | `POST` | `/v1/audio/transcriptions` | Transcribe audio to text (multipart upload). | API key or master key |
 | `POST` | `/v1/audio/speech` | Generate speech from text (TTS). | API key or master key |
 
+### Files
+
+OpenAI-compatible file storage. Upload a file, then reference it from a chat
+request by `file_id`. See [files.md](files.md) for how uploaded files are turned
+into something a text-only local model can read.
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| `POST` | `/v1/files` | Upload a file (multipart: `file`, `purpose`). Returns a file object with an `id`. | API key or master key |
+| `GET` | `/v1/files` | List the caller's files. Query params: `purpose`. | API key or master key |
+| `GET` | `/v1/files/{file_id}` | Get file metadata. | API key or master key |
+| `GET` | `/v1/files/{file_id}/content` | Download the raw file bytes. | API key or master key |
+| `DELETE` | `/v1/files/{file_id}` | Delete a file. | API key or master key |
+
 ### Batches
 
 | Method | Path | Description | Auth |

--- a/docs/files.md
+++ b/docs/files.md
@@ -1,0 +1,89 @@
+# File uploads & document understanding
+
+Frontier models read PDFs, office documents, and images natively. Most local /
+open-source models can't — many are text-only. The gateway closes that gap: a
+user can attach a file and a text-only local model can still understand it,
+because the gateway extracts the file to text (and captions images) before the
+model ever sees the request.
+
+This works the same way the gateway's other "frontier capabilities" do: it
+inspects the request, decides what to do per attachment, and only does work the
+target model actually needs.
+
+> Standalone mode only. Platform mode routes to frontier providers that already
+> understand documents/images, so attachments pass through untouched.
+
+## Uploading a file
+
+```bash
+curl -X POST http://localhost:8000/v1/files \
+  -H "Otari-Key: Bearer $KEY" \
+  -F purpose=user_data \
+  -F file=@report.pdf
+# -> {"id": "file-abc123", "object": "file", "bytes": 84213, "filename": "report.pdf", ...}
+```
+
+Then reference it from a chat request (OpenAI shape shown; Anthropic `document`
+blocks and Responses `input_file` items work too):
+
+```json
+{
+  "model": "ollama:llama3",
+  "messages": [
+    {"role": "user", "content": [
+      {"type": "text", "text": "Summarize the attached report."},
+      {"type": "file", "file": {"file_id": "file-abc123"}}
+    ]}
+  ]
+}
+```
+
+You can also inline a file as a base64 `data:` URL (`file.file_data`) or send an
+`image_url` block, with or without uploading first.
+
+## What the gateway does per attachment
+
+For each file/image block it resolves the **target model's** capabilities, then:
+
+| Target model | Documents | Images |
+|---|---|---|
+| **Natively capable** (e.g. Anthropic, OpenAI, GPT-4o) | forwarded unchanged | forwarded unchanged |
+| **Text-only** (most local models) | extracted to text (markitdown) and inlined | captioned by a vision model / OCR, or dropped with a log line |
+
+Scanned/image-only PDFs (no extractable text) are rasterized page-by-page and
+sent through the image path.
+
+### Capability resolution
+
+The gateway must know whether the target model is natively multimodal. It uses,
+in order:
+
+1. **`model_capabilities` config override** — authoritative.
+2. **any-llm provider metadata** — trusted only for hosted providers.
+3. **Default: extract** — safe, since a needless extraction still yields a
+   correct answer while a wrong passthrough silently drops the file.
+
+> any-llm's capability flags are set per provider *class*, so they over-report
+> for text-only models served behind OpenAI-compatible servers (vLLM, llama.cpp,
+> Ollama). For those, set a `model_capabilities` override to enable native
+> passthrough where the served model truly supports it.
+
+## Configuration
+
+See [`config.example.yml`](../config.example.yml) for the full list. Key knobs:
+
+- `files_enabled`, `files_backend`, `files_local_dir`, `files_max_bytes`,
+  `files_retention_hours` — upload storage.
+- `file_understanding_enabled` — master switch for content normalization.
+- `vision_strategy` (`describe` | `ocr` | `off`) and `vision_describe_model` —
+  how images are handled for text-only models. The describe model may be a local
+  vision model (e.g. `ollama:qwen2-vl`) to keep captioning free.
+- `model_capabilities` — per-model `supports_image` / `supports_pdf` overrides.
+
+## Dependencies
+
+Text/office/PDF extraction uses [`markitdown`](https://github.com/microsoft/markitdown)
+(MIT); scanned-PDF rasterization uses [`pypdfium2`](https://github.com/pypdfium2-team/pypdfium2)
+(Apache-2.0). Both are permissively licensed — deliberately avoiding AGPL PDF
+libraries since the gateway is a network service. OCR is optional; install the
+`ocr` extra (`pip install gateway[ocr]`) to enable it.

--- a/docs/files.md
+++ b/docs/files.md
@@ -1,7 +1,7 @@
 # File uploads & document understanding
 
 Frontier models read PDFs, office documents, and images natively. Most local /
-open-source models can't — many are text-only. The gateway closes that gap: a
+open-source models can't; many are text-only. The gateway closes that gap: a
 user can attach a file and a text-only local model can still understand it,
 because the gateway extracts the file to text (and captions images) before the
 model ever sees the request.
@@ -58,9 +58,9 @@ sent through the image path.
 The gateway must know whether the target model is natively multimodal. It uses,
 in order:
 
-1. **`model_capabilities` config override** — authoritative.
-2. **any-llm provider metadata** — trusted only for hosted providers.
-3. **Default: extract** — safe, since a needless extraction still yields a
+1. **`model_capabilities` config override**: authoritative.
+2. **any-llm provider metadata**: trusted only for hosted providers.
+3. **Default: extract**, safe, since a needless extraction still yields a
    correct answer while a wrong passthrough silently drops the file.
 
 > any-llm's capability flags are set per provider *class*, so they over-report
@@ -73,17 +73,17 @@ in order:
 See [`config.example.yml`](../config.example.yml) for the full list. Key knobs:
 
 - `files_enabled`, `files_backend`, `files_local_dir`, `files_max_bytes`,
-  `files_retention_hours` — upload storage.
-- `file_understanding_enabled` — master switch for content normalization.
-- `vision_strategy` (`describe` | `ocr` | `off`) and `vision_describe_model` —
+  `files_retention_hours`: upload storage.
+- `file_understanding_enabled`: master switch for content normalization.
+- `vision_strategy` (`describe` | `ocr` | `off`) and `vision_describe_model`:
   how images are handled for text-only models. The describe model may be a local
   vision model (e.g. `ollama:qwen2-vl`) to keep captioning free.
-- `model_capabilities` — per-model `supports_image` / `supports_pdf` overrides.
+- `model_capabilities`: per-model `supports_image` / `supports_pdf` overrides.
 
 ## Dependencies
 
 Text/office/PDF extraction uses [`markitdown`](https://github.com/microsoft/markitdown)
 (MIT); scanned-PDF rasterization uses [`pypdfium2`](https://github.com/pypdfium2-team/pypdfium2)
-(Apache-2.0). Both are permissively licensed — deliberately avoiding AGPL PDF
+(Apache-2.0). Both are permissively licensed, deliberately avoiding AGPL PDF
 libraries since the gateway is a network service. OCR is optional; install the
 `ocr` extra (`pip install gateway[ocr]`) to enable it.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ Start with the [Quickstart](quickstart.md). It gets the gateway running locally 
 - [Deployment](deployment.md) — platform mode, optional services, and deployment-specific configuration.
 - [Modes](modes.md) — standalone vs connected, and what changes between them.
 - [Built-in tools](tools.md) — sandboxed code execution and web search the gateway runs itself.
+- [Files](files.md) — file uploads and document understanding for local models.
 - [Guardrails](guardrails.md) — request-level checks like prompt-injection detection.
 - [Configuration](configuration.md) — the full config file and environment variable reference.
 - [API reference](api-reference.md) — every endpoint, with auth and availability per mode.

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -88,6 +88,36 @@
         "title": "BatchRequestItem",
         "type": "object"
       },
+      "Body_create_file_v1_files_post": {
+        "properties": {
+          "file": {
+            "contentMediaType": "application/octet-stream",
+            "title": "File",
+            "type": "string"
+          },
+          "purpose": {
+            "default": "user_data",
+            "title": "Purpose",
+            "type": "string"
+          },
+          "user": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "Body_create_file_v1_files_post",
+        "type": "object"
+      },
       "Body_create_transcription_v1_audio_transcriptions_post": {
         "properties": {
           "file": {
@@ -3145,6 +3175,293 @@
         "summary": "Create Embedding",
         "tags": [
           "embeddings"
+        ]
+      }
+    },
+    "/v1/files": {
+      "get": {
+        "description": "List the authenticated user's uploaded files.",
+        "operationId": "list_files_v1_files_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "user",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User"
+            }
+          },
+          {
+            "in": "query",
+            "name": "purpose",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Purpose"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Files V1 Files Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Files",
+        "tags": [
+          "files"
+        ]
+      },
+      "post": {
+        "description": "OpenAI-compatible file upload endpoint.",
+        "operationId": "create_file_v1_files_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_create_file_v1_files_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Create File V1 Files Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create File",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/v1/files/{file_id}": {
+      "delete": {
+        "description": "Soft-delete a file's metadata and remove its bytes from the backend.",
+        "operationId": "delete_file_v1_files__file_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "title": "File Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "user",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Delete File V1 Files  File Id  Delete",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete File",
+        "tags": [
+          "files"
+        ]
+      },
+      "get": {
+        "description": "Retrieve metadata for a single file.",
+        "operationId": "get_file_v1_files__file_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "title": "File Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "user",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get File V1 Files  File Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get File",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/v1/files/{file_id}/content": {
+      "get": {
+        "description": "Download the raw bytes of a file.",
+        "operationId": "get_file_content_v1_files__file_id__content_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "title": "File Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "user",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get File Content",
+        "tags": [
+          "files"
         ]
       }
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,10 @@ dependencies = [
     "asyncpg>=0.29.0",
     "click>=8.1.0",
     "fastapi>=0.115.0",
+    "markitdown[docx,pptx,xlsx,pdf]>=0.1.0",
     "mcp>=1.0.0",
+    "pillow>=10.0.0",
+    "pypdfium2>=4.30.0",
     "prometheus-client>=0.20.0",
     "psycopg2-binary>=2.9.9",
     "pydantic-settings>=2.0.0",
@@ -24,6 +27,14 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0.0",
     "trafilatura>=2.0.0",
     "uvicorn[standard]>=0.30.0",
+]
+
+[project.optional-dependencies]
+# Optional OCR backend for image/scanned-PDF text extraction. Heavy (onnxruntime),
+# so it's opt-in; the gateway degrades to vision-describe / drop when absent.
+ocr = [
+    "rapidocr-onnxruntime>=1.3.0",
+    "numpy>=1.26.0",
 ]
 
 [dependency-groups]
@@ -79,5 +90,12 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["trafilatura.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+# Optional/untyped extraction deps imported at the root (e.g. `import pypdfium2`,
+# `from markitdown import ...`). Bare root names are required — a `foo.*` pattern
+# alone does not match the top-level `foo` module these are imported as.
+module = ["markitdown", "pypdfium2", "rapidocr_onnxruntime", "numpy", "PIL"]
 ignore_missing_imports = true
 

--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -13,6 +13,7 @@ from gateway.core.config import API_KEY_HEADER, LEGACY_API_KEY_HEADERS, GatewayC
 from gateway.core.database import get_db
 from gateway.metrics import record_auth_failure
 from gateway.models.entities import APIKey
+from gateway.services.file_store import FileStore
 from gateway.services.log_writer import LogWriter
 
 _config: GatewayConfig | None = None
@@ -246,12 +247,19 @@ def get_log_writer(request: Request) -> LogWriter:
     return writer
 
 
+def get_file_store(request: Request) -> FileStore:
+    """Return the configured blob store for uploaded files (standalone mode)."""
+    store: FileStore = request.app.state.file_store
+    return store
+
+
 __all__ = [
     "get_config",
     "get_db",
     "reset_config",
     "set_config",
     "get_db_if_needed",
+    "get_file_store",
     "get_log_writer",
     "verify_api_key",
     "verify_api_key_or_master_key",

--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -6,6 +6,7 @@ from gateway.api.routes import (
     budgets,
     chat,
     embeddings,
+    files,
     health,
     images,
     keys,
@@ -37,6 +38,7 @@ def register_routers(app: FastAPI, config: GatewayConfig) -> None:
     app.include_router(embeddings.router)
     app.include_router(images.router)
     app.include_router(audio.router)
+    app.include_router(files.router)
     app.include_router(rerank.router)
     app.include_router(batches.router)
     app.include_router(moderations.router)

--- a/src/gateway/api/routes/_normalize.py
+++ b/src/gateway/api/routes/_normalize.py
@@ -1,0 +1,65 @@
+"""Shared glue for running the content normalizer from the request routes.
+
+Resolves the target model's multimodal capabilities and rewrites file/image
+content blocks in place — passthrough for natively-capable providers, extract to
+text for text-only models. Used by the Chat-Completions, Anthropic Messages, and
+OpenAI Responses endpoints so all three get identical handling.
+
+Only the standalone path calls this: platform mode routes to frontier providers
+that natively understand documents/images (passthrough is already correct) and
+has no local DB / file store to resolve ``file_id`` references against.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from any_llm import LLMProvider
+from fastapi import Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger
+from gateway.services.content_normalizer import NormalizationStats, WireFormat, normalize_messages
+from gateway.services.model_capabilities import resolve_capabilities
+
+
+async def normalize_request_messages(
+    messages: list[dict[str, Any]],
+    *,
+    fmt: WireFormat,
+    config: GatewayConfig,
+    provider: LLMProvider | None,
+    model: str,
+    db: AsyncSession | None,
+    raw_request: Request,
+    user_id: str | None,
+) -> tuple[list[dict[str, Any]], NormalizationStats]:
+    """Normalize ``messages`` for the resolved ``provider/model``.
+
+    No-ops (returns the input untouched) when file understanding is disabled or
+    the provider couldn't be parsed — the downstream provider call surfaces an
+    unknown model with its own status code.
+
+    This is called after the budget reservation, so it must never raise: an
+    unexpected failure would otherwise leak the in-flight reservation. The
+    normalizer is already defensive per-block; this is a belt-and-suspenders
+    guard that forwards the original messages unchanged on any error.
+    """
+    if provider is None or not config.file_understanding_enabled:
+        return messages, NormalizationStats()
+    try:
+        caps = resolve_capabilities(config, provider, model)
+        file_store = getattr(raw_request.app.state, "file_store", None)
+        return await normalize_messages(
+            messages,
+            config=config,
+            caps=caps,
+            fmt=fmt,
+            db=db,
+            file_store=file_store,
+            user_id=user_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — never fail the request / leak the reservation
+        logger.warning("content normalization failed; forwarding messages unchanged: %s", exc)
+        return messages, NormalizationStats()

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -291,6 +291,52 @@ class RequestContext:
         self.reservation = reservation
 
 
+async def _bill_vision_side_call(
+    *,
+    db: AsyncSession,
+    log_writer: LogWriter,
+    config: GatewayConfig,
+    api_key_id: str | None,
+    user_id: str,
+    endpoint: str,
+    usage: CompletionUsage,
+) -> None:
+    """Meter and bill a vision describe side-call made during normalization.
+
+    The describe model already ran (to caption an image for a text-only target
+    model), so its cost is recorded as its own usage-log row for the configured
+    vision model and committed directly to ``users.spend``. It is intentionally
+    not gated or refundable: the cost is already incurred, so a budget reject
+    here would lose it, and refunding the main request must not erase it.
+    No-op when no vision model is configured or its selector can't be parsed.
+    """
+    model_selector = config.vision_describe_model
+    if not model_selector:
+        return
+    try:
+        provider, model = AnyLLM.split_model_provider(model_selector)
+    except (ValueError, AnyLLMError):
+        logger.warning("vision billing: cannot parse vision_describe_model %r", model_selector)
+        return
+    cost = await log_usage(
+        db=db,
+        log_writer=log_writer,
+        api_key_id=api_key_id,
+        model=model,
+        provider=provider.value if provider else None,
+        endpoint=endpoint,
+        user_id=user_id,
+        usage_override=usage,
+    )
+    # Commit the spend directly via an unreserved handle (no held estimate to
+    # release): this just adds the actual cost to users.spend.
+    await reconcile_reservation(
+        db,
+        ReservationHandle(user_id=user_id, estimate=0.0, reserved=False, strategy=config.budget_strategy),
+        cost or 0.0,
+    )
+
+
 async def resolve_request_context(
     *,
     adapter: FormatAdapter[Any, Any],
@@ -305,7 +351,8 @@ async def resolve_request_context(
     estimate_max_output_tokens: int | None,
     master_key_user_required_detail: str,
     user_forbidden_detail: str,
-    normalize_messages: Callable[[str, LLMProvider | None, str], Awaitable[int]] | None = None,
+    normalize_messages: Callable[[str, LLMProvider | None, str], Awaitable[tuple[int, CompletionUsage | None]]]
+    | None = None,
 ) -> RequestContext:
     """Run the shared handler preamble up to (and including) budget pre-debit.
 
@@ -324,7 +371,10 @@ async def resolve_request_context(
     user-scoped) and after the provider/model split (capability detection needs
     it), and returns the post-normalization prompt-char count so the reservation
     reflects any text extracted from attachments. It is never called in platform
-    mode, where the files feature is unavailable.
+    mode, where the files feature is unavailable. It returns
+    ``(prompt_chars, vision_usage)``; any vision describe side-call it made is
+    metered and billed here as committed spend (the call already happened, so it
+    is not gated or refundable).
     """
     platform_mode = config.is_platform_mode
     route: ResolvedRoute | None = None
@@ -405,7 +455,7 @@ async def resolve_request_context(
         # provider-call settlement does not cover.
         if normalize_messages is not None:
             try:
-                post_chars = await normalize_messages(user_id, gate_provider, gate_model)
+                post_chars, vision_usage = await normalize_messages(user_id, gate_provider, gate_model)
                 post_estimate = estimate_cost(
                     gate_pricing,
                     prompt_chars=post_chars,
@@ -419,6 +469,16 @@ async def resolve_request_context(
                     model=model,
                     strategy=config.budget_strategy,
                 )
+                if vision_usage is not None:
+                    await _bill_vision_side_call(
+                        db=db,
+                        log_writer=log_writer,
+                        config=config,
+                        api_key_id=api_key_id,
+                        user_id=user_id,
+                        endpoint=adapter.endpoint,
+                        usage=vision_usage,
+                    )
             except HTTPException:
                 await refund_reservation(db, reservation)
                 raise

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -32,7 +32,7 @@ import asyncio
 import os
 import time
 import uuid
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import AsyncExitStack
 from datetime import UTC, datetime
 from enum import Enum, auto
@@ -82,6 +82,7 @@ from gateway.rate_limit import RateLimitInfo, check_rate_limit
 from gateway.services.budget_service import (
     ReservationHandle,
     estimate_cost,
+    increase_reservation,
     reconcile_reservation,
     refund_reservation,
     reserve_budget,
@@ -304,6 +305,7 @@ async def resolve_request_context(
     estimate_max_output_tokens: int | None,
     master_key_user_required_detail: str,
     user_forbidden_detail: str,
+    normalize_messages: Callable[[str, LLMProvider | None, str], Awaitable[int]] | None = None,
 ) -> RequestContext:
     """Run the shared handler preamble up to (and including) budget pre-debit.
 
@@ -315,6 +317,14 @@ async def resolve_request_context(
     before the missing-pricing gate so user/blocked/budget rejections
     (404/403) take precedence over the 402; it is refunded if the request is
     then rejected for missing pricing.
+
+    ``normalize_messages`` (standalone only) is an optional hook the file
+    feature uses to resolve uploaded attachments into the wire payload before
+    the cost estimate. It runs after the billed user is known (file access is
+    user-scoped) and after the provider/model split (capability detection needs
+    it), and returns the post-normalization prompt-char count so the reservation
+    reflects any text extracted from attachments. It is never called in platform
+    mode, where the files feature is unavailable.
     """
     platform_mode = config.is_platform_mode
     route: ResolvedRoute | None = None
@@ -365,6 +375,7 @@ async def resolve_request_context(
             gate_provider, gate_model = AnyLLM.split_model_provider(model)
         except (ValueError, AnyLLMError):
             gate_provider, gate_model = None, model
+
         gate_pricing = await find_model_pricing(db, gate_provider, gate_model)
         estimate = estimate_cost(
             gate_pricing,
@@ -383,6 +394,42 @@ async def resolve_request_context(
                 f"No pricing configured for model '{model}'",
                 ErrorKind.INVALID_REQUEST,
             )
+
+        # Resolve uploaded attachments only once the request is authorized
+        # (user exists, not blocked, within budget, pricing OK). Done after the
+        # budget gate so a blocked/over-budget user can't trigger extraction or
+        # vision side-calls. Attachments may expand the prompt (extracted
+        # document text, image captions), so top up the reservation to the
+        # post-normalization size; the top-up rejects if it no longer fits.
+        # Refund on any failure in this setup phase, which the downstream
+        # provider-call settlement does not cover.
+        if normalize_messages is not None:
+            try:
+                post_chars = await normalize_messages(user_id, gate_provider, gate_model)
+                post_estimate = estimate_cost(
+                    gate_pricing,
+                    prompt_chars=post_chars,
+                    max_output_tokens=estimate_max_output_tokens,
+                    default_output_tokens=config.budget_estimate_default_output_tokens,
+                )
+                await increase_reservation(
+                    db,
+                    reservation,
+                    post_estimate - estimate,
+                    model=model,
+                    strategy=config.budget_strategy,
+                )
+            except HTTPException:
+                await refund_reservation(db, reservation)
+                raise
+            except Exception as exc:
+                await refund_reservation(db, reservation)
+                logger.error("Request setup failed after reservation: %s", exc)
+                raise adapter.error(
+                    500,
+                    "Failed to process request attachments",
+                    ErrorKind.API,
+                ) from exc
 
     return RequestContext(
         config=config,

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -4,7 +4,7 @@ from collections.abc import AsyncIterator, Callable
 from typing import Annotated, Any
 
 import httpx
-from any_llm import AnyLLM, acompletion
+from any_llm import AnyLLM, LLMProvider, acompletion
 from any_llm.types.completion import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db_if_needed, get_log_writer
 from gateway.api.routes._helpers import latest_user_text
+from gateway.api.routes._normalize import normalize_request_messages
 from gateway.api.routes._pipeline import (
     ALL_PROVIDERS_FAILED_DETAIL,
     ALL_PROVIDERS_TIMED_OUT_DETAIL,
@@ -247,6 +248,23 @@ async def chat_completions(
             detail="Invalid request: model is required",
         )
 
+    async def _normalize(user_id: str, provider: LLMProvider | None, model: str) -> int:
+        # Resolve uploaded file/image blocks into the wire payload (extract to
+        # text for text-only models, inline for natively-capable ones) before
+        # the cost estimate. Standalone only; no-op when the files feature is
+        # off or the request has no attachments.
+        request.messages, _ = await normalize_request_messages(
+            request.messages,
+            fmt="openai",
+            config=config,
+            provider=provider,
+            model=model,
+            db=db,
+            raw_request=raw_request,
+            user_id=user_id,
+        )
+        return len(str(request.messages))
+
     ctx = await resolve_request_context(
         adapter=_ADAPTER,
         raw_request=raw_request,
@@ -262,6 +280,7 @@ async def chat_completions(
         ),
         master_key_user_required_detail=_MASTER_KEY_USER_REQUIRED,
         user_forbidden_detail=_USER_FORBIDDEN,
+        normalize_messages=_normalize,
     )
 
     tool_ctx = await prepare_gateway_tools(

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -248,12 +248,14 @@ async def chat_completions(
             detail="Invalid request: model is required",
         )
 
-    async def _normalize(user_id: str, provider: LLMProvider | None, model: str) -> int:
+    async def _normalize(
+        user_id: str, provider: LLMProvider | None, model: str
+    ) -> tuple[int, CompletionUsage | None]:
         # Resolve uploaded file/image blocks into the wire payload (extract to
         # text for text-only models, inline for natively-capable ones) before
         # the cost estimate. Standalone only; no-op when the files feature is
         # off or the request has no attachments.
-        request.messages, _ = await normalize_request_messages(
+        request.messages, stats = await normalize_request_messages(
             request.messages,
             fmt="openai",
             config=config,
@@ -263,7 +265,7 @@ async def chat_completions(
             raw_request=raw_request,
             user_id=user_id,
         )
-        return len(str(request.messages))
+        return len(str(request.messages)), stats.vision_usage()
 
     ctx = await resolve_request_context(
         adapter=_ADAPTER,

--- a/src/gateway/api/routes/files.py
+++ b/src/gateway/api/routes/files.py
@@ -265,6 +265,13 @@ async def delete_file(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to delete file",
         ) from exc
-    await file_store.delete(storage_ref)
+
+    # The soft-delete already committed, so the file is gone from the user's
+    # view. Removing the blob is best-effort cleanup: a backend failure must not
+    # turn a successful delete into a 500 (it would only leave an orphaned blob).
+    try:
+        await file_store.delete(storage_ref)
+    except OSError as exc:
+        logger.warning("Soft-deleted file %s but failed to remove its blob %s: %s", file_id, storage_ref, exc)
 
     return {"id": file_id, "object": "file", "deleted": True}

--- a/src/gateway/api/routes/files.py
+++ b/src/gateway/api/routes/files.py
@@ -1,0 +1,270 @@
+"""OpenAI-compatible file upload/storage endpoints.
+
+Stores uploaded files so they can later be referenced from chat messages by
+``file_id``. The content normalizer (gateway.services.content_normalizer)
+resolves those references and either forwards them to natively-capable
+providers or extracts them to text for text-only local models.
+"""
+
+import mimetypes
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Annotated, Any
+from urllib.parse import quote
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from fastapi.responses import Response
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.api.deps import get_config, get_db, get_file_store, verify_api_key_or_master_key
+from gateway.api.routes._helpers import resolve_user_id
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger
+from gateway.models.entities import APIKey, FileObject
+from gateway.services.file_service import fetch_file, read_file_bytes
+from gateway.services.file_store import FileStore
+
+router = APIRouter(prefix="/v1", tags=["files"])
+
+# OpenAI's documented file purposes plus a generic default. We don't enforce the
+# enum (forward-compat), but normalise the empty case to "user_data".
+_DEFAULT_PURPOSE = "user_data"
+
+
+def _resolve_user(
+    auth_result: tuple[APIKey | None, bool],
+    user: str | None,
+) -> str:
+    api_key, is_master_key = auth_result
+    return resolve_user_id(
+        user_id_from_request=user,
+        api_key=api_key,
+        is_master_key=is_master_key,
+        master_key_error=HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="When using master key, 'user' field is required",
+        ),
+        no_api_key_error=HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key validation failed",
+        ),
+        no_user_error=HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key has no associated user",
+        ),
+        forbidden_user_error=HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="'user' field does not match the authenticated API key's user",
+        ),
+    )
+
+
+_READ_CHUNK_BYTES = 1024 * 1024
+
+
+async def _read_capped(file: UploadFile, max_bytes: int) -> bytes:
+    """Read an upload in chunks, aborting with 413 once it exceeds ``max_bytes``.
+
+    Avoids buffering an unbounded upload before the size check — reading stops
+    at most one chunk past the limit.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    while chunk := await file.read(_READ_CHUNK_BYTES):
+        total += len(chunk)
+        if total > max_bytes:
+            raise HTTPException(
+                status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                detail=f"File exceeds maximum upload size of {max_bytes // (1024 * 1024)} MB",
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _content_disposition(filename: str) -> str:
+    """Build a Content-Disposition header value that is safe from injection.
+
+    ``filename`` is user-controlled (set at upload), so interpolating it raw
+    would allow CRLF/quote header injection. We emit an ASCII-sanitized
+    ``filename`` for legacy clients plus an RFC 5987 percent-encoded
+    ``filename*`` for the real (possibly non-ASCII) name.
+    """
+    ascii_name = "".join(c for c in filename if c.isprintable() and c not in '"\\').encode(
+        "ascii", "ignore"
+    ).decode("ascii")
+    ascii_name = ascii_name.strip() or "download"
+    encoded = quote(filename, safe="")
+    return f"attachment; filename=\"{ascii_name}\"; filename*=UTF-8''{encoded}"
+
+
+def _guess_mime(filename: str | None, declared: str | None) -> str:
+    if declared and declared != "application/octet-stream":
+        return declared
+    if filename:
+        guessed, _ = mimetypes.guess_type(filename)
+        if guessed:
+            return guessed
+    return declared or "application/octet-stream"
+
+
+@router.post("/files")
+async def create_file(
+    auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    file_store: Annotated[FileStore, Depends(get_file_store)],
+    file: UploadFile = File(...),
+    purpose: str = Form(_DEFAULT_PURPOSE),
+    user: str | None = Form(None),
+) -> dict[str, Any]:
+    """OpenAI-compatible file upload endpoint."""
+    if not config.files_enabled:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File uploads are disabled")
+
+    user_id = _resolve_user(auth_result, user)
+
+    data = await _read_capped(file, config.files_max_bytes)
+    if not data:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Uploaded file is empty")
+
+    file_id = f"file-{uuid.uuid4().hex}"
+    storage_ref = await file_store.put(file_id, data)
+
+    expires_at: datetime | None = None
+    if config.files_retention_hours is not None:
+        expires_at = datetime.now(UTC) + timedelta(hours=config.files_retention_hours)
+
+    record = FileObject(
+        id=file_id,
+        user_id=user_id,
+        filename=file.filename or file_id,
+        mime_type=_guess_mime(file.filename, file.content_type),
+        bytes=len(data),
+        purpose=purpose or _DEFAULT_PURPOSE,
+        storage_ref=storage_ref,
+        created_at=datetime.now(UTC),
+        expires_at=expires_at,
+    )
+    db.add(record)
+    try:
+        await db.commit()
+    except SQLAlchemyError as exc:
+        await db.rollback()
+        # The bytes were written before the metadata commit; drop them so a
+        # failed insert doesn't leak an unreferenced blob.
+        await file_store.delete(storage_ref)
+        logger.error("Failed to persist file metadata for %s: %s", file_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to store file",
+        ) from exc
+
+    logger.info("Stored file %s (%d bytes) for user %s", file_id, len(data), user_id)
+    return record.to_dict()
+
+
+@router.get("/files")
+async def list_files(
+    auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    user: str | None = None,
+    purpose: str | None = None,
+) -> dict[str, Any]:
+    """List the authenticated user's uploaded files."""
+    if not config.files_enabled:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File uploads are disabled")
+
+    user_id = _resolve_user(auth_result, user)
+    stmt = select(FileObject).where(
+        FileObject.user_id == user_id,
+        FileObject.deleted_at.is_(None),
+    )
+    if purpose is not None:
+        stmt = stmt.where(FileObject.purpose == purpose)
+    stmt = stmt.order_by(FileObject.created_at.desc())
+
+    result = await db.execute(stmt)
+    records = result.scalars().all()
+    return {"object": "list", "data": [r.to_dict() for r in records]}
+
+
+@router.get("/files/{file_id}")
+async def get_file(
+    file_id: str,
+    auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    user: str | None = None,
+) -> dict[str, Any]:
+    """Retrieve metadata for a single file."""
+    if not config.files_enabled:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File uploads are disabled")
+
+    user_id = _resolve_user(auth_result, user)
+    record = await fetch_file(db, file_id, user_id)
+    if record is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
+    return record.to_dict()
+
+
+@router.get("/files/{file_id}/content")
+async def get_file_content(
+    file_id: str,
+    auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    file_store: Annotated[FileStore, Depends(get_file_store)],
+    user: str | None = None,
+) -> Response:
+    """Download the raw bytes of a file."""
+    if not config.files_enabled:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File uploads are disabled")
+
+    user_id = _resolve_user(auth_result, user)
+    record = await fetch_file(db, file_id, user_id)
+    if record is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
+
+    data = await read_file_bytes(file_store, record)
+    return Response(
+        content=data,
+        media_type=record.mime_type,
+        headers={"Content-Disposition": _content_disposition(record.filename)},
+    )
+
+
+@router.delete("/files/{file_id}")
+async def delete_file(
+    file_id: str,
+    auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    file_store: Annotated[FileStore, Depends(get_file_store)],
+    user: str | None = None,
+) -> dict[str, Any]:
+    """Soft-delete a file's metadata and remove its bytes from the backend."""
+    if not config.files_enabled:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File uploads are disabled")
+
+    user_id = _resolve_user(auth_result, user)
+    record = await fetch_file(db, file_id, user_id)
+    if record is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
+
+    storage_ref = record.storage_ref
+    record.deleted_at = datetime.now(UTC)
+    try:
+        await db.commit()
+    except SQLAlchemyError as exc:
+        await db.rollback()
+        logger.error("Failed to delete file %s: %s", file_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete file",
+        ) from exc
+    await file_store.delete(storage_ref)
+
+    return {"id": file_id, "object": "file", "deleted": True}

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -289,11 +289,13 @@ async def create_message(
     """
     user_from_metadata = request.metadata.get("user_id") if request.metadata else None
 
-    async def _normalize(user_id: str, provider: LLMProvider | None, model: str) -> int:
+    async def _normalize(
+        user_id: str, provider: LLMProvider | None, model: str
+    ) -> tuple[int, CompletionUsage | None]:
         # Resolve uploaded file/image blocks into the Anthropic wire payload
         # before the cost estimate. Standalone only; no-op when the files
         # feature is off or the request has no attachments.
-        request.messages, _ = await normalize_request_messages(
+        request.messages, stats = await normalize_request_messages(
             request.messages,
             fmt="anthropic",
             config=config,
@@ -303,7 +305,7 @@ async def create_message(
             raw_request=raw_request,
             user_id=user_id,
         )
-        return len(str(request.messages)) + len(str(request.system or ""))
+        return len(str(request.messages)) + len(str(request.system or "")), stats.vision_usage()
 
     ctx = await resolve_request_context(
         adapter=_ADAPTER,

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db_if_needed, get_log_writer, verify_api_key_or_master_key
 from gateway.api.routes._helpers import latest_user_text
+from gateway.api.routes._normalize import normalize_request_messages
 from gateway.api.routes._pipeline import (
     ALL_PROVIDERS_FAILED_DETAIL,
     ALL_PROVIDERS_TIMED_OUT_DETAIL,
@@ -287,6 +288,23 @@ async def create_message(
     follow-up will enable pre-lock-in fallback for tool-loop requests too.
     """
     user_from_metadata = request.metadata.get("user_id") if request.metadata else None
+
+    async def _normalize(user_id: str, provider: LLMProvider | None, model: str) -> int:
+        # Resolve uploaded file/image blocks into the Anthropic wire payload
+        # before the cost estimate. Standalone only; no-op when the files
+        # feature is off or the request has no attachments.
+        request.messages, _ = await normalize_request_messages(
+            request.messages,
+            fmt="anthropic",
+            config=config,
+            provider=provider,
+            model=model,
+            db=db,
+            raw_request=raw_request,
+            user_id=user_id,
+        )
+        return len(str(request.messages)) + len(str(request.system or ""))
+
     ctx = await resolve_request_context(
         adapter=_ADAPTER,
         raw_request=raw_request,
@@ -300,6 +318,7 @@ async def create_message(
         estimate_max_output_tokens=request.max_tokens,
         master_key_user_required_detail=_MASTER_KEY_USER_REQUIRED,
         user_forbidden_detail=_USER_FORBIDDEN,
+        normalize_messages=_normalize,
     )
 
     tool_ctx = await prepare_gateway_tools(

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db_if_needed, get_log_writer
 from gateway.api.routes._helpers import latest_user_text, text_from_content
+from gateway.api.routes._normalize import normalize_request_messages
 from gateway.api.routes._pipeline import (
     ALL_PROVIDERS_FAILED_DETAIL,
     ALL_PROVIDERS_TIMED_OUT_DETAIL,
@@ -262,6 +263,22 @@ async def create_response(
     raw_max_output = getattr(request_body, "max_output_tokens", None)
     max_output_tokens = raw_max_output if isinstance(raw_max_output, int) and raw_max_output >= 0 else None
 
+    async def _normalize(user_id: str, provider: LLMProvider | None, model: str) -> int:
+        # Resolve uploaded file/image blocks into the Responses input payload
+        # before the cost estimate. Standalone only; no-op when the files
+        # feature is off or the request has no attachments.
+        request_body.input, _ = await normalize_request_messages(
+            request_body.input,
+            fmt="responses",
+            config=config,
+            provider=provider,
+            model=model,
+            db=db,
+            raw_request=raw_request,
+            user_id=user_id,
+        )
+        return len(str(request_body.input)) + len(str(getattr(request_body, "instructions", "") or ""))
+
     ctx = await resolve_request_context(
         adapter=_ADAPTER,
         raw_request=raw_request,
@@ -276,6 +293,7 @@ async def create_response(
         estimate_max_output_tokens=max_output_tokens,
         master_key_user_required_detail=_MASTER_KEY_USER_REQUIRED,
         user_forbidden_detail=_USER_FORBIDDEN,
+        normalize_messages=_normalize,
     )
 
     # Provider-support guard: an unsupported provider would just fail

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -263,11 +263,13 @@ async def create_response(
     raw_max_output = getattr(request_body, "max_output_tokens", None)
     max_output_tokens = raw_max_output if isinstance(raw_max_output, int) and raw_max_output >= 0 else None
 
-    async def _normalize(user_id: str, provider: LLMProvider | None, model: str) -> int:
+    async def _normalize(
+        user_id: str, provider: LLMProvider | None, model: str
+    ) -> tuple[int, CompletionUsage | None]:
         # Resolve uploaded file/image blocks into the Responses input payload
         # before the cost estimate. Standalone only; no-op when the files
         # feature is off or the request has no attachments.
-        request_body.input, _ = await normalize_request_messages(
+        request_body.input, stats = await normalize_request_messages(
             request_body.input,
             fmt="responses",
             config=config,
@@ -277,7 +279,8 @@ async def create_response(
             raw_request=raw_request,
             user_id=user_id,
         )
-        return len(str(request_body.input)) + len(str(getattr(request_body, "instructions", "") or ""))
+        chars = len(str(request_body.input)) + len(str(getattr(request_body, "instructions", "") or ""))
+        return chars, stats.vision_usage()
 
     ctx = await resolve_request_context(
         adapter=_ADAPTER,

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -206,7 +206,11 @@ class GatewayConfig(BaseSettings):
     files_retention_hours: int | None = Field(
         default=None,
         ge=1,
-        description="Delete stored files older than this many hours (None keeps them indefinitely).",
+        description=(
+            "Stop serving files older than this many hours: expired files become inaccessible "
+            "(404) and can no longer be referenced. Their stored bytes are not yet reclaimed "
+            "automatically, so periodic cleanup is an operator task. None keeps files indefinitely."
+        ),
     )
     file_understanding_enabled: bool = Field(
         default=True,

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -46,6 +46,28 @@ class PricingConfig(BaseModel):
     )
 
 
+class ModelCapabilityConfig(BaseModel):
+    """Per-model multimodal capability override.
+
+    any-llm exposes provider-class-level ``SUPPORTS_COMPLETION_IMAGE`` /
+    ``SUPPORTS_COMPLETION_PDF`` flags, but those are set on the OpenAI-compatible
+    base class and so over-report for text-only local models served behind an
+    OpenAI-compatible endpoint (vLLM, llama.cpp, LM Studio). This map lets an
+    operator state the truth per ``provider/model`` key so the content
+    normalizer extracts files to text instead of forwarding blocks the model
+    silently drops. See gateway.services.model_capabilities.
+    """
+
+    supports_image: bool = Field(
+        default=False,
+        description="Model can natively understand image content blocks (vision).",
+    )
+    supports_pdf: bool = Field(
+        default=False,
+        description="Model can natively understand PDF/document content blocks.",
+    )
+
+
 class GatewayConfig(BaseSettings):
     """Gateway configuration with support for YAML files and environment variables."""
 
@@ -164,6 +186,60 @@ class GatewayConfig(BaseSettings):
         ge=0,
         description="TTL in seconds for the in-memory model discovery cache (0 disables caching)",
     )
+    files_enabled: bool = Field(
+        default=True,
+        description="Enable the /v1/files upload/storage endpoints (standalone mode).",
+    )
+    files_backend: str = Field(
+        default="local",
+        description="Blob backend for uploaded file bytes: 'local' (filesystem). Future: 's3', 'gcs'.",
+    )
+    files_local_dir: str = Field(
+        default="./otari-files",
+        description="Directory for the 'local' files backend to store uploaded bytes.",
+    )
+    files_max_bytes: int = Field(
+        default=512 * 1024 * 1024,
+        ge=1,
+        description="Maximum size in bytes for a single uploaded file.",
+    )
+    files_retention_hours: int | None = Field(
+        default=None,
+        ge=1,
+        description="Delete stored files older than this many hours (None keeps them indefinitely).",
+    )
+    file_understanding_enabled: bool = Field(
+        default=True,
+        description=(
+            "Normalize file/image content blocks before the provider call: pass through for "
+            "natively-capable models, extract to text for text-only models. When False, content "
+            "blocks are forwarded unchanged (legacy pass-through)."
+        ),
+    )
+    vision_strategy: str = Field(
+        default="describe",
+        description=(
+            "How image blocks are handled for text-only models: 'describe' (side-call a vision "
+            "model, falling back to a logged drop if none is configured), 'ocr' (extract text only), "
+            "or 'off' (drop with a log line)."
+        ),
+    )
+    vision_describe_model: str | None = Field(
+        default=None,
+        description=(
+            "provider/model used to caption images for text-only target models when "
+            "vision_strategy='describe'. May point at a local vision model (e.g. ollama/qwen2-vl) "
+            "to keep captioning free. When unset, 'describe' falls back to a logged drop."
+        ),
+    )
+    model_capabilities: dict[str, ModelCapabilityConfig] = Field(
+        default_factory=dict,
+        description=(
+            "Per-model multimodal capability overrides (provider/model -> {supports_image, "
+            "supports_pdf}). Authoritative over any-llm's provider-level flags; needed for text-only "
+            "local models behind OpenAI-compatible servers."
+        ),
+    )
     mode: str = Field(default="standalone", description="Gateway operating mode: standalone or platform")
     platform: dict[str, Any] = Field(default_factory=dict, description="Platform integration settings")
 
@@ -188,6 +264,16 @@ class GatewayConfig(BaseSettings):
         allowed = {"estimate", "fail", "allow_free"}
         if normalized not in allowed:
             msg = f"stream_missing_usage_policy must be one of {sorted(allowed)}, got '{value}'"
+            raise ValueError(msg)
+        return normalized
+
+    @field_validator("vision_strategy")
+    @classmethod
+    def _validate_vision_strategy(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        allowed = {"describe", "ocr", "off"}
+        if normalized not in allowed:
+            msg = f"vision_strategy must be one of {sorted(allowed)}, got '{value}'"
             raise ValueError(msg)
         return normalized
 

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -236,6 +236,15 @@ class GatewayConfig(BaseSettings):
             "to keep captioning free. When unset, 'describe' falls back to a logged drop."
         ),
     )
+    vision_describe_max_tokens: int = Field(
+        default=1024,
+        gt=0,
+        description=(
+            "Cap on the describe model's output tokens per image. Bounds the cost and latency "
+            "of the vision side-call, which is billed to the user and runs once per image (and "
+            "once per page for scanned PDFs)."
+        ),
+    )
     model_capabilities: dict[str, ModelCapabilityConfig] = Field(
         default_factory=dict,
         description=(

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -14,6 +14,7 @@ from gateway.core.config import API_KEY_HEADER, LEGACY_API_KEY_HEADERS, GatewayC
 from gateway.core.database import create_session, init_db
 from gateway.rate_limit import RateLimiter
 from gateway.services.bootstrap_service import bootstrap_first_api_key
+from gateway.services.file_store import build_file_store
 from gateway.services.log_writer import LogWriter, NoopLogWriter, create_log_writer
 from gateway.services.pricing_init_service import (
     initialize_pricing_from_config,
@@ -170,6 +171,7 @@ def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
                 await initialize_pricing_from_config(config, session)
                 await warn_if_require_pricing_without_pricing(config, session)
             log_writer = create_log_writer(config.log_writer_strategy)
+            app.state.file_store = build_file_store(config)
 
         await log_writer.start()
         app.state.log_writer = log_writer

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -196,6 +196,47 @@ class UsageLog(Base):
         }
 
 
+class FileObject(Base):
+    """Uploaded file metadata for the OpenAI-compatible /v1/files API.
+
+    The raw bytes live in a pluggable blob backend (see
+    gateway.services.file_store); this row holds metadata plus the backend
+    ``storage_ref`` used to fetch them. Files are scoped to ``user_id`` for
+    tenant isolation and soft-deleted via ``deleted_at``.
+    """
+
+    __tablename__ = "file_objects"
+
+    id: Mapped[str] = mapped_column(primary_key=True, default=lambda: f"file-{uuid.uuid4().hex}")
+    # Always set to the authenticated user; non-null enforces the user-scoping
+    # contract at the schema level. CASCADE removes a user's files on delete.
+    user_id: Mapped[str] = mapped_column(ForeignKey("users.user_id", ondelete="CASCADE"), index=True)
+    filename: Mapped[str] = mapped_column()
+    mime_type: Mapped[str] = mapped_column()
+    bytes: Mapped[int] = mapped_column()
+    purpose: Mapped[str] = mapped_column(default="user_data")
+    storage_ref: Mapped[str] = mapped_column()
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), index=True
+    )
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), default=None, index=True)
+
+    metadata_: Mapped[dict[str, Any]] = mapped_column("metadata", JSON, default=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to the OpenAI file object shape."""
+        return {
+            "id": self.id,
+            "object": "file",
+            "bytes": self.bytes,
+            "created_at": int(self.created_at.timestamp()) if self.created_at else None,
+            "expires_at": int(self.expires_at.timestamp()) if self.expires_at else None,
+            "filename": self.filename,
+            "purpose": self.purpose,
+        }
+
+
 class BudgetResetLog(Base):
     """Budget reset log model for tracking budget resets."""
 

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -10,6 +10,20 @@ class Base(DeclarativeBase):
     """Base class for SQLAlchemy models."""
 
 
+def _epoch_seconds(value: datetime | None) -> int | None:
+    """Return a UTC epoch from a stored datetime.
+
+    SQLite hands datetimes back naive; ``datetime.timestamp()`` would then read
+    them as local time and skew the epoch by the server's UTC offset. Treat a
+    naive value as the UTC it was stored as before converting.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return int(value.timestamp())
+
+
 class APIKey(Base):
     """API Key model for authentication and authorization."""
 
@@ -230,8 +244,8 @@ class FileObject(Base):
             "id": self.id,
             "object": "file",
             "bytes": self.bytes,
-            "created_at": int(self.created_at.timestamp()) if self.created_at else None,
-            "expires_at": int(self.expires_at.timestamp()) if self.expires_at else None,
+            "created_at": _epoch_seconds(self.created_at),
+            "expires_at": _epoch_seconds(self.expires_at),
             "filename": self.filename,
             "purpose": self.purpose,
         }

--- a/src/gateway/services/budget_service.py
+++ b/src/gateway/services/budget_service.py
@@ -407,3 +407,33 @@ async def refund_reservation(db: AsyncSession, handle: ReservationHandle) -> Non
         .execution_options(synchronize_session=False)
     )
     await db.commit()
+
+
+async def increase_reservation(
+    db: AsyncSession,
+    handle: ReservationHandle,
+    additional_estimate: float,
+    *,
+    model: str | None = None,
+    strategy: str = "for_update",
+) -> None:
+    """Grow an existing reservation atomically when the request size increases.
+
+    Used when the billable size grows after the initial reservation — e.g. the
+    content normalizer expands an attachment into extracted prompt text. The
+    delta is reserved with the same atomic conditional UPDATE as
+    :func:`reserve_budget` (so the budget gate stays effective on the true
+    size), then folded into ``handle`` so the existing reconcile/refund path
+    releases the full held amount.
+
+    Like :func:`reserve_budget`, this raises on budget rejection and does *not*
+    clean up the prior hold — the caller owns refunding ``handle`` on failure
+    (the request routes wrap the whole post-reservation setup in a
+    refund-on-error block). No-op when ``additional_estimate`` is not positive.
+    """
+    if additional_estimate <= 0:
+        return
+    delta = await reserve_budget(db, handle.user_id, additional_estimate, model=model, strategy=strategy)
+    if delta.reserved:
+        handle.estimate += delta.estimate
+        handle.reserved = True

--- a/src/gateway/services/content_normalizer.py
+++ b/src/gateway/services/content_normalizer.py
@@ -1,0 +1,365 @@
+"""Normalize file/image content blocks for the target model.
+
+For each non-text content block in the request messages, decide — based on the
+resolved :class:`~gateway.services.model_capabilities.Capabilities` — whether to:
+
+* **pass through** to a natively-capable provider (resolving any ``file_id`` to
+  inline bytes first, since the upstream provider doesn't know our file ids), or
+* **extract to text** for a text-only model: documents via markitdown, images
+  via a vision side-call / OCR, scanned PDFs via rasterize-then-describe.
+
+The normalizer is format-aware (OpenAI chat, Anthropic messages, OpenAI
+Responses) because each wire shape names its blocks and its text block
+differently. It is defensive by construction: any per-block failure leaves the
+original block untouched and is logged — it must never turn a chat request into
+a 500.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger
+from gateway.services.file_extractors import extract_text_from_file, ocr_image, rasterize_pdf
+from gateway.services.file_service import fetch_file, read_file_bytes
+from gateway.services.file_store import FileStore
+from gateway.services.model_capabilities import Capabilities
+from gateway.services.vision import describe_image
+
+WireFormat = Literal["openai", "anthropic", "responses"]
+
+# Kinds of content we normalize.
+_IMAGE = "image"
+_DOCUMENT = "document"
+
+
+@dataclass
+class NormalizationStats:
+    """Per-request tally, surfaced into usage-log metadata for observability."""
+
+    files_extracted: int = 0
+    images_described: int = 0
+    dropped: int = 0
+    chars_added: int = 0
+    details: list[str] = field(default_factory=list)
+
+    @property
+    def touched(self) -> bool:
+        return bool(self.files_extracted or self.images_described or self.dropped)
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "files_extracted": self.files_extracted,
+            "images_described": self.images_described,
+            "dropped": self.dropped,
+            "chars_added": self.chars_added,
+        }
+
+
+@dataclass
+class _Source:
+    """A resolved content block's bytes + descriptor."""
+
+    kind: str  # _IMAGE | _DOCUMENT
+    data: bytes | None  # None for a remote URL we won't fetch (SSRF-safe)
+    mime: str
+    filename: str | None
+    data_url: str | None  # original/remote data: or http(s) URL when present
+    # True only when bytes came from a stored file_id, so a native model needs
+    # the block rewritten to inline data. Already-inline / remote blocks pass
+    # through unchanged (no wasteful decode→re-encode round-trip).
+    needs_inline: bool = False
+
+
+def _text_block(fmt: WireFormat, text: str) -> dict[str, Any]:
+    if fmt == "responses":
+        return {"type": "input_text", "text": text}
+    return {"type": "text", "text": text}
+
+
+def _decode_data_url(url: str) -> tuple[bytes | None, str]:
+    """Return (bytes, mime) for a ``data:`` URL, or (None, '') if not one."""
+    if not url.startswith("data:"):
+        return None, ""
+    header, _, payload = url[5:].partition(",")
+    mime = header.split(";", 1)[0] or "application/octet-stream"
+    if "base64" not in header:
+        return payload.encode("utf-8"), mime
+    try:
+        return base64.b64decode(payload), mime
+    except (binascii.Error, ValueError):
+        return None, mime
+
+
+def _to_data_url(data: bytes, mime: str) -> str:
+    return f"data:{mime};base64,{base64.b64encode(data).decode('ascii')}"
+
+
+async def _resolve_from_ref(
+    ref: dict[str, Any],
+    *,
+    db: AsyncSession | None,
+    file_store: FileStore | None,
+    user_id: str | None,
+) -> tuple[bytes, str, str | None, bool] | None:
+    """Resolve a ``{file_data|url|file_id, filename}`` descriptor to bytes.
+
+    Returns ``(data, mime, filename, from_file_id)``; ``from_file_id`` is True
+    when the bytes came from a stored upload (so a native model needs the block
+    rewritten to inline data).
+    """
+    filename = ref.get("filename")
+    file_id = ref.get("file_id")
+    if file_id and db is not None and file_store is not None:
+        record = await fetch_file(db, str(file_id), user_id)
+        if record is None:
+            logger.warning("content normalizer: file_id %s not found for user %s", file_id, user_id)
+            return None
+        data = await read_file_bytes(file_store, record)
+        return data, record.mime_type, record.filename, True
+
+    url = ref.get("file_data") or ref.get("url")
+    if isinstance(url, str) and url.startswith("data:"):
+        decoded, mime = _decode_data_url(url)
+        if decoded is not None:
+            return decoded, mime, filename, False
+    return None
+
+
+async def _classify(
+    block: dict[str, Any],
+    fmt: WireFormat,
+    *,
+    db: AsyncSession | None,
+    file_store: FileStore | None,
+    user_id: str | None,
+) -> _Source | None:
+    """Identify an image/document block and resolve its bytes, or return None."""
+    btype = block.get("type")
+
+    # --- image blocks ---------------------------------------------------
+    if (fmt in ("openai", "responses") and btype in ("image_url", "input_image")) or (
+        fmt == "anthropic" and btype == "image"
+    ):
+        if fmt == "anthropic":
+            src = block.get("source", {})
+            if src.get("type") == "base64":
+                data = _decode_data_url(f"data:{src.get('media_type', '')};base64,{src.get('data', '')}")[0]
+                return _Source(_IMAGE, data, src.get("media_type", "image/png"), None, None)
+            if src.get("type") == "file":
+                resolved = await _resolve_from_ref(src, db=db, file_store=file_store, user_id=user_id)
+                if resolved:
+                    return _Source(_IMAGE, resolved[0], resolved[1], resolved[2], None, resolved[3])
+            return _Source(_IMAGE, None, "image/png", None, src.get("url"))
+        # openai / responses image
+        image_url = block.get("image_url")
+        url = image_url.get("url") if isinstance(image_url, dict) else image_url
+        if block.get("file_id"):
+            resolved = await _resolve_from_ref(block, db=db, file_store=file_store, user_id=user_id)
+            if resolved:
+                return _Source(_IMAGE, resolved[0], resolved[1], resolved[2], None, resolved[3])
+        if isinstance(url, str):
+            data, mime = _decode_data_url(url)
+            return _Source(_IMAGE, data, mime or "image/png", None, None if data else url)
+        return None
+
+    # --- document/file blocks ------------------------------------------
+    if (fmt in ("openai", "responses") and btype in ("file", "input_file")) or (
+        fmt == "anthropic" and btype == "document"
+    ):
+        if fmt == "anthropic":
+            src = block.get("source", {})
+            if src.get("type") == "text":
+                return _Source(_DOCUMENT, str(src.get("data", "")).encode("utf-8"), "text/plain", None, None)
+            if src.get("type") == "base64":
+                data = _decode_data_url(f"data:{src.get('media_type', '')};base64,{src.get('data', '')}")[0]
+                return _Source(_DOCUMENT, data, src.get("media_type", "application/pdf"), None, None)
+            if src.get("type") == "file":
+                resolved = await _resolve_from_ref(src, db=db, file_store=file_store, user_id=user_id)
+                if resolved:
+                    return _Source(_DOCUMENT, resolved[0], resolved[1], resolved[2], None, resolved[3])
+            return _Source(_DOCUMENT, None, "application/pdf", None, src.get("url"))
+        ref = block.get("file", block) if btype == "file" else block
+        resolved = await _resolve_from_ref(ref, db=db, file_store=file_store, user_id=user_id)
+        if resolved:
+            return _Source(_DOCUMENT, resolved[0], resolved[1], resolved[2], None, resolved[3])
+        return None
+
+    return None
+
+
+def _inline_passthrough(block: dict[str, Any], fmt: WireFormat, src: _Source) -> dict[str, Any]:
+    """Rewrite a (possibly file_id) block to inline bytes for a native provider."""
+    if src.data is None:  # remote URL or unresolved — forward unchanged
+        return block
+    data_url = _to_data_url(src.data, src.mime)
+    if fmt == "anthropic":
+        atype = "image" if src.kind == _IMAGE else "document"
+        return {
+            "type": atype,
+            "source": {"type": "base64", "media_type": src.mime, "data": base64.b64encode(src.data).decode("ascii")},
+        }
+    if src.kind == _IMAGE:
+        if fmt == "responses":
+            return {"type": "input_image", "image_url": data_url}
+        return {"type": "image_url", "image_url": {"url": data_url}}
+    # document
+    file_obj = {"file_data": data_url}
+    if src.filename:
+        file_obj["filename"] = src.filename
+    if fmt == "responses":
+        return {"type": "input_file", "file_data": data_url, **({"filename": src.filename} if src.filename else {})}
+    return {"type": "file", "file": file_obj}
+
+
+async def _extract_to_text(src: _Source, config: GatewayConfig, stats: NormalizationStats) -> str | None:
+    """Produce a text rendering of a non-text block for a text-only model."""
+    if src.data is None:
+        stats.details.append(f"skip remote {src.kind} url (not fetched)")
+        return None
+
+    if src.kind == _DOCUMENT:
+        result = await extract_text_from_file(src.data, src.mime, src.filename)
+        if result.ok:
+            label = src.filename or "document"
+            return f"[Attached file: {label}]\n{result.text}\n[End of {label}]"
+        # Scanned/image-only PDF → rasterize and describe pages.
+        if src.mime.split(";", 1)[0] == "application/pdf":
+            return await _describe_pdf_pages(src, config, stats)
+        stats.details.append(f"document extract failed: {result.detail}")
+        return None
+
+    # image
+    return await _render_image(src, config, stats)
+
+
+async def _render_image(src: _Source, config: GatewayConfig, stats: NormalizationStats) -> str | None:
+    assert src.data is not None
+    strategy = config.vision_strategy
+    if strategy == "describe":
+        described = await describe_image(config, _to_data_url(src.data, src.mime))
+        if described:
+            return f"[Attached image description]\n{described}"
+        # Fall through to OCR as a cheaper recovery, then give up.
+    if strategy in ("describe", "ocr"):
+        text = await ocr_image(src.data)
+        if text:
+            return f"[Attached image — extracted text]\n{text}"
+    stats.details.append(f"image dropped (strategy={strategy}, no description available)")
+    return None
+
+
+async def _describe_pdf_pages(src: _Source, config: GatewayConfig, stats: NormalizationStats) -> str | None:
+    assert src.data is not None
+    pages = await rasterize_pdf(src.data)
+    if not pages:
+        stats.details.append("scanned PDF: rasterization unavailable")
+        return None
+    descriptions: list[str] = []
+    for index, page_png in enumerate(pages, start=1):
+        page_src = _Source(_IMAGE, page_png, "image/png", None, None)
+        rendered = await _render_image(page_src, config, stats)
+        if rendered:
+            descriptions.append(f"-- Page {index} --\n{rendered}")
+    if not descriptions:
+        return None
+    label = src.filename or "document.pdf"
+    return f"[Attached scanned file: {label}]\n" + "\n".join(descriptions) + f"\n[End of {label}]"
+
+
+async def _normalize_block(
+    block: Any,
+    fmt: WireFormat,
+    caps: Capabilities,
+    config: GatewayConfig,
+    stats: NormalizationStats,
+    *,
+    db: AsyncSession | None,
+    file_store: FileStore | None,
+    user_id: str | None,
+) -> Any:
+    if not isinstance(block, dict):
+        return block
+    try:
+        src = await _classify(block, fmt, db=db, file_store=file_store, user_id=user_id)
+    except Exception as exc:  # noqa: BLE001 — never fail the request over a block
+        logger.warning("content normalizer: failed to classify block: %s", exc)
+        return block
+    if src is None:
+        return block
+
+    native = caps.image if src.kind == _IMAGE else caps.pdf
+    if native:
+        # Only rewrite when bytes came from a stored file_id (the provider can't
+        # resolve our ids); already-inline / remote blocks pass through as-is.
+        return _inline_passthrough(block, fmt, src) if src.needs_inline else block
+
+    try:
+        text = await _extract_to_text(src, config, stats)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("content normalizer: extraction failed for %s: %s", src.kind, exc)
+        return block
+
+    if text is None:
+        stats.dropped += 1
+        logger.info("content normalizer: dropped a %s block (no text rendering)", src.kind)
+        # Drop the block entirely; leaving it would let the provider silently
+        # ignore it. A short marker keeps the turn coherent for the model.
+        return _text_block(fmt, f"[Unprocessable {src.kind} attachment omitted]")
+
+    if src.kind == _IMAGE:
+        stats.images_described += 1
+    else:
+        stats.files_extracted += 1
+    stats.chars_added += len(text)
+    return _text_block(fmt, text)
+
+
+async def normalize_messages(
+    messages: list[dict[str, Any]],
+    *,
+    config: GatewayConfig,
+    caps: Capabilities,
+    fmt: WireFormat,
+    db: AsyncSession | None,
+    file_store: FileStore | None,
+    user_id: str | None,
+) -> tuple[list[dict[str, Any]], NormalizationStats]:
+    """Return (possibly-rewritten messages, stats).
+
+    Messages whose ``content`` is a plain string are returned untouched (the
+    common, zero-overhead path). Only list-content messages are walked.
+    """
+    stats = NormalizationStats()
+    if not config.file_understanding_enabled:
+        return messages, stats
+
+    out: list[dict[str, Any]] = []
+    for message in messages:
+        content = message.get("content") if isinstance(message, dict) else None
+        if not isinstance(content, list):
+            out.append(message)
+            continue
+        new_content = [
+            await _normalize_block(
+                block, fmt, caps, config, stats, db=db, file_store=file_store, user_id=user_id
+            )
+            for block in content
+        ]
+        out.append({**message, "content": new_content})
+
+    if stats.touched:
+        logger.info(
+            "content normalizer: extracted=%d described=%d dropped=%d (+%d chars)",
+            stats.files_extracted,
+            stats.images_described,
+            stats.dropped,
+            stats.chars_added,
+        )
+    return out, stats

--- a/src/gateway/services/content_normalizer.py
+++ b/src/gateway/services/content_normalizer.py
@@ -22,6 +22,7 @@ import binascii
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from any_llm.types.completion import CompletionUsage
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.core.config import GatewayConfig
@@ -47,11 +48,26 @@ class NormalizationStats:
     images_described: int = 0
     dropped: int = 0
     chars_added: int = 0
+    # Token usage of any vision describe side-calls made while extracting images
+    # for a text-only model. Accumulated across every describe call (including
+    # per-page calls for a scanned PDF) so the caller can meter and bill them.
+    vision_prompt_tokens: int = 0
+    vision_completion_tokens: int = 0
     details: list[str] = field(default_factory=list)
 
     @property
     def touched(self) -> bool:
         return bool(self.files_extracted or self.images_described or self.dropped)
+
+    def vision_usage(self) -> CompletionUsage | None:
+        """The summed describe-call usage, or ``None`` if no describe call ran."""
+        if not (self.vision_prompt_tokens or self.vision_completion_tokens):
+            return None
+        return CompletionUsage(
+            prompt_tokens=self.vision_prompt_tokens,
+            completion_tokens=self.vision_completion_tokens,
+            total_tokens=self.vision_prompt_tokens + self.vision_completion_tokens,
+        )
 
     def to_metadata(self) -> dict[str, Any]:
         return {
@@ -243,7 +259,10 @@ async def _render_image(src: _Source, config: GatewayConfig, stats: Normalizatio
     assert src.data is not None
     strategy = config.vision_strategy
     if strategy == "describe":
-        described = await describe_image(config, _to_data_url(src.data, src.mime))
+        described, usage = await describe_image(config, _to_data_url(src.data, src.mime))
+        if usage is not None:
+            stats.vision_prompt_tokens += usage.prompt_tokens or 0
+            stats.vision_completion_tokens += usage.completion_tokens or 0
         if described:
             return f"[Attached image description]\n{described}"
         # Fall through to OCR as a cheaper recovery, then give up.

--- a/src/gateway/services/content_normalizer.py
+++ b/src/gateway/services/content_normalizer.py
@@ -354,9 +354,12 @@ async def normalize_messages(
 
     Messages whose ``content`` is a plain string are returned untouched (the
     common, zero-overhead path). Only list-content messages are walked.
+
+    The Responses endpoint accepts a bare-string ``input``; iterating that would
+    walk it character-by-character, so non-list ``messages`` are returned as-is.
     """
     stats = NormalizationStats()
-    if not config.file_understanding_enabled:
+    if not config.file_understanding_enabled or not isinstance(messages, list):
         return messages, stats
 
     out: list[dict[str, Any]] = []

--- a/src/gateway/services/file_extractors.py
+++ b/src/gateway/services/file_extractors.py
@@ -1,0 +1,146 @@
+"""Extract a text representation of an uploaded file for text-only models.
+
+Text/office/PDF extraction goes through `markitdown` (MIT) which converts a
+broad set of formats to Markdown. When a PDF carries no extractable text (a
+scanned/image-only PDF), :func:`rasterize_pdf` renders its pages to PNGs via
+`pypdfium2` (Apache-2.0) so the caller can fall back to the vision path —
+deliberately avoiding AGPL-licensed PDF libraries since the gateway is a
+network service.
+
+All heavy dependencies are imported lazily so the gateway starts (and the rest
+of the test suite runs) even when the optional extras aren't installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import io
+import mimetypes
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from gateway.log_config import logger
+
+# MIME → file extension hints for formats markitdown keys off the suffix.
+_MIME_TO_EXT: dict[str, str] = {
+    "application/pdf": ".pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
+    "application/msword": ".doc",
+    "text/csv": ".csv",
+    "text/markdown": ".md",
+    "text/plain": ".txt",
+    "text/html": ".html",
+    "application/json": ".json",
+    "application/xml": ".xml",
+    "text/xml": ".xml",
+}
+
+
+@dataclass(frozen=True)
+class ExtractionResult:
+    """Outcome of a text-extraction attempt."""
+
+    text: str
+    ok: bool
+    detail: str
+
+
+def _resolve_extension(mime_type: str, filename: str | None) -> str:
+    if filename and (suffix := Path(filename).suffix):
+        return suffix.lower()
+    mime = (mime_type or "").split(";", 1)[0].strip().lower()
+    if mime in _MIME_TO_EXT:
+        return _MIME_TO_EXT[mime]
+    return mimetypes.guess_extension(mime) or ".bin"
+
+
+def _extract_sync(data: bytes, extension: str) -> ExtractionResult:
+    try:
+        from markitdown import MarkItDown
+    except ImportError:
+        return ExtractionResult("", False, "markitdown not installed")
+
+    # markitdown's stable API is path-based; write to a temp file with the right
+    # suffix so format detection works across library versions. We close the
+    # handle before markitdown re-opens the path and unlink it ourselves —
+    # NamedTemporaryFile's auto-delete-on-close would race the re-open on Windows.
+    tmp = tempfile.NamedTemporaryFile(suffix=extension, delete=False)  # noqa: SIM115
+    try:
+        tmp.write(data)
+        tmp.close()
+        result = MarkItDown(enable_plugins=False).convert(tmp.name)
+    except Exception as exc:  # noqa: BLE001 — surface as a failed extraction, not a 500
+        logger.warning("markitdown extraction failed for %s: %s", extension, exc)
+        return ExtractionResult("", False, f"extraction error: {exc}")
+    finally:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp.name)
+
+    text = (result.text_content or "").strip()
+    if not text:
+        return ExtractionResult("", False, "no extractable text")
+    return ExtractionResult(text, True, "ok")
+
+
+async def extract_text_from_file(data: bytes, mime_type: str, filename: str | None) -> ExtractionResult:
+    """Extract a Markdown/text representation of ``data``.
+
+    Returns ``ok=False`` (with bytes intact for a possible vision fallback) when
+    the format is unsupported, the library is missing, or no text could be read.
+    """
+    extension = _resolve_extension(mime_type, filename)
+    return await asyncio.to_thread(_extract_sync, data, extension)
+
+
+def _rasterize_sync(data: bytes, max_pages: int) -> list[bytes]:
+    try:
+        import pypdfium2 as pdfium
+    except ImportError:
+        logger.warning("pypdfium2 not installed; cannot rasterize scanned PDF")
+        return []
+
+    images: list[bytes] = []
+    pdf = pdfium.PdfDocument(data)
+    try:
+        for index in range(min(len(pdf), max_pages)):
+            page = pdf[index]
+            bitmap = page.render(scale=2.0)
+            pil_image = bitmap.to_pil()
+            buffer = io.BytesIO()
+            pil_image.save(buffer, format="PNG")
+            images.append(buffer.getvalue())
+    finally:
+        pdf.close()
+    return images
+
+
+async def rasterize_pdf(data: bytes, max_pages: int = 10) -> list[bytes]:
+    """Render up to ``max_pages`` PDF pages to PNG bytes for the vision fallback."""
+    return await asyncio.to_thread(_rasterize_sync, data, max_pages)
+
+
+def _ocr_sync(image_data: bytes) -> str:
+    try:
+        from rapidocr_onnxruntime import RapidOCR
+    except ImportError:
+        logger.warning("rapidocr_onnxruntime not installed; OCR unavailable")
+        return ""
+
+    import numpy as np
+    from PIL import Image
+
+    image = Image.open(io.BytesIO(image_data)).convert("RGB")
+    result, _ = RapidOCR()(np.asarray(image))
+    if not result:
+        return ""
+    return "\n".join(str(line[1]) for line in result).strip()
+
+
+async def ocr_image(image_data: bytes) -> str:
+    """Extract text from a raster image via RapidOCR (returns '' if unavailable)."""
+    return await asyncio.to_thread(_ocr_sync, image_data)

--- a/src/gateway/services/file_service.py
+++ b/src/gateway/services/file_service.py
@@ -1,0 +1,51 @@
+"""Shared data-access helpers for uploaded files.
+
+Used by both the ``/v1/files`` route and the content normalizer, which resolves
+``file_id`` references in chat messages back to bytes. Centralising the
+user-scoping + soft-delete + expiry rules here keeps the two call sites
+consistent.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.models.entities import FileObject
+from gateway.services.file_store import FileStore
+
+
+def _is_expired(record: FileObject) -> bool:
+    if record.expires_at is None:
+        return False
+    expires_at = record.expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=UTC)
+    return expires_at < datetime.now(UTC)
+
+
+async def fetch_file(db: AsyncSession, file_id: str, user_id: str | None) -> FileObject | None:
+    """Return a live, non-deleted, unexpired file owned by ``user_id``.
+
+    Returns ``None`` if the file does not exist, belongs to another user, is
+    soft-deleted, or has expired — callers map that to a 404 so cross-user
+    access is indistinguishable from a missing file.
+    """
+    result = await db.execute(
+        select(FileObject).where(
+            FileObject.id == file_id,
+            FileObject.user_id == user_id,
+            FileObject.deleted_at.is_(None),
+        )
+    )
+    record = result.scalar_one_or_none()
+    if record is None or _is_expired(record):
+        return None
+    return record
+
+
+async def read_file_bytes(file_store: FileStore, record: FileObject) -> bytes:
+    """Load the raw bytes for ``record`` from the blob backend."""
+    return await file_store.get(record.storage_ref)

--- a/src/gateway/services/file_store.py
+++ b/src/gateway/services/file_store.py
@@ -1,0 +1,103 @@
+"""Pluggable blob storage for uploaded file bytes.
+
+The ``/v1/files`` API stores file *metadata* in the database (see
+``gateway.models.entities.FileObject``) and the raw *bytes* here, keyed by an
+opaque ``storage_ref``. Keeping bytes out of the relational store lets large
+uploads live on a filesystem / object store while the DB stays lean.
+
+Only a local-filesystem backend ships today; ``S3FileStore`` / ``GCSFileStore``
+can implement the same :class:`FileStore` protocol without touching callers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger
+
+
+@runtime_checkable
+class FileStore(Protocol):
+    """Storage backend for raw uploaded file bytes."""
+
+    async def put(self, file_id: str, data: bytes) -> str:
+        """Persist ``data`` for ``file_id`` and return an opaque storage ref."""
+        ...
+
+    async def get(self, storage_ref: str) -> bytes:
+        """Return the bytes previously stored under ``storage_ref``."""
+        ...
+
+    async def delete(self, storage_ref: str) -> None:
+        """Remove the bytes under ``storage_ref`` (no-op if already gone)."""
+        ...
+
+
+class LocalDirFileStore:
+    """Filesystem-backed :class:`FileStore`.
+
+    Files are sharded into 256 subdirectories by the first two hex characters of
+    the file id to avoid pathologically large directories. The ``storage_ref``
+    is the POSIX-relative path under the root, so it survives a root relocation.
+    """
+
+    def __init__(self, root: str) -> None:
+        self._root = Path(root)
+
+    def _shard(self, file_id: str) -> str:
+        # file ids look like ``file-<hex>``; shard on the first two hex chars.
+        token = file_id.split("-", 1)[-1] or file_id
+        prefix = (token[:2] or "00").lower()
+        return f"{prefix}/{file_id}"
+
+    def _resolve(self, storage_ref: str) -> Path:
+        """Resolve ``storage_ref`` under the root, rejecting any escape.
+
+        ``storage_ref`` is server-generated today, but this is defence-in-depth:
+        if a value ever came from elsewhere, a ``../`` traversal must not read or
+        delete outside the store root.
+        """
+        root = self._root.resolve()
+        path = (root / storage_ref).resolve()
+        if not path.is_relative_to(root):
+            msg = f"Invalid storage_ref escapes the file store root: {storage_ref!r}"
+            raise ValueError(msg)
+        return path
+
+    async def put(self, file_id: str, data: bytes) -> str:
+        ref = self._shard(file_id)
+        path = self._resolve(ref)
+
+        def _write() -> None:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(data)
+
+        await asyncio.to_thread(_write)
+        return ref
+
+    async def get(self, storage_ref: str) -> bytes:
+        path = self._resolve(storage_ref)
+        return await asyncio.to_thread(path.read_bytes)
+
+    async def delete(self, storage_ref: str) -> None:
+        path = self._resolve(storage_ref)
+
+        def _unlink() -> None:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                logger.debug("file_store delete: %s already absent", storage_ref)
+
+        await asyncio.to_thread(_unlink)
+
+
+def build_file_store(config: GatewayConfig) -> FileStore:
+    """Construct the configured :class:`FileStore` backend."""
+    backend = config.files_backend.strip().lower()
+    if backend == "local":
+        return LocalDirFileStore(config.files_local_dir)
+    msg = f"Unsupported files_backend: {config.files_backend!r} (supported: 'local')"
+    raise ValueError(msg)

--- a/src/gateway/services/model_capabilities.py
+++ b/src/gateway/services/model_capabilities.py
@@ -1,0 +1,74 @@
+"""Resolve whether a target model natively understands images / documents.
+
+The content normalizer uses this to decide, per request, whether to forward a
+file/image content block to the provider (native) or extract it to text
+(text-only). Getting the *default* right matters: a wrong "native" verdict for a
+text-only local model means the block is silently dropped and the model answers
+as if no file were attached.
+
+Resolution order (most → least authoritative):
+
+1. **Operator override** — ``config.model_capabilities[provider/model]`` (or the
+   bare model key). The only fully reliable signal for local models.
+2. **any-llm provider metadata** — trusted only for hosted providers. Local /
+   OpenAI-compatible servers (ollama, vllm, llamacpp, lmstudio) set the flags on
+   a shared base class and over-report (e.g. Ollama claims PDF support but its
+   adapter silently drops document blocks), so we ignore metadata there and fall
+   through to the safe default.
+3. **Default** — ``False`` (extract). A needless extraction still yields a
+   correct answer; a wrong passthrough does not.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from any_llm import AnyLLM, LLMProvider
+
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger
+
+# Providers whose any-llm capability flags over-report because they are set on a
+# shared base class rather than derived from the actually-served model. For
+# these, native passthrough must be opted into per-model via model_capabilities.
+_LOCAL_PROVIDERS: frozenset[LLMProvider] = frozenset(
+    {
+        LLMProvider.OLLAMA,
+        LLMProvider.VLLM,
+        LLMProvider.LLAMACPP,
+        LLMProvider.LMSTUDIO,
+    }
+)
+
+
+@dataclass(frozen=True)
+class Capabilities:
+    """Whether the target model natively understands each modality."""
+
+    image: bool
+    pdf: bool
+    source: str  # "config" | "provider_metadata" | "default"
+
+
+def resolve_capabilities(
+    config: GatewayConfig,
+    provider: LLMProvider,
+    model: str,
+) -> Capabilities:
+    """Resolve native image/pdf support for ``provider/model``."""
+    # Accept both separators: model selectors and the pricing config use
+    # ``provider:model`` (colon), while ``provider/model`` (slash) is also common.
+    # The bare model key is the final fallback.
+    for key in (f"{provider.value}:{model}", f"{provider.value}/{model}", model):
+        override = config.model_capabilities.get(key)
+        if override is not None:
+            return Capabilities(override.supports_image, override.supports_pdf, "config")
+
+    if provider not in _LOCAL_PROVIDERS:
+        try:
+            meta = AnyLLM.get_provider_class(provider).get_provider_metadata()
+            return Capabilities(meta.image, meta.pdf, "provider_metadata")
+        except Exception as exc:  # noqa: BLE001 — metadata lookup is best-effort
+            logger.debug("provider metadata lookup failed for %s: %s", provider.value, exc)
+
+    return Capabilities(image=False, pdf=False, source="default")

--- a/src/gateway/services/vision.py
+++ b/src/gateway/services/vision.py
@@ -1,0 +1,66 @@
+"""Caption images with a vision model so text-only models can 'see' them.
+
+When the target model can't process images natively, the content normalizer
+calls :func:`describe_image` to turn each image into a text description via a
+configured vision model (``config.vision_describe_model``). That model may be a
+local one (e.g. ``ollama/qwen2-vl``) to keep captioning free, or a frontier
+model for best quality.
+"""
+
+from __future__ import annotations
+
+from any_llm import AnyLLM, acompletion
+
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger
+from gateway.services.provider_kwargs import get_provider_kwargs
+
+_DESCRIBE_PROMPT = (
+    "You are assisting a text-only language model that cannot see images. "
+    "Describe the following image thoroughly and objectively so the model can "
+    "reason about it: transcribe any visible text verbatim, and describe layout, "
+    "charts, diagrams, tables, and notable visual details. Reply with the "
+    "description only."
+)
+
+
+async def describe_image(config: GatewayConfig, image_data_url: str) -> str | None:
+    """Return a text description of an image, or ``None`` if unavailable.
+
+    ``None`` (no configured model, or a failed side-call) signals the caller to
+    fall back to its configured strategy (OCR or drop-with-log) rather than
+    failing the user's request.
+    """
+    model = config.vision_describe_model
+    if not model:
+        return None
+
+    provider, model_name = AnyLLM.split_model_provider(model)
+    provider_kwargs = get_provider_kwargs(config, provider)
+
+    try:
+        completion = await acompletion(
+            model=model_name,
+            provider=provider,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": _DESCRIBE_PROMPT},
+                        {"type": "image_url", "image_url": {"url": image_data_url}},
+                    ],
+                }
+            ],
+            **provider_kwargs,
+        )
+    except Exception as exc:  # noqa: BLE001 — captioning is best-effort
+        logger.warning("vision describe via %s failed: %s", model, exc)
+        return None
+
+    try:
+        content = completion.choices[0].message.content  # type: ignore[union-attr]
+    except (AttributeError, IndexError):
+        return None
+    if isinstance(content, str) and content.strip():
+        return content.strip()
+    return None

--- a/src/gateway/services/vision.py
+++ b/src/gateway/services/vision.py
@@ -10,6 +10,7 @@ model for best quality.
 from __future__ import annotations
 
 from any_llm import AnyLLM, acompletion
+from any_llm.types.completion import CompletionUsage
 
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
@@ -24,16 +25,19 @@ _DESCRIBE_PROMPT = (
 )
 
 
-async def describe_image(config: GatewayConfig, image_data_url: str) -> str | None:
-    """Return a text description of an image, or ``None`` if unavailable.
+async def describe_image(config: GatewayConfig, image_data_url: str) -> tuple[str | None, CompletionUsage | None]:
+    """Caption an image, returning ``(description, usage)``.
 
-    ``None`` (no configured model, or a failed side-call) signals the caller to
-    fall back to its configured strategy (OCR or drop-with-log) rather than
-    failing the user's request.
+    ``description`` is ``None`` (no configured model, or a failed side-call) to
+    signal the caller to fall back to its configured strategy (OCR or
+    drop-with-log) rather than failing the user's request. ``usage`` is the
+    describe model's token usage when the call succeeded, so the caller can
+    meter and bill this side-call against the user's budget; it is ``None`` when
+    no call was made or the provider returned no usage.
     """
     model = config.vision_describe_model
     if not model:
-        return None
+        return None, None
 
     provider, model_name = AnyLLM.split_model_provider(model)
     provider_kwargs = get_provider_kwargs(config, provider)
@@ -55,12 +59,13 @@ async def describe_image(config: GatewayConfig, image_data_url: str) -> str | No
         )
     except Exception as exc:  # noqa: BLE001 — captioning is best-effort
         logger.warning("vision describe via %s failed: %s", model, exc)
-        return None
+        return None, None
 
+    usage = getattr(completion, "usage", None)
     try:
         content = completion.choices[0].message.content  # type: ignore[union-attr]
     except (AttributeError, IndexError):
-        return None
+        return None, usage
     if isinstance(content, str) and content.strip():
-        return content.strip()
-    return None
+        return content.strip(), usage
+    return None, usage

--- a/src/gateway/services/vision.py
+++ b/src/gateway/services/vision.py
@@ -55,6 +55,7 @@ async def describe_image(config: GatewayConfig, image_data_url: str) -> tuple[st
                     ],
                 }
             ],
+            max_tokens=config.vision_describe_max_tokens,
             **provider_kwargs,
         )
     except Exception as exc:  # noqa: BLE001 — captioning is best-effort

--- a/tests/integration/test_budget_race_condition.py
+++ b/tests/integration/test_budget_race_condition.py
@@ -10,6 +10,7 @@ from gateway.models.entities import Budget, ModelPricing, User
 from gateway.repositories.users_repository import get_active_user
 from gateway.services.budget_service import (
     estimate_cost,
+    increase_reservation,
     reconcile_reservation,
     refund_reservation,
     reserve_budget,
@@ -166,6 +167,80 @@ async def test_reserve_budget_clamps_negative_estimate(async_db: Any) -> None:
     assert user is not None
     assert user.reserved == pytest.approx(4.0)  # unchanged — negative clamped to 0
     assert user.spend == pytest.approx(10.0)
+
+
+@pytest.mark.asyncio
+async def test_increase_reservation_grows_hold_and_folds_handle(async_db: Any) -> None:
+    """A fitting top-up adds to `reserved` and folds the delta into the handle."""
+    async_db.add(Budget(budget_id="inc-budget", max_budget=100.0))
+    async_db.add(User(user_id="inc-user", spend=10.0, budget_id="inc-budget"))
+    await async_db.commit()
+
+    handle = await reserve_budget(async_db, "inc-user", 5.0)
+    await increase_reservation(async_db, handle, 7.0)
+
+    # Delta folded into the handle so the single reconcile/refund covers it all.
+    assert handle.estimate == pytest.approx(12.0)
+    async_db.expire_all()
+    user = await get_active_user(async_db, "inc-user")
+    assert user is not None and user.reserved == pytest.approx(12.0)
+
+    # Reconcile releases the full held amount.
+    await reconcile_reservation(async_db, handle, 9.0)
+    async_db.expire_all()
+    user = await get_active_user(async_db, "inc-user")
+    assert user is not None
+    assert user.reserved == pytest.approx(0.0)
+    assert user.spend == pytest.approx(19.0)  # 10 + actual 9
+
+
+@pytest.mark.asyncio
+async def test_increase_reservation_rejects_without_touching_original(async_db: Any) -> None:
+    """An over-budget top-up raises and leaves the original hold for the caller.
+
+    Like ``reserve_budget``, ``increase_reservation`` does not self-refund — the
+    request routes own refunding on failure. The rejected delta must not have
+    been added to ``reserved`` (the atomic UPDATE either fully applies or not).
+    """
+    async_db.add(Budget(budget_id="incr-budget", max_budget=10.0))
+    async_db.add(User(user_id="incr-user", spend=8.0, budget_id="incr-budget"))
+    await async_db.commit()
+
+    handle = await reserve_budget(async_db, "incr-user", 1.0)  # 8 + 1 <= 10, fits
+    # Topping up by 5 would need 8 + 1 + 5 = 14 > 10 → rejected.
+    with pytest.raises(HTTPException) as exc_info:
+        await increase_reservation(async_db, handle, 5.0)
+    assert exc_info.value.status_code == 403
+
+    # Only the original 1.0 hold remains; the delta was not applied. The caller
+    # (a request route) is responsible for refunding the original on failure.
+    async_db.expire_all()
+    user = await get_active_user(async_db, "incr-user")
+    assert user is not None
+    assert user.reserved == pytest.approx(1.0)
+    assert user.spend == pytest.approx(8.0)
+
+    await refund_reservation(async_db, handle)
+    async_db.expire_all()
+    user = await get_active_user(async_db, "incr-user")
+    assert user is not None and user.reserved == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_increase_reservation_noop_for_nonpositive_delta(async_db: Any) -> None:
+    """A zero/negative delta leaves the reservation untouched."""
+    async_db.add(Budget(budget_id="incn-budget", max_budget=100.0))
+    async_db.add(User(user_id="incn-user", spend=0.0, budget_id="incn-budget"))
+    await async_db.commit()
+
+    handle = await reserve_budget(async_db, "incn-user", 5.0)
+    await increase_reservation(async_db, handle, 0.0)
+    await increase_reservation(async_db, handle, -3.0)
+
+    assert handle.estimate == pytest.approx(5.0)
+    async_db.expire_all()
+    user = await get_active_user(async_db, "incn-user")
+    assert user is not None and user.reserved == pytest.approx(5.0)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_files_endpoint.py
+++ b/tests/integration/test_files_endpoint.py
@@ -1,0 +1,290 @@
+"""Integration tests for the /v1/files API and end-to-end file understanding.
+
+The headline test exercises the full path: upload a file, send a chat request
+that references it by ``file_id``, and assert the gateway extracted the file to
+text and that text reached the provider — proving a text-only local model can
+"read" an uploaded file.
+
+The markitdown extraction boundary is monkeypatched for determinism so the test
+needs no optional extraction deps; everything else (HTTP, DB, blob store,
+file_id resolution, capability resolution, message rewriting) is real.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway.services.file_extractors import ExtractionResult
+from gateway.services.file_store import LocalDirFileStore
+
+
+@pytest.fixture
+def tmp_file_store(client: TestClient, tmp_path: Path) -> None:
+    """Point the app's blob store at a temp dir (default writes to cwd)."""
+    cast(Any, client.app).state.file_store = LocalDirFileStore(str(tmp_path))
+
+
+def _make_completion() -> Any:
+    from any_llm.types.completion import (
+        ChatCompletion,
+        ChatCompletionMessage,
+        Choice,
+        CompletionUsage,
+    )
+
+    return ChatCompletion(
+        id="chatcmpl-test",
+        object="chat.completion",
+        created=1700000000,
+        model="llama3",
+        choices=[
+            Choice(index=0, message=ChatCompletionMessage(role="assistant", content="ok"), finish_reason="stop")
+        ],
+        usage=CompletionUsage(prompt_tokens=10, completion_tokens=2, total_tokens=12),
+    )
+
+
+def test_upload_requires_auth(client: TestClient) -> None:
+    resp = client.post("/v1/files", files={"file": ("a.txt", b"x", "text/plain")})
+    assert resp.status_code == 401
+
+
+def test_upload_empty_file_rejected(
+    client: TestClient, api_key_header: dict[str, str], tmp_file_store: None
+) -> None:
+    resp = client.post("/v1/files", headers=api_key_header, files={"file": ("empty.txt", b"", "text/plain")})
+    assert resp.status_code == 400
+
+
+def test_upload_too_large_rejected(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    tmp_file_store: None,
+    test_config: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(test_config, "files_max_bytes", 16)
+    resp = client.post(
+        "/v1/files",
+        headers=api_key_header,
+        files={"file": ("big.bin", b"x" * 64, "application/octet-stream")},
+    )
+    assert resp.status_code == 413
+
+
+def test_files_are_user_scoped(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    master_key_header: dict[str, str],
+    tmp_file_store: None,
+) -> None:
+    # Upload as the first key's user.
+    up = client.post("/v1/files", headers=api_key_header, files={"file": ("a.txt", b"hi", "text/plain")})
+    file_id = up.json()["id"]
+
+    # A second, independent key (its own auto-created user) must not see it.
+    other = client.post("/v1/keys", json={"key_name": "other"}, headers=master_key_header)
+    other_header = {list(api_key_header)[0]: f"Bearer {other.json()['key']}"}
+
+    assert client.get(f"/v1/files/{file_id}", headers=other_header).status_code == 404
+    assert client.get(f"/v1/files/{file_id}/content", headers=other_header).status_code == 404
+    # Owner still sees it.
+    assert client.get(f"/v1/files/{file_id}", headers=api_key_header).status_code == 200
+
+
+def test_download_filename_header_is_injection_safe(
+    client: TestClient, api_key_header: dict[str, str], tmp_file_store: None
+) -> None:
+    up = client.post(
+        "/v1/files",
+        headers=api_key_header,
+        files={"file": ('ev"il\r\nX-Injected: 1.txt', b"data", "text/plain")},
+    )
+    assert up.status_code == 200
+    file_id = up.json()["id"]
+
+    resp = client.get(f"/v1/files/{file_id}/content", headers=api_key_header)
+    assert resp.status_code == 200
+    cd = resp.headers["content-disposition"]
+    # No raw CR/LF or unescaped quotes leaked into the header.
+    assert "\r" not in cd and "\n" not in cd
+    assert "X-Injected" not in resp.headers
+    assert "filename*=UTF-8''" in cd
+
+
+def test_upload_get_list_delete_roundtrip(
+    client: TestClient, api_key_header: dict[str, str], tmp_file_store: None
+) -> None:
+    up = client.post(
+        "/v1/files",
+        headers=api_key_header,
+        data={"purpose": "user_data"},
+        files={"file": ("notes.txt", b"hello world", "text/plain")},
+    )
+    assert up.status_code == 200, up.text
+    obj = up.json()
+    file_id = obj["id"]
+    assert obj["object"] == "file"
+    assert obj["bytes"] == len(b"hello world")
+    assert obj["filename"] == "notes.txt"
+
+    got = client.get(f"/v1/files/{file_id}", headers=api_key_header)
+    assert got.status_code == 200
+    assert got.json()["id"] == file_id
+
+    content = client.get(f"/v1/files/{file_id}/content", headers=api_key_header)
+    assert content.status_code == 200
+    assert content.content == b"hello world"
+
+    listed = client.get("/v1/files", headers=api_key_header)
+    assert listed.status_code == 200
+    assert any(f["id"] == file_id for f in listed.json()["data"])
+
+    deleted = client.delete(f"/v1/files/{file_id}", headers=api_key_header)
+    assert deleted.status_code == 200
+    assert deleted.json()["deleted"] is True
+
+    # Gone after delete.
+    assert client.get(f"/v1/files/{file_id}", headers=api_key_header).status_code == 404
+
+
+def test_file_id_extracted_reaches_provider(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    tmp_file_store: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Upload → chat with file_id on a text-only model → extracted text is sent."""
+
+    async def fake_extract(data: bytes, mime: str, filename: str | None) -> ExtractionResult:
+        return ExtractionResult(f"EXTRACTED::{data.decode()}", True, "ok")
+
+    monkeypatch.setattr("gateway.services.content_normalizer.extract_text_from_file", fake_extract)
+
+    up = client.post(
+        "/v1/files",
+        headers=api_key_header,
+        files={"file": ("report.txt", b"quarterly numbers", "text/plain")},
+    )
+    assert up.status_code == 200, up.text
+    file_id = up.json()["id"]
+
+    captured: dict[str, Any] = {}
+
+    async def mock_acompletion(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _make_completion()
+
+    # ollama is a local provider → capabilities default to "extract" (text-only),
+    # so the file block must be turned into text before the provider call.
+    body = {
+        "model": "ollama:llama3",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Summarize the attached file."},
+                    {"type": "file", "file": {"file_id": file_id}},
+                ],
+            }
+        ],
+    }
+
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
+        resp = client.post("/v1/chat/completions", headers=api_key_header, json=body)
+
+    assert resp.status_code == 200, resp.text
+
+    sent = json.dumps(captured["messages"])
+    # The extracted text — framed with the filename header — reached the provider...
+    assert "EXTRACTED::quarterly numbers" in sent
+    assert "report.txt" in sent
+    # ...and the raw file block did not (it was replaced by a text block).
+    assert "file_id" not in sent
+
+
+def test_budget_rejection_skips_normalization(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    tmp_file_store: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A request rejected at the budget gate must not run extraction/vision.
+
+    Locks in the ordering fix: normalization happens only after reserve_budget,
+    so a blocked/over-budget user can't trigger extraction or vision side-calls.
+    """
+    from fastapi import HTTPException, status
+
+    extracted = {"called": False}
+
+    async def spy_extract(*args: Any, **kwargs: Any) -> ExtractionResult:
+        extracted["called"] = True
+        return ExtractionResult("should-not-run", True, "ok")
+
+    async def deny_budget(*args: Any, **kwargs: Any) -> Any:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="over budget")
+
+    monkeypatch.setattr("gateway.services.content_normalizer.extract_text_from_file", spy_extract)
+    monkeypatch.setattr("gateway.api.routes._pipeline.reserve_budget", deny_budget)
+
+    pdf_url = "data:application/pdf;base64," + base64.b64encode(b"%PDF-1.4 fake").decode("ascii")
+    body = {
+        "model": "ollama:llama3",  # text-only → would extract if normalization ran
+        "messages": [
+            {"role": "user", "content": [{"type": "file", "file": {"file_data": pdf_url, "filename": "x.pdf"}}]}
+        ],
+    }
+
+    resp = client.post("/v1/chat/completions", headers=api_key_header, json=body)
+    assert resp.status_code == 403
+    assert extracted["called"] is False
+
+
+def test_native_model_passes_file_through(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    tmp_file_store: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A natively-capable model gets the file forwarded (file_id inlined), not extracted."""
+
+    async def fail_extract(*args: Any, **kwargs: Any) -> ExtractionResult:  # pragma: no cover
+        raise AssertionError("extraction must not run for a native model")
+
+    monkeypatch.setattr("gateway.services.content_normalizer.extract_text_from_file", fail_extract)
+
+    up = client.post(
+        "/v1/files",
+        headers=api_key_header,
+        files={"file": ("doc.pdf", b"%PDF-1.4 fake", "application/pdf")},
+    )
+    file_id = up.json()["id"]
+
+    captured: dict[str, Any] = {}
+
+    async def mock_acompletion(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _make_completion()
+
+    body = {
+        "model": "openai:gpt-4o",  # hosted, natively multimodal → passthrough
+        "messages": [
+            {"role": "user", "content": [{"type": "file", "file": {"file_id": file_id}}]}
+        ],
+    }
+
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
+        resp = client.post("/v1/chat/completions", headers=api_key_header, json=body)
+
+    assert resp.status_code == 200, resp.text
+    sent = json.dumps(captured["messages"])
+    # file_id was resolved to an inline data: URL the provider understands.
+    assert "data:application/pdf;base64," in sent

--- a/tests/integration/test_files_endpoint.py
+++ b/tests/integration/test_files_endpoint.py
@@ -94,7 +94,10 @@ def test_files_are_user_scoped(
 
     # A second, independent key (its own auto-created user) must not see it.
     other = client.post("/v1/keys", json={"key_name": "other"}, headers=master_key_header)
-    other_header = {list(api_key_header)[0]: f"Bearer {other.json()['key']}"}
+    # Match the fixture's auth scheme: the gateway requires a "Bearer " prefix on
+    # every header form, including Otari-Key (see api_key_header / deps.py
+    # _extract_bearer_token), so reuse the fixture's header name with a Bearer value.
+    other_header = {next(iter(api_key_header)): f"Bearer {other.json()['key']}"}
 
     assert client.get(f"/v1/files/{file_id}", headers=other_header).status_code == 404
     assert client.get(f"/v1/files/{file_id}/content", headers=other_header).status_code == 404

--- a/tests/integration/test_files_endpoint.py
+++ b/tests/integration/test_files_endpoint.py
@@ -14,13 +14,16 @@ from __future__ import annotations
 
 import base64
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
 
+from gateway.models.entities import FileObject
 from gateway.services.file_extractors import ExtractionResult
 from gateway.services.file_store import LocalDirFileStore
 
@@ -288,3 +291,86 @@ def test_native_model_passes_file_through(
     sent = json.dumps(captured["messages"])
     # file_id was resolved to an inline data: URL the provider understands.
     assert "data:application/pdf;base64," in sent
+
+
+def test_expired_file_returns_404(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    tmp_file_store: None,
+    db_session: Session,
+) -> None:
+    """A file past its retention window is no longer served (404)."""
+    up = client.post(
+        "/v1/files",
+        headers=api_key_header,
+        files={"file": ("a.txt", b"hi", "text/plain")},
+    )
+    file_id = up.json()["id"]
+
+    # Backdate the stored expiry into the past, simulating retention elapsing.
+    record = db_session.get(FileObject, file_id)
+    assert record is not None
+    record.expires_at = datetime.now(UTC) - timedelta(hours=1)
+    db_session.commit()
+
+    assert client.get(f"/v1/files/{file_id}", headers=api_key_header).status_code == 404
+    assert client.get(f"/v1/files/{file_id}/content", headers=api_key_header).status_code == 404
+
+
+def test_vision_describe_side_call_is_billed(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    tmp_file_store: None,
+    test_config: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A describe side-call for a text-only model is metered and billed.
+
+    Captioning an image for a text-only target model issues a side-call to the
+    configured vision model. Its cost must land on the user's spend even though
+    the target model itself has no pricing.
+    """
+    from any_llm.types.completion import CompletionUsage
+
+    monkeypatch.setattr(test_config, "vision_strategy", "describe")
+    monkeypatch.setattr(test_config, "vision_describe_model", "openai:gpt-4o-mini")
+
+    # Pricing for the vision model → the side-call has a non-zero cost.
+    client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "openai:gpt-4o-mini",
+            "input_price_per_million": 2.5,
+            "output_price_per_million": 10.0,
+        },
+        headers=master_key_header,
+    )
+    client.post("/v1/users", json={"user_id": "vision-user"}, headers=master_key_header)
+
+    async def fake_describe(config: Any, data_url: str) -> tuple[str | None, CompletionUsage | None]:
+        return "a chart of revenue", CompletionUsage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
+
+    monkeypatch.setattr("gateway.services.content_normalizer.describe_image", fake_describe)
+
+    captured: dict[str, Any] = {}
+
+    async def mock_acompletion(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return _make_completion()
+
+    image = "data:image/png;base64," + base64.b64encode(b"\x89PNG\r\n\x1a\n").decode("ascii")
+    body = {
+        "model": "ollama:llama3",  # text-only local → image is described, not forwarded
+        "user": "vision-user",
+        "messages": [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": image}}]}],
+    }
+
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
+        resp = client.post("/v1/chat/completions", headers=master_key_header, json=body)
+
+    assert resp.status_code == 200, resp.text
+    # The caption reached the provider in place of the image block...
+    assert "a chart of revenue" in json.dumps(captured["messages"])
+    # ...and the describe side-call's cost (1000/1e6*2.5 + 500/1e6*10) was billed.
+    user = client.get("/v1/users/vision-user", headers=master_key_header).json()
+    assert user["spend"] == pytest.approx(0.0075)

--- a/tests/integration/test_responses_route_dispatch.py
+++ b/tests/integration/test_responses_route_dispatch.py
@@ -73,6 +73,34 @@ def test_no_tools_falls_through_to_plain_aresponses(
     assert "tools" not in captured
 
 
+def test_bare_string_input_not_corrupted_by_normalization(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """A bare-string ``input`` must reach the provider verbatim.
+
+    The default config enables file understanding; the normalizer used to iterate
+    ``input`` as a sequence, rewriting a plain string into a list of one-character
+    items. Regression guard: the string survives unchanged.
+    """
+    captured: dict[str, Any] = {}
+
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        captured.update(kwargs)
+        return _response()
+
+    prompt = "What is the capital of France?"
+    with patch("gateway.api.routes.responses.aresponses", new=fake_aresponses):
+        resp = client.post(
+            "/v1/responses",
+            json={"model": _MODEL, "input": prompt},
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert captured["input_data"] == prompt
+
+
 def test_gateway_internal_fields_are_stripped_from_upstream_kwargs(
     client: TestClient,
     api_key_header: dict[str, str],

--- a/tests/unit/test_content_normalizer.py
+++ b/tests/unit/test_content_normalizer.py
@@ -10,6 +10,7 @@ import base64
 from typing import Any, cast
 
 import pytest
+from any_llm.types.completion import CompletionUsage
 
 from gateway.core.config import GatewayConfig
 from gateway.models.entities import FileObject
@@ -58,8 +59,10 @@ async def test_native_image_passthrough() -> None:
 
 @pytest.mark.asyncio
 async def test_text_only_image_described(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def fake_describe(config: GatewayConfig, data_url: str) -> str:
-        return "a red circle"
+    async def fake_describe(
+        config: GatewayConfig, data_url: str
+    ) -> tuple[str | None, CompletionUsage | None]:
+        return "a red circle", CompletionUsage(prompt_tokens=11, completion_tokens=7, total_tokens=18)
 
     monkeypatch.setattr(cn, "describe_image", fake_describe)
     cfg = GatewayConfig(vision_strategy="describe")
@@ -70,6 +73,11 @@ async def test_text_only_image_described(monkeypatch: pytest.MonkeyPatch) -> Non
     assert block["type"] == "text"
     assert "a red circle" in block["text"]
     assert stats.images_described == 1
+    # The describe side-call's usage is surfaced so the pipeline can bill it.
+    usage = stats.vision_usage()
+    assert usage is not None
+    assert usage.prompt_tokens == 11
+    assert usage.completion_tokens == 7
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_content_normalizer.py
+++ b/tests/unit/test_content_normalizer.py
@@ -43,6 +43,25 @@ async def test_string_content_untouched() -> None:
 
 
 @pytest.mark.asyncio
+async def test_bare_string_messages_untouched() -> None:
+    # The Responses endpoint accepts a bare-string ``input``. Iterating it would
+    # walk the string character-by-character; it must be returned verbatim.
+    cfg = GatewayConfig()
+    text = "What is the capital of France?"
+    out, stats = await normalize_messages(
+        cast("list[dict[str, Any]]", text),
+        config=cfg,
+        caps=_TEXT_ONLY,
+        fmt="responses",
+        db=None,
+        file_store=None,
+        user_id="u",
+    )
+    assert cast("Any", out) == text
+    assert not stats.touched
+
+
+@pytest.mark.asyncio
 async def test_native_image_passthrough() -> None:
     cfg = GatewayConfig()
     msg = _image_msg()

--- a/tests/unit/test_content_normalizer.py
+++ b/tests/unit/test_content_normalizer.py
@@ -1,0 +1,203 @@
+"""Unit tests for the content normalizer.
+
+The heavy extraction/vision boundaries (markitdown, vision side-call, file
+store) are monkeypatched so these tests run with no optional deps and no DB.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any, cast
+
+import pytest
+
+from gateway.core.config import GatewayConfig
+from gateway.models.entities import FileObject
+from gateway.services import content_normalizer as cn
+from gateway.services.content_normalizer import normalize_messages
+from gateway.services.file_extractors import ExtractionResult
+from gateway.services.model_capabilities import Capabilities
+
+_NATIVE = Capabilities(image=True, pdf=True, source="test")
+_TEXT_ONLY = Capabilities(image=False, pdf=False, source="test")
+
+_PNG_B64 = base64.b64encode(b"\x89PNG\r\n\x1a\n").decode("ascii")
+_PNG_DATA_URL = f"data:image/png;base64,{_PNG_B64}"
+
+
+def _image_msg(url: str = _PNG_DATA_URL) -> list[dict[str, Any]]:
+    content = [{"type": "text", "text": "hi"}, {"type": "image_url", "image_url": {"url": url}}]
+    return [{"role": "user", "content": content}]
+
+
+@pytest.mark.asyncio
+async def test_string_content_untouched() -> None:
+    cfg = GatewayConfig()
+    msgs = [{"role": "user", "content": "plain text"}]
+    out, stats = await normalize_messages(
+        msgs, config=cfg, caps=_TEXT_ONLY, fmt="openai", db=None, file_store=None, user_id="u"
+    )
+    assert out == msgs
+    assert not stats.touched
+
+
+@pytest.mark.asyncio
+async def test_native_image_passthrough() -> None:
+    cfg = GatewayConfig()
+    msg = _image_msg()
+    out, stats = await normalize_messages(
+        msg, config=cfg, caps=_NATIVE, fmt="openai", db=None, file_store=None, user_id="u"
+    )
+    block = out[0]["content"][1]
+    assert block["type"] == "image_url"
+    # An already-inline block must pass through byte-identical — no decode/
+    # re-encode round-trip for a native model.
+    assert block["image_url"]["url"] == _PNG_DATA_URL
+    assert not stats.touched
+
+
+@pytest.mark.asyncio
+async def test_text_only_image_described(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_describe(config: GatewayConfig, data_url: str) -> str:
+        return "a red circle"
+
+    monkeypatch.setattr(cn, "describe_image", fake_describe)
+    cfg = GatewayConfig(vision_strategy="describe")
+    out, stats = await normalize_messages(
+        _image_msg(), config=cfg, caps=_TEXT_ONLY, fmt="openai", db=None, file_store=None, user_id="u"
+    )
+    block = out[0]["content"][1]
+    assert block["type"] == "text"
+    assert "a red circle" in block["text"]
+    assert stats.images_described == 1
+
+
+@pytest.mark.asyncio
+async def test_text_only_image_dropped_when_off() -> None:
+    cfg = GatewayConfig(vision_strategy="off")
+    out, stats = await normalize_messages(
+        _image_msg(), config=cfg, caps=_TEXT_ONLY, fmt="openai", db=None, file_store=None, user_id="u"
+    )
+    block = out[0]["content"][1]
+    assert block["type"] == "text"
+    assert "omitted" in block["text"]
+    assert stats.dropped == 1
+
+
+@pytest.mark.asyncio
+async def test_remote_image_url_not_fetched_and_passed_through() -> None:
+    cfg = GatewayConfig(vision_strategy="off")
+    out, _ = await normalize_messages(
+        _image_msg("https://example.com/a.png"),
+        config=cfg,
+        caps=_TEXT_ONLY,
+        fmt="openai",
+        db=None,
+        file_store=None,
+        user_id="u",
+    )
+    # Remote URLs are never fetched (SSRF-safe); the block is left for the model
+    # turn marker since it can't be rendered.
+    assert out[0]["content"][1]["type"] == "text"
+
+
+@pytest.mark.asyncio
+async def test_document_extracted_to_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_extract(data: bytes, mime: str, filename: str | None) -> ExtractionResult:
+        return ExtractionResult("Quarterly numbers up.", True, "ok")
+
+    monkeypatch.setattr(cn, "extract_text_from_file", fake_extract)
+    cfg = GatewayConfig()
+    pdf_data_url = "data:application/pdf;base64," + base64.b64encode(b"%PDF-1.4").decode("ascii")
+    msgs = [
+        {
+            "role": "user",
+            "content": [{"type": "file", "file": {"file_data": pdf_data_url, "filename": "q3.pdf"}}],
+        }
+    ]
+    out, stats = await normalize_messages(
+        msgs, config=cfg, caps=_TEXT_ONLY, fmt="openai", db=None, file_store=None, user_id="u"
+    )
+    block = out[0]["content"][0]
+    assert block["type"] == "text"
+    assert "q3.pdf" in block["text"]
+    assert "Quarterly numbers up." in block["text"]
+    assert stats.files_extracted == 1
+
+
+@pytest.mark.asyncio
+async def test_anthropic_image_passthrough_native() -> None:
+    cfg = GatewayConfig()
+    msgs = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": _PNG_B64}}
+            ],
+        }
+    ]
+    out, stats = await normalize_messages(
+        msgs, config=cfg, caps=_NATIVE, fmt="anthropic", db=None, file_store=None, user_id="u"
+    )
+    assert out[0]["content"][0]["type"] == "image"
+    assert out[0]["content"][0]["source"]["type"] == "base64"
+    assert not stats.touched
+
+
+@pytest.mark.asyncio
+async def test_responses_uses_input_text_block() -> None:
+    cfg = GatewayConfig(vision_strategy="off")
+    msgs = [{"role": "user", "content": [{"type": "input_image", "image_url": _PNG_DATA_URL}]}]
+    out, _ = await normalize_messages(
+        msgs, config=cfg, caps=_TEXT_ONLY, fmt="responses", db=None, file_store=None, user_id="u"
+    )
+    assert out[0]["content"][0]["type"] == "input_text"
+
+
+@pytest.mark.asyncio
+async def test_file_id_resolved_and_inlined_for_native(monkeypatch: pytest.MonkeyPatch) -> None:
+    record = FileObject(
+        id="file-x",
+        user_id="u",
+        filename="pic.png",
+        mime_type="image/png",
+        bytes=8,
+        purpose="user_data",
+        storage_ref="x/file-x",
+    )
+
+    async def fake_fetch(db, file_id, user_id):  # type: ignore[no-untyped-def]
+        assert file_id == "file-x"
+        return record
+
+    async def fake_read(file_store, rec):  # type: ignore[no-untyped-def]
+        return b"\x89PNG\r\n\x1a\n"
+
+    monkeypatch.setattr(cn, "fetch_file", fake_fetch)
+    monkeypatch.setattr(cn, "read_file_bytes", fake_read)
+
+    cfg = GatewayConfig()
+    msgs = [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "x"}, "file_id": "file-x"}]}]
+    out, _ = await normalize_messages(
+        msgs,
+        config=cfg,
+        caps=_NATIVE,
+        fmt="openai",
+        db=cast(Any, object()),
+        file_store=cast(Any, object()),
+        user_id="u",
+    )
+    block = out[0]["content"][0]
+    # file_id rewritten to an inline data URL the upstream provider understands.
+    assert block["type"] == "image_url"
+    assert block["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+@pytest.mark.asyncio
+async def test_disabled_is_noop() -> None:
+    cfg = GatewayConfig(file_understanding_enabled=False, vision_strategy="off")
+    out, stats = await normalize_messages(
+        _image_msg(), config=cfg, caps=_TEXT_ONLY, fmt="openai", db=None, file_store=None, user_id="u"
+    )
+    assert out == _image_msg()
+    assert not stats.touched

--- a/tests/unit/test_file_store.py
+++ b/tests/unit/test_file_store.py
@@ -1,0 +1,57 @@
+"""Unit tests for the local-filesystem file store."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gateway.core.config import GatewayConfig
+from gateway.services.file_store import LocalDirFileStore, build_file_store
+
+
+@pytest.mark.asyncio
+async def test_put_get_roundtrip(tmp_path: Path) -> None:
+    store = LocalDirFileStore(str(tmp_path))
+    ref = await store.put("file-abcdef0123", b"hello bytes")
+    assert await store.get(ref) == b"hello bytes"
+
+
+@pytest.mark.asyncio
+async def test_put_shards_by_prefix(tmp_path: Path) -> None:
+    store = LocalDirFileStore(str(tmp_path))
+    ref = await store.put("file-ab12cd34", b"x")
+    # Sharded under the first two hex chars of the id token.
+    assert ref == "ab/file-ab12cd34"
+    assert (tmp_path / "ab" / "file-ab12cd34").exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_is_idempotent(tmp_path: Path) -> None:
+    store = LocalDirFileStore(str(tmp_path))
+    ref = await store.put("file-deadbeef", b"data")
+    await store.delete(ref)
+    assert not (tmp_path / ref).exists()
+    # Deleting again must not raise.
+    await store.delete(ref)
+
+
+@pytest.mark.asyncio
+async def test_rejects_path_traversal(tmp_path: Path) -> None:
+    store = LocalDirFileStore(str(tmp_path))
+    for ref in ("../escape", "../../etc/passwd", "ab/../../escape"):
+        with pytest.raises(ValueError, match="escapes the file store root"):
+            await store.get(ref)
+        with pytest.raises(ValueError, match="escapes the file store root"):
+            await store.delete(ref)
+
+
+def test_build_file_store_local(tmp_path: Path) -> None:
+    config = GatewayConfig(files_backend="local", files_local_dir=str(tmp_path))
+    assert isinstance(build_file_store(config), LocalDirFileStore)
+
+
+def test_build_file_store_rejects_unknown_backend() -> None:
+    config = GatewayConfig(files_backend="ceph")
+    with pytest.raises(ValueError, match="Unsupported files_backend"):
+        build_file_store(config)

--- a/tests/unit/test_model_capabilities.py
+++ b/tests/unit/test_model_capabilities.py
@@ -1,0 +1,61 @@
+"""Unit tests for the model-capability resolver."""
+
+from __future__ import annotations
+
+from any_llm import LLMProvider
+
+from gateway.core.config import GatewayConfig, ModelCapabilityConfig
+from gateway.services.model_capabilities import resolve_capabilities
+
+
+def test_hosted_provider_trusts_metadata() -> None:
+    caps = resolve_capabilities(GatewayConfig(), LLMProvider.OPENAI, "gpt-4o")
+    assert caps.source == "provider_metadata"
+    assert caps.image is True
+    assert caps.pdf is True
+
+
+def test_local_provider_defaults_to_extract() -> None:
+    # Ollama over-reports image/pdf support at the class level; we must NOT trust
+    # it, or document blocks get silently dropped.
+    caps = resolve_capabilities(GatewayConfig(), LLMProvider.OLLAMA, "llama3")
+    assert caps.source == "default"
+    assert caps.image is False
+    assert caps.pdf is False
+
+
+def test_config_override_wins_with_provider_model_key() -> None:
+    config = GatewayConfig(
+        model_capabilities={"ollama/qwen2-vl": ModelCapabilityConfig(supports_image=True, supports_pdf=False)}
+    )
+    caps = resolve_capabilities(config, LLMProvider.OLLAMA, "qwen2-vl")
+    assert caps.source == "config"
+    assert caps.image is True
+    assert caps.pdf is False
+
+
+def test_config_override_accepts_colon_separator() -> None:
+    # Users write model selectors and pricing keys with a colon, so the colon
+    # form must match too — not just the slash form.
+    config = GatewayConfig(
+        model_capabilities={"ollama:qwen2-vl": ModelCapabilityConfig(supports_image=True)}
+    )
+    caps = resolve_capabilities(config, LLMProvider.OLLAMA, "qwen2-vl")
+    assert caps.source == "config"
+    assert caps.image is True
+
+
+def test_config_override_matches_bare_model_key() -> None:
+    config = GatewayConfig(model_capabilities={"my-vision": ModelCapabilityConfig(supports_image=True)})
+    caps = resolve_capabilities(config, LLMProvider.VLLM, "my-vision")
+    assert caps.source == "config"
+    assert caps.image is True
+
+
+def test_override_beats_hosted_metadata() -> None:
+    # An operator can also downgrade a hosted model (e.g. a text-only deployment).
+    config = GatewayConfig(model_capabilities={"openai/gpt-4o": ModelCapabilityConfig()})
+    caps = resolve_capabilities(config, LLMProvider.OPENAI, "gpt-4o")
+    assert caps.source == "config"
+    assert caps.image is False
+    assert caps.pdf is False

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.13"
+resolution-markers = [
+    "sys_platform == 'win32'",
+    "sys_platform != 'win32'",
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -326,6 +330,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "boto3"
 version = "1.42.81"
 source = { registry = "https://pypi.org/simple" }
@@ -503,6 +520,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cobble"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/7a/a507c709be2c96e1bb6102eb7b7f4026c5e5e223ef7d745a17d239e9d844/cobble-0.1.4.tar.gz", hash = "sha256:de38be1539992c8a06e569630717c485a5f91be2192c461ea2b220607dfa78aa", size = 3805, upload-time = "2024-06-01T18:11:09.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/e1/3714a2f371985215c219c2a70953d38e3eed81ef165aed061d21de0e998b/cobble-0.1.4-py3-none-any.whl", hash = "sha256:36c91b1655e599fd428e2b95fdd5f0da1ca2e9f1abb0bc871dec21a0e78a2b44", size = 3984, upload-time = "2024-06-01T18:11:07.911Z" },
+]
+
+[[package]]
 name = "cohere"
 version = "5.21.1"
 source = { registry = "https://pypi.org/simple" }
@@ -528,6 +554,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coloredlogs"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanfriendly" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
 ]
 
 [[package]]
@@ -682,6 +720,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -711,6 +758,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
 ]
 
 [[package]]
@@ -795,6 +851,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -899,16 +963,25 @@ dependencies = [
     { name = "asyncpg" },
     { name = "click" },
     { name = "fastapi" },
+    { name = "markitdown", extra = ["docx", "pdf", "pptx", "xlsx"] },
     { name = "mcp" },
+    { name = "pillow" },
     { name = "prometheus-client" },
     { name = "psycopg2-binary" },
     { name = "pydantic-settings" },
+    { name = "pypdfium2" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "trafilatura" },
     { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.optional-dependencies]
+ocr = [
+    { name = "numpy" },
+    { name = "rapidocr-onnxruntime" },
 ]
 
 [package.dev-dependencies]
@@ -932,17 +1005,23 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "markitdown", extras = ["docx", "pptx", "xlsx", "pdf"], specifier = ">=0.1.0" },
     { name = "mcp", specifier = ">=1.0.0" },
+    { name = "numpy", marker = "extra == 'ocr'", specifier = ">=1.26.0" },
+    { name = "pillow", specifier = ">=10.0.0" },
     { name = "prometheus-client", specifier = ">=0.20.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
+    { name = "pypdfium2", specifier = ">=4.30.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "rapidocr-onnxruntime", marker = "extra == 'ocr'", specifier = ">=1.3.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
     { name = "trafilatura", specifier = ">=2.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
+provides-extras = ["ocr"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1342,6 +1421,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/2a/a847fd02261cd051da218baf99f90ee7c7040c109a01833db4f838f25256/huggingface_hub-1.8.0.tar.gz", hash = "sha256:c5627b2fd521e00caf8eff4ac965ba988ea75167fad7ee72e17f9b7183ec63f3", size = 735839, upload-time = "2026-03-25T16:01:28.152Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/ae/8a3a16ea4d202cb641b51d2681bdd3d482c1c592d7570b3fa264730829ce/huggingface_hub-1.8.0-py3-none-any.whl", hash = "sha256:d3eb5047bd4e33c987429de6020d4810d38a5bef95b3b40df9b17346b7f353f2", size = 625208, upload-time = "2026-03-25T16:01:26.603Z" },
+]
+
+[[package]]
+name = "humanfriendly"
+version = "10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
 ]
 
 [[package]]
@@ -1793,6 +1884,24 @@ wheels = [
 ]
 
 [[package]]
+name = "magika"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/f3/3d1dcdd7b9c41d589f5cff252d32ed91cdf86ba84391cfc81d9d8773571d/magika-0.6.3.tar.gz", hash = "sha256:7cc52aa7359af861957043e2bf7265ed4741067251c104532765cd668c0c0cb1", size = 3042784, upload-time = "2025-10-30T15:22:34.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/e4/35c323beb3280482c94299d61626116856ac2d4ec16ecef50afc4fdd4291/magika-0.6.3-py3-none-any.whl", hash = "sha256:eda443d08006ee495e02083b32e51b98cb3696ab595a7d13900d8e2ef506ec9d", size = 2969474, upload-time = "2025-10-30T15:22:25.298Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8f/132b0d7cd51c02c39fd52658a5896276c30c8cc2fd453270b19db8c40f7e/magika-0.6.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:86901e64b05dde5faff408c9b8245495b2e1fd4c226e3393d3d2a3fee65c504b", size = 13358841, upload-time = "2025-10-30T15:22:27.413Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/03/5ed859be502903a68b7b393b17ae0283bf34195cfcca79ce2dc25b9290e7/magika-0.6.3-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:3d9661eedbdf445ac9567e97e7ceefb93545d77a6a32858139ea966b5806fb64", size = 15367335, upload-time = "2025-10-30T15:22:29.907Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/9e/f8ee7d644affa3b80efdd623a3d75865c8f058f3950cb87fb0c48e3559bc/magika-0.6.3-py3-none-win_amd64.whl", hash = "sha256:e57f75674447b20cab4db928ae58ab264d7d8582b55183a0b876711c2b2787f3", size = 12692831, upload-time = "2025-10-30T15:22:32.063Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1805,6 +1914,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mammoth"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cobble" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/3c/a58418d2af00f2da60d4a51e18cd0311307b72d48d2fffec36a97b4a5e44/mammoth-1.11.0.tar.gz", hash = "sha256:a0f59e442f34d5b6447f4b0999306cbf3e67aaabfa8cb516f878fb1456744637", size = 53142, upload-time = "2025-09-19T10:35:20.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/54/2e39566a131b13f6d8d193f974cb6a34e81bb7cc2fa6f7e03de067b36588/mammoth-1.11.0-py2.py3-none-any.whl", hash = "sha256:c077ab0d450bd7c0c6ecd529a23bf7e0fa8190c929e28998308ff4eada3f063b", size = 54752, upload-time = "2025-09-19T10:35:18.699Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1814,6 +1935,53 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markdownify"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/bc/c8c8eea5335341306b0fa7e1cb33c5e1c8d24ef70ddd684da65f41c49c92/markdownify-1.2.2.tar.gz", hash = "sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09", size = 18816, upload-time = "2025-11-16T19:21:18.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ce/f1e3e9d959db134cedf06825fae8d5b294bd368aacdd0831a3975b7c4d55/markdownify-1.2.2-py3-none-any.whl", hash = "sha256:3f02d3cc52714084d6e589f70397b6fc9f2f3a8531481bf35e8cc39f975e186a", size = 15724, upload-time = "2025-11-16T19:21:17.622Z" },
+]
+
+[[package]]
+name = "markitdown"
+version = "0.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "charset-normalizer" },
+    { name = "defusedxml" },
+    { name = "magika" },
+    { name = "markdownify" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/b7/91fe0e2df07107ab701a15c8ad3213135707e4d6206ae9bd8f457a7ad86a/markitdown-0.1.6.tar.gz", hash = "sha256:e5bdbaffd971b29598c7c39ef0e9afce2f08c0751fbfa4e4257678ebaf8cfc7e", size = 50795, upload-time = "2026-05-26T22:43:59.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/30/8031f183ee86ea8ac4e7ea1296bab4cca1bee2fd036a26df69764eb7ca74/markitdown-0.1.6-py3-none-any.whl", hash = "sha256:07b2d5bf87b5c53e13a9f2fdc440df8ccc85e26f40c1e557781727b700049775", size = 70032, upload-time = "2026-05-26T22:44:03.209Z" },
+]
+
+[package.optional-dependencies]
+docx = [
+    { name = "lxml" },
+    { name = "mammoth" },
+]
+pdf = [
+    { name = "pdfminer-six" },
+    { name = "pdfplumber" },
+]
+pptx = [
+    { name = "python-pptx" },
+]
+xlsx = [
+    { name = "openpyxl" },
+    { name = "pandas" },
 ]
 
 [[package]]
@@ -1919,6 +2087,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/3f/5624d57c5897c83c55d3e4c7dd4127de42ad14fd3183e26566cdc7dca1bf/mistralai-2.4.5.tar.gz", hash = "sha256:ef165bb004ec4423cbf19a440bf0983ca0c3fc92ab12a35ebca097bdf418e33a", size = 424611, upload-time = "2026-05-07T11:46:43.888Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/48/2c5c4f853dec32a625c1a3d23809b80cf2e135c3441fe1764f72910dfea9/mistralai-2.4.5-py3-none-any.whl", hash = "sha256:bf3b6550258ab16dec8547b90e9c18bebf9099f55b7fc25a884bf0bbeffced0f", size = 995999, upload-time = "2026-05-07T11:46:41.915Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
 ]
 
 [[package]]
@@ -2143,6 +2320,27 @@ wheels = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/71/c5d980ac4189589267a06f758bd6c5667d07e55656bed6c6c0580733ad07/onnxruntime-1.20.1-cp313-cp313-macosx_13_0_universal2.whl", hash = "sha256:cc01437a32d0042b606f462245c8bbae269e5442797f6213e36ce61d5abdd8cc", size = 31007574, upload-time = "2024-11-21T00:49:23.225Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0d/13bbd9489be2a6944f4a940084bfe388f1100472f38c07080a46fbd4ab96/onnxruntime-1.20.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb44b08e017a648924dbe91b82d89b0c105b1adcfe31e90d1dc06b8677ad37be", size = 11951459, upload-time = "2024-11-21T00:49:26.269Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/4454ae122874fd52bbb8a961262de81c5f932edeb1b72217f594c700d6ef/onnxruntime-1.20.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bda6aebdf7917c1d811f21d41633df00c58aff2bef2f598f69289c1f1dabc4b3", size = 13331620, upload-time = "2024-11-21T00:49:28.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/e0/50db43188ca1c945decaa8fc2a024c33446d31afed40149897d4f9de505f/onnxruntime-1.20.1-cp313-cp313-win_amd64.whl", hash = "sha256:d30367df7e70f1d9fc5a6a68106f5961686d39b54d3221f760085524e8d38e16", size = 11331758, upload-time = "2024-11-21T00:49:31.417Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/55/3821c5fd60b52a6c82a00bba18531793c93c4addfe64fbf061e235c5617a/onnxruntime-1.20.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9158465745423b2b5d97ed25aa7740c7d38d2993ee2e5c3bfacb0c4145c49d8", size = 11950342, upload-time = "2024-11-21T00:49:34.164Z" },
+    { url = "https://files.pythonhosted.org/packages/14/56/fd990ca222cef4f9f4a9400567b9a15b220dee2eafffb16b2adbc55c8281/onnxruntime-1.20.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0df6f2df83d61f46e842dbcde610ede27218947c33e994545a22333491e72a3b", size = 13337040, upload-time = "2024-11-21T00:49:37.271Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2159,6 +2357,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/9e/5bfa2270f902d5b92ab7d41ce0475b8630572e71e349b2a4996d14bdda93/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d", size = 1146656, upload-time = "2026-03-25T22:08:58.2Z" },
+]
+
+[[package]]
+name = "opencv-python"
+version = "4.13.0.92"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/6f/5a28fef4c4a382be06afe3938c64cc168223016fa520c5abaf37e8862aa5/opencv_python-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:caf60c071ec391ba51ed00a4a920f996d0b64e3e46068aac1f646b5de0326a19", size = 46247052, upload-time = "2026-02-05T07:01:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ac/6c98c44c650b8114a0fb901691351cfb3956d502e8e9b5cd27f4ee7fbf2f/opencv_python-4.13.0.92-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:5868a8c028a0b37561579bfb8ac1875babdc69546d236249fff296a8c010ccf9", size = 32568781, upload-time = "2026-02-05T07:01:41.379Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/51/82fed528b45173bf629fa44effb76dff8bc9f4eeaee759038362dfa60237/opencv_python-4.13.0.92-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0bc2596e68f972ca452d80f444bc404e08807d021fbba40df26b61b18e01838a", size = 47685527, upload-time = "2026-02-05T06:59:11.24Z" },
+    { url = "https://files.pythonhosted.org/packages/db/07/90b34a8e2cf9c50fe8ed25cac9011cde0676b4d9d9c973751ac7616223a2/opencv_python-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:402033cddf9d294693094de5ef532339f14ce821da3ad7df7c9f6e8316da32cf", size = 70460872, upload-time = "2026-02-05T06:59:19.162Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/7a9cc719b3eaf4377b9c2e3edeb7ed3a81de41f96421510c0a169ca3cfd4/opencv_python-4.13.0.92-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:bccaabf9eb7f897ca61880ce2869dcd9b25b72129c28478e7f2a5e8dee945616", size = 46708208, upload-time = "2026-02-05T06:59:15.419Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/55/b3b49a1b97aabcfbbd6c7326df9cb0b6fa0c0aefa8e89d500939e04aa229/opencv_python-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:620d602b8f7d8b8dab5f4b99c6eb353e78d3fb8b0f53db1bd258bb1aa001c1d5", size = 72927042, upload-time = "2026-02-05T06:59:23.389Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/17/de5458312bcb07ddf434d7bfcb24bb52c59635ad58c6e7c751b48949b009/opencv_python-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:372fe164a3148ac1ca51e5f3ad0541a4a276452273f503441d718fab9c5e5f59", size = 30932638, upload-time = "2026-02-05T07:02:14.98Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a5/1be1516390333ff9be3a9cb648c9f33df79d5096e5884b5df71a588af463/opencv_python-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:423d934c9fafb91aad38edf26efb46da91ffbc05f3f59c4b0c72e699720706f5", size = 40212062, upload-time = "2026-02-05T07:02:12.724Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
 ]
 
 [[package]]
@@ -2362,6 +2590,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "pdfminer-six"
+version = "20251230"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/9a/d79d8fa6d47a0338846bb558b39b9963b8eb2dfedec61867c138c1b17eeb/pdfminer_six-20251230.tar.gz", hash = "sha256:e8f68a14c57e00c2d7276d26519ea64be1b48f91db1cdc776faa80528ca06c1e", size = 8511285, upload-time = "2025-12-30T15:49:13.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/d7/b288ea32deb752a09aab73c75e1e7572ab2a2b56c3124a5d1eb24c62ceb3/pdfminer_six-20251230-py3-none-any.whl", hash = "sha256:9ff2e3466a7dfc6de6fd779478850b6b7c2d9e9405aa2a5869376a822771f485", size = 6591909, upload-time = "2025-12-30T15:49:10.76Z" },
+]
+
+[[package]]
+name = "pdfplumber"
+version = "0.11.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pdfminer-six" },
+    { name = "pillow" },
+    { name = "pypdfium2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/37/9ca3519e92a8434eb93be570b131476cc0a4e840bb39c62ddb7813a39d53/pdfplumber-0.11.9.tar.gz", hash = "sha256:481224b678b2bbdbf376e2c39bf914144eef7c3d301b4a28eebf0f7f6109d6dc", size = 102768, upload-time = "2026-01-05T08:10:29.072Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/c8/cdbc975f5b634e249cfa6597e37c50f3078412474f21c015e508bfbfe3c3/pdfplumber-0.11.9-py3-none-any.whl", hash = "sha256:33ec5580959ba524e9100138746e090879504c42955df1b8a997604dd326c443", size = 60045, upload-time = "2026-01-05T08:10:27.512Z" },
 ]
 
 [[package]]
@@ -2588,6 +2843,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pyclipper"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/21/3c06205bb407e1f79b73b7b4dfb3950bd9537c4f625a68ab5cc41177f5bc/pyclipper-1.4.0.tar.gz", hash = "sha256:9882bd889f27da78add4dd6f881d25697efc740bf840274e749988d25496c8e1", size = 54489, upload-time = "2025-12-01T13:15:35.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/d0/cbce7d47de1e6458f66a4d999b091640134deb8f2c7351eab993b70d2e10/pyclipper-1.4.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d49df13cbb2627ccb13a1046f3ea6ebf7177b5504ec61bdef87d6a704046fd6e", size = 264342, upload-time = "2025-12-01T13:15:12.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/cc/742b9d69d96c58ac156947e1b56d0f81cbacbccf869e2ac7229f2f86dc4e/pyclipper-1.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:37bfec361e174110cdddffd5ecd070a8064015c99383d95eb692c253951eee8a", size = 139839, upload-time = "2025-12-01T13:15:13.911Z" },
+    { url = "https://files.pythonhosted.org/packages/db/48/dd301d62c1529efdd721b47b9e5fb52120fcdac5f4d3405cfc0d2f391414/pyclipper-1.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:14c8bdb5a72004b721c4e6f448d2c2262d74a7f0c9e3076aeff41e564a92389f", size = 972142, upload-time = "2025-12-01T13:15:15.477Z" },
+    { url = "https://files.pythonhosted.org/packages/07/bf/d493fd1b33bb090fa64e28c1009374d5d72fa705f9331cd56517c35e381e/pyclipper-1.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f2a50c22c3a78cb4e48347ecf06930f61ce98cf9252f2e292aa025471e9d75b1", size = 952789, upload-time = "2025-12-01T13:15:17.042Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/88/b95ea8ea21ddca34aa14b123226a81526dd2faaa993f9aabd3ed21231604/pyclipper-1.4.0-cp313-cp313-win32.whl", hash = "sha256:c9a3faa416ff536cee93417a72bfb690d9dea136dc39a39dbbe1e5dadf108c9c", size = 94817, upload-time = "2025-12-01T13:15:18.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/42/0a1920d276a0e1ca21dc0d13ee9e3ba10a9a8aa3abac76cd5e5a9f503306/pyclipper-1.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:d4b2d7c41086f1927d14947c563dfc7beed2f6c0d9af13c42fe3dcdc20d35832", size = 104007, upload-time = "2025-12-01T13:15:19.763Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/20/04d58c70f3ccd404f179f8dd81d16722a05a3bf1ab61445ee64e8218c1f8/pyclipper-1.4.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:7c87480fc91a5af4c1ba310bdb7de2f089a3eeef5fe351a3cedc37da1fcced1c", size = 265167, upload-time = "2025-12-01T13:15:20.844Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2e/a570c1abe69b7260ca0caab4236ce6ea3661193ebf8d1bd7f78ccce537a5/pyclipper-1.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:81d8bb2d1fb9d66dc7ea4373b176bb4b02443a7e328b3b603a73faec088b952e", size = 139966, upload-time = "2025-12-01T13:15:22.036Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/3b/e0859e54adabdde8a24a29d3f525ebb31c71ddf2e8d93edce83a3c212ffc/pyclipper-1.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:773c0e06b683214dcfc6711be230c83b03cddebe8a57eae053d4603dd63582f9", size = 968216, upload-time = "2025-12-01T13:15:23.18Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6b/e3c4febf0a35ae643ee579b09988dd931602b5bf311020535fd9e5b7e715/pyclipper-1.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9bc45f2463d997848450dbed91c950ca37c6cf27f84a49a5cad4affc0b469e39", size = 954198, upload-time = "2025-12-01T13:15:24.522Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/74/728efcee02e12acb486ce9d56fa037120c9bf5b77c54bbdbaa441c14a9d9/pyclipper-1.4.0-cp314-cp314-win32.whl", hash = "sha256:0b8c2105b3b3c44dbe1a266f64309407fe30bf372cf39a94dc8aaa97df00da5b", size = 96951, upload-time = "2025-12-01T13:15:25.79Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d7/7f4354e69f10a917e5c7d5d72a499ef2e10945312f5e72c414a0a08d2ae4/pyclipper-1.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:6c317e182590c88ec0194149995e3d71a979cfef3b246383f4e035f9d4a11826", size = 106782, upload-time = "2025-12-01T13:15:26.945Z" },
+    { url = "https://files.pythonhosted.org/packages/63/60/fc32c7a3d7f61a970511ec2857ecd09693d8ac80d560ee7b8e67a6d268c9/pyclipper-1.4.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f160a2c6ba036f7eaf09f1f10f4fbfa734234af9112fb5187877efed78df9303", size = 269880, upload-time = "2025-12-01T13:15:28.117Z" },
+    { url = "https://files.pythonhosted.org/packages/49/df/c4a72d3f62f0ba03ec440c4fff56cd2d674a4334d23c5064cbf41c9583f6/pyclipper-1.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a9f11ad133257c52c40d50de7a0ca3370a0cdd8e3d11eec0604ad3c34ba549e9", size = 141706, upload-time = "2025-12-01T13:15:30.134Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/0b/cf55df03e2175e1e2da9db585241401e0bc98f76bee3791bed39d0313449/pyclipper-1.4.0-cp314-cp314t-win32.whl", hash = "sha256:bbc827b77442c99deaeee26e0e7f172355ddb097a5e126aea206d447d3b26286", size = 105308, upload-time = "2025-12-01T13:15:31.225Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/dc/53df8b6931d47080b4fe4ee8450d42e660ee1c5c1556c7ab73359182b769/pyclipper-1.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:29dae3e0296dff8502eeb7639fcfee794b0eec8590ba3563aee28db269da6b04", size = 117608, upload-time = "2025-12-01T13:15:32.69Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2737,6 +3016,44 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdfium2"
+version = "5.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/98/6b44bf82ddb3c7a3e0249203772aad8981b4491d6227f182685f310faeff/pypdfium2-5.9.0.tar.gz", hash = "sha256:db1274bd27844db6fda17ef1dbcd0026c47d357437058d838e98060c0da9e92e", size = 272455, upload-time = "2026-06-01T15:43:38.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/d9/59630cb40e5f37e7712e6ea65e9cac633f4195e8b737bb3a46054aa63340/pypdfium2-5.9.0-py3-none-android_23_arm64_v8a.whl", hash = "sha256:91914837c4a4285b3e0724a84eca8079363db7475acbcab405933d1807785664", size = 3407817, upload-time = "2026-06-01T15:42:58.426Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/3d/e205708835a3730d5242652b6577ac06ad4721e6fcef77cc7c9d3541c686/pypdfium2-5.9.0-py3-none-android_23_armeabi_v7a.whl", hash = "sha256:90610d352f050b065b703f3a46602a852fce7dd8787300c8c7a472485b644d8f", size = 2862706, upload-time = "2026-06-01T15:43:00.581Z" },
+    { url = "https://files.pythonhosted.org/packages/01/47/e843fb895a891438b3f8c6d834fdc9c19183cd60980fc9325429d5c01505/pypdfium2-5.9.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6c4fbe3a7190b329c526358fb2855d797f7b74b5ecfc61d19657ef20bcebc108", size = 3489945, upload-time = "2026-06-01T15:43:02.542Z" },
+    { url = "https://files.pythonhosted.org/packages/35/bd/f5e6afd556f97fcaa2bec4cb04669664c166028fc2a059bd65447c852b43/pypdfium2-5.9.0-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:e93f0cf440169a3e445e6fbd06c803877e7418f3e13254287875cb67f208bb5a", size = 3674186, upload-time = "2026-06-01T15:43:04.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4d/5286812216a292d51dfba8e7bff276da198f126508f8c2afa3630bf701dc/pypdfium2-5.9.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d902e03dff5efd51d93cd23d3e55bde53802fa6207bcd0e455239518859a069", size = 3669571, upload-time = "2026-06-01T15:43:06.571Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/c8/822db2c89baa13e6cee321d587fcd42df463a1fc2f7520b3f6814768bc71/pypdfium2-5.9.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6cf38d7ad3575947b82384869f2ab69ba345eb21d83118d25db3e83f967b0421", size = 3400412, upload-time = "2026-06-01T15:43:08.35Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/dd/7d09d8cdc28383df13f739a97ac4f1215a704a97a29506dee2bf89d8a350/pypdfium2-5.9.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:77f7479a28b43aa658735e3ce79cfd1fccd5d42db035c21bb4c26e8bd7e280e5", size = 3803326, upload-time = "2026-06-01T15:43:10.054Z" },
+    { url = "https://files.pythonhosted.org/packages/99/58/3f4e04ffe1ae62b437de07a96da672091cef62b619d0dc78207c1af442e6/pypdfium2-5.9.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:07e6ba170d577eabf60dbba701d051c64318dd029d38ca5907d83ae1a66fe779", size = 4216890, upload-time = "2026-06-01T15:43:11.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f6/2dde4656750c4a6da99e1f070ca09d2b5a9d68186b42e711a1a3e5b1cb32/pypdfium2-5.9.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ce3a3dd23ec0adaa079d8be54565ba2aa2f6060e76a4989cd42dabc163d74ee", size = 3728830, upload-time = "2026-06-01T15:43:13.329Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ca/f2ff8b9200c7dfc5aee85126edc856eb93c7056085da2454a75ef1e4dbc4/pypdfium2-5.9.0-py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae177938f5cf95a275db25a4f8553e2ebd954ecda2f9bc84848ba4b027ce438f", size = 4063322, upload-time = "2026-06-01T15:43:15.158Z" },
+    { url = "https://files.pythonhosted.org/packages/64/88/0b587de03c873c28adc59f6ac959de4032d3f3bc946094523b14a192d9c3/pypdfium2-5.9.0-py3-none-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ffe49edde2ac86f28ca7e58f565255a442f38a7508fff31b79a55f508f25a31e", size = 4039738, upload-time = "2026-06-01T15:43:16.975Z" },
+    { url = "https://files.pythonhosted.org/packages/83/4c/fa627f00a954e66465e929077cf43bd012595091fff82758d989486e7bdc/pypdfium2-5.9.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b7b760bc2957ecf73c274af6ed8b168a2dcb328ac0a0f7ed6123cd92f6e7c9c9", size = 4997259, upload-time = "2026-06-01T15:43:18.915Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f0/1736d80c5d12d931f74ca6b4213b006ee016ec33c6325fad870234cc240c/pypdfium2-5.9.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7cdc8e5d2f8d82add1e4f70a4fbe5f3b33c17f301ebde38c669fd7f78a7d032c", size = 4537061, upload-time = "2026-06-01T15:43:20.879Z" },
+    { url = "https://files.pythonhosted.org/packages/01/00/aa8890dfd385b2e7365034231987029cff15cc7eb4f06e8380da5608738a/pypdfium2-5.9.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:38a058dbd4929acaf0ab9171179eb86c24d8c6655a6836006796105a9f200890", size = 5232786, upload-time = "2026-06-01T15:43:23.73Z" },
+    { url = "https://files.pythonhosted.org/packages/65/12/8f45ea698781a0bed96ac4fbde440060790863273943461f0f160a993d52/pypdfium2-5.9.0-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:1894511a0e862e7ec5679f3a6dc43ac72c4ef92c7ca438357203913e8634a643", size = 5170121, upload-time = "2026-06-01T15:43:25.858Z" },
+    { url = "https://files.pythonhosted.org/packages/25/bd/9bb6ba375796e1de1d6c1af8d8303dd1781190346871c81a94d4e09eddfd/pypdfium2-5.9.0-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:040f5513b808db705d4878f57e2bf0b9dc6e6a0ad8d765c36cf62febf3933b28", size = 4663540, upload-time = "2026-06-01T15:43:27.677Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4a/fd103bac197f22038bf70be1f7507ced7519f1214ea0dae137f37803ab8a/pypdfium2-5.9.0-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:f4991ae39bcea757552579bba4aebfaedb71c96dd35c2292f957b8ac9132f1ff", size = 5090619, upload-time = "2026-06-01T15:43:29.522Z" },
+    { url = "https://files.pythonhosted.org/packages/22/89/9531fa1e6e004fe522cdca0cd945cd6a9d7338e7125e6b0734d632d31fa6/pypdfium2-5.9.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:25ff1a5abd08ff9e87f62e5dac114ea95647c257fbbdbe029be8db71a6d7650b", size = 5050806, upload-time = "2026-06-01T15:43:31.322Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d0/e53c68555ff128b2470e4a468762b320d9c6ae2c914decea3487d923982f/pypdfium2-5.9.0-py3-none-win32.whl", hash = "sha256:b0057dc8c2033584dc3e61afb5f23a135dab52b081695b435e27f9b7b074c605", size = 3670966, upload-time = "2026-06-01T15:43:32.991Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0c/22e5fc035ad1594b44f265bc0a59ae34d377bc2ea74a92793e7a674bf96d/pypdfium2-5.9.0-py3-none-win_amd64.whl", hash = "sha256:06508c33b9772cf3878e48364c6e14c70cefc18a3abd6983ac9f338da9305275", size = 3800959, upload-time = "2026-06-01T15:43:34.536Z" },
+    { url = "https://files.pythonhosted.org/packages/11/e3/cf1711add7add22a17f7c7633cd795edc92f17ab7bdf1930493ae0f56680/pypdfium2-5.9.0-py3-none-win_arm64.whl", hash = "sha256:565ddfc98795fd2f6054b544ee9791d7b9032f9cf77a57891b6e501fafd0ef3f", size = 3585718, upload-time = "2026-06-01T15:43:36.521Z" },
+]
+
+[[package]]
+name = "pyreadline3"
+version = "3.5.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/6d/f94028646d7bbe6d9d873c47ee7c246f2d29129d253f0d96cb6fcab70733/pyreadline3-3.5.6.tar.gz", hash = "sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf", size = 100368, upload-time = "2026-05-14T17:55:04.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/5e/35c856e186b74678c24927847ad9895a51f1bc02a0c6126477a6c6040064/pyreadline3-3.5.6-py3-none-any.whl", hash = "sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d", size = 85243, upload-time = "2026-05-14T17:55:03.262Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2847,6 +3164,21 @@ wheels = [
 ]
 
 [[package]]
+name = "python-pptx"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "pillow" },
+    { name = "typing-extensions" },
+    { name = "xlsxwriter" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/a9/0c0db8d37b2b8a645666f7fd8accea4c6224e013c42b1d5c17c93590cd06/python_pptx-1.0.2.tar.gz", hash = "sha256:479a8af0eaf0f0d76b6f00b0887732874ad2e3188230315290cd1f9dd9cc7095", size = 10109297, upload-time = "2024-08-07T17:33:37.772Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/4f/00be2196329ebbff56ce564aa94efb0fbc828d00de250b1980de1a34ab49/python_pptx-1.0.2-py3-none-any.whl", hash = "sha256:160838e0b8565a8b1f67947675886e9fea18aa5e795db7ae531606d68e785cba", size = 472788, upload-time = "2024-08-07T17:33:28.192Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2026.1.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -2902,6 +3234,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rapidocr-onnxruntime"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "opencv-python" },
+    { name = "pillow" },
+    { name = "pyclipper" },
+    { name = "pyyaml" },
+    { name = "shapely" },
+    { name = "six" },
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/12/1e5497183bdbe782dbb91bad1d0d2297dba4d2831b2652657f7517bfc6df/rapidocr_onnxruntime-1.4.4-py3-none-any.whl", hash = "sha256:971d7d5f223a7a808662229df1ef69893809d8457d834e6373d3854bc1782cbf", size = 14915192, upload-time = "2025-01-17T01:48:25.104Z" },
 ]
 
 [[package]]
@@ -3133,6 +3484,49 @@ wheels = [
 ]
 
 [[package]]
+name = "shapely"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/90/98ef257c23c46425dc4d1d31005ad7c8d649fe423a38b917db02c30f1f5a/shapely-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b510dda1a3672d6879beb319bc7c5fd302c6c354584690973c838f46ec3e0fa8", size = 1832644, upload-time = "2025-09-24T13:50:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ab/0bee5a830d209adcd3a01f2d4b70e587cdd9fd7380d5198c064091005af8/shapely-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8cff473e81017594d20ec55d86b54bc635544897e13a7cfc12e36909c5309a2a", size = 1642887, upload-time = "2025-09-24T13:50:46.735Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5e/7d7f54ba960c13302584c73704d8c4d15404a51024631adb60b126a4ae88/shapely-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe7b77dc63d707c09726b7908f575fc04ff1d1ad0f3fb92aec212396bc6cfe5e", size = 2970931, upload-time = "2025-09-24T13:50:48.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ed1a5bbfb386ee8332713bf7508bc24e32d24b74fc9a7b9f8529a55db9f4ee6", size = 3082855, upload-time = "2025-09-24T13:50:50.037Z" },
+    { url = "https://files.pythonhosted.org/packages/44/2b/578faf235a5b09f16b5f02833c53822294d7f21b242f8e2d0cf03fb64321/shapely-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a84e0582858d841d54355246ddfcbd1fce3179f185da7470f41ce39d001ee1af", size = 3979960, upload-time = "2025-09-24T13:50:51.74Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/04/167f096386120f692cc4ca02f75a17b961858997a95e67a3cb6a7bbd6b53/shapely-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc3487447a43d42adcdf52d7ac73804f2312cbfa5d433a7d2c506dcab0033dfd", size = 4142851, upload-time = "2025-09-24T13:50:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/48/74/fb402c5a6235d1c65a97348b48cdedb75fb19eca2b1d66d04969fc1c6091/shapely-2.1.2-cp313-cp313-win32.whl", hash = "sha256:9c3a3c648aedc9f99c09263b39f2d8252f199cb3ac154fadc173283d7d111350", size = 1541890, upload-time = "2025-09-24T13:50:55.337Z" },
+    { url = "https://files.pythonhosted.org/packages/41/47/3647fe7ad990af60ad98b889657a976042c9988c2807cf322a9d6685f462/shapely-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:ca2591bff6645c216695bdf1614fca9c82ea1144d4a7591a466fef64f28f0715", size = 1722151, upload-time = "2025-09-24T13:50:57.153Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/49/63953754faa51ffe7d8189bfbe9ca34def29f8c0e34c67cbe2a2795f269d/shapely-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2d93d23bdd2ed9dc157b46bc2f19b7da143ca8714464249bef6771c679d5ff40", size = 1834130, upload-time = "2025-09-24T13:50:58.49Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ee/dce001c1984052970ff60eb4727164892fb2d08052c575042a47f5a9e88f/shapely-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01d0d304b25634d60bd7cf291828119ab55a3bab87dc4af1e44b07fb225f188b", size = 1642802, upload-time = "2025-09-24T13:50:59.871Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e7/fc4e9a19929522877fa602f705706b96e78376afb7fad09cad5b9af1553c/shapely-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8d8382dd120d64b03698b7298b89611a6ea6f55ada9d39942838b79c9bc89801", size = 3018460, upload-time = "2025-09-24T13:51:02.08Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/18/7519a25db21847b525696883ddc8e6a0ecaa36159ea88e0fef11466384d0/shapely-2.1.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:19efa3611eef966e776183e338b2d7ea43569ae99ab34f8d17c2c054d3205cc0", size = 3095223, upload-time = "2025-09-24T13:51:04.472Z" },
+    { url = "https://files.pythonhosted.org/packages/48/de/b59a620b1f3a129c3fecc2737104a0a7e04e79335bd3b0a1f1609744cf17/shapely-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:346ec0c1a0fcd32f57f00e4134d1200e14bf3f5ae12af87ba83ca275c502498c", size = 4030760, upload-time = "2025-09-24T13:51:06.455Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b3/c6655ee7232b417562bae192ae0d3ceaadb1cc0ffc2088a2ddf415456cc2/shapely-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6305993a35989391bd3476ee538a5c9a845861462327efe00dd11a5c8c709a99", size = 4170078, upload-time = "2025-09-24T13:51:08.584Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8e/605c76808d73503c9333af8f6cbe7e1354d2d238bda5f88eea36bfe0f42a/shapely-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:c8876673449f3401f278c86eb33224c5764582f72b653a415d0e6672fde887bf", size = 1559178, upload-time = "2025-09-24T13:51:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f7/d317eb232352a1f1444d11002d477e54514a4a6045536d49d0c59783c0da/shapely-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:4a44bc62a10d84c11a7a3d7c1c4fe857f7477c3506e24c9062da0db0ae0c449c", size = 1739756, upload-time = "2025-09-24T13:51:12.105Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c4/3ce4c2d9b6aabd27d26ec988f08cb877ba9e6e96086eff81bfea93e688c7/shapely-2.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:9a522f460d28e2bf4e12396240a5fc1518788b2fcd73535166d748399ef0c223", size = 1831290, upload-time = "2025-09-24T13:51:13.56Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b9/f6ab8918fc15429f79cb04afa9f9913546212d7fb5e5196132a2af46676b/shapely-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ff629e00818033b8d71139565527ced7d776c269a49bd78c9df84e8f852190c", size = 1641463, upload-time = "2025-09-24T13:51:14.972Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/57/91d59ae525ca641e7ac5551c04c9503aee6f29b92b392f31790fcb1a4358/shapely-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f67b34271dedc3c653eba4e3d7111aa421d5be9b4c4c7d38d30907f796cb30df", size = 2970145, upload-time = "2025-09-24T13:51:16.961Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cb/4948be52ee1da6927831ab59e10d4c29baa2a714f599f1f0d1bc747f5777/shapely-2.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21952dc00df38a2c28375659b07a3979d22641aeb104751e769c3ee825aadecf", size = 3073806, upload-time = "2025-09-24T13:51:18.712Z" },
+    { url = "https://files.pythonhosted.org/packages/03/83/f768a54af775eb41ef2e7bec8a0a0dbe7d2431c3e78c0a8bdba7ab17e446/shapely-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1f2f33f486777456586948e333a56ae21f35ae273be99255a191f5c1fa302eb4", size = 3980803, upload-time = "2025-09-24T13:51:20.37Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/559c7c195807c91c79d38a1f6901384a2878a76fbdf3f1048893a9b7534d/shapely-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cf831a13e0d5a7eb519e96f58ec26e049b1fad411fc6fc23b162a7ce04d9cffc", size = 4133301, upload-time = "2025-09-24T13:51:21.887Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cd/60d5ae203241c53ef3abd2ef27c6800e21afd6c94e39db5315ea0cbafb4a/shapely-2.1.2-cp314-cp314-win32.whl", hash = "sha256:61edcd8d0d17dd99075d320a1dd39c0cb9616f7572f10ef91b4b5b00c4aeb566", size = 1583247, upload-time = "2025-09-24T13:51:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d4/135684f342e909330e50d31d441ace06bf83c7dc0777e11043f99167b123/shapely-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:a444e7afccdb0999e203b976adb37ea633725333e5b119ad40b1ca291ecf311c", size = 1773019, upload-time = "2025-09-24T13:51:24.873Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/05/a44f3f9f695fa3ada22786dc9da33c933da1cbc4bfe876fe3a100bafe263/shapely-2.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:5ebe3f84c6112ad3d4632b1fd2290665aa75d4cef5f6c5d77c4c95b324527c6a", size = 1834137, upload-time = "2025-09-24T13:51:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7e/4d57db45bf314573427b0a70dfca15d912d108e6023f623947fa69f39b72/shapely-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5860eb9f00a1d49ebb14e881f5caf6c2cf472c7fd38bd7f253bbd34f934eb076", size = 1642884, upload-time = "2025-09-24T13:51:28.029Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/27/4e29c0a55d6d14ad7422bf86995d7ff3f54af0eba59617eb95caf84b9680/shapely-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b705c99c76695702656327b819c9660768ec33f5ce01fa32b2af62b56ba400a1", size = 3018320, upload-time = "2025-09-24T13:51:29.903Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/bb/992e6a3c463f4d29d4cd6ab8963b75b1b1040199edbd72beada4af46bde5/shapely-2.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a1fd0ea855b2cf7c9cddaf25543e914dd75af9de08785f20ca3085f2c9ca60b0", size = 3094931, upload-time = "2025-09-24T13:51:32.699Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/16/82e65e21070e473f0ed6451224ed9fa0be85033d17e0c6e7213a12f59d12/shapely-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:df90e2db118c3671a0754f38e36802db75fe0920d211a27481daf50a711fdf26", size = 4030406, upload-time = "2025-09-24T13:51:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/75/c24ed871c576d7e2b64b04b1fe3d075157f6eb54e59670d3f5ffb36e25c7/shapely-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:361b6d45030b4ac64ddd0a26046906c8202eb60d0f9f53085f5179f1d23021a0", size = 4169511, upload-time = "2025-09-24T13:51:36.297Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f7/b3d1d6d18ebf55236eec1c681ce5e665742aab3c0b7b232720a7d43df7b6/shapely-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:b54df60f1fbdecc8ebc2c5b11870461a6417b3d617f555e5033f1505d36e5735", size = 1602607, upload-time = "2025-09-24T13:51:37.757Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/f09272a71976dfc138129b8faf435d064a811ae2f708cb147dccdf7aacdb/shapely-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:0036ac886e0923417932c2e6369b6c52e38e0ff5d9120b90eef5cd9a5fc5cae9", size = 1796682, upload-time = "2025-09-24T13:51:39.233Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3157,6 +3551,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]
@@ -3226,6 +3629,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]
 
 [[package]]
@@ -3729,6 +4144,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/49/32/bb8385f7a3b05ce406b689aa000c9a34289caa1526f1c093a1cefc0d9695/xai_sdk-1.11.0.tar.gz", hash = "sha256:ca87a830d310fb8e06fba44fb2a8c5cdf0d9f716b61126eddd51b7f416a63932", size = 404313, upload-time = "2026-03-27T18:23:10.091Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/76/86d9a3589c725ce825d2ed3e7cb3ecf7f956d3fd015353d52197bb341bcd/xai_sdk-1.11.0-py3-none-any.whl", hash = "sha256:fe58ce6d8f8115ae8bd57ded57bcd847d0bb7cb28bb7b236abefd4626df1ed8d", size = 251388, upload-time = "2026-03-27T18:23:08.573Z" },
+]
+
+[[package]]
+name = "xlsxwriter"
+version = "3.2.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940, upload-time = "2025-09-16T00:16:21.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315, upload-time = "2025-09-16T00:16:20.108Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

File uploads plus document understanding so local and text-only models can read uploaded files. Full background, design, and library rationale are in the sections below (Why / What's included / Library choices / Tests).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

N/A

## Checklist

- [ ] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 4.8 (Claude Code)

**Any additional AI details you'd like to share:** Implemented and reviewed via Claude Code; the author directed the work and verified the results.

- [x] I am an AI Agent filling out this form (check box if true)

---

## Why

The otari gateway empowers local/open-source models with frontier capabilities. Frontier models (Claude, GPT-4o) read PDFs, office docs, and images natively — most local models can't; many are text-only. So when a user attaches a file, a text-only local model today gets **nothing useful**: the gateway is pure pass-through, and any-llm's Ollama adapter even *silently drops* document blocks (answers as if no file were attached).

This PR closes that gap. A user uploads a file and a text-only local model can still understand it, because the gateway extracts the file to text (and captions images) before the model sees the request — while passing blocks through unchanged to natively-capable providers.

It mirrors the gateway's existing `otari_web_search` / `otari_code_execution` pattern: inspect the request, decide per-attachment *who* does the work, do only what the target model needs.

> **Standalone mode only.** Platform mode routes to frontier providers that already understand attachments (passthrough is already correct) and has no local DB/file store to resolve `file_id` against.

## What's included

- **Files API** — `POST/GET/DELETE /v1/files` (+ `/content`), OpenAI-shaped, user-scoped with soft-delete. Bytes go to a pluggable `FileStore` (local-fs default, sharded); metadata to a new `file_objects` table (migration `c3d5e7f9a1b3`).
- **Capability resolver** (`model_capabilities.py`) — the load-bearing decision: operator override → any-llm provider metadata (hosted only) → **default-extract**. Local providers (ollama/vllm/llamacpp/lmstudio) never trust any-llm's flags because they're set per provider *class* and over-report for text-only models behind OpenAI-compatible servers.
- **Content normalizer** (`content_normalizer.py`) — walks message content across **OpenAI / Anthropic / Responses** shapes, resolves `file_id` → bytes, then **passthrough** (rewriting `file_id` to inline data the provider understands) or **extract-to-text**. Documents via markitdown; images via a configurable **describe → ocr → drop** cascade; scanned PDFs via pypdfium2 rasterize-then-describe. Per-block failures never 500 the request; string-content messages skip the path entirely (zero overhead).
- **Wiring** — hooked into chat/messages/responses *before* the budget estimate so reservations reflect extracted tokens.
- **Config** — `files_*`, `file_understanding_enabled`, `vision_strategy`, `vision_describe_model`, `model_capabilities`. Documented in `config.example.yml` and `docs/files.md`.

## Library choices

- **markitdown (MIT) + pypdfium2 (Apache-2.0) + pillow** for extraction/rasterization — **AGPL deliberately avoided** (e.g. PyMuPDF) since the gateway is a network service and AGPL §13 is an adoption blocker.
- **Vision is a configurable cascade, not a commitment** — `describe → ocr → drop`. The describe-model can point at a *local* vision model (e.g. `ollama/qwen2-vl`) to keep captioning free. OCR is an opt-in `[ocr]` extra to keep the base install lean.

## Tests

- **20 unit** — file store, capability resolver, normalizer (passthrough vs extract, drop, all three formats, `file_id` resolution).
- **4 integration** (real Postgres via testcontainers) — Files API CRUD; **end-to-end: upload → chat by `file_id` on a text-only model → assert extracted text reaches the provider and the raw block does not**; native-model passthrough; auth.
- mypy strict + ruff clean across the project; migration applies and reverts cleanly (single head).

## Note for reviewers

The real extraction libs (markitdown/pypdfium2/onnxruntime) weren't exercised end-to-end on my machine — `onnxruntime` has no Python 3.14 wheel locally (an environment constraint, the `ocr` extra). The integration test stubs only the markitdown boundary; everything else (HTTP, DB, blob store, `file_id` resolution, capability resolution, message rewriting) is real. Worth a `uv sync` + integration run on a 3.13 env with a real PDF before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- What changed (high level)
  - Added a standalone Files API (/v1/files) with endpoints to upload, list, get metadata, download content, and soft-delete files. File bytes are stored via a pluggable FileStore (default: sharded local directory); metadata is stored in a new file_objects table (Alembic revision c3d5e7f9a1b3).
  - Implemented a content-normalization pipeline so text-only/local models can consume uploaded files: resolves file_id → bytes (across OpenAI/Anthropic/Responses shapes), then either inlines native-capable media or extracts documents to text and handles images via configurable describe → OCR → drop logic. Per-block failures are non-fatal and logged.
  - Added a model-capabilities resolver (operator overrides → provider metadata for hosted providers → default extract) so routing decides whether to pass media through or extract-to-text.
  - Integrated normalization into the request pipeline and budget flow: normalization runs at standalone-only timing after initial reservation; the reservation can be increased (budget_service.increase_reservation) to cover post-normalization prompt growth; vision side-call usage is metered and committed separately.
  - Added configuration toggles and docs (config.example.yml, docs/files.md), updated OpenAPI docs, and comprehensive tests (unit + integration).

- Key benefits
  - Enables local/text-only models to handle user uploads by converting attachments into consumable text or provider-native blocks.
  - More accurate billing and fewer reservation leaks by accounting for normalization-expanded prompts and vision side-call costs.
  - Safer, more robust uploads with pluggable storage and database-backed metadata.

- Notable hardening and fixes
  - Upload streaming with 1 MiB chunk reads and 413 on size exceed; rejects empty uploads.
  - Content-Disposition filename sanitization (including RFC 5987 encoding) to prevent header injection.
  - LocalDirFileStore defends against path traversal; DB commit failures roll back metadata and delete written blobs to avoid orphaned bytes.
  - Normalization is gated to avoid extraction/vision calls for blocked or over-budget users; per-block normalization errors do not 500.
  - Centralized refund behavior to prevent reservation leaks during setup/top-up failures.

- Tests, docs, and compatibility notes
  - Extensive unit and integration test coverage added (many new tests around upload auth/validation, scoping, normalization, budget gating, native passthrough, expiry, and vision billing). Project reports mypy strict + ruff clean.
  - New dependencies for extraction/vision are opt-in where applicable; some extraction/rasterization/OCR libraries (markitdown, pypdfium2, rapidocr/onnxruntime) were not exercised end-to-end locally. Author recommends CI/integration runs on Python 3.13 with a real PDF before merge.

Technical notes (brief)
  - DB migration: alembic revision c3d5e7f9a1b3 adds file_objects table.
  - New/changed modules: file_store (LocalDirFileStore + build_file_store), file_service, file_extractors (markitdown/pypdfium2/optional OCR), content_normalizer, model_capabilities, vision.describe_image, files routes, and budget_service.increase_reservation.
  - Config knobs: files_enabled, files_backend, files_local_dir, files_max_bytes, files_retention_hours, file_understanding_enabled, vision_strategy, vision_describe_model, and model_capabilities mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
