### PR TITLE
refactor(routes): encapsulate standalone-vs-platform mode behind a strategy

### DIFF
--- a/src/gateway/api/routes/_mode_strategy.py
+++ b/src/gateway/api/routes/_mode_strategy.py
@@ -1,0 +1,493 @@
+"""Standalone-vs-platform mode seam for the LLM route handlers.
+
+The gateway's operating mode is derived once from ``config.is_platform_mode``
+(``core/config.py``). Historically each of the chat / messages / responses
+handlers consumed that single boolean and then re-branched on it inline at many
+sites, interleaving the two modes' credential-resolution and usage-reporting
+logic inside one long function body. This module lifts those two concerns
+behind a per-request strategy object so the handlers select the mode once and
+never branch on it again for resolution or settlement.
+
+Two seams live here:
+
+* :class:`RequestModeStrategy` — credential resolution. ``resolve`` runs the
+  platform resolve call (platform) or the auth + budget-reservation flow
+  (standalone) and stashes the per-request state the handler needs.
+* :class:`RequestSettlement` — usage reporting. The four async hooks match the
+  callbacks ``gateway.streaming.streaming_generator`` already accepts, plus the
+  standalone non-streaming success/error tail. Platform reports usage upstream;
+  standalone writes a ``UsageLog`` row and reconciles/refunds the reservation.
+
+Dispatch mechanics (the ``run_platform_attempts`` runner vs the standalone
+single call, and the streaming fallback-vs-single split) deliberately stay in
+the handlers — they are tool/stream plumbing, not mode-resolution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from any_llm import AnyLLM, LLMProvider
+from any_llm.exceptions import AnyLLMError
+from any_llm.types.completion import CompletionUsage
+from fastapi import HTTPException, Request, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.api.deps import verify_api_key_or_master_key
+from gateway.api.routes._helpers import resolve_user_id
+from gateway.api.routes._platform import (
+    ResolvedRoute,
+    _extract_platform_user_token,
+    _report_platform_usage,
+    _resolve_platform_credentials,
+    _resolve_platform_mcp_servers,
+)
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger
+from gateway.models.mcp import McpServerConfig
+from gateway.rate_limit import RateLimitInfo, check_rate_limit
+from gateway.services.budget_service import (
+    ReservationHandle,
+    estimate_cost,
+    reconcile_reservation,
+    refund_reservation,
+    reserve_budget,
+)
+from gateway.services.log_writer import LogWriter
+from gateway.services.pricing_service import find_model_pricing, pricing_required_but_missing
+
+# ---------------------------------------------------------------------------
+# Usage-reporting seam
+# ---------------------------------------------------------------------------
+
+
+class RequestSettlement(ABC):
+    """Settles a request's usage once the provider call resolves.
+
+    The four hooks mirror the callbacks ``streaming_generator`` accepts so a
+    settlement can be wired straight into the SSE generator, and are reused on
+    the standalone non-streaming success/error tail.
+    """
+
+    @abstractmethod
+    async def on_success(self, usage: CompletionUsage | None) -> None:
+        """A completed call (non-stream result, or stream that carried usage)."""
+
+    @abstractmethod
+    async def on_error(self, error: str) -> None:
+        """A failed call that should be recorded as an error (and, standalone,
+        release the reservation)."""
+
+    @abstractmethod
+    async def on_provider_error_precommit(self, error: str) -> None:
+        """A provider error raised before any stream bytes committed.
+
+        Standalone records the error without settling the reservation, matching
+        the long-standing messages/responses pre-commit behavior (the
+        non-streaming and chat paths refund here; messages/responses do not).
+        Platform reports nothing — this path predates platform usage reporting
+        and there is no local reservation to release.
+        """
+
+    @abstractmethod
+    async def on_no_usage(self) -> None:
+        """A stream that completed without any provider usage data."""
+
+    @abstractmethod
+    async def on_incomplete(self) -> None:
+        """A stream the client abandoned before completion."""
+
+
+class PlatformSettlement(RequestSettlement):
+    """Reports usage back to the platform via ``_report_platform_usage``.
+
+    Platform mode has no local budget reservation, so ``on_no_usage`` /
+    ``on_incomplete`` are no-ops — there is nothing local to settle.
+    """
+
+    def __init__(self, *, config: GatewayConfig, correlation_id: str) -> None:
+        self._config = config
+        self._correlation_id = correlation_id
+
+    async def on_success(self, usage: CompletionUsage | None) -> None:
+        asyncio.create_task(
+            _report_platform_usage(
+                config=self._config,
+                correlation_id=self._correlation_id,
+                outcome="success",
+                usage=usage,
+            )
+        )
+
+    async def on_error(self, error: str) -> None:
+        asyncio.create_task(
+            _report_platform_usage(
+                config=self._config,
+                correlation_id=self._correlation_id,
+                outcome="error",
+                usage=None,
+            )
+        )
+
+    async def on_provider_error_precommit(self, error: str) -> None:
+        return
+
+    async def on_no_usage(self) -> None:
+        return
+
+    async def on_incomplete(self) -> None:
+        return
+
+
+class StandaloneSettlement(RequestSettlement):
+    """Writes a ``UsageLog`` row and reconciles/refunds the local reservation."""
+
+    def __init__(
+        self,
+        *,
+        db: AsyncSession | None,
+        log_writer: LogWriter,
+        api_key_id: str | None,
+        user_id: str | None,
+        provider: LLMProvider,
+        model: str,
+        endpoint: str,
+        reservation: ReservationHandle | None,
+        config: GatewayConfig,
+    ) -> None:
+        self._db = db
+        self._log_writer = log_writer
+        self._api_key_id = api_key_id
+        self._user_id = user_id
+        self._provider = provider
+        self._model = model
+        self._endpoint = endpoint
+        self._reservation = reservation
+        self._config = config
+
+    async def on_success(self, usage: CompletionUsage | None) -> None:
+        # Local import breaks the chat <-> _mode_strategy import cycle:
+        # chat.py imports this module at top level, so this module cannot import
+        # chat.log_usage at module scope (it is defined after chat's import of us).
+        from gateway.api.routes.chat import log_usage
+
+        if self._db is None:
+            return
+        actual_cost = await log_usage(
+            db=self._db,
+            log_writer=self._log_writer,
+            api_key_id=self._api_key_id,
+            model=self._model,
+            provider=self._provider,
+            endpoint=self._endpoint,
+            user_id=self._user_id,
+            usage_override=usage,
+        )
+        if self._reservation is not None:
+            await reconcile_reservation(self._db, self._reservation, actual_cost or 0.0)
+
+    async def on_error(self, error: str) -> None:
+        from gateway.api.routes.chat import log_usage
+
+        if self._db is None:
+            return
+        await log_usage(
+            db=self._db,
+            log_writer=self._log_writer,
+            api_key_id=self._api_key_id,
+            model=self._model,
+            provider=self._provider,
+            endpoint=self._endpoint,
+            user_id=self._user_id,
+            error=error,
+        )
+        if self._reservation is not None:
+            await refund_reservation(self._db, self._reservation)
+
+    async def on_provider_error_precommit(self, error: str) -> None:
+        from gateway.api.routes.chat import log_usage
+
+        # Log the error but leave the reservation untouched, matching the
+        # existing messages/responses pre-commit streaming behavior.
+        if self._db is None:
+            return
+        await log_usage(
+            db=self._db,
+            log_writer=self._log_writer,
+            api_key_id=self._api_key_id,
+            model=self._model,
+            provider=self._provider,
+            endpoint=self._endpoint,
+            user_id=self._user_id,
+            error=error,
+        )
+
+    async def on_no_usage(self) -> None:
+        from gateway.api.routes.chat import log_usage
+
+        # Stream completed but the provider sent no usage data. Settle the
+        # reservation per stream_missing_usage_policy instead of billing $0.
+        if self._db is None or self._log_writer is None or self._reservation is None:
+            return
+        policy = self._config.stream_missing_usage_policy
+        if policy == "allow_free":
+            await log_usage(
+                db=self._db,
+                log_writer=self._log_writer,
+                api_key_id=self._api_key_id,
+                model=self._model,
+                provider=self._provider,
+                endpoint=self._endpoint,
+                user_id=self._user_id,
+            )
+            await refund_reservation(self._db, self._reservation)
+            return
+        # 'estimate' and 'fail' both charge the up-front estimate; 'fail' also
+        # records the request as errored.
+        await log_usage(
+            db=self._db,
+            log_writer=self._log_writer,
+            api_key_id=self._api_key_id,
+            model=self._model,
+            provider=self._provider,
+            endpoint=self._endpoint,
+            user_id=self._user_id,
+            error="stream completed without usage data" if policy == "fail" else None,
+            cost_override=self._reservation.estimate,
+        )
+        await reconcile_reservation(self._db, self._reservation, self._reservation.estimate)
+
+    async def on_incomplete(self) -> None:
+        # Client disconnected mid-stream — release the reservation.
+        if self._db is None or self._reservation is None:
+            return
+        await refund_reservation(self._db, self._reservation)
+
+
+# ---------------------------------------------------------------------------
+# Credential-resolution seam
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ResolveErrors:
+    """Endpoint-specific HTTPExceptions the standalone resolve flow raises.
+
+    Each handler builds these in its own error envelope (chat / responses use
+    plain ``HTTPException`` detail strings; messages uses the Anthropic error
+    envelope) so the shared resolve logic stays format-agnostic.
+    """
+
+    db_unavailable: HTTPException
+    master_key_user_required: HTTPException
+    api_key_validation_failed: HTTPException
+    no_user: HTTPException
+    forbidden_user: HTTPException
+    no_pricing: HTTPException
+
+
+@dataclass
+class ResolveSpec:
+    """Per-request inputs to :meth:`RequestModeStrategy.resolve`."""
+
+    model_selector: str
+    user_id_from_request: str | None
+    prompt_chars: int
+    max_output_tokens: int | None
+    errors: ResolveErrors
+    # Optional provider-support guard (responses' SUPPORTS_RESPONSES check).
+    # Platform applies it to every resolved attempt; standalone applies it to
+    # the split provider. Raises the endpoint's own HTTPException on rejection.
+    validate_provider: Callable[[LLMProvider], None] | None = None
+
+
+class RequestModeStrategy(ABC):
+    """Per-request seam over standalone vs platform mode.
+
+    Select once via :func:`select_request_mode_strategy`, call :meth:`resolve`,
+    then read the populated attributes. The handler never branches on mode for
+    credential resolution or usage settlement again.
+    """
+
+    is_platform: bool
+
+    def __init__(self) -> None:
+        self.route: ResolvedRoute | None = None
+        self.user_token: str | None = None
+        self.api_key_id: str | None = None
+        self.user_id: str | None = None
+        self.reservation: ReservationHandle | None = None
+        self.rate_limit_info: RateLimitInfo | None = None
+
+    @abstractmethod
+    async def resolve(self, *, raw_request: Request, response: Response, spec: ResolveSpec) -> None:
+        """Resolve credentials (platform) or authenticate + reserve budget
+        (standalone), populating the per-request attributes above."""
+
+    @abstractmethod
+    async def resolve_mcp_servers(
+        self, mcp_server_ids: list[uuid.UUID], *, reject_error: Exception
+    ) -> list[McpServerConfig]:
+        """Swap workspace-scoped MCP server ids for inline configs (platform),
+        or reject the field (standalone raises ``reject_error``)."""
+
+    @abstractmethod
+    def make_settlement(
+        self,
+        *,
+        provider: LLMProvider,
+        model: str,
+        endpoint: str,
+        correlation_id: str | None,
+    ) -> RequestSettlement:
+        """Build the settlement object for this request's mode."""
+
+
+class PlatformStrategy(RequestModeStrategy):
+    is_platform = True
+
+    def __init__(self, config: GatewayConfig) -> None:
+        super().__init__()
+        self._config = config
+
+    async def resolve(self, *, raw_request: Request, response: Response, spec: ResolveSpec) -> None:
+        self.user_token = _extract_platform_user_token(raw_request)
+        start_time = time.perf_counter()
+        route = await _resolve_platform_credentials(
+            config=self._config,
+            user_token=self.user_token,
+            model_selector=spec.model_selector,
+        )
+        self.route = route
+        resolve_latency_ms = (time.perf_counter() - start_time) * 1000
+        response.headers["X-Otari-Request-ID"] = route.request_id
+        logger.info(
+            "Platform resolve succeeded request_id=%s attempts=%d fallback_enabled=%s resolve_latency_ms=%.2f",
+            route.request_id,
+            len(route.attempts),
+            route.fallback_enabled,
+            resolve_latency_ms,
+        )
+        if spec.validate_provider is not None:
+            # Validate every resolved attempt so a fallback that lands on an
+            # unsupported provider fails fast here instead of crashing
+            # mid-fallback inside the runner.
+            for attempt in route.attempts:
+                spec.validate_provider(LLMProvider(attempt.provider))
+
+    async def resolve_mcp_servers(
+        self, mcp_server_ids: list[uuid.UUID], *, reject_error: Exception
+    ) -> list[McpServerConfig]:
+        assert self.user_token is not None  # guaranteed by resolve()
+        return await _resolve_platform_mcp_servers(
+            config=self._config,
+            user_token=self.user_token,
+            mcp_server_ids=mcp_server_ids,
+        )
+
+    def make_settlement(
+        self,
+        *,
+        provider: LLMProvider,
+        model: str,
+        endpoint: str,
+        correlation_id: str | None,
+    ) -> RequestSettlement:
+        assert correlation_id is not None  # platform settlement always has a correlation id
+        return PlatformSettlement(config=self._config, correlation_id=correlation_id)
+
+
+class StandaloneStrategy(RequestModeStrategy):
+    is_platform = False
+
+    def __init__(self, config: GatewayConfig, db: AsyncSession | None, log_writer: LogWriter) -> None:
+        super().__init__()
+        self._config = config
+        self._db = db
+        self._log_writer = log_writer
+
+    async def resolve(self, *, raw_request: Request, response: Response, spec: ResolveSpec) -> None:
+        if self._db is None:
+            raise spec.errors.db_unavailable
+        api_key, is_master_key = await verify_api_key_or_master_key(raw_request, self._db, self._config)
+        self.api_key_id = api_key.id if api_key else None
+        self.user_id = resolve_user_id(
+            user_id_from_request=spec.user_id_from_request,
+            api_key=api_key,
+            is_master_key=is_master_key,
+            master_key_error=spec.errors.master_key_user_required,
+            no_api_key_error=spec.errors.api_key_validation_failed,
+            no_user_error=spec.errors.no_user,
+            forbidden_user_error=spec.errors.forbidden_user,
+            reject_mismatch=self._config.reject_user_mismatch,
+        )
+        self.rate_limit_info = check_rate_limit(raw_request, self.user_id)
+        # Tolerate an unparseable selector here — the budget gate (404/403) and
+        # the downstream provider call surface those; an unparseable model
+        # simply has no pricing.
+        try:
+            gate_provider, gate_model = AnyLLM.split_model_provider(spec.model_selector)
+        except (ValueError, AnyLLMError):
+            gate_provider, gate_model = None, spec.model_selector
+        gate_pricing = await find_model_pricing(self._db, gate_provider, gate_model)
+        estimate = estimate_cost(
+            gate_pricing,
+            prompt_chars=spec.prompt_chars,
+            max_output_tokens=spec.max_output_tokens,
+            default_output_tokens=self._config.budget_estimate_default_output_tokens,
+        )
+        # Reserve first so user/blocked/budget rejections (404/403) take
+        # precedence over the missing-pricing rejection (402); refund if we then
+        # reject for missing pricing.
+        self.reservation = await reserve_budget(
+            self._db, self.user_id, estimate, model=spec.model_selector, strategy=self._config.budget_strategy
+        )
+        if pricing_required_but_missing(gate_pricing, require_pricing=self._config.require_pricing):
+            await refund_reservation(self._db, self.reservation)
+            raise spec.errors.no_pricing
+        if spec.validate_provider is not None:
+            # Standalone runs the provider-support guard after reservation,
+            # matching the existing responses handler order.
+            provider, _model = AnyLLM.split_model_provider(spec.model_selector)
+            spec.validate_provider(provider)
+
+    async def resolve_mcp_servers(
+        self, mcp_server_ids: list[uuid.UUID], *, reject_error: Exception
+    ) -> list[McpServerConfig]:
+        raise reject_error
+
+    def make_settlement(
+        self,
+        *,
+        provider: LLMProvider,
+        model: str,
+        endpoint: str,
+        correlation_id: str | None,
+    ) -> RequestSettlement:
+        return StandaloneSettlement(
+            db=self._db,
+            log_writer=self._log_writer,
+            api_key_id=self.api_key_id,
+            user_id=self.user_id,
+            provider=provider,
+            model=model,
+            endpoint=endpoint,
+            reservation=self.reservation,
+            config=self._config,
+        )
+
+
+def select_request_mode_strategy(
+    config: GatewayConfig,
+    db: AsyncSession | None,
+    log_writer: LogWriter,
+) -> RequestModeStrategy:
+    """Select the request mode strategy once per request from the gateway mode."""
+    if config.is_platform_mode:
+        return PlatformStrategy(config)
+    return StandaloneStrategy(config, db, log_writer)

