### PR TITLE
fix(codegen): name free-form-object union arrays so Go generates valid syntax

### DIFF
--- a/.github/workflows/otari-sdk-codegen-check.yml
+++ b/.github/workflows/otari-sdk-codegen-check.yml
@@ -36,6 +36,11 @@ jobs:
     steps:
       - name: Checkout Otari
         uses: actions/checkout@v6
+        with:
+          # Read-only job: it generates clients and opens no PRs, so the checkout
+          # credential is unused. Drop it rather than leave a token in .git/config
+          # while the generator and project code run.
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/otari-sdk-codegen-check.yml
+++ b/.github/workflows/otari-sdk-codegen-check.yml
@@ -1,0 +1,69 @@
+name: Otari SDK Codegen Check
+
+# Verifies the typed SDK core still generates cleanly from the OpenAPI spec for
+# every target language, so a spec change that breaks generation (for example a
+# new schema the Go generator names into invalid syntax) is caught on the PR
+# instead of failing the post-merge codegen workflow (otari-sdk-codegen.yml) and
+# stalling every SDK repo.
+#
+# This runs the same generate step as that workflow but stops there: it does not
+# check out or open PRs against the SDK repos, so it needs no cross-repo token.
+# Keep the toolchain in sync with otari-sdk-codegen.yml so a green check here
+# guarantees that workflow's generate step succeeds.
+
+on:
+  pull_request:
+    paths:
+      - 'docs/public/openapi.json'
+      - 'scripts/sdk_codegen/**'
+      - 'openapitools.json'
+      - '.github/workflows/otari-sdk-codegen.yml'
+      - '.github/workflows/otari-sdk-codegen-check.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # Keep this matrix in sync with FULL_TARGETS in scripts/sdk_codegen/generate.py
+      # and the matrix in otari-sdk-codegen.yml.
+      matrix:
+        language: [python, typescript, go, rust]
+    steps:
+      - name: Checkout Otari
+        uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: 3.14
+          activate-environment: true
+
+      - name: Install Otari deps
+        run: uv sync --dev --frozen
+
+      - name: Set up Java (OpenAPI Generator runtime)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Install OpenAPI Generator CLI
+        run: npm install -g @openapitools/openapi-generator-cli
+
+      - name: Install rustfmt (rust core is inlined and formatted in place)
+        if: matrix.language == 'rust'
+        # Pinned to the stable branch tip (immutable SHA); the action still
+        # installs the latest stable toolchain at runtime.
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: rustfmt
+
+      - name: Generate ${{ matrix.language }} client (full typed core)
+        # gofmt (Go postprocessing) and the other language formatters are exercised
+        # here; gofmt is preinstalled on the runner image, matching the codegen
+        # workflow. A generation or format failure fails the check.
+        run: uv run python scripts/sdk_codegen/generate.py --language "${{ matrix.language }}" --mode full --out-dir dist

--- a/scripts/sdk_codegen/README.md
+++ b/scripts/sdk_codegen/README.md
@@ -107,6 +107,12 @@ repo with the regenerated client core dropped into:
 The matrix in the workflow mirrors `FULL_TARGETS` in `generate.py`; keep them in
 sync. Target paths match what each SDK's hand-written shell imports from.
 
+`.github/workflows/otari-sdk-codegen-check.yml` runs the same generate step on
+pull requests that touch the spec or codegen tooling (but opens no PRs and needs
+no token), so a spec change that breaks generation for any language is caught on
+the PR rather than failing the post-merge codegen workflow. Keep its toolchain
+and matrix in sync with `otari-sdk-codegen.yml`.
+
 **Required secret:** `SDK_CODEGEN_TOKEN`, a fine-grained PAT or GitHub App token
 with `Contents:write` and `Pull-requests:write` on the four SDK repos. The default
 `GITHUB_TOKEN` cannot push to other repositories.
@@ -140,3 +146,11 @@ in `generate.py`, so no per-repo hand-edits to generated code are required):
   fails the SDK repo's `gofmt -l` check).
 - **python** — output is collapsed to the package directory so the workflow drops
   `otari._client` directly into the SDK.
+
+The spec is also sanitized before generation (`sanitize_freeform_object_arrays`):
+any-llm types Anthropic's `system` as `str | list[dict] | None`, whose array
+variant has inline free-form-object items. In a union with two or more non-null
+variants the Go generator names the array field from that inline item type and
+emits an invalid identifier (`ArrayOf*mapmapOfStringAny`), which fails `gofmt`.
+The sanitizer points every such array at a shared `FreeFormObject` schema so the
+variant name is deterministic across all languages.

