### PR TITLE
docs: fix platform-protocol drift from both implementations

### DIFF
--- a/docs/platform-protocol.md
+++ b/docs/platform-protocol.md
@@ -128,7 +128,7 @@ multi-attempt shape.
 
 | Status | Behaviour |
 |---|---|
-| `401`, `402`, `403`, `404`, `429` | Mapped through to the client as-is. `429`'s `Retry-After` header is preserved. |
+| `401`, `402`, `403`, `404`, `429` | Status code is forwarded to the client; `429`'s `Retry-After` header is preserved. The `detail` is the platform's JSON `detail` string when present, otherwise the fallback `"Authorization request rejected"`. |
 | `422`, `5xx`                      | Mapped to `502 Bad Gateway` with `detail = "Authorization service unavailable"`. |
 | Network/timeout                    | Mapped to `502 Bad Gateway`. |
 
@@ -176,7 +176,7 @@ configs are resolved (SSRF guard, no bearer token over cleartext `http://`).
 
 | Status | Behaviour |
 |---|---|
-| `401`, `402`, `403`, `404`, `429` | Mapped through to the client as-is. `429`'s `Retry-After` header is preserved. |
+| `401`, `402`, `403`, `404`, `429` | Status code is forwarded to the client; `429`'s `Retry-After` header is preserved. The `detail` is the platform's JSON `detail` string when present, otherwise the fallback `"MCP server resolution failed"`. |
 | `422`, `5xx`                      | Mapped to `502 Bad Gateway` with `detail = "Authorization service unavailable"`. |
 | Network/timeout                    | Mapped to `502 Bad Gateway`. |
 
@@ -227,7 +227,7 @@ this field.
 
 | Status | Behaviour |
 |---|---|
-| `401`, `402`, `403`, `404`, `429` | Mapped through to the client as-is. `429`'s `Retry-After` header is preserved. |
+| `401`, `402`, `403`, `404`, `429` | Status code is forwarded to the client; `429`'s `Retry-After` header is preserved. The `detail` is the platform's JSON `detail` string when present, otherwise the fallback `"Web search resolution failed"`. |
 | `422`, `5xx`                      | Mapped to `502 Bad Gateway` with `detail = "Authorization service unavailable"`. |
 | Network/timeout                    | Mapped to `502 Bad Gateway`. |
 

--- a/docs/platform-protocol.md
+++ b/docs/platform-protocol.md
@@ -220,6 +220,9 @@ its own value: `max_results`, `allowed_domains`, `blocked_domains`, and
 `purpose_hint` fill in when the per-request tool entry omits them (an empty list
 or empty string reads as "no preference" and does not clear the workspace
 value), and `provider_options` is shallow-merged with per-request keys winning.
+`provider` is informational: the active web-search backend is configured on the
+gateway itself via `WEB_SEARCH_URL`, so Otari does not switch backends based on
+this field.
 
 ### Failure
 

--- a/docs/platform-protocol.md
+++ b/docs/platform-protocol.md
@@ -5,8 +5,8 @@ delegates per-request authorization and provider-credential resolution to a
 peer platform service over HTTP. This document describes the wire contract
 Otari expects from that peer.
 
