### PR TITLE
fix(docker): pin python 3.13-slim (3.14 breaks onnxruntime install)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim AS builder
+FROM python:3.13-slim AS builder
 
 WORKDIR /app
 
@@ -8,7 +8,7 @@ COPY pyproject.toml uv.lock ./
 COPY src ./src
 RUN uv sync --frozen --no-dev
 
-FROM python:3.14-slim AS runtime
+FROM python:3.13-slim AS runtime
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

The image base was bumped to `python:3.14-slim` in the multi-stage runtime change (`4c7bad8`). Once Python 3.14 went GA upstream, `uv sync` started resolving a 3.14 venv, and `onnxruntime` (pulled in by the `rapidocr-onnxruntime` OCR extra) has **no `cp314` wheel** — so the image build fails on:

```
error: Distribution `onnxruntime==1.20.1` can't be installed ... only has wheels with cp313, cp313t
```

This is why `gateway-docker` CI flipped from green to red on `main` with **no Dockerfile change in between** — it was a latent pin that became fatal when the upstream `python:3.14-slim` tag started resolving to real 3.14.

This currently blocks building/publishing the gateway image (a deploy blocker).

### Fix
Pin both stages back to `python:3.13-slim`, matching `requires-python = ">=3.13"` and the 3.13 mypy target.

Verified locally: image builds, `import onnxruntime` works (1.20.1), `gateway` imports, `otari --help` runs.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

n/a

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). — N/A: Docker base-image pin; verified by building the image.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). — plus a local `docker build`.
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). — N/A: no API change.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 4.8 (via Claude Code)

**Any additional AI details you'd like to share:** Root-caused via git history + a local image build that reproduces the failure and confirms the fix.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

Updated the Docker base image for the gateway service from `python:3.14-slim` to `python:3.13-slim` in both the builder and runtime stages of the Dockerfile.

## Why

The gateway image build was failing because the `onnxruntime` dependency (used for the OCR feature) does not have pre-built packages for Python 3.14. When the upstream Python 3.14 release became available, the `python:3.14-slim` tag automatically resolved to the new version, causing `uv sync` to create a Python 3.14 environment during the build process. This incompatibility made the image unbuildable despite no changes to the Dockerfile itself.

## Benefits

- Fixes the critical Docker build failure that was blocking deployment of the gateway service
- Aligns the Docker image with the project's Python version support (Python 3.13+)
- Locally verified: image builds successfully, dependencies import correctly, and the gateway service functions as expected

<!-- end of auto-generated comment: release notes by coderabbit.ai -->