### PR TITLE
feat(messages): add /v1/messages/count_tokens for Claude Code support

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -10,6 +10,8 @@ For full request/response schemas, see the [OpenAPI spec](public/openapi.json) o
 |---|---|---|
 | Health (`/health*`) | Yes | Yes |
 | Chat completions (`/v1/chat/completions`) | Yes | Yes |
+| Messages (`/v1/messages`, `/v1/messages/count_tokens`) | Yes | Yes |
+| Responses (`/v1/responses`) | Yes | Yes |
 | All other `/v1/*` endpoints in this doc | Yes | No |
 
 ## Authentication
@@ -45,19 +47,22 @@ No authentication required.
 |--------|------|-------------|------|
 | `POST` | `/v1/chat/completions` | OpenAI-compatible chat completions. Supports streaming and tool use (`otari_code_execution`, `otari_web_search`, MCP). | Standalone: API key or master key. Connected: `Authorization` bearer token from otari.ai. |
 
-## Standalone-only endpoints
-
 ### Messages
 
 | Method | Path | Description | Auth |
 |--------|------|-------------|------|
-| `POST` | `/v1/messages` | Anthropic Messages API-compatible endpoint. Supports streaming and extended thinking. | API key or master key |
+| `POST` | `/v1/messages` | Anthropic Messages API-compatible endpoint. Supports streaming, tool use, and extended thinking. Routes to any provider in the catalog (non-Anthropic models are translated to/from the Messages format automatically). | Standalone: API key or master key. Connected: `Authorization` bearer token from otari.ai. |
+| `POST` | `/v1/messages/count_tokens` | Anthropic-compatible input-token count for a Messages request. Returns `{"input_tokens": N}`. Counts locally (no provider call, no budget debit); the count is an approximation. Used by clients such as Claude Code for context-window management. | Standalone: API key or master key. Connected: `Authorization` bearer token from otari.ai. |
+
+See [Use with Claude Code](use-with-claude-code.md) for a full client setup.
 
 ### Responses
 
 | Method | Path | Description | Auth |
 |--------|------|-------------|------|
-| `POST` | `/v1/responses` | OpenAI Responses API-compatible endpoint. Supports streaming. | API key or master key |
+| `POST` | `/v1/responses` | OpenAI Responses API-compatible endpoint. Supports streaming. | Standalone: API key or master key. Connected: `Authorization` bearer token from otari.ai. |
+
+## Standalone-only endpoints
 
 ### Embeddings
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -47,6 +47,8 @@ No authentication required.
 |--------|------|-------------|------|
 | `POST` | `/v1/chat/completions` | OpenAI-compatible chat completions. Supports streaming and tool use (`otari_code_execution`, `otari_web_search`, MCP). | Standalone: API key or master key. Connected: `Authorization` bearer token from otari.ai. |
 
+See [Use with opencode](use-with-opencode.md) for a full client setup.
+
 ### Messages
 
 | Method | Path | Description | Auth |

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,5 +24,6 @@ Start with the [Quickstart](quickstart.md). It gets the gateway running locally 
 - [Guardrails](guardrails.md) — request-level checks like prompt-injection detection.
 - [Configuration](configuration.md) — the full config file and environment variable reference.
 - [API reference](api-reference.md) — every endpoint, with auth and availability per mode.
+- [Use with Claude Code](use-with-claude-code.md) — point the Claude Code CLI at the gateway.
 - [Supported models](supported-models.md) — providers, model format, and capabilities.
 - [Platform protocol](platform-protocol.md) — the gateway/platform wire contract, for platform builders.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,5 +25,6 @@ Start with the [Quickstart](quickstart.md). It gets the gateway running locally 
 - [Configuration](configuration.md) — the full config file and environment variable reference.
 - [API reference](api-reference.md) — every endpoint, with auth and availability per mode.
 - [Use with Claude Code](use-with-claude-code.md) — point the Claude Code CLI at the gateway.