--- a/scripts/sdk_codegen/generate.py
+++ b/scripts/sdk_codegen/generate.py
@@ -338,9 +338,10 @@ def _is_free_form_object(node: Any) -> bool:
     """True for a bare ``{"type": "object"}`` schema that accepts arbitrary values.
 
     Matches an object with no declared ``properties`` whose only other key may be
-    ``additionalProperties``, and only when that does not explicitly close the
-    object (``additionalProperties: false``) -- a closed object is not free-form
-    and must not be collapsed to the shared ``FreeFormObject``.
+    ``additionalProperties``, and only when that is omitted or literally ``true``.
+    A closed object (``additionalProperties: false``) or a typed map
+    (``additionalProperties: {schema}``) is not free-form and must not be
+    collapsed to the shared open ``FreeFormObject``.
     """
     if not (
         isinstance(node, dict)
@@ -349,7 +350,7 @@ def _is_free_form_object(node: Any) -> bool:
         and set(node) <= {"type", "additionalProperties"}
     ):
         return False
-    return node.get("additionalProperties", True) is not False
+    return node.get("additionalProperties", True) is True
 
 
 def sanitize_freeform_object_arrays(spec: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/sdk_codegen/generate.py
+++ b/scripts/sdk_codegen/generate.py
@@ -335,13 +335,21 @@ _FREE_FORM_OBJECT = "FreeFormObject"
 
 
 def _is_free_form_object(node: Any) -> bool:
-    """True for a bare ``{"type": "object"}`` schema with no declared properties."""
-    return (
+    """True for a bare ``{"type": "object"}`` schema that accepts arbitrary values.
+
+    Matches an object with no declared ``properties`` whose only other key may be
+    ``additionalProperties``, and only when that does not explicitly close the
+    object (``additionalProperties: false``) -- a closed object is not free-form
+    and must not be collapsed to the shared ``FreeFormObject``.
+    """
+    if not (
         isinstance(node, dict)
         and node.get("type") == "object"
         and "properties" not in node
         and set(node) <= {"type", "additionalProperties"}
-    )
+    ):
+        return False
+    return node.get("additionalProperties", True) is not False
 
 
 def sanitize_freeform_object_arrays(spec: dict[str, Any]) -> dict[str, Any]:
@@ -388,7 +396,14 @@ def sanitize_freeform_object_arrays(spec: dict[str, Any]) -> dict[str, Any]:
 
     walk(spec)
     if used:
-        schemas[_FREE_FORM_OBJECT] = {"type": "object", "additionalProperties": True}
+        desired = {"type": "object", "additionalProperties": True}
+        existing = schemas.get(_FREE_FORM_OBJECT)
+        if existing is not None and existing != desired:
+            raise ValueError(
+                f"schema {_FREE_FORM_OBJECT!r} already exists with a different shape; "
+                "cannot reuse it for free-form array-item sanitization"
+            )
+        schemas[_FREE_FORM_OBJECT] = desired
     return spec
 
 

--- a/scripts/sdk_codegen/generate.py
+++ b/scripts/sdk_codegen/generate.py
@@ -327,6 +327,71 @@ def enrich_spec(spec: dict[str, Any]) -> dict[str, Any]:
     return spec
 
 
+# Shared schema name for an arbitrary JSON object (``{"type": "object"}`` with
+# free-form values). Injected by ``sanitize_freeform_object_arrays`` so union
+# members that are arrays of such objects reference a named type instead of an
+# inline one.
+_FREE_FORM_OBJECT = "FreeFormObject"
+
+
+def _is_free_form_object(node: Any) -> bool:
+    """True for a bare ``{"type": "object"}`` schema with no declared properties."""
+    return (
+        isinstance(node, dict)
+        and node.get("type") == "object"
+        and "properties" not in node
+        and set(node) <= {"type", "additionalProperties"}
+    )
+
+
+def sanitize_freeform_object_arrays(spec: dict[str, Any]) -> dict[str, Any]:
+    """Give ``array``-of-free-form-object union members a named item type.
+
+    any-llm's Anthropic params type fields like ``system`` as
+    ``str | list[dict] | None``, which the spec encodes as an ``anyOf`` whose
+    array variant has inline free-form-object ``items``
+    (``{"type": "object", "additionalProperties": true}``). When such a union
+    has two or more non-null variants the Go generator synthesizes a wrapper
+    struct and names the array field from that inline item type, emitting an
+    invalid identifier (``ArrayOf*mapmapOfStringAny`` — the ``*`` comes from the
+    pointer-typed item). That fails ``gofmt`` and breaks the Go SDK build. The
+    naming is generator-internal and inconsistent (a sibling field with two
+    array variants generates cleanly), so rather than depend on it, point every
+    such array at a shared named schema; the variant name is then deterministic
+    across all SDK languages.
+    """
+    schemas = spec.get("components", {}).get("schemas")
+    if not isinstance(schemas, dict):
+        return spec
+    used = False
+
+    def walk(node: Any) -> None:
+        nonlocal used
+        if isinstance(node, dict):
+            for key in ("anyOf", "oneOf"):
+                members = node.get(key)
+                if not isinstance(members, list):
+                    continue
+                for member in members:
+                    if (
+                        isinstance(member, dict)
+                        and member.get("type") == "array"
+                        and _is_free_form_object(member.get("items"))
+                    ):
+                        member["items"] = {"$ref": f"#/components/schemas/{_FREE_FORM_OBJECT}"}
+                        used = True
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(spec)
+    if used:
+        schemas[_FREE_FORM_OBJECT] = {"type": "object", "additionalProperties": True}
+    return spec
+
+
 def _generator_cli() -> str:
     return os.environ.get("OPENAPI_GENERATOR_CLI", "openapi-generator-cli")
 
@@ -625,6 +690,7 @@ def main() -> int:
         prepared = filter_spec(spec, CONTROL_PLANE_TAGS)
         targets = TARGETS
         spec_name = "control-plane.openapi.json"
+    prepared = sanitize_freeform_object_arrays(prepared)
 
     languages = list(targets) if args.language == "all" else [str(args.language)]
     out_dir = Path(args.out_dir)

--- a/tests/unit/test_sdk_codegen.py
+++ b/tests/unit/test_sdk_codegen.py
@@ -318,6 +318,28 @@ def test_sanitize_freeform_object_arrays_leaves_closed_object_arrays() -> None:
     assert array_variant["items"] == {"type": "object", "additionalProperties": False}
 
 
+def test_sanitize_freeform_object_arrays_leaves_typed_map_arrays() -> None:
+    # A typed map (additionalProperties is a schema) constrains its values, so it
+    # is not free-form and must not be collapsed to the open FreeFormObject.
+    typed_map = {"type": "object", "additionalProperties": {"type": "string"}}
+    spec = {
+        "components": {
+            "schemas": {
+                "TypedMap": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "array", "items": dict(typed_map)},
+                    ]
+                }
+            }
+        }
+    }
+    out = generate.sanitize_freeform_object_arrays(spec)
+    assert generate._FREE_FORM_OBJECT not in out["components"]["schemas"]
+    array_variant = next(v for v in out["components"]["schemas"]["TypedMap"]["anyOf"] if v.get("type") == "array")
+    assert array_variant["items"] == typed_map
+
+
 def test_sanitize_freeform_object_arrays_raises_on_conflicting_existing_schema() -> None:
     # A pre-existing FreeFormObject with different semantics must not be silently
     # overwritten; the sanitizer cannot safely reuse the name.

