### PR TITLE
feat(sdk-codegen): coordinate SDK releases with stamped spec version and staleness alert

### DIFF
--- a/.github/workflows/gateway-sdk-codegen.yml
+++ b/.github/workflows/gateway-sdk-codegen.yml
@@ -83,7 +83,18 @@ jobs:
           components: rustfmt
 
       - name: Generate ${{ matrix.language }} client (full typed core)
-        run: uv run python scripts/sdk_codegen/generate.py --language ${{ matrix.language }} --mode full --out-dir dist
+        # On a release, stamp the release tag as the spec version into the
+        # generated core so each SDK can surface the gateway/spec version it was
+        # generated from. On spec-change pushes there is no release tag, so the
+        # spec's own info.version is used.
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          args=(--language "${{ matrix.language }}" --mode full --out-dir dist)
+          if [ -n "${RELEASE_TAG}" ]; then
+            args+=(--spec-version "${RELEASE_TAG}")
+          fi
+          uv run python scripts/sdk_codegen/generate.py "${args[@]}"
 
       - name: Checkout ${{ matrix.sdk_repo }}
         uses: actions/checkout@v6

--- a/.github/workflows/gateway-sdk-codegen.yml
+++ b/.github/workflows/gateway-sdk-codegen.yml
@@ -83,16 +83,18 @@ jobs:
           components: rustfmt
 
       - name: Generate ${{ matrix.language }} client (full typed core)
-        # On a release, stamp the release tag as the spec version into the
+        # On a release, stamp the release version as the spec version into the
         # generated core so each SDK can surface the gateway/spec version it was
-        # generated from. On spec-change pushes there is no release tag, so the
-        # spec's own info.version is used.
+        # generated from. The leading "v" is stripped so the stamp is clean semver
+        # (matching how the SDK publish flows derive the version from the tag). On
+        # spec-change pushes there is no release tag, so the spec's own
+        # info.version is used.
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           args=(--language "${{ matrix.language }}" --mode full --out-dir dist)
           if [ -n "${RELEASE_TAG}" ]; then
-            args+=(--spec-version "${RELEASE_TAG}")
+            args+=(--spec-version "${RELEASE_TAG#v}")
           fi
           uv run python scripts/sdk_codegen/generate.py "${args[@]}"
 

