### PR TITLE
chore: add make openapi-check target and call make targets from CI

### DIFF
--- a/.github/workflows/gateway-lint.yml
+++ b/.github/workflows/gateway-lint.yml
@@ -37,4 +37,4 @@ jobs:
       run: uv sync --dev --frozen
 
     - name: Run Ruff lint
-      run: uv run ruff check src tests scripts
+      run: make lint

--- a/.github/workflows/gateway-tests.yml
+++ b/.github/workflows/gateway-tests.yml
@@ -75,4 +75,4 @@ jobs:
       run: uv sync --frozen
 
     - name: Verify OpenAPI spec is up to date
-      run: uv run python scripts/generate_openapi.py --check
+      run: make openapi-check

--- a/.github/workflows/gateway-typecheck.yml
+++ b/.github/workflows/gateway-typecheck.yml
@@ -37,4 +37,4 @@ jobs:
       run: uv sync --dev --frozen
 
     - name: Run mypy type check
-      run: uv run mypy
+      run: make typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ ORM entities are in `src/gateway/models/entities.py` (User, APIKey, Budget, Usag
 - Generate OpenAPI JSON:
   - `uv run python scripts/generate_openapi.py`
 - Check OpenAPI is up to date (CI behavior):
-  - `uv run python scripts/generate_openapi.py --check`
+  - `make openapi-check` (or `uv run python scripts/generate_openapi.py --check`)
 - Default output path:
   - `docs/public/openapi.json`
 ## Repository Conventions
@@ -176,7 +176,7 @@ ORM entities are in `src/gateway/models/entities.py` (User, APIKey, Budget, Usag
 - If you touched config loading, run config/env tests in `tests/integration`.
 - If you touched CLI behavior, run `tests/unit/test_gateway_cli.py`.
 - If you touched auth headers or key handling, run key-management and auth-related tests.
-- If OpenAPI-affecting code changed, run `uv run python scripts/generate_openapi.py --check`.
+- If OpenAPI-affecting code changed, run `make openapi-check` (or `uv run python scripts/generate_openapi.py --check`).
 
 ## Writing style
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev test test-unit test-integration lint typecheck
+.PHONY: help dev test test-unit test-integration lint typecheck openapi-check
 
 help:
 	@printf "Available targets:\n"
@@ -8,6 +8,7 @@ help:
 	@printf "  test-integration Run integration tests\n"
 	@printf "  lint Run Ruff lint checks\n"
 	@printf "  typecheck Run mypy type checks\n"
+	@printf "  openapi-check Verify the OpenAPI spec is up to date\n"
 
 dev:
 	@set -a; \
@@ -29,3 +30,6 @@ lint:
 
 typecheck:
 	uv run mypy
+
+openapi-check:
+	uv run python scripts/generate_openapi.py --check


### PR DESCRIPTION
## What

Two related changes that reduce drift between local commands and CI:

1. Add a `make openapi-check` target wrapping the OpenAPI spec freshness check (`scripts/generate_openapi.py --check`), and document it in `AGENTS.md`.
2. Update the CI workflows to call the Makefile targets for the steps that were byte-identical copies of those targets, so each command has a single source of truth.

## Why

The Makefile exposes the project's standard local commands (`dev`, `test`, `lint`, `typecheck`), and `AGENTS.md` treats those as the local mirror of CI. Two gaps existed:

- The OpenAPI freshness check is enforced in CI (the `openapi-spec` job in `gateway-tests.yml`) and listed in the AGENTS.md validation checklist, but it was the one CI gate with no Makefile shortcut.
- `lint`, `typecheck`, and the OpenAPI check were defined twice (once in the Makefile, once inline in the workflows) with identical commands, so they could drift apart silently.

Adding the missing target and pointing CI at the targets closes both gaps.

## Changes

- `Makefile`: new `openapi-check` target (added to `.PHONY` and `help` output).
- `AGENTS.md`: reference `make openapi-check` in the OpenAPI Spec Commands section and the change validation checklist.
- `.github/workflows/gateway-lint.yml`: run `make lint` instead of the inline `ruff` command.
- `.github/workflows/gateway-typecheck.yml`: run `make typecheck` instead of the inline `mypy` command.
- `.github/workflows/gateway-tests.yml`: the `openapi-spec` job runs `make openapi-check`.

The `uv sync --frozen` install steps are unchanged, so CI still builds the locked environment before invoking `make`.

## What is intentionally left alone

The unit and integration test steps in `gateway-tests.yml` are not converted. They add coverage and xdist flags (`--cov --cov-report=xml`, `-n auto`, `--cov-append`) that the local `make test` target deliberately does not carry, so they are not pure copies. Collapsing them would either change CI behavior or slow down the local fast path.

## Test plan

- `make openapi-check` runs `generate_openapi.py --check` and reports the spec is up to date.
- `make lint` runs the same `ruff check` command CI used previously and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
