### PR TITLE
feat(sdk-codegen): emit the rust core as an inlined src/_client module

### DIFF
--- a/.github/workflows/gateway-sdk-codegen.yml
+++ b/.github/workflows/gateway-sdk-codegen.yml
@@ -74,6 +74,12 @@ jobs:
       - name: Install OpenAPI Generator CLI
         run: npm install -g @openapitools/openapi-generator-cli
 
+      - name: Install rustfmt (rust core is inlined and formatted in place)
+        if: matrix.language == 'rust'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
       - name: Generate ${{ matrix.language }} client (full typed core)
         run: uv run python scripts/sdk_codegen/generate.py --language ${{ matrix.language }} --mode full --out-dir dist
 

--- a/.github/workflows/gateway-sdk-codegen.yml
+++ b/.github/workflows/gateway-sdk-codegen.yml
@@ -76,7 +76,9 @@ jobs:
 
       - name: Install rustfmt (rust core is inlined and formatted in place)
         if: matrix.language == 'rust'
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned to the stable branch tip (immutable SHA); the action still
+        # installs the latest stable toolchain at runtime.
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
 

--- a/.github/workflows/gateway-sdk-codegen.yml
+++ b/.github/workflows/gateway-sdk-codegen.yml
@@ -51,7 +51,7 @@ jobs:
             target_path: otari/client
           - language: rust
             sdk_repo: mozilla-ai/otari-sdk-rust
-            target_path: client
+            target_path: src/_client
 
     steps:
       - name: Checkout gateway

--- a/scripts/sdk_codegen/README.md
+++ b/scripts/sdk_codegen/README.md
@@ -94,7 +94,7 @@ with `Contents:write` and `Pull-requests:write` on the four SDK repos. The defau
 Raw generator output needs small fix-ups (applied by `postprocess`/`normalize`
 in `generate.py`, so no per-repo hand-edits to generated code are required):
 
