### PR TITLE
feat(codegen): type the image-generation response from any-llm ImagesResponse

### DIFF
--- a/scripts/sdk_codegen/generate.py
+++ b/scripts/sdk_codegen/generate.py
@@ -249,6 +249,7 @@ def enrich_spec(spec: dict[str, Any]) -> dict[str, Any]:
         ChatCompletionChunk,
         CreateEmbeddingResponse,
     )
+    from any_llm.types.image import ImagesResponse
     from any_llm.types.messages import MessageResponse
     from any_llm.types.rerank import RerankResponse
     from openai.types.chat import ChatCompletionMessageParam
@@ -288,8 +289,9 @@ def enrich_spec(spec: dict[str, Any]) -> dict[str, Any]:
     # otari-owned inference endpoints the gateway leaves ``response_model=None``.
     # Their real response shapes live in any-llm (which the gateway depends on);
     # inject them so the generated core returns typed models instead of ``object``.
-    # Audio/images are intentionally left opaque: they return binary/file payloads
-    # that do not map onto a JSON response schema.
+    # Audio is intentionally left opaque: speech returns binary audio and
+    # transcription takes a multipart file upload, neither of which maps onto a
+    # JSON response schema. Image generation is JSON-shaped, so it is typed here.
     # Response shapes too: serialization mode keeps the schema aligned with the
     # serialized wire format (see the ChatCompletion note above).
     schemas["MessageResponse"] = absorb(
@@ -306,6 +308,10 @@ def enrich_spec(spec: dict[str, Any]) -> dict[str, Any]:
         ),
         "EMB",
     )
+    schemas["ImagesResponse"] = absorb(
+        ImagesResponse.model_json_schema(mode="serialization", ref_template="#/components/schemas/IMG_{model}"),
+        "IMG",
+    )
 
     def set_json_200(path: str, schema_name: str, description: str) -> None:
         op = spec["paths"][path]["post"]
@@ -318,6 +324,7 @@ def enrich_spec(spec: dict[str, Any]) -> dict[str, Any]:
     set_json_200("/v1/messages", "MessageResponse", "Anthropic-style message")
     set_json_200("/v1/rerank", "RerankResponse", "Rerank result")
     set_json_200("/v1/embeddings", "CreateEmbeddingResponse", "Embeddings")
+    set_json_200("/v1/images/generations", "ImagesResponse", "Generated images")
 
     schemas["ChatCompletionRequest"]["properties"]["messages"] = {
         "type": "array",

--- a/scripts/sdk_codegen/generate.py
+++ b/scripts/sdk_codegen/generate.py
@@ -289,9 +289,11 @@ def enrich_spec(spec: dict[str, Any]) -> dict[str, Any]:
     # otari-owned inference endpoints the gateway leaves ``response_model=None``.
     # Their real response shapes live in any-llm (which the gateway depends on);
     # inject them so the generated core returns typed models instead of ``object``.
-    # Audio is intentionally left opaque: speech returns binary audio and
-    # transcription takes a multipart file upload, neither of which maps onto a
-    # JSON response schema. Image generation is JSON-shaped, so it is typed here.
+    # Audio stays opaque here. Speech returns binary audio, which has no JSON
+    # response schema. Transcription's response is JSON, but each SDK hand-writes
+    # it over a raw multipart upload (a request-side concern the generated core
+    # can't carry) and its shape varies by response_format, so there is no single
+    # response model to inject. Image generation is plain JSON, so it is typed.
     # Response shapes too: serialization mode keeps the schema aligned with the
     # serialized wire format (see the ChatCompletion note above).
     schemas["MessageResponse"] = absorb(

--- a/tests/unit/test_sdk_codegen.py
+++ b/tests/unit/test_sdk_codegen.py
@@ -204,6 +204,7 @@ def _full_spec_stub() -> dict[str, Any]:
             "/v1/messages": {"post": {"responses": {}}},
             "/v1/rerank": {"post": {"responses": {}}},
             "/v1/embeddings": {"post": {"responses": {}}},
+            "/v1/images/generations": {"post": {"responses": {}}},
         },
         "components": {"schemas": {"ChatCompletionRequest": {"type": "object", "properties": {}}}},
     }
@@ -218,6 +219,7 @@ def test_enrich_types_otari_owned_inference_endpoints() -> None:
         "MessageResponse",
         "RerankResponse",
         "CreateEmbeddingResponse",
+        "ImagesResponse",
         "ChatMessageInput",
     ):
         assert name in schemas, f"{name} schema missing after enrich"