--- a/src/gateway/api/routes/_mode_strategy.py
+++ b/src/gateway/api/routes/_mode_strategy.py
@@ -81,18 +81,9 @@ class RequestSettlement(ABC):
     @abstractmethod
     async def on_error(self, error: str) -> None:
         """A failed call that should be recorded as an error (and, standalone,
-        release the reservation)."""
-
-    @abstractmethod
-    async def on_provider_error_precommit(self, error: str) -> None:
-        """A provider error raised before any stream bytes committed.
-
-        Standalone records the error without settling the reservation, matching
-        the long-standing messages/responses pre-commit behavior (the
-        non-streaming and chat paths refund here; messages/responses do not).
-        Platform reports nothing — this path predates platform usage reporting
-        and there is no local reservation to release.
-        """
+        release the reservation). Used for both pre-commit provider failures
+        (surfaced as an HTTP error) and mid-stream failures (surfaced in the
+        SSE channel)."""
 
     @abstractmethod
     async def on_no_usage(self) -> None:
@@ -133,9 +124,6 @@ class PlatformSettlement(RequestSettlement):
                 usage=None,
             )
         )
-
-    async def on_provider_error_precommit(self, error: str) -> None:
-        return
 
     async def on_no_usage(self) -> None:
         return
@@ -208,24 +196,6 @@ class StandaloneSettlement(RequestSettlement):
         )
         if self._reservation is not None:
             await refund_reservation(self._db, self._reservation)
-
-    async def on_provider_error_precommit(self, error: str) -> None:
-        from gateway.api.routes.chat import log_usage
-
-        # Log the error but leave the reservation untouched, matching the
-        # existing messages/responses pre-commit streaming behavior.
-        if self._db is None:
-            return
-        await log_usage(
-            db=self._db,
-            log_writer=self._log_writer,
-            api_key_id=self._api_key_id,
-            model=self._model,
-            provider=self._provider,
-            endpoint=self._endpoint,
-            user_id=self._user_id,
-            error=error,
-        )
 
     async def on_no_usage(self) -> None:
         from gateway.api.routes.chat import log_usage

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import time
 import uuid
 from collections.abc import AsyncIterator, Callable
 from contextlib import AsyncExitStack
@@ -9,7 +8,6 @@ from typing import Annotated, Any
 
 import httpx
 from any_llm import AnyLLM, LLMProvider, acompletion
-from any_llm.exceptions import AnyLLMError
 from any_llm.types.completion import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -20,8 +18,15 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.api.deps import get_config, get_db_if_needed, get_log_writer, verify_api_key_or_master_key
-from gateway.api.routes._helpers import apply_input_guardrails, latest_user_text, resolve_user_id
+from gateway.api.deps import get_config, get_db_if_needed, get_log_writer
+from gateway.api.routes._helpers import apply_input_guardrails, latest_user_text
+from gateway.api.routes._mode_strategy import (
+    RequestModeStrategy,
+    RequestSettlement,
+    ResolveErrors,
+    ResolveSpec,
+    select_request_mode_strategy,
+)
 from gateway.api.routes._platform import (
     _DEFAULT_STREAM_FIRST_CHUNK_TIMEOUT_MS,
     _DEFAULT_STREAM_FIRST_CHUNK_TIMEOUT_MS_TOOL_LOOP,
@@ -30,10 +35,7 @@ from gateway.api.routes._platform import (
     ResolvedAttempt,
     ResolvedRoute,
     _classify_upstream_error,
-    _extract_platform_user_token,
     _report_platform_usage,
-    _resolve_platform_credentials,
-    _resolve_platform_mcp_servers,
     run_platform_attempts,
 )
 from gateway.api.routes._tools import (
@@ -46,17 +48,10 @@ from gateway.api.routes._tools import (
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.metrics import record_cost, record_tokens
-from gateway.models.entities import APIKey, UsageLog
+from gateway.models.entities import UsageLog
 from gateway.models.guardrails import GuardrailConfig
 from gateway.models.mcp import McpServerConfig
-from gateway.rate_limit import RateLimitInfo, check_rate_limit
-from gateway.services.budget_service import (
-    ReservationHandle,
-    estimate_cost,
-    reconcile_reservation,
-    refund_reservation,
-    reserve_budget,
-)
+from gateway.rate_limit import RateLimitInfo
 from gateway.services.log_writer import LogWriter
 from gateway.services.mcp_client import MCPClientPool
 from gateway.services.mcp_loop import (
@@ -67,7 +62,7 @@ from gateway.services.mcp_loop import (
     mcp_tool_loop,
     mcp_tool_loop_stream,
 )
-from gateway.services.pricing_service import find_model_pricing, pricing_required_but_missing
+from gateway.services.pricing_service import find_model_pricing
 from gateway.services.provider_kwargs import get_provider_kwargs as get_provider_kwargs  # noqa: F401
 from gateway.services.sandbox_backend import SandboxBackend, SandboxNotReachableError
 from gateway.services.web_search_backend import WebSearchNotReachableError
@@ -239,95 +234,52 @@ async def chat_completions(
             detail="Invalid request: model is required",
         )
 
-    api_key: APIKey | None = None
-    api_key_id: str | None = None
-    user_id: str | None = None
-    rate_limit_info: RateLimitInfo | None = None
-    platform_mode = config.is_platform_mode
-    route: ResolvedRoute | None = None
-    user_token: str | None = None  # set inside the platform_mode branch; referenced again later
-    # Budget pre-debit for the standalone (local-DB) path only; platform mode
-    # reports usage upstream instead. Settled (reconciled/refunded) at every
-    # completion and error hook below.
-    reservation: ReservationHandle | None = None
-
-    if platform_mode:
-        user_token = _extract_platform_user_token(raw_request)
-        start_time = time.perf_counter()
-        route = await _resolve_platform_credentials(
-            config=config,
-            user_token=user_token,
+    # Mode seam: select the strategy once, then resolve credentials (platform)
+    # or authenticate + reserve budget (standalone). The handler reads the
+    # populated per-request state off the strategy and never branches on mode
+    # again for credential resolution or usage settlement.
+    strategy = select_request_mode_strategy(config, db, log_writer)
+    await strategy.resolve(
+        raw_request=raw_request,
+        response=response,
+        spec=ResolveSpec(
             model_selector=request.model,
-        )
-        resolve_latency_ms = (time.perf_counter() - start_time) * 1000
-        response.headers["X-Otari-Request-ID"] = route.request_id
-        logger.info(
-            "Platform resolve succeeded request_id=%s attempts=%d fallback_enabled=%s resolve_latency_ms=%.2f",
-            route.request_id,
-            len(route.attempts),
-            route.fallback_enabled,
-            resolve_latency_ms,
-        )
-    else:
-        if db is None:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Database session unavailable",
-            )
-
-        api_key, is_master_key = await verify_api_key_or_master_key(raw_request, db, config)
-        api_key_id = api_key.id if api_key else None
-        user_id = resolve_user_id(
             user_id_from_request=request.user,
-            api_key=api_key,
-            is_master_key=is_master_key,
-            master_key_error=HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="When using master key, 'user' field is required in request body",
-            ),
-            no_api_key_error=HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="API key validation failed",
-            ),
-            no_user_error=HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="API key has no associated user",
-            ),
-            forbidden_user_error=HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="'user' field does not match the authenticated API key's user",
-            ),
-            reject_mismatch=config.reject_user_mismatch,
-        )
-
-        rate_limit_info = check_rate_limit(raw_request, user_id)
-
-        # Tolerate an unparseable / unknown-provider selector here — the budget
-        # check below and the downstream provider call surface those with their
-        # own status codes. A model we can't parse simply has no pricing.
-        try:
-            gate_provider, gate_model = AnyLLM.split_model_provider(request.model)
-        except (ValueError, AnyLLMError):
-            gate_provider, gate_model = None, request.model
-        gate_pricing = await find_model_pricing(db, gate_provider, gate_model)
-        estimate = estimate_cost(
-            gate_pricing,
             prompt_chars=len(str(request.messages)),
-            max_output_tokens=request.max_tokens if request.max_tokens is not None else request.max_completion_tokens,
-            default_output_tokens=config.budget_estimate_default_output_tokens,
-        )
-        # Reserve first so user/blocked/budget rejections (404/403) take
-        # precedence over the missing-pricing rejection (402); refund if we then
-        # reject for missing pricing.
-        reservation = await reserve_budget(
-            db, user_id, estimate, model=request.model, strategy=config.budget_strategy
-        )
-        if pricing_required_but_missing(gate_pricing, require_pricing=config.require_pricing):
-            await refund_reservation(db, reservation)
-            raise HTTPException(
-                status_code=status.HTTP_402_PAYMENT_REQUIRED,
-                detail=f"No pricing configured for model '{request.model}'",
-            )
+            max_output_tokens=(
+                request.max_tokens if request.max_tokens is not None else request.max_completion_tokens
+            ),
+            errors=ResolveErrors(
+                db_unavailable=HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Database session unavailable",
+                ),
+                master_key_user_required=HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="When using master key, 'user' field is required in request body",
+                ),
+                api_key_validation_failed=HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="API key validation failed",
+                ),
+                no_user=HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="API key has no associated user",
+                ),
+                forbidden_user=HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="'user' field does not match the authenticated API key's user",
+                ),
+                no_pricing=HTTPException(
+                    status_code=status.HTTP_402_PAYMENT_REQUIRED,
+                    detail=f"No pricing configured for model '{request.model}'",
+                ),
+            ),
+        ),
+    )
+    platform_mode = strategy.is_platform
+    route = strategy.route
+    rate_limit_info = strategy.rate_limit_info
 
     # Caller-requested input guardrails run before any provider/tool dispatch.
     # `block`-mode flags raise 403 here (provider never called); `monitor`-mode
@@ -341,23 +293,18 @@ async def chat_completions(
     )
 
     # Workspace-scoped MCP server references (platform mode only). Callers
-    # pass `mcp_server_ids: [uuid, ...]` instead of inlining each config; we
-    # resolve them against the platform's `/gateway/mcp-servers/resolve`
-    # endpoint and merge with any inline `mcp_servers` so the downstream
-    # MCP loop sees a single list. In standalone mode there's no platform
-    # to consult, so we reject the field with a 400 rather than silently
-    # ignoring it.
-    if request.mcp_server_ids and not platform_mode:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="mcp_server_ids is only available in platform mode",
-        )
-    if platform_mode and request.mcp_server_ids:
-        assert user_token is not None  # guaranteed by the platform_mode branch above
-        resolved_mcp_servers = await _resolve_platform_mcp_servers(
-            config=config,
-            user_token=user_token,
-            mcp_server_ids=request.mcp_server_ids,
+    # pass `mcp_server_ids: [uuid, ...]` instead of inlining each config; the
+    # platform strategy resolves them against `/gateway/mcp-servers/resolve`
+    # and we merge with any inline `mcp_servers` so the downstream MCP loop
+    # sees a single list. In standalone mode there's no platform to consult,
+    # so the strategy raises a 400 rather than silently ignoring the field.
+    if request.mcp_server_ids:
+        resolved_mcp_servers = await strategy.resolve_mcp_servers(
+            request.mcp_server_ids,
+            reject_error=HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="mcp_server_ids is only available in platform mode",
+            ),
         )
         request.mcp_servers = (request.mcp_servers or []) + resolved_mcp_servers
 
@@ -456,6 +403,7 @@ async def chat_completions(
                     request=request,
                     response=response,
                     config=config,
+                    strategy=strategy,
                     background_tasks=background_tasks,
                     rate_limit_info=rate_limit_info,
                     mcp_server_configs=stream_mcp_configs,
@@ -523,6 +471,13 @@ async def chat_completions(
         completion_kwargs = {**provider_kwargs, **request_fields}
         if completion_kwargs.get("stream_options") is None:
             completion_kwargs["stream_options"] = {"include_usage": True}
+
+        settlement = strategy.make_settlement(
+            provider=provider,
+            model=model,
+            endpoint="/v1/chat/completions",
+            correlation_id=None,
+        )
 
         try:
             if mcp_server_configs:
@@ -622,34 +577,20 @@ async def chat_completions(
             # a "provider outage" that's actually the sandbox container
             # being down. 502 keeps "upstream dependency failed" semantics.
             logger.error("Sandbox unreachable for %s:%s: %s", provider, model, exc)
-            if db is not None and reservation is not None:
-                await refund_reservation(db, reservation)
+            await settlement.on_incomplete()
             raise HTTPException(
                 status_code=status.HTTP_502_BAD_GATEWAY,
                 detail="code_execution sandbox unreachable — check GATEWAY_SANDBOX_URL",
             ) from exc
         except WebSearchNotReachableError as exc:
             logger.error("Web search backend unreachable for %s:%s: %s", provider, model, exc)
-            if db is not None and reservation is not None:
-                await refund_reservation(db, reservation)
+            await settlement.on_incomplete()
             raise HTTPException(
                 status_code=status.HTTP_502_BAD_GATEWAY,
                 detail="web_search backend unreachable — check GATEWAY_WEB_SEARCH_URL",
             ) from exc
         except Exception as exc:
-            if db is not None:
-                await log_usage(
-                    db=db,
-                    log_writer=log_writer,
-                    api_key_id=api_key_id,
-                    model=model,
-                    provider=provider,
-                    endpoint="/v1/chat/completions",
-                    user_id=user_id,
-                    error=str(exc),
-                )
-                if reservation is not None:
-                    await refund_reservation(db, reservation)
+            await settlement.on_error(str(exc))
             logger.error("Stream creation failed for %s:%s: %s", provider, model, exc)
             if isinstance(exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
                 raise HTTPException(
@@ -665,16 +606,10 @@ async def chat_completions(
             stream=stream,
             provider=provider,
             model=model,
-            platform_mode=False,
+            settlement=settlement,
             correlation_id=None,
             request_id=None,
-            config=config,
-            db=db,
-            log_writer=log_writer,
-            api_key_id=api_key_id,
-            user_id=user_id,
             rate_limit_info=rate_limit_info,
-            reservation=reservation,
         )
 
     # ------------------------------------------------------------------
@@ -826,6 +761,13 @@ async def chat_completions(
     )
     completion_kwargs = {**provider_kwargs, **request_fields}
 
+    settlement = strategy.make_settlement(
+        provider=provider,
+        model=model,
+        endpoint="/v1/chat/completions",
+        correlation_id=None,
+    )
+
     try:
         if mcp_server_configs:
             async with MCPClientPool(mcp_server_configs) as pool:
@@ -881,38 +823,23 @@ async def chat_completions(
                 )
         else:
             completion = await acompletion(**completion_kwargs)  # type: ignore[assignment]
-        if db is not None:
-            actual_cost = await log_usage(
-                db=db,
-                log_writer=log_writer,
-                api_key_id=api_key_id,
-                model=model,
-                provider=provider,
-                endpoint="/v1/chat/completions",
-                user_id=user_id,
-                response=completion,
-            )
-            if reservation is not None:
-                await reconcile_reservation(db, reservation, actual_cost or 0.0)
+        await settlement.on_success(completion.usage)
     except HTTPException:
-        if db is not None and reservation is not None:
-            await refund_reservation(db, reservation)
+        await settlement.on_incomplete()
         raise
     except SandboxNotReachableError as exc:
         # Sandbox is gateway-side infra, not an LLM provider. Clearer detail
         # so operators don't chase a provider outage that's really the
         # sandbox container being down.
         logger.error("Sandbox unreachable for %s:%s: %s", provider, model, exc)
-        if db is not None and reservation is not None:
-            await refund_reservation(db, reservation)
+        await settlement.on_incomplete()
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="code_execution sandbox unreachable — check GATEWAY_SANDBOX_URL",
         ) from exc
     except WebSearchNotReachableError as exc:
         logger.error("Web search backend unreachable for %s:%s: %s", provider, model, exc)
-        if db is not None and reservation is not None:
-            await refund_reservation(db, reservation)
+        await settlement.on_incomplete()
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="web_search backend unreachable — check GATEWAY_WEB_SEARCH_URL",
@@ -921,38 +848,13 @@ async def chat_completions(
         # Gateway-owned cap, not an upstream provider failure. 422 lets
         # callers distinguish a runaway tool loop from a real outage.
         logger.warning("Tool loop iteration cap hit (standalone): cap=%d", max_tool_iterations)
-        if db is not None:
-            await log_usage(
-                db=db,
-                log_writer=log_writer,
-                api_key_id=api_key_id,
-                model=model,
-                provider=provider,
-                endpoint="/v1/chat/completions",
-                user_id=user_id,
-                error=str(e),
-            )
-            if reservation is not None:
-                await refund_reservation(db, reservation)
+        await settlement.on_error(str(e))
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=str(e),
         ) from e
     except Exception as e:
-        if db is not None:
-            await log_usage(
-                db=db,
-                log_writer=log_writer,
-                api_key_id=api_key_id,
-                model=model,
-                provider=provider,
-                endpoint="/v1/chat/completions",
-                user_id=user_id,
-                error=str(e),
-            )
-            if reservation is not None:
-                await refund_reservation(db, reservation)
-
+        await settlement.on_error(str(e))
         logger.error("Provider call failed for %s:%s: %s", provider, model, e)
         if isinstance(e, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
             raise HTTPException(
@@ -976,18 +878,17 @@ def _build_streaming_response(
     stream: AsyncIterator[ChatCompletionChunk],
     provider: LLMProvider,
     model: str,
-    platform_mode: bool,
+    settlement: RequestSettlement,
     correlation_id: str | None,
     request_id: str | None,
-    config: GatewayConfig,
-    db: AsyncSession | None,
-    log_writer: LogWriter | None,
-    api_key_id: str | None,
-    user_id: str | None,
     rate_limit_info: RateLimitInfo | None,
-    reservation: ReservationHandle | None = None,
 ) -> StreamingResponse:
-    """Wrap an already-opened upstream stream in an SSE response."""
+    """Wrap an already-opened upstream stream in an SSE response.
+
+    Usage settlement (platform usage report vs local log + reconcile/refund) is
+    delegated to ``settlement``; ``correlation_id`` / ``request_id`` are set as
+    headers when present (platform mode).
+    """
 
     def _format_chunk(chunk: ChatCompletionChunk) -> str:
         return f"data: {chunk.model_dump_json()}\n\n"
@@ -1002,104 +903,16 @@ def _build_streaming_response(
         )
 
     async def _on_complete(usage_data: CompletionUsage) -> None:
-        if platform_mode and correlation_id:
-            asyncio.create_task(
-                _report_platform_usage(
-                    config=config,
-                    correlation_id=correlation_id,
-                    outcome="success",
-                    usage=usage_data,
-                )
-            )
-            return
-        if db is None or log_writer is None:
-            return
-        actual_cost = await log_usage(
-            db=db,
-            log_writer=log_writer,
-            api_key_id=api_key_id,
-            model=model,
-            provider=provider,
-            endpoint="/v1/chat/completions",
-            user_id=user_id,
-            usage_override=usage_data,
-        )
-        if reservation is not None:
-            await reconcile_reservation(db, reservation, actual_cost or 0.0)
-
-    async def _on_no_usage() -> None:
-        # Stream completed but the provider sent no usage data. Settle the
-        # reservation per stream_missing_usage_policy instead of billing $0.
-        if db is None or log_writer is None or reservation is None:
-            return
-        policy = config.stream_missing_usage_policy
-        if policy == "allow_free":
-            await log_usage(
-                db=db,
-                log_writer=log_writer,
-                api_key_id=api_key_id,
-                model=model,
-                provider=provider,
-                endpoint="/v1/chat/completions",
-                user_id=user_id,
-            )
-            await refund_reservation(db, reservation)
-            return
-        # 'estimate' and 'fail' both charge the up-front estimate; 'fail' also
-        # records the request as errored.
-        await log_usage(
-            db=db,
-            log_writer=log_writer,
-            api_key_id=api_key_id,
-            model=model,
-            provider=provider,
-            endpoint="/v1/chat/completions",
-            user_id=user_id,
-            error="stream completed without usage data" if policy == "fail" else None,
-            cost_override=reservation.estimate,
-        )
-        await reconcile_reservation(db, reservation, reservation.estimate)
-
-    async def _on_error(error: str) -> None:
-        if platform_mode and correlation_id:
-            asyncio.create_task(
-                _report_platform_usage(
-                    config=config,
-                    correlation_id=correlation_id,
-                    outcome="error",
-                    usage=None,
-                )
-            )
-            return
-        if db is None or log_writer is None:
-            return
-        await log_usage(
-            db=db,
-            log_writer=log_writer,
-            api_key_id=api_key_id,
-            model=model,
-            provider=provider,
-            endpoint="/v1/chat/completions",
-            user_id=user_id,
-            error=error,
-        )
-        if reservation is not None:
-            await refund_reservation(db, reservation)
-
-    async def _on_incomplete() -> None:
-        # Client disconnected mid-stream — release the reservation.
-        if db is None or reservation is None:
-            return
-        await refund_reservation(db, reservation)
+        await settlement.on_success(usage_data)
 
     rl_headers = rate_limit_headers(rate_limit_info) if rate_limit_info else {}
     # StreamingResponse builds its own response object, so headers we want on
     # the wire have to be passed in here — assigning to the dependency-injected
     # `Response` object doesn't propagate to streaming responses.
     headers = dict(rl_headers)
-    if platform_mode and correlation_id:
+    if correlation_id:
         headers["X-Correlation-ID"] = correlation_id
-    if platform_mode and request_id:
+    if request_id:
         headers["X-Otari-Request-ID"] = request_id
     return StreamingResponse(
         streaming_generator(
@@ -1108,10 +921,10 @@ def _build_streaming_response(
             extract_usage=_extract_usage,
             fmt=OPENAI_STREAM_FORMAT,
             on_complete=_on_complete,
-            on_error=_on_error,
+            on_error=settlement.on_error,
             label=f"{provider}:{model}",
-            on_no_usage=_on_no_usage,
-            on_incomplete=_on_incomplete,
+            on_no_usage=settlement.on_no_usage,
+            on_incomplete=settlement.on_incomplete,
         ),
         media_type="text/event-stream",
         headers=headers,
@@ -1124,6 +937,7 @@ async def _run_streaming_with_fallback(
     request: ChatCompletionRequest,
     response: Response,
     config: GatewayConfig,
+    strategy: RequestModeStrategy,
     background_tasks: BackgroundTasks,
     rate_limit_info: RateLimitInfo | None,
     mcp_server_configs: list[McpServerConfig] | None = None,
@@ -1303,13 +1117,13 @@ async def _run_streaming_with_fallback(
         stream=stream_to_return,
         provider=LLMProvider(chosen.provider),
         model=chosen.model,
-        platform_mode=True,
+        settlement=strategy.make_settlement(
+            provider=LLMProvider(chosen.provider),
+            model=chosen.model,
+            endpoint="/v1/chat/completions",
+            correlation_id=chosen.attempt_id,
+        ),
         correlation_id=chosen.attempt_id,
         request_id=route.request_id,
-        config=config,
-        db=None,  # platform mode doesn't use the local DB
-        log_writer=None,  # unused when db is None
-        api_key_id=None,
-        user_id=None,
         rate_limit_info=rate_limit_info,
     )

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -849,8 +849,9 @@ async def _stream_messages(
     except Exception as exc:
         # A provider error raised before the stream starts must surface as an
         # HTTP error (Anthropic envelope) rather than escaping uncaught into a
-        # 500. Matches the non-streaming handler.
-        await settlement.on_provider_error_precommit(str(exc))
+        # 500. on_error logs the error and refunds the reservation, matching the
+        # non-streaming handler and the chat streaming path.
+        await settlement.on_error(str(exc))
         logger.error("Provider call failed for %s:%s: %s", provider, model, exc)
         raise _anthropic_error(
             _ERR_API,

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -1,14 +1,12 @@
 import asyncio
 import math
 import os
-import time
 import uuid
 from collections.abc import AsyncIterator, Callable
 from typing import Annotated, Any
 
 import httpx
 from any_llm import AnyLLM, LLMProvider, amessages
-from any_llm.exceptions import AnyLLMError
 from any_llm.types.completion import CompletionUsage
 from any_llm.types.messages import (
     MessageDeltaEvent,
@@ -22,7 +20,14 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db_if_needed, get_log_writer, verify_api_key_or_master_key
-from gateway.api.routes._helpers import apply_input_guardrails, latest_user_text, resolve_user_id
+from gateway.api.routes._helpers import apply_input_guardrails, latest_user_text
+from gateway.api.routes._mode_strategy import (
+    RequestModeStrategy,
+    RequestSettlement,
+    ResolveErrors,
+    ResolveSpec,
+    select_request_mode_strategy,
+)
 from gateway.api.routes._platform import (
     ResolvedAttempt,
     ResolvedRoute,
@@ -30,7 +35,6 @@ from gateway.api.routes._platform import (
     _extract_platform_user_token,
     _report_platform_usage,
     _resolve_platform_credentials,
-    _resolve_platform_mcp_servers,
     run_platform_attempts,
 )
 from gateway.api.routes._tools import (
@@ -43,16 +47,12 @@ from gateway.api.routes._tools import (
 from gateway.api.routes.chat import get_provider_kwargs, log_usage, rate_limit_headers
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
-from gateway.models.entities import APIKey
 from gateway.models.guardrails import GuardrailConfig
 from gateway.models.mcp import McpServerConfig
-from gateway.rate_limit import RateLimitInfo, check_rate_limit
+from gateway.rate_limit import RateLimitInfo
 from gateway.services.budget_service import (
-    ReservationHandle,
-    estimate_cost,
     reconcile_reservation,
     refund_reservation,
-    reserve_budget,
 )
 from gateway.services.log_writer import LogWriter
 from gateway.services.mcp_client import MCPClientPool
@@ -63,7 +63,6 @@ from gateway.services.mcp_loop_messages import (
     anthropic_tool_loop,
     anthropic_tool_loop_stream,
 )
-from gateway.services.pricing_service import find_model_pricing, pricing_required_but_missing
 from gateway.services.sandbox_backend import SandboxBackend, SandboxNotReachableError
 from gateway.services.tool_format import inject_purpose_hints_anthropic, openai_to_anthropic_tools
 from gateway.services.web_search_backend import WebSearchNotReachableError
@@ -173,93 +172,49 @@ async def create_message(
     ``on_first_response`` lock-in plumbing lands across the codebase, a
     follow-up will enable pre-lock-in fallback for tool-loop requests too.
     """
