### PR TITLE
feat(usage): forward provider cached-token counts in usage reports

### DIFF
--- a/alembic/versions/d4e6f8a0b2c4_add_usage_logs_cache_tokens.py
+++ b/alembic/versions/d4e6f8a0b2c4_add_usage_logs_cache_tokens.py
@@ -1,0 +1,30 @@
+"""Add usage_logs cache_read_tokens and cache_write_tokens columns.
+
+Revision ID: d4e6f8a0b2c4
+Revises: c3d5e7f9a1b3
+Create Date: 2026-06-23 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d4e6f8a0b2c4"
+down_revision: str | Sequence[str] | None = "c3d5e7f9a1b3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("usage_logs", sa.Column("cache_read_tokens", sa.Integer(), nullable=True))
+    op.add_column("usage_logs", sa.Column("cache_write_tokens", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("usage_logs", "cache_write_tokens")
+    op.drop_column("usage_logs", "cache_read_tokens")

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -259,13 +259,33 @@ Content-Type: application/json
   "usage": {                           // present on success only
     "prompt_tokens": 13,
     "completion_tokens": 7,
-    "total_tokens": 20
+    "total_tokens": 20,
+    "cache_read_tokens": 8,            // provider cache-read input tokens
+    "cache_write_tokens": 0           // cache-write (creation) input tokens; Anthropic only
   },
   "error_class": "http_401"            // optional on error; omitted when the
                                        // Otari can't classify the failure
                                        // (e.g. mid-stream errors). See below.
 }
 ```
+
+`cache_read_tokens` and `cache_write_tokens` are additive fields carrying the
+provider cached-token counts (default `0` when a provider reports none). Their
+inclusion convention differs by provider, so the platform must price them with
+that in mind:
+
+- OpenAI (chat and Responses) and Gemini report cached tokens as a **subset** of
+  `prompt_tokens`. `cache_read_tokens` is informational for re-pricing those
+  tokens at the cached rate; there is no cache-write concept, so
+  `cache_write_tokens` is always `0`.
+- Anthropic reports `prompt_tokens` (mapped from `input_tokens`) **excluding**
+  cache. `cache_read_tokens` and `cache_write_tokens` are reported **separately**
+  and are not part of `prompt_tokens`. `cache_write_tokens` is a true cache
+  creation charge billed at a premium.
+
+The platform must accept these additive keys with lenient parsing; a handler that
+rejects unknown fields would 422 the report (a non-retryable status), silently
+dropping it. See companion issue mozilla-ai/otari-ai#1168.
 
 A multi-attempt request that iterates two attempts produces two usage reports —
 one per attempt — sharing the same `request_id` (recoverable via the original

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -2450,6 +2450,28 @@
             ],
             "title": "Api Key Id"
           },
+          "cache_read_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cache Read Tokens"
+          },
+          "cache_write_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cache Write Tokens"
+          },
           "completion_tokens": {
             "anyOf": [
               {
@@ -2559,6 +2581,8 @@
           "prompt_tokens",
           "completion_tokens",
           "total_tokens",
+          "cache_read_tokens",
+          "cache_write_tokens",
           "cost",
           "status",
           "error_message"

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -74,6 +74,7 @@ from gateway.api.routes._tools import (
 )
 from gateway.core.config import GatewayConfig
 from gateway.core.env import otari_env
+from gateway.core.usage import cache_read_tokens_of, cache_write_tokens_of
 from gateway.log_config import logger
 from gateway.metrics import record_cost, record_tokens
 from gateway.models.entities import UsageLog
@@ -793,6 +794,8 @@ async def log_usage(
         usage_log.prompt_tokens = usage_data.prompt_tokens
         usage_log.completion_tokens = usage_data.completion_tokens
         usage_log.total_tokens = usage_data.total_tokens
+        usage_log.cache_read_tokens = cache_read_tokens_of(usage_data)
+        usage_log.cache_write_tokens = cache_write_tokens_of(usage_data)
 
         record_tokens(
             str(provider or ""),

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -23,6 +23,7 @@ from fastapi import HTTPException, Request, status
 from pydantic import BaseModel
 
 from gateway.core.config import GatewayConfig
+from gateway.core.usage import cache_read_tokens_of, cache_write_tokens_of
 from gateway.log_config import logger
 from gateway.models.mcp import McpServerConfig
 from gateway.services.mcp_loop import MaxToolIterationsExceeded
@@ -613,6 +614,8 @@ async def _report_platform_usage(
             "prompt_tokens": token_usage.prompt_tokens,
             "completion_tokens": token_usage.completion_tokens,
             "total_tokens": token_usage.total_tokens,
+            "cache_read_tokens": cache_read_tokens_of(token_usage),
+            "cache_write_tokens": cache_write_tokens_of(token_usage),
         }
     elif error_class is not None:
         payload["error_class"] = error_class

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -42,6 +42,7 @@ from gateway.api.routes._platform import ResolvedAttempt
 from gateway.api.routes._schema_derive import derive_request_base
 from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
+from gateway.core.usage import GatewayUsage
 from gateway.log_config import logger
 from gateway.models.guardrails import GuardrailConfig
 from gateway.models.mcp import McpServerConfig
@@ -147,14 +148,19 @@ class _ChatAdapter:
     def extract_stream_usage(self, chunk: ChatCompletionChunk) -> CompletionUsage | None:
         if not chunk.usage:
             return None
-        return CompletionUsage(
+        details = chunk.usage.prompt_tokens_details
+        return GatewayUsage(
             prompt_tokens=chunk.usage.prompt_tokens or 0,
             completion_tokens=chunk.usage.completion_tokens or 0,
             total_tokens=chunk.usage.total_tokens or 0,
+            prompt_tokens_details=details,
+            cache_read_tokens=(details.cached_tokens or 0) if details is not None else 0,
         )
 
     def extract_usage(self, result: ChatCompletion) -> CompletionUsage | None:
-        return result.usage
+        if result.usage is None:
+            return None
+        return GatewayUsage.from_completion_usage(result.usage)
 
     async def call_provider(self, kwargs: dict[str, Any]) -> ChatCompletion:
         return await acompletion(**kwargs)  # type: ignore[return-value]

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -49,6 +49,7 @@ from gateway.api.routes._platform import (
 from gateway.api.routes._schema_derive import derive_request_base
 from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
+from gateway.core.usage import GatewayUsage
 from gateway.log_config import logger
 from gateway.models.guardrails import GuardrailConfig
 from gateway.models.mcp import McpServerConfig
@@ -145,18 +146,25 @@ def _messages_stream_usage(event: MessageStreamEvent) -> CompletionUsage | None:
     if isinstance(event, MessageDeltaEvent):
         input_tokens = event.usage.input_tokens or 0
         output_tokens = event.usage.output_tokens or 0
-        return CompletionUsage(
+        return GatewayUsage(
             prompt_tokens=input_tokens,
             completion_tokens=output_tokens,
             total_tokens=input_tokens + output_tokens,
+            cache_read_tokens=event.usage.cache_read_input_tokens or 0,
+            cache_write_tokens=event.usage.cache_creation_input_tokens or 0,
         )
     if isinstance(event, MessageStartEvent):
-        input_tokens = event.message.usage.input_tokens or 0
-        if input_tokens:
-            return CompletionUsage(
+        usage = event.message.usage
+        input_tokens = usage.input_tokens or 0
+        cache_read = usage.cache_read_input_tokens or 0
+        cache_write = usage.cache_creation_input_tokens or 0
+        if input_tokens or cache_read or cache_write:
+            return GatewayUsage(
                 prompt_tokens=input_tokens,
                 completion_tokens=0,
                 total_tokens=input_tokens,
+                cache_read_tokens=cache_read,
+                cache_write_tokens=cache_write,
             )
     return None
 
@@ -192,10 +200,12 @@ class _MessagesAdapter:
     def extract_usage(self, result: MessageResponse) -> CompletionUsage | None:
         if not result.usage:
             return None
-        return CompletionUsage(
+        return GatewayUsage(
             prompt_tokens=result.usage.input_tokens,
             completion_tokens=result.usage.output_tokens,
             total_tokens=result.usage.input_tokens + result.usage.output_tokens,
+            cache_read_tokens=result.usage.cache_read_input_tokens or 0,
+            cache_write_tokens=result.usage.cache_creation_input_tokens or 0,
         )
 
     async def call_provider(self, kwargs: dict[str, Any]) -> MessageResponse:

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -41,6 +41,7 @@ from gateway.api.routes._platform import ResolvedAttempt
 from gateway.api.routes._schema_derive import derive_request_base
 from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
+from gateway.core.usage import GatewayUsage
 from gateway.log_config import logger
 from gateway.models.guardrails import GuardrailConfig
 from gateway.models.mcp import McpServerConfig
@@ -114,10 +115,13 @@ def _usage_to_completion_usage(
 ) -> CompletionUsage | None:
     if usage is None:
         return None
-    return CompletionUsage(
+    details = getattr(usage, "input_tokens_details", None)
+    cache_read_tokens = (getattr(details, "cached_tokens", 0) or 0) if details is not None else 0
+    return GatewayUsage(
         prompt_tokens=getattr(usage, "input_tokens", 0) or 0,
         completion_tokens=getattr(usage, "output_tokens", 0) or 0,
         total_tokens=getattr(usage, "total_tokens", 0) or 0,
+        cache_read_tokens=cache_read_tokens,
     )
 
 

--- a/src/gateway/api/routes/usage.py
+++ b/src/gateway/api/routes/usage.py
@@ -32,6 +32,8 @@ class UsageEntry(BaseModel):
     prompt_tokens: int | None
     completion_tokens: int | None
     total_tokens: int | None
+    cache_read_tokens: int | None
+    cache_write_tokens: int | None
     cost: float | None
     status: str
     error_message: str | None
@@ -49,6 +51,8 @@ class UsageEntry(BaseModel):
             prompt_tokens=log.prompt_tokens,
             completion_tokens=log.completion_tokens,
             total_tokens=log.total_tokens,
+            cache_read_tokens=log.cache_read_tokens,
+            cache_write_tokens=log.cache_write_tokens,
             cost=log.cost,
             status=log.status,
             error_message=log.error_message,

--- a/src/gateway/core/usage.py
+++ b/src/gateway/core/usage.py
@@ -30,16 +30,17 @@ class GatewayUsage(CompletionUsage):
         cls,
         usage: CompletionUsage,
         *,
-        cache_read_tokens: int = 0,
+        cache_read_tokens: int | None = None,
         cache_write_tokens: int = 0,
     ) -> "GatewayUsage":
         """Build a ``GatewayUsage`` from a base ``CompletionUsage`` plus cache counts.
 
