### PR TITLE
fix(deploy): dispatch to renamed otari-ai platform repo

### DIFF
--- a/.github/workflows/gateway-docker.yml
+++ b/.github/workflows/gateway-docker.yml
@@ -136,4 +136,4 @@ jobs:
           IMAGE_TAG="${IMAGE_REF##*:}"
           jq -nc --arg tag "$IMAGE_TAG" \
             '{event_type:"otari-image-published",client_payload:{image_tag:$tag}}' \
-            | gh api -X POST /repos/mozilla-ai/any-llm-platform/dispatches --input -
+            | gh api -X POST /repos/mozilla-ai/otari-ai/dispatches --input -


### PR DESCRIPTION
## Summary

The `gateway deploy` workflow has been failing on `main`. The `notify-platform` job posts a `repository_dispatch` event to trigger the platform deploy, but it targeted the old repo name `mozilla-ai/any-llm-platform`, which was renamed to `otari-ai`.

GitHub returns `HTTP 307 Moved Permanently` for the renamed repo, and `gh api` does not follow redirects on POST, so the job exits 1. The app-token scope was already updated to `otari-ai` in the previous commit (d4b29f7); this updates the dispatch URL to match.

Failing run: https://github.com/mozilla-ai/otari/actions/runs/27357803578/job/80837339634

## Change

One line in `.github/workflows/gateway-docker.yml`:

```diff
-            | gh api -X POST /repos/mozilla-ai/any-llm-platform/dispatches --input -
+            | gh api -X POST /repos/mozilla-ai/otari-ai/dispatches --input -
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)