-    api_key: APIKey | None = None
-    api_key_id: str | None = None
-    user_id: str | None = None
-    rate_limit_info: RateLimitInfo | None = None
-    platform_mode = config.is_platform_mode
-    route: ResolvedRoute | None = None
-    user_token: str | None = None
-    # Budget pre-debit for the standalone (local-DB) path only; platform mode
-    # reports usage upstream instead. Settled (reconciled/refunded) at every
-    # completion and error hook below.
-    reservation: ReservationHandle | None = None
-
-    if platform_mode:
-        user_token = _extract_platform_user_token(raw_request)
-        start_time = time.perf_counter()
-        route = await _resolve_platform_credentials(
-            config=config,
-            user_token=user_token,
+    # Mode seam: select the strategy once, then resolve credentials (platform)
+    # or authenticate + reserve budget (standalone). See chat.py for the shared
+    # rationale; the only differences here are the Anthropic error envelope and
+    # the metadata-based user id.
+    user_from_metadata = request.metadata.get("user_id") if request.metadata else None
+    strategy = select_request_mode_strategy(config, db, log_writer)
+    await strategy.resolve(
+        raw_request=raw_request,
+        response=response,
+        spec=ResolveSpec(
             model_selector=request.model,
-        )
-        resolve_latency_ms = (time.perf_counter() - start_time) * 1000
-        response.headers["X-Otari-Request-ID"] = route.request_id
-        logger.info(
-            "Platform resolve succeeded request_id=%s attempts=%d fallback_enabled=%s resolve_latency_ms=%.2f",
-            route.request_id,
-            len(route.attempts),
-            route.fallback_enabled,
-            resolve_latency_ms,
-        )
-    else:
-        if db is None:
-            raise _anthropic_error(_ERR_API, "Database session unavailable", status.HTTP_500_INTERNAL_SERVER_ERROR)
-        api_key, is_master_key = await verify_api_key_or_master_key(raw_request, db, config)
-        api_key_id = api_key.id if api_key else None
-        user_from_metadata = request.metadata.get("user_id") if request.metadata else None
-        user_id = resolve_user_id(
             user_id_from_request=str(user_from_metadata) if user_from_metadata else None,
-            api_key=api_key,
-            is_master_key=is_master_key,
-            master_key_error=_anthropic_error(
-                _ERR_INVALID_REQUEST,
-                _MASTER_KEY_USER_REQUIRED,
-                status.HTTP_400_BAD_REQUEST,
-            ),
-            no_api_key_error=_anthropic_error(
-                _ERR_API,
-                _API_KEY_VALIDATION_FAILED,
-                status.HTTP_500_INTERNAL_SERVER_ERROR,
-            ),
-            no_user_error=_anthropic_error(
-                _ERR_API,
-                _API_KEY_NO_USER,
-                status.HTTP_500_INTERNAL_SERVER_ERROR,
-            ),
-            forbidden_user_error=_anthropic_error(
-                _ERR_PERMISSION,
-                _USER_FORBIDDEN,
-                status.HTTP_403_FORBIDDEN,
-            ),
-            reject_mismatch=config.reject_user_mismatch,
-        )
-        rate_limit_info = check_rate_limit(raw_request, user_id)
-        # Tolerate an unparseable selector: the budget gate (404/403) and the
-        # downstream call surface those; an unparseable model simply has no pricing.
-        try:
-            gate_provider, gate_model = AnyLLM.split_model_provider(request.model)
-        except (ValueError, AnyLLMError):
-            gate_provider, gate_model = None, request.model
-        pricing = await find_model_pricing(db, gate_provider, gate_model)
-        estimate = estimate_cost(
-            pricing,
             prompt_chars=len(str(request.messages)) + len(str(request.system or "")),
             max_output_tokens=request.max_tokens,
-            default_output_tokens=config.budget_estimate_default_output_tokens,
-        )
-        # Reserve first so user/blocked/budget rejections (404/403) precede the
-        # missing-pricing rejection (402); refund if we then reject for no pricing.
-        reservation = await reserve_budget(
-            db, user_id, estimate, model=request.model, strategy=config.budget_strategy
-        )
-        if pricing_required_but_missing(pricing, require_pricing=config.require_pricing):
-            await refund_reservation(db, reservation)
-            raise _anthropic_error(
-                _ERR_INVALID_REQUEST,
-                f"No pricing configured for model '{request.model}'",
-                status.HTTP_402_PAYMENT_REQUIRED,
-            )
+            errors=ResolveErrors(
+                db_unavailable=_anthropic_error(
+                    _ERR_API, "Database session unavailable", status.HTTP_500_INTERNAL_SERVER_ERROR
+                ),
+                master_key_user_required=_anthropic_error(
+                    _ERR_INVALID_REQUEST, _MASTER_KEY_USER_REQUIRED, status.HTTP_400_BAD_REQUEST
+                ),
+                api_key_validation_failed=_anthropic_error(
+                    _ERR_API, _API_KEY_VALIDATION_FAILED, status.HTTP_500_INTERNAL_SERVER_ERROR
+                ),
+                no_user=_anthropic_error(_ERR_API, _API_KEY_NO_USER, status.HTTP_500_INTERNAL_SERVER_ERROR),
+                forbidden_user=_anthropic_error(_ERR_PERMISSION, _USER_FORBIDDEN, status.HTTP_403_FORBIDDEN),
+                no_pricing=_anthropic_error(
+                    _ERR_INVALID_REQUEST,
+                    f"No pricing configured for model '{request.model}'",
+                    status.HTTP_402_PAYMENT_REQUIRED,
+                ),
+            ),
+        ),
+    )
+    platform_mode = strategy.is_platform
+    route = strategy.route
+    rate_limit_info = strategy.rate_limit_info
+    # Used only by the standalone non-streaming tail below (platform returns
+    # earlier via the multi-attempt runner); the streaming path settles through
+    # the strategy's settlement object instead.
+    api_key_id = strategy.api_key_id
+    user_id = strategy.user_id
+    reservation = strategy.reservation
 
     # Caller-requested input guardrails run before any provider/tool dispatch
     # (see chat.py for the rationale). Stripped before forwarding upstream.