-        When ``cache_read_tokens`` is not supplied, it falls back to the OpenAI-style
+        When ``cache_read_tokens`` is left as ``None`` it falls back to the OpenAI-style
         ``prompt_tokens_details.cached_tokens`` already present on ``usage`` (a subset
-        of ``prompt_tokens``), which is purely informational for re-pricing.
+        of ``prompt_tokens``), which is purely informational for re-pricing. An explicit
+        ``0`` is honored and does not trigger the fallback.
         """
-        if not cache_read_tokens and usage.prompt_tokens_details is not None:
+        if cache_read_tokens is None and usage.prompt_tokens_details is not None:
             cache_read_tokens = usage.prompt_tokens_details.cached_tokens or 0
         return cls(
             prompt_tokens=usage.prompt_tokens,
@@ -47,7 +48,7 @@ class GatewayUsage(CompletionUsage):
             total_tokens=usage.total_tokens,
             completion_tokens_details=usage.completion_tokens_details,
             prompt_tokens_details=usage.prompt_tokens_details,
-            cache_read_tokens=cache_read_tokens,
+            cache_read_tokens=cache_read_tokens or 0,
             cache_write_tokens=cache_write_tokens,
         )
 

--- a/src/gateway/core/usage.py
+++ b/src/gateway/core/usage.py
@@ -31,24 +31,28 @@ class GatewayUsage(CompletionUsage):
         usage: CompletionUsage,
         *,
         cache_read_tokens: int | None = None,
-        cache_write_tokens: int = 0,
+        cache_write_tokens: int | None = None,
     ) -> "GatewayUsage":
         """Build a ``GatewayUsage`` from a base ``CompletionUsage`` plus cache counts.
 
