### PR TITLE
test: guard against silently dropped completion params (chat request coverage)

### DIFF
--- a/tests/unit/test_chat_request_param_coverage.py
+++ b/tests/unit/test_chat_request_param_coverage.py
@@ -1,0 +1,67 @@
+"""Guard against the gateway silently dropping OpenAI completion params.
+
+The OpenAI-compatible chat request schema (``ChatCompletionRequest``) is a hand-maintained
+allowlist. The gateway forwards only the fields it declares to ``acompletion(**kwargs)``, so a
+parameter any-llm understands can be left out of the schema and silently dropped before the
+provider call (this is how ``reasoning_effort`` ended up being ignored, mozilla-ai/otari#150).
+
+These tests pin that gap against any-llm's ``CompletionParams`` (the gateway already depends on
+any-llm): every completion param must either be accepted by the gateway schema or be listed,
+with a reason, in ``KNOWN_UNSUPPORTED``. A new any-llm param then fails CI until someone makes a
+conscious decision, instead of being dropped unnoticed.
+"""
+
+from any_llm.types.completion import CompletionParams
+
+from gateway.api.routes.chat import ChatCompletionRequest
+
+# any-llm ``CompletionParams`` fields the gateway's chat schema does not accept today. Each entry
+# needs a reason: a naming difference, a deliberate non-support decision, or a tracked bug.
+# Remove an entry once the field is added to ``ChatCompletionRequest`` (the accuracy test below
+# enforces that the allowlist and the schema never overlap).
+KNOWN_UNSUPPORTED: dict[str, str] = {
+    "model_id": "any-llm's internal name; the gateway exposes it as `model`",
+    "reasoning_effort": "BUG: dropped today, so reasoning never reaches the provider (mozilla-ai/otari#150)",
+    # Standard OpenAI completion params the gateway does not currently forward. Each should be
+    # triaged: either wired into ChatCompletionRequest, or kept here as an intentional non-support
+    # decision with a clearer reason / tracking issue.
+    "n": "not currently forwarded; triage: support or document as intentional",
+    "stop": "not currently forwarded; triage: support or document as intentional",
+    "seed": "not currently forwarded; triage: support or document as intentional",
+    "presence_penalty": "not currently forwarded; triage: support or document as intentional",
+    "frequency_penalty": "not currently forwarded; triage: support or document as intentional",
+    "parallel_tool_calls": "not currently forwarded; triage: support or document as intentional",
+    "logprobs": "not currently forwarded; triage: support or document as intentional",
+    "top_logprobs": "not currently forwarded; triage: support or document as intentional",
+    "logit_bias": "not currently forwarded; triage: support or document as intentional",
+}
+
+
+def test_chat_request_covers_any_llm_completion_params() -> None:
+    """Every any-llm completion param is accepted by the gateway or explicitly allow-listed."""
+    any_llm_fields = set(CompletionParams.model_fields)
+    gateway_fields = set(ChatCompletionRequest.model_fields)
+
+    uncovered = any_llm_fields - gateway_fields - set(KNOWN_UNSUPPORTED)
+
+    assert not uncovered, (
+        f"any-llm CompletionParams the gateway neither accepts nor allow-lists, so they are "
+        f"silently dropped before the provider call: {sorted(uncovered)}. Add them to "
+        f"ChatCompletionRequest (they are then forwarded), or add to KNOWN_UNSUPPORTED with a reason."
+    )
+
+
+def test_known_unsupported_allowlist_stays_accurate() -> None:
+    """The allowlist never lists a field that is actually supported or no longer exists."""
+    any_llm_fields = set(CompletionParams.model_fields)
+    gateway_fields = set(ChatCompletionRequest.model_fields)
+
+    now_supported = set(KNOWN_UNSUPPORTED) & gateway_fields
+    assert not now_supported, (
+        f"these are now accepted by ChatCompletionRequest; remove them from KNOWN_UNSUPPORTED: {sorted(now_supported)}"
+    )
+
+    stale = set(KNOWN_UNSUPPORTED) - any_llm_fields
+    assert not stale, (
+        f"these are no longer any-llm CompletionParams; remove them from KNOWN_UNSUPPORTED: {sorted(stale)}"
+    )

