### PR TITLE
Pin OpenAPI Generator via openapitools.json in SDK codegen workflow

### DIFF
--- a/.github/workflows/gateway-sdk-codegen.yml
+++ b/.github/workflows/gateway-sdk-codegen.yml
@@ -25,6 +25,11 @@ on:
 permissions:
   contents: read
 
+env:
+  # Pin the generator so regeneration is reproducible and matches the validated
+  # SDK cores; bump deliberately and review the resulting diff.
+  OPENAPI_GENERATOR_VERSION: '7.22.0'
+
 jobs:
   codegen:
     runs-on: ubuntu-latest

--- a/.github/workflows/gateway-sdk-codegen.yml
+++ b/.github/workflows/gateway-sdk-codegen.yml
@@ -19,16 +19,18 @@ on:
     paths:
       - 'docs/public/openapi.json'
       - 'scripts/sdk_codegen/**'
+      - 'openapitools.json'
       - '.github/workflows/gateway-sdk-codegen.yml'
   workflow_dispatch:
 
 permissions:
   contents: read
 
-env:
-  # Pin the generator so regeneration is reproducible and matches the validated
-  # SDK cores; bump deliberately and review the resulting diff.
-  OPENAPI_GENERATOR_VERSION: '7.22.0'
+# The OpenAPI Generator version is pinned in openapitools.json
+# (generator-cli.version). That file is the ONLY mechanism the
+# @openapitools/openapi-generator-cli wrapper honors; the OPENAPI_GENERATOR_VERSION
+# env var is ignored by the wrapper and must not be relied on. Bump the generator
+# by editing openapitools.json deliberately and reviewing the resulting diff.
 
 jobs:
   codegen:

--- a/openapitools.json
+++ b/openapitools.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenAPITools/openapi-generator-cli/master/apps/generator-cli/src/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.22.0"
+  }
+}


### PR DESCRIPTION
> _Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Summary

Pins the OpenAPI Generator version used by the SDK codegen automation so regeneration is reproducible, using the mechanism the generator CLI actually honors.

The `gateway-sdk-codegen.yml` workflow installed the generator with `npm install -g @openapitools/openapi-generator-cli`, which resolves to the latest version. The first version of this PR tried to pin via an `OPENAPI_GENERATOR_VERSION` env var, but the `@openapitools/openapi-generator-cli` wrapper ignores that env var. A `workflow_dispatch` run (`27147431610`) confirmed it: the log shows `Did set selected version to 7.23.0` even with the env var set to `7.22.0`. That unpinned 7.23.0 generation is what produced the spurious regen PRs on every SDK repo (dropped `cc_reasoning` / `cc_top_logprob` / `cc_completion_tokens_details` typed sub-models, changed the audio transcription file param), and it also breaks the TypeScript SDK's strict typecheck.

`7.22.0` is the version all four SDK cores were generated and live-validated against.

This pins the generator through the only mechanism the wrapper honors: `generator-cli.version` in a committed `openapitools.json` at the repo root. The dead env var is removed (replaced with a comment explaining why). `openapitools.json` is added to the workflow's `push` path filter so a future deliberate generator bump regenerates the SDKs. `any-llm` is already pinned via `uv sync --frozen`.

## Test plan

- Local regen with `openapitools.json` pinning `7.22.0` (env var unset) reproduces the current SDK cores exactly: a no-op diff, with the typed sub-models and audio param matching what is on each SDK's `main`.
- After merge, the `push` to `main` (touching the workflow file and `openapitools.json`) re-triggers the codegen workflow; it should produce no churn PR.

Relates to #96.
