### PR TITLE
fix(codegen): map bare empty-schema union members to FreeFormObject

### DIFF
--- a/scripts/sdk_codegen/generate.py
+++ b/scripts/sdk_codegen/generate.py
@@ -362,21 +362,45 @@ def _is_free_form_object(node: Any) -> bool:
     return node.get("additionalProperties", True) is True
 
 
-def sanitize_freeform_object_arrays(spec: dict[str, Any]) -> dict[str, Any]:
-    """Give ``array``-of-free-form-object union members a named item type.
+def _is_empty_schema(node: Any) -> bool:
+    """True for an always-matching schema used as a direct union member.
 
-    any-llm's Anthropic params type fields like ``system`` as
-    ``str | list[dict] | None``, which the spec encodes as an ``anyOf`` whose
-    array variant has inline free-form-object ``items``
-    (``{"type": "object", "additionalProperties": true}``). When such a union
-    has two or more non-null variants the Go generator synthesizes a wrapper
-    struct and names the array field from that inline item type, emitting an
-    invalid identifier (``ArrayOf*mapmapOfStringAny`` — the ``*`` comes from the
-    pointer-typed item). That fails ``gofmt`` and breaks the Go SDK build. The
-    naming is generator-internal and inconsistent (a sibling field with two
-    array variants generates cleanly), so rather than depend on it, point every
-    such array at a shared named schema; the variant name is then deterministic
-    across all SDK languages.
+    An empty ``{}`` (or one carrying only annotation keys such as ``title`` /
+    ``description``) accepts any JSON value. As a direct ``anyOf`` / ``oneOf``
+    member it gives the generator no name to bind to, so the statically typed
+    SDKs emit a dangling placeholder type for it (Rust
+    ``models::AnyOfLessThanGreaterThan``, Go ``AnyOf`` / ``NullableAnyOf``,
+    TypeScript an empty ``| null`` union with bare ``FromJSON`` / ``ToJSON``
+    calls). any-llm produces these for loosely typed passthrough fields such as
+    ``ResponsesRequest.text`` (``anyOf: [{}, {"type": "null"}]``). Point the
+    member at the shared ``FreeFormObject`` so it is a named, generatable type.
+    """
+    return isinstance(node, dict) and not (set(node) - {"title", "description"})
+
+
+def sanitize_freeform_object_arrays(spec: dict[str, Any]) -> dict[str, Any]:
+    """Give free-form-object union members a named, generatable type.
+
+    Two inline free-form shapes break the statically typed generators when they
+    appear in an ``anyOf`` / ``oneOf`` union, so both are pointed at a shared
+    named ``FreeFormObject`` schema:
+
+    - **array-of-free-form-object members.** any-llm's Anthropic params type
+      fields like ``system`` as ``str | list[dict] | None``, whose array variant
+      has inline free-form-object ``items``
+      (``{"type": "object", "additionalProperties": true}``). When such a union
+      has two or more non-null variants the Go generator synthesizes a wrapper
+      struct and names the array field from that inline item type, emitting an
+      invalid identifier (``ArrayOf*mapmapOfStringAny`` — the ``*`` comes from
+      the pointer-typed item). That fails ``gofmt`` and breaks the Go SDK build.
+    - **bare empty-schema members.** A direct ``{}`` member (see
+      :func:`_is_empty_schema`) has no name for the generator to bind to, so the
+      static SDKs emit a dangling placeholder type that never gets generated and
+      fails to compile (e.g. ``ResponsesRequest.text``).
+
+    The generator-internal naming is inconsistent, so rather than depend on it,
+    rewrite every such member to reference the shared schema; the member name is
+    then deterministic across all SDK languages.
     """
     schemas = spec.get("components", {}).get("schemas")
     if not isinstance(schemas, dict):
@@ -390,13 +414,16 @@ def sanitize_freeform_object_arrays(spec: dict[str, Any]) -> dict[str, Any]:
                 members = node.get(key)
                 if not isinstance(members, list):
                     continue
-                for member in members:
+                for index, member in enumerate(members):
                     if (
                         isinstance(member, dict)
                         and member.get("type") == "array"
                         and _is_free_form_object(member.get("items"))
                     ):
                         member["items"] = {"$ref": f"#/components/schemas/{_FREE_FORM_OBJECT}"}
+                        used = True
+                    elif _is_empty_schema(member):
+                        members[index] = {"$ref": f"#/components/schemas/{_FREE_FORM_OBJECT}"}
                         used = True
             for value in node.values():
                 walk(value)

--- a/tests/unit/test_sdk_codegen.py
+++ b/tests/unit/test_sdk_codegen.py
@@ -303,6 +303,49 @@ def test_sanitize_freeform_object_arrays_names_union_array_items() -> None:
         }, f"{field} array items should reference the shared free-form object schema"
 
 
+def test_sanitize_freeform_object_collapses_empty_union_member() -> None:
+    # any-llm types ResponsesRequest.text as anyOf: [{}, {"type": "null"}]. The
+    # empty {} member has no name for the static generators to bind to, so point
+    # it at the shared FreeFormObject (the null member is left alone).
+    spec = {
+        "components": {
+            "schemas": {
+                "ResponsesRequest": {
+                    "type": "object",
+                    "properties": {
+                        "text": {"anyOf": [{}, {"type": "null"}], "title": "Text"},
+                    },
+                }
+            }
+        }
+    }
+    out = generate.sanitize_freeform_object_arrays(spec)
+    schemas = out["components"]["schemas"]
+    assert schemas[generate._FREE_FORM_OBJECT] == {"type": "object", "additionalProperties": True}
+    members = schemas["ResponsesRequest"]["properties"]["text"]["anyOf"]
+    assert {"$ref": f"#/components/schemas/{generate._FREE_FORM_OBJECT}"} in members
+    assert {"type": "null"} in members
+
+
+def test_sanitize_freeform_object_leaves_typed_union_members() -> None:
+    # A union of concrete members has nothing to collapse: no FreeFormObject is
+    # introduced and the members are untouched.
+    spec = {
+        "components": {
+            "schemas": {
+                "Typed": {"anyOf": [{"type": "string"}, {"type": "integer"}, {"type": "null"}]}
+            }
+        }
+    }
+    out = generate.sanitize_freeform_object_arrays(spec)
+    assert generate._FREE_FORM_OBJECT not in out["components"]["schemas"]
+    assert out["components"]["schemas"]["Typed"]["anyOf"] == [
+        {"type": "string"},
+        {"type": "integer"},
+        {"type": "null"},
+    ]
+
+
 def test_sanitize_freeform_object_arrays_leaves_closed_object_arrays() -> None:
     # A closed object (additionalProperties: false) is not free-form: collapsing it
     # to the open FreeFormObject would change the contract, so it must be left alone.


### PR DESCRIPTION
## Description

any-llm types loosely typed passthrough fields like `ResponsesRequest.text` as `anyOf: [{}, {"type": "null"}]`. The empty `{}` member has no name for the statically typed SDK generators to bind to, so each emits a dangling placeholder type that is never generated and fails to compile:

- Rust: `models::AnyOfLessThanGreaterThan` (undefined)
- Go: `AnyOf` / `NullableAnyOf` (undefined)
- TypeScript: an empty `| null` union with bare `FromJSON` / `ToJSON` calls

This was surfaced when landing the regenerated SDK cores: the Rust regen would not compile, and TS/Go needed manual core patches. The fix is at the source: extend `sanitize_freeform_object_arrays` to rewrite a bare empty-schema (or annotation-only) `anyOf` / `oneOf` member to a `$ref` to the shared `FreeFormObject`, mirroring how free-form array items are already handled. Every SDK language then generates a valid named type.

This only affects the SDK codegen path; the gateway's own published `docs/public/openapi.json` is unchanged (`make openapi-check` passes).

Verified on the real spec: `ResponsesRequest.text` becomes `[{"$ref": ".../FreeFormObject"}, {"type": "null"}]` after sanitization.

## PR Type

- [x] Bug Fix

## Relevant issues

Unblocks the SDK regen across otari-sdk-{ts,go,rust}; complements the image-typing work (#178).

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec. Not applicable: published spec unchanged; `make openapi-check` passes.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 4.8 (1M context) via Claude Code

**Any additional AI details you'd like to share:**

Diagnosed while landing the regenerated SDK cores (the Rust core would not compile); @njbrake reviewed. The four `generate (*)` codegen-check jobs on this PR regenerate all languages from the sanitized spec.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)