### PR TITLE
feat(web-search): forward X-Gateway-Token to the search backend

### DIFF
--- a/docs/platform-protocol.md
+++ b/docs/platform-protocol.md
@@ -27,6 +27,13 @@ deployment. The resolve endpoint additionally requires `X-User-Token: <tk_...>`,
 which is the workspace API token forwarded opaquely from the end user's
 `Authorization: Bearer ...` header.
 
+When the operator points Otari's web-search backend at the platform
+(`GATEWAY_WEB_SEARCH_URL` under `base_url`), Otari also sends `X-Gateway-Token`
+on its search queries (`GET {base}/gateway/web-search/search`) so a
+platform-hosted search endpoint can authenticate the gateway. The token is sent
+only when that URL shares the platform origin (scheme/host/port, under the base
+path); it is never sent to a standalone or third-party search backend.
+
 ## Resolve
 
 ### Request

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -523,6 +523,7 @@ class ToolContext:
         use_web_search: bool,
         web_search_tool_entry: dict[str, Any] | None,
         web_search_url: str | None,
+        web_search_auth_token: str | None,
         remaining_user_tools: list[dict[str, Any]] | None,
         max_tool_iterations: int,
         tools_header: str | None,
@@ -534,6 +535,7 @@ class ToolContext:
         self.use_web_search = use_web_search
         self.web_search_tool_entry = web_search_tool_entry
         self.web_search_url = web_search_url
+        self.web_search_auth_token = web_search_auth_token
         self.remaining_user_tools = remaining_user_tools
         self.max_tool_iterations = max_tool_iterations
         self.tools_header = tools_header
