### PR TITLE
fix(usage): treat 402 from the usage-report endpoint as non-retryable

### DIFF
--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -30,9 +30,12 @@ from gateway.services.mcp_loop import MaxToolIterationsExceeded
 T = TypeVar("T")
 
 # Status codes returned by the platform's usage-report endpoint that the
-# gateway should NOT retry. Auth / not-found / conflict / unprocessable are
-# all permanent rejection signals — retrying would just hammer the platform.
-_USAGE_NON_RETRYABLE_STATUS_CODES = {401, 404, 409, 422}
+# gateway should NOT retry. Auth / payment-required / not-found / conflict /
+# unprocessable are all permanent rejection signals — retrying would just
+# hammer the platform (an overdrawn or missing wallet won't recover within the
+# retry window). 402 is already excluded by the >= 500 retry predicate below;
+# listing it keeps the intent explicit and robust to changes in that predicate.
+_USAGE_NON_RETRYABLE_STATUS_CODES = {401, 402, 404, 409, 422}
 
 # Status codes that cause the gateway to move on to the next attempt in a
 # multi-attempt route. 401/403 are included because users configure

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -587,7 +587,8 @@ async def _report_platform_usage(
 
     Best-effort — failures are swallowed after ``max_retries`` so they don't
     impact the user's response path. Non-retryable status codes (auth /
-    not-found / conflict / unprocessable) short-circuit the retry loop.
+    payment-required / not-found / conflict / unprocessable) short-circuit the
+    retry loop.
     """
     platform_base_url = config.platform.get("base_url")
     if not platform_base_url:

--- a/tests/unit/test_run_platform_attempts.py
+++ b/tests/unit/test_run_platform_attempts.py
@@ -7,12 +7,18 @@ through a full request, such as the empty-attempts guard.
 
 from __future__ import annotations
 
-from typing import Any
+import asyncio
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
 
+import httpx
 import pytest
 from fastapi import HTTPException
 
+from gateway.api.routes import _platform
 from gateway.api.routes._platform import ResolvedRoute, run_platform_attempts
+from gateway.core.config import GatewayConfig
 
 
 @pytest.mark.asyncio
@@ -43,3 +49,27 @@ async def test_empty_attempts_raises_500_with_explicit_diagnostic() -> None:
         )
     assert ei.value.status_code == 500
     assert "empty attempts list" in ei.value.detail
+
+
+@pytest.mark.asyncio
+async def test_report_platform_usage_does_not_retry_on_402(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 402 from the usage-report endpoint is a permanent rejection (the org
+    wallet is overdrawn or missing and won't recover within the retry window).
+    The gateway must POST once and give up, never retry."""
+    config = cast(
+        GatewayConfig,
+        SimpleNamespace(
+            platform={"base_url": "http://platform", "usage_max_retries": 3},
+            platform_token="gw-test",
+        ),
+    )
+
+    post_mock = AsyncMock(return_value=httpx.Response(402))
+    monkeypatch.setattr(_platform, "_post_platform", post_mock)
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(asyncio, "sleep", sleep_mock)
+
+    await _platform._report_platform_usage(config, "corr-1", "success", None)
+
+    assert post_mock.call_count == 1
+    sleep_mock.assert_not_awaited()

--- a/tests/unit/test_run_platform_attempts.py
+++ b/tests/unit/test_run_platform_attempts.py
@@ -73,3 +73,7 @@ async def test_report_platform_usage_does_not_retry_on_402(monkeypatch: pytest.M
 
     assert post_mock.call_count == 1
     sleep_mock.assert_not_awaited()
+    # Pin the classification itself, not just the (currently equivalent) retry
+    # behaviour: 402 must stay in the non-retryable set even if the >= 500 retry
+    # predicate changes.
+    assert 402 in _platform._USAGE_NON_RETRYABLE_STATUS_CODES


### PR DESCRIPTION
## Description

Add `402` to `_USAGE_NON_RETRYABLE_STATUS_CODES` in `_platform.py` (now `{401, 402, 404, 409, 422}`), plus a unit test asserting the usage reporter POSTs once and gives up on a `402`.

A `402` (payment required / insufficient balance) returned by the platform's `/gateway/usage` endpoint is a **permanent** rejection: the org wallet is overdrawn or missing and won't recover within the retry window, so retrying only hammers the platform. It belongs alongside the other permanent-rejection codes (`401/404/409/422`) the reporter already short-circuits on.

This is **behavior-preserving today** — `402` is already excluded from retry by the `should_retry = response.status_code >= 500` predicate in `_report_platform_usage`, so it isn't retried even now. The change makes the intent explicit in the documented set and keeps the usage reporter robust if that `>= 500` predicate is ever changed to retry 4xx.

Companion to a platform-side fix where an over-budget managed completion now settles the already-incurred charge (driving the org wallet to zero/negative) instead of dropping it, so `/gateway/usage` returns `204` for that request rather than `402`. This PR hardens handling of the remaining `402` cases (e.g. a missing wallet) on the usage-report path. Distinct from #173, which makes `404/405/409/410` retryable on the provider-fallback path (`_FALLBACK_RETRYABLE_STATUS_CODES`) — different set, non-overlapping hunks.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

No otari-side issue. Companion to platform-side fix mozilla-ai/any-llm-platform#1105.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran lint, typecheck, and the relevant unit tests locally (`ruff check`, `mypy` on the changed files, and `pytest tests/unit/test_run_platform_attempts.py`). I did not run the full integration suite.
- [x] Documentation was updated where necessary. (No docs change needed.)
- [x] If the API contract changed, I regenerated the OpenAPI spec. (No API contract change.)

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Claude Opus 4.8)


**Any additional AI details you'd like to share:** Authored as a companion to the platform-side billing fix referenced above.

- [x] I am an AI Agent filling out this form (check box if true)