### PR TITLE
fix(chat): forward reasoning_effort to the provider

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -335,6 +335,17 @@
             "title": "Model",
             "type": "string"
           },
+          "reasoning_effort": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasoning Effort"
+          },
           "response_format": {
             "anyOf": [
               {

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -88,6 +88,7 @@ class ChatCompletionRequest(BaseModel):
     max_tokens: int | None = None
     max_completion_tokens: int | None = None
     top_p: float | None = None
+    reasoning_effort: str | None = None
     stream: bool = False
     stream_options: dict[str, Any] | None = None
     tools: list[dict[str, Any]] | None = None

--- a/tests/integration/test_client_args.py
+++ b/tests/integration/test_client_args.py
@@ -140,3 +140,36 @@ async def test_provider_config_without_client_args(
         )
 
     assert "client_args" not in captured_kwargs or captured_kwargs.get("client_args") is None
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_passed_to_acompletion(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """`reasoning_effort` must reach acompletion (mozilla-ai/otari#150).
+
+    The schema is a hand-maintained allowlist, so a field missing from
+    ``ChatCompletionRequest`` is silently dropped by pydantic before the
+    provider call and reasoning never gets enabled.
+    """
+    captured_kwargs: dict[str, Any] = {}
+
+    async def mock_acompletion(**kwargs: Any) -> None:
+        captured_kwargs.update(kwargs)
+        raise MockCompletionError
+
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
+        client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "openai:gpt-4",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "user": test_user["user_id"],
+                "reasoning_effort": "high",
+            },
+            headers=master_key_header,
+        )
+
+    assert captured_kwargs.get("reasoning_effort") == "high", "reasoning_effort not passed to acompletion"

--- a/tests/unit/test_chat_request_param_coverage.py
+++ b/tests/unit/test_chat_request_param_coverage.py
@@ -21,7 +21,6 @@ from gateway.api.routes.chat import ChatCompletionRequest
 # enforces that the allowlist and the schema never overlap).
 KNOWN_UNSUPPORTED: dict[str, str] = {
     "model_id": "any-llm's internal name; the gateway exposes it as `model`",
-    "reasoning_effort": "BUG: dropped today, so reasoning never reaches the provider (mozilla-ai/otari#150)",
     # Standard OpenAI completion params the gateway does not currently forward; triage (forward or
     # document as intentional) is tracked in mozilla-ai/otari#152. Remove each entry as it is resolved.
     "n": "not currently forwarded (mozilla-ai/otari#152)",


### PR DESCRIPTION
## Description

The OpenAI-compatible chat completions endpoint silently dropped `reasoning_effort`. `ChatCompletionRequest` (`src/gateway/api/routes/chat.py`) is a hand-maintained allowlist of accepted fields and did not declare `reasoning_effort`, so pydantic dropped the value before `request.model_dump(exclude_unset=True)`, and it never reached `acompletion(**kwargs)`. Models that rely on it to enable reasoning (Anthropic extended thinking, OpenAI reasoning effort levels) therefore never produced reasoning content through the gateway. any-llm already maps `reasoning_effort` to the provider-specific behavior; it just never received the parameter.

This PR:

- Adds `reasoning_effort: str | None = None` to `ChatCompletionRequest`. The loose `str | None` typing matches neighboring fields and leaves value translation/validation to any-llm. Default `None` plus `exclude_unset=True` means callers who do not set it keep any-llm's own default (`auto`), so existing traffic is unchanged.
- Removes the `reasoning_effort` entry from `KNOWN_UNSUPPORTED` in the chat-request param coverage test (the allowlist-accuracy test enforces this removal).
- Adds an integration test asserting `reasoning_effort` reaches `acompletion`.
- Regenerates the OpenAPI spec.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #150

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Note: the new integration test could not run locally (no Docker for the testcontainers Postgres); it will run in CI. The forwarding path was validated directly: the field is accepted, survives `_strip_gateway_fields`, forwards to `acompletion`, and is omitted when unset. Unit suite, ruff, mypy, and `openapi-check` all pass locally.

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:**

Implemented via Claude Code through back-and-forth with @njbrake. The reasoning and decisions are his; the code and prose were drafted by Claude.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