@@ -603,6 +605,11 @@ async def prepare_gateway_tools(
 
         web_search_tool_entry, remaining_user_tools = _extract_web_search_tool(tools_after_sandbox)
         web_search_url: str | None = otari_env("WEB_SEARCH_URL") or None
+        # Forwarded to the search backend as `X-Gateway-Token`. Only set in
+        # platform mode, where the backend may be the platform-hosted web-search
+        # endpoint that authenticates the gateway. Standalone backends (SearXNG /
+        # self-hosted adapter) get no token and ignore the header.
+        web_search_auth_token: str | None = None
         use_web_search = False
         if web_search_tool_entry is not None:
             if web_search_url is None:
@@ -626,6 +633,7 @@ async def prepare_gateway_tools(
             # Standalone mode has no platform to consult.
             if ctx.platform_mode:
                 assert ctx.user_token is not None  # guaranteed by the platform-mode preamble
+                web_search_auth_token = ctx.config.platform_token
                 web_search_policy = await _resolve_platform_web_search(
                     config=ctx.config,
                     user_token=ctx.user_token,
@@ -656,6 +664,7 @@ async def prepare_gateway_tools(
         use_web_search=use_web_search,
         web_search_tool_entry=web_search_tool_entry,
         web_search_url=web_search_url,
+        web_search_auth_token=web_search_auth_token,
         remaining_user_tools=remaining_user_tools,
         max_tool_iterations=min(
             max_tool_iterations or DEFAULT_MAX_TOOL_ITERATIONS,
@@ -828,6 +837,7 @@ async def dispatch_non_stream(
     async with _build_web_search_backend(
         base_url=tool_ctx.web_search_url,
         tool_entry=tool_ctx.web_search_tool_entry,
+        auth_token=tool_ctx.web_search_auth_token,
     ) as web_backend:
         kwargs = adapter.inject_hints(call_kwargs, web_backend.purpose_hints(), header=tool_ctx.tools_header)
         return await adapter.run_tool_loop(kwargs, web_backend, tool_ctx.max_tool_iterations, on_first_response)
@@ -899,6 +909,7 @@ async def open_stream(
     web_search_backend = _build_web_search_backend(
         base_url=tool_ctx.web_search_url,
         tool_entry=tool_ctx.web_search_tool_entry,
+        auth_token=tool_ctx.web_search_auth_token,
     )
     await web_search_backend.__aenter__()  # may raise WebSearchNotReachableError
     return _eager_backend_stream(adapter, kwargs, web_search_backend, tool_ctx)
@@ -1196,6 +1207,7 @@ async def run_streaming_with_fallback(
                 _build_web_search_backend(
                     base_url=tool_ctx.web_search_url,
                     tool_entry=tool_ctx.web_search_tool_entry,
+                    auth_token=tool_ctx.web_search_auth_token,
                 ),
             )
     except BaseException:

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -633,7 +633,14 @@ async def prepare_gateway_tools(
             # Standalone mode has no platform to consult.
             if ctx.platform_mode:
                 assert ctx.user_token is not None  # guaranteed by the platform-mode preamble
-                web_search_auth_token = ctx.config.platform_token
+                # Forward the platform token only when the search backend IS the
+                # platform (its URL is under the platform base URL the gateway
+                # already trusts this token with for resolve). Never leak this
+                # high-privilege credential to a bundled SearXNG or a third-party
+                # adapter that an operator happened to point GATEWAY_WEB_SEARCH_URL at.
+                platform_base = (ctx.config.platform.get("base_url") or "").rstrip("/")
+                if platform_base and web_search_url.startswith(platform_base):
+                    web_search_auth_token = ctx.config.platform_token
                 web_search_policy = await _resolve_platform_web_search(
                     config=ctx.config,
                     user_token=ctx.user_token,

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -36,7 +36,7 @@ from contextlib import AsyncExitStack
 from datetime import UTC, datetime
 from enum import Enum, auto
 from typing import Any, Generic, Protocol, TypeVar
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
 
 from any_llm import AnyLLM, LLMProvider
 from any_llm.exceptions import AnyLLMError
@@ -155,6 +155,19 @@ class ErrorKind(Enum):
     PERMISSION = auto()
 
 
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def _normalized_origin(parsed: ParseResult) -> tuple[str, str | None, int | None]:
+    """(scheme, host, port) with the scheme's default port filled in.
+
+    So ``https://h`` and ``https://h:443`` compare equal (and ``http`` / ``:80``),
+    rather than failing on ``None != 443`` and silently not forwarding the token.
+    """
+    port = parsed.port if parsed.port is not None else _DEFAULT_PORTS.get(parsed.scheme)
+    return (parsed.scheme, parsed.hostname, port)
+
+
 def web_search_url_targets_platform(web_search_url: str, platform_base_url: str | None) -> bool:
     """True when ``web_search_url`` is the platform itself (same origin, under its base path).
 
@@ -164,14 +177,15 @@ def web_search_url_targets_platform(web_search_url: str, platform_base_url: str 
     enough: with a path-less ``PLATFORM_BASE_URL`` (e.g. ``https://api.otari.ai``)
     a confusable URL like ``https://api.otari.ai.evil.com`` or
     ``https://api.otari.ai@evil.com`` would satisfy ``startswith`` and leak the
-    token. So compare the parsed (scheme, host, port) origin exactly, and require
-    the search path to sit under the base path at a ``/`` boundary.
+    token. So compare the parsed (scheme, host, port) origin exactly — with
+    default ports normalized — and require the search path to sit under the base
+    path at a ``/`` boundary.
     """
     if not platform_base_url:
         return False
     base = urlparse(platform_base_url)
     target = urlparse(web_search_url)
-    if (target.scheme, target.hostname, target.port) != (base.scheme, base.hostname, base.port):
+    if _normalized_origin(target) != _normalized_origin(base):
         return False
     base_path = base.path.rstrip("/")
     return target.path == base_path or target.path.startswith(base_path + "/")

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -36,6 +36,7 @@ from contextlib import AsyncExitStack
 from datetime import UTC, datetime
 from enum import Enum, auto
 from typing import Any, Generic, Protocol, TypeVar
+from urllib.parse import urlparse
 
 from any_llm import AnyLLM, LLMProvider
 from any_llm.exceptions import AnyLLMError
@@ -152,6 +153,28 @@ class ErrorKind(Enum):
     INVALID_REQUEST = auto()
     API = auto()
     PERMISSION = auto()
+
+
+def web_search_url_targets_platform(web_search_url: str, platform_base_url: str | None) -> bool:
+    """True when ``web_search_url`` is the platform itself (same origin, under its base path).
+
+    Gates forwarding the platform token to the web-search backend: it is only
+    safe to hand that high-privilege credential to the platform — the host the
+    gateway already trusts it with for resolve. A raw string prefix check is not
+    enough: with a path-less ``PLATFORM_BASE_URL`` (e.g. ``https://api.otari.ai``)
+    a confusable URL like ``https://api.otari.ai.evil.com`` or
+    ``https://api.otari.ai@evil.com`` would satisfy ``startswith`` and leak the
+    token. So compare the parsed (scheme, host, port) origin exactly, and require
+    the search path to sit under the base path at a ``/`` boundary.
+    """
+    if not platform_base_url:
+        return False
+    base = urlparse(platform_base_url)
+    target = urlparse(web_search_url)
+    if (target.scheme, target.hostname, target.port) != (base.scheme, base.hostname, base.port):
+        return False
+    base_path = base.path.rstrip("/")
+    return target.path == base_path or target.path.startswith(base_path + "/")
 
 
 def rate_limit_headers(info: RateLimitInfo) -> dict[str, str]:
@@ -638,8 +661,7 @@ async def prepare_gateway_tools(
                 # already trusts this token with for resolve). Never leak this
                 # high-privilege credential to a bundled SearXNG or a third-party
                 # adapter that an operator happened to point GATEWAY_WEB_SEARCH_URL at.
-                platform_base = (ctx.config.platform.get("base_url") or "").rstrip("/")
-                if platform_base and web_search_url.startswith(platform_base):
+                if web_search_url_targets_platform(web_search_url, ctx.config.platform.get("base_url")):
                     web_search_auth_token = ctx.config.platform_token
                 web_search_policy = await _resolve_platform_web_search(
                     config=ctx.config,

--- a/src/gateway/api/routes/_tools.py
+++ b/src/gateway/api/routes/_tools.py
@@ -177,14 +177,12 @@ def _extract_web_search_tool(
 
 def _resolve_web_search_purpose_hint(tool_entry: dict[str, Any] | None) -> str | None:
     """Per-tool entry → ``OTARI_WEB_SEARCH_PURPOSE_HINT`` → ``None`` (backend default)."""
-    return (
-        (tool_entry.get("purpose_hint") if tool_entry else None)
-        or otari_env("WEB_SEARCH_PURPOSE_HINT")
-        or None
-    )
+    return (tool_entry.get("purpose_hint") if tool_entry else None) or otari_env("WEB_SEARCH_PURPOSE_HINT") or None
 
 
-def _build_web_search_backend(*, base_url: str, tool_entry: dict[str, Any]) -> WebSearchBackend:
+def _build_web_search_backend(
+    *, base_url: str, tool_entry: dict[str, Any], auth_token: str | None = None
+) -> WebSearchBackend:
     """Construct a WebSearchBackend honouring env-level + per-tool config.
 
     Per-tool entry fields (``max_results``, ``allowed_domains``,
@@ -240,5 +238,10 @@ def _build_web_search_backend(*, base_url: str, tool_entry: dict[str, Any]) -> W
     provider_options = tool_entry.get("provider_options")
     if isinstance(provider_options, dict) and provider_options:
         kwargs["provider_options"] = provider_options
+
+    # Forwarded to the search backend as `X-Gateway-Token` so the platform-hosted
+    # backend can authenticate the gateway. Unset (and so unsent) in standalone.
+    if auth_token:
+        kwargs["auth_token"] = auth_token
 
     return WebSearchBackend(**kwargs)

--- a/src/gateway/services/web_search_backend.py
+++ b/src/gateway/services/web_search_backend.py
@@ -113,6 +113,7 @@ class WebSearchBackend:
         search_timeout_s: float = _DEFAULT_SEARCH_TIMEOUT_S,
         purpose_hint: str | None = None,
         provider_options: dict[str, Any] | None = None,
+        auth_token: str | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._engines = engines
@@ -134,6 +135,11 @@ class WebSearchBackend:
         # (see `_search`); complex / None values are dropped so a misconfigured
         # entry can't smuggle structured payloads into the GET.
         self._provider_options = dict(provider_options) if provider_options else {}
+        # Optional bearer-style credential forwarded as `X-Gateway-Token` on the
+        # `/search` request. Set when the search backend is the platform-hosted
+        # endpoint (which authenticates the gateway); unset for a standalone
+        # SearXNG / self-hosted adapter, which ignores the header.
+        self._auth_token = auth_token
         self._client: httpx.AsyncClient | None = None
         self._stack: AsyncExitStack = AsyncExitStack()
 
@@ -234,9 +240,11 @@ class WebSearchBackend:
                 params[key] = "true" if value else "false"
             elif isinstance(value, (str, int, float)):
                 params[key] = value
+        headers = {"X-Gateway-Token": self._auth_token} if self._auth_token else None
         response = await self._client.get(
             f"{self._base_url}/search",
             params=params,
+            headers=headers,
             timeout=self._search_timeout_s,
         )
         response.raise_for_status()

--- a/tests/integration/test_platform_mode_chat.py
+++ b/tests/integration/test_platform_mode_chat.py
@@ -957,6 +957,7 @@ def test_platform_mode_web_search_merges_workspace_config(
     entry with per-request values winning over workspace defaults."""
     monkeypatch.setenv("GATEWAY_WEB_SEARCH_URL", "http://searxng:8080")
     _FakeWebSearchBackend.last_tool_entry = None
+    _FakeWebSearchBackend.last_auth_token = None
 
     async def fake_post_platform(
         url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
@@ -1016,8 +1017,62 @@ def test_platform_mode_web_search_merges_workspace_config(
     assert merged["allowed_domains"] == ["docs.python.org"]
     assert merged["purpose_hint"] == "workspace hint"
     assert merged["provider_options"] == {"search_depth": "advanced"}
-    # Platform mode forwards the gateway token so the search backend can
-    # authenticate the gateway (e.g. a platform-hosted backend).
+    # The backend here is searxng (NOT the platform base URL), so the gateway
+    # must NOT leak the platform token to it.
+    assert _FakeWebSearchBackend.last_auth_token is None
+
+
+def test_platform_mode_web_search_forwards_token_to_platform_backend(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When GATEWAY_WEB_SEARCH_URL points at the platform itself, the gateway
+    forwards its platform token as X-Gateway-Token so the platform-hosted
+    backend can authenticate it. (Non-platform backends get no token.)"""
+    # platform_client's base_url is http://platform.test/api/v1.
+    monkeypatch.setenv("GATEWAY_WEB_SEARCH_URL", "http://platform.test/api/v1/gateway/web-search")
+    _FakeWebSearchBackend.last_auth_token = None
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _single_attempt_resolve_response(request_id="ws-req-platform")
+        if url.endswith("/gateway/web-search/resolve"):
+            return httpx.Response(200, json={"enabled": True})
+        return httpx.Response(204)
+
+    async def fake_loop_acompletion(**kwargs: Any) -> ChatCompletion:
+        return ChatCompletion(
+            id="cmpl-ws-plat",
+            object="chat.completion",
+            created=0,
+            model="openai:gpt-4o-mini",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="answer"),
+                )
+            ],
+            usage=CompletionUsage(prompt_tokens=3, completion_tokens=2, total_tokens=5),
+        )
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes._pipeline._build_web_search_backend", _FakeWebSearchBackend)
+    monkeypatch.setattr("gateway.services.mcp_loop.acompletion", fake_loop_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "otari_web_search"}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
     assert _FakeWebSearchBackend.last_auth_token == "gw_test_token"
 
 

--- a/tests/integration/test_platform_mode_chat.py
+++ b/tests/integration/test_platform_mode_chat.py
@@ -869,9 +869,11 @@ class _FakeWebSearchBackend:
     built from and resolves the tool loop in a single round (no real search)."""
 
     last_tool_entry: dict[str, Any] | None = None
+    last_auth_token: str | None = None
 
-    def __init__(self, *, base_url: str, tool_entry: dict[str, Any]) -> None:
+    def __init__(self, *, base_url: str, tool_entry: dict[str, Any], auth_token: str | None = None) -> None:
         type(self).last_tool_entry = dict(tool_entry)
+        type(self).last_auth_token = auth_token
 
     async def __aenter__(self) -> "_FakeWebSearchBackend":
         return self
@@ -1014,6 +1016,9 @@ def test_platform_mode_web_search_merges_workspace_config(
     assert merged["allowed_domains"] == ["docs.python.org"]
     assert merged["purpose_hint"] == "workspace hint"
     assert merged["provider_options"] == {"search_depth": "advanced"}
+    # Platform mode forwards the gateway token so the search backend can
+    # authenticate the gateway (e.g. a platform-hosted backend).
+    assert _FakeWebSearchBackend.last_auth_token == "gw_test_token"
 
 
 def test_platform_mode_web_search_empty_request_list_keeps_workspace_policy(

--- a/tests/unit/test_pipeline_settlement.py
+++ b/tests/unit/test_pipeline_settlement.py
@@ -51,6 +51,7 @@ def _tool_ctx(**overrides: Any) -> ToolContext:
         "use_web_search": False,
         "web_search_tool_entry": None,
         "web_search_url": None,
+        "web_search_auth_token": None,
         "remaining_user_tools": None,
         "max_tool_iterations": 10,
         "tools_header": None,

--- a/tests/unit/test_web_search_backend.py
+++ b/tests/unit/test_web_search_backend.py
@@ -584,3 +584,32 @@ async def test_no_gateway_header_when_auth_token_unset(monkeypatch: pytest.Monke
         await backend.call_tool(WEB_SEARCH_TOOL_NAME, {"query": "x"})
 
     assert "X-Gateway-Token" not in transport.captured[0].headers
+
+
+@pytest.mark.asyncio
+async def test_auth_token_not_leaked_to_result_page_fetches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With extraction enabled, X-Gateway-Token rides only the /search call to the
+    backend — never the per-result page fetches (headers are per-request). Locks
+    in the no-leak behaviour against future refactors."""
+    transport = _patched_async_client(
+        {
+            ("searxng", "/search"): httpx.Response(200, json=SEARXNG_OK_BODY),
+            ("example.com", "/post-a"): httpx.Response(200, text="<html><body><p>A</p></body></html>"),
+            ("example.org", "/post-b"): httpx.Response(200, text="<html><body><p>B</p></body></html>"),
+        },
+        monkeypatch,
+    )
+
+    with patch("gateway.services.web_search_backend.trafilatura.extract") as mock_extract:
+        mock_extract.side_effect = lambda html, **_: "extracted"
+        async with WebSearchBackend(
+            base_url="http://searxng:8080",
+            extract_content=True,
+            auth_token="gw-secret-token",  # noqa: S106 — test fixture, not a real secret
+        ) as backend:
+            await backend.call_tool(WEB_SEARCH_TOOL_NAME, {"query": "claude code"})
+
+    search_reqs = [r for r in transport.captured if r.url.path == "/search"]
+    fetch_reqs = [r for r in transport.captured if r.url.path in ("/post-a", "/post-b")]
+    assert search_reqs and all(r.headers.get("X-Gateway-Token") == "gw-secret-token" for r in search_reqs)
+    assert fetch_reqs and all("X-Gateway-Token" not in r.headers for r in fetch_reqs)

--- a/tests/unit/test_web_search_backend.py
+++ b/tests/unit/test_web_search_backend.py
@@ -549,3 +549,38 @@ def test_max_results_clamps_above_cap_to_max_results_cap() -> None:
 
     backend = WebSearchBackend(base_url="http://searxng:8080", max_results=10_000)
     assert backend._max_results == _MAX_RESULTS_CAP  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_auth_token_forwarded_as_gateway_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``auth_token`` is set, the /search request carries X-Gateway-Token.
+
+    This lets the platform-hosted web-search backend authenticate the gateway.
+    """
+    transport = _patched_async_client(
+        {("searxng", "/search"): httpx.Response(200, json=SEARXNG_OK_BODY)},
+        monkeypatch,
+    )
+
+    async with WebSearchBackend(
+        base_url="http://searxng:8080",
+        extract_content=False,
+        auth_token="gw-secret-token",  # noqa: S106 — test fixture, not a real secret
+    ) as backend:
+        await backend.call_tool(WEB_SEARCH_TOOL_NAME, {"query": "x"})
+
+    assert transport.captured[0].headers["X-Gateway-Token"] == "gw-secret-token"
+
+
+@pytest.mark.asyncio
+async def test_no_gateway_header_when_auth_token_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A standalone backend (no auth_token) sends no X-Gateway-Token header."""
+    transport = _patched_async_client(
+        {("searxng", "/search"): httpx.Response(200, json=SEARXNG_OK_BODY)},
+        monkeypatch,
+    )
+
+    async with WebSearchBackend(base_url="http://searxng:8080", extract_content=False) as backend:
+        await backend.call_tool(WEB_SEARCH_TOOL_NAME, {"query": "x"})
+
+    assert "X-Gateway-Token" not in transport.captured[0].headers

--- a/tests/unit/test_web_search_url_scoping.py
+++ b/tests/unit/test_web_search_url_scoping.py
@@ -19,6 +19,11 @@ from gateway.api.routes._pipeline import web_search_url_targets_platform
         ("http://backend:8000/api/v1/gateway/web-search", "http://backend:8000/api/v1"),
         # Trailing slash on the base must not matter.
         ("http://backend:8000/api/v1/gateway/web-search", "http://backend:8000/api/v1/"),
+        # Path-less base (base_path == "") — any path on the same origin is "under" it.
+        ("https://api.otari.ai/gateway/web-search", "https://api.otari.ai"),
+        # Explicit default port on one side must normalize against an omitted one.
+        ("https://api.otari.ai:443/api/v1/gateway/web-search", "https://api.otari.ai/api/v1"),
+        ("http://backend/api/v1/gateway/web-search", "http://backend:80/api/v1"),
     ],
 )
 def test_accepts_platform_targets(web_search_url: str, platform_base: str) -> None:

--- a/tests/unit/test_web_search_url_scoping.py
+++ b/tests/unit/test_web_search_url_scoping.py
@@ -1,0 +1,49 @@
+"""Unit tests for `web_search_url_targets_platform`.
+
+Guards the decision to forward the platform token to the web-search backend:
+the token may only go to the platform itself, never to a confusable foreign
+host. See the [major] review note on raw-prefix matching.
+"""
+
+import pytest
+
+from gateway.api.routes._pipeline import web_search_url_targets_platform
+
+
+@pytest.mark.parametrize(
+    ("web_search_url", "platform_base"),
+    [
+        # Canonical base (with path) -> the platform's own web-search endpoint.
+        ("https://api.otari.ai/api/v1/gateway/web-search", "https://api.otari.ai/api/v1"),
+        # Internal service addressing (what deployments actually use).
+        ("http://backend:8000/api/v1/gateway/web-search", "http://backend:8000/api/v1"),
+        # Trailing slash on the base must not matter.
+        ("http://backend:8000/api/v1/gateway/web-search", "http://backend:8000/api/v1/"),
+    ],
+)
+def test_accepts_platform_targets(web_search_url: str, platform_base: str) -> None:
+    assert web_search_url_targets_platform(web_search_url, platform_base) is True
+
+
+@pytest.mark.parametrize(
+    ("web_search_url", "platform_base"),
+    [
+        # Different backend entirely (bundled SearXNG / third-party adapter).
+        ("http://searxng:8080", "http://backend:8000/api/v1"),
+        # Confusable host suffix against a path-less base — the startswith trap.
+        ("https://api.otari.ai.evil.com/api/v1/gateway/web-search", "https://api.otari.ai"),
+        # Userinfo confusable: real host is evil.com.
+        ("https://api.otari.ai@evil.com/gateway/web-search", "https://api.otari.ai"),
+        # Same host, but path not under the base path.
+        ("http://backend:8000/api/v2/gateway/web-search", "http://backend:8000/api/v1"),
+        # Path-prefix collision without a `/` boundary.
+        ("http://backend:8000/api/v1beta/web-search", "http://backend:8000/api/v1"),
+        # Scheme mismatch.
+        ("http://api.otari.ai/api/v1/gateway/web-search", "https://api.otari.ai/api/v1"),
+        # No base configured.
+        ("http://backend:8000/api/v1/gateway/web-search", None),
+        ("http://backend:8000/api/v1/gateway/web-search", ""),
+    ],
+)
+def test_rejects_non_platform_targets(web_search_url: str, platform_base: str | None) -> None:
+    assert web_search_url_targets_platform(web_search_url, platform_base) is False


### PR DESCRIPTION
## Description

In platform mode, forward the gateway's platform token as an `X-Gateway-Token` header on the web-search backend's `/search` call.

This lets a web-search backend authenticate the calling gateway. When the backend is reachable beyond the gateway's private network, an unauthenticated `/search` could be abused to spend provider quota; forwarding the gateway token lets the backend reject arbitrary clients.

Standalone backends (a bundled SearXNG or a self-hosted adapter) receive **no** token and ignore the header, so their behaviour is unchanged.

### How
- `WebSearchBackend` gains an optional `auth_token`; when set it is sent as `X-Gateway-Token` on the `/search` GET.
- `_build_web_search_backend` threads the token through.
- `ToolContext` carries `web_search_auth_token`, set from `config.platform_token` **only in platform mode and only when `GATEWAY_WEB_SEARCH_URL` targets the platform base URL** (it is `None` in standalone and for non-platform backends, so a high-privilege platform credential is never leaked to a SearXNG/third-party adapter).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

n/a

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). — N/A: the gateway's own API is unchanged; this only adds a header the gateway *sends* to an external backend.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 4.8 (via Claude Code)

**Any additional AI details you'd like to share:** Change scoped and reviewed against the existing web-search backend; tests added for both the header-present and header-absent paths.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR updates the gateway’s **platform mode** so it can safely forward its platform authentication token to the web-search backend. The token is only sent to the trusted, platform-hosted web-search endpoint, and **never** to standalone or third-party search backends.

## What Changed
- **Web-search backend:** Added optional `auth_token` support so the backend includes an `X-Gateway-Token` header on **`/search`** requests when a token is provided.
- **Gateway plumbing:** Added `web_search_auth_token` to tool context and threaded it through all web-search backend construction paths (so it’s applied consistently where applicable).
- **Secure URL scoping:** Added URL/origin + base-path boundary checks to ensure the token is forwarded **only** when the configured web-search URL truly targets the platform (exact scheme/host/port match, and only when it falls under the platform base path with a `/` boundary). This blocks spoofed hosts and path-prefix collisions.
- **Documentation:** Updated `docs/platform-protocol.md` to document the platform-mode web-search token-forwarding rules.

## Tests
- Added/updated **unit tests** for:
  - sending `X-Gateway-Token` when `auth_token` is set
  - omitting the header when no token is set
  - ensuring the header is sent **only** on `/search` and never on per-result page fetches
  - validating the URL scoping logic (including confusable/spoofed host cases and port normalization)
- Added **integration test** coverage confirming:
  - the platform token is forwarded to the platform web-search backend in platform mode
  - the token is not leaked to non-platform web-search backends
  - test stub state is reset between assertions

## Benefits
- **Security:** Prevents leakage of a high-privilege platform token to untrusted web-search destinations.
- **Safety & abuse prevention:** Enables the backend to authenticate gateway-originated search requests while reducing risk of unauthorized access and provider quota misuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
