### PR TITLE
docs: link to Otari CLI in the ecosystem table

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ You'll hear a few names. Here's how they fit together:
 | **Otari** | The proxy server otari.ai deploys (this repo). Run it standalone or connected to the platform. | [mozilla-ai/otari](https://github.com/mozilla-ai/otari) |
 | **any-llm** | The Python SDK Otari uses for core LLM routing across 40+ providers. | [mozilla-ai/any-llm](https://github.com/mozilla-ai/any-llm) |
 | **Otari SDKs** | Client SDKs you use to talk to otari.ai or a self-hosted Otari. | [Python](https://github.com/mozilla-ai/otari-sdk-python) · [TypeScript](https://github.com/mozilla-ai/otari-sdk-ts) · [Rust](https://github.com/mozilla-ai/otari-sdk-rust) · [Go](https://github.com/mozilla-ai/otari-sdk-go) |
+| **Otari CLI** | Command-line tool for accessing and managing Otari, a thin wrapper over the Python SDK (`pip install otari-cli`). | [mozilla-ai/otari-cli](https://github.com/mozilla-ai/otari-cli) |
 
 You can also use Otari with any OpenAI-compatible client (see [First request](#first-request-openai-sdk)).
 


### PR DESCRIPTION
## Description

Adds an **Otari CLI** row to the "The Otari ecosystem" table in `README.md`, pointing at [mozilla-ai/otari-cli](https://github.com/mozilla-ai/otari-cli). The CLI is now public and published to PyPI (`pip install otari-cli`), but there was no pointer to it from the gateway repo. It sits next to the SDKs row since the CLI is a thin wrapper over the Python SDK.

> **Draft:** awaiting https://github.com/mozilla-ai/otari-cli/issues/4 to be ready before merging.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #132

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

<!-- docs-only change (one README line): no test, lint, typecheck, or OpenAPI impact, so those boxes are intentionally left unchecked. -->

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:**

Drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
