### PR TITLE
feat: add PR template and enforcement workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+## Description
+<!-- What does this PR do and why? -->
+
+
+## PR Type
+<!-- Check all that apply -->
+
+- [ ] New Feature
+- [ ] Bug Fix
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Infrastructure / CI
+
+## Relevant issues
+<!-- e.g. "Fixes #123" -->
+
+## Checklist
+<!-- If you delete this checklist, your PR will be automatically closed -->
+
+- [ ] I understand the code I am submitting.
+- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
+- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
+- [ ] Documentation was updated where necessary.
+- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py --check`).
+
+## AI Usage
+<!-- Check one -->
+
+- [ ] No AI was used.
+- [ ] AI was used for drafting/refactoring.
+- [ ] This is fully AI-generated.
+
+**AI Model/Tool used:**
+
+
+**Any additional AI details you'd like to share:**
+
+
+**NOTE:**
+When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)
+
+- [ ] I am an AI Agent filling out this form (check box if true)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@
 - [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
 - [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
 - [ ] Documentation was updated where necessary.
-- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py --check`).
+- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).
 
 ## AI Usage
 <!-- Check one -->

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -132,8 +132,10 @@ jobs:
             const labelName = 'missing-template';
             const cutoffMs = 24 * 60 * 60 * 1000; // 24 hours
 
-            // Find open PRs with the missing-template label
-            const { data: prs } = await github.rest.issues.listForRepo({
+            // Find open PRs with the missing-template label. Paginate so a
+            // backlog of more than one page of labeled PRs is not silently
+            // truncated.
+            const prs = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
@@ -151,8 +153,11 @@ jobs:
                 continue;
               }
 
-              // Check when the label was added by looking at timeline events
-              const { data: events } = await github.rest.issues.listEventsForTimeline({
+              // Check when the label was added by looking at timeline events.
+              // Paginate: an active PR's timeline can exceed one page, which
+              // could push the `labeled` event past the first 100 and leave a
+              // stale PR open forever.
+              const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -1,0 +1,197 @@
+name: PR Template Check
+
+on:
+  # Use pull_request_target to have write access for PRs from forks.
+  # This is safe because we only read the PR body from the event payload
+  # and don't checkout or execute any code from the fork.
+  pull_request_target:
+    types: [opened, edited]
+  schedule:
+    # Run daily at midnight UTC to close stale PRs missing the template
+    - cron: '0 0 * * *'
+
+jobs:
+  check-template:
+    # Key the skip on the PR author, not github.actor. The actor is whoever
+    # triggered the event; on an `edited` event fired by a maintainer or
+    # another bot the actor is the editor, so a github.actor guard would let
+    # the check run against Dependabot's templateless body.
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Check PR body for required template sections
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+
+            // Check that the required template sections are all present. This
+            // catches wholesale template stripping without depending on a
+            // single literal checklist line that may be renamed or removed
+            // when the template is updated.
+            const hasAllTemplateSections =
+              body.includes('## PR Type') &&
+              body.includes('## Checklist') &&
+              body.includes('## AI Usage');
+
+            const prNumber = context.payload.pull_request.number;
+            const labelName = 'missing-template';
+
+            if (!hasAllTemplateSections) {
+              // Check if we already labeled this PR
+              const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber
+              });
+
+              if (labels.some(l => l.name === labelName)) {
+                console.log('PR already labeled, skipping comment');
+                core.setFailed('PR template sections are missing');
+                return;
+              }
+
+              // Ensure the label exists
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: labelName,
+                  color: 'e11d21',
+                  description: 'PR is missing required template sections'
+                });
+              } catch (e) {
+                // Label already exists, ignore
+              }
+
+              // Add label to track when this was flagged
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                labels: [labelName]
+              });
+
+              // Add comment explaining the issue
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: `⚠️ **PR Template Missing**\n\nThis PR appears to be missing required sections from the [PR template](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/.github/pull_request_template.md).\n\nPlease edit your PR description to include the **PR Type**, **Checklist**, and **AI Usage** sections. The template helps maintainers review your contribution.\n\n**This PR will be automatically closed in 24 hours if the template is not restored.**\n\nIf you're using an AI coding tool, please ensure it preserves the PR template.`
+              });
+
+              core.setFailed('PR template sections are missing');
+            } else {
+              // Template is present, remove the label if it exists
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  name: labelName
+                });
+                console.log('Removed missing-template label');
+              } catch (e) {
+                // Label wasn't present, ignore
+              }
+
+              // Clean up any warning comments left from a previous check
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber
+              });
+
+              for (const comment of comments) {
+                if (comment.user.login === 'github-actions[bot]' &&
+                    comment.body.includes('PR Template Missing')) {
+                  await github.rest.issues.deleteComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: comment.id
+                  });
+                  console.log(`Deleted warning comment ${comment.id}`);
+                }
+              }
+            }
+
+  close-stale:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Close PRs missing template for over 24 hours
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const labelName = 'missing-template';
+            const cutoffMs = 24 * 60 * 60 * 1000; // 24 hours
+
+            // Find open PRs with the missing-template label
+            const { data: prs } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: labelName,
+              per_page: 100
+            });
+
+            for (const pr of prs) {
+              // Only process pull requests (not issues)
+              if (!pr.pull_request) continue;
+
+              // Skip Dependabot PRs
+              if (pr.user?.login === 'dependabot[bot]') {
+                console.log(`Skipping Dependabot PR #${pr.number}`);
+                continue;
+              }
+
+              // Check when the label was added by looking at timeline events
+              const { data: events } = await github.rest.issues.listEventsForTimeline({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100
+              });
+
+              const labelEvent = events
+                .filter(e => e.event === 'labeled' && e.label?.name === labelName)
+                .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+
+              if (!labelEvent) {
+                console.log(`No label event found for PR #${pr.number}, skipping`);
+                continue;
+              }
+
+              const labeledAt = new Date(labelEvent.created_at);
+              const now = new Date();
+              const ageMs = now - labeledAt;
+
+              if (ageMs < cutoffMs) {
+                console.log(`PR #${pr.number} labeled ${Math.round(ageMs / 3600000)}h ago, not yet 24h`);
+                continue;
+              }
+
+              console.log(`Closing PR #${pr.number} - missing template for over 24 hours`);
+
+              // Add closing comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: `This PR has been automatically closed because the required template sections were not restored within 24 hours.\n\nPlease create a new PR using the template and complete the checklist. The template helps maintainers review your contribution.`
+              });
+
+              // Close the PR
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                state: 'closed'
+              });
+            }