--- a/tests/unit/test_chat_request_param_coverage.py
+++ b/tests/unit/test_chat_request_param_coverage.py
@@ -22,18 +22,17 @@ from gateway.api.routes.chat import ChatCompletionRequest
 KNOWN_UNSUPPORTED: dict[str, str] = {
     "model_id": "any-llm's internal name; the gateway exposes it as `model`",
     "reasoning_effort": "BUG: dropped today, so reasoning never reaches the provider (mozilla-ai/otari#150)",
-    # Standard OpenAI completion params the gateway does not currently forward. Each should be
-    # triaged: either wired into ChatCompletionRequest, or kept here as an intentional non-support
-    # decision with a clearer reason / tracking issue.
-    "n": "not currently forwarded; triage: support or document as intentional",
-    "stop": "not currently forwarded; triage: support or document as intentional",
-    "seed": "not currently forwarded; triage: support or document as intentional",
-    "presence_penalty": "not currently forwarded; triage: support or document as intentional",
-    "frequency_penalty": "not currently forwarded; triage: support or document as intentional",
-    "parallel_tool_calls": "not currently forwarded; triage: support or document as intentional",
-    "logprobs": "not currently forwarded; triage: support or document as intentional",
-    "top_logprobs": "not currently forwarded; triage: support or document as intentional",
-    "logit_bias": "not currently forwarded; triage: support or document as intentional",
+    # Standard OpenAI completion params the gateway does not currently forward; triage (forward or
+    # document as intentional) is tracked in mozilla-ai/otari#152. Remove each entry as it is resolved.
+    "n": "not currently forwarded (mozilla-ai/otari#152)",
+    "stop": "not currently forwarded (mozilla-ai/otari#152)",
+    "seed": "not currently forwarded (mozilla-ai/otari#152)",
+    "presence_penalty": "not currently forwarded (mozilla-ai/otari#152)",
+    "frequency_penalty": "not currently forwarded (mozilla-ai/otari#152)",
+    "parallel_tool_calls": "not currently forwarded (mozilla-ai/otari#152)",
+    "logprobs": "not currently forwarded (mozilla-ai/otari#152)",
+    "top_logprobs": "not currently forwarded (mozilla-ai/otari#152)",
+    "logit_bias": "not currently forwarded (mozilla-ai/otari#152)",
 }
 
 


### PR DESCRIPTION
## Description

The OpenAI-compatible chat request schema (`ChatCompletionRequest` in `src/gateway/api/routes/chat.py`) is a hand-maintained allowlist. The gateway forwards only the fields it declares to `acompletion(**kwargs)`, so a completion param any-llm understands can be left out of the schema and silently dropped before the provider call. That is how `reasoning_effort` came to be ignored (#150).

This adds a unit test that pins the schema against any-llm's `CompletionParams` (the gateway already depends on any-llm): every completion param must either be accepted by `ChatCompletionRequest` or be listed, with a reason, in an explicit `KNOWN_UNSUPPORTED` allowlist. A new any-llm param then fails CI until someone makes a conscious decision, rather than being dropped unnoticed. A second test keeps the allowlist accurate (nothing in it is actually supported or no longer exists), so when a param is added to the schema the allowlist must be pruned.

**What the test surfaces today** (the current any-llm vs gateway delta):
- `model_id`: any-llm's internal name; the gateway exposes it as `model`.
- `reasoning_effort`: dropped today (#150).
- Nine standard OpenAI completion params the gateway does not currently forward: `n`, `stop`, `seed`, `presence_penalty`, `frequency_penalty`, `parallel_tool_calls`, `logprobs`, `top_logprobs`, `logit_bias`. Each is allow-listed with a "triage" note: worth deciding whether to support or document as intentional.

## PR Type

- [x] Infrastructure / CI

## Relevant issues

Relates to #150

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (ran `ruff check`/`format`, project-wide `mypy` (Success, 158 files), and the new test (2 passed); did not run the full `make test` suite).
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (not applicable; test-only, no schema change).

## AI Usage

- [x] This is fully AI-generated.

**AI Model/Tool used:** Opus 4.8 / Claude Code

**Any additional AI details you'd like to share:** Drafted by Claude via back-and-forth with @njbrake; the reasoning and decisions are his.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Added unit tests to ensure the gateway does not silently drop any any-llm completion parameters. Tests require every any-llm CompletionParams field to be either accepted by the gateway ChatCompletionRequest schema or explicitly listed in a KNOWN_UNSUPPORTED allowlist with a reason.

## What Changed

- **Added**: `tests/unit/test_chat_request_param_coverage.py` (+66 lines)
  - `KNOWN_UNSUPPORTED` allowlist mapping completion parameters the gateway intentionally does not forward to reasons/triage links
  - `test_chat_request_covers_any_llm_completion_params()` — asserts every any-llm completion param is supported by the gateway schema or present in the allowlist
  - `test_known_unsupported_allowlist_stays_accurate()` — fails if an allowlist entry becomes supported by the schema or no longer exists in any-llm

## Benefits

- Prevents silent parameter drops by making unsupported parameters explicit
- Surfaces mismatches for triage; currently identifies 11 parameters not forwarded by the gateway:
  - reasoning_effort (relates to `#150`)
  - model_id (any-llm internal name; gateway exposes as model)
  - n, stop, seed, presence_penalty, frequency_penalty, parallel_tool_calls, logprobs, top_logprobs, logit_bias
- Enables clear, auditable decisions about intentionally excluded parameters

## Technical Notes

- Tests compare Pydantic model fields between any-llm's `CompletionParams` and the gateway's `ChatCompletionRequest`.
- The allowlist permits temporary, documented exclusions and will fail CI if the schema later adds support without updating the allowlist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->