-The reference peer implementation is the [Otari platform](https://github.com/mozilla-ai/otari-ai),
-but any service that implements this contract can stand in.
+The reference peer is the [otari.ai](https://otari.ai) platform, but any service
+that implements this contract can stand in.
 
 ## Endpoints
 
@@ -38,10 +38,9 @@ Otari ignores any it does not recognise. Consumers of this contract MUST do the
 same (ignore unknown fields) so the platform can add fields without breaking
 older gateways.
 
-For example, the reference platform's resolve response (`GatewayResolveResponse`
-in otari-ai) also carries `workspace_id`, `organization_id`, `provider_key_id`,
-and `allowed_models`. Otari does not read these today, so they are intentionally
-absent from the shapes documented here.
+For example, the otari.ai resolve response also carries `workspace_id`,
+`organization_id`, `provider_key_id`, and `allowed_models`. Otari does not read
+these today, so they are intentionally absent from the shapes documented here.
 
 ## Resolve
 

--- a/docs/platform-protocol.md
+++ b/docs/platform-protocol.md
@@ -5,27 +5,43 @@ delegates per-request authorization and provider-credential resolution to a
 peer platform service over HTTP. This document describes the wire contract
 Otari expects from that peer.
 
-The default peer implementation is [otari](https://github.com/mozilla-ai/otari),
+The reference peer implementation is the [Otari platform](https://github.com/mozilla-ai/otari-ai),
 but any service that implements this contract can stand in.
 
 ## Endpoints
 
-Otari calls two endpoints, both rooted at the configured platform base URL:
+Otari calls these endpoints, all rooted at the configured platform base URL:
 
 | Endpoint | Purpose |
 |---|---|
 | `POST {base}/gateway/provider-keys/resolve` | Authorize a request and return one or more provider credentials to try |
 | `POST {base}/gateway/usage`                 | Report the outcome of an attempt back to the platform |
+| `POST {base}/gateway/mcp-servers/resolve`   | Swap workspace-scoped MCP server ids for inline server configs (called only when a request references MCP server ids) |
+| `POST {base}/gateway/web-search/resolve`    | Resolve the workspace's web-search policy (called only when a request uses the `otari_web_search` tool) |
 
 `{base}` means Otari platform `base_url` setting. Otari concatenates literally. The peer service is responsible for including any API-version prefix it exposes its own routes under. For the reference otari deployment that prefix is `/api/v1`, so the base URL is `http://backend:8000/api/v1` and Otari ends up POSTing to `http://backend:8000/api/v1/gateway/provider-keys/resolve`.
 
 ## Authentication
 
-Both endpoints require `X-Gateway-Token: <gw_...>` in the request headers. This
-proves the caller is Otari instance configured against this platform
-deployment. The resolve endpoint additionally requires `X-User-Token: <tk_...>`,
-which is the workspace API token forwarded opaquely from the end user's
-`Authorization: Bearer ...` header.
+Every endpoint requires `X-Gateway-Token: <gw_...>` in the request headers. This
+proves the caller is an Otari instance configured against this platform
+deployment. The three resolve endpoints additionally require `X-User-Token:
+<tk_...>`, which is the workspace API token forwarded opaquely from the end
+user's `Authorization: Bearer ...` header. The usage endpoint sends only the
+gateway token.
+
+## Extension policy
+
+This document describes only the fields Otari actually reads. Every response
+shape below is **open for extension**: a peer may return additional fields, and
+Otari ignores any it does not recognise. Consumers of this contract MUST do the
+same (ignore unknown fields) so the platform can add fields without breaking
+older gateways.
+
+For example, the reference platform's resolve response (`GatewayResolveResponse`
+in otari-ai) also carries `workspace_id`, `organization_id`, `provider_key_id`,
+and `allowed_models`. Otari does not read these today, so they are intentionally
+absent from the shapes documented here.
 
 ## Resolve
 
@@ -116,6 +132,108 @@ multi-attempt shape.
 | `401`, `402`, `403`, `404`, `429` | Mapped through to the client as-is. `429`'s `Retry-After` header is preserved. |
 | `422`, `5xx`                      | Mapped to `502 Bad Gateway` with `detail = "Authorization service unavailable"`. |
 | Network/timeout                    | Mapped to `502 Bad Gateway`. |
+
+## MCP server resolution
+
+Called only when a request references one or more workspace-scoped MCP server
+ids (a platform-only feature). Otari swaps those ids for the inline server
+configs it needs to open the connections.
+
+### Request
+
+```http
+POST /gateway/mcp-servers/resolve
+X-Gateway-Token: gw_...
+X-User-Token: tk_...
+Content-Type: application/json
+
+{
+  "mcp_server_ids": ["01HX1...", "01HX2..."]
+}
+```
+
+### Response
+
+```json
+{
+  "servers": [
+    {
+      "name": "github",
+      "url": "https://mcp.example.com/github",
+      "authorization_token": "ghp_...",   // optional
+      "purpose_hint": "Repo and issue lookups",   // optional
+      "allowed_tools": ["list_issues", "get_file"] // optional
+    }
+  ]
+}
+```
+
+Otari reads `name`, `url`, `authorization_token`, `purpose_hint`, and
+`allowed_tools` off each entry in `servers`; a missing `servers` key is treated
+as an empty list. The same URL-safety rules as inline MCP configs apply once the
+configs are resolved (SSRF guard, no bearer token over cleartext `http://`).
+
+### Failure
+
+| Status | Behaviour |
+|---|---|
+| `401`, `402`, `403`, `404`, `429` | Mapped through to the client as-is. `429`'s `Retry-After` header is preserved. |
+| `422`, `5xx`                      | Mapped to `502 Bad Gateway` with `detail = "Authorization service unavailable"`. |
+| Network/timeout                    | Mapped to `502 Bad Gateway`. |
+
+## Web search resolution
+
+Called only when a request uses the `otari_web_search` tool. The platform owns
+the per-workspace web-search policy: whether it is enabled at all, plus the
+workspace-default limits and filters.
+
+### Request
+
+```http
+POST /gateway/web-search/resolve
+X-Gateway-Token: gw_...
+X-User-Token: tk_...
+Content-Type: application/json
+
+{}
+```
+
+The request body is empty; the workspace is identified by `X-User-Token`.
+
+### Response
+
+```json
+{
+  "enabled": true,
+  "provider": "searxng",
+  "max_results": 5,
+  "purpose_hint": "Background research",
+  "allowed_domains": ["example.com"],
+  "blocked_domains": ["spam.example"],
+  "provider_options": { "engines": "google,bing" }
+}
+```
+
+If `enabled` is falsy, Otari rejects the request with `403`. The remaining
+fields are workspace defaults that apply only where the request did not supply
+its own value: `max_results`, `allowed_domains`, `blocked_domains`, and
+`purpose_hint` fill in when the per-request tool entry omits them (an empty list
+or empty string reads as "no preference" and does not clear the workspace
+value), and `provider_options` is shallow-merged with per-request keys winning.
+
+### Failure
+
+| Status | Behaviour |
+|---|---|
+| `401`, `402`, `403`, `404`, `429` | Mapped through to the client as-is. `429`'s `Retry-After` header is preserved. |
+| `422`, `5xx`                      | Mapped to `502 Bad Gateway` with `detail = "Authorization service unavailable"`. |
+| Network/timeout                    | Mapped to `502 Bad Gateway`. |
+
+> The resolve endpoints share the timeout (`PLATFORM_RESOLVE_TIMEOUT_MS`) and
+> token headers with `provider-keys/resolve`. Their exact response shapes will
+> become the contract of record once the consumer-side fixtures land
+> ([#146](https://github.com/mozilla-ai/otari/issues/146)); until then this
+> document is authoritative.
 
 ## Usage report
 


### PR DESCRIPTION
## Description

`docs/platform-protocol.md` had drifted from both the gateway (consumer) and the reference platform (peer). This PR realigns it:

- **Wrong peer link.** The "default peer implementation" link pointed at this repo (the consumer) instead of the platform. Repointed it at `mozilla-ai/otari-ai` and reworded "default" to "reference peer implementation".
- **Undocumented response fields.** Added an **Extension policy** section taking the issue's preferred approach: the doc describes only the fields the gateway actually reads, responses are open for extension, and consumers must ignore unknown fields. The known extras from `GatewayResolveResponse` in otari-ai (`workspace_id`, `organization_id`, `provider_key_id`, `allowed_models`) are listed as the concrete example.
- **Missing endpoints.** Documented the two resolve endpoints the gateway now consumes (#144): `mcp-servers/resolve` and `web-search/resolve`, each with request/response shapes, auth headers, and failure mapping. Corrected the **Authentication** section (was "Both endpoints"; now all four require `X-Gateway-Token`, the three resolve endpoints add `X-User-Token`, and usage sends only the gateway token). Added a forward pointer to #146 as the eventual contract of record.

All shapes were verified against the code in `src/gateway/api/routes/_platform.py` and `_pipeline.py`.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #149

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). _(Docs-only change; no code paths affected.)_
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). _(Docs-only change; no code, lint, typecheck, or OpenAPI surface touched.)_
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). _(No API contract change.)_

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:**

Claude drafted the doc changes via back-and-forth with @njbrake; the reasoning and decisions are his.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR corrects and expands the documentation of Otari's platform-mode HTTP API contract in `docs/platform-protocol.md`, addressing documentation drift between the gateway implementation and its specification.

## Key Changes

**Updated references and clarifications:**
- Fixed the "default peer implementation" link to point to the public reference platform repository
- Added an explicit **Extension policy** section clarifying that response shapes are open to additional fields and consumers must ignore unknown ones

**Documented previously undocumented resolve endpoints:**
- Added full documentation for two resolve endpoints the gateway now uses: MCP server ID resolution and web-search policy resolution
- Included request/response payloads, expected behaviors, and field descriptions for each

**Clarified authentication requirements:**
- Specified that all endpoints require the `X-Gateway-Token` header
- Noted that resolve endpoints additionally require the `X-User-Token` header, while the usage endpoint sends only the gateway token

**Improved error handling documentation:**
- Clarified how the gateway handles different error responses from the platform
- Documented explicit mappings for client-facing forwarding (`401/402/403/404/429`) and error fallbacks (`422`/`5xx` and timeouts → `502 Bad Gateway`)

## Benefits
This documentation now accurately reflects the gateway's current implementation, reducing confusion for platform integrators and making the API contract clearer and more maintainable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->