### PR TITLE
fix(bootstrap): keep bootstrap API key on a single log line

### DIFF
--- a/src/gateway/log_config.py
+++ b/src/gateway/log_config.py
@@ -1,9 +1,33 @@
 import logging
 from typing import Any
 
+from rich.console import Console
 from rich.logging import RichHandler
 
 logger = logging.getLogger("gateway")
+
+
+def _log_console() -> Console:
+    """Return the console used by the active RichHandler, or a stderr fallback."""
+    for handler in logger.handlers:
+        if isinstance(handler, RichHandler):
+            return handler.console
+    return Console(stderr=True)
+
+
+def log_secret(message: str, secret: str, *, level: int = logging.WARNING) -> None:
+    """Log a message, then emit a secret value on its own unbroken line.
+
+    RichHandler hard-wraps long tokens within its narrow message column, which
+    splits a value like an API key across multiple physical lines and makes it
+    impossible to copy reliably from container logs. We log the contextual
+    message normally, then write the secret through a soft-wrapping console so
+    it stays on a single line that can be copied verbatim.
+    """
+    logger.log(level, message)
+    if not logger.isEnabledFor(level):
+        return
+    _log_console().print(secret, soft_wrap=True, crop=False, highlight=False, markup=False)
 
 
 def setup_logger(

--- a/src/gateway/services/bootstrap_service.py
+++ b/src/gateway/services/bootstrap_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.auth import generate_api_key, hash_key
 from gateway.core.config import GatewayConfig
-from gateway.log_config import logger
+from gateway.log_config import log_secret
 from gateway.models.entities import APIKey, User
 
 
@@ -45,7 +45,7 @@ async def bootstrap_first_api_key(config: GatewayConfig, db: AsyncSession) -> No
         await db.rollback()
         raise
 
-    logger.warning(
-        "No API keys found. Created bootstrap key for first run. Save this key now: %s",
+    log_secret(
+        "No API keys found. Created bootstrap key for first run. Save this key now:",
         api_key,
     )

--- a/tests/unit/test_log_config.py
+++ b/tests/unit/test_log_config.py
@@ -1,0 +1,53 @@
+import io
+import logging
+from collections.abc import Iterator
+
+import pytest
+from rich.console import Console
+from rich.logging import RichHandler
+
+from gateway import log_config
+
+# A token long enough that RichHandler's narrow message column would hard-wrap it.
+LONG_SECRET = "gw-0cfzM-l0TufXyaDVCVE8J-P4dIgCle_lF8SVsF45Ty46Os3djCG8RfmLq8O-Mqwl"
+
+
+@pytest.fixture
+def captured_logger() -> Iterator[io.StringIO]:
+    """Point the gateway logger at a fixed-width StringIO console (mimics container logs)."""
+    buffer = io.StringIO()
+    console = Console(file=buffer, width=80)
+    logger = log_config.logger
+    saved_handlers = logger.handlers[:]
+    saved_level = logger.level
+    logger.handlers = [RichHandler(console=console, markup=True)]
+    logger.setLevel(logging.WARNING)
+    try:
+        yield buffer
+    finally:
+        logger.handlers = saved_handlers
+        logger.setLevel(saved_level)
+
+
+def test_log_secret_keeps_value_on_single_unbroken_line(captured_logger: io.StringIO) -> None:
+    log_config.log_secret("Save this key now:", LONG_SECRET)
+
+    output = captured_logger.getvalue()
+    # The whole secret must appear verbatim (no hard-wrap newlines inserted mid-token).
+    assert LONG_SECRET in output
+    # And it must occupy its own line with nothing else on it, so it copies cleanly.
+    assert any(line.strip() == LONG_SECRET for line in output.splitlines())
+
+
+def test_log_secret_emits_context_message(captured_logger: io.StringIO) -> None:
+    log_config.log_secret("Save this key now:", LONG_SECRET)
+
+    assert "Save this key now:" in captured_logger.getvalue()
+
+
+def test_log_secret_respects_log_level(captured_logger: io.StringIO) -> None:
+    log_config.logger.setLevel(logging.ERROR)
+
+    log_config.log_secret("Save this key now:", LONG_SECRET, level=logging.INFO)
+
+    assert captured_logger.getvalue() == ""


### PR DESCRIPTION
## Summary

- On a fresh `docker compose up`, `bootstrap_service.py` logged the generated API key through `RichHandler`. Rich hard-wraps its message column at the console width, and the key is one long whitespace-free token, so it was split across multiple physical lines. A user copying "the key line" got a truncated token and hit `{"detail":"Invalid API key"}` on their first request (issue #118).
- Added a `log_secret(message, secret, *, level=WARNING)` helper in `log_config.py`: it logs the contextual message normally, then writes the secret via a soft-wrapping console (`soft_wrap=True, crop=False`) so the value lands on its own unbroken line that copies verbatim from container logs. It respects the log level and reuses the active `RichHandler` console (stderr fallback otherwise).
- Bootstrap now calls `log_secret(...)` instead of interpolating the key into the wrapped warning.

Output now:

```
[..] WARNING  No API keys found. Created bootstrap key for first run. Save this key now:
gw-0cfzM-l0TufXyaDVCVE8J-P4dIgCle_lF8SVsF45Ty46Os3djCG8RfmLq8O-Mqwl
```

## Test plan

- [x] New `tests/unit/test_log_config.py`: verifies the secret stays verbatim on its own line (fails under the old wrapped behavior), the context message is still emitted, and the log level is respected.
- [x] `make lint` passes
- [x] `make typecheck` passes (152 files)
- [x] `uv run pytest tests/unit` passes (306 passed, 1 skipped)
- No API/schema/DB/config/CLI changes, so OpenAPI spec is unaffected.

Fixes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Problem
When the bootstrap API key was generated and logged during initial startup, the Rich logging handler would wrap the key across multiple physical lines. This made it impossible for users to copy a valid key from the logs—copying the visible "key line" would result in a truncated, broken key that failed authentication and broke the documented quickstart flow.

## Solution
Added a `log_secret()` helper function that ensures sensitive information (like API keys) is logged on a single, unbroken line without text wrapping. The context message is logged normally, and the secret itself appears on its own dedicated line using soft-wrapping that preserves the complete token.

Updated the bootstrap service to use this new function when emitting the generated API key.

## Changes
- **log_config.py**: Added `log_secret()` helper that logs messages with sensitive values on single unbroken lines, respecting the configured log level
- **bootstrap_service.py**: Updated to use `log_secret()` instead of directly logging the API key
- **test_log_config.py**: Added tests verifying the secret remains unbroken on a single line, the context message is emitted, and log level settings are respected

## Impact
Users can now reliably copy the bootstrap API key directly from container logs and use it as documented in the quickstart guide.

Fixes `#118`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->