-- **rust** — the generator emits a standalone crate, but the SDK inlines it as a
+- **rust**: the generator emits a standalone crate, but the SDK inlines it as a
   private `src/_client` module so the crate publishes to crates.io as a single
   unit (a path dependency on a separate `otari-client` crate is unpublishable;
   see mozilla-ai/otari-sdk-rust#37). `_rust_inline_module` reduces the crate to a

--- a/scripts/sdk_codegen/README.md
+++ b/scripts/sdk_codegen/README.md
@@ -80,7 +80,7 @@ repo with the regenerated client core dropped into:
 | python     | `mozilla-ai/otari-sdk-python` | `src/otari/_client`         |
 | typescript | `mozilla-ai/otari-sdk-ts`     | `src/_client`               |
 | go         | `mozilla-ai/otari-sdk-go`     | `otari/client`              |
-| rust       | `mozilla-ai/otari-sdk-rust`   | `client`                    |
+| rust       | `mozilla-ai/otari-sdk-rust`   | `src/_client`               |
 
 The matrix in the workflow mirrors `FULL_TARGETS` in `generate.py`; keep them in
 sync. Target paths match what each SDK's hand-written shell imports from.
@@ -94,11 +94,22 @@ with `Contents:write` and `Pull-requests:write` on the four SDK repos. The defau
 Raw generator output needs small fix-ups (applied by `postprocess`/`normalize`
 in `generate.py`, so no per-repo hand-edits to generated code are required):
 
-- **rust** — a `rustfmt.toml` with `disable_all_formatting` is written into the
-  crate, because the SDK's CI runs `cargo fmt --all -- --check`, which reaches
-  the generated crate (and `ignore` needs nightly). The emitted `Cargo.toml` is
-  also patched (placeholder version, and a `reqwest` pin/feature set that does
-  not build against the SDK's pinned `reqwest 0.12`).
+- **rust** — the generator emits a standalone crate, but the SDK inlines it as a
+  private `src/_client` module so the crate publishes to crates.io as a single
+  unit (a path dependency on a separate `otari-client` crate is unpublishable;
+  see mozilla-ai/otari-sdk-rust#37). `_rust_inline_module` reduces the crate to a
+  module tree: `src/lib.rs` becomes `mod.rs` with the crate-root attributes
+  replaced by a lint-exemption header (the module declarations are kept), the
+  rest of `src/` is hoisted up, the crate scaffolding (`Cargo.toml`, docs,
+  generator metadata) is dropped, and every `.rs` file is run through `rustfmt`
+  (the module is now reached by the SDK's `cargo fmt --all -- --check`).
+
+  Because the emitted `Cargo.toml` is dropped, the generated core's
+  dependencies live in the SDK crate's `Cargo.toml` (`serde_with`, `url`,
+  `uuid`, the `chrono` `serde` feature, the `reqwest` `multipart` feature). If a
+  regeneration starts using a new crate, add that dependency to the SDK
+  `Cargo.toml` by hand; the endpoint-coverage drift gate will not catch a
+  missing dependency.
 - **typescript** — the `mapValues` helper the models import is appended to
   `runtime.ts` (this generator version omits it).
 - **go** — the generated `test/` dir is dropped (its unfilled

--- a/scripts/sdk_codegen/generate.py
+++ b/scripts/sdk_codegen/generate.py
@@ -457,7 +457,14 @@ def _rust_inline_module(dest: Path) -> None:
         body = "pub mod apis;\npub mod models;"
 
     for child in sorted(src.iterdir()):
-        shutil.move(str(child), str(dest / child.name))
+        # Clear any same-named entry first so re-running into a non-empty
+        # out-dir overwrites rather than nesting (e.g. apis/ into apis/apis/).
+        target = dest / child.name
+        if target.is_dir():
+            shutil.rmtree(target)
+        elif target.exists():
+            target.unlink()
+        shutil.move(str(child), str(target))
     src.rmdir()
     (dest / "mod.rs").write_text(_RUST_MODULE_HEADER + body + "\n")
 

--- a/scripts/sdk_codegen/generate.py
+++ b/scripts/sdk_codegen/generate.py
@@ -58,6 +58,11 @@ class LanguageTarget:
     additional_properties: str
     sdk_repo: str
     target_path: str
+    # When true, the generated output is reduced from a standalone crate to a
+    # single module tree (lib.rs -> mod.rs, crate scaffolding dropped) so the SDK
+    # publishes as one crate with no path dependency. Rust full mode only; see
+    # _rust_inline_module.
+    inline_module: bool = False
 
 
 # target_path is where the generated client is dropped inside the SDK repo by
@@ -120,9 +125,32 @@ FULL_TARGETS: dict[str, LanguageTarget] = {
         generator="rust",
         additional_properties="packageName=otari-client,library=reqwest",
         sdk_repo="mozilla-ai/otari-sdk-rust",
-        target_path="client",
+        # Inlined as a private module of the SDK crate (not a separate crate), so
+        # the crate publishes to crates.io as a single unit with no path
+        # dependency. The SDK's src/lib.rs declares `mod _client` and re-exports
+        # `apis` / `models` at the crate root for the generated code's
+        # `crate::models` / `crate::apis` paths.
+        target_path="src/_client",
+        inline_module=True,
     ),
 }
+
+
+# Header prepended to the inlined Rust core's mod.rs (replacing the generator's
+# own crate-root attributes). Exempts the generated code from the SDK crate's
+# strict lints, the way it had its own relaxed lints as a separate crate.
+_RUST_MODULE_HEADER = """\
+//! OpenAPI-generated typed core. This module is produced by the otari codegen
+//! pipeline (scripts/sdk_codegen) and is not hand-edited; the lint allowances
+//! below exempt it from the SDK crate's strict lints, which it escaped when it
+//! lived in its own crate. Do not add hand-written code here.
+#![allow(unused_imports)]
+#![allow(dead_code)]
+#![allow(clippy::all)]
+#![allow(clippy::pedantic)]
+#![allow(clippy::nursery)]
+
+"""
 
 
 # Helper that this generator version's typescript-fetch models import from
@@ -377,6 +405,78 @@ def normalize(language: str, dest: Path, python_package: str) -> None:
             shutil.move(str(staged), str(dest))
 
 
+def _rustfmt_tree(dest: Path) -> None:
+    """Format the inlined Rust module in place with rustfmt.
+
+    The inlined core becomes part of the SDK crate, so it is reached by the SDK
+    repo's ``cargo fmt --all -- --check``; the old separate crate was exempted
+    via ``rustfmt.toml``. rustfmt recurses into child ``mod`` declarations by
+    default, so formatting the module root (``mod.rs``) formats the whole tree.
+    Missing rustfmt warns and skips rather than failing, mirroring the go path.
+    """
+    rustfmt = shutil.which("rustfmt")
+    if rustfmt is None:
+        warnings.warn(
+            "rustfmt not found on PATH; skipping format of the generated Rust "
+            "core (the SDK repo's `cargo fmt --all -- --check` may then fail).",
+            stacklevel=2,
+        )
+        return
+    root = dest / "mod.rs"
+    if root.exists():
+        subprocess.run([rustfmt, "--edition", "2021", str(root)], check=True)
+
+
+def _rust_inline_module(dest: Path) -> None:
+    """Reduce the generated Rust crate at ``dest`` to a single module tree.
+
+    The crate split (`otari` shell + generated `otari-client` core wired as a
+    path dependency) made the SDK unpublishable: ``cargo publish`` rejects a path
+    dependency with no version. Inlining the core as a private module of the SDK
+    crate fixes that (see mozilla-ai/otari-sdk-rust#37). This rewrites the
+    generator's crate output so it drops cleanly into the SDK's ``src/_client``:
+
+    - ``src/lib.rs`` -> ``mod.rs`` with the crate-root attributes replaced by the
+      SDK lint-exemption header (the module declarations are preserved);
+    - the rest of ``src/`` (``apis/``, ``models/``) is hoisted to ``dest``;
+    - crate scaffolding (``Cargo.toml``, docs, generator metadata, etc.) is
+      dropped, since the core's dependencies live in the SDK crate's Cargo.toml;
+    - every ``.rs`` file is formatted (the old separate crate was rustfmt-exempt).
+    """
+    src = dest / "src"
+    lib = src / "lib.rs"
+    if lib.exists():
+        lines = lib.read_text().splitlines()
+        start = next(
+            (i for i, line in enumerate(lines) if line.startswith(("pub mod ", "mod "))),
+            len(lines),
+        )
+        body = "\n".join(lines[start:]).strip()
+        lib.unlink()
+    else:
+        body = "pub mod apis;\npub mod models;"
+
+    for child in sorted(src.iterdir()):
+        shutil.move(str(child), str(dest / child.name))
+    src.rmdir()
+    (dest / "mod.rs").write_text(_RUST_MODULE_HEADER + body + "\n")
+
+    for name in (
+        "Cargo.toml",
+        "README.md",
+        ".travis.yml",
+        "git_push.sh",
+        ".gitignore",
+        "rustfmt.toml",
+        ".openapi-generator-ignore",
+    ):
+        (dest / name).unlink(missing_ok=True)
+    for directory in ("docs", ".openapi-generator"):
+        shutil.rmtree(dest / directory, ignore_errors=True)
+
+    _rustfmt_tree(dest)
+
+
 def generate_language(language: str, spec_path: Path, out_dir: Path, target: LanguageTarget) -> Path:
     """Run OpenAPI Generator for ``language`` and return the output directory."""
     dest = out_dir / language
@@ -393,8 +493,11 @@ def generate_language(language: str, spec_path: Path, out_dir: Path, target: Lan
         target.additional_properties,
     ]
     subprocess.run(cmd, check=True)
-    postprocess(language, dest)
-    normalize(language, dest, target.target_path.rsplit("/", 1)[-1])
+    if target.inline_module:
+        _rust_inline_module(dest)
+    else:
+        postprocess(language, dest)
+        normalize(language, dest, target.target_path.rsplit("/", 1)[-1])
     return dest
 
 

--- a/tests/unit/test_sdk_codegen.py
+++ b/tests/unit/test_sdk_codegen.py
@@ -330,6 +330,27 @@ def test_rust_inline_module_without_lib_rs_falls_back(
     assert "pub mod models;" in text
 
 
+def test_rust_inline_module_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Re-running into the same out-dir (a fresh generator payload dropped beside
+    # the previous inlined output) must overwrite, not nest (no apis/apis/).
+    monkeypatch.setattr(generate, "_rustfmt_tree", lambda _dest: None)
+    dest = tmp_path / "rust"
+    dest.mkdir()
+    _fake_rust_crate(dest)
+    generate._rust_inline_module(dest)
+
+    # Second generator run drops a fresh crate payload beside the inlined output.
+    _fake_rust_crate(dest)
+    generate._rust_inline_module(dest)
+
+    assert (dest / "apis" / "configuration.rs").exists()
+    assert not (dest / "apis" / "apis").exists()
+    assert not (dest / "models" / "models").exists()
+    assert not (dest / "src").exists()
+
+
 def test_rust_inline_module_skips_rustfmt_gracefully(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_sdk_codegen.py
+++ b/tests/unit/test_sdk_codegen.py
@@ -246,3 +246,112 @@ def test_control_plane_tags_are_typed_management_only() -> None:
     # untyped in the spec (so generation would regress them).
     for excluded in ("chat", "responses", "embeddings", "batches"):
         assert excluded not in generate.CONTROL_PLANE_TAGS
+
+
+def _fake_rust_crate(dest: Path) -> None:
+    """Build a minimal stand-in for the rust generator's crate output."""
+    src = dest / "src"
+    (src / "apis").mkdir(parents=True)
+    (src / "models").mkdir(parents=True)
+    (src / "lib.rs").write_text(
+        "#![allow(unused_imports)]\n"
+        "#![allow(clippy::too_many_arguments)]\n"
+        "\n"
+        "extern crate serde;\n"
+        "extern crate reqwest;\n"
+        "\n"
+        "pub mod apis;\n"
+        "pub mod models;\n"
+    )
+    (src / "apis" / "mod.rs").write_text("pub mod configuration;\n")
+    (src / "apis" / "configuration.rs").write_text("pub struct Configuration {}\n")
+    (src / "models" / "mod.rs").write_text("pub mod thing;\n")
+    (src / "models" / "thing.rs").write_text("pub struct Thing {}\n")
+    (dest / "Cargo.toml").write_text('[package]\nname = "otari-client"\n')
+    (dest / "README.md").write_text("# generated\n")
+    (dest / ".travis.yml").write_text("language: rust\n")
+    (dest / "rustfmt.toml").write_text("disable_all_formatting = true\n")
+    docs = dest / "docs"
+    docs.mkdir()
+    (docs / "Thing.md").write_text("# Thing\n")
+    meta = dest / ".openapi-generator"
+    meta.mkdir()
+    (meta / "VERSION").write_text("7.0.0\n")
+
+
+def test_rust_inline_module_reduces_crate_to_module(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Format is exercised separately; stub it so this test is deterministic and
+    # does not depend on rustfmt being installed.
+    monkeypatch.setattr(generate, "_rustfmt_tree", lambda _dest: None)
+    dest = tmp_path / "rust"
+    dest.mkdir()
+    _fake_rust_crate(dest)
+
+    generate._rust_inline_module(dest)
+
+    # lib.rs -> mod.rs: SDK lint header replaces the crate-root attributes /
+    # extern crate lines, module declarations preserved.
+    mod = dest / "mod.rs"
+    assert mod.exists()
+    text = mod.read_text()
+    assert "pub mod apis;" in text
+    assert "pub mod models;" in text
+    assert "#![allow(clippy::pedantic)]" in text
+    assert "extern crate" not in text
+    assert "clippy::too_many_arguments" not in text
+
+    # src/ hoisted up to the module root; nested module files preserved.
+    assert (dest / "apis" / "configuration.rs").exists()
+    assert (dest / "models" / "thing.rs").exists()
+    assert not (dest / "src").exists()
+
+    # crate scaffolding dropped.
+    for gone in ("Cargo.toml", "README.md", ".travis.yml", "rustfmt.toml", "lib.rs"):
+        assert not (dest / gone).exists()
+    assert not (dest / "docs").exists()
+    assert not (dest / ".openapi-generator").exists()
+
+
+def test_rust_inline_module_without_lib_rs_falls_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A partial payload with no lib.rs must still yield a usable mod.rs.
+    monkeypatch.setattr(generate, "_rustfmt_tree", lambda _dest: None)
+    dest = tmp_path / "rust"
+    (dest / "src" / "apis").mkdir(parents=True)
+    (dest / "src" / "models").mkdir(parents=True)
+
+    generate._rust_inline_module(dest)
+
+    text = (dest / "mod.rs").read_text()
+    assert "pub mod apis;" in text
+    assert "pub mod models;" in text
+
+
+def test_rust_inline_module_skips_rustfmt_gracefully(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # When rustfmt is absent, the transform still runs and only formatting is
+    # skipped (with a warning), mirroring the go/gofmt path.
+    monkeypatch.setattr(generate.shutil, "which", lambda _name: None)
+    dest = tmp_path / "rust"
+    dest.mkdir()
+    _fake_rust_crate(dest)
+
+    with pytest.warns(UserWarning, match="rustfmt"):
+        generate._rust_inline_module(dest)
+
+    assert (dest / "mod.rs").exists()
+    assert (dest / "apis" / "configuration.rs").exists()
+    assert not (dest / "src").exists()
+
+
+def test_full_rust_target_is_inlined_module() -> None:
+    # The full rust target must drop into src/_client as an inlined module, so a
+    # regeneration does not recreate the separate `client/` crate that made the
+    # SDK unpublishable.
+    rust = generate.FULL_TARGETS["rust"]
+    assert rust.target_path == "src/_client"
+    assert rust.inline_module is True


### PR DESCRIPTION
## Description
<!-- What does this PR do and why? -->

The rust SDK could not publish to crates.io. When the generated SDK landed, `otari-sdk-rust` was split into the `otari` shell crate plus a generated `otari-client` core, wired as a path dependency; `cargo publish` rejects a path dependency that has no version and is not itself on crates.io. The SDK was fixed by inlining the generated core as a private `src/_client` module (mozilla-ai/otari-sdk-rust#37), but this codegen still emitted the core as a separate `client/` crate, so the next regeneration would revert that fix and re-break publishing.

This makes the codegen reproduce the inlined layout:

- Add an `inline_module` flag to `LanguageTarget`; set it on the full rust target, whose `target_path` becomes `src/_client`.
- `_rust_inline_module` reduces the generated crate to a module tree: `src/lib.rs` becomes `mod.rs` with the crate-root attributes replaced by a lint-exemption header (module declarations preserved), the rest of `src/` is hoisted up, the crate scaffolding (`Cargo.toml`, docs, generator metadata) is dropped, and every `.rs` file is run through rustfmt (the module is now reached by the SDK's `cargo fmt --all -- --check`).
- `generate_language` runs this transform for inline targets and keeps `postprocess`/`normalize` for everything else, so other languages and legacy control-plane rust are unchanged.
- The workflow rust `target_path` and the codegen README are updated, including a note that the core's dependencies now live in the SDK crate's `Cargo.toml`.

**Validation:** running `_rust_inline_module` on the real pre-#37 generated crate reproduces the hand-built `src/_client` exactly (184/184 `.rs` files byte-identical; only the `mod.rs` header comment differs, by design). So a regeneration produces the same working module rather than reverting the SDK fix.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

Fixes #134

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). (N/A: no API contract change; codegen tooling only.)

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:** Implemented via the fix-github-issue workflow; validated by diffing the transform output against the hand-built `src/_client` from mozilla-ai/otari-sdk-rust#37.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR modifies the Rust SDK code generator to emit the generated core code as an inlined module within the SDK package instead of as a separate standalone crate. This change resolves a publishing issue where the generated code couldn't be published to crates.io due to unresolved path dependencies.

## Key Changes

**Workflow Updates**
- Updated the code generation workflow to change the Rust output location from a `client/` crate to `src/_client` within the SDK repository
- Added installation of `rustfmt` to the workflow when generating Rust code

**Generator Logic**
- Added an `inline_module` flag to the language target configuration to support inline module generation
- Implemented transformation logic that:
  - Converts the generated crate structure into a single module by rewriting `src/lib.rs` into `mod.rs`
  - Hoists all generated source files up to the module level
  - Removes crate scaffolding files (like `Cargo.toml`, documentation, and generator metadata)
  - Adds a lint-exemption header to the generated module
  - Runs code formatting via `rustfmt` on the inlined files

**Documentation & Testing**
- Updated the codegen README to document the new inlining approach and clarify that dependencies are now maintained in the SDK's `Cargo.toml`
- Added comprehensive tests validating the inline transformation, including fallback behavior when `lib.rs` is missing and graceful handling when `rustfmt` is unavailable

## Benefits

- Eliminates the crates.io publishing failure by making the generated code part of the SDK package
- Simplifies the SDK structure by combining the generated and hand-written code into a single package
- Reduces maintenance burden since dependency management is consolidated in one `Cargo.toml` file
- Ensures regenerated code remains compatible with the SDK's existing code formatting standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->