### PR TITLE
feat(sandbox): forward caller token to the sandbox backend as Bearer auth

### DIFF
--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -557,6 +557,7 @@ class ToolContext:
         use_sandbox: bool,
         sandbox_tool_entry: dict[str, Any] | None,
         sandbox_url: str | None,
+        sandbox_auth_token: str | None,
         use_web_search: bool,
         web_search_tool_entry: dict[str, Any] | None,
         web_search_url: str | None,
@@ -569,6 +570,7 @@ class ToolContext:
         self.use_sandbox = use_sandbox
         self.sandbox_tool_entry = sandbox_tool_entry
         self.sandbox_url = sandbox_url
+        self.sandbox_auth_token = sandbox_auth_token
         self.use_web_search = use_web_search
         self.web_search_tool_entry = web_search_tool_entry
         self.web_search_url = web_search_url
@@ -640,6 +642,18 @@ async def prepare_gateway_tools(
                 raise adapter.error(400, SANDBOX_MCP_CONFLICT_DETAIL, ErrorKind.INVALID_REQUEST)
             use_sandbox = True
 
+        # Forwarded to the sandbox backend as `Authorization: Bearer`. Only set in
+        # platform mode when the backend IS the platform (its URL is under the
+        # platform base URL the gateway already trusts this token with for resolve):
+        # the platform-hosted /v1/sandbox proxy authenticates the caller's workspace
+        # token and derives tenancy + per-workspace code-exec policy from it. Never
+        # leak it to a standalone exec-service an operator pointed the URL at.
+        sandbox_auth_token: str | None = None
+        if use_sandbox and ctx.platform_mode and sandbox_url is not None:
+            assert ctx.user_token is not None  # guaranteed by the platform-mode preamble
+            if web_search_url_targets_platform(sandbox_url, ctx.config.platform.get("base_url")):
+                sandbox_auth_token = ctx.user_token
+
         web_search_tool_entry, remaining_user_tools = _extract_web_search_tool(tools_after_sandbox)
         web_search_url: str | None = otari_env("WEB_SEARCH_URL") or None
         # Forwarded to the search backend as `X-Gateway-Token`. Only set in
@@ -704,6 +718,7 @@ async def prepare_gateway_tools(
         use_sandbox=use_sandbox,
         sandbox_tool_entry=sandbox_tool_entry,
         sandbox_url=sandbox_url,
+        sandbox_auth_token=sandbox_auth_token,
         use_web_search=use_web_search,
         web_search_tool_entry=web_search_tool_entry,
         web_search_url=web_search_url,
@@ -870,7 +885,9 @@ async def dispatch_non_stream(
     if tool_ctx.use_sandbox:
         assert tool_ctx.sandbox_url is not None  # guaranteed past the missing-URL 400 in prepare_gateway_tools
         sandbox_hint = _resolve_sandbox_purpose_hint(tool_ctx.sandbox_tool_entry)
-        async with SandboxBackend(sandbox_url=tool_ctx.sandbox_url, purpose_hint=sandbox_hint) as backend:
+        async with SandboxBackend(
+            sandbox_url=tool_ctx.sandbox_url, purpose_hint=sandbox_hint, auth_token=tool_ctx.sandbox_auth_token
+        ) as backend:
             kwargs = adapter.inject_hints(call_kwargs, backend.purpose_hints(), header=tool_ctx.tools_header)
             return await adapter.run_tool_loop(kwargs, backend, tool_ctx.max_tool_iterations, on_first_response)
 
@@ -942,7 +959,9 @@ async def open_stream(
     if tool_ctx.use_sandbox:
         assert tool_ctx.sandbox_url is not None  # guaranteed past the missing-URL 400 in prepare_gateway_tools
         sandbox_hint = _resolve_sandbox_purpose_hint(tool_ctx.sandbox_tool_entry)
-        sandbox_backend = SandboxBackend(sandbox_url=tool_ctx.sandbox_url, purpose_hint=sandbox_hint)
+        sandbox_backend = SandboxBackend(
+            sandbox_url=tool_ctx.sandbox_url, purpose_hint=sandbox_hint, auth_token=tool_ctx.sandbox_auth_token
+        )
         await sandbox_backend.__aenter__()  # may raise SandboxNotReachableError
         return _eager_backend_stream(adapter, kwargs, sandbox_backend, tool_ctx)
 
@@ -1241,7 +1260,9 @@ async def run_streaming_with_fallback(
             assert tool_ctx.sandbox_url is not None  # guaranteed past the missing-URL 400 in prepare_gateway_tools
             sandbox_hint = _resolve_sandbox_purpose_hint(tool_ctx.sandbox_tool_entry)
             pool_for_loop = await backend_stack.enter_async_context(
-                SandboxBackend(sandbox_url=tool_ctx.sandbox_url, purpose_hint=sandbox_hint),
+                SandboxBackend(
+                    sandbox_url=tool_ctx.sandbox_url, purpose_hint=sandbox_hint, auth_token=tool_ctx.sandbox_auth_token
+                ),
             )
         elif tool_ctx.use_web_search:
             assert tool_ctx.web_search_url is not None  # guaranteed past the missing-URL 400

--- a/src/gateway/services/sandbox_backend.py
+++ b/src/gateway/services/sandbox_backend.py
@@ -73,17 +73,27 @@ class SandboxBackend:
         sandbox_url: str,
         purpose_hint: str | None = None,
         timeout_s: float = _DEFAULT_TIMEOUT_S,
+        auth_token: str | None = None,
     ) -> None:
         self._sandbox_url = sandbox_url.rstrip("/")
         self._purpose_hint = purpose_hint or _DEFAULT_PURPOSE_HINT
         self._timeout_s = timeout_s
+        # Optional bearer credential forwarded as `Authorization: Bearer` on every
+        # call to the sandbox backend. Set in platform mode so the platform-hosted
+        # /v1/sandbox proxy (which authenticates the caller's workspace token) admits
+        # the request and derives tenancy from it. Unset (and unsent) when the
+        # backend is a standalone exec-service that needs no auth.
+        self._auth_token = auth_token
         self._client: httpx.AsyncClient | None = None
         self._session_id: str | None = None
         self._stack: AsyncExitStack = AsyncExitStack()
 
     async def __aenter__(self) -> SandboxBackend:
         try:
-            self._client = await self._stack.enter_async_context(httpx.AsyncClient(timeout=self._timeout_s))
+            headers = {"Authorization": f"Bearer {self._auth_token}"} if self._auth_token else None
+            self._client = await self._stack.enter_async_context(
+                httpx.AsyncClient(timeout=self._timeout_s, headers=headers)
+            )
             response = await self._client.post(f"{self._sandbox_url}/sessions", json={})
             response.raise_for_status()
             self._session_id = response.json()["session_id"]

--- a/tests/unit/test_pipeline_settlement.py
+++ b/tests/unit/test_pipeline_settlement.py
@@ -48,6 +48,7 @@ def _tool_ctx(**overrides: Any) -> ToolContext:
         "use_sandbox": False,
         "sandbox_tool_entry": None,
         "sandbox_url": None,
+        "sandbox_auth_token": None,
         "use_web_search": False,
         "web_search_tool_entry": None,
         "web_search_url": None,

--- a/tests/unit/test_sandbox_backend.py
+++ b/tests/unit/test_sandbox_backend.py
@@ -203,3 +203,51 @@ async def test_purpose_hint_is_emitted() -> None:
     hints = backend.purpose_hints()
     assert len(hints) == 1
     assert hints[0][0] == CODE_EXECUTION_TOOL_NAME
+
+
+@pytest.mark.asyncio
+async def test_auth_token_forwarded_as_bearer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``auth_token`` is set, every sandbox call carries Authorization: Bearer.
+
+    This lets the platform-hosted /v1/sandbox proxy authenticate the caller's
+    workspace token and derive tenancy + per-workspace code-exec policy from it.
+    """
+    result_block = {"type": "code_execution_tool_result", "content": {"stdout": "ok"}}
+    transport = _patched_async_client(
+        {
+            ("POST", "/sessions"): httpx.Response(200, json={"session_id": "sbx_abc"}),
+            ("POST", "/sessions/sbx_abc/exec"): httpx.Response(200, json={"result_block": result_block}),
+            ("DELETE", "/sessions/sbx_abc"): httpx.Response(204),
+        },
+        monkeypatch,
+    )
+
+    async with SandboxBackend(
+        sandbox_url="http://sandbox:8080",
+        auth_token="tk_workspace_token",  # noqa: S106 — test fixture, not a real secret
+    ) as backend:
+        await backend.call_tool(CODE_EXECUTION_TOOL_NAME, {"code": "print(1)"})
+
+    # Every request to the backend (create / exec / delete) carries the header.
+    assert transport.captured, "expected at least one request"
+    for request in transport.captured:
+        assert request.headers["Authorization"] == "Bearer tk_workspace_token"
+
+
+@pytest.mark.asyncio
+async def test_no_auth_header_when_auth_token_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A standalone exec-service backend (no auth_token) sends no Authorization header."""
+    transport = _patched_async_client(
+        {
+            ("POST", "/sessions"): httpx.Response(200, json={"session_id": "sbx_abc"}),
+            ("DELETE", "/sessions/sbx_abc"): httpx.Response(204),
+        },
+        monkeypatch,
+    )
+
+    async with SandboxBackend(sandbox_url="http://sandbox:8080"):
+        pass
+
+    assert transport.captured, "expected at least one request"
+    for request in transport.captured:
+        assert "Authorization" not in request.headers


### PR DESCRIPTION
## Description
In platform mode the gateway runs `otari_code_execution` server-side and calls the sandbox backend at `GATEWAY_SANDBOX_URL`. When that URL is the platform-hosted **otari-ai `/v1/sandbox` proxy** (the tenancy + per-workspace code-exec policy boundary), the proxy authenticates the caller's **workspace token** — but `SandboxBackend` sent **no auth header**, so every call returned **401**, surfaced to the model as `error=unknown` / a 502. (It worked against a standalone exec-service, e.g. the kind e2e, which points the URL straight at `exec-service` and needs no auth — which is why the gap went unnoticed.)

This is the sandbox analogue of the web-search `X-Gateway-Token` forwarding: the sandbox path simply never had auth plumbed (`ToolContext` carried `web_search_auth_token` but no sandbox token).

Fix:
- `SandboxBackend` accepts an optional `auth_token` and forwards it as `Authorization: Bearer` on every backend call (create / exec / delete).
- `prepare_gateway_tools` sets `sandbox_auth_token = ctx.user_token` in platform mode, **gated on the backend URL targeting the platform** (reuses the same origin check that gates the web-search token), so the caller's token is never leaked to a standalone exec-service an operator pointed the URL at.
- Threaded through `ToolContext` to all three `SandboxBackend` construction sites.

No change needed on the otari-ai side — the proxy was already correct; the gateway just wasn't authenticating.

## PR Type
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
N/A (no tracking issue; gap found while wiring the otari-ai `/v1/sandbox` proxy into the gateway loop).

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). — `make lint` + `make typecheck` pass repo-wide; full `tests/unit` suite passes; the container-backed `tests/integration` suite was deferred to CI.
- [x] Documentation was updated where necessary. — none required (internal auth header; no behavior change for standalone backends).
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). — N/A, the HTTP contract is unchanged (no new endpoint/schema; only an outbound auth header).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**
Claude (Opus 4.8) via Claude Code.

**Any additional AI details you'd like to share:**
Claude Code diagnosed the 401 (traced the masked `error=unknown` to the gateway sending no auth to the sandbox proxy), implemented the fix mirroring the existing web-search `X-Gateway-Token` pattern, added the unit tests, and verified it end-to-end: built this branch into a local image and ran a model-driven `otari_code_execution` loop through the otari-ai `/v1/sandbox` proxy to otari-exec on EKS (proxy returned `200` on sessions/exec/delete; code ran on the arm64 sandbox → `arch= aarch64`, `factorial12= 479001600`). Reviewer questions will be answered by a human.

- [x] I am an AI Agent filling out this form (check box if true)