@@ -269,21 +224,16 @@ async def create_message(
         response=response,
     )
 
-    # mcp_server_ids is platform-only — standalone has no platform to
-    # resolve them against, so we reject with a 400 rather than silently
-    # ignoring the field.
-    if request.mcp_server_ids and not platform_mode:
-        raise _anthropic_error(
-            _ERR_INVALID_REQUEST,
-            "mcp_server_ids is only available in platform mode",
-            status.HTTP_400_BAD_REQUEST,
-        )
-    if platform_mode and request.mcp_server_ids:
-        assert user_token is not None  # guaranteed by the platform-mode branch above
-        resolved_mcp_servers = await _resolve_platform_mcp_servers(
-            config=config,
-            user_token=user_token,
-            mcp_server_ids=request.mcp_server_ids,
+    # mcp_server_ids is platform-only — the platform strategy resolves them,
+    # the standalone strategy rejects the field with a 400.
+    if request.mcp_server_ids:
+        resolved_mcp_servers = await strategy.resolve_mcp_servers(
+            request.mcp_server_ids,
+            reject_error=_anthropic_error(
+                _ERR_INVALID_REQUEST,
+                "mcp_server_ids is only available in platform mode",
+                status.HTTP_400_BAD_REQUEST,
+            ),
         )
         request.mcp_servers = (request.mcp_servers or []) + resolved_mcp_servers
 
@@ -375,6 +325,7 @@ async def create_message(
                     base_request_fields=request_fields,
                     response=response,
                     config=config,
+                    strategy=strategy,
                     background_tasks=background_tasks,
                     rate_limit_info=rate_limit_info,
                 )
@@ -420,25 +371,26 @@ async def create_message(
             provider_kwargs = get_provider_kwargs(config, provider)
             call_kwargs = {**provider_kwargs, **request_fields}
 
-        # Platform tool-loop streaming is currently single-attempt; pass the
+        # Platform tool-loop streaming is currently single-attempt; carry the
         # primary attempt's correlation id + the route's request id so the
-        # response still carries the platform contract (X-Correlation-ID,
-        # X-Otari-Request-ID, usage reported via _report_platform_usage).
-        platform_correlation_id: str | None = None
-        platform_request_id: str | None = None
-        platform_config: GatewayConfig | None = None
+        # response still presents the platform contract (X-Correlation-ID,
+        # X-Otari-Request-ID, usage reported via the platform settlement).
+        correlation_id: str | None = None
+        request_id: str | None = None
         if platform_mode and route is not None and route.attempts:
-            platform_correlation_id = route.attempts[0].attempt_id
-            platform_request_id = route.request_id
-            platform_config = config
+            correlation_id = route.attempts[0].attempt_id
+            request_id = route.request_id
+
+        settlement = strategy.make_settlement(
+            provider=provider,
+            model=model,
+            endpoint="/v1/messages",
+            correlation_id=correlation_id,
+        )
 
         return await _stream_messages(
             call_kwargs=call_kwargs,
             request=request,
-            db=db,
-            log_writer=log_writer,
-            api_key_id=api_key_id,
-            user_id=user_id,
             provider=provider,
             model=model,
             rate_limit_info=rate_limit_info,
@@ -451,11 +403,9 @@ async def create_message(
             web_search_tool_entry=web_search_tool_entry,
             web_search_url=web_search_url,
             max_tool_iterations=max_tool_iterations,
-            config=config,
-            platform_correlation_id=platform_correlation_id,
-            platform_request_id=platform_request_id,
-            platform_config=platform_config,
-            reservation=reservation,
+            settlement=settlement,
+            correlation_id=correlation_id,
+            request_id=request_id,
         )
 
     # ------------------------------------------------------------------
@@ -810,10 +760,6 @@ async def _stream_messages(
     *,
     call_kwargs: dict[str, Any],
     request: MessagesRequest,
-    db: AsyncSession | None,
-    log_writer: LogWriter,
-    api_key_id: str | None,
-    user_id: str | None,
     provider: Any,
     model: str,
     rate_limit_info: Any,
@@ -826,11 +772,9 @@ async def _stream_messages(
     web_search_tool_entry: dict[str, Any] | None,
     web_search_url: str | None,
     max_tool_iterations: int,
-    config: GatewayConfig,
-    platform_correlation_id: str | None = None,
-    platform_request_id: str | None = None,
-    platform_config: GatewayConfig | None = None,
-    reservation: ReservationHandle | None = None,
+    settlement: RequestSettlement,
+    correlation_id: str | None = None,
+    request_id: str | None = None,
 ) -> StreamingResponse:
     """Streaming dispatch for single-attempt requests.
 
@@ -838,14 +782,11 @@ async def _stream_messages(
     (where streaming fallback is still single-attempt — multi-attempt
     streaming for non-tool-loop uses ``_run_streaming_with_fallback_messages``).
 
-    When ``platform_correlation_id`` / ``platform_request_id`` /
-    ``platform_config`` are set (platform mode, single-attempt path), the
-    response includes ``X-Correlation-ID`` / ``X-Otari-Request-ID`` headers
-    and usage is reported to the platform on complete/error. When unset, the
-    response logs usage to the local DB via ``log_usage`` (standalone mode).
+    Usage settlement (platform usage report vs local log + reconcile/refund) is
+    delegated to ``settlement``; ``correlation_id`` / ``request_id`` are set as
+    headers when present (platform mode).
     """
     call_kwargs["stream"] = True
-    platform_mode_active = platform_correlation_id is not None and platform_config is not None
 
     def _format_chunk(event: MessageStreamEvent) -> str:
         return f"event: {event.type}\ndata: {event.model_dump_json(exclude_none=True)}\n\n"
@@ -870,99 +811,7 @@ async def _stream_messages(
         return None
 
     async def _on_complete(usage_data: CompletionUsage) -> None:
-        if platform_mode_active:
-            assert platform_config is not None  # guaranteed by the platform-mode branch above
-            assert platform_correlation_id is not None  # guaranteed by the platform-mode branch above
-            asyncio.create_task(
-                _report_platform_usage(
-                    config=platform_config,
-                    correlation_id=platform_correlation_id,
-                    outcome="success",
-                    usage=usage_data,
-                )
-            )
-            return
-        if db is None:
-            return
-        actual_cost = await log_usage(
-            db=db,
-            log_writer=log_writer,
-            api_key_id=api_key_id,
-            model=model,
-            provider=provider,
-            endpoint="/v1/messages",
-            user_id=user_id,
-            usage_override=usage_data,
-        )
-        if reservation is not None:
-            await reconcile_reservation(db, reservation, actual_cost or 0.0)
-
-    async def _on_no_usage() -> None:
-        # Stream completed but the provider sent no usage data. Settle the
-        # reservation per stream_missing_usage_policy instead of billing $0.
-        if db is None or log_writer is None or reservation is None:
-            return
-        policy = config.stream_missing_usage_policy
-        if policy == "allow_free":
-            await log_usage(
-                db=db,
-                log_writer=log_writer,
-                api_key_id=api_key_id,
-                model=model,
-                provider=provider,
-                endpoint="/v1/messages",
-                user_id=user_id,
-            )
-            await refund_reservation(db, reservation)
-            return
-        # 'estimate' and 'fail' both charge the up-front estimate; 'fail' also
-        # records the request as errored.
-        await log_usage(
-            db=db,
-            log_writer=log_writer,
-            api_key_id=api_key_id,
-            model=model,
-            provider=provider,
-            endpoint="/v1/messages",
-            user_id=user_id,
-            error="stream completed without usage data" if policy == "fail" else None,
-            cost_override=reservation.estimate,
-        )
-        await reconcile_reservation(db, reservation, reservation.estimate)
-
-    async def _on_error(error: str) -> None:
-        if platform_mode_active:
-            assert platform_config is not None  # guaranteed by the platform-mode branch above
-            assert platform_correlation_id is not None  # guaranteed by the platform-mode branch above
-            asyncio.create_task(
-                _report_platform_usage(
-                    config=platform_config,
-                    correlation_id=platform_correlation_id,
-                    outcome="error",
-                    usage=None,
-                )
-            )
-            return
-        if db is None:
-            return
-        await log_usage(
-            db=db,
-            log_writer=log_writer,
-            api_key_id=api_key_id,
-            model=model,
-            provider=provider,
-            endpoint="/v1/messages",
-            user_id=user_id,
-            error=error,
-        )
-        if reservation is not None:
-            await refund_reservation(db, reservation)
-
-    async def _on_incomplete() -> None:
-        # Client disconnected mid-stream — release the reservation.
-        if db is None or reservation is None:
-            return
-        await refund_reservation(db, reservation)
+        await settlement.on_success(usage_data)
 
     try:
         if not use_tool_loop:
@@ -1001,17 +850,7 @@ async def _stream_messages(
         # A provider error raised before the stream starts must surface as an
         # HTTP error (Anthropic envelope) rather than escaping uncaught into a
         # 500. Matches the non-streaming handler.
-        if db is not None:
-            await log_usage(
-                db=db,
-                log_writer=log_writer,
-                api_key_id=api_key_id,
-                model=model,
-                provider=provider,
-                endpoint="/v1/messages",
-                user_id=user_id,
-                error=str(exc),
-            )
+        await settlement.on_provider_error_precommit(str(exc))
         logger.error("Provider call failed for %s:%s: %s", provider, model, exc)
         raise _anthropic_error(
             _ERR_API,
@@ -1022,10 +861,10 @@ async def _stream_messages(
     headers: dict[str, str] = {}
     if rate_limit_info:
         headers.update(rate_limit_headers(rate_limit_info))
-    if platform_correlation_id:
-        headers["X-Correlation-ID"] = platform_correlation_id
-    if platform_request_id:
-        headers["X-Otari-Request-ID"] = platform_request_id
+    if correlation_id:
+        headers["X-Correlation-ID"] = correlation_id
+    if request_id:
+        headers["X-Otari-Request-ID"] = request_id
 
     return StreamingResponse(
         streaming_generator(
@@ -1034,10 +873,10 @@ async def _stream_messages(
             extract_usage=_extract_usage,
             fmt=ANTHROPIC_STREAM_FORMAT,
             on_complete=_on_complete,
-            on_error=_on_error,
+            on_error=settlement.on_error,
             label=f"{provider}:{model}",
-            on_no_usage=_on_no_usage,
-            on_incomplete=_on_incomplete,
+            on_no_usage=settlement.on_no_usage,
+            on_incomplete=settlement.on_incomplete,
         ),
         media_type="text/event-stream",
         headers=headers,
@@ -1050,6 +889,7 @@ async def _run_streaming_with_fallback_messages(
     base_request_fields: dict[str, Any],
     response: Response,
     config: GatewayConfig,
+    strategy: RequestModeStrategy,
     background_tasks: BackgroundTasks,
     rate_limit_info: RateLimitInfo | None,
 ) -> StreamingResponse:
@@ -1108,9 +948,14 @@ async def _run_streaming_with_fallback_messages(
         stream=stream,
         provider=LLMProvider(chosen.provider),
         model=chosen.model,
+        settlement=strategy.make_settlement(
+            provider=LLMProvider(chosen.provider),
+            model=chosen.model,
+            endpoint="/v1/messages",
+            correlation_id=chosen.attempt_id,
+        ),
         correlation_id=chosen.attempt_id,
         request_id=route.request_id,
-        config=config,
         rate_limit_info=rate_limit_info,
     )
 
@@ -1120,14 +965,14 @@ def _build_streaming_response_messages(
     stream: AsyncIterator[MessageStreamEvent],
     provider: LLMProvider,
     model: str,
+    settlement: RequestSettlement,
     correlation_id: str,
     request_id: str,
-    config: GatewayConfig,
     rate_limit_info: RateLimitInfo | None,
 ) -> StreamingResponse:
     """Wrap an already-opened Anthropic stream in an SSE response for
     platform-mode requests. Sets correlation / request-id headers and reports
-    usage to the platform on complete.
+    usage through ``settlement`` on complete/error.
     """
 
     def _format_chunk(event: MessageStreamEvent) -> str:
@@ -1153,24 +998,7 @@ def _build_streaming_response_messages(
         return None
 
     async def _on_complete(usage_data: CompletionUsage) -> None:
-        asyncio.create_task(
-            _report_platform_usage(
-                config=config,
-                correlation_id=correlation_id,
-                outcome="success",
-                usage=usage_data,
-            )
-        )
-
-    async def _on_error(error: str) -> None:
-        asyncio.create_task(
-            _report_platform_usage(
-                config=config,
-                correlation_id=correlation_id,
-                outcome="error",
-                usage=None,
-            )
-        )
+        await settlement.on_success(usage_data)
 
     headers: dict[str, str] = {}
     if rate_limit_info:
@@ -1185,7 +1013,7 @@ def _build_streaming_response_messages(
             extract_usage=_extract_usage,
             fmt=ANTHROPIC_STREAM_FORMAT,
             on_complete=_on_complete,
-            on_error=_on_error,
+            on_error=settlement.on_error,
             label=f"{provider}:{model}",
         ),
         media_type="text/event-stream",

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -844,10 +844,10 @@ async def _stream_responses(
     except Exception as exc:
         # A provider error raised before the stream starts (e.g. auth failure,
         # 5xx, connection error) must surface as a 502 HTTP error rather than
-        # escaping uncaught into a 500. Matches the non-streaming handler and
-        # the pre-existing behavior before streaming was factored into this
-        # helper.
-        await settlement.on_provider_error_precommit(str(exc))
+        # escaping uncaught into a 500. on_error logs the error and refunds the
+        # reservation, matching the non-streaming handler and the chat streaming
+        # path.
+        await settlement.on_error(str(exc))
         logger.error("Provider call failed for %s:%s: %s", provider, model, exc)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -1,13 +1,11 @@
 import asyncio
 import os
-import time
 import uuid
 from collections.abc import AsyncIterator, Callable
 from typing import Annotated, Any
 
 import httpx
 from any_llm import AnyLLM, LLMProvider, aresponses
-from any_llm.exceptions import AnyLLMError
 from any_llm.types.completion import CompletionUsage
 from any_llm.types.responses import Response as ResponsesResponse
 from any_llm.types.responses import ResponseStreamEvent
@@ -19,21 +17,24 @@ from openresponses_types.types import Usage as OpenResponsesUsage
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.api.deps import get_config, get_db_if_needed, get_log_writer, verify_api_key_or_master_key
+from gateway.api.deps import get_config, get_db_if_needed, get_log_writer
 from gateway.api.routes._helpers import (
     apply_input_guardrails,
     latest_user_text,
-    resolve_user_id,
     text_from_content,
+)
+from gateway.api.routes._mode_strategy import (
+    RequestModeStrategy,
+    RequestSettlement,
+    ResolveErrors,
+    ResolveSpec,
+    select_request_mode_strategy,
 )
 from gateway.api.routes._platform import (
     ResolvedAttempt,
     ResolvedRoute,
     _classify_upstream_error,
-    _extract_platform_user_token,
     _report_platform_usage,
-    _resolve_platform_credentials,
-    _resolve_platform_mcp_servers,
     run_platform_attempts,
 )
 from gateway.api.routes._tools import (
@@ -46,16 +47,12 @@ from gateway.api.routes._tools import (
 from gateway.api.routes.chat import get_provider_kwargs, log_usage, rate_limit_headers
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
-from gateway.models.entities import APIKey
 from gateway.models.guardrails import GuardrailConfig
 from gateway.models.mcp import McpServerConfig
-from gateway.rate_limit import RateLimitInfo, check_rate_limit
+from gateway.rate_limit import RateLimitInfo
 from gateway.services.budget_service import (
-    ReservationHandle,
-    estimate_cost,
     reconcile_reservation,
     refund_reservation,
-    reserve_budget,
 )
 from gateway.services.log_writer import LogWriter
 from gateway.services.mcp_client import MCPClientPool
@@ -66,7 +63,6 @@ from gateway.services.mcp_loop_responses import (
     responses_tool_loop,
     responses_tool_loop_stream,
 )
-from gateway.services.pricing_service import find_model_pricing, pricing_required_but_missing
 from gateway.services.sandbox_backend import SandboxBackend, SandboxNotReachableError
 from gateway.services.tool_format import inject_purpose_hints_responses, openai_to_responses_tools
 from gateway.services.web_search_backend import WebSearchNotReachableError
@@ -157,116 +153,74 @@ async def create_response(
     ``on_first_response`` lock-in plumbing lands across the codebase, a
     follow-up will enable pre-lock-in fallback for tool-loop requests too.
     """
-    api_key: APIKey | None = None
-    api_key_id: str | None = None
-    user_id: str | None = None
-    rate_limit_info: RateLimitInfo | None = None
-    platform_mode = config.is_platform_mode
-    route: ResolvedRoute | None = None
-    user_token: str | None = None
-    # Budget pre-debit for the standalone (local-DB) path only; platform mode
-    # reports usage upstream instead. Settled (reconciled/refunded) at every
-    # completion and error hook below.
-    reservation: ReservationHandle | None = None
-
-    if platform_mode:
-        user_token = _extract_platform_user_token(raw_request)
-        start_time = time.perf_counter()
-        route = await _resolve_platform_credentials(
-            config=config,
-            user_token=user_token,
-            model_selector=request_body.model,
-        )
-        resolve_latency_ms = (time.perf_counter() - start_time) * 1000
-        response.headers["X-Otari-Request-ID"] = route.request_id
-        logger.info(
-            "Platform resolve succeeded request_id=%s attempts=%d fallback_enabled=%s resolve_latency_ms=%.2f",
-            route.request_id,
-            len(route.attempts),
-            route.fallback_enabled,
-            resolve_latency_ms,
-        )
-        # Provider-support guard: even in platform mode, an unsupported provider
-        # would just fail downstream — surface a clearer 400 upfront. Validate
-        # *every* resolved attempt so a fallback that lands on an unsupported
-        # provider (e.g. primary OpenAI, fallback Anthropic) fails fast here
-        # instead of crashing mid-fallback when the runner calls ``aresponses``
-        # on a provider that doesn't speak the Responses API.
-        for attempt in route.attempts:
-            provider = LLMProvider(attempt.provider)
-            provider_class = AnyLLM.get_provider_class(provider)
-            if not getattr(provider_class, "SUPPORTS_RESPONSES", False):
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Provider '{provider.value}' does not support the Responses API",
-                )
-    else:
-        if db is None:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Database session unavailable",
-            )
-        api_key, is_master_key = await verify_api_key_or_master_key(raw_request, db, config)
-        api_key_id = api_key.id if api_key else None
-        user_id = resolve_user_id(
-            user_id_from_request=request_body.user,
-            api_key=api_key,
-            is_master_key=is_master_key,
-            master_key_error=HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=_MASTER_KEY_USER_REQUIRED,
-            ),
-            no_api_key_error=HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=_API_KEY_VALIDATION_FAILED,
-            ),
-            no_user_error=HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=_API_KEY_NO_USER,
-            ),
-            forbidden_user_error=HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=_USER_FORBIDDEN,
-            ),
-            reject_mismatch=config.reject_user_mismatch,
-        )
-        rate_limit_info = check_rate_limit(raw_request, user_id)
-        # Tolerate an unparseable selector: the budget gate (404/403) and the
-        # downstream call surface those; an unparseable model simply has no pricing.
-        try:
-            gate_provider, gate_model = AnyLLM.split_model_provider(request_body.model)
-        except (ValueError, AnyLLMError):
-            gate_provider, gate_model = None, request_body.model
-        gate_pricing = await find_model_pricing(db, gate_provider, gate_model)
-        # max_output_tokens comes from an extra="allow" body, so it may be absent,
-        # non-int, or negative — only trust a non-negative int for the estimate.
-        raw_max_output = getattr(request_body, "max_output_tokens", None)
-        max_output_tokens = raw_max_output if isinstance(raw_max_output, int) and raw_max_output >= 0 else None
-        estimate = estimate_cost(
-            gate_pricing,
-            prompt_chars=len(str(request_body.input))
-            + len(str(getattr(request_body, "instructions", "") or "")),
-            max_output_tokens=max_output_tokens,
-            default_output_tokens=config.budget_estimate_default_output_tokens,
-        )
-        # Reserve first so user/blocked/budget rejections (404/403) precede the
-        # missing-pricing rejection (402); refund if we then reject for no pricing.
-        reservation = await reserve_budget(
-            db, user_id, estimate, model=request_body.model, strategy=config.budget_strategy
-        )
-        if pricing_required_but_missing(gate_pricing, require_pricing=config.require_pricing):
-            await refund_reservation(db, reservation)
-            raise HTTPException(
-                status_code=status.HTTP_402_PAYMENT_REQUIRED,
-                detail=f"No pricing configured for model '{request_body.model}'",
-            )
-        provider, model = AnyLLM.split_model_provider(request_body.model)
+    # Provider-support guard: the Responses API is only spoken by some
+    # providers, so reject an unsupported one with a clear 400 upfront rather
+    # than crashing downstream. Applied to every resolved attempt in platform
+    # mode (so a fallback onto an unsupported provider fails fast) and to the
+    # split provider in standalone mode.
+    def _validate_responses_support(provider: LLMProvider) -> None:
         provider_class = AnyLLM.get_provider_class(provider)
         if not getattr(provider_class, "SUPPORTS_RESPONSES", False):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Provider '{provider.value}' does not support the Responses API",
             )
+
+    # max_output_tokens comes from an extra="allow" body, so it may be absent,
+    # non-int, or negative — only trust a non-negative int for the estimate.
+    raw_max_output = getattr(request_body, "max_output_tokens", None)
+    max_output_tokens = raw_max_output if isinstance(raw_max_output, int) and raw_max_output >= 0 else None
+
+    # Mode seam: select the strategy once, then resolve credentials (platform)
+    # or authenticate + reserve budget (standalone). See chat.py for the shared
+    # rationale.
+    strategy = select_request_mode_strategy(config, db, log_writer)
+    await strategy.resolve(
+        raw_request=raw_request,
+        response=response,
+        spec=ResolveSpec(
+            model_selector=request_body.model,
+            user_id_from_request=request_body.user,
+            prompt_chars=(
+                len(str(request_body.input)) + len(str(getattr(request_body, "instructions", "") or ""))
+            ),
+            max_output_tokens=max_output_tokens,
+            errors=ResolveErrors(
+                db_unavailable=HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Database session unavailable",
+                ),
+                master_key_user_required=HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST, detail=_MASTER_KEY_USER_REQUIRED
+                ),
+                api_key_validation_failed=HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=_API_KEY_VALIDATION_FAILED
+                ),
+                no_user=HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=_API_KEY_NO_USER
+                ),
+                forbidden_user=HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=_USER_FORBIDDEN),
+                no_pricing=HTTPException(
+                    status_code=status.HTTP_402_PAYMENT_REQUIRED,
+                    detail=f"No pricing configured for model '{request_body.model}'",
+                ),
+            ),
+            validate_provider=_validate_responses_support,
+        ),
+    )
+    platform_mode = strategy.is_platform
+    route = strategy.route
+    rate_limit_info = strategy.rate_limit_info
+    # Used only by the standalone non-streaming tail below (platform returns
+    # earlier via the multi-attempt runner); the streaming path settles through
+    # the strategy's settlement object instead.
+    api_key_id = strategy.api_key_id
+    user_id = strategy.user_id
+    reservation = strategy.reservation
+    # Standalone dispatch needs the split provider/model; platform sets them
+    # per-attempt from the resolved route.
+    if not platform_mode:
+        provider, model = AnyLLM.split_model_provider(request_body.model)
 
     # Caller-requested input guardrails run before any provider/tool dispatch
     # (see chat.py for the rationale). Stripped before forwarding upstream.
@@ -276,18 +230,15 @@ async def create_response(
         response=response,
     )
 
-    # mcp_server_ids is platform-only.
-    if request_body.mcp_server_ids and not platform_mode:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="mcp_server_ids is only available in platform mode",
-        )
-    if platform_mode and request_body.mcp_server_ids:
-        assert user_token is not None  # guaranteed by the platform-mode branch above
-        resolved_mcp_servers = await _resolve_platform_mcp_servers(
-            config=config,
-            user_token=user_token,
-            mcp_server_ids=request_body.mcp_server_ids,
+    # mcp_server_ids is platform-only — the platform strategy resolves them,
+    # the standalone strategy rejects the field with a 400.
+    if request_body.mcp_server_ids:
+        resolved_mcp_servers = await strategy.resolve_mcp_servers(
+            request_body.mcp_server_ids,
+            reject_error=HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="mcp_server_ids is only available in platform mode",
+            ),
         )
         request_body.mcp_servers = (request_body.mcp_servers or []) + resolved_mcp_servers
 
@@ -388,6 +339,7 @@ async def create_response(
                     base_request_fields=base_request_fields,
                     response=response,
                     config=config,
+                    strategy=strategy,
                     background_tasks=background_tasks,
                     rate_limit_info=rate_limit_info,
                 )
@@ -436,26 +388,26 @@ async def create_response(
             call_kwargs["provider"] = provider
             call_kwargs["input_data"] = input_payload
 
-        # Platform tool-loop streaming is currently single-attempt; pass the
+        # Platform tool-loop streaming is currently single-attempt; carry the
         # primary attempt's correlation id + the route's request id so the
-        # response still carries the platform contract (X-Correlation-ID,
-        # X-Otari-Request-ID, usage reported via _report_platform_usage).
-        platform_correlation_id: str | None = None
-        platform_request_id: str | None = None
-        platform_config: GatewayConfig | None = None
+        # response still presents the platform contract (X-Correlation-ID,
+        # X-Otari-Request-ID, usage reported via the platform settlement).
+        correlation_id: str | None = None
+        request_id: str | None = None
         if platform_mode and route is not None and route.attempts:
-            platform_correlation_id = route.attempts[0].attempt_id
-            platform_request_id = route.request_id
-            platform_config = config
+            correlation_id = route.attempts[0].attempt_id
+            request_id = route.request_id
+
+        settlement = strategy.make_settlement(
+            provider=provider,
+            model=model,
+            endpoint="/v1/responses",
+            correlation_id=correlation_id,
+        )
 
         return await _stream_responses(
             call_kwargs=call_kwargs,
             tools_header=request_body.tools_header,
-            config=config,
-            db=db,
-            log_writer=log_writer,
-            api_key_id=api_key_id,
-            user_id=user_id,
             provider=provider,
             model=model,
             rate_limit_info=rate_limit_info,
@@ -468,10 +420,9 @@ async def create_response(
             web_search_tool_entry=web_search_tool_entry,
             web_search_url=web_search_url,
             max_tool_iterations=max_tool_iterations,
-            platform_correlation_id=platform_correlation_id,
-            platform_request_id=platform_request_id,
-            platform_config=platform_config,
-            reservation=reservation,
+            settlement=settlement,
+            correlation_id=correlation_id,
+            request_id=request_id,
         )
 
     # ------------------------------------------------------------------
@@ -819,11 +770,6 @@ async def _stream_responses(
     *,
     call_kwargs: dict[str, Any],
     tools_header: str | None,
-    config: GatewayConfig,
-    db: AsyncSession | None,
-    log_writer: LogWriter,
-    api_key_id: str | None,
-    user_id: str | None,
     provider: Any,
     model: str,
     rate_limit_info: Any,
@@ -836,10 +782,9 @@ async def _stream_responses(
     web_search_tool_entry: dict[str, Any] | None,
     web_search_url: str | None,
     max_tool_iterations: int,
-    platform_correlation_id: str | None = None,
-    platform_request_id: str | None = None,
-    platform_config: GatewayConfig | None = None,
-    reservation: ReservationHandle | None = None,
+    settlement: RequestSettlement,
+    correlation_id: str | None = None,
+    request_id: str | None = None,
 ) -> StreamingResponse:
     """Streaming dispatch for single-attempt requests.
 
@@ -847,14 +792,11 @@ async def _stream_responses(
     streaming fallback is still single-attempt — multi-attempt streaming for
     non-tool-loop uses ``_run_streaming_with_fallback_responses``).
 
-    When ``platform_correlation_id`` / ``platform_request_id`` /
-    ``platform_config`` are set (platform mode, single-attempt path), the
-    response includes ``X-Correlation-ID`` / ``X-Otari-Request-ID`` headers
-    and usage is reported to the platform on complete/error. When unset, the
-    response logs usage to the local DB via ``log_usage`` (standalone mode).
+    Usage settlement (platform usage report vs local log + reconcile/refund) is
+    delegated to ``settlement``; ``correlation_id`` / ``request_id`` are set as
+    headers when present (platform mode).
     """
     call_kwargs["stream"] = True
-    platform_mode_active = platform_correlation_id is not None and platform_config is not None
 
     def _format_chunk(event: ResponseStreamEvent) -> str:
         return f"event: {event.type}\ndata: {event.model_dump_json(exclude_none=True)}\n\n"
@@ -866,99 +808,7 @@ async def _stream_responses(
         return None
 
     async def _on_complete(usage_data: CompletionUsage) -> None:
-        if platform_mode_active:
-            assert platform_config is not None  # guaranteed by the platform-mode branch above
-            assert platform_correlation_id is not None  # guaranteed by the platform-mode branch above
-            asyncio.create_task(
-                _report_platform_usage(
-                    config=platform_config,
-                    correlation_id=platform_correlation_id,
-                    outcome="success",
-                    usage=usage_data,
-                )
-            )
-            return
-        if db is None:
-            return
-        actual_cost = await log_usage(
-            db=db,
-            log_writer=log_writer,
-            api_key_id=api_key_id,
-            model=model,
-            provider=provider,
-            endpoint="/v1/responses",
-            user_id=user_id,
-            usage_override=usage_data,
-        )
-        if reservation is not None:
-            await reconcile_reservation(db, reservation, actual_cost or 0.0)
-
-    async def _on_no_usage() -> None:
-        # Stream completed but the provider sent no usage data. Settle the
-        # reservation per stream_missing_usage_policy instead of billing $0.
-        if db is None or log_writer is None or reservation is None:
-            return
-        policy = config.stream_missing_usage_policy
-        if policy == "allow_free":
-            await log_usage(
-                db=db,
-                log_writer=log_writer,
-                api_key_id=api_key_id,
-                model=model,
-                provider=provider,
-                endpoint="/v1/responses",
-                user_id=user_id,
-            )
-            await refund_reservation(db, reservation)
-            return
-        # 'estimate' and 'fail' both charge the up-front estimate; 'fail' also
-        # records the request as errored.
-        await log_usage(
-            db=db,
-            log_writer=log_writer,
-            api_key_id=api_key_id,
-            model=model,
-            provider=provider,
-            endpoint="/v1/responses",
-            user_id=user_id,
-            error="stream completed without usage data" if policy == "fail" else None,
-            cost_override=reservation.estimate,
-        )
-        await reconcile_reservation(db, reservation, reservation.estimate)
-
-    async def _on_error(error: str) -> None:
-        if platform_mode_active:
-            assert platform_config is not None  # guaranteed by the platform-mode branch above
-            assert platform_correlation_id is not None  # guaranteed by the platform-mode branch above
-            asyncio.create_task(
-                _report_platform_usage(
-                    config=platform_config,
-                    correlation_id=platform_correlation_id,
-                    outcome="error",
-                    usage=None,
-                )
-            )
-            return
-        if db is None:
-            return
-        await log_usage(
-            db=db,
-            log_writer=log_writer,
-            api_key_id=api_key_id,
-            model=model,
-            provider=provider,
-            endpoint="/v1/responses",
-            user_id=user_id,
-            error=error,
-        )
-        if reservation is not None:
-            await refund_reservation(db, reservation)
-
-    async def _on_incomplete() -> None:
-        # Client disconnected mid-stream — release the reservation.
-        if db is None or reservation is None:
-            return
-        await refund_reservation(db, reservation)
+        await settlement.on_success(usage_data)
 
     try:
         if not use_tool_loop:
@@ -997,17 +847,7 @@ async def _stream_responses(
         # escaping uncaught into a 500. Matches the non-streaming handler and
         # the pre-existing behavior before streaming was factored into this
         # helper.
-        if db is not None:
-            await log_usage(
-                db=db,
-                log_writer=log_writer,
-                api_key_id=api_key_id,
-                model=model,
-                provider=provider,
-                endpoint="/v1/responses",
-                user_id=user_id,
-                error=str(exc),
-            )
+        await settlement.on_provider_error_precommit(str(exc))
         logger.error("Provider call failed for %s:%s: %s", provider, model, exc)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -1017,10 +857,10 @@ async def _stream_responses(
     headers: dict[str, str] = {}
     if rate_limit_info:
         headers.update(rate_limit_headers(rate_limit_info))
-    if platform_correlation_id:
-        headers["X-Correlation-ID"] = platform_correlation_id
-    if platform_request_id:
-        headers["X-Otari-Request-ID"] = platform_request_id
+    if correlation_id:
+        headers["X-Correlation-ID"] = correlation_id
+    if request_id:
+        headers["X-Otari-Request-ID"] = request_id
 
     return StreamingResponse(
         streaming_generator(
@@ -1029,10 +869,10 @@ async def _stream_responses(
             extract_usage=_extract_usage,
             fmt=RESPONSES_STREAM_FORMAT,
             on_complete=_on_complete,
-            on_error=_on_error,
+            on_error=settlement.on_error,
             label=f"{provider}:{model}",
-            on_no_usage=_on_no_usage,
-            on_incomplete=_on_incomplete,
+            on_no_usage=settlement.on_no_usage,
+            on_incomplete=settlement.on_incomplete,
         ),
         media_type="text/event-stream",
         headers=headers,
@@ -1045,6 +885,7 @@ async def _run_streaming_with_fallback_responses(
     base_request_fields: dict[str, Any],
     response: FastAPIResponse,
     config: GatewayConfig,
+    strategy: RequestModeStrategy,
     background_tasks: BackgroundTasks,
     rate_limit_info: RateLimitInfo | None,
 ) -> StreamingResponse:
@@ -1103,9 +944,14 @@ async def _run_streaming_with_fallback_responses(
         stream=stream,
         provider=LLMProvider(chosen.provider),
         model=chosen.model,
+        settlement=strategy.make_settlement(
+            provider=LLMProvider(chosen.provider),
+            model=chosen.model,
+            endpoint="/v1/responses",
+            correlation_id=chosen.attempt_id,
+        ),
         correlation_id=chosen.attempt_id,
         request_id=route.request_id,
-        config=config,
         rate_limit_info=rate_limit_info,
     )
 
@@ -1115,14 +961,14 @@ def _build_streaming_response_responses(
     stream: AsyncIterator[ResponseStreamEvent],
     provider: LLMProvider,
     model: str,
+    settlement: RequestSettlement,
     correlation_id: str,
     request_id: str,
-    config: GatewayConfig,
     rate_limit_info: RateLimitInfo | None,
 ) -> StreamingResponse:
     """Wrap an already-opened Responses stream in an SSE response for
     platform-mode requests. Sets correlation / request-id headers and reports
-    usage to the platform on complete.
+    usage through ``settlement`` on complete/error.
     """
 
     def _format_chunk(event: ResponseStreamEvent) -> str:
@@ -1135,24 +981,7 @@ def _build_streaming_response_responses(
         return None
 
     async def _on_complete(usage_data: CompletionUsage) -> None:
-        asyncio.create_task(
-            _report_platform_usage(
-                config=config,
-                correlation_id=correlation_id,
-                outcome="success",
-                usage=usage_data,
-            )
-        )
-
-    async def _on_error(error: str) -> None:
-        asyncio.create_task(
-            _report_platform_usage(
-                config=config,
-                correlation_id=correlation_id,
-                outcome="error",
-                usage=None,
-            )
-        )
+        await settlement.on_success(usage_data)
 
     headers: dict[str, str] = {}
     if rate_limit_info:
@@ -1167,7 +996,7 @@ def _build_streaming_response_responses(
             extract_usage=_extract_usage,
             fmt=RESPONSES_STREAM_FORMAT,
             on_complete=_on_complete,
-            on_error=_on_error,
+            on_error=settlement.on_error,
             label=f"{provider}:{model}",
         ),
         media_type="text/event-stream",

--- a/tests/integration/test_mode_strategy_e2e.py
+++ b/tests/integration/test_mode_strategy_e2e.py
@@ -1,0 +1,506 @@
+"""End-to-end tests for the standalone-vs-platform mode strategy seam.
+
+These drive real HTTP requests through the FastAPI app (TestClient) with mocked
+upstream providers, and assert the observable contracts the
+``RequestModeStrategy`` / ``RequestSettlement`` seam is responsible for:
+
+- standalone settlement: success reconciles spend and releases the budget hold;
+  a provider error refunds the hold and logs an error row;
+- the deliberately-preserved asymmetry where a pre-commit streaming provider
+  error refunds for chat but logs-without-refund for messages (see
+  ``on_provider_error_precommit``);
+- mode-resolution: ``mcp_server_ids`` is rejected in standalone mode, and
+  platform mode sets the ``X-Otari-Request-ID`` / ``X-Correlation-ID`` headers
+  and reports usage upstream.
+
+The existing standalone and platform integration suites prove the refactor did
+not regress; this file adds seam-targeted coverage that asserts budget /
+UsageLog state, not just status codes.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import AsyncIterator, Generator
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+from any_llm.types.completion import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    ChatCompletionMessage,
+    Choice,
+    CompletionUsage,
+)
+from any_llm.types.messages import MessageResponse
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from gateway.api.deps import reset_config
+from gateway.core.config import GatewayConfig
+from gateway.core.database import reset_db
+from gateway.main import create_app
+from gateway.models.entities import UsageLog, User
+
+from .conftest import MODEL_NAME
+
+_PRICING = {"input_price_per_million": 2.5, "output_price_per_million": 10.0}
+
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+
+
+def _seed_budgeted_user(client: TestClient, headers: dict[str, str], user_id: str) -> None:
+    budget = client.post("/v1/budgets", json={"max_budget": 100.0}, headers=headers)
+    assert budget.status_code == 200
+    budget_id = budget.json()["budget_id"]
+    created = client.post(
+        "/v1/users",
+        json={"user_id": user_id, "budget_id": budget_id},
+        headers=headers,
+    )
+    assert created.status_code == 200
+
+
+def _configure_pricing(client: TestClient, headers: dict[str, str], model_key: str = MODEL_NAME) -> None:
+    res = client.post(
+        "/v1/pricing",
+        json={"model_key": model_key, **_PRICING},
+        headers=headers,
+    )
+    assert res.status_code == 200
+
+
+def _user_state(test_config: GatewayConfig, user_id: str) -> tuple[float, float]:
+    """Return ``(spend, reserved)`` for a user, read on a fresh sync session."""
+    engine = create_engine(test_config.database_url)
+    session_local = sessionmaker(bind=engine)
+    db = session_local()
+    try:
+        user = db.query(User).filter(User.user_id == user_id).first()
+        assert user is not None
+        return float(user.spend), float(user.reserved)
+    finally:
+        db.close()
+        engine.dispose()
+
+
+def _poll_usage_logs(
+    test_config: GatewayConfig, user_id: str, *, timeout: float = 3.0
+) -> list[tuple[str, str | None]]:
+    """Poll the async log writer until at least one row exists for the user."""
+    engine = create_engine(test_config.database_url)
+    session_local = sessionmaker(bind=engine)
+    deadline = time.time() + timeout
+    try:
+        while True:
+            db = session_local()
+            try:
+                rows = db.query(UsageLog).filter(UsageLog.user_id == user_id).all()
+                if rows or time.time() > deadline:
+                    return [(r.status, r.error_message) for r in rows]
+            finally:
+                db.close()
+            time.sleep(0.1)
+    finally:
+        engine.dispose()
+
+
+def _chat_completion(usage: CompletionUsage) -> ChatCompletion:
+    return ChatCompletion(
+        id="chatcmpl-e2e",
+        object="chat.completion",
+        created=0,
+        model=MODEL_NAME,
+        choices=[
+            Choice(
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content="hi"),
+                finish_reason="stop",
+            )
+        ],
+        usage=usage,
+    )
+
+
+# --------------------------------------------------------------------------
+# Standalone settlement
+# --------------------------------------------------------------------------
+
+
+def test_standalone_chat_success_reconciles_and_releases_hold(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    test_config: GatewayConfig,
+) -> None:
+    """settlement.on_success: a successful non-stream chat completion logs the
+    usage row, charges the actual cost to spend, and frees the reservation."""
+    user_id = "e2e-chat-success"
+    _seed_budgeted_user(client, master_key_header, user_id)
+    _configure_pricing(client, master_key_header)
+
+    # 1,000,000 prompt + 500,000 completion tokens -> 2.5 + 5.0 = 7.5
+    usage = CompletionUsage(prompt_tokens=1_000_000, completion_tokens=500_000, total_tokens=1_500_000)
+
+    async def _fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        return _chat_completion(usage)
+
+    with patch("gateway.api.routes.chat.acompletion", side_effect=_fake_acompletion):
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": MODEL_NAME, "messages": [{"role": "user", "content": "hi"}], "user": user_id},
+            headers=master_key_header,
+        )
+
+    assert response.status_code == 200
+    spend, reserved = _user_state(test_config, user_id)
+    assert spend == pytest.approx(7.5)
+    assert reserved == pytest.approx(0.0)
+    logs = _poll_usage_logs(test_config, user_id)
+    assert [s for s, _ in logs] == ["success"]
+
+
+def test_standalone_chat_provider_error_refunds_hold(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    test_config: GatewayConfig,
+) -> None:
+    """settlement.on_error: a non-stream provider error logs an error row,
+    refunds the reservation, and leaves spend untouched."""
+    user_id = "e2e-chat-error"
+    _seed_budgeted_user(client, master_key_header, user_id)
+    _configure_pricing(client, master_key_header)
+
+    async def _boom(**kwargs: Any) -> ChatCompletion:
+        raise RuntimeError("simulated upstream failure")
+
+    with patch("gateway.api.routes.chat.acompletion", side_effect=_boom):
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": MODEL_NAME, "messages": [{"role": "user", "content": "hi"}], "user": user_id},
+            headers=master_key_header,
+        )
+
+    assert response.status_code == 502
+    spend, reserved = _user_state(test_config, user_id)
+    assert spend == pytest.approx(0.0)
+    assert reserved == pytest.approx(0.0)  # hold refunded
+    logs = _poll_usage_logs(test_config, user_id)
+    assert [s for s, _ in logs] == ["error"]
+
+
+def test_standalone_chat_streaming_success_reconciles(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    test_config: GatewayConfig,
+) -> None:
+    """settlement.on_success via the streaming generator: a streamed completion
+    aggregates usage, charges spend, and releases the hold."""
+    user_id = "e2e-chat-stream"
+    _seed_budgeted_user(client, master_key_header, user_id)
+    _configure_pricing(client, master_key_header)
+
+    async def _fake_acompletion(**kwargs: Any) -> AsyncIterator[ChatCompletionChunk]:
+        async def _stream() -> AsyncIterator[ChatCompletionChunk]:
+            yield ChatCompletionChunk.model_validate(
+                {
+                    "id": "c1",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": MODEL_NAME,
+                    "choices": [{"index": 0, "delta": {"content": "hi"}, "finish_reason": None}],
+                }
+            )
+            yield ChatCompletionChunk.model_validate(
+                {
+                    "id": "c2",
+                    "object": "chat.completion.chunk",
+                    "created": 0,
+                    "model": MODEL_NAME,
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 1_000_000, "completion_tokens": 500_000, "total_tokens": 1_500_000},
+                }
+            )
+
+        return _stream()
+
+    with patch("gateway.api.routes.chat.acompletion", side_effect=_fake_acompletion):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": MODEL_NAME,
+                "messages": [{"role": "user", "content": "hi"}],
+                "user": user_id,
+                "stream": True,
+            },
+            headers=master_key_header,
+        )
+        assert response.status_code == 200
+        body = response.text  # fully consume the SSE stream so settlement runs
+
+    assert "[DONE]" in body
+    spend, reserved = _user_state(test_config, user_id)
+    assert spend == pytest.approx(7.5)
+    assert reserved == pytest.approx(0.0)
+    logs = _poll_usage_logs(test_config, user_id)
+    assert [s for s, _ in logs] == ["success"]
+
+
+def test_standalone_messages_streaming_precommit_error_refunds(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    test_config: GatewayConfig,
+) -> None:
+    """settlement.on_error: a messages streaming request whose provider call
+    fails before the first event logs an error row AND refunds the reservation,
+    matching chat and the non-streaming handlers. (Regression guard for the
+    pre-commit reservation leak that messages/responses streaming used to have.)"""
+    user_id = "e2e-messages-precommit"
+    _seed_budgeted_user(client, master_key_header, user_id)
+    _configure_pricing(client, master_key_header)
+
+    async def _boom(**kwargs: Any) -> MessageResponse:
+        raise RuntimeError("simulated upstream failure before first event")
+
+    with patch("gateway.api.routes.messages.amessages", side_effect=_boom):
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": MODEL_NAME,
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 64,
+                "stream": True,
+                "metadata": {"user_id": user_id},
+            },
+            headers=master_key_header,
+        )
+
+    assert response.status_code == 500
+    spend, reserved = _user_state(test_config, user_id)
+    assert spend == pytest.approx(0.0)
+    assert reserved == pytest.approx(0.0)  # hold refunded (no leak)
+    logs = _poll_usage_logs(test_config, user_id)
+    assert [s for s, _ in logs] == ["error"]
+
+
+def test_standalone_responses_streaming_precommit_error_refunds(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    test_config: GatewayConfig,
+) -> None:
+    """settlement.on_error on /v1/responses streaming pre-commit: logs an error
+    row and refunds the reservation, same uniform contract as the other two."""
+    user_id = "e2e-responses-precommit"
+    _seed_budgeted_user(client, master_key_header, user_id)
+    # openai supports the Responses API; price it so the reservation hold is
+    # genuinely non-zero before the failure refunds it.
+    _configure_pricing(client, master_key_header, model_key="openai:gpt-4o-mini")
+
+    async def _boom(**kwargs: Any) -> Any:
+        raise RuntimeError("simulated upstream failure before first event")
+
+    with patch("gateway.api.routes.responses.aresponses", side_effect=_boom):
+        response = client.post(
+            "/v1/responses",
+            json={"model": "openai:gpt-4o-mini", "input": "hi", "stream": True, "user": user_id},
+            headers=master_key_header,
+        )
+
+    assert response.status_code == 502
+    spend, reserved = _user_state(test_config, user_id)
+    assert spend == pytest.approx(0.0)
+    assert reserved == pytest.approx(0.0)  # hold refunded (no leak)
+    logs = _poll_usage_logs(test_config, user_id)
+    assert [s for s, _ in logs] == ["error"]
+
+
+def test_standalone_chat_streaming_precommit_error_refunds(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    test_config: GatewayConfig,
+) -> None:
+    """A chat streaming request whose provider call fails before the first
+    chunk logs an error row and refunds the reservation (settlement.on_error on
+    the pre-commit path) — the same uniform contract as messages and responses."""
+    user_id = "e2e-chat-precommit"
+    _seed_budgeted_user(client, master_key_header, user_id)
+    _configure_pricing(client, master_key_header)
+
+    async def _boom(**kwargs: Any) -> AsyncIterator[ChatCompletionChunk]:
+        raise RuntimeError("simulated upstream failure before first chunk")
+
+    with patch("gateway.api.routes.chat.acompletion", side_effect=_boom):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": MODEL_NAME,
+                "messages": [{"role": "user", "content": "hi"}],
+                "user": user_id,
+                "stream": True,
+            },
+            headers=master_key_header,
+        )
+
+    assert response.status_code == 502
+    spend, reserved = _user_state(test_config, user_id)
+    assert spend == pytest.approx(0.0)
+    assert reserved == pytest.approx(0.0)  # hold refunded (contrast with messages)
+    logs = _poll_usage_logs(test_config, user_id)
+    assert [s for s, _ in logs] == ["error"]
+
+
+@pytest.mark.parametrize(
+    ("path", "body"),
+    [
+        ("/v1/chat/completions", {"messages": [{"role": "user", "content": "hi"}]}),
+        ("/v1/messages", {"messages": [{"role": "user", "content": "hi"}], "max_tokens": 16}),
+        ("/v1/responses", {"input": "hi"}),
+    ],
+)
+def test_standalone_rejects_mcp_server_ids(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    path: str,
+    body: dict[str, Any],
+) -> None:
+    """strategy.resolve_mcp_servers (standalone) rejects workspace-scoped MCP
+    server ids with a 400 on every LLM endpoint."""
+    response = client.post(
+        path,
+        json={"model": "openai:gpt-4o-mini", "mcp_server_ids": ["11111111-1111-1111-1111-111111111111"], **body},
+        headers=master_key_header,
+    )
+    assert response.status_code == 400
+
+
+# --------------------------------------------------------------------------
+# Platform resolution + settlement
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def platform_client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient]:
+    monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
+    app = create_app(GatewayConfig(mode="platform", platform={"base_url": "http://platform.test/api/v1"}))
+    with TestClient(app) as client:
+        yield client
+    reset_config()
+    reset_db()
+
+
+def test_platform_resolve_sets_request_id_header_and_reports_usage(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PlatformStrategy.resolve sets X-Otari-Request-ID from the resolve call;
+    the platform settlement sets X-Correlation-ID and reports usage upstream."""
+    usage_reports: list[dict[str, Any]] = []
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json={
+                    "request_id": "req-e2e-1",
+                    "fallback_enabled": False,
+                    "attempts": [
+                        {
+                            "attempt_id": "att-e2e-1",
+                            "position": 0,
+                            "provider": "openai",
+                            "model": "gpt-4o-mini",
+                            "api_key": "sk-platform-key",
+                            "api_base": "https://api.openai.com/v1",
+                            "managed": True,
+                        }
+                    ],
+                },
+            )
+        usage_reports.append(body)
+        return httpx.Response(204)
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        return _chat_completion(CompletionUsage(prompt_tokens=10, completion_tokens=7, total_tokens=17))
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.acompletion", fake_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["X-Otari-Request-ID"] == "req-e2e-1"
+    assert response.headers["X-Correlation-ID"] == "att-e2e-1"
+    assert usage_reports == [
+        {
+            "correlation_id": "att-e2e-1",
+            "status": "success",
+            "usage": {"prompt_tokens": 10, "completion_tokens": 7, "total_tokens": 17},
+        }
+    ]
+
+
+def test_platform_resolves_mcp_server_ids_via_platform(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """strategy.resolve_mcp_servers (platform) swaps workspace-scoped ids for
+    inline configs by calling the platform's mcp-servers/resolve endpoint."""
+    called_urls: list[str] = []
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        called_urls.append(url)
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json={
+                    "request_id": "req-mcp-1",
+                    "fallback_enabled": False,
+                    "attempts": [
+                        {
+                            "attempt_id": "att-mcp-1",
+                            "position": 0,
+                            "provider": "openai",
+                            "model": "gpt-4o-mini",
+                            "api_key": "sk-platform-key",
+                            "api_base": "https://api.openai.com/v1",
+                            "managed": True,
+                        }
+                    ],
+                },
+            )
+        if url.endswith("/gateway/mcp-servers/resolve"):
+            return httpx.Response(200, json={"servers": []})
+        return httpx.Response(204)
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        return _chat_completion(CompletionUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2))
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.acompletion", fake_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hi"}],
+            "mcp_server_ids": ["22222222-2222-2222-2222-222222222222"],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+    # The platform mcp-servers/resolve endpoint was consulted by the strategy.
+    assert any(u.endswith("/gateway/mcp-servers/resolve") for u in called_urls)