@@ -233,6 +235,9 @@ def test_enrich_types_otari_owned_inference_endpoints() -> None:
     assert ref("/v1/messages").endswith("/MessageResponse")
     assert ref("/v1/rerank").endswith("/RerankResponse")
     assert ref("/v1/embeddings").endswith("/CreateEmbeddingResponse")
+    # Image generation is JSON-shaped (unlike binary speech / multipart
+    # transcription), so it is typed from any-llm's ImagesResponse.
+    assert ref("/v1/images/generations").endswith("/ImagesResponse")
 
     messages_field = schemas["ChatCompletionRequest"]["properties"]["messages"]
     assert messages_field["items"]["$ref"].endswith("/ChatMessageInput")

--- a/tests/unit/test_sdk_codegen.py
+++ b/tests/unit/test_sdk_codegen.py
@@ -235,8 +235,9 @@ def test_enrich_types_otari_owned_inference_endpoints() -> None:
     assert ref("/v1/messages").endswith("/MessageResponse")
     assert ref("/v1/rerank").endswith("/RerankResponse")
     assert ref("/v1/embeddings").endswith("/CreateEmbeddingResponse")
-    # Image generation is JSON-shaped (unlike binary speech / multipart
-    # transcription), so it is typed from any-llm's ImagesResponse.
+    # Image generation is plain JSON, so it is typed from any-llm's
+    # ImagesResponse. Speech (binary response) and transcription (multipart
+    # request) stay opaque in the codegen enrichment.
     assert ref("/v1/images/generations").endswith("/ImagesResponse")
 
     messages_field = schemas["ChatCompletionRequest"]["properties"]["messages"]


### PR DESCRIPTION
## Description

Types the `/v1/images/generations` response in the SDK codegen, so the generated cores stop modeling it as an opaque `object` and the per-language shells can return a typed image response instead of an untyped dict.

The gateway leaves this endpoint with `response_model=None` (like the other inference endpoints), so `enrich_spec` in `scripts/sdk_codegen/generate.py` is the place that injects real `any-llm` types before generation. This adds `any_llm.types.image.ImagesResponse` there, in serialization mode with an `IMG_` ref prefix, exactly as chat / messages / rerank / embeddings are already typed. The next full regen makes `ImagesApi.create_image…` return a typed `ImagesResponse` across python, ts, go, and rust.

Audio stays opaque on purpose: speech returns binary audio and transcription takes a multipart file upload, neither of which maps onto a JSON response schema.

This only touches the SDK codegen path. The gateway's own published `docs/public/openapi.json` keeps `response_model=None` and is unchanged (`make openapi-check` still passes).

Changes:
- `scripts/sdk_codegen/generate.py`: inject `ImagesResponse` into `enrich_spec` and set the `/v1/images/generations` `200` schema; update the "intentionally opaque" comment to reflect that only audio remains opaque.
- `tests/unit/test_sdk_codegen.py`: extend `test_enrich_types_otari_owned_inference_endpoints` to cover the image endpoint.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Pairs with the image/audio SDK PRs in otari-sdk-{python,ts,go,rust}. No gateway issue; this is the codegen-side complement to mozilla-ai/otari#138.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). Not applicable: the published spec is unchanged (the typing is injected only in the SDK codegen path), and `make openapi-check` passes.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 4.8 (1M context) via Claude Code

**Any additional AI details you'd like to share:**

Implemented as a follow-up to the cross-SDK image/audio rollout; @njbrake reviewed. The real integration gate here is the `otari-sdk-codegen-check.yml` workflow, which regenerated all four cores from the enriched spec on this PR.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR updates the SDK code generation pipeline so the image generation endpoint (`/v1/images/generations`) returns a properly typed `ImagesResponse` instead of an untyped dictionary.

### Changes Made

**SDK code generation pipeline** (`scripts/sdk_codegen/generate.py`)
- Enriches the generated OpenAPI spec with the `ImagesResponse` type (using the same typed-schema approach already used for other inference endpoints).
- Updates the `/v1/images/generations` `200` response schema to reference the new typed `ImagesResponse`.
- Keeps audio endpoints intentionally opaque because their request/response shapes don’t match standard JSON schemas (e.g., binary audio output and multipart request handling).

**Test coverage** (`tests/unit/test_sdk_codegen.py`)
- Extends the existing spec-enrichment unit test to include `/v1/images/generations`, asserting that it now resolves to an `ImagesResponse` schema.

### Impact

After the next full SDK regeneration, `ImagesApi.create_image()` will return a typed `ImagesResponse` across supported SDK languages, improving type safety and developer experience compared to returning an untyped structure.

### Scope

Changes are limited to the SDK codegen pipeline; the published/public OpenAPI spec remains unchanged and existing OpenAPI validation checks continue to pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->