### PR TITLE
chore: drop the internal "Option C" codename from codegen tooling

### DIFF
--- a/.github/workflows/gateway-sdk-codegen.yml
+++ b/.github/workflows/gateway-sdk-codegen.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install OpenAPI Generator CLI
         run: npm install -g @openapitools/openapi-generator-cli
 
-      - name: Generate ${{ matrix.language }} client (full Option C core)
+      - name: Generate ${{ matrix.language }} client (full typed core)
         run: uv run python scripts/sdk_codegen/generate.py --language ${{ matrix.language }} --mode full --out-dir dist
 
       - name: Checkout ${{ matrix.sdk_repo }}

--- a/scripts/sdk_codegen/generate.py
+++ b/scripts/sdk_codegen/generate.py
@@ -8,7 +8,7 @@ Two modes:
   hand-written wrapper around the official OpenAI SDK; batches are hand-written
   (their responses are untyped in the spec).
 
-- ``full`` (Option C): enriches the spec's inference surface with the real typed
+- ``full``: enriches the spec's inference surface with the real typed
   completion schemas (from ``any-llm``), then generates a typed core covering
   *every* endpoint. The SDK hand-writes a thin shell over this core for the
   three things generation can't do: streaming (SSE), typed error mapping, and
@@ -95,7 +95,7 @@ TARGETS: dict[str, LanguageTarget] = {
     ),
 }
 
-# Option C: the FULL client (every endpoint, typed core). The SDK hand-writes a
+# The FULL client (every endpoint, typed core). The SDK hand-writes a
 # thin shell over this for streaming, error mapping, and ergonomic method names.
 FULL_TARGETS: dict[str, LanguageTarget] = {
     "python": LanguageTarget(
@@ -203,7 +203,7 @@ def enrich_spec(spec: dict[str, Any]) -> dict[str, Any]:
     """Type the inference surface so the FULL client generates typed methods.
 
     The gateway spec leaves chat loosely typed (``messages`` are untyped dicts,
-    the chat ``200`` response has no schema). For Option C (a generated core that
+    the chat ``200`` response has no schema). For the full client (a generated core that
     covers every endpoint) we inject the real, typed completion schemas from
     ``any-llm`` (which the gateway already depends on) so the generated chat
     method returns a typed ``ChatCompletion`` and accepts typed messages.
@@ -406,7 +406,7 @@ def main() -> int:
         choices=["control-plane", "full"],
         default="control-plane",
         help="control-plane: typed management endpoints only. full: every endpoint "
-        "(typed inference core) with the spec enriched (Option C).",
+        "(typed inference core) with the spec enriched.",
     )
     parser.add_argument("--spec", type=Path, default=DEFAULT_SPEC)
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)


### PR DESCRIPTION
> _Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Summary

Removes the internal "Option C" codename from the gateway's SDK-codegen tooling, matching the codename removal in the SDK repos.

- `scripts/sdk_codegen/generate.py`: dropped "Option C" from docstrings, comments, and the `--mode` help text (rephrased to keep the technical meaning, e.g. "the full client" / "the full typed core").
- `.github/workflows/gateway-sdk-codegen.yml`: renamed the generate step from "full Option C core" to "full typed core".

Comment, docstring, and step-name only. The codegen behavior is unchanged and `tests/unit/test_sdk_codegen.py` passes (12/12).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated SDK code generation documentation with refined terminology for improved clarity

* **Chores**
  * Refreshed internal workflow configuration references for SDK generation processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->