--- a/tests/unit/test_mode_strategy.py
+++ b/tests/unit/test_mode_strategy.py
@@ -142,7 +142,6 @@ async def test_platform_settlement_no_usage_and_incomplete_are_noops(monkeypatch
 
     await settlement.on_no_usage()
     await settlement.on_incomplete()
-    await settlement.on_provider_error_precommit("boom")
     await _drain_tasks()
 
     assert calls == []
@@ -224,19 +223,6 @@ async def test_standalone_incomplete_refunds_without_logging(monkeypatch: pytest
 
     assert recorded["log"] == []
     assert recorded["refund"] == [reservation]
-
-
-@pytest.mark.asyncio
-async def test_standalone_precommit_logs_without_refund(monkeypatch: pytest.MonkeyPatch) -> None:
-    recorded = _patch_budget(monkeypatch)
-    reservation = _reservation()
-    settlement = _standalone_settlement(GatewayConfig(), reservation)
-
-    await settlement.on_provider_error_precommit("boom")
-
-    assert recorded["log"][0]["error"] == "boom"
-    assert recorded["refund"] == []
-    assert recorded["reconcile"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mode_strategy.py
+++ b/tests/unit/test_mode_strategy.py
@@ -1,0 +1,343 @@
+"""Unit tests for the request mode-strategy seam.
+
+These exercise each strategy / settlement in isolation — selection, the
+platform usage-report scheduling, and the standalone log + reconcile/refund
+behavior — without spinning up a full request. The end-to-end behavior is
+covered by the standalone and platform-mode integration suites.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from any_llm import LLMProvider
+from any_llm.types.completion import CompletionUsage
+from fastapi import HTTPException, Response
+from starlette.requests import Request
+
+from gateway.api.routes import _mode_strategy
+from gateway.api.routes._mode_strategy import (
+    PlatformSettlement,
+    PlatformStrategy,
+    RequestSettlement,
+    ResolveErrors,
+    ResolveSpec,
+    StandaloneSettlement,
+    StandaloneStrategy,
+    select_request_mode_strategy,
+)
+from gateway.core.config import GatewayConfig
+from gateway.services.budget_service import ReservationHandle
+
+_PLATFORM_TOKEN_ENV_VARS = ("OTARI_AI_TOKEN", "OTARI_PLATFORM_TOKEN", "ANY_LLM_PLATFORM_TOKEN")
+
+
+def _clear_platform_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in _PLATFORM_TOKEN_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _make_request(headers: dict[str, str] | None = None) -> Request:
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    return Request({"type": "http", "method": "POST", "path": "/v1/chat/completions", "headers": raw_headers})
+
+
+def _spec(**overrides: Any) -> ResolveSpec:
+    err = HTTPException(status_code=400, detail="boom")
+    defaults: dict[str, Any] = {
+        "model_selector": "openai:gpt-4o-mini",
+        "user_id_from_request": None,
+        "prompt_chars": 10,
+        "max_output_tokens": None,
+        "errors": ResolveErrors(
+            db_unavailable=HTTPException(status_code=500, detail="Database session unavailable"),
+            master_key_user_required=err,
+            api_key_validation_failed=err,
+            no_user=err,
+            forbidden_user=err,
+            no_pricing=HTTPException(status_code=402, detail="no pricing"),
+        ),
+    }
+    defaults.update(overrides)
+    return ResolveSpec(**defaults)
+
+
+def _reservation() -> ReservationHandle:
+    return ReservationHandle(user_id="u1", estimate=0.5, reserved=True, strategy="for_update")
+
+
+# ---------------------------------------------------------------------------
+# Strategy selection
+# ---------------------------------------------------------------------------
+
+
+def test_select_strategy_standalone(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_platform_env(monkeypatch)
+    config = GatewayConfig()
+    strategy = select_request_mode_strategy(config, db=None, log_writer=object())  # type: ignore[arg-type]
+    assert isinstance(strategy, StandaloneStrategy)
+    assert strategy.is_platform is False
+
+
+def test_select_strategy_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
+    config = GatewayConfig(mode="platform", platform={"base_url": "http://platform.test/api/v1"})
+    strategy = select_request_mode_strategy(config, db=None, log_writer=object())  # type: ignore[arg-type]
+    assert isinstance(strategy, PlatformStrategy)
+    assert strategy.is_platform is True
+
+
+# ---------------------------------------------------------------------------
+# PlatformSettlement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_platform_settlement_success_reports_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, str, CompletionUsage | None]] = []
+
+    async def _fake_report(
+        *, config: Any, correlation_id: str, outcome: str, usage: Any, error_class: Any = None
+    ) -> None:
+        calls.append((correlation_id, outcome, usage))
+
+    monkeypatch.setattr(_mode_strategy, "_report_platform_usage", _fake_report)
+    settlement: RequestSettlement = PlatformSettlement(config=GatewayConfig(), correlation_id="corr-1")
+    usage = CompletionUsage(prompt_tokens=1, completion_tokens=2, total_tokens=3)
+
+    await settlement.on_success(usage)
+    await _drain_tasks()
+
+    assert calls == [("corr-1", "success", usage)]
+
+
+@pytest.mark.asyncio
+async def test_platform_settlement_error_reports_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, str, Any]] = []
+
+    async def _fake_report(
+        *, config: Any, correlation_id: str, outcome: str, usage: Any, error_class: Any = None
+    ) -> None:
+        calls.append((correlation_id, outcome, usage))
+
+    monkeypatch.setattr(_mode_strategy, "_report_platform_usage", _fake_report)
+    settlement = PlatformSettlement(config=GatewayConfig(), correlation_id="corr-2")
+
+    await settlement.on_error("boom")
+    await _drain_tasks()
+
+    assert calls == [("corr-2", "error", None)]
+
+
+@pytest.mark.asyncio
+async def test_platform_settlement_no_usage_and_incomplete_are_noops(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[Any] = []
+
+    async def _fake_report(**kwargs: Any) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr(_mode_strategy, "_report_platform_usage", _fake_report)
+    settlement = PlatformSettlement(config=GatewayConfig(), correlation_id="corr-3")
+
+    await settlement.on_no_usage()
+    await settlement.on_incomplete()
+    await settlement.on_provider_error_precommit("boom")
+    await _drain_tasks()
+
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# StandaloneSettlement
+# ---------------------------------------------------------------------------
+
+
+def _patch_budget(monkeypatch: pytest.MonkeyPatch) -> dict[str, list[Any]]:
+    recorded: dict[str, list[Any]] = {"log": [], "reconcile": [], "refund": []}
+
+    async def _fake_log_usage(**kwargs: Any) -> float | None:
+        recorded["log"].append(kwargs)
+        return 0.5
+
+    async def _fake_reconcile(db: Any, reservation: Any, amount: float) -> None:
+        recorded["reconcile"].append((reservation, amount))
+
+    async def _fake_refund(db: Any, reservation: Any) -> None:
+        recorded["refund"].append(reservation)
+
+    monkeypatch.setattr("gateway.api.routes.chat.log_usage", _fake_log_usage)
+    monkeypatch.setattr(_mode_strategy, "reconcile_reservation", _fake_reconcile)
+    monkeypatch.setattr(_mode_strategy, "refund_reservation", _fake_refund)
+    return recorded
+
+
+def _standalone_settlement(config: GatewayConfig, reservation: ReservationHandle | None) -> StandaloneSettlement:
+    return StandaloneSettlement(
+        db=object(),  # type: ignore[arg-type]
+        log_writer=object(),  # type: ignore[arg-type]
+        api_key_id="key-1",
+        user_id="u1",
+        provider=LLMProvider.OPENAI,
+        model="gpt-4o-mini",
+        endpoint="/v1/chat/completions",
+        reservation=reservation,
+        config=config,
+    )
+
+
+@pytest.mark.asyncio
+async def test_standalone_success_logs_and_reconciles(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded = _patch_budget(monkeypatch)
+    reservation = _reservation()
+    settlement = _standalone_settlement(GatewayConfig(), reservation)
+    usage = CompletionUsage(prompt_tokens=1, completion_tokens=2, total_tokens=3)
+
+    await settlement.on_success(usage)
+
+    assert len(recorded["log"]) == 1
+    assert recorded["log"][0]["usage_override"] is usage
+    assert recorded["reconcile"] == [(reservation, 0.5)]
+    assert recorded["refund"] == []
+
+
+@pytest.mark.asyncio
+async def test_standalone_error_logs_and_refunds(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded = _patch_budget(monkeypatch)
+    reservation = _reservation()
+    settlement = _standalone_settlement(GatewayConfig(), reservation)
+
+    await settlement.on_error("boom")
+
+    assert recorded["log"][0]["error"] == "boom"
+    assert recorded["refund"] == [reservation]
+    assert recorded["reconcile"] == []
+
+
+@pytest.mark.asyncio
+async def test_standalone_incomplete_refunds_without_logging(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded = _patch_budget(monkeypatch)
+    reservation = _reservation()
+    settlement = _standalone_settlement(GatewayConfig(), reservation)
+
+    await settlement.on_incomplete()
+
+    assert recorded["log"] == []
+    assert recorded["refund"] == [reservation]
+
+
+@pytest.mark.asyncio
+async def test_standalone_precommit_logs_without_refund(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded = _patch_budget(monkeypatch)
+    reservation = _reservation()
+    settlement = _standalone_settlement(GatewayConfig(), reservation)
+
+    await settlement.on_provider_error_precommit("boom")
+
+    assert recorded["log"][0]["error"] == "boom"
+    assert recorded["refund"] == []
+    assert recorded["reconcile"] == []
+
+
+@pytest.mark.asyncio
+async def test_standalone_no_usage_allow_free_refunds(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded = _patch_budget(monkeypatch)
+    reservation = _reservation()
+    config = GatewayConfig(stream_missing_usage_policy="allow_free")
+    settlement = _standalone_settlement(config, reservation)
+
+    await settlement.on_no_usage()
+
+    assert len(recorded["log"]) == 1
+    assert recorded["log"][0].get("error") is None
+    assert recorded["log"][0].get("cost_override") is None
+    assert recorded["refund"] == [reservation]
+    assert recorded["reconcile"] == []
+
+
+@pytest.mark.asyncio
+async def test_standalone_no_usage_estimate_charges_estimate(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded = _patch_budget(monkeypatch)
+    reservation = _reservation()
+    config = GatewayConfig(stream_missing_usage_policy="estimate")
+    settlement = _standalone_settlement(config, reservation)
+
+    await settlement.on_no_usage()
+
+    assert recorded["log"][0]["cost_override"] == reservation.estimate
+    assert recorded["log"][0].get("error") is None
+    assert recorded["reconcile"] == [(reservation, reservation.estimate)]
+    assert recorded["refund"] == []
+
+
+@pytest.mark.asyncio
+async def test_standalone_no_usage_fail_records_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded = _patch_budget(monkeypatch)
+    reservation = _reservation()
+    config = GatewayConfig(stream_missing_usage_policy="fail")
+    settlement = _standalone_settlement(config, reservation)
+
+    await settlement.on_no_usage()
+
+    assert recorded["log"][0]["error"] == "stream completed without usage data"
+    assert recorded["log"][0]["cost_override"] == reservation.estimate
+    assert recorded["reconcile"] == [(reservation, reservation.estimate)]
+
+
+@pytest.mark.asyncio
+async def test_standalone_settlement_noop_without_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded = _patch_budget(monkeypatch)
+    settlement = StandaloneSettlement(
+        db=None,
+        log_writer=object(),  # type: ignore[arg-type]
+        api_key_id=None,
+        user_id=None,
+        provider=LLMProvider.OPENAI,
+        model="gpt-4o-mini",
+        endpoint="/v1/chat/completions",
+        reservation=_reservation(),
+        config=GatewayConfig(),
+    )
+
+    await settlement.on_success(None)
+    await settlement.on_error("boom")
+    await settlement.on_incomplete()
+
+    assert recorded == {"log": [], "reconcile": [], "refund": []}
+
+
+# ---------------------------------------------------------------------------
+# resolve() reject paths that need no DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_platform_resolve_missing_bearer_raises_401() -> None:
+    strategy = PlatformStrategy(GatewayConfig(platform={"base_url": "http://platform.test"}))
+    request = _make_request()  # no Authorization header
+    with pytest.raises(HTTPException) as ei:
+        await strategy.resolve(raw_request=request, response=Response(), spec=_spec())
+    assert ei.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_standalone_resolve_db_none_raises_spec_error() -> None:
+    strategy = StandaloneStrategy(GatewayConfig(), db=None, log_writer=object())  # type: ignore[arg-type]
+    request = _make_request()
+    with pytest.raises(HTTPException) as ei:
+        await strategy.resolve(raw_request=request, response=Response(), spec=_spec())
+    assert ei.value.status_code == 500
+    assert ei.value.detail == "Database session unavailable"
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+async def _drain_tasks() -> None:
+    """Yield control so any ``asyncio.create_task`` scheduled by a settlement runs."""
+    import asyncio
+
+    for _ in range(3):
+        await asyncio.sleep(0)


### PR DESCRIPTION
> _Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Summary

Fixes #102. The chat, messages, and responses handlers each read `config.is_platform_mode` and re-branched on it inline at many sites (chat 15, responses 13, messages 11), interleaving the two modes' credential-resolution and usage-reporting logic in one long function body. A bug had to be fixed in three places and it was easy to add a path that silently worked in only one mode.

- New module `src/gateway/api/routes/_mode_strategy.py` with two seams, selected once per request:
  - `RequestModeStrategy` (`StandaloneStrategy` / `PlatformStrategy`): `resolve()` runs the platform resolve call or the auth plus budget-reservation flow and stashes the per-request state; `resolve_mcp_servers()` replaces the `mcp_server_ids` mode branch; `make_settlement()` builds the right settlement.
  - `RequestSettlement` (`StandaloneSettlement` / `PlatformSettlement`): supplies the `on_success` / `on_error` / `on_no_usage` / `on_incomplete` hooks the streaming generators already accept, replacing the inline `if platform_mode` branches in the streaming callbacks and the standalone non-streaming tail.
- The three handlers shed about 529 net lines; the top resolve block becomes `strategy.resolve(spec=...)`.
- Dispatch mechanics (the `run_platform_attempts` runner vs the standalone single call, the streaming fallback-vs-single split) stay in the handlers, as the issue permits.

### Scope notes

- Lighter seam, not full convergence onto `run_platform_attempts`. Standalone keeps its own dispatch because `get_provider_kwargs` returns richer credentials (`client_args`, `api_version`, Vertex env) than `ResolvedAttempt` models, so routing it through the attempt-based runner would silently drop them.
- No behavior change on the wire for the refactor itself: status codes, headers, and budget reconcile/refund semantics are preserved.

## Bundled bug fix: streaming pre-commit reservation leak

Investigating the seam surfaced a pre-existing standalone bug (introduced when the reservation system landed, not by this refactor). On `/v1/messages` and `/v1/responses`, a streaming request whose provider call failed before the first chunk logged the error but did not refund the budget reservation, while `/v1/chat/completions` and all non-streaming paths did. The leaked hold was never released (a budget-period reset zeroes `spend` but not `reserved`), so repeated pre-commit streaming failures accumulated `reserved` until the user hit a spurious "budget exceeded" 403 with low actual spend.

The fix routes the messages/responses pre-commit path through `settlement.on_error` (log plus refund), matching chat and the non-streaming handlers, and removes the now-dead `on_provider_error_precommit` hook. In platform mode this also reports an error outcome upstream on a pre-commit failure, consistent with how mid-stream errors already report. The HTTP status and body are unchanged; only `users.reserved` is released instead of leaked.

## Test plan

- [x] `make lint` (ruff) and `make typecheck` (mypy strict, 154 files)
- [x] New `tests/unit/test_mode_strategy.py`: strategy selection, both settlements, no-DB reject paths
- [x] New `tests/integration/test_mode_strategy_e2e.py` (11 tests): standalone reconcile/refund settlement, the now-uniform pre-commit refund across all three endpoints, `mcp_server_ids` resolution, and platform request-id/correlation headers plus upstream usage reporting
- [x] Full suite green: 749 passed, 10 env-gated skips, including the platform-mode and standalone chat/messages/responses suites unchanged
- [x] `uv run python scripts/generate_openapi.py --check` (no schema change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)