### PR TITLE
fix(fallback): report each failed attempt when the whole chain is exhausted

### DIFF
--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -1399,6 +1399,14 @@ async def run_platform_non_stream(
             on_first_response=on_first_response,
         )
 
+    # FastAPI BackgroundTasks only run after a *successful* response. When every
+    # attempt fails the runner raises (502/504) and the queued usage reports are
+    # silently dropped — so the platform never records the failed attempts and
+    # can't fire its fallback-exhausted accounting. Keep the background task for
+    # the success-response path (non-blocking), but also stash the error reports
+    # so they can be flushed inline if the request ends in an exception.
+    pending_error_reports: list[tuple[str, str, Any, str | None]] = []
+
     def _report_attempt_outcome(
         attempt: ResolvedAttempt,
         outcome: str,
@@ -1413,6 +1421,8 @@ async def run_platform_non_stream(
             usage,
             error_class,
         )
+        if outcome != "success":
+            pending_error_reports.append((attempt.attempt_id, outcome, usage, error_class))
 
     def _on_attempt_success(attempt: ResolvedAttempt) -> None:
         response.headers["X-Correlation-ID"] = attempt.attempt_id
@@ -1420,17 +1430,31 @@ async def run_platform_non_stream(
             for key, value in rate_limit_headers(rate_limit_info).items():
                 response.headers[key] = value
 
-    return await run_platform_attempts(
-        route=route,
-        attempts=attempts,
-        base_request_fields=base_request_fields,
-        run_attempt=_run_attempt,
-        extract_usage=adapter.extract_usage,
-        classify_error=_classify_upstream_error,
-        report_attempt_outcome=_report_attempt_outcome,
-        on_success=_on_attempt_success,
-        max_tool_iterations=tool_ctx.max_tool_iterations,
-    )
+    try:
+        return await run_platform_attempts(
+            route=route,
+            attempts=attempts,
+            base_request_fields=base_request_fields,
+            run_attempt=_run_attempt,
+            extract_usage=adapter.extract_usage,
+            classify_error=_classify_upstream_error,
+            report_attempt_outcome=_report_attempt_outcome,
+            on_success=_on_attempt_success,
+            max_tool_iterations=tool_ctx.max_tool_iterations,
+        )
+    except HTTPException:
+        # An error response drops the queued BackgroundTasks, so send the
+        # per-attempt error reports inline before propagating. The background
+        # copies never run on this path, so there is no double-report.
+        if pending_error_reports:
+            await asyncio.gather(
+                *(
+                    _report_platform_usage(config, attempt_id, outcome, usage, error_class)
+                    for attempt_id, outcome, usage, error_class in pending_error_reports
+                ),
+                return_exceptions=True,
+            )
+        raise
 
 
 async def run_standalone_non_stream(

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -1401,7 +1401,7 @@ async def run_platform_non_stream(
 
     # FastAPI BackgroundTasks only run after a *successful* response. When every
     # attempt fails the runner raises (502/504) and the queued usage reports are
-    # silently dropped — so the platform never records the failed attempts and
+    # silently dropped, so the platform never records the failed attempts and
     # can't fire its fallback-exhausted accounting. Keep the background task for
     # the success-response path (non-blocking), but also stash the error reports
     # so they can be flushed inline if the request ends in an exception.
@@ -1445,15 +1445,25 @@ async def run_platform_non_stream(
     except HTTPException:
         # An error response drops the queued BackgroundTasks, so send the
         # per-attempt error reports inline before propagating. The background
-        # copies never run on this path, so there is no double-report.
+        # copies never run on this path, so there is no double-report. This
+        # branch only catches HTTPException (what the runner raises on the
+        # all-failed path); a CancelledError propagates without doing reporting
+        # I/O during teardown.
         if pending_error_reports:
-            await asyncio.gather(
+            results = await asyncio.gather(
                 *(
                     _report_platform_usage(config, attempt_id, outcome, usage, error_class)
                     for attempt_id, outcome, usage, error_class in pending_error_reports
                 ),
                 return_exceptions=True,
             )
+            for result in results:
+                if isinstance(result, BaseException):
+                    logger.warning(
+                        "Inline usage report failed on all-failed path request_id=%s: %s",
+                        route.request_id,
+                        result,
+                    )
         raise
 
 

--- a/tests/integration/test_platform_mode_messages.py
+++ b/tests/integration/test_platform_mode_messages.py
@@ -353,6 +353,64 @@ def test_platform_mode_returns_502_when_all_attempts_fail(
     assert response.json() == {"detail": "All upstream providers failed"}
 
 
+def test_platform_mode_reports_every_attempt_when_all_fail(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When every attempt fails, each attempt's error outcome is still reported
+    back to the platform. The terminal 502 response drops the queued
+    BackgroundTasks, so the reports must be sent inline — otherwise total
+    outages leave no per-attempt record and the platform can't account for a
+    fully-exhausted fallback chain.
+    """
+    usage_reports: list[dict[str, Any]] = []
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json=_resolve_payload([
+                    _attempt(0, "att-1", "claude-3-5-sonnet-20241022", "sk-1"),
+                    _attempt(1, "att-2", "claude-3-5-sonnet-20241022", "sk-2"),
+                ]),
+            )
+        usage_reports.append(body)
+        return httpx.Response(204)
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        raise httpx.HTTPStatusError(
+            "500",
+            request=httpx.Request("POST", "http://upstream"),
+            response=httpx.Response(500, request=httpx.Request("POST", "http://upstream")),
+        )
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.messages.amessages", fake_amessages)
+
+    response = platform_client.post(
+        "/v1/messages",
+        json={
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 502
+    # Both failed attempts were reported as errors, despite the terminal 502.
+    reported = {(r["correlation_id"], r["status"], r.get("error_class")) for r in usage_reports}
+    assert reported == {
+        ("att-1", "error", "http_500"),
+        ("att-2", "error", "http_500"),
+    }
+
+
 def test_platform_mode_non_retryable_error_raises_immediately(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_platform_mode_messages.py
+++ b/tests/integration/test_platform_mode_messages.py
@@ -359,7 +359,7 @@ def test_platform_mode_reports_every_attempt_when_all_fail(
 ) -> None:
     """When every attempt fails, each attempt's error outcome is still reported
     back to the platform. The terminal 502 response drops the queued
-    BackgroundTasks, so the reports must be sent inline — otherwise total
+    BackgroundTasks, so the reports must be sent inline; otherwise total
     outages leave no per-attempt record and the platform can't account for a
     fully-exhausted fallback chain.
     """

--- a/tests/integration/test_platform_mode_messages.py
+++ b/tests/integration/test_platform_mode_messages.py
@@ -403,12 +403,16 @@ def test_platform_mode_reports_every_attempt_when_all_fail(
     )
 
     assert response.status_code == 502
-    # Both failed attempts were reported as errors, despite the terminal 502.
-    reported = {(r["correlation_id"], r["status"], r.get("error_class")) for r in usage_reports}
-    assert reported == {
+    # Each failed attempt is reported exactly once, despite the terminal 502. A
+    # set would mask a double-report (the dropped-then-also-flushed bug), so pin
+    # the exact count and contents: the inline flush and the dropped background
+    # copies must not both fire.
+    assert len(usage_reports) == 2
+    reported = sorted((r["correlation_id"], r["status"], r.get("error_class")) for r in usage_reports)
+    assert reported == [
         ("att-1", "error", "http_500"),
         ("att-2", "error", "http_500"),
-    }
+    ]
 
 
 def test_platform_mode_non_retryable_error_raises_immediately(


### PR DESCRIPTION
## Description

### Problem
On the non-streaming platform path, when **every** attempt in a multi-attempt route fails, the gateway returns `502 "All upstream providers failed"` (or `504` on timeout) but **does not report the per-attempt outcomes** back to the platform. Total outages (the case most worth observing) leave no per-attempt record, and the platform can't account for a fully-exhausted fallback chain.

### Root cause
Per-attempt outcomes are reported via FastAPI `BackgroundTasks` (`_report_attempt_outcome` calls `background_tasks.add_task(_report_platform_usage, ...)`). Background tasks only run **after a successful response**. When the attempts runner raises the terminal `HTTPException`, FastAPI builds an error response without running those tasks, so the queued reports are silently dropped.

A partially-failed request (a later attempt succeeds, returning `200`) reports fine, because the success response flushes the background tasks; this is why the bug only bites the all-failed path.

### Fix
Keep the non-blocking background reporting for the success-response path, but also stash the per-attempt **error** reports and flush them inline (`await asyncio.gather(...)`) if `run_platform_attempts` raises. The inline flush and the background copies are mutually exclusive (the runner either returns or raises), and background tasks never run on an error response, so there is no double-report.

### Tests
- `tests/integration/test_platform_mode_messages.py::test_platform_mode_reports_every_attempt_when_all_fail`: both attempts fail (`500`); asserts each is reported as `error` with its `error_class` despite the terminal `502`. Verified to fail without the fix and pass with it.

Verified locally: `make lint`, `uv run mypy src/gateway/api/routes/_pipeline.py`, and the platform-mode integration suites pass.

### Scope
Non-streaming platform path only. The streaming path is covered by its companion PR #176.

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
N/A

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). (No API contract change.)

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:**
Reviewed and verified by a human before merge.

- [x] I am an AI Agent filling out this form (check box if true)