--- a/tests/unit/test_sdk_codegen.py
+++ b/tests/unit/test_sdk_codegen.py
@@ -252,6 +252,66 @@ def test_enrich_types_reasoning_as_string_matching_wire_format() -> None:
         assert reasoning == {"type": "string"}, f"{prefix}_Reasoning must be a plain string, got {reasoning}"
 
 
+def _spec_with_freeform_union() -> dict[str, Any]:
+    # Mirrors how any-llm types Anthropic's ``system`` (``str | list[dict] | None``):
+    # an anyOf whose array variant has inline free-form-object items, alongside a
+    # single-variant ``tools`` (``list[dict] | None``) array.
+    free_form = {"additionalProperties": True, "type": "object"}
+    return {
+        "openapi": "3.1.0",
+        "info": {"title": "t", "version": "0"},
+        "components": {
+            "schemas": {
+                "MessagesRequest": {
+                    "type": "object",
+                    "properties": {
+                        "system": {
+                            "anyOf": [
+                                {"type": "string"},
+                                {"type": "array", "items": dict(free_form)},
+                                {"type": "null"},
+                            ]
+                        },
+                        "tools": {
+                            "anyOf": [
+                                {"type": "array", "items": dict(free_form)},
+                                {"type": "null"},
+                            ]
+                        },
+                    },
+                }
+            }
+        },
+    }
+
+
+def test_sanitize_freeform_object_arrays_names_union_array_items() -> None:
+    spec = generate.sanitize_freeform_object_arrays(_spec_with_freeform_union())
+    schemas = spec["components"]["schemas"]
+    assert schemas[generate._FREE_FORM_OBJECT] == {"type": "object", "additionalProperties": True}
+    props = schemas["MessagesRequest"]["properties"]
+    for field in ("system", "tools"):
+        array_variant = next(v for v in props[field]["anyOf"] if v.get("type") == "array")
+        assert array_variant["items"] == {
+            "$ref": f"#/components/schemas/{generate._FREE_FORM_OBJECT}"
+        }, f"{field} array items should reference the shared free-form object schema"
+
+
+def test_sanitize_freeform_object_arrays_is_noop_without_freeform_unions() -> None:
+    spec = {
+        "components": {
+            "schemas": {
+                "Plain": {
+                    "type": "object",
+                    "properties": {"items": {"type": "array", "items": {"type": "string"}}},
+                }
+            }
+        }
+    }
+    out = generate.sanitize_freeform_object_arrays(spec)
+    assert generate._FREE_FORM_OBJECT not in out["components"]["schemas"]
+
+
 def test_control_plane_tags_are_typed_management_only() -> None:
     assert generate.CONTROL_PLANE_TAGS == frozenset(
         {"keys", "users", "budgets", "pricing", "usage"}

--- a/tests/unit/test_sdk_codegen.py
+++ b/tests/unit/test_sdk_codegen.py
@@ -297,6 +297,39 @@ def test_sanitize_freeform_object_arrays_names_union_array_items() -> None:
         }, f"{field} array items should reference the shared free-form object schema"
 
 