--- a/.github/workflows/sdk-regen-staleness.yml
+++ b/.github/workflows/sdk-regen-staleness.yml
@@ -30,7 +30,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gateway
+        # The script authenticates via the gh CLI using the env tokens below, so
+        # the checkout's persisted git credential is unused; drop it to avoid
+        # leaving GITHUB_TOKEN in .git/config while repository code runs.
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/sdk-regen-staleness.yml
+++ b/.github/workflows/sdk-regen-staleness.yml
@@ -1,0 +1,52 @@
+name: SDK Regen PR Staleness
+
+# Alerts when an SDK regeneration PR (opened by gateway-sdk-codegen.yml on the
+# sdk-codegen/client-core branch) sits unmerged beyond the freshness window,
+# which signals an SDK lagging the gateway spec. Keeps a single tracking issue on
+# this repo in sync: opened/updated while any PR is stale, closed once none are.
+#
+# Reading PRs on the SDK repos needs a token with pull-requests:read on
+# mozilla-ai/otari-sdk-{python,ts,go,rust}; the SDK_CODEGEN_TOKEN used by the
+# codegen workflow already has it. The default GITHUB_TOKEN manages the tracking
+# issue on this repo.
+
+on:
+  schedule:
+    # Mondays at 13:00 UTC.
+    - cron: '0 13 * * 1'
+  workflow_dispatch:
+    inputs:
+      max_age_days:
+        description: 'Days a regeneration PR may stay open before it is flagged'
+        required: false
+        default: '7'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gateway
+        uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: 3.13
+
+      - name: Check for stale regeneration PRs
+        env:
+          # SDK repos live outside this repo, so the cross-repo read token is
+          # required; the tracking issue on this repo uses GITHUB_TOKEN.
+          GH_TOKEN: ${{ secrets.SDK_CODEGEN_TOKEN }}
+          GATEWAY_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAX_AGE_DAYS: ${{ github.event.inputs.max_age_days || '7' }}
+        # The script is stdlib-only and shells out to the preinstalled gh CLI, so
+        # the project environment does not need syncing.
+        run: |
+          uv run --no-project python scripts/check_stale_regen_prs.py \
+            --max-age-days "${MAX_AGE_DAYS}" \
+            --tracking-repo "${GITHUB_REPOSITORY}" \
+            --apply

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,57 @@
+# Releasing
+
+This document covers releasing the otari gateway. The language SDKs release
+separately on their own tracks; see [SDK releases](#sdk-releases) below.
+
+## Releasing the gateway
+
+The gateway is distributed as a Docker image (`docker.io/mzdotai/otari`). A
+release is cut manually by publishing a GitHub Release with a semver tag; there is
+no release-please on the gateway.
+
+### Steps
+
+1. Update `CHANGELOG.md`: move the `[Unreleased]` entries into a new versioned
+   section (this project follows [Keep a Changelog](https://keepachangelog.com/)).
+   Open this as a normal PR and merge it to `main`.
+2. Publish a GitHub Release with a semver tag (for example `v0.4.0`). Creating the
+   Release creates the tag.
+
+Two workflows react to the published Release:
+
+- **`gateway-docker.yml`** builds and pushes the multi-arch image to Docker Hub,
+  tagged `{{version}}` (e.g. `0.4.0`), `{{major}}.{{minor}}` (e.g. `0.4`), and the
+  short commit SHA. The release tag is baked in as the `GATEWAY_VERSION` build
+  arg, so the running gateway reports it on `/health` and in the OpenAPI
+  `info.version`.
+- **`gateway-sdk-codegen.yml`** regenerates each SDK's typed core, stamps the
+  release version into the core, and opens a regeneration PR on each SDK repo.
+
+### Continuous (non-release) builds
+
+Every push to `main` that touches the service also builds and pushes a Docker
+image tagged `latest` and the short SHA, with `GATEWAY_VERSION` set to the commit
+SHA. These are not releases; only a published GitHub Release produces a
+semver-tagged image.
+
+### Prerequisites (repository secrets)
+
+- `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`, used by `gateway-docker.yml` to push
+  the image.
+- `SDK_CODEGEN_TOKEN`, used by `gateway-sdk-codegen.yml` to open regeneration PRs
+  on the SDK repos.
+
+## SDK releases
+
+The four language SDKs (`otari-sdk-python`, `otari-sdk-ts`, `otari-sdk-go`,
+`otari-sdk-rust`) are versioned independently of the gateway and release on their
+own tracks with [release-please](https://github.com/googleapis/release-please). A
+gateway release does not release any SDK; it only opens the regeneration PRs
+described above. A maintainer reviews and merges each, after which that SDK's own
+release-please flow opens a release PR, and merging it cuts and publishes that
+SDK's release.
+
+For the full model (the spec-version compatibility scheme, the two-merge
+lifecycle, and the per-SDK registries and secrets) see
+[`docs/sdk-compatibility.md`](docs/sdk-compatibility.md) and each SDK repo's
+`RELEASE.md`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,3 +28,4 @@ Start with the [Quickstart](quickstart.md). It gets the gateway running locally 
 - [Use with opencode](use-with-opencode.md) — point the opencode CLI at the gateway.
 - [Supported models](supported-models.md) — providers, model format, and capabilities.
 - [Platform protocol](platform-protocol.md) — the gateway/platform wire contract, for platform builders.
+- [SDK compatibility](sdk-compatibility.md) — how the language SDKs are released and which SDK version works with which gateway.

--- a/docs/sdk-compatibility.md
+++ b/docs/sdk-compatibility.md
@@ -30,6 +30,35 @@ wiring, which the endpoint-coverage drift gate exists to catch. Auto-publishing 
 a gateway release would either ship an incomplete SDK or block the gateway release
 on shell work across four repos.
 
+## Release flow
+
+The gateway and the SDKs release on independent tracks, joined only by the spec
+version stamped into each generated core. End to end:
+
+1. **Regeneration.** The codegen workflow (`.github/workflows/gateway-sdk-codegen.yml`)
+   runs on a gateway release or on a push to `main` that changes
+   `docs/public/openapi.json`. It regenerates each SDK's typed core, stamps the
+   spec version into the core's marker (the release version on a release, the
+   spec's `info.version` otherwise), and opens a regeneration PR on each SDK repo
+   on the `sdk-codegen/client-core` branch.
+2. **Review and merge the regeneration PR.** This is the first human gate: a
+   regenerated core is not automatically releasable, because a new endpoint may
+   still need hand-written shell wiring (the endpoint-coverage drift gate catches
+   this). A shell-only change (streaming, error mapping) follows the same path as
+   an ordinary PR to the SDK repo, with no regeneration needed.
+3. **release-please accumulates.** Each SDK repo runs release-please on `main`.
+   From the conventional commits since the last release it opens or updates a
+   single release PR that bumps the SDK's own version and writes `CHANGELOG.md`.
+4. **Review and merge the release PR.** This is the second human gate. Merging it
+   makes release-please tag the release and create a GitHub Release.
+5. **Publish.** In the same workflow run (gated on `release_created`), the SDK is
+   published to its registry (PyPI, npm, crates.io). Go has no publish step: the
+   tag is the release, consumed via `go get`.
+
+So a spec change reaches users through two reviewable merges: the regeneration PR,
+then the release PR. Each SDK repo documents its own registry, secrets, and version
+file in that repo's `RELEASE.md`.
+
 ## Spec version
 
 Each SDK reports the gateway/spec version its generated core was built from. The

--- a/docs/sdk-compatibility.md
+++ b/docs/sdk-compatibility.md
@@ -1,0 +1,78 @@
+# SDK release coordination and compatibility
+
+This page describes how the language SDKs (`otari-sdk-python`, `otari-sdk-ts`,
+`otari-sdk-go`, `otari-sdk-rust`) are released relative to the gateway, and how to
+tell which SDK version works with which gateway.
+
+## Release policy
+
+The SDKs are not version-locked to the gateway. The policy:
+
+1. **A gateway release does not directly trigger SDK releases.** The codegen
+   workflow opens a regeneration PR against each SDK repo on spec change; that PR
+   stays the human review gate.
+2. **The trigger for regeneration is a change to `docs/public/openapi.json`,** not
+   the gateway release event. Most gateway releases do not touch the spec.
+3. **Each SDK is versioned independently** with its own semver, not locked to the
+   gateway version. A shell-only fix (streaming, error mapping) can warrant an SDK
+   release with no gateway change, and a no-op spec change should not bump every
+   SDK.
+4. **Compatibility is expressed through the spec version,** not matching package
+   numbers. The gateway/spec version is stamped into each generated core so the
+   SDK can surface it, and this page documents the compatibility matrix.
+5. **Release automation lives in each SDK repo,** triggered when a regeneration or
+   shell PR merges to that repo's main.
+
+The reason releases are decoupled: the SDKs are a generated typed core plus a
+hand-written shell (streaming, typed error mapping, ergonomic methods). A
+regenerated core is not automatically releasable; a new endpoint may need shell
+wiring, which the endpoint-coverage drift gate exists to catch. Auto-publishing on
+a gateway release would either ship an incomplete SDK or block the gateway release
+on shell work across four repos.
+
+## Spec version
+
+Each SDK reports the gateway/spec version its generated core was built from. The
+gateway stamps that version into the core during codegen
+(`scripts/sdk_codegen/generate.py`); on a gateway release the codegen workflow
+passes the release tag, so the stamp is the real release version rather than the
+`0.0.0-dev` placeholder in the committed spec.
+
+How each SDK surfaces it:
+
+| Language   | Accessor                          |
+|------------|-----------------------------------|
+| python     | `otari.__spec_version__`          |
+| typescript | `SPEC_VERSION`                    |
+| go         | `otari.SpecVersion`               |
+| rust       | `otari::SPEC_VERSION`             |
+
+The exact accessor each SDK exports is finalized in that SDK's shell; the value is
+the gateway/spec version the core was generated from.
+
+## Compatibility matrix
+
+A given SDK version targets the gateway/spec version stamped into its core. An SDK
+works against any gateway whose spec version is greater than or equal to the
+version the SDK was generated from, as long as the gateway has not removed an
+endpoint or field the SDK relies on. New gateway endpoints are additive: an older
+SDK simply does not surface them.
+
+The matrix below maps each gateway/spec version to the minimum SDK version that
+targets it. It is updated as the gateway and SDKs cut releases; until the first
+tagged releases land, every component reports the `0.0.0-dev` placeholder.
+
+| Gateway / spec version | otari-sdk-python | otari-sdk-ts | otari-sdk-go | otari-sdk-rust |
+|------------------------|------------------|--------------|--------------|----------------|
+| `0.0.0-dev` (unreleased) | unreleased     | unreleased   | unreleased   | unreleased     |
+
+To read the matrix: find the gateway/spec version you run (its value is in the
+spec's `info.version` and is reported on `/health`), then use at least the SDK
+version in that row for your language.
+
+## Related
+
+- [`scripts/sdk_codegen/README.md`](https://github.com/mozilla-ai/otari/blob/main/scripts/sdk_codegen/README.md)
+  for how the core is generated and where the spec version is stamped.
+- The codegen workflow (`.github/workflows/gateway-sdk-codegen.yml`) and the
+  staleness alert (`.github/workflows/sdk-regen-staleness.yml`).

--- a/docs/sdk-compatibility.md
+++ b/docs/sdk-compatibility.md
@@ -35,8 +35,8 @@ on shell work across four repos.
 Each SDK reports the gateway/spec version its generated core was built from. The
 gateway stamps that version into the core during codegen
 (`scripts/sdk_codegen/generate.py`); on a gateway release the codegen workflow
-passes the release tag, so the stamp is the real release version rather than the
-`0.0.0-dev` placeholder in the committed spec.
+passes the release version (the tag without its leading `v`), so the stamp is the
+real release version rather than the `0.0.0-dev` placeholder in the committed spec.
 
 How each SDK surfaces it:
 

--- a/scripts/check_stale_regen_prs.py
+++ b/scripts/check_stale_regen_prs.py
@@ -57,9 +57,9 @@ def pr_age_days(pr: dict[str, Any], now: datetime) -> float:
 
 
 def select_stale(prs: list[dict[str, Any]], max_age_days: float, now: datetime) -> list[dict[str, Any]]:
-    """Return ``prs`` older than ``max_age_days``, newest-first.
+    """Return ``prs`` older than ``max_age_days``, oldest-first.
 
-    A PR exactly at the threshold is not yet stale; it must exceed it.
+    A PR at the threshold is not yet stale; it must exceed it.
     """
     stale = [pr for pr in prs if pr_age_days(pr, now) > max_age_days]
     return sorted(stale, key=lambda pr: pr["createdAt"])

--- a/scripts/check_stale_regen_prs.py
+++ b/scripts/check_stale_regen_prs.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Alert when an SDK regeneration PR sits unmerged beyond a threshold.
+
+The gateway opens a regeneration PR against each SDK repo whenever the OpenAPI
+spec changes (``.github/workflows/gateway-sdk-codegen.yml``, branch
+``sdk-codegen/client-core``). That PR is the human review gate: the generated
+core can land in the spec without the matching hand-written shell wiring, so the
+PR is meant to be reviewed and merged, not left open. A regeneration PR that
+lingers means an SDK is lagging the spec.
+
+This script lists the open regeneration PR (if any) on each SDK repo, flags the
+ones older than ``--max-age-days``, and renders a report. With ``--apply`` it
+also keeps a single tracking issue on the gateway repo in sync: opened/updated
+while any PR is stale, closed once none are.
+
+Pure selection/rendering is unit-tested; the ``gh`` calls are thin wrappers.
+
+Usage:
+    python scripts/check_stale_regen_prs.py --max-age-days 7
+    python scripts/check_stale_regen_prs.py --apply   # CI: sync the tracking issue
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+from typing import Any
+
+# The SDK repos the codegen workflow opens regeneration PRs against. Keep in sync
+# with the matrix in .github/workflows/gateway-sdk-codegen.yml.
+DEFAULT_SDK_REPOS: tuple[str, ...] = (
+    "mozilla-ai/otari-sdk-python",
+    "mozilla-ai/otari-sdk-ts",
+    "mozilla-ai/otari-sdk-go",
+    "mozilla-ai/otari-sdk-rust",
+)
+# Head branch the codegen workflow pushes regeneration PRs from.
+DEFAULT_BRANCH = "sdk-codegen/client-core"
+DEFAULT_MAX_AGE_DAYS = 7
+DEFAULT_TRACKING_REPO = "mozilla-ai/otari"
+# Marks the single tracking issue this script owns, so reruns update it in place.
+TRACKING_LABEL = "sdk-regen-stale"
+
+
+def parse_iso8601(value: str) -> datetime:
+    """Parse a GitHub ISO-8601 timestamp (``...Z``) into an aware UTC datetime."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def pr_age_days(pr: dict[str, Any], now: datetime) -> float:
+    """Age of ``pr`` in days from its ``createdAt`` to ``now``."""
+    created = parse_iso8601(pr["createdAt"])
+    return (now - created).total_seconds() / 86400.0
+
+
+def select_stale(prs: list[dict[str, Any]], max_age_days: float, now: datetime) -> list[dict[str, Any]]:
+    """Return ``prs`` older than ``max_age_days``, newest-first.
+
+    A PR exactly at the threshold is not yet stale; it must exceed it.
+    """
+    stale = [pr for pr in prs if pr_age_days(pr, now) > max_age_days]
+    return sorted(stale, key=lambda pr: pr["createdAt"])
+
+
+def render_report(stale: list[dict[str, Any]], max_age_days: float, now: datetime) -> str:
+    """Render a markdown report of the stale regeneration PRs."""
+    if not stale:
+        return "All SDK regeneration PRs are within the freshness window (or none are open)."
+    lines = [
+        f"The following SDK regeneration PRs have been open longer than {max_age_days:g} "
+        "days, signalling an SDK lagging the gateway spec. Review and merge them, or "
+        "close any that are obsolete.",
+        "",
+        "| Repo | PR | Age (days) | Opened |",
+        "| --- | --- | --- | --- |",
+    ]
+    for pr in stale:
+        age = pr_age_days(pr, now)
+        lines.append(
+            f"| {pr['repo']} | [#{pr['number']}]({pr['url']}) | {age:.1f} | {pr['createdAt']} |"
+        )
+    return "\n".join(lines)
+
+
+def _gh(args: list[str], token: str | None = None) -> str:
+    """Run a ``gh`` command and return stdout, raising on failure.
+
+    When ``token`` is given it overrides ``GH_TOKEN`` for that call only. The SDK
+    repos and this repo can need different tokens (a cross-repo PAT reads the SDK
+    PRs; this repo's own token manages the tracking issue), so each call selects
+    its credential rather than relying on a single ambient one.
+    """
+    env = None
+    if token:
+        env = {**os.environ, "GH_TOKEN": token}
+    result = subprocess.run(["gh", *args], check=True, capture_output=True, text=True, env=env)
+    return result.stdout
+
+
+def fetch_open_regen_prs(repo: str, branch: str) -> list[dict[str, Any]]:
+    """List the open regeneration PRs on ``repo`` for head ``branch``.
+
+    Each returned PR is annotated with its ``repo`` for the report.
+    """
+    out = _gh(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--head",
+            branch,
+            "--state",
+            "open",
+            "--json",
+            "number,title,url,createdAt",
+        ]
+    )
+    prs: list[dict[str, Any]] = json.loads(out) if out.strip() else []
+    for pr in prs:
+        pr["repo"] = repo
+    return prs
+
+
+def _find_tracking_issue(tracking_repo: str, token: str | None) -> int | None:
+    """Return the open tracking issue number for this script, if one exists."""
+    out = _gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            tracking_repo,
+            "--label",
+            TRACKING_LABEL,
+            "--state",
+            "open",
+            "--json",
+            "number",
+        ],
+        token=token,
+    )
+    issues: list[dict[str, Any]] = json.loads(out) if out.strip() else []
+    return int(issues[0]["number"]) if issues else None
+
+
+def sync_tracking_issue(
+    tracking_repo: str, stale: list[dict[str, Any]], body: str, token: str | None = None
+) -> None:
+    """Open/update the tracking issue while PRs are stale; close it once none are.
+
+    A single issue (identified by the ``sdk-regen-stale`` label) is reused across
+    runs so the alert does not pile up duplicates. ``token`` authenticates the
+    issue operations on ``tracking_repo``.
+    """
+    existing = _find_tracking_issue(tracking_repo, token)
+    title = "SDK regeneration PRs are stale"
+    if stale:
+        if existing is None:
+            # --force upserts the label so `gh issue create --label` cannot fail on a
+            # missing label in a fresh repo.
+            _gh(["label", "create", TRACKING_LABEL, "--repo", tracking_repo, "--force",
+                 "--color", "B60205", "--description", "An SDK regeneration PR is lagging the spec"],
+                token=token)
+            _gh(["issue", "create", "--repo", tracking_repo, "--title", title,
+                 "--label", TRACKING_LABEL, "--body", body], token=token)
+        else:
+            _gh(["issue", "edit", str(existing), "--repo", tracking_repo, "--body", body], token=token)
+    elif existing is not None:
+        _gh(["issue", "comment", str(existing), "--repo", tracking_repo,
+             "--body", "All regeneration PRs are merged or within the freshness window. Closing."],
+            token=token)
+        _gh(["issue", "close", str(existing), "--repo", tracking_repo], token=token)
+
+
+def _write_step_summary(report: str) -> None:
+    """Append the report to the GitHub Actions job summary, when running in CI."""
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(report + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Alert on stale SDK regeneration PRs.")
+    parser.add_argument("--repos", nargs="+", default=list(DEFAULT_SDK_REPOS))
+    parser.add_argument("--branch", default=DEFAULT_BRANCH)
+    parser.add_argument("--max-age-days", type=float, default=DEFAULT_MAX_AGE_DAYS)
+    parser.add_argument("--tracking-repo", default=DEFAULT_TRACKING_REPO)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Open/update/close the tracking issue. Without it, only report.",
+    )
+    args = parser.parse_args()
+
+    now = datetime.now(timezone.utc)
+    all_prs: list[dict[str, Any]] = []
+    for repo in args.repos:
+        all_prs.extend(fetch_open_regen_prs(repo, args.branch))
+
+    stale = select_stale(all_prs, args.max_age_days, now)
+    report = render_report(stale, args.max_age_days, now)
+    print(report)
+    _write_step_summary(report)
+
+    if args.apply:
+        # PR reads above used the ambient GH_TOKEN (the cross-repo PAT); the
+        # tracking issue on this repo uses GATEWAY_GH_TOKEN when supplied.
+        sync_tracking_issue(
+            args.tracking_repo, stale, report, token=os.environ.get("GATEWAY_GH_TOKEN")
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sdk_codegen/README.md
+++ b/scripts/sdk_codegen/README.md
@@ -48,8 +48,9 @@ language-native marker file the SDK's hand-written shell reads to surface it
 | rust       | `spec_version.rs`  | `SPEC_VERSION` (`spec_version` mod) |
 
 The version is the spec's `info.version` by default; the codegen workflow passes
-the gateway release tag via `--spec-version` on a release so the stamp is the real
-release version rather than the `0.0.0-dev` placeholder in the committed spec. See
+the gateway release version (the tag without its leading `v`) via `--spec-version`
+on a release so the stamp is the real release version rather than the `0.0.0-dev`
+placeholder in the committed spec. See
 [`docs/sdk-compatibility.md`](../../docs/sdk-compatibility.md) for the release
 policy and the spec-version to minimum-SDK-version matrix.
 

--- a/scripts/sdk_codegen/README.md
+++ b/scripts/sdk_codegen/README.md
@@ -32,6 +32,27 @@ The shell is **not** regenerated; only the core is. Audio and images are left
 opaque in the core: they return binary/file payloads that do not map onto a
 JSON response schema.
 
+## Spec version stamping
+
+Compatibility between an SDK and the gateway is expressed through the spec
+version, not matching package numbers (each SDK is versioned independently). So
+every generated core carries the gateway/spec version it was generated from, as a
+language-native marker file the SDK's hand-written shell reads to surface it
+(`__spec_version__` / `SPEC_VERSION` / equivalent):
+
+| Language   | Marker file        | Symbol                            |
+|------------|--------------------|-----------------------------------|
+| python     | `_spec_version.py` | `__spec_version__`                |
+| typescript | `specVersion.ts`   | `SPEC_VERSION`                    |
+| go         | `spec_version.go`  | `SpecVersion` (core's package)    |
+| rust       | `spec_version.rs`  | `SPEC_VERSION` (`spec_version` mod) |
+
+The version is the spec's `info.version` by default; the codegen workflow passes
+the gateway release tag via `--spec-version` on a release so the stamp is the real
+release version rather than the `0.0.0-dev` placeholder in the committed spec. See
+[`docs/sdk-compatibility.md`](../../docs/sdk-compatibility.md) for the release
+policy and the spec-version to minimum-SDK-version matrix.
+
 ## Endpoint-coverage drift gate
 
 Because the core is generated but the shell is hand-written, a new gateway

--- a/scripts/sdk_codegen/generate.py
+++ b/scripts/sdk_codegen/generate.py
@@ -41,6 +41,11 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 DEFAULT_SPEC = REPO_ROOT / "docs" / "public" / "openapi.json"
 DEFAULT_OUT_DIR = REPO_ROOT / "dist" / "sdk-codegen"
 
+# Placeholder stamped into the spec's ``info.version`` until a real gateway
+# release supplies one (see gateway.version.__version__). Mirrors that default so
+# a marker is always written even outside a release build.
+DEFAULT_SPEC_VERSION = "0.0.0-dev"
+
 # Operations carrying one of these tags form the control plane we generate: the
 # management endpoints whose responses are fully typed in the spec. See the
 # module docstring for what is excluded and why (notably batches, whose
@@ -405,6 +410,53 @@ def normalize(language: str, dest: Path, python_package: str) -> None:
             shutil.move(str(staged), str(dest))
 
 
+def _go_package_name(target: LanguageTarget) -> str:
+    """Read ``packageName=`` out of a go target's additional properties.
+
+    The marker file must declare the same ``package`` as the rest of the generated
+    Go core (``generated`` for control-plane, ``client`` for full); fall back to the
+    target path's last segment if the property is absent.
+    """
+    for prop in target.additional_properties.split(","):
+        key, _, value = prop.partition("=")
+        if key.strip() == "packageName" and value.strip():
+            return value.strip()
+    return target.target_path.rsplit("/", 1)[-1]
+
+
+def write_spec_version(language: str, dest: Path, version: str, target: LanguageTarget) -> None:
+    """Stamp ``version`` into the generated core as a language-native marker file.
+
+    Compatibility between an SDK and the gateway is expressed through the spec
+    version, not matching package numbers, so each generated core carries the
+    gateway/spec version it was generated from. The SDK's hand-written shell reads
+    this marker to surface it (``__spec_version__`` / ``SPEC_VERSION`` / equivalent).
+
+    Each file is self-contained so no SDK-side wiring beyond an import is needed:
+    Python and TypeScript are imported by path; Go shares the core's package and so
+    the const is in scope automatically; for Rust the marker is declared as a
+    submodule of the inlined core's ``mod.rs`` (created by ``_rust_inline_module``).
+    Runs last in ``generate_language`` so ``dest`` is already in its final layout.
+    """
+    if language == "python":
+        (dest / "_spec_version.py").write_text(f'__spec_version__ = "{version}"\n')
+    elif language == "typescript":
+        (dest / "specVersion.ts").write_text(f'export const SPEC_VERSION = "{version}";\n')
+    elif language == "go":
+        package = _go_package_name(target)
+        (dest / "spec_version.go").write_text(f'package {package}\n\nconst SpecVersion = "{version}"\n')
+    elif language == "rust":
+        (dest / "spec_version.rs").write_text(f'pub const SPEC_VERSION: &str = "{version}";\n')
+        mod_rs = dest / "mod.rs"
+        declaration = "pub mod spec_version;"
+        if mod_rs.exists():
+            text = mod_rs.read_text()
+            if declaration not in text:
+                mod_rs.write_text(f"{text.rstrip()}\n{declaration}\n")
+        else:
+            mod_rs.write_text(f"{declaration}\n")
+
+
 def _rustfmt_tree(dest: Path) -> None:
     """Format the inlined Rust module in place with rustfmt.
 
@@ -484,7 +536,9 @@ def _rust_inline_module(dest: Path) -> None:
     _rustfmt_tree(dest)
 
 
-def generate_language(language: str, spec_path: Path, out_dir: Path, target: LanguageTarget) -> Path:
+def generate_language(
+    language: str, spec_path: Path, out_dir: Path, target: LanguageTarget, spec_version: str
+) -> Path:
     """Run OpenAPI Generator for ``language`` and return the output directory."""
     dest = out_dir / language
     cmd = [
@@ -505,6 +559,7 @@ def generate_language(language: str, spec_path: Path, out_dir: Path, target: Lan
     else:
         postprocess(language, dest)
         normalize(language, dest, target.target_path.rsplit("/", 1)[-1])
+    write_spec_version(language, dest, spec_version, target)
     return dest
 
 
@@ -521,6 +576,13 @@ def main() -> int:
     parser.add_argument("--spec", type=Path, default=DEFAULT_SPEC)
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
     parser.add_argument(
+        "--spec-version",
+        default=None,
+        help="Gateway/spec version stamped into each generated core (and into the "
+        "spec's info.version). Defaults to the spec's own info.version. The codegen "
+        "workflow passes the gateway release tag here.",
+    )
+    parser.add_argument(
         "--write-spec",
         type=Path,
         default=None,
@@ -529,6 +591,9 @@ def main() -> int:
     args = parser.parse_args()
 
     spec: dict[str, Any] = json.loads(Path(args.spec).read_text())
+    spec_version = args.spec_version or spec.get("info", {}).get("version", DEFAULT_SPEC_VERSION)
+    if args.spec_version:
+        spec.setdefault("info", {})["version"] = args.spec_version
     if args.mode == "full":
         prepared = enrich_spec(spec)
         targets = FULL_TARGETS
@@ -548,8 +613,8 @@ def main() -> int:
         spec_path = Path(tmp) / spec_name
         spec_path.write_text(json.dumps(prepared, indent=2))
         for language in languages:
-            dest = generate_language(language, spec_path, out_dir, targets[language])
-            print(f"generated {language} ({args.mode}) -> {dest}")
+            dest = generate_language(language, spec_path, out_dir, targets[language], spec_version)
+            print(f"generated {language} ({args.mode}) at spec version {spec_version} -> {dest}")
 
     return 0
 

--- a/scripts/sdk_codegen/generate.py
+++ b/scripts/sdk_codegen/generate.py
@@ -446,15 +446,22 @@ def write_spec_version(language: str, dest: Path, version: str, target: Language
         package = _go_package_name(target)
         (dest / "spec_version.go").write_text(f'package {package}\n\nconst SpecVersion = "{version}"\n')
     elif language == "rust":
-        (dest / "spec_version.rs").write_text(f'pub const SPEC_VERSION: &str = "{version}";\n')
-        mod_rs = dest / "mod.rs"
+        # The crate root is ``dest/mod.rs`` for the inlined full core, or
+        # ``dest/src/lib.rs`` for the standalone crate the rust generator emits in
+        # control-plane mode. Place the marker beside whichever root exists and
+        # declare the module there, so it is compiled and importable in both
+        # layouts (the bare ``dest/mod.rs`` fallback covers a partial payload).
+        root = dest / "mod.rs"
+        if not root.exists() and (dest / "src" / "lib.rs").exists():
+            root = dest / "src" / "lib.rs"
+        (root.parent / "spec_version.rs").write_text(f'pub const SPEC_VERSION: &str = "{version}";\n')
         declaration = "pub mod spec_version;"
-        if mod_rs.exists():
-            text = mod_rs.read_text()
+        if root.exists():
+            text = root.read_text()
             if declaration not in text:
-                mod_rs.write_text(f"{text.rstrip()}\n{declaration}\n")
+                root.write_text(f"{text.rstrip()}\n{declaration}\n")
         else:
-            mod_rs.write_text(f"{declaration}\n")
+            root.write_text(f"{declaration}\n")
 
 
 def _rustfmt_tree(dest: Path) -> None:

--- a/tests/unit/test_check_stale_regen_prs.py
+++ b/tests/unit/test_check_stale_regen_prs.py
@@ -1,0 +1,87 @@
+"""Unit tests for the stale SDK regeneration PR alert (pure selection/render)."""
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_stale_regen_prs.py"
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_stale_regen_prs", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load()
+
+_NOW = datetime(2026, 6, 11, tzinfo=timezone.utc)
+
+
+def _pr(repo: str, number: int, age_days: float) -> dict[str, Any]:
+    created = _NOW - timedelta(days=age_days)
+    return {
+        "repo": repo,
+        "number": number,
+        "title": "Regenerate SDK client core",
+        "url": f"https://github.com/{repo}/pull/{number}",
+        "createdAt": created.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+
+def test_parse_iso8601_handles_z_suffix() -> None:
+    parsed = check.parse_iso8601("2026-06-01T12:00:00Z")
+    assert parsed == datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_select_stale_keeps_only_prs_past_threshold() -> None:
+    prs = [
+        _pr("mozilla-ai/otari-sdk-python", 1, age_days=10),
+        _pr("mozilla-ai/otari-sdk-go", 2, age_days=3),
+    ]
+    stale = check.select_stale(prs, max_age_days=7, now=_NOW)
+    assert [pr["number"] for pr in stale] == [1]
+
+
+def test_select_stale_threshold_is_strict() -> None:
+    # A PR exactly at the threshold is not yet stale; just past it is.
+    at_threshold = _pr("mozilla-ai/otari-sdk-ts", 5, age_days=7)
+    just_over = _pr("mozilla-ai/otari-sdk-ts", 6, age_days=7.01)
+    stale = check.select_stale([at_threshold, just_over], max_age_days=7, now=_NOW)
+    assert [pr["number"] for pr in stale] == [6]
+
+
+def test_select_stale_sorts_oldest_first() -> None:
+    prs = [
+        _pr("a/b", 1, age_days=9),
+        _pr("c/d", 2, age_days=30),
+        _pr("e/f", 3, age_days=15),
+    ]
+    stale = check.select_stale(prs, max_age_days=7, now=_NOW)
+    # createdAt ascending == oldest first.
+    assert [pr["number"] for pr in stale] == [2, 3, 1]
+
+
+def test_select_stale_empty_when_all_fresh() -> None:
+    prs = [_pr("a/b", 1, age_days=1), _pr("c/d", 2, age_days=6)]
+    assert check.select_stale(prs, max_age_days=7, now=_NOW) == []
+
+
+def test_render_report_lists_each_stale_pr() -> None:
+    prs = [_pr("mozilla-ai/otari-sdk-python", 12, age_days=10)]
+    report = check.render_report(prs, max_age_days=7, now=_NOW)
+    assert "mozilla-ai/otari-sdk-python" in report
+    assert "[#12](https://github.com/mozilla-ai/otari-sdk-python/pull/12)" in report
+    assert "| Repo | PR | Age (days) | Opened |" in report
+
+
+def test_render_report_when_none_stale() -> None:
+    report = check.render_report([], max_age_days=7, now=_NOW)
+    assert "within the freshness window" in report
+    assert "|" not in report  # no table rendered

--- a/tests/unit/test_sdk_codegen.py
+++ b/tests/unit/test_sdk_codegen.py
@@ -420,6 +420,22 @@ def test_spec_version_rust_marker_declaration_is_idempotent(tmp_path: Path) -> N
     assert (tmp_path / "mod.rs").read_text().count("pub mod spec_version;") == 1
 
 
+def test_spec_version_rust_marker_non_inlined_crate_layout(tmp_path: Path) -> None:
+    # Control-plane mode emits a standalone crate (src/lib.rs), not an inlined
+    # mod.rs. The marker must land under src/ and be declared in lib.rs so it is
+    # compiled, not dropped beside an unreferenced top-level mod.rs.
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "lib.rs").write_text("pub mod apis;\npub mod models;\n")
+    generate.write_spec_version("rust", tmp_path, "1.2.3", generate.TARGETS["rust"])
+    assert (src / "spec_version.rs").read_text() == 'pub const SPEC_VERSION: &str = "1.2.3";\n'
+    assert not (tmp_path / "spec_version.rs").exists()
+    assert not (tmp_path / "mod.rs").exists()
+    lib_text = (src / "lib.rs").read_text()
+    assert "pub mod apis;" in lib_text
+    assert "pub mod spec_version;" in lib_text
+
+
 def test_spec_version_rust_marker_without_mod_rs(tmp_path: Path) -> None:
     # A partial payload with no mod.rs must still yield a usable declaration.
     generate.write_spec_version("rust", tmp_path, "1.2.3", generate.FULL_TARGETS["rust"])

--- a/tests/unit/test_sdk_codegen.py
+++ b/tests/unit/test_sdk_codegen.py
@@ -376,3 +376,61 @@ def test_full_rust_target_is_inlined_module() -> None:
     rust = generate.FULL_TARGETS["rust"]
     assert rust.target_path == "src/_client"
     assert rust.inline_module is True
+
+
+def test_spec_version_python_marker(tmp_path: Path) -> None:
+    generate.write_spec_version("python", tmp_path, "1.2.3", generate.FULL_TARGETS["python"])
+    assert (tmp_path / "_spec_version.py").read_text() == '__spec_version__ = "1.2.3"\n'
+
+
+def test_spec_version_typescript_marker(tmp_path: Path) -> None:
+    generate.write_spec_version("typescript", tmp_path, "1.2.3", generate.FULL_TARGETS["typescript"])
+    assert (tmp_path / "specVersion.ts").read_text() == 'export const SPEC_VERSION = "1.2.3";\n'
+
+
+def test_spec_version_go_marker_uses_core_package(tmp_path: Path) -> None:
+    # The full go core is package `client`; the marker must share that package so
+    # the const compiles into the same package as the rest of the core.
+    generate.write_spec_version("go", tmp_path, "1.2.3", generate.FULL_TARGETS["go"])
+    assert (tmp_path / "spec_version.go").read_text() == 'package client\n\nconst SpecVersion = "1.2.3"\n'
+
+
+def test_spec_version_go_marker_uses_control_plane_package(tmp_path: Path) -> None:
+    # The control-plane go core is package `generated`; the marker follows it.
+    generate.write_spec_version("go", tmp_path, "1.2.3", generate.TARGETS["go"])
+    assert (tmp_path / "spec_version.go").read_text().startswith("package generated\n")
+
+
+def test_spec_version_rust_marker_and_mod_declaration(tmp_path: Path) -> None:
+    # mod.rs already exists (created by _rust_inline_module); the marker module
+    # declaration is appended without disturbing existing declarations.
+    (tmp_path / "mod.rs").write_text("pub mod apis;\npub mod models;\n")
+    generate.write_spec_version("rust", tmp_path, "1.2.3", generate.FULL_TARGETS["rust"])
+    assert (tmp_path / "spec_version.rs").read_text() == 'pub const SPEC_VERSION: &str = "1.2.3";\n'
+    mod_text = (tmp_path / "mod.rs").read_text()
+    assert "pub mod apis;" in mod_text
+    assert "pub mod models;" in mod_text
+    assert "pub mod spec_version;" in mod_text
+
+
+def test_spec_version_rust_marker_declaration_is_idempotent(tmp_path: Path) -> None:
+    (tmp_path / "mod.rs").write_text("pub mod apis;\n")
+    generate.write_spec_version("rust", tmp_path, "1.2.3", generate.FULL_TARGETS["rust"])
+    generate.write_spec_version("rust", tmp_path, "1.2.3", generate.FULL_TARGETS["rust"])
+    assert (tmp_path / "mod.rs").read_text().count("pub mod spec_version;") == 1
+
+
+def test_spec_version_rust_marker_without_mod_rs(tmp_path: Path) -> None:
+    # A partial payload with no mod.rs must still yield a usable declaration.
+    generate.write_spec_version("rust", tmp_path, "1.2.3", generate.FULL_TARGETS["rust"])
+    assert (tmp_path / "mod.rs").read_text() == "pub mod spec_version;\n"
+
+
+def test_go_package_name_falls_back_to_target_path() -> None:
+    target = generate.LanguageTarget(
+        generator="go",
+        additional_properties="withGoMod=false",
+        sdk_repo="x/y",
+        target_path="otari/client",
+    )
+    assert generate._go_package_name(target) == "client"


### PR DESCRIPTION
## Description

Implements the gateway-side work for the SDK release coordination policy from #133: SDKs are versioned independently of the gateway, and compatibility is expressed through the spec version rather than matching package numbers.

Three changes:

1. **Stamp the gateway/spec version into each generated core.** `scripts/sdk_codegen/generate.py` writes a language-native marker into every generated core so an SDK's hand-written shell can surface it:
   - python `_spec_version.py` (`__spec_version__`)
   - typescript `specVersion.ts` (`SPEC_VERSION`)
   - go `spec_version.go` (`SpecVersion`, sharing the core's package)
   - rust `spec_version.rs` plus a `pub mod spec_version;` line on the inlined core's `mod.rs`

   A new `--spec-version` flag overrides the value (and the spec's `info.version`); it defaults to the spec's own `info.version`. The codegen workflow passes the gateway release tag on a `release` event, so the stamp is the real release version rather than the `0.0.0-dev` placeholder in the committed spec.

2. **Alert when a regeneration PR sits unmerged beyond N days.** `scripts/check_stale_regen_prs.py` lists each SDK repo's open PR on `sdk-codegen/client-core`, flags any older than the freshness window (default 7 days), and keeps a single tracking issue (`sdk-regen-stale` label) in sync: opened/updated while any PR is stale, closed once none are. A new scheduled workflow (`.github/workflows/sdk-regen-staleness.yml`) runs it weekly and on dispatch.

3. **Document the policy and compatibility matrix.** `docs/sdk-compatibility.md` covers the decoupled-release policy, how each SDK surfaces the spec version, and the gateway-spec-version to minimum-SDK-version matrix; linked from the docs index.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [x] Infrastructure / CI

## Relevant issues

Refs #133 (gateway-side items; the per-SDK child work is tracked separately, so this does not close the issue).

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). (No API contract change; `make openapi-check` passes.)

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:**

Implemented by Claude Code via back-and-forth with @njbrake. The reasoning and decisions are his.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds gateway-side support to coordinate SDK releases via the gateway OpenAPI/spec version and to detect stale SDK regeneration work.

High-level changes and benefits
- Spec version stamping: Generated SDK cores are now stamped with the gateway/spec version (replacing the dev placeholder during release builds). The generator emits per-language marker files so SDKs can surface which spec/gateway they target (Python, TypeScript, Go, Rust). Benefit: SDKs can report/verify compatibility against a running gateway without coupling SDK semantic versions to gateway releases.
- Staleness monitoring: A new weekly/manual workflow plus a CLI script scan SDK repositories for open "regen" PRs, flag ones older than a configurable freshness window (default 7 days), and keep a single tracking issue labeled sdk-regen-stale in sync while stale PRs exist. Benefit: automated visibility and follow-up for backlogged regeneration PRs.
- Documentation and release guidance: Adds docs describing the decoupled-release policy, how SDKs expose spec versions, and a compatibility matrix mapping gateway/spec versions to minimum SDK versions; README and release docs updated to reflect the flow.
- Tests: Unit tests cover per-language spec-version markers and the staleness-selection/reporting logic.

Technical notes
- Codegen:
  - scripts/sdk_codegen/generate.py: new --spec-version CLI (defaults to the spec's info.version or DEFAULT_SPEC_VERSION = "0.0.0-dev"); threads spec_version into generation and writes language-specific marker files.
  - Per-language markers: _spec_version.py (__spec_version__), specVersion.ts (SPEC_VERSION), spec_version.go (SpecVersion; package derived from additional_properties or path fallback), spec_version.rs plus insertion of pub mod spec_version; into the appropriate Rust crate root (handles inlined vs standalone crate layouts).
  - Fix: rust marker placement detects crate layout and writes the module beside the correct crate root; tests added for non-inlined layout.
- CI/workflows:
  - gateway release codegen step now extracts RELEASE_TAG (strips leading "v") and passes it to generate.py so generated cores carry the real release version.
  - New .github/workflows/sdk-regen-staleness.yml runs weekly and on dispatch; uses SDK_CODEGEN_TOKEN for cross-repo reads and GITHUB_TOKEN for local issue operations.
- Staleness script:
  - scripts/check_stale_regen_prs.py: fetches open regen PRs, computes age (strictly greater than threshold), selects oldest-first, renders a markdown report, and when run with --apply creates/updates/closes a single tracking issue (uses gh subprocess calls). CI run appends the report to GITHUB_STEP_SUMMARY.
- Tests: tests added for ISO-8601 Z parsing, strict threshold behavior, oldest-first ordering, report rendering, and per-language marker behaviors (including Rust mod.rs idempotency and Go package name fallback).

Other
- RELEASE.md added with release steps and workflows.
- docs/index.md links to docs/sdk-compatibility.md.
- scripts/sdk_codegen/README.md documents spec-stamping and per-language markers.

Overall effect
Enables an explicit, decoupled compatibility mechanism (spec stamping) between the gateway and SDKs and adds automated tracking to prevent regeneration PRs from becoming overlooked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->