### PR TITLE
fix(sdk-codegen): type response schemas in serialization mode so reasoning is a string

### DIFF
--- a/scripts/sdk_codegen/generate.py
+++ b/scripts/sdk_codegen/generate.py
@@ -264,11 +264,20 @@ def enrich_spec(spec: dict[str, Any]) -> dict[str, Any]:
             schemas[f"{prefix}_{name}"] = body
         return js
 
+    # These are response shapes, so generate the JSON Schema in ``serialization``
+    # mode: it reflects the bytes the gateway actually puts on the wire, not the
+    # (looser) validation shape. The any-llm ``Reasoning`` type is the motivating
+    # case: it accepts ``{"content": str}`` on input but a ``model_serializer``
+    # emits a plain string, so ``message.reasoning`` is a string in responses.
+    # Validation-mode schema typed it as an object, and the generated client then
+    # rejected the string the server sends. See mozilla-ai/otari#143.
     schemas["ChatCompletion"] = absorb(
-        ChatCompletion.model_json_schema(ref_template="#/components/schemas/CC_{model}"), "CC"
+        ChatCompletion.model_json_schema(mode="serialization", ref_template="#/components/schemas/CC_{model}"),
+        "CC",
     )
     schemas["ChatCompletionChunk"] = absorb(
-        ChatCompletionChunk.model_json_schema(ref_template="#/components/schemas/CCK_{model}"), "CCK"
+        ChatCompletionChunk.model_json_schema(mode="serialization", ref_template="#/components/schemas/CCK_{model}"),
+        "CCK",
     )
     msgs = absorb(
         TypeAdapter(list[ChatCompletionMessageParam]).json_schema(ref_template="#/components/schemas/MSG_{model}"),
@@ -281,14 +290,21 @@ def enrich_spec(spec: dict[str, Any]) -> dict[str, Any]:
     # inject them so the generated core returns typed models instead of ``object``.
     # Audio/images are intentionally left opaque: they return binary/file payloads
     # that do not map onto a JSON response schema.
+    # Response shapes too: serialization mode keeps the schema aligned with the
+    # serialized wire format (see the ChatCompletion note above).
     schemas["MessageResponse"] = absorb(
-        MessageResponse.model_json_schema(ref_template="#/components/schemas/MR_{model}"), "MR"
+        MessageResponse.model_json_schema(mode="serialization", ref_template="#/components/schemas/MR_{model}"),
+        "MR",
     )
     schemas["RerankResponse"] = absorb(
-        RerankResponse.model_json_schema(ref_template="#/components/schemas/RR_{model}"), "RR"
+        RerankResponse.model_json_schema(mode="serialization", ref_template="#/components/schemas/RR_{model}"),
+        "RR",
     )
     schemas["CreateEmbeddingResponse"] = absorb(
-        CreateEmbeddingResponse.model_json_schema(ref_template="#/components/schemas/EMB_{model}"), "EMB"
+        CreateEmbeddingResponse.model_json_schema(
+            mode="serialization", ref_template="#/components/schemas/EMB_{model}"
+        ),
+        "EMB",
     )
 
     def set_json_200(path: str, schema_name: str, description: str) -> None:

--- a/tests/unit/test_sdk_codegen.py
+++ b/tests/unit/test_sdk_codegen.py
@@ -238,6 +238,20 @@ def test_enrich_types_otari_owned_inference_endpoints() -> None:
     assert messages_field["items"]["$ref"].endswith("/ChatMessageInput")
 
 
+def test_enrich_types_reasoning_as_string_matching_wire_format() -> None:
+    # The gateway serializes ``message.reasoning`` as a plain string (any-llm's
+    # ``Reasoning`` model has a ``model_serializer`` that emits a string), but the
+    # validation-mode JSON Schema typed it as an object, so the generated client
+    # rejected the string the server returns. Generating the response schemas in
+    # serialization mode keeps the schema aligned with the wire format.
+    # Regression test for mozilla-ai/otari#143.
+    spec = generate.enrich_spec(_full_spec_stub())
+    schemas = spec["components"]["schemas"]
+    for prefix in ("CC", "CCK"):
+        reasoning = schemas[f"{prefix}_Reasoning"]
+        assert reasoning == {"type": "string"}, f"{prefix}_Reasoning must be a plain string, got {reasoning}"
+
+
 def test_control_plane_tags_are_typed_management_only() -> None:
     assert generate.CONTROL_PLANE_TAGS == frozenset(
         {"keys", "users", "budgets", "pricing", "usage"}


### PR DESCRIPTION
## Description

The SDK codegen enriches the spec with the typed response schemas from `any-llm` via `model_json_schema()`. Those calls used the default validation mode, which typed any-llm's `Reasoning` as an object (`{content: str}`). But `Reasoning` has a `model_serializer` that emits a plain string, so the gateway puts a string on the wire for `message.reasoning`. The generated client, built from the object-typed schema, then failed to deserialize the string, and every reasoning-emitting model (for example `mzai:openai/gpt-oss-120b`, `mzai:nvidia/nemotron-3-super-120b-a12b`) broke during response parsing before the caller ever saw the content.

This switches the five response schemas (`ChatCompletion`, `ChatCompletionChunk`, `MessageResponse`, `RerankResponse`, `CreateEmbeddingResponse`) to `mode="serialization"`, so the schema reflects the serialized wire format. Today that changes only the `Reasoning` shape (object to string); the other response types are byte-identical, but serialization mode keeps them aligned with what is actually sent should their serializers ever diverge from their validation shape.

A regression test asserts `CC_Reasoning` and `CCK_Reasoning` are plain strings. It was verified to fail without the fix (schema is an object) and pass with it.

Note: the linked any-llm issue (mozilla-ai/any-llm#1126) describes two further failures (tool_calls wrapper shape and non-streaming `MessageResponse`); both are characterized there as any-llm-side conversion bugs, not otari schema bugs, so they are out of scope here.

## PR Type

- [x] Bug Fix

## Relevant issues

Fixes #143

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). (No change: the main spec is unaffected; this only touches SDK-codegen enrichment, and `make openapi-check` passes.)

## AI Usage

- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:**

Implemented via the fix-github-issue workflow under @njbrake's direction; reasoning and decisions are his.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes SDK client deserialization errors for AI models that return reasoning outputs. The generated SDK schemas are now aligned with the actual wire format sent by the gateway, preventing validation failures when receiving reasoning fields.

## What Changed

**SDK Code Generation (`scripts/sdk_codegen/generate.py`)**
- Modified the `enrich_spec` function to generate response schemas using Pydantic's serialization mode instead of the default validation mode
- Applies to 5 response types: ChatCompletion, ChatCompletionChunk, MessageResponse, RerankResponse, and CreateEmbeddingResponse
- The serialization-mode schemas now match the actual wire format that the gateway sends

**Tests (`tests/unit/test_sdk_codegen.py`)**
- Added a regression test (`test_enrich_types_reasoning_as_string_matching_wire_format`) to verify that reasoning fields (`CC_Reasoning` and `CCK_Reasoning`) are correctly typed as plain strings in the generated schemas

## Why This Matters

Previously, the `Reasoning` type was generated as an object (`{content: string}`) in the SDK schema, but the gateway serializes it as a plain string on the wire. This mismatch caused client-side deserialization failures for reasoning-capable models (like `mzai:openai/gpt-oss-120b` and `mzai:nvidia/nemotron-3-super-120b-a12b`). By switching to serialization-mode schema generation, the SDK now correctly expects a string, eliminating these validation errors.

## Technical Notes

The fix uses Pydantic's `model_json_schema(mode="serialization")` to generate schemas that reflect the actual serialized output rather than the validation input format. While this specifically addresses the `Reasoning` field conversion (object → string), it keeps other response types aligned with their wire format and prepares for any future serializer changes in upstream dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->