-        When ``cache_read_tokens`` is left as ``None`` it falls back to the OpenAI-style
-        ``prompt_tokens_details.cached_tokens`` already present on ``usage`` (a subset
-        of ``prompt_tokens``), which is purely informational for re-pricing. An explicit
-        ``0`` is honored and does not trigger the fallback.
+        When ``cache_read_tokens`` / ``cache_write_tokens`` are left as ``None`` they
+        fall back to whatever ``usage`` already carries: the explicit fields when
+        ``usage`` is itself a :class:`GatewayUsage`, otherwise the OpenAI-style
+        ``prompt_tokens_details.cached_tokens`` (a subset of ``prompt_tokens``, purely
+        informational for re-pricing). An explicit ``0`` is honored and does not
+        trigger the fallback.
         """
-        if cache_read_tokens is None and usage.prompt_tokens_details is not None:
-            cache_read_tokens = usage.prompt_tokens_details.cached_tokens or 0
+        if cache_read_tokens is None:
+            cache_read_tokens = cache_read_tokens_of(usage)
+        if cache_write_tokens is None:
+            cache_write_tokens = cache_write_tokens_of(usage)
         return cls(
             prompt_tokens=usage.prompt_tokens,
             completion_tokens=usage.completion_tokens,
             total_tokens=usage.total_tokens,
             completion_tokens_details=usage.completion_tokens_details,
             prompt_tokens_details=usage.prompt_tokens_details,
-            cache_read_tokens=cache_read_tokens or 0,
+            cache_read_tokens=cache_read_tokens,
             cache_write_tokens=cache_write_tokens,
         )
 

--- a/src/gateway/core/usage.py
+++ b/src/gateway/core/usage.py
@@ -1,0 +1,72 @@
+"""Internal usage carrier that extends the provider usage shape with cache counts.
+
+The provider-neutral usage object that flows through the request pipeline is
+``any_llm``'s :class:`CompletionUsage` (the OpenAI shape). It exposes a single
+``prompt_tokens_details.cached_tokens`` read slot and has no representation for a
+cache *write* (creation) charge, which Anthropic bills separately.
+
+:class:`GatewayUsage` subclasses ``CompletionUsage`` so it remains type-compatible
+with every signature that already accepts a ``CompletionUsage`` while carrying two
+explicit integers: ``cache_read_tokens`` and ``cache_write_tokens``. Capturing these
+as plain integers (rather than relying on ``prompt_tokens_details``) lets the report
+builder forward them uniformly across providers, including Anthropic cache writes.
+"""
+
+from any_llm.types.completion import CompletionUsage
+
+
+class GatewayUsage(CompletionUsage):
+    """Usage with explicit provider cache-token counts.
+
+    ``cache_read_tokens`` and ``cache_write_tokens`` default to ``0`` so the carrier
+    behaves like a plain ``CompletionUsage`` for providers that report no cache usage.
+    """
+
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+
+    @classmethod
+    def from_completion_usage(
+        cls,
+        usage: CompletionUsage,
+        *,
+        cache_read_tokens: int = 0,
+        cache_write_tokens: int = 0,
+    ) -> "GatewayUsage":
+        """Build a ``GatewayUsage`` from a base ``CompletionUsage`` plus cache counts.
+
+        When ``cache_read_tokens`` is not supplied, it falls back to the OpenAI-style
+        ``prompt_tokens_details.cached_tokens`` already present on ``usage`` (a subset
+        of ``prompt_tokens``), which is purely informational for re-pricing.
+        """
+        if not cache_read_tokens and usage.prompt_tokens_details is not None:
+            cache_read_tokens = usage.prompt_tokens_details.cached_tokens or 0
+        return cls(
+            prompt_tokens=usage.prompt_tokens,
+            completion_tokens=usage.completion_tokens,
+            total_tokens=usage.total_tokens,
+            completion_tokens_details=usage.completion_tokens_details,
+            prompt_tokens_details=usage.prompt_tokens_details,
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
+        )
+
+
+def cache_read_tokens_of(usage: CompletionUsage) -> int:
+    """Return the cache-read count carried by ``usage``.
+
+    Handles both :class:`GatewayUsage` (explicit field) and a plain
+    ``CompletionUsage`` (falls back to ``prompt_tokens_details.cached_tokens``).
+    """
+    if isinstance(usage, GatewayUsage):
+        return usage.cache_read_tokens
+    if usage.prompt_tokens_details is not None:
+        return usage.prompt_tokens_details.cached_tokens or 0
+    return 0
+
+
+def cache_write_tokens_of(usage: CompletionUsage) -> int:
+    """Return the cache-write count carried by ``usage`` (0 for non-Anthropic)."""
+    if isinstance(usage, GatewayUsage):
+        return usage.cache_write_tokens
+    return 0

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -184,6 +184,8 @@ class UsageLog(Base):
     prompt_tokens: Mapped[int | None] = mapped_column()
     completion_tokens: Mapped[int | None] = mapped_column()
     total_tokens: Mapped[int | None] = mapped_column()
+    cache_read_tokens: Mapped[int | None] = mapped_column()
+    cache_write_tokens: Mapped[int | None] = mapped_column()
     cost: Mapped[float | None] = mapped_column()
 
     status: Mapped[str] = mapped_column()
@@ -204,6 +206,8 @@ class UsageLog(Base):
             "prompt_tokens": self.prompt_tokens,
             "completion_tokens": self.completion_tokens,
             "total_tokens": self.total_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "cache_write_tokens": self.cache_write_tokens,
             "cost": self.cost,
             "status": self.status,
             "error_message": self.error_message,

--- a/src/gateway/services/mcp_loop.py
+++ b/src/gateway/services/mcp_loop.py
@@ -18,6 +18,7 @@ from collections.abc import AsyncIterator, Callable
 from typing import TYPE_CHECKING, Any, Protocol
 
 from any_llm import acompletion
+from any_llm.types.completion import PromptTokensDetails
 
 from gateway.core.env import otari_env
 from gateway.log_config import logger
@@ -352,3 +353,7 @@ def _fold_usage(
     details = completion.usage.prompt_tokens_details
     if details is not None:
         details.cached_tokens = cache_read_total
+    elif cache_read_total > 0:
+        # The final iteration carried no prompt_tokens_details, but an earlier
+        # one did; create the sub-object so the accumulated count is not lost.
+        completion.usage.prompt_tokens_details = PromptTokensDetails(cached_tokens=cache_read_total)

--- a/src/gateway/services/mcp_loop.py
+++ b/src/gateway/services/mcp_loop.py
@@ -278,6 +278,7 @@ async def mcp_tool_loop(
                 acc_cache_read += details.cached_tokens or 0
 
         if not completion.choices:
+            _fold_usage(completion, acc_prompt, acc_completion, acc_cache_read)
             return completion
 
         choice = completion.choices[0]

--- a/src/gateway/services/mcp_loop.py
+++ b/src/gateway/services/mcp_loop.py
@@ -257,6 +257,7 @@ async def mcp_tool_loop(
 
     acc_prompt = 0
     acc_completion = 0
+    acc_cache_read = 0
     first_response_signaled = False
 
     for _ in range(max_iterations):
@@ -272,13 +273,16 @@ async def mcp_tool_loop(
         if completion.usage:
             acc_prompt += completion.usage.prompt_tokens or 0
             acc_completion += completion.usage.completion_tokens or 0
+            details = completion.usage.prompt_tokens_details
+            if details is not None:
+                acc_cache_read += details.cached_tokens or 0
 
         if not completion.choices:
             return completion
 
         choice = completion.choices[0]
         if choice.finish_reason != "tool_calls":
-            _fold_usage(completion, acc_prompt, acc_completion)
+            _fold_usage(completion, acc_prompt, acc_completion, acc_cache_read)
             return completion
 
         sdk_calls = choice.message.tool_calls or []
@@ -317,10 +321,10 @@ async def mcp_tool_loop(
                         "MCP-mixed: could not filter tool_calls on response; client will see MCP calls "
                         "the gateway already executed (no-op on the client side).",
                     )
-            _fold_usage(completion, acc_prompt, acc_completion)
+            _fold_usage(completion, acc_prompt, acc_completion, acc_cache_read)
             return completion
         if not mcp_calls:
-            _fold_usage(completion, acc_prompt, acc_completion)
+            _fold_usage(completion, acc_prompt, acc_completion, acc_cache_read)
             return completion
 
         messages.append({"role": "assistant", "tool_calls": mcp_calls})
@@ -329,9 +333,21 @@ async def mcp_tool_loop(
     raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")
 
 
-def _fold_usage(completion: ChatCompletion, prompt_total: int, completion_total: int) -> None:
+def _fold_usage(
+    completion: ChatCompletion,
+    prompt_total: int,
+    completion_total: int,
+    cache_read_total: int = 0,
+) -> None:
     if completion.usage is None:
         return
     completion.usage.prompt_tokens = prompt_total
     completion.usage.completion_tokens = completion_total
     completion.usage.total_tokens = prompt_total + completion_total
+    # OpenAI chat reports cached tokens as a subset of prompt_tokens. Fold the
+    # accumulated read count back into prompt_tokens_details so the downstream
+    # GatewayUsage wrapper forwards the loop-wide total, not just the last
+    # iteration's slice. (Chat has no cache-write concept.)
+    details = completion.usage.prompt_tokens_details
+    if details is not None:
+        details.cached_tokens = cache_read_total

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -9,6 +9,7 @@ from typing import Any, TypeVar
 
 from any_llm.types.completion import CompletionUsage
 
+from gateway.core.usage import GatewayUsage, cache_read_tokens_of, cache_write_tokens_of
 from gateway.log_config import logger
 
 A = TypeVar("A")  # Attempt-like, opaque to this module
@@ -61,10 +62,12 @@ ANTHROPIC_STREAM_FORMAT = StreamFormat(
 
 def _merge_usage(current: CompletionUsage, update: CompletionUsage) -> CompletionUsage:
     """Merge usage data, keeping the last non-zero value for each field."""
-    return CompletionUsage(
+    return GatewayUsage(
         prompt_tokens=update.prompt_tokens or current.prompt_tokens,
         completion_tokens=update.completion_tokens or current.completion_tokens,
         total_tokens=update.total_tokens or current.total_tokens,
+        cache_read_tokens=cache_read_tokens_of(update) or cache_read_tokens_of(current),
+        cache_write_tokens=cache_write_tokens_of(update) or cache_write_tokens_of(current),
     )
 
 

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -8,6 +8,7 @@ from any_llm.types.completion import (
     ChatCompletionMessage,
     Choice,
     CompletionUsage,
+    PromptTokensDetails,
 )
 from fastapi.testclient import TestClient
 
@@ -118,7 +119,12 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
                     finish_reason="stop",
                 )
             ],
-            usage=CompletionUsage(prompt_tokens=10, completion_tokens=7, total_tokens=17),
+            usage=CompletionUsage(
+                prompt_tokens=10,
+                completion_tokens=7,
+                total_tokens=17,
+                prompt_tokens_details=PromptTokensDetails(cached_tokens=6),
+            ),
         )
 
     monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
@@ -140,6 +146,8 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
                 "prompt_tokens": 10,
                 "completion_tokens": 7,
                 "total_tokens": 17,
+                "cache_read_tokens": 6,
+                "cache_write_tokens": 0,
             },
         }
     ]

--- a/tests/integration/test_hybrid_mode_messages.py
+++ b/tests/integration/test_hybrid_mode_messages.py
@@ -83,8 +83,8 @@ def _message_response(text: str = "hello") -> MessageResponse:
         usage=MessageUsage(
             input_tokens=10,
             output_tokens=7,
-            cache_creation_input_tokens=None,
-            cache_read_input_tokens=None,
+            cache_creation_input_tokens=4,
+            cache_read_input_tokens=3,
             cache_creation=None,
             server_tool_use=None,
             service_tier=None,
@@ -180,7 +180,13 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
         {
             "correlation_id": "att-1",
             "status": "success",
-            "usage": {"prompt_tokens": 10, "completion_tokens": 7, "total_tokens": 17},
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 7,
+                "total_tokens": 17,
+                "cache_read_tokens": 3,
+                "cache_write_tokens": 4,
+            },
         }
     ]
 

--- a/tests/integration/test_hybrid_mode_responses.py
+++ b/tests/integration/test_hybrid_mode_responses.py
@@ -78,7 +78,7 @@ def _response_object() -> Response:
         tools=[],
         usage=ResponseUsage(
             input_tokens=10,
-            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            input_tokens_details=InputTokensDetails(cached_tokens=5),
             output_tokens=7,
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
             total_tokens=17,
@@ -142,7 +142,13 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
         {
             "correlation_id": "att-1",
             "status": "success",
-            "usage": {"prompt_tokens": 10, "completion_tokens": 7, "total_tokens": 17},
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 7,
+                "total_tokens": 17,
+                "cache_read_tokens": 5,
+                "cache_write_tokens": 0,
+            },
         }
     ]
 

--- a/tests/integration/test_log_usage_commit_scope.py
+++ b/tests/integration/test_log_usage_commit_scope.py
@@ -9,6 +9,7 @@ from any_llm.types.completion import CompletionUsage
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.routes.chat import log_usage
+from gateway.core.usage import GatewayUsage
 from gateway.models.entities import ModelPricing, UsageLog
 
 
@@ -54,6 +55,33 @@ async def test_log_usage_records_usage_data(async_db: AsyncSession) -> None:
     assert log.completion_tokens == 500
     assert log.cost == pytest.approx((1000 / 1_000_000) * 2.0 + (500 / 1_000_000) * 4.0)
     assert log.status == "success"
+
+
+@pytest.mark.asyncio
+async def test_log_usage_records_cache_tokens(async_db: AsyncSession) -> None:
+    usage = GatewayUsage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        cache_read_tokens=200,
+        cache_write_tokens=50,
+    )
+    writer = StubLogWriter()
+
+    await log_usage(
+        db=async_db,
+        log_writer=writer,
+        api_key_id=None,
+        model="gpt-4o",
+        provider="openai",
+        endpoint="/v1/chat/completions",
+        usage_override=usage,
+    )
+
+    assert len(writer.logs) == 1
+    log = writer.logs[0]
+    assert log.cache_read_tokens == 200
+    assert log.cache_write_tokens == 50
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_usage_endpoint.py
+++ b/tests/integration/test_usage_endpoint.py
@@ -244,6 +244,8 @@ def test_list_usage_response_shape(
         "prompt_tokens": 42,
         "completion_tokens": 7,
         "total_tokens": 49,
+        "cache_read_tokens": None,
+        "cache_write_tokens": None,
         "cost": 1.23,
         "status": "error",
         "error_message": "capacity",

--- a/tests/unit/test_mcp_loop.py
+++ b/tests/unit/test_mcp_loop.py
@@ -299,6 +299,53 @@ async def test_loop_accumulates_cached_tokens_across_iterations(monkeypatch: pyt
 
 
 @pytest.mark.asyncio
+async def test_loop_folds_usage_when_final_completion_has_empty_choices(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Accumulated usage must survive a final completion that carries no choices."""
+    empty = ChatCompletion(
+        id="cmpl-empty",
+        choices=[],
+        created=0,
+        model="fake",
+        object="chat.completion",
+        usage=CompletionUsage(
+            prompt_tokens=12,
+            completion_tokens=3,
+            total_tokens=15,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=6),
+        ),
+    )
+    responses = iter(
+        [
+            _completion(
+                finish="tool_calls",
+                tool_calls=[("c1", "fetch_url", "{}")],
+                prompt=10,
+                completion_tokens=2,
+                cached=4,
+            ),
+            empty,
+        ]
+    )
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        return next(responses)
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    out = await mcp_tool_loop(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+        pool=_FakePool(tool_names=["fetch_url"]),
+        max_iterations=5,
+    )
+    assert out.usage is not None
+    assert out.usage.prompt_tokens == 22
+    assert out.usage.completion_tokens == 5
+    assert out.usage.total_tokens == 27
+    assert out.usage.prompt_tokens_details is not None
+    assert out.usage.prompt_tokens_details.cached_tokens == 10
+
+
+@pytest.mark.asyncio
 async def test_loop_max_iter_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
         return _completion(finish="tool_calls", tool_calls=[("c", "fetch_url", "{}")])

