### PR TITLE
chore: remove stray config.yaml, ignore both config extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build/
 
 .env
 config.yml
+config.yaml
 service_account.json
 gateway.db
 otari-gateway.db

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,0 @@
-mode: platform
-platform:
-  base_url: http://localhost:8100/api/v1


### PR DESCRIPTION
## What

- Delete the tracked `config.yaml`.
- Add `config.yaml` to `.gitignore` (alongside the existing `config.yml`).

## Why

`config.yaml` was a developer-local platform config that got committed by accident on the async-conversion PR. It only contained a localhost platform URL (no secrets), but it should never have been tracked.

Root cause: `.gitignore` ignored `config.yml` (the file users are told to create) but not `config.yaml`, so git happily tracked the latter.

The gateway convention is `config.yml` everywhere (README, docs, `docker-compose.yml`, scripts, demos, test fixtures). The loader (`load_config` in `src/gateway/core/config.py`) loads whatever path is passed to `--config` and does not care about the extension, so this was purely a stray-file/gitignore gap, not a behavior change. The guardrails sidecar `*-service.yaml` files are config for a separate service and are intentionally left alone.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)