### PR TITLE
fix(fallback): report each failed attempt when a streaming chain is exhausted

### DIFF
--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -1294,6 +1294,14 @@ async def run_streaming_with_fallback(
         )
         return adapter.open_tool_loop_stream(kwargs, pool_for_loop, tool_ctx.max_tool_iterations)
 
+    # See run_platform_non_stream: BackgroundTasks only run after a successful
+    # response, so if every attempt fails before its first chunk the queued
+    # reports are dropped with the terminal 502/504. Keep the background task
+    # for the success path (it flushes once the SSE response completes), but
+    # also stash the error reports so they can be flushed inline on the
+    # all-failed path below.
+    pending_error_reports: list[tuple[str, str, Any, str | None]] = []
+
     async def _on_attempt_failed(attempt: ResolvedAttempt, failure: StreamingAttemptFailure) -> None:
         background_tasks.add_task(
             _report_platform_usage,
@@ -1303,6 +1311,7 @@ async def run_streaming_with_fallback(
             None,
             failure.error_class,
         )
+        pending_error_reports.append((attempt.attempt_id, "error", None, failure.error_class))
         logger.warning(
             "Streaming attempt failed request_id=%s position=%d provider=%s model=%s error=%s",
             route.request_id,
@@ -1321,8 +1330,18 @@ async def run_streaming_with_fallback(
             first_chunk_timeout_seconds=first_chunk_timeout,
         )
     except BaseException:
-        # No attempt yielded a first chunk: close the tool backend before
-        # propagating the failure. The route handler maps it to HTTP.
+        # No attempt yielded a first chunk: the request ends in an error
+        # response, which drops the queued BackgroundTasks — flush the
+        # per-attempt error reports inline so the platform still records every
+        # failed attempt. Then close the tool backend before propagating.
+        if pending_error_reports:
+            await asyncio.gather(
+                *(
+                    _report_platform_usage(config, attempt_id, outcome, usage, error_class)
+                    for attempt_id, outcome, usage, error_class in pending_error_reports
+                ),
+                return_exceptions=True,
+            )
         await backend_stack.aclose()
         raise
 

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -1329,20 +1329,31 @@ async def run_streaming_with_fallback(
             on_attempt_failed=_on_attempt_failed,
             first_chunk_timeout_seconds=first_chunk_timeout,
         )
-    except BaseException:
+    except BaseException as exc:
         # No attempt yielded a first chunk: the request ends in an error
-        # response, which drops the queued BackgroundTasks — flush the
-        # per-attempt error reports inline so the platform still records every
-        # failed attempt. Then close the tool backend before propagating.
-        if pending_error_reports:
-            await asyncio.gather(
-                *(
-                    _report_platform_usage(config, attempt_id, outcome, usage, error_class)
-                    for attempt_id, outcome, usage, error_class in pending_error_reports
-                ),
-                return_exceptions=True,
-            )
-        await backend_stack.aclose()
+        # response, which drops the queued BackgroundTasks, so flush the
+        # per-attempt error reports inline to keep the platform's per-attempt
+        # record. Skip the flush on cancellation (reporting I/O must not delay
+        # teardown), and always close the tool backend before propagating, even
+        # if the flush raises or is interrupted.
+        try:
+            if pending_error_reports and not isinstance(exc, asyncio.CancelledError):
+                results = await asyncio.gather(
+                    *(
+                        _report_platform_usage(config, attempt_id, outcome, usage, error_class)
+                        for attempt_id, outcome, usage, error_class in pending_error_reports
+                    ),
+                    return_exceptions=True,
+                )
+                for result in results:
+                    if isinstance(result, BaseException):
+                        logger.warning(
+                            "Inline usage report failed on all-failed streaming path request_id=%s: %s",
+                            route.request_id,
+                            result,
+                        )
+        finally:
+            await backend_stack.aclose()
         raise
 
     if tool_mode:

--- a/tests/integration/test_platform_mode_chat.py
+++ b/tests/integration/test_platform_mode_chat.py
@@ -636,11 +636,16 @@ def test_platform_mode_streaming_reports_every_attempt_when_all_fail(
     )
 
     assert response.status_code == 502
-    reported = {(r["correlation_id"], r["status"], r.get("error_class")) for r in usage_reports}
-    assert reported == {
+    # Each failed attempt is reported exactly once, despite the terminal 502. A
+    # set would mask a double-report (the dropped-then-also-flushed bug), so pin
+    # the exact count and contents: the inline flush and the dropped background
+    # copies must not both fire.
+    assert len(usage_reports) == 2
+    reported = sorted((r["correlation_id"], r["status"], r.get("error_class")) for r in usage_reports)
+    assert reported == [
         ("att-a", "error", "http_500"),
         ("att-b", "error", "http_500"),
-    }
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_platform_mode_chat.py
+++ b/tests/integration/test_platform_mode_chat.py
@@ -573,7 +573,7 @@ def test_platform_mode_streaming_reports_every_attempt_when_all_fail(
 ) -> None:
     """When every streaming attempt fails before its first chunk, each attempt's
     error outcome is still reported back to the platform. The terminal 502 drops
-    the queued BackgroundTasks, so the reports must be sent inline — otherwise a
+    the queued BackgroundTasks, so the reports must be sent inline; otherwise a
     total streaming outage leaves no per-attempt record.
     """
     usage_reports: list[dict[str, Any]] = []

--- a/tests/integration/test_platform_mode_chat.py
+++ b/tests/integration/test_platform_mode_chat.py
@@ -567,6 +567,82 @@ def test_platform_mode_streaming_returns_502_when_all_attempts_fail(
     assert response.json() == {"detail": "All upstream providers failed"}
 
 
+def test_platform_mode_streaming_reports_every_attempt_when_all_fail(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When every streaming attempt fails before its first chunk, each attempt's
+    error outcome is still reported back to the platform. The terminal 502 drops
+    the queued BackgroundTasks, so the reports must be sent inline — otherwise a
+    total streaming outage leaves no per-attempt record.
+    """
+    usage_reports: list[dict[str, Any]] = []
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json={
+                    "request_id": "stream-req-fail",
+                    "fallback_enabled": True,
+                    "attempts": [
+                        {
+                            "attempt_id": "att-a",
+                            "position": 0,
+                            "provider": "anthropic",
+                            "model": "claude-haiku-4-5",
+                            "api_key": "sk-ant-broken",
+                            "api_base": None,
+                            "managed": False,
+                        },
+                        {
+                            "attempt_id": "att-b",
+                            "position": 1,
+                            "provider": "openai",
+                            "model": "gpt-4o-mini",
+                            "api_key": "sk-openai-broken",
+                            "api_base": None,
+                            "managed": False,
+                        },
+                    ],
+                },
+            )
+        usage_reports.append(body)
+        return httpx.Response(204)
+
+    async def fake_acompletion(**kwargs: Any) -> Any:
+        raise httpx.HTTPStatusError(
+            "500",
+            request=httpx.Request("POST", "http://upstream"),
+            response=httpx.Response(500, request=httpx.Request("POST", "http://upstream")),
+        )
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.acompletion", fake_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 502
+    reported = {(r["correlation_id"], r["status"], r.get("error_class")) for r in usage_reports}
+    assert reported == {
+        ("att-a", "error", "http_500"),
+        ("att-b", "error", "http_500"),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Tool-loop fallback (pre-lock-in)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

### Problem
The streaming platform path has the same dropped-reporting bug as the non-streaming path (PR #174's sibling): when every streaming attempt fails before its first chunk, the per-attempt error outcomes are never reported back to the platform. A total streaming outage leaves no per-attempt record.

### Root cause
`run_streaming_with_fallback` reports failures via `_on_attempt_failed`, which calls `background_tasks.add_task(_report_platform_usage, ...)`. When `iterate_streaming_attempts` exhausts all attempts pre-first-chunk it raises; the route returns a terminal `502`/`504`, and FastAPI drops the queued background tasks (they only run after a successful response). `iterate_streaming_attempts` already calls `on_attempt_failed` for every failed attempt, so the reports are built but never sent.

The partial-fail streaming case reports correctly, because the successful SSE response flushes the background tasks.

### Fix
Mirror the non-streaming fix: keep the background task for the success path, but stash the per-attempt error reports and flush them inline (`await asyncio.gather(...)`) in the all-failed `except` branch, right where the backend stack is already closed before re-raising. The inline flush and the background copies are mutually exclusive (iteration either returns a stream or raises), and background tasks never run on an error response, so there is no double-report.

### Tests
- `tests/integration/test_platform_mode_chat.py::test_platform_mode_streaming_reports_every_attempt_when_all_fail`: both streaming attempts fail (`500`); asserts each is reported as `error` with its `error_class` despite the terminal `502`. Verified to fail without the fix and pass with it.

Verified locally: `make lint`, `uv run mypy src/gateway/api/routes/_pipeline.py`, and the platform-mode integration suites pass.

### Companion
Same root cause and fix shape as the non-streaming path PR #174. This PR covers the streaming path that #174 explicitly scoped out.

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
N/A

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). (No API contract change.)

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:**
Reviewed and verified by a human before merge.

- [x] I am an AI Agent filling out this form (check box if true)