--- a/tests/unit/test_mcp_loop.py
+++ b/tests/unit/test_mcp_loop.py
@@ -18,6 +18,7 @@ from any_llm.types.completion import (
     ChunkChoice,
     CompletionUsage,
     Function,
+    PromptTokensDetails,
 )
 from any_llm.types.completion import (
     ChoiceDeltaToolCallFunction as DeltaFn,
@@ -77,6 +78,7 @@ def _completion(
     tool_calls: list[tuple[str, str, str]] | None = None,
     prompt: int = 1,
     completion_tokens: int = 1,
+    cached: int = 0,
 ) -> ChatCompletion:
     """Build a ChatCompletion. tool_calls items are (id, name, arguments_json)."""
     sdk_calls = (
@@ -97,7 +99,10 @@ def _completion(
         model="fake",
         object="chat.completion",
         usage=CompletionUsage(
-            prompt_tokens=prompt, completion_tokens=completion_tokens, total_tokens=prompt + completion_tokens
+            prompt_tokens=prompt,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt + completion_tokens,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=cached) if cached else None,
         ),
     )
 
@@ -261,6 +266,36 @@ async def test_loop_accumulates_usage_across_iterations(monkeypatch: pytest.Monk
     assert out.usage.prompt_tokens == 22
     assert out.usage.completion_tokens == 5
     assert out.usage.total_tokens == 27
+
+
+@pytest.mark.asyncio
+async def test_loop_accumulates_cached_tokens_across_iterations(monkeypatch: pytest.MonkeyPatch) -> None:
+    responses = iter(
+        [
+            _completion(
+                finish="tool_calls",
+                tool_calls=[("c1", "fetch_url", "{}")],
+                prompt=10,
+                completion_tokens=2,
+                cached=4,
+            ),
+            _completion(finish="stop", content="done", prompt=12, completion_tokens=3, cached=6),
+        ]
+    )
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        return next(responses)
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    out = await mcp_tool_loop(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+        pool=_FakePool(tool_names=["fetch_url"]),
+        max_iterations=5,
+    )
+    assert out.usage is not None
+    assert out.usage.prompt_tokens_details is not None
+    assert out.usage.prompt_tokens_details.cached_tokens == 10
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mcp_loop.py
+++ b/tests/unit/test_mcp_loop.py
@@ -346,6 +346,41 @@ async def test_loop_folds_usage_when_final_completion_has_empty_choices(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_loop_preserves_cached_tokens_when_final_iteration_lacks_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cached tokens from earlier iterations survive even if the last completion
+    carries no prompt_tokens_details: _fold_usage creates the sub-object."""
+    responses = iter(
+        [
+            _completion(
+                finish="tool_calls",
+                tool_calls=[("c1", "fetch_url", "{}")],
+                prompt=10,
+                completion_tokens=2,
+                cached=4,
+            ),
+            # Final iteration has usage but no prompt_tokens_details (cached=0).
+            _completion(finish="stop", content="done", prompt=12, completion_tokens=3, cached=0),
+        ]
+    )
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        return next(responses)
+
+    monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
+
+    out = await mcp_tool_loop(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+        pool=_FakePool(tool_names=["fetch_url"]),
+        max_iterations=5,
+    )
+    assert out.usage is not None
+    assert out.usage.prompt_tokens_details is not None
+    assert out.usage.prompt_tokens_details.cached_tokens == 4
+
+
+@pytest.mark.asyncio
 async def test_loop_max_iter_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
         return _completion(finish="tool_calls", tool_calls=[("c", "fetch_url", "{}")])

--- a/tests/unit/test_streaming_token_aggregation.py
+++ b/tests/unit/test_streaming_token_aggregation.py
@@ -1,7 +1,8 @@
 """Unit tests for streaming token aggregation logic."""
 
-from any_llm.types.completion import CompletionUsage
+from any_llm.types.completion import CompletionUsage, PromptTokensDetails
 
+from gateway.core.usage import GatewayUsage
 from gateway.streaming import _merge_usage
 
 
@@ -41,3 +42,54 @@ def test_merge_usage_preserves_current_on_zero_update() -> None:
     assert result.prompt_tokens == 100
     assert result.completion_tokens == 75
     assert result.total_tokens == 150
+
+
+def test_merge_usage_preserves_cache_tokens() -> None:
+    current = GatewayUsage(prompt_tokens=100, completion_tokens=10, total_tokens=110, cache_read_tokens=40)
+    update = GatewayUsage(
+        prompt_tokens=100,
+        completion_tokens=20,
+        total_tokens=120,
+        cache_read_tokens=60,
+        cache_write_tokens=15,
+    )
+
+    result = _merge_usage(current, update)
+
+    assert isinstance(result, GatewayUsage)
+    assert result.cache_read_tokens == 60
+    assert result.cache_write_tokens == 15
+
+
+def test_merge_usage_keeps_current_cache_on_zero_update() -> None:
+    current = GatewayUsage(
+        prompt_tokens=100,
+        completion_tokens=10,
+        total_tokens=110,
+        cache_read_tokens=40,
+        cache_write_tokens=5,
+    )
+    update = GatewayUsage(prompt_tokens=0, completion_tokens=20, total_tokens=0)
+
+    result = _merge_usage(current, update)
+
+    assert isinstance(result, GatewayUsage)
+    assert result.cache_read_tokens == 40
+    assert result.cache_write_tokens == 5
+
+
+def test_merge_usage_reads_plain_completion_usage_cached_tokens() -> None:
+    """A plain CompletionUsage carries cache reads via prompt_tokens_details."""
+    current = CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+    update = CompletionUsage(
+        prompt_tokens=100,
+        completion_tokens=20,
+        total_tokens=120,
+        prompt_tokens_details=PromptTokensDetails(cached_tokens=30),
+    )
+
+    result = _merge_usage(current, update)
+
+    assert isinstance(result, GatewayUsage)
+    assert result.cache_read_tokens == 30
+    assert result.cache_write_tokens == 0

--- a/tests/unit/test_usage_cache_tokens.py
+++ b/tests/unit/test_usage_cache_tokens.py
@@ -43,6 +43,18 @@ def test_from_completion_usage_explicit_overrides_fallback() -> None:
     assert usage.cache_write_tokens == 3
 
 
+def test_from_completion_usage_honors_explicit_zero() -> None:
+    """An explicit cache_read_tokens=0 must not be overridden by the fallback."""
+    base = CompletionUsage(
+        prompt_tokens=100,
+        completion_tokens=20,
+        total_tokens=120,
+        prompt_tokens_details=PromptTokensDetails(cached_tokens=42),
+    )
+    usage = GatewayUsage.from_completion_usage(base, cache_read_tokens=0)
+    assert usage.cache_read_tokens == 0
+
+
 def test_cache_helpers_on_plain_completion_usage() -> None:
     plain = CompletionUsage(
         prompt_tokens=100,

--- a/tests/unit/test_usage_cache_tokens.py
+++ b/tests/unit/test_usage_cache_tokens.py
@@ -1,0 +1,144 @@
+"""Unit tests for cache-token capture in the usage carrier and parse sites."""
+
+from any_llm.types.completion import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    CompletionUsage,
+    PromptTokensDetails,
+)
+
+from gateway.api.routes.chat import _ChatAdapter
+from gateway.api.routes.messages import _messages_stream_usage, _MessagesAdapter
+from gateway.api.routes.responses import _usage_to_completion_usage
+from gateway.core.usage import GatewayUsage, cache_read_tokens_of, cache_write_tokens_of
+
+
+def test_gateway_usage_defaults_to_zero() -> None:
+    usage = GatewayUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    assert usage.cache_read_tokens == 0
+    assert usage.cache_write_tokens == 0
+
+
+def test_from_completion_usage_reads_cached_tokens_fallback() -> None:
+    base = CompletionUsage(
+        prompt_tokens=100,
+        completion_tokens=20,
+        total_tokens=120,
+        prompt_tokens_details=PromptTokensDetails(cached_tokens=42),
+    )
+    usage = GatewayUsage.from_completion_usage(base)
+    assert usage.cache_read_tokens == 42
+    assert usage.cache_write_tokens == 0
+
+
+def test_from_completion_usage_explicit_overrides_fallback() -> None:
+    base = CompletionUsage(
+        prompt_tokens=100,
+        completion_tokens=20,
+        total_tokens=120,
+        prompt_tokens_details=PromptTokensDetails(cached_tokens=42),
+    )
+    usage = GatewayUsage.from_completion_usage(base, cache_read_tokens=7, cache_write_tokens=3)
+    assert usage.cache_read_tokens == 7
+    assert usage.cache_write_tokens == 3
+
+
+def test_cache_helpers_on_plain_completion_usage() -> None:
+    plain = CompletionUsage(
+        prompt_tokens=100,
+        completion_tokens=20,
+        total_tokens=120,
+        prompt_tokens_details=PromptTokensDetails(cached_tokens=8),
+    )
+    assert cache_read_tokens_of(plain) == 8
+    assert cache_write_tokens_of(plain) == 0
+
+
+def test_cache_helpers_on_completion_usage_without_details() -> None:
+    plain = CompletionUsage(prompt_tokens=10, completion_tokens=2, total_tokens=12)
+    assert cache_read_tokens_of(plain) == 0
+    assert cache_write_tokens_of(plain) == 0
+
+
+def test_chat_non_stream_captures_cached_tokens() -> None:
+    result = ChatCompletion.model_construct(
+        usage=CompletionUsage(
+            prompt_tokens=100,
+            completion_tokens=20,
+            total_tokens=120,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=25),
+        ),
+    )
+    usage = _ChatAdapter().extract_usage(result)
+    assert isinstance(usage, GatewayUsage)
+    assert usage.cache_read_tokens == 25
+    assert usage.cache_write_tokens == 0
+
+
+def test_chat_stream_captures_cached_tokens() -> None:
+    chunk = ChatCompletionChunk.model_construct(
+        usage=CompletionUsage(
+            prompt_tokens=100,
+            completion_tokens=20,
+            total_tokens=120,
+            prompt_tokens_details=PromptTokensDetails(cached_tokens=11),
+        ),
+    )
+    usage = _ChatAdapter().extract_stream_usage(chunk)
+    assert isinstance(usage, GatewayUsage)
+    assert usage.cache_read_tokens == 11
+
+
+def test_messages_non_stream_captures_read_and_write() -> None:
+    from anthropic.types.usage import Usage
+    from any_llm.types.messages import MessageResponse
+
+    result = MessageResponse.model_construct(
+        usage=Usage(
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_input_tokens=40,
+            cache_creation_input_tokens=15,
+        ),
+    )
+    usage = _MessagesAdapter().extract_usage(result)
+    assert isinstance(usage, GatewayUsage)
+    assert usage.prompt_tokens == 100
+    assert usage.total_tokens == 120
+    assert usage.cache_read_tokens == 40
+    assert usage.cache_write_tokens == 15
+
+
+def test_messages_stream_delta_captures_read_and_write() -> None:
+    from anthropic.types.message_delta_usage import MessageDeltaUsage
+    from any_llm.types.messages import MessageDeltaEvent
+
+    event = MessageDeltaEvent.model_construct(
+        usage=MessageDeltaUsage(
+            input_tokens=10,
+            output_tokens=30,
+            cache_read_input_tokens=5,
+            cache_creation_input_tokens=2,
+        ),
+    )
+    usage = _messages_stream_usage(event)
+    assert isinstance(usage, GatewayUsage)
+    assert usage.cache_read_tokens == 5
+    assert usage.cache_write_tokens == 2
+
+
+def test_responses_captures_cached_tokens() -> None:
+    from openai.types.responses import ResponseUsage
+    from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+
+    usage_in = ResponseUsage(
+        input_tokens=100,
+        output_tokens=20,
+        total_tokens=120,
+        input_tokens_details=InputTokensDetails(cached_tokens=33),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+    )
+    usage = _usage_to_completion_usage(usage_in)
+    assert isinstance(usage, GatewayUsage)
+    assert usage.cache_read_tokens == 33
+    assert usage.cache_write_tokens == 0

--- a/tests/unit/test_usage_cache_tokens.py
+++ b/tests/unit/test_usage_cache_tokens.py
@@ -55,6 +55,21 @@ def test_from_completion_usage_honors_explicit_zero() -> None:
     assert usage.cache_read_tokens == 0
 
 
+def test_from_completion_usage_preserves_gateway_usage_cache_fields() -> None:
+    """When the input is already a GatewayUsage, its explicit cache fields are
+    carried over (not silently dropped) without re-supplying them."""
+    source = GatewayUsage(
+        prompt_tokens=100,
+        completion_tokens=20,
+        total_tokens=120,
+        cache_read_tokens=11,
+        cache_write_tokens=9,
+    )
+    usage = GatewayUsage.from_completion_usage(source)
+    assert usage.cache_read_tokens == 11
+    assert usage.cache_write_tokens == 9
+
+
 def test_cache_helpers_on_plain_completion_usage() -> None:
     plain = CompletionUsage(
         prompt_tokens=100,


### PR DESCRIPTION
## Description

The gateway dropped every provider cached-token count at parse time, so the platform could not price cached input tokens at their discounted (or, for Anthropic cache writes, premium) rate. Cached tokens were effectively billed at the full input rate.

This change forwards two explicit integers, `cache_read_tokens` and `cache_write_tokens`, alongside the existing usage fields.

### Design

Introduced `GatewayUsage` (`src/gateway/core/usage.py`), a pydantic subclass of `any_llm`'s `CompletionUsage` that adds the two cache fields (defaulting to `0`). Subclassing keeps it type-compatible with every existing `CompletionUsage` signature, so the values thread through the pipeline without a broad signature refactor. Two helper accessors (`cache_read_tokens_of`, `cache_write_tokens_of`) branch on `isinstance` and fall back to `prompt_tokens_details.cached_tokens` for plain instances.

Provider conventions are handled at capture, keeping the carrier neutral:
- **OpenAI (chat & Responses), Gemini**: cached tokens are a subset of prompt/input tokens; `cache_read_tokens` is informational for re-pricing, no write concept.
- **Anthropic**: `cache_read_input_tokens` and `cache_creation_input_tokens` are reported separately and excluded from `input_tokens`; the latter maps to `cache_write_tokens`.

### Changes

- Capture at each parse site: `chat.py` (stream + non-stream), `messages.py` (stream + non-stream), `responses.py` (Responses + Gemini).
- Preserve through aggregation: `streaming._merge_usage` and `mcp_loop._fold_usage` (the agentic tool-loop path, on the same data flow).
- Forward in `_report_platform_usage` report dict.
- Standalone parity: new nullable `cache_read_tokens` / `cache_write_tokens` columns on `UsageLog`, hand-written Alembic migration (`d4e6f8a0b2c4`, upgrade/downgrade roundtrip tested), populated in `log_usage`, and surfaced on the usage API.
- Docs: documented the additive fields and per-provider conventions in `docs/platform-protocol.md`; regenerated `docs/public/openapi.json`.

### Compatibility constraint (must coordinate with the platform)

The usage payload is a hand-built dict with no schema-validated contract on the gateway side. If the platform's `/gateway/usage` handler validates with `extra="forbid"`, the new keys cause a **422**, which is non-retryable, so the report is **silently dropped**. The platform must accept the additive fields with lenient parsing **before or together with** this change. Companion platform issue: mozilla-ai/otari-ai#1168.

## PR Type
<!-- Check all that apply -->

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Closes #195.

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** opencode

**Any additional AI details you'd like to share:**

Implementation, tests, and docs were drafted with AI assistance and reviewed before submission.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)