+- [Use with opencode](use-with-opencode.md) — point the opencode CLI at the gateway.
 - [Supported models](supported-models.md) — providers, model format, and capabilities.
 - [Platform protocol](platform-protocol.md) — the gateway/platform wire contract, for platform builders.

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -419,8 +419,20 @@
         "type": "object"
       },
       "CountTokensRequest": {
-        "description": "Anthropic ``/v1/messages/count_tokens`` request.\n\nA subset of :class:`MessagesRequest`: the same input fields, minus\n``max_tokens`` and the streaming/sampling controls, since the endpoint only\ncounts input tokens. Clients such as Claude Code call this on every turn to\nkeep their prompt within the model's context window.",
+        "description": "Anthropic ``/v1/messages/count_tokens`` request.\n\nA subset of :class:`MessagesRequest`: the input fields that affect the token\ncount, minus ``max_tokens`` and the streaming/sampling controls, since the\nendpoint only counts input tokens. Clients such as Claude Code call this on\nevery turn to keep their prompt within the model's context window.",
         "properties": {
+          "cache_control": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cache Control"
+          },
           "messages": {
             "items": {
               "additionalProperties": true,
@@ -429,6 +441,18 @@
             "minItems": 1,
             "title": "Messages",
             "type": "array"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
           },
           "model": {
             "title": "Model",
@@ -497,6 +521,20 @@
           "messages"
         ],
         "title": "CountTokensRequest",
+        "type": "object"
+      },
+      "CountTokensResponse": {
+        "description": "Anthropic ``/v1/messages/count_tokens`` response.",
+        "properties": {
+          "input_tokens": {
+            "title": "Input Tokens",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "input_tokens"
+        ],
+        "title": "CountTokensResponse",
         "type": "object"
       },
       "CreateBatchRequest": {
@@ -3421,7 +3459,7 @@
     },
     "/v1/messages/count_tokens": {
       "post": {
-        "description": "Anthropic ``/v1/messages/count_tokens``-compatible endpoint.\n\nReturns ``{\"input_tokens\": N}`` without contacting an upstream provider:\ncounting is local, so there is no budget reservation, pricing, or usage\nlogging. Authentication mirrors :func:`create_message` \u2014 platform mode\nrequires the caller's bearer token; standalone mode validates the API key \u2014\nso the endpoint is not an open token-counting oracle.",
+        "description": "Anthropic ``/v1/messages/count_tokens``-compatible endpoint.\n\nReturns ``{\"input_tokens\": N}`` without contacting an upstream provider:\ncounting is local, so there is no budget reservation, pricing, or usage\nlogging. Authentication mirrors :func:`create_message` \u2014 platform mode\nresolves the caller's token against the platform, standalone mode validates\nthe API key \u2014 so the endpoint is not an open token-counting oracle.",
         "operationId": "count_message_tokens_v1_messages_count_tokens_post",
         "requestBody": {
           "content": {
@@ -3437,7 +3475,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/CountTokensResponse"
+                }
               }
             },
             "description": "Successful Response"

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -418,6 +418,87 @@
         "title": "ChatCompletionRequest",
         "type": "object"
       },
+      "CountTokensRequest": {
+        "description": "Anthropic ``/v1/messages/count_tokens`` request.\n\nA subset of :class:`MessagesRequest`: the same input fields, minus\n``max_tokens`` and the streaming/sampling controls, since the endpoint only\ncounts input tokens. Clients such as Claude Code call this on every turn to\nkeep their prompt within the model's context window.",
+        "properties": {
+          "messages": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "minItems": 1,
+            "title": "Messages",
+            "type": "array"
+          },
+          "model": {
+            "title": "Model",
+            "type": "string"
+          },
+          "system": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "System"
+          },
+          "thinking": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thinking"
+          },
+          "tool_choice": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Choice"
+          },
+          "tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tools"
+          }
+        },
+        "required": [
+          "model",
+          "messages"
+        ],
+        "title": "CountTokensRequest",
+        "type": "object"
+      },
       "CreateBatchRequest": {
         "properties": {
           "completion_window": {
@@ -3333,6 +3414,46 @@
           }
         },
         "summary": "Create Message",
+        "tags": [
+          "messages"
+        ]
+      }
+    },
+    "/v1/messages/count_tokens": {
+      "post": {
+        "description": "Anthropic ``/v1/messages/count_tokens``-compatible endpoint.\n\nReturns ``{\"input_tokens\": N}`` without contacting an upstream provider:\ncounting is local, so there is no budget reservation, pricing, or usage\nlogging. Authentication mirrors :func:`create_message` \u2014 platform mode\nrequires the caller's bearer token; standalone mode validates the API key \u2014\nso the endpoint is not an open token-counting oracle.",
+        "operationId": "count_message_tokens_v1_messages_count_tokens_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CountTokensRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Count Message Tokens",
         "tags": [
           "messages"
         ]

--- a/docs/use-with-claude-code.md
+++ b/docs/use-with-claude-code.md
@@ -1,0 +1,107 @@
+# Use with Claude Code
+
+[Claude Code](https://code.claude.com) speaks the Anthropic Messages API and lets
+you redirect it at any compatible endpoint with a couple of environment
+variables. The gateway exposes that surface (`POST /v1/messages` and
+`POST /v1/messages/count_tokens`) in both standalone and connected modes, so you
+can route Claude Code through Otari to get budgets, usage tracking, and traces
+without changing how you use the CLI.
+
+## Quick start
+
+```bash
+export ANTHROPIC_BASE_URL="https://api.otari.ai"   # your gateway root, no /v1
+export ANTHROPIC_AUTH_TOKEN="tk_your_otari_token"  # sent as Authorization: Bearer
+export ANTHROPIC_MODEL="anthropic:claude-sonnet-4-6"
+claude
+```
+
+Claude Code appends `/v1/messages` and `/v1/messages/count_tokens` to
+`ANTHROPIC_BASE_URL` itself, so the base URL must be the gateway root (for local
+development, `http://localhost:8000`).
+
+### Standalone mode: allow Claude Code's user_id
+
+Claude Code attaches its own `metadata.user_id` to every request. In standalone
+mode the gateway binds spend to the API key's own user and, by default, rejects a
+request that names a different user (`403 permission_error`). Set
+`reject_user_mismatch: false` in your config so Claude Code's `user_id` is
+ignored and spend is bound to the key. (Connected/platform mode authenticates via
+the user token and does not compare `metadata.user_id`, so this setting does not
+apply there.)
+
+Use `ANTHROPIC_AUTH_TOKEN` (not `ANTHROPIC_API_KEY`): it is sent as
+`Authorization: Bearer <token>`, which is the scheme the gateway accepts for
+both standalone API keys and connected user tokens. `ANTHROPIC_API_KEY` sends an
+`x-api-key` header instead, which the gateway does not read.
+
+### settings.json
+
+The same configuration works in `~/.claude/settings.json` (or a project-level
+`.claude/settings.json`):
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://api.otari.ai",
+    "ANTHROPIC_AUTH_TOKEN": "tk_your_otari_token",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "anthropic:claude-opus-4-8",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "anthropic:claude-sonnet-4-6",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "anthropic:claude-haiku-4-5"
+  }
+}
+```
+
+## You are not limited to Claude models
+
+Claude Code speaks the Anthropic *wire format*, but the `model` field is just a
+string the gateway forwards to [any-llm](https://github.com/mozilla-ai/any-llm).
+any-llm translates the Messages format to and from each provider's native API, so
+**any model in the catalog works** — OpenAI, Mistral, Mozilla.ai inference
+models, Moonshot, and so on — not just Anthropic's Opus/Sonnet/Haiku.
+
+Set the model strings to whatever your deployment expects:
+
+- **Connected to otari.ai (platform mode):** use the platform's model selector,
+  e.g. `mzai:openai/gpt-4o` or `mzai:moonshotai/Kimi-K2.6`. The platform resolves
+  the selector to a configured route.
+- **Standalone:** use `provider:model`, e.g. `openai:gpt-4o`,
+  `mistral:mistral-large-latest`, or `anthropic:claude-sonnet-4-6`.
+
+Claude Code uses two tiers you can point independently: a primary model for the
+agent loop (`ANTHROPIC_MODEL`, or the `ANTHROPIC_DEFAULT_*_MODEL` tier the
+`opus`/`sonnet`/`haiku` aliases resolve to) and a small/fast model for background
+work like title generation (`ANTHROPIC_DEFAULT_HAIKU_MODEL`). Set both so neither
+tier falls back to a model your gateway does not serve. For example, to run the
+whole CLI on a single non-Anthropic model:
+
+```bash
+export ANTHROPIC_BASE_URL="https://api.otari.ai"
+export ANTHROPIC_AUTH_TOKEN="tk_your_otari_token"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="mzai:openai/gpt-4o"
+export ANTHROPIC_DEFAULT_SONNET_MODEL="mzai:openai/gpt-4o"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="mzai:openai/gpt-4o-mini"
+claude
+```
+
+### Caveats with non-Claude models
+
+Routing works at the protocol level, but quality does not transfer
+automatically. Claude Code's prompts and tool-use loop are tuned for Claude
+models; other models run through the same gateway path but may produce weaker
+tool calling and agentic behavior. Anthropic-only features (extended thinking,
+prompt caching via `cache_control`) have no equivalent on most providers and are
+dropped in translation. Treat non-Claude models as usable, not equivalent.
+
+## What the gateway provides
+
+- **`POST /v1/messages`** — the Anthropic Messages endpoint Claude Code drives,
+  with streaming and tool use.
+- **`POST /v1/messages/count_tokens`** — Claude Code calls this every turn to keep
+  the prompt within the context window. The gateway counts locally (no provider
+  call, no budget debit) and returns `{"input_tokens": N}`. The count is an
+  approximation; it is used only to gauge headroom, not for billing.
+
+Token usage and cost from `/v1/messages` are recorded and reconciled exactly as
+for `/v1/chat/completions`, so Claude Code sessions show up in usage and budgets
+like any other client.

--- a/docs/use-with-claude-code.md
+++ b/docs/use-with-claude-code.md
@@ -62,9 +62,12 @@ models, Moonshot, and so on — not just Anthropic's Opus/Sonnet/Haiku.
 
 Set the model strings to whatever your deployment expects:
 
-- **Connected to otari.ai (platform mode):** use the platform's model selector,
-  e.g. `mzai:openai/gpt-4o` or `mzai:moonshotai/Kimi-K2.6`. The platform resolves
-  the selector to a configured route.
+- **Connected to otari.ai (platform mode):** use `mzai:<catalog-id>` for a
+  managed open-weight model (e.g. `mzai:moonshotai/Kimi-K2.6`), or
+  `provider/model` for one of your own provider keys (e.g. `openai/gpt-4o`,
+  `anthropic/claude-sonnet-4-6`). An `mzai:` prefix selects the managed catalog,
+  so adding it to a proprietary model routes it there instead of your key and it
+  will not resolve.
 - **Standalone:** use `provider:model`, e.g. `openai:gpt-4o`,
   `mistral:mistral-large-latest`, or `anthropic:claude-sonnet-4-6`.
 
@@ -73,14 +76,15 @@ agent loop (`ANTHROPIC_MODEL`, or the `ANTHROPIC_DEFAULT_*_MODEL` tier the
 `opus`/`sonnet`/`haiku` aliases resolve to) and a small/fast model for background
 work like title generation (`ANTHROPIC_DEFAULT_HAIKU_MODEL`). Set both so neither
 tier falls back to a model your gateway does not serve. For example, to run the
-whole CLI on a single non-Anthropic model:
+CLI entirely on managed open-weight models (a capable main model and a smaller
+background model):
 
 ```bash
 export ANTHROPIC_BASE_URL="https://api.otari.ai"
 export ANTHROPIC_AUTH_TOKEN="tk_your_otari_token"
-export ANTHROPIC_DEFAULT_OPUS_MODEL="mzai:openai/gpt-4o"
-export ANTHROPIC_DEFAULT_SONNET_MODEL="mzai:openai/gpt-4o"
-export ANTHROPIC_DEFAULT_HAIKU_MODEL="mzai:openai/gpt-4o-mini"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="mzai:moonshotai/Kimi-K2.6"
+export ANTHROPIC_DEFAULT_SONNET_MODEL="mzai:moonshotai/Kimi-K2.6"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="mzai:Qwen/Qwen3-32B"
 claude
 ```
 

--- a/docs/use-with-opencode.md
+++ b/docs/use-with-opencode.md
@@ -1,0 +1,58 @@
+# Use with opencode
+
+[opencode](https://opencode.ai) lets you register any OpenAI-compatible backend
+as a provider. The gateway exposes an OpenAI-compatible endpoint
+(`POST /v1/chat/completions`) in both standalone and connected modes, so you can
+route opencode through Otari to get budgets, usage tracking, and traces without
+changing how you code.
+
+## Quick start
+
+Add Otari as a provider in your `opencode.jsonc`:
+
+```jsonc
+{
+  "provider": {
+    "otari": {
+      "npm": "@ai-sdk/openai-compatible",
+      "options": {
+        "baseURL": "http://localhost:8000/v1",
+        "apiKey": "{env:OTARI_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+`baseURL` is the gateway root plus `/v1` (opencode appends `/chat/completions`
+itself). Point it at your gateway: `http://localhost:8000/v1` for local
+development, or `https://api.otari.ai/v1` when connected to otari.ai.
+
+Export your key so opencode reads it from the environment instead of the config
+file, then run with a model:
+
+```bash
+export OTARI_API_KEY=<your-token>          # standalone API key, or tk_ user token
+opencode --model otari/openai:gpt-4o
+```
+
+The `apiKey` is sent as `Authorization: Bearer <token>`, which the gateway
+accepts for both standalone API keys and connected user tokens.
+
+## Choosing a model
+
+The provider id is `otari` (from your config) and the model selector is whatever
+your deployment expects:
+
+- **Standalone:** `provider:model`, e.g. `otari/openai:gpt-4o`,
+  `otari/anthropic:claude-sonnet-4-6`, `otari/mistral:mistral-large-latest`.
+- **Connected to otari.ai:** the platform selector, e.g.
+  `otari/mzai:openai/gpt-4o` or `otari/mzai:moonshotai/Kimi-K2.6`.
+
+Any model in the catalog works; the gateway routes the request to the right
+provider and records usage and cost for it the same way as any other client.
+
+## See also
+
+- [Use with Claude Code](use-with-claude-code.md) — drive the Claude Code CLI
+  through the same gateway via the Anthropic Messages API.

--- a/docs/use-with-opencode.md
+++ b/docs/use-with-opencode.md
@@ -46,8 +46,10 @@ your deployment expects:
 
 - **Standalone:** `provider:model`, e.g. `otari/openai:gpt-4o`,
   `otari/anthropic:claude-sonnet-4-6`, `otari/mistral:mistral-large-latest`.
-- **Connected to otari.ai:** the platform selector, e.g.
-  `otari/mzai:openai/gpt-4o` or `otari/mzai:moonshotai/Kimi-K2.6`.
+- **Connected to otari.ai:** `otari/mzai:<catalog-id>` for a managed open-weight
+  model (e.g. `otari/mzai:moonshotai/Kimi-K2.6`), or `otari/provider/model` for
+  one of your own provider keys (e.g. `otari/openai/gpt-4o`). An `mzai:` prefix
+  selects the managed catalog, so adding it to a proprietary model misroutes it.
 
 Any model in the catalog works; the gateway routes the request to the right
 provider and records usage and cost for it the same way as any other client.

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -109,6 +109,23 @@ class MessagesRequest(BaseModel):
     max_tool_iterations: int | None = Field(default=None, ge=1, le=MAX_TOOL_ITERATIONS_CAP)
 
 
+class CountTokensRequest(BaseModel):
+    """Anthropic ``/v1/messages/count_tokens`` request.
+
+    A subset of :class:`MessagesRequest`: the same input fields, minus
+    ``max_tokens`` and the streaming/sampling controls, since the endpoint only
+    counts input tokens. Clients such as Claude Code call this on every turn to
+    keep their prompt within the model's context window.
+    """
+
+    model: str
+    messages: list[dict[str, Any]] = Field(min_length=1)
+    system: str | list[dict[str, Any]] | None = None
+    tools: list[dict[str, Any]] | None = None
+    tool_choice: dict[str, Any] | None = None
+    thinking: dict[str, Any] | None = None
+
+
 def _anthropic_error(error_type: str, message: str, status_code: int) -> HTTPException:
     """Create an HTTPException with Anthropic-style error body."""
     return HTTPException(
@@ -1263,3 +1280,45 @@ async def _open_tool_loop_stream(
             await web_search_backend.__aexit__(None, None, None)
 
     return _web_search_iter()
+
+
+# The gateway has no tokenizer (see budget_service.estimate_cost), so input
+# tokens are approximated as ``chars / 4`` — the same heuristic used for budget
+# pre-debit. count_tokens callers (e.g. Claude Code) use the result only to
+# gauge headroom against the context window, so an approximate count is fine.
+_CHARS_PER_TOKEN = 4
+
+
+def _estimate_input_tokens(request: CountTokensRequest) -> int:
+    """Approximate the prompt's input-token count from its serialized length."""
+    chars = len(str(request.messages))
+    if request.system:
+        chars += len(str(request.system))
+    if request.tools:
+        chars += len(str(request.tools))
+    return max(1, round(chars / _CHARS_PER_TOKEN))
+
+
+@router.post("/messages/count_tokens", response_model=None)
+async def count_message_tokens(
+    raw_request: Request,
+    request: CountTokensRequest,
+    db: Annotated[AsyncSession | None, Depends(get_db_if_needed)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+) -> dict[str, int]:
+    """Anthropic ``/v1/messages/count_tokens``-compatible endpoint.
+
+    Returns ``{"input_tokens": N}`` without contacting an upstream provider:
+    counting is local, so there is no budget reservation, pricing, or usage
+    logging. Authentication mirrors :func:`create_message` — platform mode
+    requires the caller's bearer token; standalone mode validates the API key —
+    so the endpoint is not an open token-counting oracle.
+    """
+    if config.is_platform_mode:
+        _extract_platform_user_token(raw_request)
+    else:
+        if db is None:
+            raise _anthropic_error(_ERR_API, "Database session unavailable", status.HTTP_500_INTERNAL_SERVER_ERROR)
+        await verify_api_key_or_master_key(raw_request, db, config)
+
+    return {"input_tokens": _estimate_input_tokens(request)}

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 import os
 import time
 import uuid
@@ -112,10 +113,10 @@ class MessagesRequest(BaseModel):
 class CountTokensRequest(BaseModel):
     """Anthropic ``/v1/messages/count_tokens`` request.
 
-    A subset of :class:`MessagesRequest`: the same input fields, minus
-    ``max_tokens`` and the streaming/sampling controls, since the endpoint only
-    counts input tokens. Clients such as Claude Code call this on every turn to
-    keep their prompt within the model's context window.
+    A subset of :class:`MessagesRequest`: the input fields that affect the token
+    count, minus ``max_tokens`` and the streaming/sampling controls, since the
+    endpoint only counts input tokens. Clients such as Claude Code call this on
+    every turn to keep their prompt within the model's context window.
     """
 
     model: str
@@ -124,6 +125,14 @@ class CountTokensRequest(BaseModel):
     tools: list[dict[str, Any]] | None = None
     tool_choice: dict[str, Any] | None = None
     thinking: dict[str, Any] | None = None
+    metadata: dict[str, Any] | None = None
+    cache_control: dict[str, Any] | None = None
+
+
+class CountTokensResponse(BaseModel):
+    """Anthropic ``/v1/messages/count_tokens`` response."""
+
+    input_tokens: int
 
 
 def _anthropic_error(error_type: str, message: str, status_code: int) -> HTTPException:
@@ -1286,6 +1295,8 @@ async def _open_tool_loop_stream(
 # tokens are approximated as ``chars / 4`` — the same heuristic used for budget
 # pre-debit. count_tokens callers (e.g. Claude Code) use the result only to
 # gauge headroom against the context window, so an approximate count is fine.
+# Round up: an over-count keeps callers safely inside the context window, while
+# an under-count could let a prompt slip over the limit.
 _CHARS_PER_TOKEN = 4
 
 
@@ -1296,29 +1307,37 @@ def _estimate_input_tokens(request: CountTokensRequest) -> int:
         chars += len(str(request.system))
     if request.tools:
         chars += len(str(request.tools))
-    return max(1, round(chars / _CHARS_PER_TOKEN))
+    return max(1, math.ceil(chars / _CHARS_PER_TOKEN))
 
 
-@router.post("/messages/count_tokens", response_model=None)
+@router.post("/messages/count_tokens")
 async def count_message_tokens(
     raw_request: Request,
     request: CountTokensRequest,
     db: Annotated[AsyncSession | None, Depends(get_db_if_needed)],
     config: Annotated[GatewayConfig, Depends(get_config)],
-) -> dict[str, int]:
+) -> CountTokensResponse:
     """Anthropic ``/v1/messages/count_tokens``-compatible endpoint.
 
     Returns ``{"input_tokens": N}`` without contacting an upstream provider:
     counting is local, so there is no budget reservation, pricing, or usage
     logging. Authentication mirrors :func:`create_message` — platform mode
-    requires the caller's bearer token; standalone mode validates the API key —
-    so the endpoint is not an open token-counting oracle.
+    resolves the caller's token against the platform, standalone mode validates
+    the API key — so the endpoint is not an open token-counting oracle.
     """
     if config.is_platform_mode:
-        _extract_platform_user_token(raw_request)
+        # Resolve against the platform purely to authenticate the caller (same
+        # as create_message); the routing plan is discarded since counting is
+        # local. Without this, any non-empty bearer string would be accepted.
+        user_token = _extract_platform_user_token(raw_request)
+        await _resolve_platform_credentials(
+            config=config,
+            user_token=user_token,
+            model_selector=request.model,
+        )
     else:
         if db is None:
             raise _anthropic_error(_ERR_API, "Database session unavailable", status.HTTP_500_INTERNAL_SERVER_ERROR)
         await verify_api_key_or_master_key(raw_request, db, config)
 
-    return {"input_tokens": _estimate_input_tokens(request)}
+    return CountTokensResponse(input_tokens=_estimate_input_tokens(request))

--- a/tests/integration/test_messages_endpoint.py
+++ b/tests/integration/test_messages_endpoint.py
@@ -359,8 +359,8 @@ def test_count_tokens_bearer_auth(
     client: TestClient,
     api_key_obj: dict[str, Any],
 ) -> None:
-    """count_tokens authenticates via a standard Bearer token, as Claude Code
-    sends when ANTHROPIC_AUTH_TOKEN is set.
+    """count_tokens authenticates via the standard ``Authorization: Bearer``
+    header, which is what Claude Code sends when ANTHROPIC_AUTH_TOKEN is set.
     """
     response = client.post(
         "/v1/messages/count_tokens",
@@ -368,7 +368,7 @@ def test_count_tokens_bearer_auth(
             "model": "anthropic:claude-3-5-sonnet",
             "messages": [{"role": "user", "content": "Hello"}],
         },
-        headers={API_KEY_HEADER: f"Bearer {api_key_obj['key']}"},
+        headers={"Authorization": f"Bearer {api_key_obj['key']}"},
     )
     assert response.status_code == 200
     assert response.json()["input_tokens"] > 0

--- a/tests/integration/test_messages_endpoint.py
+++ b/tests/integration/test_messages_endpoint.py
@@ -226,3 +226,149 @@ def test_messages_endpoint_bearer_auth(
         )
 
     assert response.status_code == 200
+
+
+def _claude_code_request_body() -> dict[str, Any]:
+    """A request shaped the way Claude Code sends it: a structured ``system``
+    block with cache_control, tool definitions, and ``metadata.user_id``.
+    """
+    return {
+        "model": "anthropic:claude-3-5-sonnet",
+        "max_tokens": 1024,
+        "system": [
+            {
+                "type": "text",
+                "text": "You are Claude Code, Anthropic's official CLI.",
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+        "messages": [{"role": "user", "content": "List the files here."}],
+        "tools": [
+            {
+                "name": "Bash",
+                "description": "Run a shell command",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                    "required": ["command"],
+                },
+            }
+        ],
+        "metadata": {"user_id": "test-user"},
+    }
+
+
+def test_messages_endpoint_claude_code_shape(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """A realistic Claude Code request (system blocks + tools) completes."""
+    mock_response = _make_message_response()
+
+    with patch("gateway.api.routes.messages.amessages", new_callable=AsyncMock, return_value=mock_response):
+        response = client.post(
+            "/v1/messages",
+            json=_claude_code_request_body(),
+            headers=master_key_header,
+        )
+
+    assert response.status_code == 200
+    assert response.json()["type"] == "message"
+
+
+def test_count_tokens_basic(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """count_tokens returns a positive integer input-token estimate."""
+    response = client.post(
+        "/v1/messages/count_tokens",
+        json={
+            "model": "anthropic:claude-3-5-sonnet",
+            "messages": [{"role": "user", "content": "Hello, world!"}],
+        },
+        headers=master_key_header,
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data["input_tokens"], int)
+    assert data["input_tokens"] > 0
+
+
+def test_count_tokens_requires_auth(client: TestClient) -> None:
+    """count_tokens rejects unauthenticated callers."""
+    response = client.post(
+        "/v1/messages/count_tokens",
+        json={
+            "model": "anthropic:claude-3-5-sonnet",
+            "messages": [{"role": "user", "content": "Hello"}],
+        },
+    )
+    assert response.status_code == 401
+
+
+def test_count_tokens_validation_error(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """Missing required fields produce a 422 before any counting."""
+    response = client.post(
+        "/v1/messages/count_tokens",
+        json={"model": "anthropic:claude-3-5-sonnet"},
+        headers=master_key_header,
+    )
+    assert response.status_code == 422
+
+
+def test_count_tokens_scales_with_input(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """A longer prompt yields a strictly larger token estimate."""
+    short = client.post(
+        "/v1/messages/count_tokens",
+        json={
+            "model": "anthropic:claude-3-5-sonnet",
+            "messages": [{"role": "user", "content": "Hi"}],
+        },
+        headers=master_key_header,
+    ).json()["input_tokens"]
+
+    long = client.post(
+        "/v1/messages/count_tokens",
+        json={
+            "model": "anthropic:claude-3-5-sonnet",
+            "messages": [{"role": "user", "content": "Hello " * 200}],
+        },
+        headers=master_key_header,
+    ).json()["input_tokens"]
+
+    with_extras = client.post(
+        "/v1/messages/count_tokens",
+        json=_claude_code_request_body(),
+        headers=master_key_header,
+    ).json()["input_tokens"]
+
+    assert long > short
+    assert with_extras > 0
+
+
+def test_count_tokens_bearer_auth(
+    client: TestClient,
+    api_key_obj: dict[str, Any],
+) -> None:
+    """count_tokens authenticates via a standard Bearer token, as Claude Code
+    sends when ANTHROPIC_AUTH_TOKEN is set.
+    """
+    response = client.post(
+        "/v1/messages/count_tokens",
+        json={
+            "model": "anthropic:claude-3-5-sonnet",
+            "messages": [{"role": "user", "content": "Hello"}],
+        },
+        headers={API_KEY_HEADER: f"Bearer {api_key_obj['key']}"},
+    )
+    assert response.status_code == 200
+    assert response.json()["input_tokens"] > 0

--- a/tests/integration/test_platform_mode_messages.py
+++ b/tests/integration/test_platform_mode_messages.py
@@ -694,3 +694,88 @@ def test_platform_mode_tool_loop_streaming_sets_correlation_id_and_reports_usage
     success_reports = [r for r in usage_reports if r.get("status") == "success"]
     assert success_reports, "expected a success usage report for the platform-mode tool-loop stream"
     assert success_reports[0]["correlation_id"] == "stream-att-1"
+
+
+def test_platform_mode_count_tokens_requires_authorization_header(
+    platform_client: TestClient,
+) -> None:
+    response = platform_client.post(
+        "/v1/messages/count_tokens",
+        json={
+            "model": "anthropic:claude-3-5-sonnet-20241022",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Missing authentication token"}
+
+
+def test_platform_mode_count_tokens_validates_token(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A present-but-invalid bearer token is rejected: platform mode resolves
+    the token rather than just checking the header exists.
+    """
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "Invalid user token"})
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+
+    response = platform_client.post(
+        "/v1/messages/count_tokens",
+        json={
+            "model": "anthropic:claude-3-5-sonnet-20241022",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+        headers={"Authorization": "Bearer not_a_real_token"},
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid user token"}
+
+
+def test_platform_mode_count_tokens_succeeds_without_provider_call(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A valid token resolves, and the count is returned without any upstream
+    provider call (counting is local).
+    """
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        assert url.endswith("/gateway/provider-keys/resolve")
+        return httpx.Response(
+            200,
+            json=_resolve_payload([_attempt(0, "att-1", "claude-3-5-sonnet-20241022", "sk-platform-key")]),
+        )
+
+    async def fail_amessages(**kwargs: Any) -> MessageResponse:
+        raise AssertionError("count_tokens must not call the provider")
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.messages.amessages", fail_amessages)
+
+    response = platform_client.post(
+        "/v1/messages/count_tokens",
+        json={
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["input_tokens"] > 0


### PR DESCRIPTION
## Summary

Makes the [Claude Code](https://code.claude.com) CLI work against the Otari gateway, the same way [opencode does](https://blog.mozilla.ai/use-the-otari-gateway-with-opencode/). Claude Code speaks the Anthropic Messages API and calls `POST /v1/messages/count_tokens` every turn to manage its context window. The gateway already serves `/v1/messages` in both modes, but had no `count_tokens` endpoint, so Claude Code would `404` on token counts.

This PR adds the missing endpoint plus docs.

## Changes

- **`POST /v1/messages/count_tokens`** — Anthropic-compatible, returns `{"input_tokens": N}`. Counts locally with the same `chars/4` heuristic as budget estimation (the gateway has no tokenizer), so there is no provider call, no budget reservation, and no usage logging. Auth mirrors `create_message`: platform mode requires the caller's bearer token; standalone validates the API key.
- **Tests** — count_tokens basic/auth/validation/scaling/bearer, plus a realistic Claude Code request shape (structured `system` blocks + tools) against `/v1/messages`.
- **Docs** — new `use-with-claude-code.md` (env vars, using any provider's models not just Claude, and the standalone `reject_user_mismatch` caveat); corrected `api-reference.md` (Messages/Responses run in both modes, not standalone-only); regenerated `openapi.json` so the generated SDK clients pick up the route.

## Verification

- `14 passed` in `tests/integration/test_messages_endpoint.py`; ruff + mypy clean; OpenAPI sync-check passes.
- Drove the real `claude` CLI (v2.1.169) at a local standalone gateway backed by a mock OpenAI upstream: `POST /v1/messages?beta=true` → `200`, streamed end to end, correct output. Confirms the path works across a **non-Anthropic** provider (any-llm translates Messages ↔ Completions), so Claude Code is not limited to Anthropic models.
- `count_tokens` verified returning `{"input_tokens": N}` via curl and tests. (Headless `-p` mode doesn't call it; the interactive TUI does.)

## Notes

- No changes needed to `any-llm` (already provides `amessages` + universal Messages↔Completions translation) or the `otari-sdk-*` clients (generated from the OpenAPI spec; they pick up the route on next codegen).
- Standalone-only caveat: Claude Code injects `metadata.user_id`, which trips the user-mismatch guard. Documented `reject_user_mismatch: false`. Platform mode is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds Claude Code support to the Otari gateway by implementing a new POST /v1/messages/count_tokens endpoint and the related docs and tests. Claude Code calls this endpoint each turn to estimate context usage; before this change the gateway returned 404s for those requests.

### What changed

- Added POST /v1/messages/count_tokens which accepts messages/system/tools and returns {"input_tokens": N} computed locally.
- Authentication mirrors existing messages behavior: platform mode resolves the caller's bearer token; standalone mode validates API/master key.
- Added a CountTokensRequest/CountTokensResponse models and route in the messages API.
- Tests: integration and platform-mode tests covering authentication (including bearer/platform checks), validation, scaling with input length, realistic Claude Code request shapes, and ensuring no upstream provider calls for counting. Integration suite reports passing tests for the messages endpoints.
- Documentation: new "Use with Claude Code" guide, new "Use with opencode" doc, updated API reference and index to show Messages/Responses available in both deployment modes, and regenerated OpenAPI so SDKs pick up the new route.
- Tooling: OpenAPI sync-check, ruff and mypy are clean.

### Benefits

- Claude Code can now interact with Otari without 404s for token counting.
- Local token estimation gives fast, offline feedback without provider calls.
- Docs clarify configuration and deployment-mode behavior, reducing setup friction.
- Tests provide coverage for auth, validation, and realistic request shapes.

### Technical notes

- Token estimate is a simple heuristic (ceil(char_count / 4), minimum 1); no tokenizer, no budget reservation, and no usage logging performed by the count_tokens endpoint.
- Standalone mode caveat: Claude Code injects metadata.user_id which can trigger the user-mismatch guard; the docs recommend setting reject_user_mismatch: false if needed.
- No changes required to any-llm or otari-sdk-* clients beyond codegen picking up the updated OpenAPI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->