### PR DESCRIPTION
## Description

Adds a pull request template and a workflow that enforces its presence, closing #120. Contributors now describe their change, classify its type, complete a review checklist, and disclose AI usage. The `PR Template Check` workflow labels and warns on PRs missing the required sections, clears the label once restored, and a daily scheduled job closes PRs that stay templateless for over 24 hours. This mirrors the enforcement already used in [any-llm](https://github.com/mozilla-ai/any-llm) and [agent-of-empires](https://github.com/agent-of-empires/agent-of-empires).

Design choices follow the newer agent-of-empires variant:
- Matches on section headers (`## PR Type`, `## Checklist`, `## AI Usage`) rather than a single literal checklist line, so the template can evolve without silently disabling the gate.
- Keys the Dependabot skip on the PR author (`pull_request.user.login`) rather than the event actor, so an `edited` event from a maintainer cannot slip a templateless body through.
- One improvement over both references: the "already labeled" branch still calls `core.setFailed`, so a re-edited PR that is still missing the template keeps reporting a failed check instead of going green.
- Dropped the aoe-specific bot escape hatches (nix-npm-hash, release-version), which otari has no equivalent of.

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

Fixes #120

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py --check`).

Notes: this change is GitHub Actions config (a YAML workflow plus a markdown template) with no pytest-testable surface, so no unit/integration test is added. It touches no Python, so lint/typecheck/test and the OpenAPI spec are unaffected; the workflow YAML parses cleanly and both embedded github-script bodies pass `node --check`.

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 4.8 via Claude Code, drafted through back-and-forth with @njbrake.

**Any additional AI details you'd like to share:** The reasoning and decisions are @njbrake's; the prose and implementation are Claude's.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds a standardized pull request template and automated enforcement workflow to ensure contributors provide consistent information when submitting PRs. The changes consist of a new PR template document and a GitHub Actions workflow that validates and enforces the template's completion.

## What Changed

**Pull Request Template** (`.github/pull_request_template.md`)
- Adds a standardized template that guides contributors to include a description of their change, classify the PR type, reference relevant issues, complete a submission checklist, and declare any AI tool usage
- Uses helpful prompts and checkboxes to make submission requirements clear

**PR Template Enforcement Workflow** (`.github/workflows/pr-template-check.yml`)
- Automatically validates that PRs include the required template sections (PR Type, Checklist, and AI Usage declaration)
- When a required section is missing, the workflow applies a `missing-template` label and posts a warning comment to notify the author
- When the author adds missing sections, the label and warning comment are automatically cleaned up
- Includes a daily scheduled job that closes PRs if they remain incomplete (missing required sections) for more than 24 hours
- Automatically skips Dependabot PRs to avoid false positives

## Benefits

- **Consistency**: Ensures all PRs follow the same structure, making reviews more predictable and organized
- **Clear Requirements**: Template and automation make it immediately obvious what information is needed before a PR can proceed
- **Automation**: Enforces standards without manual intervention, reducing back-and-forth between reviewers and authors
- **Transparency**: Requires explicit disclosure of AI tool usage, maintaining visibility into how contributions were created

## Technical Notes

The workflow uses `pull_request_target` to safely run on external contributions, validates PR bodies by checking for section headers (`## PR Type`, `## Checklist`, `## AI Usage`), and manages cleanup by detecting and removing the bot's prior warning comments. The implementation follows the same enforcement pattern used in related projects (any-llm and agent-of-empires). The PR was auto-generated using Claude Opus 4.8 with review and direction by `@njbrake`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->