### PR TITLE
fix(fallback): bound the inline usage-report flush on the all-failed path

### DIFF
--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -1223,6 +1223,56 @@ async def run_single_attempt_stream(
     )
 
 
+async def _flush_pending_usage_reports(
+    config: GatewayConfig,
+    pending_error_reports: list[tuple[str, str, Any, str | None]],
+    request_id: str,
+) -> None:
+    """Send the per-attempt error reports inline on the all-failed path.
+
+    FastAPI BackgroundTasks are dropped when the request ends in an error
+    response, so on a fully-exhausted fallback chain these reports must be
+    flushed before the terminal 502/504 (the queued background copies never
+    run, so there is no double-report).
+
+    The flush is bounded: this is best-effort telemetry and must not materially
+    delay the already-failing response. Reports run concurrently, and the whole
+    batch is capped at ``usage_timeout_ms`` so a degraded usage endpoint is cut
+    off rather than stacking each report's full retry/backoff budget onto the
+    response. Callers on the streaming path skip this entirely on cancellation.
+    """
+    if not pending_error_reports:
+        return
+
+    timeout_s = int(config.platform.get("usage_timeout_ms", 5000)) / 1000
+    try:
+        results = await asyncio.wait_for(
+            asyncio.gather(
+                *(
+                    _report_platform_usage(config, attempt_id, outcome, usage, error_class)
+                    for attempt_id, outcome, usage, error_class in pending_error_reports
+                ),
+                return_exceptions=True,
+            ),
+            timeout=timeout_s,
+        )
+    except (asyncio.TimeoutError, TimeoutError):
+        logger.warning(
+            "Inline usage-report flush timed out after %.1fs on the all-failed path request_id=%s",
+            timeout_s,
+            request_id,
+        )
+        return
+
+    for result in results:
+        if isinstance(result, BaseException):
+            logger.warning(
+                "Inline usage report failed on the all-failed path request_id=%s: %s",
+                request_id,
+                result,
+            )
+
+
 async def run_streaming_with_fallback(
     *,
     adapter: FormatAdapter[Any, ChunkT],
@@ -1337,21 +1387,8 @@ async def run_streaming_with_fallback(
         # teardown), and always close the tool backend before propagating, even
         # if the flush raises or is interrupted.
         try:
-            if pending_error_reports and not isinstance(exc, asyncio.CancelledError):
-                results = await asyncio.gather(
-                    *(
-                        _report_platform_usage(config, attempt_id, outcome, usage, error_class)
-                        for attempt_id, outcome, usage, error_class in pending_error_reports
-                    ),
-                    return_exceptions=True,
-                )
-                for result in results:
-                    if isinstance(result, BaseException):
-                        logger.warning(
-                            "Inline usage report failed on all-failed streaming path request_id=%s: %s",
-                            route.request_id,
-                            result,
-                        )
+            if not isinstance(exc, asyncio.CancelledError):
+                await _flush_pending_usage_reports(config, pending_error_reports, route.request_id)
         finally:
             await backend_stack.aclose()
         raise
@@ -1479,21 +1516,7 @@ async def run_platform_non_stream(
         # branch only catches HTTPException (what the runner raises on the
         # all-failed path); a CancelledError propagates without doing reporting
         # I/O during teardown.
-        if pending_error_reports:
-            results = await asyncio.gather(
-                *(
-                    _report_platform_usage(config, attempt_id, outcome, usage, error_class)
-                    for attempt_id, outcome, usage, error_class in pending_error_reports
-                ),
-                return_exceptions=True,
-            )
-            for result in results:
-                if isinstance(result, BaseException):
-                    logger.warning(
-                        "Inline usage report failed on all-failed path request_id=%s: %s",
-                        route.request_id,
-                        result,
-                    )
+        await _flush_pending_usage_reports(config, pending_error_reports, route.request_id)
         raise
 
 

--- a/tests/integration/test_platform_mode_messages.py
+++ b/tests/integration/test_platform_mode_messages.py
@@ -305,63 +305,15 @@ def test_platform_mode_falls_through_on_404_model_unavailable(
     assert len(calls) == 2, "404 on the primary must fall through to the next attempt"
 
 
-def test_platform_mode_returns_502_when_all_attempts_fail(
+def test_platform_mode_returns_502_and_reports_every_attempt_when_all_fail(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """All attempts failing with retryable errors → 502 with the all-failed
-    detail wording.
-    """
-
-    async def fake_post_platform(
-        url: str,
-        headers: dict[str, str],
-        body: dict[str, Any],
-        timeout_seconds: float,
-    ) -> httpx.Response:
-        if url.endswith("/gateway/provider-keys/resolve"):
-            return httpx.Response(
-                200,
-                json=_resolve_payload([
-                    _attempt(0, "att-1", "claude-3-5-sonnet-20241022", "sk-1"),
-                    _attempt(1, "att-2", "claude-3-5-sonnet-20241022", "sk-2"),
-                ]),
-            )
-        return httpx.Response(204)
-
-    async def fake_amessages(**kwargs: Any) -> MessageResponse:
-        raise httpx.HTTPStatusError(
-            "500",
-            request=httpx.Request("POST", "http://upstream"),
-            response=httpx.Response(500, request=httpx.Request("POST", "http://upstream")),
-        )
-
-    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
-    monkeypatch.setattr("gateway.api.routes.messages.amessages", fake_amessages)
-
-    response = platform_client.post(
-        "/v1/messages",
-        json={
-            "model": "claude-3-5-sonnet-20241022",
-            "messages": [{"role": "user", "content": "hi"}],
-            "max_tokens": 100,
-        },
-        headers={"Authorization": "Bearer user_test_token"},
-    )
-
-    assert response.status_code == 502
-    assert response.json() == {"detail": "All upstream providers failed"}
-
-
-def test_platform_mode_reports_every_attempt_when_all_fail(
-    platform_client: TestClient,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """When every attempt fails, each attempt's error outcome is still reported
-    back to the platform. The terminal 502 response drops the queued
-    BackgroundTasks, so the reports must be sent inline; otherwise total
-    outages leave no per-attempt record and the platform can't account for a
-    fully-exhausted fallback chain.
+    detail wording, and each attempt's error outcome is still reported back to
+    the platform. The terminal 502 drops the queued BackgroundTasks, so the
+    reports must be sent inline; otherwise a total outage leaves no per-attempt
+    record and the platform can't account for a fully-exhausted fallback chain.
     """
     usage_reports: list[dict[str, Any]] = []
 
@@ -403,6 +355,7 @@ def test_platform_mode_reports_every_attempt_when_all_fail(
     )
 
     assert response.status_code == 502
+    assert response.json() == {"detail": "All upstream providers failed"}
     # Each failed attempt is reported exactly once, despite the terminal 502. A
     # set would mask a double-report (the dropped-then-also-flushed bug), so pin
     # the exact count and contents: the inline flush and the dropped background

--- a/tests/unit/test_flush_pending_usage_reports.py
+++ b/tests/unit/test_flush_pending_usage_reports.py
@@ -1,0 +1,72 @@
+"""Unit tests for ``_flush_pending_usage_reports`` — the inline, bounded flush
+of per-attempt error reports on the all-failed platform path.
+"""
+
+import asyncio
+from typing import Any
+
+import gateway.api.routes._pipeline as _pipeline
+from gateway.core.config import GatewayConfig
+
+
+def test_flush_delivers_all_reports_when_fast(monkeypatch: Any) -> None:
+    sent: list[tuple[str, str, str | None]] = []
+
+    async def fake_report(config: Any, cid: str, outcome: str, usage: Any, error_class: str | None) -> None:
+        sent.append((cid, outcome, error_class))
+
+    monkeypatch.setattr(_pipeline, "_report_platform_usage", fake_report)
+    config = GatewayConfig(platform={"base_url": "http://platform.test"})
+
+    asyncio.run(
+        _pipeline._flush_pending_usage_reports(
+            config,
+            [("att-1", "error", None, "http_500"), ("att-2", "error", None, "http_429")],
+            "req-1",
+        )
+    )
+
+    assert sorted(sent) == [("att-1", "error", "http_500"), ("att-2", "error", "http_429")]
+
+
+def test_flush_is_bounded_and_does_not_wait_for_a_slow_report(monkeypatch: Any) -> None:
+    """A degraded usage endpoint must not stall the already-failing response.
+
+    The flush is capped at ``usage_timeout_ms``; a report that hangs past that
+    is cut off rather than awaited to completion.
+    """
+    completed: list[str] = []
+
+    async def slow_report(config: Any, cid: str, outcome: str, usage: Any, error_class: str | None) -> None:
+        await asyncio.sleep(10)
+        completed.append(cid)
+
+    monkeypatch.setattr(_pipeline, "_report_platform_usage", slow_report)
+    # 20ms cap so the test returns promptly without a wall-clock assertion.
+    config = GatewayConfig(platform={"base_url": "http://platform.test", "usage_timeout_ms": 20})
+
+    asyncio.run(
+        _pipeline._flush_pending_usage_reports(
+            config,
+            [("att-1", "error", None, "http_500")],
+            "req-1",
+        )
+    )
+
+    # The slow report was cancelled by the bound, never running to completion.
+    assert completed == []
+
+
+def test_flush_is_noop_when_no_pending_reports(monkeypatch: Any) -> None:
+    called = False
+
+    async def fake_report(*args: Any, **kwargs: Any) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(_pipeline, "_report_platform_usage", fake_report)
+    config = GatewayConfig(platform={"base_url": "http://platform.test"})
+
+    asyncio.run(_pipeline._flush_pending_usage_reports(config, [], "req-1"))
+
+    assert called is False

--- a/tests/unit/test_flush_pending_usage_reports.py
+++ b/tests/unit/test_flush_pending_usage_reports.py
@@ -1,15 +1,17 @@
-"""Unit tests for ``_flush_pending_usage_reports`` — the inline, bounded flush
+"""Unit tests for ``_flush_pending_usage_reports``: the inline, bounded flush
 of per-attempt error reports on the all-failed platform path.
 """
 
 import asyncio
 from typing import Any
 
+import pytest
+
 import gateway.api.routes._pipeline as _pipeline
 from gateway.core.config import GatewayConfig
 
 
-def test_flush_delivers_all_reports_when_fast(monkeypatch: Any) -> None:
+def test_flush_delivers_all_reports_when_fast(monkeypatch: pytest.MonkeyPatch) -> None:
     sent: list[tuple[str, str, str | None]] = []
 
     async def fake_report(config: Any, cid: str, outcome: str, usage: Any, error_class: str | None) -> None:
@@ -29,7 +31,7 @@ def test_flush_delivers_all_reports_when_fast(monkeypatch: Any) -> None:
     assert sorted(sent) == [("att-1", "error", "http_500"), ("att-2", "error", "http_429")]
 
 
-def test_flush_is_bounded_and_does_not_wait_for_a_slow_report(monkeypatch: Any) -> None:
+def test_flush_is_bounded_and_does_not_wait_for_a_slow_report(monkeypatch: pytest.MonkeyPatch) -> None:
     """A degraded usage endpoint must not stall the already-failing response.
 
     The flush is capped at ``usage_timeout_ms``; a report that hangs past that
@@ -57,7 +59,7 @@ def test_flush_is_bounded_and_does_not_wait_for_a_slow_report(monkeypatch: Any) 
     assert completed == []
 
 
-def test_flush_is_noop_when_no_pending_reports(monkeypatch: Any) -> None:
+def test_flush_is_noop_when_no_pending_reports(monkeypatch: pytest.MonkeyPatch) -> None:
     called = False
 
     async def fake_report(*args: Any, **kwargs: Any) -> None:


### PR DESCRIPTION
## Description

Follow-up to the platform-mode fallback fixes (#173/#174/#176), addressing the post-merge review on #174.

The review raised one **[major]** and two **[minor]** points:

- **[major] streaming path has the same dropped-report bug** — already fixed and merged in #176 (the reviewer reviewed #174 in isolation, before #176 landed). No further code needed; this PR only touches the shared helper both paths now use.
- **[minor] inline flush can delay the 502/504** — addressed here. The earlier "resolve already proved the platform healthy" rebuttal was weak: resolve runs *before* the upstream attempts that then take seconds to all fail, so the usage endpoint may be degraded by flush time. The flush is now bounded.
- **[minor] duplicated all-failed test** — merged.

### Changes

- **Bound the inline flush.** The per-attempt error-report flush on the all-failed path is now capped at `usage_timeout_ms` via `asyncio.wait_for`. Reports still run concurrently, but a degraded usage endpoint is cut off instead of stacking each report's full retry/backoff budget (~15s worst case) onto the already-failing response. A timeout logs a warning and returns.
- **Deduplicate the flush logic.** The non-streaming and streaming all-failed branches now share one `_flush_pending_usage_reports` helper. The streaming caller still skips it on `CancelledError` and closes the backend stack in a `finally`.
- **Merge the two all-failed messages tests** into one asserting both the 502 wording and exactly-once reporting. The chat streaming pair is intentionally left separate: those raise different exception types (`RuntimeError` vs `httpx.HTTPStatusError`), so they cover distinct paths.
- **Add unit tests** for the bounded flush: delivers when fast, is cut off when a report hangs past the bound, and is a no-op when there's nothing pending.

### Tests
- `tests/unit/test_flush_pending_usage_reports.py` (new).
- Updated `tests/integration/test_platform_mode_messages.py`.

Verified locally: `make lint`, `uv run mypy` (177 files clean), and the full unit + platform-integration suites (507 passed).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
Follow-up to #174 (review), #176.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). (No API contract change.)

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:**
Reviewed and verified by a human before merge.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes Made

### Core Functionality: Unified Usage Report Flushing
Added a new `_flush_pending_usage_reports()` helper function that centralizes the delivery of queued error reports when all fallback attempts fail. This function is now used by both streaming and non-streaming request paths, replacing duplicate inline logic. The flush runs with a configurable timeout (via `usage_timeout_ms`), preventing slow or degraded usage endpoints from excessively delaying error responses that have already failed.

**Benefit:** When a provider is already responding with errors, slow usage report delivery won't stack an additional 15+ seconds of retry/backoff onto an already-failing response. Timeouts are logged as warnings but don't block the error from being returned to the client.

### Test Updates
- **Integration Tests**: Consolidated two nearly-identical test cases into a single comprehensive test that verifies both the error response format and that usage reports are sent exactly once per attempt
- **Unit Tests**: Added three new tests covering the bounded flush behavior:
  - Fast report delivery completes successfully
  - Reports exceeding the timeout boundary are not awaited
  - No work is performed when there are no reports to send

### Code Organization
The streaming and non-streaming fallback paths now share the same flushing logic, reducing duplication and simplifying maintenance. The streaming path's existing behavior—skipping the flush on cancellation and properly closing resources—is preserved.

## Technical Notes
- The `_flush_pending_usage_reports()` helper uses `asyncio.wait_for()` to enforce the timeout boundary while running reports concurrently
- The change follows up on review feedback from prior platform-mode fallback fixes (`#173`, `#174`, `#176`)
- Type checking and test suites confirmed clean (177 files, 507 tests passing)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->