### PR TITLE
feat(web-search): per-workspace web-search policy via platform resolve

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,11 @@ OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 MISTRAL_API_KEY=
 GEMINI_API_KEY=
+
+# Web-search backend (optional). Point the gateway at a SearXNG-compatible
+# /search?format=json service. The bundled `web-search-tavily` /
+# `web-search-brave` compose profiles front a licensed API; the key lives in
+# the adapter container, not the gateway.
+# GATEWAY_WEB_SEARCH_URL=http://tavily-adapter:8080
+# TAVILY_API_KEY=
+# BRAVE_API_KEY=

--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ A ready-to-run **Brave Search** adapter ships in
 `scripts/web-search-brave-adapter/`: set `BRAVE_API_KEY` and
 `GATEWAY_WEB_SEARCH_URL=http://brave-adapter:8080`, then
 `docker compose --profile web-search-brave up -d --build brave-adapter gateway`.
+A **Tavily** adapter ships in `scripts/web-search-tavily-adapter/` (set
+`TAVILY_API_KEY` and `GATEWAY_WEB_SEARCH_URL=http://tavily-adapter:8080`, then
+`docker compose --profile web-search-tavily up -d --build tavily-adapter gateway`).
 See that folder's README for details and how to adapt it to another provider.
 
 Per-tool overrides (`max_results`, `allowed_domains`, `blocked_domains`,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,9 @@ services:
   # uses a licensed API (Tavily, Brave Search API with key, Exa, Linkup,
   # Serper). Any HTTP service that exposes a SearXNG-compatible
   # /search?format=json shape is a drop-in replacement — just change
-  # GATEWAY_WEB_SEARCH_URL in the gateway's environment.
+  # GATEWAY_WEB_SEARCH_URL in the gateway's environment. Bundled adapters:
+  # the `web-search-brave` profile (Brave API) and the `web-search-tavily`
+  # profile (Tavily API) below.
   #
   # Opt-in via the `web-search` compose profile so operators who don't use
   # the web_search tool aren't forced to pull this image. Bring it up with
@@ -184,6 +186,32 @@ services:
     environment:
       # Brave Search API subscription token. Kept here, not in the gateway.
       - BRAVE_API_KEY=${BRAVE_API_KEY:-}
+    restart: unless-stopped
+
+  # Commercial-API web-search backend — a thin adapter that fronts the Tavily
+  # Search API with the SearXNG-compatible /search?format=json shape the
+  # gateway expects. Tavily is LLM-oriented (returns extracted page content
+  # directly), so the gateway can skip its own per-URL fetch. Use this instead
+  # of the `searxng` profile when the free metasearch engines rate-limit your
+  # IP. Source + how-to live in scripts/web-search-tavily-adapter/.
+  #
+  # Opt-in via the `web-search-tavily` profile. To use it, set
+  #   GATEWAY_WEB_SEARCH_URL=http://tavily-adapter:8080
+  #   TAVILY_API_KEY=<your key from https://tavily.com/>
+  # then `docker compose --profile web-search-tavily up -d --build tavily-adapter gateway`.
+  tavily-adapter:
+    profiles: ["web-search-tavily"]
+    build:
+      context: ./scripts/web-search-tavily-adapter
+      dockerfile: Dockerfile
+    ports:
+      # Localhost-only, like the other internal backends — the gateway reaches
+      # it over the Docker network at `tavily-adapter:8080`; this mapping is for
+      # ad-hoc curl/debugging.
+      - "127.0.0.1:8184:8080"
+    environment:
+      # Tavily Search API key. Kept here, not in the gateway.
+      - TAVILY_API_KEY=${TAVILY_API_KEY:-}
     restart: unless-stopped
 
   # Guardrails service — the otari-anyguardrails container, a stateless FastAPI

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,8 +207,9 @@ services:
     ports:
       # Localhost-only, like the other internal backends — the gateway reaches
       # it over the Docker network at `tavily-adapter:8080`; this mapping is for
-      # ad-hoc curl/debugging.
-      - "127.0.0.1:8184:8080"
+      # ad-hoc curl/debugging. 8184 is taken by encoderfile, so use 8185 to
+      # avoid a clash when the web-search-tavily and guardrails profiles run together.
+      - "127.0.0.1:8185:8080"
     environment:
       # Tavily Search API key. Kept here, not in the gateway.
       - TAVILY_API_KEY=${TAVILY_API_KEY:-}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -116,9 +116,18 @@ export GATEWAY_WEB_SEARCH_URL=http://brave-adapter:8080
 docker compose --profile web-search-brave up -d --build brave-adapter gateway
 ```
 
+A ready-to-run **Tavily** adapter also ships in
+`scripts/web-search-tavily-adapter/`:
+
+```bash
+export TAVILY_API_KEY=...   # from https://tavily.com/
+export GATEWAY_WEB_SEARCH_URL=http://tavily-adapter:8080
+docker compose --profile web-search-tavily up -d --build tavily-adapter gateway
+```
+
 `WebSearchBackend` is URL-configured, so any service exposing a
 SearXNG-compatible `/search?format=json` endpoint works — copy the adapter to
-front Tavily, Exa, Serper, etc.
+front Exa, Serper, etc.
 
 Both code-exec and web-search profiles can be combined:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,11 @@ select = ["E", "F", "I"]
 python_version = "3.13"
 strict = true
 files = ["src", "tests", "scripts"]
+# Standalone web-search adapters are independent services (own Dockerfile +
+# requirements), not part of the gateway package. They each ship a top-level
+# `app.py`, so type-checking them together trips mypy's duplicate-module guard.
+# Their behaviour is covered by tests/unit/test_*_adapter.py.
+exclude = ["scripts/web-search-[^/]+-adapter/"]
 
 [[tool.mypy.overrides]]
 module = ["testcontainers.*"]

--- a/scripts/web-search-tavily-adapter/Dockerfile
+++ b/scripts/web-search-tavily-adapter/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+
+EXPOSE 8080
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 --start-period=5s \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')" || exit 1
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/scripts/web-search-tavily-adapter/Dockerfile
+++ b/scripts/web-search-tavily-adapter/Dockerfile
@@ -5,6 +5,10 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY app.py .
 
+# Run as a non-root user to limit blast radius if the process is compromised.
+RUN addgroup --system app && adduser --system --ingroup app app
+USER app
+
 EXPOSE 8080
 HEALTHCHECK --interval=10s --timeout=5s --retries=5 --start-period=5s \
   CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')" || exit 1

--- a/scripts/web-search-tavily-adapter/README.md
+++ b/scripts/web-search-tavily-adapter/README.md
@@ -1,0 +1,68 @@
+# Tavily Search adapter
+
+A thin SearXNG-compatible front-end over the [Tavily Search API](https://tavily.com/),
+so the gateway's `otari_web_search` tool can use a licensed, LLM-oriented
+search API instead of the bundled SearXNG metasearch (whose free engines
+rate-limit/CAPTCHA automated queries by IP).
+
+It exposes `GET /search?q=…&format=json` returning
+`{"results": [{"url", "title", "content", "extracted_content"?}]}` — the exact
+shape `WebSearchBackend` expects — and translates that to/from Tavily's API.
+The Tavily key lives in this service, never in the gateway.
+
+Tavily can return the full extracted page text (`raw_content`); the adapter
+maps it onto each result's `extracted_content`, so the gateway skips its own
+per-URL fetch + trafilatura step.
+
+## Provider options
+
+The gateway forwards provider-specific knobs (set via `provider_options` on the
+`otari_web_search` tool entry, or as workspace defaults in platform mode) as
+extra query params. This adapter whitelists only the Tavily params it knows
+about — anything else is ignored:
+
+- `max_results` (int)
+- `search_depth` (`basic` | `advanced`)
+- `topic` (`general` | `news` | `finance`)
+- `time_range`
+- `include_answer` (bool)
+
+## Run it via docker-compose
+
+1. Get a key from <https://tavily.com/>. Provide it via the environment —
+   either `export TAVILY_API_KEY=...`, or (cleaner) drop it in a gitignored
+   `.env` in the repo root, which `docker compose` auto-loads. You also need to
+   point the gateway at the adapter, so set both:
+
+   ```bash
+   # ./.env  (gitignored)
+   TAVILY_API_KEY=tvly-xxxxxxxx
+   GATEWAY_WEB_SEARCH_URL=http://tavily-adapter:8080
+   ```
+
+   (If you pass an explicit `--env-file PATH`, compose reads that instead of
+   the root `.env`, so put both vars in the file you actually pass.)
+
+2. Start the adapter and the gateway:
+
+   ```bash
+   docker compose --profile web-search-tavily up -d --build tavily-adapter gateway
+   ```
+
+   (The `web-search-tavily` profile brings up the adapter; the `searxng`
+   container is not needed.)
+
+3. `otari_web_search` requests now resolve through Tavily. Verify directly:
+
+   ```bash
+   curl -s "http://localhost:8184/search?q=latest+python+version&format=json" | jq '.results | length'
+   ```
+
+## Swapping in a different provider
+
+Any HTTP service exposing the same `/search?format=json` contract is a drop-in
+replacement (Brave, Exa, Linkup, Serper, …). Copy this adapter and change the
+upstream call in `app.py`. This adapter sets `extracted_content` (from Tavily's
+`raw_content`), so the gateway uses that text directly and skips its own per-URL
+fetch + trafilatura. Omit `extracted_content` instead if you want the gateway to
+fetch and extract each page itself.

--- a/scripts/web-search-tavily-adapter/README.md
+++ b/scripts/web-search-tavily-adapter/README.md
@@ -6,8 +6,8 @@ search API instead of the bundled SearXNG metasearch (whose free engines
 rate-limit/CAPTCHA automated queries by IP).
 
 It exposes `GET /search?q=…&format=json` returning
-`{"results": [{"url", "title", "content", "extracted_content"?}]}` — the exact
-shape `WebSearchBackend` expects — and translates that to/from Tavily's API.
+`{"results": [{"url", "title", "content", "extracted_content"?}]}` (the exact
+shape `WebSearchBackend` expects) and translates that to/from Tavily's API.
 The Tavily key lives in this service, never in the gateway.
 
 Tavily can return the full extracted page text (`raw_content`); the adapter
@@ -19,7 +19,7 @@ per-URL fetch + trafilatura step.
 The gateway forwards provider-specific knobs (set via `provider_options` on the
 `otari_web_search` tool entry, or as workspace defaults in platform mode) as
 extra query params. This adapter whitelists only the Tavily params it knows
-about — anything else is ignored:
+about; anything else is ignored:
 
 - `max_results` (int)
 - `search_depth` (`basic` | `advanced`)
@@ -29,7 +29,7 @@ about — anything else is ignored:
 
 ## Run it via docker-compose
 
-1. Get a key from <https://tavily.com/>. Provide it via the environment —
+1. Get a key from <https://tavily.com/>. Provide it via the environment:
    either `export TAVILY_API_KEY=...`, or (cleaner) drop it in a gitignored
    `.env` in the repo root, which `docker compose` auto-loads. You also need to
    point the gateway at the adapter, so set both:
@@ -55,7 +55,7 @@ about — anything else is ignored:
 3. `otari_web_search` requests now resolve through Tavily. Verify directly:
 
    ```bash
-   curl -s "http://localhost:8184/search?q=latest+python+version&format=json" | jq '.results | length'
+   curl -s "http://localhost:8185/search?q=latest+python+version&format=json" | jq '.results | length'
    ```
 
 ## Swapping in a different provider

--- a/scripts/web-search-tavily-adapter/app.py
+++ b/scripts/web-search-tavily-adapter/app.py
@@ -37,9 +37,12 @@ app = FastAPI(title="otari web-search Tavily adapter")
 
 
 @app.get("/health")
-async def health() -> dict[str, str]:
-    # Surfaces a misconfigured deployment (missing key) without a live query.
-    return {"status": "healthy" if TAVILY_API_KEY else "missing TAVILY_API_KEY"}
+async def health() -> JSONResponse:
+    # Fail closed when misconfigured (missing key) so orchestrators don't treat
+    # an unusable adapter as healthy.
+    if not TAVILY_API_KEY:
+        return JSONResponse(status_code=503, content={"status": "missing TAVILY_API_KEY"})
+    return JSONResponse(status_code=200, content={"status": "healthy"})
 
 
 @app.get("/search")
@@ -92,7 +95,11 @@ async def search(
     if not isinstance(payload, dict):
         return JSONResponse(status_code=502, content={"error": "tavily search returned an unexpected shape"})
 
-    hits = payload.get("results") or []
+    hits = payload.get("results")
+    if not isinstance(hits, list):
+        # A missing/non-list `results` is an upstream contract break, not "no
+        # hits" — surface it as a 502 instead of silently returning empty.
+        return JSONResponse(status_code=502, content={"error": "tavily search returned an unexpected shape"})
     results: list[dict[str, Any]] = []
     for h in hits:
         if not isinstance(h, dict) or not h.get("url"):

--- a/scripts/web-search-tavily-adapter/app.py
+++ b/scripts/web-search-tavily-adapter/app.py
@@ -14,7 +14,7 @@ The gateway may forward provider-specific knobs as extra query params
 (``provider_options`` on the ``otari_web_search`` tool entry). This adapter
 WHITELISTS only the Tavily params it knows about (``max_results``,
 ``search_depth``, ``topic``, ``time_range``, ``include_answer``) and ignores
-anything else — arbitrary params are never forwarded to Tavily.
+anything else; arbitrary params are never forwarded to Tavily.
 
 Tavily's ``raw_content`` (full extracted page text) is mapped onto each
 result's ``extracted_content`` when present, so the gateway can skip its own
@@ -51,14 +51,14 @@ async def search(
     max_results: int | None = Query(default=None, ge=1),
     search_depth: str | None = Query(default=None, pattern="^(basic|advanced)$"),
     topic: str | None = Query(default=None, pattern="^(general|news|finance)$"),
-    time_range: str | None = Query(default=None),
+    time_range: str | None = Query(default=None, pattern="^(day|week|month|year|d|w|m|y)$"),
     include_answer: bool | None = Query(default=None),
 ) -> JSONResponse:
     """Translate a SearXNG-style query into a Tavily Search API call."""
     if not TAVILY_API_KEY:
         return JSONResponse(status_code=503, content={"error": "TAVILY_API_KEY is not set"})
 
-    # Whitelist: only known Tavily params are forwarded — never arbitrary
+    # Whitelist: only known Tavily params are forwarded, never arbitrary
     # query string keys.
     body: dict[str, Any] = {"query": q, "include_raw_content": True}
     if max_results is not None:
@@ -98,7 +98,7 @@ async def search(
     hits = payload.get("results")
     if not isinstance(hits, list):
         # A missing/non-list `results` is an upstream contract break, not "no
-        # hits" — surface it as a 502 instead of silently returning empty.
+        # hits", so surface it as a 502 instead of silently returning empty.
         return JSONResponse(status_code=502, content={"error": "tavily search returned an unexpected shape"})
     results: list[dict[str, Any]] = []
     for h in hits:

--- a/scripts/web-search-tavily-adapter/app.py
+++ b/scripts/web-search-tavily-adapter/app.py
@@ -1,0 +1,111 @@
+"""SearXNG-compatible adapter in front of the Tavily Search API.
+
+The gateway's ``WebSearchBackend`` speaks one protocol: it issues
+``GET {url}/search?q=…&format=json`` and expects
+
+    {"results": [{"url": ..., "title": ..., "content": ...}, ...]}
+
+Tavily's API has a different shape and its own auth header, so this thin
+service translates between the two. Point the gateway at it with
+``GATEWAY_WEB_SEARCH_URL=http://tavily-adapter:8080``; the Tavily key lives
+here, never in the gateway.
+
+The gateway may forward provider-specific knobs as extra query params
+(``provider_options`` on the ``otari_web_search`` tool entry). This adapter
+WHITELISTS only the Tavily params it knows about (``max_results``,
+``search_depth``, ``topic``, ``time_range``, ``include_answer``) and ignores
+anything else — arbitrary params are never forwarded to Tavily.
+
+Tavily's ``raw_content`` (full extracted page text) is mapped onto each
+result's ``extracted_content`` when present, so the gateway can skip its own
+per-URL fetch + trafilatura step. ``content`` carries Tavily's snippet.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+from fastapi import FastAPI, Query
+from fastapi.responses import JSONResponse
+
+TAVILY_API_KEY = os.environ.get("TAVILY_API_KEY", "")
+TAVILY_ENDPOINT = "https://api.tavily.com/search"
+
+app = FastAPI(title="otari web-search Tavily adapter")
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    # Surfaces a misconfigured deployment (missing key) without a live query.
+    return {"status": "healthy" if TAVILY_API_KEY else "missing TAVILY_API_KEY"}
+
+
+@app.get("/search")
+async def search(
+    q: str = Query(..., min_length=1),
+    max_results: int | None = Query(default=None, ge=1),
+    search_depth: str | None = Query(default=None, pattern="^(basic|advanced)$"),
+    topic: str | None = Query(default=None, pattern="^(general|news|finance)$"),
+    time_range: str | None = Query(default=None),
+    include_answer: bool | None = Query(default=None),
+) -> JSONResponse:
+    """Translate a SearXNG-style query into a Tavily Search API call."""
+    if not TAVILY_API_KEY:
+        return JSONResponse(status_code=503, content={"error": "TAVILY_API_KEY is not set"})
+
+    # Whitelist: only known Tavily params are forwarded — never arbitrary
+    # query string keys.
+    body: dict[str, Any] = {"query": q, "include_raw_content": True}
+    if max_results is not None:
+        body["max_results"] = max_results
+    if search_depth is not None:
+        body["search_depth"] = search_depth
+    if topic is not None:
+        body["topic"] = topic
+    if time_range is not None:
+        body["time_range"] = time_range
+    if include_answer is not None:
+        body["include_answer"] = include_answer
+
+    headers = {"Authorization": f"Bearer {TAVILY_API_KEY}", "Content-Type": "application/json"}
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(TAVILY_ENDPOINT, json=body, headers=headers)
+            resp.raise_for_status()
+            payload = resp.json()
+    except httpx.HTTPStatusError as exc:
+        # Surface Tavily's status (e.g. 401 bad key, 429 quota) so the gateway
+        # logs make the cause obvious instead of a generic "unreachable".
+        return JSONResponse(
+            status_code=502,
+            content={"error": f"tavily search returned {exc.response.status_code}"},
+        )
+    except httpx.HTTPError as exc:
+        return JSONResponse(status_code=502, content={"error": f"tavily search failed: {exc}"})
+    except ValueError as exc:
+        # Invalid / non-JSON body from Tavily. Translate to a 502 rather than
+        # letting it bubble up as a 500, so the gateway sees a consistent signal.
+        return JSONResponse(status_code=502, content={"error": f"tavily search returned invalid JSON: {exc}"})
+
+    if not isinstance(payload, dict):
+        return JSONResponse(status_code=502, content={"error": "tavily search returned an unexpected shape"})
+
+    hits = payload.get("results") or []
+    results: list[dict[str, Any]] = []
+    for h in hits:
+        if not isinstance(h, dict) or not h.get("url"):
+            continue
+        result: dict[str, Any] = {
+            "url": h["url"],
+            "title": h.get("title", ""),
+            "content": h.get("content", ""),
+        }
+        # Tavily can return the full extracted page text; pass it through as
+        # extracted_content so the gateway skips its own fetch + trafilatura.
+        raw_content = h.get("raw_content")
+        if raw_content:
+            result["extracted_content"] = raw_content
+        results.append(result)
+    return JSONResponse(content={"results": results})

--- a/scripts/web-search-tavily-adapter/requirements.txt
+++ b/scripts/web-search-tavily-adapter/requirements.txt
@@ -1,0 +1,3 @@
+fastapi>=0.115
+uvicorn[standard]>=0.30
+httpx>=0.27

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -63,6 +63,7 @@ from gateway.api.routes._platform import (
     _report_platform_usage,
     _resolve_platform_credentials,
     _resolve_platform_mcp_servers,
+    _resolve_platform_web_search,
     run_platform_attempts,
 )
 from gateway.api.routes._tools import (
@@ -132,9 +133,9 @@ WEB_SEARCH_NOT_CONFIGURED_DETAIL = (
     "Set GATEWAY_WEB_SEARCH_URL on the gateway, or remove otari_web_search from `tools`."
 )
 WEB_SEARCH_CONFLICT_DETAIL = (
-    "otari_web_search cannot be combined with otari_code_execution or mcp_servers in the same "
-    "request yet; pick one."
+    "otari_web_search cannot be combined with otari_code_execution or mcp_servers in the same request yet; pick one."
 )
+WEB_SEARCH_NOT_ENABLED_DETAIL = "web search is not enabled for this workspace"
 SANDBOX_UNREACHABLE_DETAIL = "code_execution sandbox unreachable — check GATEWAY_SANDBOX_URL"
 WEB_SEARCH_UNREACHABLE_DETAIL = "web_search backend unreachable — check GATEWAY_WEB_SEARCH_URL"
 
@@ -502,6 +503,37 @@ async def prepare_gateway_tools(
             if use_sandbox or mcp_servers:
                 raise adapter.error(400, WEB_SEARCH_CONFLICT_DETAIL, ErrorKind.INVALID_REQUEST)
             use_web_search = True
+
+            # Platform mode owns the per-workspace web-search policy (whether it's
+            # enabled at all, plus workspace-default max_results / domain filters /
+            # purpose hint / provider_options). Mirrors the mcp_server_ids resolve
+            # above. Precedence is "per-request overrides workspace default":
+            #  * top-level keys are applied only when the request's own tool entry
+            #    didn't already set them;
+            #  * provider_options is shallow-merged so workspace defaults fill the
+            #    keys the request omitted while per-request keys still win (rather
+            #    than the request's dict replacing the workspace dict wholesale).
+            # Standalone mode has no platform to consult.
+            if ctx.platform_mode:
+                assert ctx.user_token is not None  # guaranteed by the platform-mode preamble
+                web_search_policy = await _resolve_platform_web_search(
+                    config=ctx.config,
+                    user_token=ctx.user_token,
+                )
+                if not web_search_policy.get("enabled"):
+                    raise adapter.error(403, WEB_SEARCH_NOT_ENABLED_DETAIL, ErrorKind.PERMISSION)
+                for key in ("max_results", "allowed_domains", "blocked_domains", "purpose_hint"):
+                    resolved_value = web_search_policy.get(key)
+                    if key not in web_search_tool_entry and resolved_value is not None:
+                        web_search_tool_entry[key] = resolved_value
+                workspace_options = web_search_policy.get("provider_options")
+                if isinstance(workspace_options, dict):
+                    request_options = web_search_tool_entry.get("provider_options")
+                    web_search_tool_entry["provider_options"] = (
+                        {**workspace_options, **request_options}
+                        if isinstance(request_options, dict)
+                        else workspace_options
+                    )
     except HTTPException:
         await release_reservation(ctx)
         raise

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -508,8 +508,11 @@ async def prepare_gateway_tools(
             # enabled at all, plus workspace-default max_results / domain filters /
             # purpose hint / provider_options). Mirrors the mcp_server_ids resolve
             # above. Precedence is "per-request overrides workspace default":
-            #  * top-level keys are applied only when the request's own tool entry
-            #    didn't already set them;
+            #  * top-level keys are applied only when the request didn't supply a
+            #    meaningful (truthy) value of its own. An empty list / empty string
+            #    reads as "no preference" and falls back to the workspace value
+            #    rather than silently clearing the workspace's policy (e.g. a
+            #    request `allowed_domains: []` must NOT wipe a workspace allow-list);
             #  * provider_options is shallow-merged so workspace defaults fill the
             #    keys the request omitted while per-request keys still win (rather
             #    than the request's dict replacing the workspace dict wholesale).
@@ -524,7 +527,7 @@ async def prepare_gateway_tools(
                     raise adapter.error(403, WEB_SEARCH_NOT_ENABLED_DETAIL, ErrorKind.PERMISSION)
                 for key in ("max_results", "allowed_domains", "blocked_domains", "purpose_hint"):
                     resolved_value = web_search_policy.get(key)
-                    if key not in web_search_tool_entry and resolved_value is not None:
+                    if not web_search_tool_entry.get(key) and resolved_value is not None:
                         web_search_tool_entry[key] = resolved_value
                 workspace_options = web_search_policy.get("provider_options")
                 if isinstance(workspace_options, dict):

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -509,6 +509,70 @@ async def _resolve_platform_mcp_servers(
     )
 
 
+async def _resolve_platform_web_search(
+    config: GatewayConfig,
+    user_token: str,
+) -> dict[str, Any]:
+    """Resolve the workspace's web-search policy via the platform.
+
+    Mirrors `_resolve_platform_mcp_servers`: same base_url guard, timeout,
+    headers, `_post_platform` call, and status-code handling. POSTs an empty
+    body to `/gateway/web-search/resolve` and returns the parsed JSON dict on
+    200 (``{enabled, provider, max_results, purpose_hint, allowed_domains,
+    blocked_domains, provider_options}``). Client errors (auth/quota/not-found/
+    rate-limit) forward verbatim; the platform's server-side or unexpected
+    responses collapse to 502.
+    """
+    platform_base_url = config.platform.get("base_url")
+    if not platform_base_url:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Platform mode is misconfigured",
+        )
+
+    timeout_ms = int(config.platform.get("resolve_timeout_ms", 5000))
+    resolve_url = _platform_url(platform_base_url, "/gateway/web-search/resolve")
+    headers = {
+        "X-Gateway-Token": config.platform_token or "",
+        "X-User-Token": user_token,
+    }
+    body: dict[str, Any] = {}
+
+    try:
+        response = await _post_platform(url=resolve_url, headers=headers, body=body, timeout_seconds=timeout_ms / 1000)
+    except (httpx.TimeoutException, httpx.NetworkError):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authorization service unavailable",
+        ) from None
+
+    if response.status_code == 200:
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
+    # Mirror the status-code semantics of `_resolve_platform_mcp_servers`:
+    # client errors (auth/quota/not-found/rate-limit) are forwarded so the
+    # caller sees the real status (and can honour Retry-After on 429), while
+    # the platform's server-side or unexpected responses collapse to 502.
+    if response.status_code in {401, 402, 403, 404, 429}:
+        detail = _safe_detail_from_platform(response, "Web search resolution failed")
+        response_headers: dict[str, str] | None = None
+        if response.status_code == 429 and response.headers.get("Retry-After"):
+            response_headers = {"Retry-After": response.headers["Retry-After"]}
+        raise HTTPException(status_code=response.status_code, detail=detail, headers=response_headers)
+
+    if response.status_code == 422 or response.status_code >= 500:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authorization service unavailable",
+        )
+
+    raise HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail="Authorization service unavailable",
+    )
+
+
 async def _report_platform_usage(
     config: GatewayConfig,
     correlation_id: str,

--- a/src/gateway/api/routes/_tools.py
+++ b/src/gateway/api/routes/_tools.py
@@ -225,4 +225,10 @@ def _build_web_search_backend(*, base_url: str, tool_entry: dict[str, Any]) -> W
     if purpose_hint:
         kwargs["purpose_hint"] = purpose_hint
 
+    # Provider-specific knobs (e.g. Tavily's search_depth / topic). The gateway
+    # forwards these to the search backend as-is; the adapter interprets them.
+    provider_options = tool_entry.get("provider_options")
+    if isinstance(provider_options, dict) and provider_options:
+        kwargs["provider_options"] = provider_options
+
     return WebSearchBackend(**kwargs)

--- a/src/gateway/services/web_search_backend.py
+++ b/src/gateway/services/web_search_backend.py
@@ -46,6 +46,9 @@ logger = logging.getLogger(__name__)
 
 WEB_SEARCH_TOOL_NAME = "web_search"
 
+# Gateway-controlled /search query params that provider_options must never override.
+_RESERVED_SEARCH_PARAMS = frozenset({"q", "format", "engines"})
+
 _DEFAULT_SEARCH_TIMEOUT_S = 15.0
 _DEFAULT_FETCH_TIMEOUT_S = 5.0
 _DEFAULT_MAX_RESULTS = 5
@@ -109,6 +112,7 @@ class WebSearchBackend:
         extract_concurrency: int = _DEFAULT_EXTRACT_CONCURRENCY,
         search_timeout_s: float = _DEFAULT_SEARCH_TIMEOUT_S,
         purpose_hint: str | None = None,
+        provider_options: dict[str, Any] | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._engines = engines
@@ -125,6 +129,11 @@ class WebSearchBackend:
         self._extract_concurrency = extract_concurrency
         self._search_timeout_s = search_timeout_s
         self._purpose_hint = purpose_hint or _DEFAULT_PURPOSE_HINT
+        # Sanitised copy of provider-specific knobs forwarded to the search
+        # backend as extra `/search` query params. Only scalar values survive
+        # (see `_search`); complex / None values are dropped so a misconfigured
+        # entry can't smuggle structured payloads into the GET.
+        self._provider_options = dict(provider_options) if provider_options else {}
         self._client: httpx.AsyncClient | None = None
         self._stack: AsyncExitStack = AsyncExitStack()
 
@@ -201,12 +210,30 @@ class WebSearchBackend:
     # ----- internals -----
 
     async def _search(self, query: str) -> list[dict[str, Any]]:
+        """Issue the backend's ``/search`` GET.
+
+        ``q`` / ``format`` / ``engines`` are the fixed SearXNG params. Any
+        configured ``provider_options`` are forwarded as additional query
+        params so the backend (the adapter) can interpret provider-specific
+        knobs; the gateway does not interpret these keys itself. Only scalar
+        values (str / int / float / bool) are forwarded — bools serialise as
+        lowercase ``"true"`` / ``"false"`` — and None / complex values are
+        skipped. Reserved gateway-controlled params (``q`` / ``format`` /
+        ``engines``) are never overridable by ``provider_options``.
+        """
         assert self._client is not None
-        params = {
+        params: dict[str, str | int | float] = {
             "q": query,
             "format": "json",
             "engines": ",".join(self._engines),
         }
+        for key, value in self._provider_options.items():
+            if key in _RESERVED_SEARCH_PARAMS or value is None:
+                continue
+            if isinstance(value, bool):
+                params[key] = "true" if value else "false"
+            elif isinstance(value, (str, int, float)):
+                params[key] = value
         response = await self._client.get(
             f"{self._base_url}/search",
             params=params,

--- a/tests/integration/test_platform_mode_chat.py
+++ b/tests/integration/test_platform_mode_chat.py
@@ -1014,3 +1014,59 @@ def test_platform_mode_web_search_merges_workspace_config(
     assert merged["allowed_domains"] == ["docs.python.org"]
     assert merged["purpose_hint"] == "workspace hint"
     assert merged["provider_options"] == {"search_depth": "advanced"}
+
+
+def test_platform_mode_web_search_empty_request_list_keeps_workspace_policy(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A request `allowed_domains: []` reads as "no preference" and must NOT clear
+    the workspace allow-list — empty/falsy per-request values fall back to the
+    workspace value instead of overriding it."""
+    monkeypatch.setenv("GATEWAY_WEB_SEARCH_URL", "http://searxng:8080")
+    _FakeWebSearchBackend.last_tool_entry = None
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _single_attempt_resolve_response(request_id="ws-req-empty")
+        if url.endswith("/gateway/web-search/resolve"):
+            return httpx.Response(200, json={"enabled": True, "allowed_domains": ["docs.python.org"]})
+        return httpx.Response(204)
+
+    async def fake_loop_acompletion(**kwargs: Any) -> ChatCompletion:
+        return ChatCompletion(
+            id="cmpl-ws",
+            object="chat.completion",
+            created=0,
+            model="openai:gpt-4o-mini",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="answer"),
+                )
+            ],
+            usage=CompletionUsage(prompt_tokens=3, completion_tokens=2, total_tokens=5),
+        )
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes._pipeline._build_web_search_backend", _FakeWebSearchBackend)
+    monkeypatch.setattr("gateway.services.mcp_loop.acompletion", fake_loop_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "otari_web_search", "allowed_domains": []}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+    merged = _FakeWebSearchBackend.last_tool_entry
+    assert merged is not None
+    # Empty per-request list did not wipe the workspace allow-list.
+    assert merged["allowed_domains"] == ["docs.python.org"]

--- a/tests/integration/test_platform_mode_chat.py
+++ b/tests/integration/test_platform_mode_chat.py
@@ -852,3 +852,165 @@ def test_platform_mode_tool_loop_streaming_falls_through_pre_lock_in(
     assert response.headers["X-Correlation-ID"] == "tool-att-openai"
     assert calls == ["anthropic:claude-haiku-4-5", "openai:gpt-4o-mini"]
     assert "hello" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Web-search platform policy resolution
+# ---------------------------------------------------------------------------
+#
+# In platform mode an `otari_web_search` request consults the platform's
+# `/gateway/web-search/resolve` endpoint: if web search is disabled for the
+# workspace the gateway 403s; otherwise the resolved workspace config is
+# merged into the tool entry (per-request values win) before the backend runs.
+
+
+class _FakeWebSearchBackend:
+    """Minimal WebSearchBackend duck-type that records the tool_entry it was
+    built from and resolves the tool loop in a single round (no real search)."""
+
+    last_tool_entry: dict[str, Any] | None = None
+
+    def __init__(self, *, base_url: str, tool_entry: dict[str, Any]) -> None:
+        type(self).last_tool_entry = dict(tool_entry)
+
+    async def __aenter__(self) -> "_FakeWebSearchBackend":
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    @property
+    def openai_tools(self) -> list[dict[str, Any]]:
+        return [{"type": "function", "function": {"name": "web_search", "description": "", "parameters": {}}}]
+
+    def owns_tool(self, name: str) -> bool:
+        return name == "web_search"
+
+    def purpose_hints(self) -> list[tuple[str, str]]:
+        return []
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+        return "results"
+
+
+def _single_attempt_resolve_response(*, request_id: str) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "request_id": request_id,
+            "fallback_enabled": False,
+            "attempts": [
+                {
+                    "attempt_id": request_id,
+                    "position": 0,
+                    "provider": "openai",
+                    "model": "gpt-4o-mini",
+                    "api_key": "sk-platform-key",
+                    "api_base": "https://api.openai.com/v1",
+                    "managed": True,
+                }
+            ],
+        },
+    )
+
+
+def test_platform_mode_web_search_403_when_disabled(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An `otari_web_search` request whose workspace has web search disabled
+    is rejected with 403 before any provider call."""
+    monkeypatch.setenv("GATEWAY_WEB_SEARCH_URL", "http://searxng:8080")
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _single_attempt_resolve_response(request_id="ws-req-disabled")
+        if url.endswith("/gateway/web-search/resolve"):
+            return httpx.Response(200, json={"enabled": False})
+        return httpx.Response(204)
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "otari_web_search"}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "web search is not enabled for this workspace"}
+
+
+def test_platform_mode_web_search_merges_workspace_config(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When enabled, the resolved workspace config is merged into the tool
+    entry with per-request values winning over workspace defaults."""
+    monkeypatch.setenv("GATEWAY_WEB_SEARCH_URL", "http://searxng:8080")
+    _FakeWebSearchBackend.last_tool_entry = None
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _single_attempt_resolve_response(request_id="ws-req-enabled")
+        if url.endswith("/gateway/web-search/resolve"):
+            return httpx.Response(
+                200,
+                json={
+                    "enabled": True,
+                    "max_results": 9,
+                    "allowed_domains": ["docs.python.org"],
+                    "purpose_hint": "workspace hint",
+                    "provider_options": {"search_depth": "advanced"},
+                },
+            )
+        return httpx.Response(204)
+
+    async def fake_loop_acompletion(**kwargs: Any) -> ChatCompletion:
+        return ChatCompletion(
+            id="cmpl-ws",
+            object="chat.completion",
+            created=0,
+            model="openai:gpt-4o-mini",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="answer"),
+                )
+            ],
+            usage=CompletionUsage(prompt_tokens=3, completion_tokens=2, total_tokens=5),
+        )
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes._pipeline._build_web_search_backend", _FakeWebSearchBackend)
+    monkeypatch.setattr("gateway.services.mcp_loop.acompletion", fake_loop_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            # Per-request max_results=3 must win over the workspace default 9.
+            "tools": [{"type": "otari_web_search", "max_results": 3}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+    merged = _FakeWebSearchBackend.last_tool_entry
+    assert merged is not None
+    # Per-request value wins.
+    assert merged["max_results"] == 3
+    # Workspace defaults fill in the unset keys.
+    assert merged["allowed_domains"] == ["docs.python.org"]
+    assert merged["purpose_hint"] == "workspace hint"
+    assert merged["provider_options"] == {"search_depth": "advanced"}

--- a/tests/unit/test_tavily_adapter.py
+++ b/tests/unit/test_tavily_adapter.py
@@ -1,0 +1,189 @@
+"""Unit tests for the Tavily web-search adapter (scripts/web-search-tavily-adapter).
+
+The adapter is a standalone service outside the gateway package, so we load
+it by path. Outbound Tavily calls are mocked via an httpx transport; the test
+suite needs no network access or live key.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+_ADAPTER_PATH = Path(__file__).resolve().parents[2] / "scripts" / "web-search-tavily-adapter" / "app.py"
+
+
+def _load_adapter(monkeypatch: pytest.MonkeyPatch, *, api_key: str = "tvly-test") -> Any:
+    monkeypatch.setenv("TAVILY_API_KEY", api_key)
+    spec = importlib.util.spec_from_file_location("tavily_adapter_app", _ADAPTER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["tavily_adapter_app"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_health_reports_missing_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_adapter(monkeypatch, api_key="")
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "missing TAVILY_API_KEY"}
+
+
+@pytest.mark.asyncio
+async def test_health_healthy_with_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_adapter(monkeypatch)
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get("/health")
+    assert resp.json() == {"status": "healthy"}
+
+
+@pytest.mark.asyncio
+async def test_search_maps_tavily_shape_and_whitelists(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_adapter(monkeypatch)
+
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["auth"] = request.headers.get("authorization")
+        captured["body"] = json_body(request)
+        return httpx.Response(
+            200,
+            json={
+                "results": [
+                    {
+                        "title": "Post A",
+                        "url": "https://example.com/a",
+                        "content": "snippet a",
+                        "raw_content": "full page a",
+                    },
+                    {
+                        "title": "Post B",
+                        "url": "https://example.org/b",
+                        "content": "snippet b",
+                        "raw_content": None,
+                    },
+                    {"title": "no url", "content": "x"},
+                ]
+            },
+        )
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", _mock_async_client(handler))
+
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get(
+            "/search",
+            params={
+                "q": "claude code",
+                "max_results": 5,
+                "search_depth": "advanced",
+                "topic": "news",
+                # Not a whitelisted Tavily param at the body level — FastAPI
+                # ignores unknown query params, so it never reaches Tavily.
+                "bogus": "should-not-forward",
+            },
+        )
+
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert len(results) == 2  # the url-less hit is dropped
+    assert results[0] == {
+        "url": "https://example.com/a",
+        "title": "Post A",
+        "content": "snippet a",
+        "extracted_content": "full page a",
+    }
+    # raw_content None → no extracted_content key
+    assert "extracted_content" not in results[1]
+
+    assert captured["url"] == "https://api.tavily.com/search"
+    assert captured["auth"] == "Bearer tvly-test"
+    body = captured["body"]
+    assert body["query"] == "claude code"
+    assert body["include_raw_content"] is True
+    assert body["max_results"] == 5
+    assert body["search_depth"] == "advanced"
+    assert body["topic"] == "news"
+    assert "bogus" not in body
+
+
+@pytest.mark.asyncio
+async def test_search_surfaces_tavily_status_as_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_adapter(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": "bad key"})
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", _mock_async_client(handler))
+
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get("/search", params={"q": "x"})
+
+    assert resp.status_code == 502
+    assert resp.json() == {"error": "tavily search returned 401"}
+
+
+@pytest.mark.asyncio
+async def test_search_invalid_json_returns_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_adapter(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"<html>not json</html>", headers={"content-type": "application/json"})
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", _mock_async_client(handler))
+
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get("/search", params={"q": "x"})
+
+    assert resp.status_code == 502
+    assert "invalid JSON" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_search_503_when_key_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_adapter(monkeypatch, api_key="")
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get("/search", params={"q": "x"})
+    assert resp.status_code == 503
+
+
+# ----- helpers -----
+
+
+def json_body(request: httpx.Request) -> dict[str, Any]:
+    import json
+
+    body: dict[str, Any] = json.loads(request.content.decode())
+    return body
+
+
+def _mock_async_client(handler: Any) -> Any:
+    """Return an httpx.AsyncClient subclass whose outbound calls use a mock
+    transport — so the adapter's POST to Tavily is intercepted."""
+
+    real_async_client = httpx.AsyncClient
+
+    class _MockAsyncClient(real_async_client):  # type: ignore[valid-type, misc]
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            # The test drives the ASGI app through its own AsyncClient with an
+            # explicit transport; leave that one untouched. Only the adapter's
+            # own outbound call (which passes no transport) gets the mock.
+            if "transport" not in kwargs:
+                kwargs["transport"] = httpx.MockTransport(handler)
+            super().__init__(*args, **kwargs)
+
+    return _MockAsyncClient

--- a/tests/unit/test_tavily_adapter.py
+++ b/tests/unit/test_tavily_adapter.py
@@ -170,6 +170,16 @@ async def test_search_non_list_results_returns_502(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.asyncio
+async def test_search_invalid_time_range_returns_422(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Bad time_range is rejected at the edge (Query pattern) before any Tavily call.
+    module = _load_adapter(monkeypatch)
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get("/search", params={"q": "x", "time_range": "bogus"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_search_503_when_key_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_adapter(monkeypatch, api_key="")
     transport = httpx.ASGITransport(app=module.app)

--- a/tests/unit/test_tavily_adapter.py
+++ b/tests/unit/test_tavily_adapter.py
@@ -34,7 +34,7 @@ async def test_health_reports_missing_key(monkeypatch: pytest.MonkeyPatch) -> No
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
         resp = await client.get("/health")
-    assert resp.status_code == 200
+    assert resp.status_code == 503
     assert resp.json() == {"status": "missing TAVILY_API_KEY"}
 
 
@@ -150,6 +150,23 @@ async def test_search_invalid_json_returns_502(monkeypatch: pytest.MonkeyPatch) 
 
     assert resp.status_code == 502
     assert "invalid JSON" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_search_non_list_results_returns_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_adapter(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"results": "not-a-list"})
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", _mock_async_client(handler))
+
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get("/search", params={"q": "x"})
+
+    assert resp.status_code == 502
+    assert "unexpected shape" in resp.json()["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_web_search_backend.py
+++ b/tests/unit/test_web_search_backend.py
@@ -196,12 +196,7 @@ async def test_blocked_domains_filter_in_gateway(monkeypatch: pytest.MonkeyPatch
 
 @pytest.mark.asyncio
 async def test_max_results_truncates(monkeypatch: pytest.MonkeyPatch) -> None:
-    body = {
-        "results": [
-            {"url": f"https://ex.com/{i}", "title": f"T{i}", "content": f"s{i}"}
-            for i in range(10)
-        ]
-    }
+    body = {"results": [{"url": f"https://ex.com/{i}", "title": f"T{i}", "content": f"s{i}"} for i in range(10)]}
     _patched_async_client(
         {("searxng", "/search"): httpx.Response(200, json=body)},
         monkeypatch,
@@ -213,6 +208,64 @@ async def test_max_results_truncates(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "[1] T0" in result
     assert "[3] T2" in result
     assert "[4]" not in result
+
+
+@pytest.mark.asyncio
+async def test_provider_options_forwarded_as_query_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scalar provider_options become extra /search query params; bools
+    serialise as lowercase strings and None/complex values are dropped."""
+    transport = _patched_async_client(
+        {("searxng", "/search"): httpx.Response(200, json=SEARXNG_OK_BODY)},
+        monkeypatch,
+    )
+
+    async with WebSearchBackend(
+        base_url="http://searxng:8080",
+        extract_content=False,
+        provider_options={
+            "search_depth": "advanced",
+            "max_results": 7,
+            "include_answer": True,
+            "exclude_news": False,
+            "dropped_none": None,
+            "dropped_list": ["a", "b"],
+        },
+    ) as backend:
+        await backend.call_tool(WEB_SEARCH_TOOL_NAME, {"query": "x"})
+
+    req = transport.captured[0]
+    params = dict(req.url.params)
+    assert params["q"] == "x"
+    assert params["format"] == "json"
+    assert params["search_depth"] == "advanced"
+    assert params["max_results"] == "7"
+    assert params["include_answer"] == "true"
+    assert params["exclude_news"] == "false"
+    assert "dropped_none" not in params
+    assert "dropped_list" not in params
+
+
+@pytest.mark.asyncio
+async def test_provider_options_cannot_override_reserved_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    """provider_options must never override the gateway-controlled q/format/engines."""
+    transport = _patched_async_client(
+        {("searxng", "/search"): httpx.Response(200, json=SEARXNG_OK_BODY)},
+        monkeypatch,
+    )
+
+    async with WebSearchBackend(
+        base_url="http://searxng:8080",
+        engines=("duckduckgo",),
+        extract_content=False,
+        provider_options={"q": "evil", "format": "xml", "engines": "google", "topic": "news"},
+    ) as backend:
+        await backend.call_tool(WEB_SEARCH_TOOL_NAME, {"query": "real query"})
+
+    params = dict(transport.captured[0].url.params)
+    assert params["q"] == "real query"
+    assert params["format"] == "json"
+    assert params["engines"] == "duckduckgo"
+    assert params["topic"] == "news"
 
 
 @pytest.mark.asyncio
@@ -376,9 +429,7 @@ async def test_ssrf_guard_blocks_redirect_to_metadata(monkeypatch: pytest.Monkey
     naive client follows. We walk redirects manually and re-validate each
     hop — the metadata IP must be rejected here too.
     """
-    body = {
-        "results": [{"url": "https://attacker.example.com/start", "title": "trap", "content": "snippet"}]
-    }
+    body = {"results": [{"url": "https://attacker.example.com/start", "title": "trap", "content": "snippet"}]}
     transport = _patched_async_client(
         {
             ("searxng", "/search"): httpx.Response(200, json=body),
@@ -413,9 +464,7 @@ async def test_fetch_capped_truncates_huge_response(monkeypatch: pytest.MonkeyPa
     that's fine; the contract is "don't OOM", not "always extract").
     """
     huge_html = "<html><body>" + "A" * (10 * 1024 * 1024) + "</body></html>"
-    body = {
-        "results": [{"url": "https://example.com/huge", "title": "Huge", "content": "snippet"}]
-    }
+    body = {"results": [{"url": "https://example.com/huge", "title": "Huge", "content": "snippet"}]}
     _patched_async_client(
         {
             ("searxng", "/search"): httpx.Response(200, json=body),

--- a/tests/unit/test_web_search_resolve.py
+++ b/tests/unit/test_web_search_resolve.py
@@ -1,0 +1,138 @@
+"""Unit tests for resolving the workspace web-search policy via the platform."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from gateway.api.routes import _platform as platform_module
+from gateway.api.routes._platform import _resolve_platform_web_search
+
+
+def _config(*, base_url: str | None = "https://platform.local") -> Any:
+    cfg = MagicMock()
+    cfg.platform = {"base_url": base_url, "resolve_timeout_ms": 5000} if base_url else {}
+    cfg.platform_token = "gw_test_token"
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_policy_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_post(
+        *, url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["body"] = body
+        return httpx.Response(
+            200,
+            json={
+                "enabled": True,
+                "provider": "tavily",
+                "max_results": 7,
+                "purpose_hint": "search the docs",
+                "allowed_domains": ["docs.python.org"],
+                "blocked_domains": None,
+                "provider_options": {"search_depth": "advanced"},
+            },
+        )
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    out = await _resolve_platform_web_search(_config(), "tk_user")
+
+    assert out["enabled"] is True
+    assert out["max_results"] == 7
+    assert out["provider_options"] == {"search_depth": "advanced"}
+
+    assert captured["url"].endswith("/gateway/web-search/resolve")
+    assert captured["headers"]["X-Gateway-Token"] == "gw_test_token"
+    assert captured["headers"]["X-User-Token"] == "tk_user"
+    assert captured["body"] == {}
+
+
+@pytest.mark.asyncio
+async def test_resolve_403_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return httpx.Response(403, json={"detail": "web search disabled"})
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_web_search(_config(), "tk")
+    assert ei.value.status_code == 403
+    assert ei.value.detail == "web search disabled"
+
+
+@pytest.mark.asyncio
+async def test_resolve_429_passthrough_with_retry_after(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return httpx.Response(429, json={"detail": "slow down"}, headers={"Retry-After": "30"})
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_web_search(_config(), "tk")
+    assert ei.value.status_code == 429
+    assert ei.value.headers == {"Retry-After": "30"}
+    assert ei.value.detail == "slow down"
+
+
+@pytest.mark.asyncio
+async def test_resolve_5xx_maps_to_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return httpx.Response(503, text="busy")
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_web_search(_config(), "tk")
+    assert ei.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_resolve_422_collapses_to_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return httpx.Response(422, json={"detail": "schema mismatch"})
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_web_search(_config(), "tk")
+    assert ei.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_resolve_network_error_maps_to_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        raise httpx.NetworkError("connection refused")
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_web_search(_config(), "tk")
+    assert ei.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_resolve_misconfigured_platform_500() -> None:
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_web_search(_config(base_url=None), "tk")
+    assert ei.value.status_code == 500


### PR DESCRIPTION
## Description

Gateway half of per-workspace web search. In **platform mode**, an `otari_web_search` request consults the platform's `POST /gateway/web-search/resolve`: **403** if the workspace has web search disabled, otherwise the workspace's saved config (`max_results`, `allowed_domains`, `blocked_domains`, `purpose_hint`, `provider_options`) is merged into the tool entry with **per-request values taking precedence**. Wired into the shared `prepare_gateway_tools` (mirrors the `mcp_server_ids` resolve), so chat / messages / responses all inherit it — no streaming-machinery signatures changed.

- `_resolve_platform_web_search` mirrors `_resolve_platform_mcp_servers` (same auth/timeout/status mapping; reuses the `platform`/`platform_token` abstraction, no new brand strings).
- `WebSearchBackend` forwards `provider_options` to the search backend as scalar query params (gateway doesn't interpret provider-specific keys).
- New SearXNG-compatible **Tavily adapter** (`scripts/web-search-tavily-adapter/`) — the Tavily key lives in the adapter, never the gateway.

Companion (platform side, required for end-to-end): mozilla-ai/otari-ai#1063

## PR Type

- [x] New Feature

## Relevant issues

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). _(Ran `ruff check`, `mypy`, and the web-search + platform chat/messages/responses + pipeline test subsets — all green; have not run the full `make` targets yet.)_
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec — N/A (no new gateway-exposed endpoint; only an outbound platform call).

## AI Usage

- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Claude Opus 4.8)

**Any additional AI details you'd like to share:** Authored under direct human review/direction; verified end-to-end locally against the otari-ai platform with a real Tavily key.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR adds per-workspace web-search policy resolution to the gateway in platform mode and ships a new, SearXNG-compatible Tavily web-search adapter as a separate containerized service.

What changed (high level)
- Gateway policy resolution: in platform mode the gateway calls the platform POST /gateway/web-search/resolve. If the workspace policy disables web search the gateway returns 403; if enabled, the workspace’s saved web-search settings (max_results, allowed_domains, blocked_domains, purpose_hint, provider_options) are merged into the web_search tool entry with per-request values taking precedence.
- Merge semantics: empty/falsy per-request lists (e.g., allowed_domains: []) are treated as “no override” and do not erase workspace defaults.
- Provider options forwarding and safety: the gateway now carries provider_options into WebSearchBackend and forwards them to adapters as scalar query parameters only; gateway-reserved parameters (q, format, engines) cannot be overridden by provider_options. Non-scalar values are dropped; booleans serialize to "true"/"false".
- Platform helper: adds _resolve_platform_web_search mirroring existing platform-resolution helpers (same auth/timeout/status mapping and error translations).
- Tavily adapter: new FastAPI adapter (scripts/web-search-tavily-adapter) exposing /health and /search, validating/whitelisting provider options, forwarding a sanitized payload to Tavily, mapping Tavily’s raw_content → extracted_content, and returning clear 502/422/503 responses for upstream or validation failures. The adapter holds its API key (not in the gateway).
- Deployment/docs: docker-compose, README, .env.example, and deployment docs updated to include the Tavily adapter and related env vars; pyproject mypy config excludes adapter directories.
- Tests: added/updated unit and integration tests covering platform resolution, merge semantics (including empty-list behavior), provider_options forwarding and reservation, and the Tavily adapter (validation, error mapping, response shaping).

Benefits
- Enables workspace-level control over web-search usage and settings.
- Keeps provider credentials and provider-specific logic out of the gateway by using separate adapters.
- Allows per-workspace provider tuning while preserving gateway safety through reserved-parameter and scalar-only forwarding.
- Improves documentation and test coverage for the new adapter and platform-resolve behavior.

Notes
- The Tavily adapter is a standalone service (excluded from gateway mypy) and stores its API key locally.
- A companion platform PR is required for end-to-end behavior (platform must implement /gateway/web-search/resolve).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->