### PR TITLE
feat(sandbox): consume the platform code-execution resolve (apply purpose hint + max iterations)

### DIFF
--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -62,6 +62,7 @@ from gateway.api.routes._platform import (
     _classify_upstream_error,
     _extract_platform_user_token,
     _report_platform_usage,
+    _resolve_platform_code_execution,
     _resolve_platform_credentials,
     _resolve_platform_mcp_servers,
     _resolve_platform_web_search,
@@ -148,6 +149,7 @@ WEB_SEARCH_CONFLICT_DETAIL = (
     "otari_web_search cannot be combined with otari_code_execution or mcp_servers in the same request yet; pick one."
 )
 WEB_SEARCH_NOT_ENABLED_DETAIL = "web search is not enabled for this workspace"
+SANDBOX_NOT_ENABLED_DETAIL = "code execution is not enabled for this workspace"
 SANDBOX_UNREACHABLE_DETAIL = "code_execution sandbox unreachable — check OTARI_SANDBOX_URL"
 WEB_SEARCH_UNREACHABLE_DETAIL = "web_search backend unreachable — check OTARI_WEB_SEARCH_URL"
 
@@ -725,10 +727,27 @@ async def prepare_gateway_tools(
         # token and derives tenancy + per-workspace code-exec policy from it. Never
         # leak it to a standalone exec-service an operator pointed the URL at.
         sandbox_auth_token: str | None = None
-        if use_sandbox and ctx.hybrid_mode and sandbox_url is not None:
+        sandbox_max_iterations: int | None = None
+        if use_sandbox and ctx.hybrid_mode:
             assert ctx.user_token is not None  # guaranteed by the hybrid-mode preamble
-            if web_search_url_targets_platform(sandbox_url, ctx.config.platform.get("base_url")):
+            assert sandbox_tool_entry is not None  # use_sandbox implies the entry is present
+            if sandbox_url is not None and web_search_url_targets_platform(
+                sandbox_url, ctx.config.platform.get("base_url")
+            ):
                 sandbox_auth_token = ctx.user_token
+
+            # Platform owns the per-workspace code-exec policy: 403 if the workspace
+            # has it off, otherwise apply the workspace defaults (per-request values
+            # win) — the default purpose hint and the loop-iteration ceiling. The
+            # tools allow-list + exec timeout are re-enforced by the /v1/sandbox proxy.
+            policy = await _resolve_platform_code_execution(config=ctx.config, user_token=ctx.user_token)
+            if not policy.get("enabled"):
+                raise adapter.error(403, SANDBOX_NOT_ENABLED_DETAIL, ErrorKind.PERMISSION)
+            if not sandbox_tool_entry.get("purpose_hint") and policy.get("default_purpose_hint"):
+                sandbox_tool_entry["purpose_hint"] = policy["default_purpose_hint"]
+            resolved_iters = policy.get("max_iterations")
+            if isinstance(resolved_iters, int) and resolved_iters > 0:
+                sandbox_max_iterations = resolved_iters
 
         web_search_tool_entry, remaining_user_tools = _extract_web_search_tool(tools_after_sandbox)
         web_search_url: str | None = otari_env("WEB_SEARCH_URL") or None
@@ -803,6 +822,8 @@ async def prepare_gateway_tools(
         max_tool_iterations=min(
             max_tool_iterations or DEFAULT_MAX_TOOL_ITERATIONS,
             MAX_TOOL_ITERATIONS_CAP,
+            # The workspace's code-exec max_iterations bounds the loop too (no-op when unset).
+            sandbox_max_iterations or MAX_TOOL_ITERATIONS_CAP,
         ),
         tools_header=tools_header,
     )

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -150,6 +150,7 @@ WEB_SEARCH_CONFLICT_DETAIL = (
 )
 WEB_SEARCH_NOT_ENABLED_DETAIL = "web search is not enabled for this workspace"
 SANDBOX_NOT_ENABLED_DETAIL = "code execution is not enabled for this workspace"
+MALFORMED_CODE_EXEC_POLICY_DETAIL = "Authorization service returned a malformed code-execution policy"
 SANDBOX_UNREACHABLE_DETAIL = "code_execution sandbox unreachable — check OTARI_SANDBOX_URL"
 WEB_SEARCH_UNREACHABLE_DETAIL = "web_search backend unreachable — check OTARI_WEB_SEARCH_URL"
 
@@ -235,23 +236,23 @@ def _normalized_origin(parsed: ParseResult) -> tuple[str, str | None, int | None
     return (parsed.scheme, parsed.hostname, port)
 
 
-def web_search_url_targets_platform(web_search_url: str, platform_base_url: str | None) -> bool:
-    """True when ``web_search_url`` is the platform itself (same origin, under its base path).
+def url_targets_platform(url: str, platform_base_url: str | None) -> bool:
+    """True when ``url`` is the platform itself (same origin, under its base path).
 
-    Gates forwarding the platform token to the web-search backend: it is only
-    safe to hand that high-privilege credential to the platform — the host the
-    gateway already trusts it with for resolve. A raw string prefix check is not
-    enough: with a path-less ``PLATFORM_BASE_URL`` (e.g. ``https://api.otari.ai``)
-    a confusable URL like ``https://api.otari.ai.evil.com`` or
-    ``https://api.otari.ai@evil.com`` would satisfy ``startswith`` and leak the
-    token. So compare the parsed (scheme, host, port) origin exactly — with
-    default ports normalized — and require the search path to sit under the base
-    path at a ``/`` boundary.
+    Gates forwarding the platform token to a gateway-managed backend (web search,
+    sandbox): it is only safe to hand that high-privilege credential to the
+    platform — the host the gateway already trusts it with for resolve. A raw
+    string prefix check is not enough: with a path-less ``PLATFORM_BASE_URL``
+    (e.g. ``https://api.otari.ai``) a confusable URL like
+    ``https://api.otari.ai.evil.com`` or ``https://api.otari.ai@evil.com`` would
+    satisfy ``startswith`` and leak the token. So compare the parsed
+    (scheme, host, port) origin exactly — with default ports normalized — and
+    require the target path to sit under the base path at a ``/`` boundary.
     """
     if not platform_base_url:
         return False
     base = urlparse(platform_base_url)
-    target = urlparse(web_search_url)
+    target = urlparse(url)
     if _normalized_origin(target) != _normalized_origin(base):
         return False
     base_path = base.path.rstrip("/")
@@ -731,9 +732,7 @@ async def prepare_gateway_tools(
         if use_sandbox and ctx.hybrid_mode:
             assert ctx.user_token is not None  # guaranteed by the hybrid-mode preamble
             assert sandbox_tool_entry is not None  # use_sandbox implies the entry is present
-            if sandbox_url is not None and web_search_url_targets_platform(
-                sandbox_url, ctx.config.platform.get("base_url")
-            ):
+            if sandbox_url is not None and url_targets_platform(sandbox_url, ctx.config.platform.get("base_url")):
                 sandbox_auth_token = ctx.user_token
 
             # Platform owns the per-workspace code-exec policy: 403 if the workspace
@@ -741,12 +740,18 @@ async def prepare_gateway_tools(
             # win) — the default purpose hint and the loop-iteration ceiling. The
             # tools allow-list + exec timeout are re-enforced by the /v1/sandbox proxy.
             policy = await _resolve_platform_code_execution(config=ctx.config, user_token=ctx.user_token)
-            if not policy.get("enabled"):
+            # Fail closed on a malformed policy: a non-bool `enabled` is a cross-service
+            # contract break, not a "disabled" signal — surface it as 502, never run.
+            enabled = policy.get("enabled")
+            if not isinstance(enabled, bool):
+                raise adapter.error(502, MALFORMED_CODE_EXEC_POLICY_DETAIL, ErrorKind.API)
+            if not enabled:
                 raise adapter.error(403, SANDBOX_NOT_ENABLED_DETAIL, ErrorKind.PERMISSION)
             if not sandbox_tool_entry.get("purpose_hint") and policy.get("default_purpose_hint"):
                 sandbox_tool_entry["purpose_hint"] = policy["default_purpose_hint"]
             resolved_iters = policy.get("max_iterations")
-            if isinstance(resolved_iters, int) and resolved_iters > 0:
+            # `bool` is an `int` subclass — exclude it so a JSON `true` isn't read as 1.
+            if isinstance(resolved_iters, int) and not isinstance(resolved_iters, bool) and resolved_iters > 0:
                 sandbox_max_iterations = resolved_iters
 
         web_search_tool_entry, remaining_user_tools = _extract_web_search_tool(tools_after_sandbox)
@@ -784,7 +789,7 @@ async def prepare_gateway_tools(
                 # already trusts this token with for resolve). Never leak this
                 # high-privilege credential to a bundled SearXNG or a third-party
                 # adapter that an operator happened to point GATEWAY_WEB_SEARCH_URL at.
-                if web_search_url_targets_platform(web_search_url, ctx.config.platform.get("base_url")):
+                if url_targets_platform(web_search_url, ctx.config.platform.get("base_url")):
                     web_search_auth_token = ctx.config.platform_token
                 web_search_policy = await _resolve_platform_web_search(
                     config=ctx.config,

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -603,6 +603,65 @@ async def _resolve_platform_web_search(
     )
 
 
+async def _resolve_platform_code_execution(
+    config: GatewayConfig,
+    user_token: str,
+) -> dict[str, Any]:
+    """Resolve the workspace's code-execution policy via the platform.
+
+    Mirrors `_resolve_platform_web_search`: same base_url guard, timeout, headers,
+    `_post_platform` call, and status-code handling. POSTs an empty body to
+    `/gateway/code-execution/resolve` and returns the parsed JSON dict on 200
+    (``{enabled, tools, default_purpose_hint, max_iterations, exec_timeout_s}``,
+    soft limits already clamped to operator ceilings platform-side). Client errors
+    forward verbatim; server-side/unexpected responses collapse to 502.
+    """
+    platform_base_url = config.platform.get("base_url")
+    if not platform_base_url:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Platform mode is misconfigured",
+        )
+
+    timeout_ms = int(config.platform.get("resolve_timeout_ms", 5000))
+    resolve_url = _platform_url(platform_base_url, "/gateway/code-execution/resolve")
+    headers = {
+        "X-Gateway-Token": config.platform_token or "",
+        "X-User-Token": user_token,
+    }
+    body: dict[str, Any] = {}
+
+    try:
+        response = await _post_platform(url=resolve_url, headers=headers, body=body, timeout_seconds=timeout_ms / 1000)
+    except (httpx.TimeoutException, httpx.NetworkError):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authorization service unavailable",
+        ) from None
+
+    if response.status_code == 200:
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
+    if response.status_code in {401, 402, 403, 404, 429}:
+        detail = _safe_detail_from_platform(response, "Code execution resolution failed")
+        response_headers: dict[str, str] | None = None
+        if response.status_code == 429 and response.headers.get("Retry-After"):
+            response_headers = {"Retry-After": response.headers["Retry-After"]}
+        raise HTTPException(status_code=response.status_code, detail=detail, headers=response_headers)
+
+    if response.status_code == 422 or response.status_code >= 500:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authorization service unavailable",
+        )
+
+    raise HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail="Authorization service unavailable",
+    )
+
+
 async def _report_platform_usage(
     config: GatewayConfig,
     correlation_id: str,

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -1500,3 +1500,45 @@ def test_platform_mode_sandbox_per_request_hint_wins(
 
     assert response.status_code == 200
     assert _FakeSandboxBackend.last_purpose_hint == "request hint"
+
+
+def test_platform_mode_sandbox_applies_workspace_max_iterations_cap(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The workspace's resolved code-exec max_iterations caps the tool loop.
+    The request omits max_tool_iterations, so the workspace cap (2) binds over
+    the default (10) and reaches the loop unchanged."""
+    monkeypatch.setenv("OTARI_SANDBOX_URL", "http://sandbox:8080")
+
+    captured: dict[str, int] = {}
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _single_attempt_resolve_response(request_id="sbx-max-iters")
+        if url.endswith("/gateway/code-execution/resolve"):
+            return httpx.Response(200, json={"enabled": True, "max_iterations": 2})
+        return httpx.Response(204)
+
+    async def fake_mcp_tool_loop(**kwargs: Any) -> ChatCompletion:
+        captured["max_iterations"] = kwargs["max_iterations"]
+        return _sandbox_loop_completion()
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes._pipeline.SandboxBackend", _FakeSandboxBackend)
+    monkeypatch.setattr("gateway.api.routes.chat.mcp_tool_loop", fake_mcp_tool_loop)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "otari_code_execution"}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+    assert captured["max_iterations"] == 2

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -1348,3 +1348,155 @@ def test_hybrid_mode_streaming_multi_attempt_classifies_non_retryable_invalid_re
     }
     # Non-retryable: the fallback must short-circuit after the first attempt.
     assert len(calls) == 1
+
+
+class _FakeSandboxBackend:
+    """Minimal SandboxBackend duck-type that records the purpose_hint it was built
+    with and resolves the tool loop in a single round (no real sandbox call)."""
+
+    last_purpose_hint: str | None = None
+
+    def __init__(self, *, sandbox_url: str, purpose_hint: str | None = None, auth_token: str | None = None) -> None:
+        type(self).last_purpose_hint = purpose_hint
+
+    async def __aenter__(self) -> "_FakeSandboxBackend":
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    @property
+    def openai_tools(self) -> list[dict[str, Any]]:
+        return [{"type": "function", "function": {"name": "code_execution", "description": "", "parameters": {}}}]
+
+    def owns_tool(self, name: str) -> bool:
+        return name == "code_execution"
+
+    def purpose_hints(self) -> list[tuple[str, str]]:
+        return []
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+        return "ok"
+
+
+def _sandbox_loop_completion() -> ChatCompletion:
+    return ChatCompletion(
+        id="cmpl-sbx",
+        object="chat.completion",
+        created=0,
+        model="openai:gpt-4o-mini",
+        choices=[
+            Choice(finish_reason="stop", index=0, message=ChatCompletionMessage(role="assistant", content="done"))
+        ],
+        usage=CompletionUsage(prompt_tokens=3, completion_tokens=2, total_tokens=5),
+    )
+
+
+def test_platform_mode_sandbox_403_when_disabled(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An otari_code_execution request whose workspace has code execution disabled
+    is rejected with 403 before any provider call."""
+    monkeypatch.setenv("OTARI_SANDBOX_URL", "http://sandbox:8080")
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _single_attempt_resolve_response(request_id="sbx-disabled")
+        if url.endswith("/gateway/code-execution/resolve"):
+            return httpx.Response(200, json={"enabled": False})
+        return httpx.Response(204)
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "otari_code_execution"}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "code execution is not enabled for this workspace"}
+
+
+def test_platform_mode_sandbox_applies_workspace_default_purpose_hint(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When enabled and the request omits a purpose_hint, the workspace
+    default_purpose_hint is applied to the sandbox tool surface."""
+    monkeypatch.setenv("OTARI_SANDBOX_URL", "http://sandbox:8080")
+    _FakeSandboxBackend.last_purpose_hint = None
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _single_attempt_resolve_response(request_id="sbx-default-hint")
+        if url.endswith("/gateway/code-execution/resolve"):
+            return httpx.Response(200, json={"enabled": True, "default_purpose_hint": "workspace hint"})
+        return httpx.Response(204)
+
+    async def fake_loop_acompletion(**kwargs: Any) -> ChatCompletion:
+        return _sandbox_loop_completion()
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes._pipeline.SandboxBackend", _FakeSandboxBackend)
+    monkeypatch.setattr("gateway.services.mcp_loop.acompletion", fake_loop_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "otari_code_execution"}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+    assert _FakeSandboxBackend.last_purpose_hint == "workspace hint"
+
+
+def test_platform_mode_sandbox_per_request_hint_wins(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A per-request purpose_hint overrides the workspace default."""
+    monkeypatch.setenv("OTARI_SANDBOX_URL", "http://sandbox:8080")
+    _FakeSandboxBackend.last_purpose_hint = None
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _single_attempt_resolve_response(request_id="sbx-req-hint")
+        if url.endswith("/gateway/code-execution/resolve"):
+            return httpx.Response(200, json={"enabled": True, "default_purpose_hint": "workspace hint"})
+        return httpx.Response(204)
+
+    async def fake_loop_acompletion(**kwargs: Any) -> ChatCompletion:
+        return _sandbox_loop_completion()
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes._pipeline.SandboxBackend", _FakeSandboxBackend)
+    monkeypatch.setattr("gateway.services.mcp_loop.acompletion", fake_loop_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "otari_code_execution", "purpose_hint": "request hint"}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+    assert _FakeSandboxBackend.last_purpose_hint == "request hint"

--- a/tests/unit/test_code_execution_resolve.py
+++ b/tests/unit/test_code_execution_resolve.py
@@ -1,0 +1,137 @@
+"""Unit tests for resolving the workspace code-execution policy via the platform."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from gateway.api.routes import _platform as platform_module
+from gateway.api.routes._platform import _resolve_platform_code_execution
+
+
+def _config(*, base_url: str | None = "https://platform.local") -> Any:
+    cfg = MagicMock()
+    cfg.platform = {"base_url": base_url, "resolve_timeout_ms": 5000} if base_url else {}
+    cfg.platform_token = "gw_test_token"
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_policy_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_post(
+        *, url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["body"] = body
+        return httpx.Response(
+            200,
+            json={
+                "enabled": True,
+                "tools": ["code_execution"],
+                "default_purpose_hint": "prefer running code",
+                "max_iterations": 5,
+                "exec_timeout_s": 30,
+            },
+        )
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    out = await _resolve_platform_code_execution(_config(), "tk_user")
+
+    assert out["enabled"] is True
+    assert out["tools"] == ["code_execution"]
+    assert out["default_purpose_hint"] == "prefer running code"
+    assert out["max_iterations"] == 5
+
+    assert captured["url"].endswith("/gateway/code-execution/resolve")
+    assert captured["headers"]["X-Gateway-Token"] == "gw_test_token"
+    assert captured["headers"]["X-User-Token"] == "tk_user"
+    assert captured["body"] == {}
+
+
+@pytest.mark.asyncio
+async def test_resolve_403_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return httpx.Response(403, json={"detail": "code execution disabled"})
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_code_execution(_config(), "tk")
+    assert ei.value.status_code == 403
+    assert ei.value.detail == "code execution disabled"
+
+
+@pytest.mark.asyncio
+async def test_resolve_429_passthrough_with_retry_after(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return httpx.Response(429, json={"detail": "slow down"}, headers={"Retry-After": "30"})
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_code_execution(_config(), "tk")
+    assert ei.value.status_code == 429
+    assert ei.value.headers == {"Retry-After": "30"}
+    assert ei.value.detail == "slow down"
+
+
+@pytest.mark.asyncio
+async def test_resolve_5xx_maps_to_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return httpx.Response(503, text="busy")
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_code_execution(_config(), "tk")
+    assert ei.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_resolve_422_collapses_to_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return httpx.Response(422, json={"detail": "schema mismatch"})
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_code_execution(_config(), "tk")
+    assert ei.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_resolve_network_error_maps_to_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        raise httpx.NetworkError("connection refused")
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_code_execution(_config(), "tk")
+    assert ei.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_resolve_misconfigured_platform_500() -> None:
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_code_execution(_config(base_url=None), "tk")
+    assert ei.value.status_code == 500

--- a/tests/unit/test_web_search_url_scoping.py
+++ b/tests/unit/test_web_search_url_scoping.py
@@ -1,4 +1,4 @@
-"""Unit tests for `web_search_url_targets_platform`.
+"""Unit tests for `url_targets_platform`.
 
 Guards the decision to forward the platform token to the web-search backend:
 the token may only go to the platform itself, never to a confusable foreign
@@ -7,7 +7,7 @@ host. See the [major] review note on raw-prefix matching.
 
 import pytest
 
-from gateway.api.routes._pipeline import web_search_url_targets_platform
+from gateway.api.routes._pipeline import url_targets_platform
 
 
 @pytest.mark.parametrize(
@@ -27,7 +27,7 @@ from gateway.api.routes._pipeline import web_search_url_targets_platform
     ],
 )
 def test_accepts_platform_targets(web_search_url: str, platform_base: str) -> None:
-    assert web_search_url_targets_platform(web_search_url, platform_base) is True
+    assert url_targets_platform(web_search_url, platform_base) is True
 
 
 @pytest.mark.parametrize(
@@ -51,4 +51,4 @@ def test_accepts_platform_targets(web_search_url: str, platform_base: str) -> No
     ],
 )
 def test_rejects_non_platform_targets(web_search_url: str, platform_base: str | None) -> None:
-    assert web_search_url_targets_platform(web_search_url, platform_base) is False
+    assert url_targets_platform(web_search_url, platform_base) is False


### PR DESCRIPTION
## Description
<!-- What does this PR do and why? -->
Consumer half of the per-workspace **code-execution resolve** channel (the otari-ai side is mozilla-ai/otari-ai#991).

When a request opts into `otari_code_execution` in **platform mode**, `prepare_gateway_tools` now resolves the workspace's code-exec policy from the platform (`POST /gateway/code-execution/resolve`, mirroring the web-search resolve):
- **403** if the workspace has code execution disabled (gateway-side gate, before calling the model);
- applies the workspace **`default_purpose_hint`** to the `otari_code_execution` tool surface (a per-request `purpose_hint` still wins);
- bounds the tool loop by the workspace **`max_iterations`** (folded into the existing iteration cap).

This is what makes `default_purpose_hint`/`max_iterations` actually reach the model — previously they were configurable but never delivered. The platform clamps the soft limits to operator ceilings at resolve time, and the `/v1/sandbox` proxy still re-enforces `enabled` + the `tools` allow-list + the exec timeout.

Adds `_resolve_platform_code_execution` (mirrors `_resolve_platform_web_search`: same base-url guard, timeout, headers, status-code handling).

## PR Type
- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
Pairs with mozilla-ai/otari-ai#991 (the resolve endpoint + per-workspace config).

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit/test_code_execution_resolve.py`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). — `make lint` + `make typecheck` pass; full `tests/unit` passes (441); container-backed integration deferred to CI.
- [x] Documentation was updated where necessary. — none required (internal platform-resolve call; no user-facing behavior beyond the policy now applying).
- [x] If the API contract changed, I regenerated the OpenAPI spec. — N/A, the gateway's own API contract is unchanged (this consumes a platform endpoint; it adds none).

## AI Usage
- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**
Claude (Opus 4.8) via Claude Code.

**Any additional AI details you'd like to share:**
Implemented by mirroring the existing web-search resolve consumer, with unit tests mirroring `test_web_search_resolve`. Verified `make lint`/`make typecheck` and the full unit suite locally. Reviewer questions will be answered by a human.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
The gateway now consults the platform for each workspace’s sandbox code-execution policy before running any sandbox tools. It blocks requests when code execution is disabled, applies the workspace’s default “purpose hint” (unless the request provides one), and uses the workspace’s configured iteration limit to cap tool-loop runs. URL-safety checks were also consolidated and reused for both sandbox and web-search flows.

## What changed
- Added a platform “resolve” step for sandbox code execution to fetch the workspace policy before invocation.
- Enforced workspace-level access:
  - Returns **403** when code execution is disabled for the workspace.
- Aligned sandbox execution configuration to platform workspace policy:
  - Uses workspace `default_purpose_hint` when the request omits `purpose_hint`.
  - Preserves request-level `purpose_hint` as an override.
  - Applies workspace `max_iterations` to the sandbox tool-loop iteration cap.
- Consolidated URL-safety logic by replacing the previous web-search-specific helper with a shared platform-target helper used by both flows.
- Added/updated tests:
  - Unit tests for the platform resolve behavior and error/status mapping.
  - Integration tests covering 403 blocking, hint precedence, and iteration capping.

## Benefits
- Prevents unauthorized code execution by fail-fast enforcement at the gateway.
- Ensures sandbox tool behavior matches the platform’s workspace configuration.
- Improves reliability and maintainability with shared URL-safety logic and expanded test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->