+def test_sanitize_freeform_object_arrays_leaves_closed_object_arrays() -> None:
+    # A closed object (additionalProperties: false) is not free-form: collapsing it
+    # to the open FreeFormObject would change the contract, so it must be left alone.
+    spec = {
+        "components": {
+            "schemas": {
+                "Closed": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "array", "items": {"type": "object", "additionalProperties": False}},
+                    ]
+                }
+            }
+        }
+    }
+    out = generate.sanitize_freeform_object_arrays(spec)
+    assert generate._FREE_FORM_OBJECT not in out["components"]["schemas"]
+    array_variant = next(v for v in out["components"]["schemas"]["Closed"]["anyOf"] if v.get("type") == "array")
+    assert array_variant["items"] == {"type": "object", "additionalProperties": False}
+
+
+def test_sanitize_freeform_object_arrays_raises_on_conflicting_existing_schema() -> None:
+    # A pre-existing FreeFormObject with different semantics must not be silently
+    # overwritten; the sanitizer cannot safely reuse the name.
+    spec = _spec_with_freeform_union()
+    spec["components"]["schemas"][generate._FREE_FORM_OBJECT] = {
+        "type": "object",
+        "properties": {"id": {"type": "string"}},
+    }
+    with pytest.raises(ValueError, match="different shape"):
+        generate.sanitize_freeform_object_arrays(spec)
+
+
 def test_sanitize_freeform_object_arrays_is_noop_without_freeform_unions() -> None:
     spec = {
         "components": {


### PR DESCRIPTION
## Description

The post-merge **Otari SDK Codegen** workflow failed on the Go target after #160 ([failing run](https://github.com/mozilla-ai/otari/actions/runs/27552982164/job/81444124282)). `gofmt -w dist/go` exited 2 on `model_system.go`, whose `System` anyOf wrapper emitted an invalid Go field identifier:

```go
type System struct {
	ArrayOf*mapmapOfStringAny *[]*map[string]interface{}   // '*' is illegal in an identifier
	String *string
}
```

#160 added `MessagesRequest`/`CountTokensRequest`, whose `system` field is `str | list[dict] | None`. The spec encodes that as an `anyOf` whose array variant has inline free-form-object items. When such a union has two or more non-null variants (here `string` + `array`), the Go generator names the array field from that inline pointer type and produces a `*` in the identifier. The naming is generator-internal and inconsistent (the sibling `ModerationRequest.input`, with two array variants, generated cleanly), so it cannot be relied on. Python, TypeScript, and Rust handle the same construct fine, which is why only Go failed.

**Fix:** `sanitize_freeform_object_arrays()` runs on the prepared spec before generation and points every `anyOf`/`oneOf` array-of-free-form-object member at a shared named `FreeFormObject` schema, making the synthesized variant name deterministic across all languages. Result: `ArrayOfMapmapOfStringAny *[]map[string]interface{}` (valid). Semantically identical; all four languages generate cleanly end-to-end and Go `gofmt -w` exits 0.

**Pre-merge CI gate:** adds `.github/workflows/otari-sdk-codegen-check.yml`, which on PRs touching the spec or codegen tooling runs the same generate step for all four languages (same toolchain, including `gofmt`) but opens no SDK PRs and needs no cross-repo token. This breakage would have been caught on #160's PR instead of post-merge. (Stale-but-unregenerated `openapi.json` stays covered by `make openapi-check`.)

## PR Type

- [x] Bug Fix
- [x] Infrastructure / CI

## Relevant issues

Fixes the failure in https://github.com/mozilla-ai/otari/actions/runs/27552982164 (regression from #160).

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). (No API contract change; the gateway and `openapi.json` are untouched.)

## AI Usage

- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:** Drafted via back-and-forth with @njbrake; the reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)