### PR TITLE
feat(tools): add resolve_time gateway tool backed by dateparser

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Otari sits between your applications and LLM providers so you can control access
 - User and budget controls (`/v1/users`, `/v1/budgets`)
 - Usage and pricing tracking (`/v1/usage`, `/v1/pricing`)
 - Health and metrics endpoints (`/health`, optional `/metrics`)
-- Built-in tools Otari runs itself, `otari_code_execution` (sandboxed Python REPL) and `otari_web_search`. See [Built-in tools](#built-in-tools).
+- Built-in tools Otari runs itself, `otari_code_execution` (sandboxed Python REPL), `otari_web_search`, and `otari_resolve_time` (natural-language date resolution). See [Built-in tools](#built-in-tools).
 - Request-level [guardrails](#guardrails) (e.g. prompt-injection detection) Otari enforces on input before calling the provider.
 
 ## Quickstart
@@ -173,11 +173,12 @@ Otari will be available at `http://localhost:8000`.
 
 ## Built-in tools
 
-Otari can run a couple of tools itself so any model, including
+Otari can run a few tools itself so any model, including
 open-weight ones, gets parity with what frontier APIs expose as managed
-tools. Both are opt-in via the request's `tools` array and run inside
-docker-compose profiles so operators who don't use them don't pull extra
-images.
+tools. They are opt-in via the request's `tools` array. The sandbox and search
+backends run inside docker-compose profiles so operators who don't use them
+don't pull extra images; `otari_resolve_time` is pure local computation and
+needs no extra service.
 
 These use dedicated `otari_*` tool types. The keyword decides who runs the
 code: an `otari_*` type means Otari runs it. Every other tool type, the
@@ -246,6 +247,35 @@ Per-tool overrides (`max_results`, `allowed_domains`, `blocked_domains`,
 (`OTARI_WEB_SEARCH_ENGINES`, `OTARI_WEB_SEARCH_MAX_RESULTS`,
 `OTARI_WEB_SEARCH_EXTRACT`, `OTARI_WEB_SEARCH_PURPOSE_HINT`) live
 alongside `OTARI_WEB_SEARCH_URL`.
+
+### `otari_resolve_time`, natural-language date resolution
+
+```json
+{
+  "model": "anthropic:claude-sonnet-4-6",
+  "messages": [{"role": "user", "content": "Summarize my notes from the last 2 weeks."}],
+  "tools": [{"type": "otari_resolve_time"}]
+}
+```
+
+Unlike the sandbox and search tools, `otari_resolve_time` is pure local
+computation (the `dateparser` library), so it needs no docker-compose profile
+or extra service, no upstream provider, and no credential. The model calls it
+to turn a natural-language or relative date ("last 2 weeks", "yesterday",
+"9 days ago to today") into deterministic ISO 8601 timestamps before passing
+them to other tools, rather than doing brittle date math itself. No argument
+returns the current time; single points return one timestamp; periods and
+ranges return a `{"start", "end"}` object.
+
+Parsing is policy-driven: `timezone_mode` (`request` / `default` / `forced`)
+reconciles the per-call `timezone_name` with a workspace timezone, alongside
+`prefer_dates_from`, `date_order`, `week_start`, `languages`, and an opaque
+`parser_options` bag forwarded to `dateparser`. Per-tool overrides live on the
+tool entry; in platform mode the per-workspace defaults come from the
+platform's `/gateway/resolve-time/resolve` endpoint. `OTARI_RESOLVE_TIME_PURPOSE_HINT`
+sets the operator-level prompt hint. Because it shares the single tool-loop
+pool, it can't be combined with `otari_code_execution`, `otari_web_search`, or
+MCP servers in the same request yet.
 
 ## Guardrails
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "aiosqlite>=0.19.0",
     "asyncpg>=0.29.0",
     "click>=8.1.0",
+    "dateparser>=1.2.0",
     "fastapi>=0.115.0",
     "markitdown[docx,pptx,xlsx,pdf]>=0.1.0",
     "mcp>=1.0.0",
@@ -108,6 +109,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["trafilatura.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["dateparser"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -63,12 +63,15 @@ from gateway.api.routes._platform import (
     _report_platform_usage,
     _resolve_platform_credentials,
     _resolve_platform_mcp_servers,
+    _resolve_platform_time,
     _resolve_platform_web_search,
     run_platform_attempts,
 )
 from gateway.api.routes._tools import (
+    _build_resolve_time_backend,
     _build_web_search_backend,
     _extract_code_execution_tool,
+    _extract_resolve_time_tool,
     _extract_web_search_tool,
     _resolve_sandbox_purpose_hint,
 )
@@ -139,6 +142,11 @@ WEB_SEARCH_CONFLICT_DETAIL = (
     "otari_web_search cannot be combined with otari_code_execution or mcp_servers in the same request yet; pick one."
 )
 WEB_SEARCH_NOT_ENABLED_DETAIL = "web search is not enabled for this workspace"
+RESOLVE_TIME_CONFLICT_DETAIL = (
+    "otari_resolve_time cannot be combined with otari_code_execution, otari_web_search, "
+    "or mcp_servers in the same request yet; pick one. Multi-backend dispatch is a planned refinement."
+)
+RESOLVE_TIME_NOT_ENABLED_DETAIL = "resolve_time is not enabled for this workspace"
 SANDBOX_UNREACHABLE_DETAIL = "code_execution sandbox unreachable — check OTARI_SANDBOX_URL"
 WEB_SEARCH_UNREACHABLE_DETAIL = "web_search backend unreachable — check OTARI_WEB_SEARCH_URL"
 
@@ -563,6 +571,8 @@ class ToolContext:
         web_search_tool_entry: dict[str, Any] | None,
         web_search_url: str | None,
         web_search_auth_token: str | None,
+        use_resolve_time: bool,
+        resolve_time_tool_entry: dict[str, Any] | None,
         remaining_user_tools: list[dict[str, Any]] | None,
         max_tool_iterations: int,
         tools_header: str | None,
@@ -576,17 +586,23 @@ class ToolContext:
         self.web_search_tool_entry = web_search_tool_entry
         self.web_search_url = web_search_url
         self.web_search_auth_token = web_search_auth_token
+        self.use_resolve_time = use_resolve_time
+        self.resolve_time_tool_entry = resolve_time_tool_entry
         self.remaining_user_tools = remaining_user_tools
         self.max_tool_iterations = max_tool_iterations
         self.tools_header = tools_header
 
     @property
     def tools_extracted(self) -> bool:
-        return self.sandbox_tool_entry is not None or self.web_search_tool_entry is not None
+        return (
+            self.sandbox_tool_entry is not None
+            or self.web_search_tool_entry is not None
+            or self.resolve_time_tool_entry is not None
+        )
 
     @property
     def use_tool_loop(self) -> bool:
-        return bool(self.mcp_server_configs) or self.use_sandbox or self.use_web_search
+        return bool(self.mcp_server_configs) or self.use_sandbox or self.use_web_search or self.use_resolve_time
 
 
 async def prepare_gateway_tools(
@@ -655,7 +671,7 @@ async def prepare_gateway_tools(
             if web_search_url_targets_platform(sandbox_url, ctx.config.platform.get("base_url")):
                 sandbox_auth_token = ctx.user_token
 
-        web_search_tool_entry, remaining_user_tools = _extract_web_search_tool(tools_after_sandbox)
+        web_search_tool_entry, tools_after_web_search = _extract_web_search_tool(tools_after_sandbox)
         web_search_url: str | None = otari_env("WEB_SEARCH_URL") or None
         # Forwarded to the search backend as `X-Gateway-Token`. Only set in
         # hybrid mode, where the backend may be the platform-hosted web-search
@@ -710,6 +726,50 @@ async def prepare_gateway_tools(
                         if isinstance(request_options, dict)
                         else workspace_options
                     )
+
+        resolve_time_tool_entry, remaining_user_tools = _extract_resolve_time_tool(tools_after_web_search)
+        use_resolve_time = False
+        if resolve_time_tool_entry is not None:
+            # resolve_time is pure-local (no backend URL, no credential), so there
+            # is no "not configured" gate. It still shares the single tool-loop
+            # pool, so for now it cannot combine with the other gateway-run tools.
+            if use_sandbox or use_web_search or mcp_servers:
+                raise adapter.error(400, RESOLVE_TIME_CONFLICT_DETAIL, ErrorKind.INVALID_REQUEST)
+            use_resolve_time = True
+
+            # Hybrid mode owns the per-workspace resolve_time policy (whether it's
+            # enabled at all, plus the parsing knobs). Precedence mirrors
+            # web_search: a meaningful per-request value wins; otherwise the
+            # workspace default fills in. parser_options is shallow-merged.
+            # Standalone mode has no platform to consult.
+            if ctx.hybrid_mode:
+                assert ctx.user_token is not None  # guaranteed by the hybrid-mode preamble
+                resolve_time_policy = await _resolve_platform_time(
+                    config=ctx.config,
+                    user_token=ctx.user_token,
+                )
+                if not resolve_time_policy.get("enabled"):
+                    raise adapter.error(403, RESOLVE_TIME_NOT_ENABLED_DETAIL, ErrorKind.PERMISSION)
+                for key in (
+                    "timezone_mode",
+                    "timezone",
+                    "prefer_dates_from",
+                    "date_order",
+                    "week_start",
+                    "languages",
+                    "purpose_hint",
+                ):
+                    resolved_value = resolve_time_policy.get(key)
+                    if not resolve_time_tool_entry.get(key) and resolved_value is not None:
+                        resolve_time_tool_entry[key] = resolved_value
+                workspace_parser_options = resolve_time_policy.get("parser_options")
+                if isinstance(workspace_parser_options, dict):
+                    request_parser_options = resolve_time_tool_entry.get("parser_options")
+                    resolve_time_tool_entry["parser_options"] = (
+                        {**workspace_parser_options, **request_parser_options}
+                        if isinstance(request_parser_options, dict)
+                        else workspace_parser_options
+                    )
     except HTTPException:
         await release_reservation(ctx)
         raise
@@ -724,6 +784,8 @@ async def prepare_gateway_tools(
         web_search_tool_entry=web_search_tool_entry,
         web_search_url=web_search_url,
         web_search_auth_token=web_search_auth_token,
+        use_resolve_time=use_resolve_time,
+        resolve_time_tool_entry=resolve_time_tool_entry,
         remaining_user_tools=remaining_user_tools,
         max_tool_iterations=min(
             max_tool_iterations or DEFAULT_MAX_TOOL_ITERATIONS,
@@ -894,16 +956,24 @@ async def dispatch_non_stream(
             kwargs = adapter.inject_hints(call_kwargs, backend.purpose_hints(), header=tool_ctx.tools_header)
             return await adapter.run_tool_loop(kwargs, backend, tool_ctx.max_tool_iterations, on_first_response)
 
-    assert tool_ctx.use_web_search
-    assert tool_ctx.web_search_url is not None  # guaranteed past the missing-URL 400 in prepare_gateway_tools
-    assert tool_ctx.web_search_tool_entry is not None  # guaranteed by the web_search opt-in
-    async with _build_web_search_backend(
-        base_url=tool_ctx.web_search_url,
-        tool_entry=tool_ctx.web_search_tool_entry,
-        auth_token=tool_ctx.web_search_auth_token,
-    ) as web_backend:
-        kwargs = adapter.inject_hints(call_kwargs, web_backend.purpose_hints(), header=tool_ctx.tools_header)
-        return await adapter.run_tool_loop(kwargs, web_backend, tool_ctx.max_tool_iterations, on_first_response)
+    if tool_ctx.use_web_search:
+        assert tool_ctx.web_search_url is not None  # guaranteed past the missing-URL 400 in prepare_gateway_tools
+        assert tool_ctx.web_search_tool_entry is not None  # guaranteed by the web_search opt-in
+        async with _build_web_search_backend(
+            base_url=tool_ctx.web_search_url,
+            tool_entry=tool_ctx.web_search_tool_entry,
+            auth_token=tool_ctx.web_search_auth_token,
+        ) as web_backend:
+            kwargs = adapter.inject_hints(call_kwargs, web_backend.purpose_hints(), header=tool_ctx.tools_header)
+            return await adapter.run_tool_loop(kwargs, web_backend, tool_ctx.max_tool_iterations, on_first_response)
+
+    assert tool_ctx.use_resolve_time
+    assert tool_ctx.resolve_time_tool_entry is not None  # guaranteed by the resolve_time opt-in
+    async with _build_resolve_time_backend(tool_entry=tool_ctx.resolve_time_tool_entry) as resolve_time_backend:
+        kwargs = adapter.inject_hints(call_kwargs, resolve_time_backend.purpose_hints(), header=tool_ctx.tools_header)
+        return await adapter.run_tool_loop(
+            kwargs, resolve_time_backend, tool_ctx.max_tool_iterations, on_first_response
+        )
 
 
 async def _lazy_mcp_stream(
@@ -968,16 +1038,24 @@ async def open_stream(
         await sandbox_backend.__aenter__()  # may raise SandboxNotReachableError
         return _eager_backend_stream(adapter, kwargs, sandbox_backend, tool_ctx)
 
-    assert tool_ctx.use_web_search
-    assert tool_ctx.web_search_url is not None  # guaranteed past the missing-URL 400 in prepare_gateway_tools
-    assert tool_ctx.web_search_tool_entry is not None  # guaranteed by the web_search opt-in
-    web_search_backend = _build_web_search_backend(
-        base_url=tool_ctx.web_search_url,
-        tool_entry=tool_ctx.web_search_tool_entry,
-        auth_token=tool_ctx.web_search_auth_token,
-    )
-    await web_search_backend.__aenter__()  # may raise WebSearchNotReachableError
-    return _eager_backend_stream(adapter, kwargs, web_search_backend, tool_ctx)
+    if tool_ctx.use_web_search:
+        assert tool_ctx.web_search_url is not None  # guaranteed past the missing-URL 400 in prepare_gateway_tools
+        assert tool_ctx.web_search_tool_entry is not None  # guaranteed by the web_search opt-in
+        web_search_backend = _build_web_search_backend(
+            base_url=tool_ctx.web_search_url,
+            tool_entry=tool_ctx.web_search_tool_entry,
+            auth_token=tool_ctx.web_search_auth_token,
+        )
+        await web_search_backend.__aenter__()  # may raise WebSearchNotReachableError
+        return _eager_backend_stream(adapter, kwargs, web_search_backend, tool_ctx)
+
+    assert tool_ctx.use_resolve_time
+    assert tool_ctx.resolve_time_tool_entry is not None  # guaranteed by the resolve_time opt-in
+    # resolve_time is pure-local: its __aenter__ is a no-op and never raises, but
+    # we open it eagerly to stay uniform with the other eager backends.
+    resolve_time_backend = _build_resolve_time_backend(tool_entry=tool_ctx.resolve_time_tool_entry)
+    await resolve_time_backend.__aenter__()
+    return _eager_backend_stream(adapter, kwargs, resolve_time_backend, tool_ctx)
 
 
 # ---------------------------------------------------------------------------
@@ -1326,6 +1404,11 @@ async def run_streaming_with_fallback(
                     tool_entry=tool_ctx.web_search_tool_entry,
                     auth_token=tool_ctx.web_search_auth_token,
                 ),
+            )
+        elif tool_ctx.use_resolve_time:
+            assert tool_ctx.resolve_time_tool_entry is not None  # guaranteed by the resolve_time opt-in
+            pool_for_loop = await backend_stack.enter_async_context(
+                _build_resolve_time_backend(tool_entry=tool_ctx.resolve_time_tool_entry),
             )
     except BaseException:
         # Eager-open failure (e.g. SandboxNotReachableError): propagate so the

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -584,6 +584,70 @@ async def _resolve_platform_web_search(
     )
 
 
+async def _resolve_platform_time(
+    config: GatewayConfig,
+    user_token: str,
+) -> dict[str, Any]:
+    """Resolve the workspace's resolve_time policy via the platform.
+
+    Mirrors `_resolve_platform_web_search`: same base_url guard, timeout,
+    headers, `_post_platform` call, and status-code handling. POSTs an empty
+    body to `/gateway/resolve-time/resolve` and returns the parsed JSON dict on
+    200 (``{enabled, timezone_mode, timezone, prefer_dates_from, date_order,
+    week_start, languages, purpose_hint, parser_options}``). Client errors
+    (auth/quota/not-found/rate-limit) forward verbatim; the platform's
+    server-side or unexpected responses collapse to 502.
+    """
+    platform_base_url = config.platform.get("base_url")
+    if not platform_base_url:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Hybrid mode is misconfigured",
+        )
+
+    timeout_ms = int(config.platform.get("resolve_timeout_ms", 5000))
+    resolve_url = _platform_url(platform_base_url, "/gateway/resolve-time/resolve")
+    headers = {
+        "X-Gateway-Token": config.platform_token or "",
+        "X-User-Token": user_token,
+    }
+    body: dict[str, Any] = {}
+
+    try:
+        response = await _post_platform(url=resolve_url, headers=headers, body=body, timeout_seconds=timeout_ms / 1000)
+    except (httpx.TimeoutException, httpx.NetworkError):
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authorization service unavailable",
+        ) from None
+
+    if response.status_code == 200:
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
+    # Mirror the status-code semantics of `_resolve_platform_web_search`:
+    # client errors (auth/quota/not-found/rate-limit) are forwarded so the
+    # caller sees the real status (and can honour Retry-After on 429), while
+    # the platform's server-side or unexpected responses collapse to 502.
+    if response.status_code in {401, 402, 403, 404, 429}:
+        detail = _safe_detail_from_platform(response, "Resolve time resolution failed")
+        response_headers: dict[str, str] | None = None
+        if response.status_code == 429 and response.headers.get("Retry-After"):
+            response_headers = {"Retry-After": response.headers["Retry-After"]}
+        raise HTTPException(status_code=response.status_code, detail=detail, headers=response_headers)
+
+    if response.status_code == 422 or response.status_code >= 500:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Authorization service unavailable",
+        )
+
+    raise HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail="Authorization service unavailable",
+    )
+
+
 async def _report_platform_usage(
     config: GatewayConfig,
     correlation_id: str,

--- a/src/gateway/api/routes/_tools.py
+++ b/src/gateway/api/routes/_tools.py
@@ -61,7 +61,7 @@ def _is_resolve_time_tool_type(type_value: Any) -> bool:
     """Recognise the explicit gateway-managed resolve_time tool type.
 
     Matches only ``"otari_resolve_time"``. There is no provider-named
-    equivalent — time resolution is always gateway-local.
+    equivalent; time resolution is always gateway-local.
     """
     if not isinstance(type_value, str):
         return False
@@ -279,7 +279,7 @@ def _resolve_resolve_time_purpose_hint(tool_entry: dict[str, Any] | None) -> str
 def _build_resolve_time_backend(*, tool_entry: dict[str, Any]) -> ResolveTimeBackend:
     """Construct a ResolveTimeBackend from the (merged) per-tool config entry.
 
-    resolve_time is pure-local — no backend URL, no credential. The entry's
+    resolve_time is pure-local: no backend URL, no credential. The entry's
     fields are the workspace policy (in hybrid mode, merged from the platform's
     resolve response) plus any per-request overrides: ``timezone_mode``,
     ``timezone``, ``prefer_dates_from``, ``date_order``, ``week_start``,

--- a/src/gateway/api/routes/_tools.py
+++ b/src/gateway/api/routes/_tools.py
@@ -23,6 +23,7 @@ from typing import Any
 from gateway.api.routes._schema_derive import SENSITIVE_PARAM_FIELDS
 from gateway.core.env import otari_env
 from gateway.log_config import logger
+from gateway.services.resolve_time_backend import ResolveTimeBackend
 from gateway.services.web_search_backend import WebSearchBackend
 
 
@@ -41,6 +42,7 @@ class Tool(StrEnum):
 
     CODE_EXECUTION = auto()  # -> "otari_code_execution"
     WEB_SEARCH = auto()  # -> "otari_web_search"
+    RESOLVE_TIME = auto()  # -> "otari_resolve_time"
 
 
 def _is_web_search_tool_type(type_value: Any) -> bool:
@@ -53,6 +55,17 @@ def _is_web_search_tool_type(type_value: Any) -> bool:
     if not isinstance(type_value, str):
         return False
     return type_value == Tool.WEB_SEARCH
+
+
+def _is_resolve_time_tool_type(type_value: Any) -> bool:
+    """Recognise the explicit gateway-managed resolve_time tool type.
+
+    Matches only ``"otari_resolve_time"``. There is no provider-named
+    equivalent — time resolution is always gateway-local.
+    """
+    if not isinstance(type_value, str):
+        return False
+    return type_value == Tool.RESOLVE_TIME
 
 
 def _is_code_execution_tool_type(type_value: Any) -> bool:
@@ -245,3 +258,60 @@ def _build_web_search_backend(
         kwargs["auth_token"] = auth_token
 
     return WebSearchBackend(**kwargs)
+
+
+def _extract_resolve_time_tool(
+    tools: list[dict[str, Any]] | None,
+) -> tuple[dict[str, Any] | None, list[dict[str, Any]] | None]:
+    """Pull the first ``{"type": "otari_resolve_time"}`` entry out of ``tools``.
+
+    Only the explicit gateway-managed type is extracted (and run against the
+    gateway's resolve_time backend). Everything else passes through unchanged.
+    """
+    return _extract_first_matching_tool(tools, _is_resolve_time_tool_type)
+
+
+def _resolve_resolve_time_purpose_hint(tool_entry: dict[str, Any] | None) -> str | None:
+    """Per-tool entry → ``OTARI_RESOLVE_TIME_PURPOSE_HINT`` → ``None`` (backend default)."""
+    return (tool_entry.get("purpose_hint") if tool_entry else None) or otari_env("RESOLVE_TIME_PURPOSE_HINT") or None
+
+
+def _build_resolve_time_backend(*, tool_entry: dict[str, Any]) -> ResolveTimeBackend:
+    """Construct a ResolveTimeBackend from the (merged) per-tool config entry.
+
+    resolve_time is pure-local — no backend URL, no credential. The entry's
+    fields are the workspace policy (in hybrid mode, merged from the platform's
+    resolve response) plus any per-request overrides: ``timezone_mode``,
+    ``timezone``, ``prefer_dates_from``, ``date_order``, ``week_start``,
+    ``languages``, ``parser_options``, and ``purpose_hint`` (per-tool →
+    ``OTARI_RESOLVE_TIME_PURPOSE_HINT`` → backend default).
+    """
+    kwargs: dict[str, Any] = {}
+
+    timezone_mode = tool_entry.get("timezone_mode")
+    if isinstance(timezone_mode, str) and timezone_mode:
+        kwargs["timezone_mode"] = timezone_mode
+    tz = tool_entry.get("timezone")
+    if isinstance(tz, str) and tz:
+        kwargs["timezone_name"] = tz
+    prefer = tool_entry.get("prefer_dates_from")
+    if isinstance(prefer, str) and prefer:
+        kwargs["prefer_dates_from"] = prefer
+    date_order = tool_entry.get("date_order")
+    if isinstance(date_order, str) and date_order:
+        kwargs["date_order"] = date_order
+    week_start = tool_entry.get("week_start")
+    if isinstance(week_start, str) and week_start:
+        kwargs["week_start"] = week_start
+    languages = tool_entry.get("languages")
+    if isinstance(languages, list) and languages:
+        kwargs["languages"] = [str(lang) for lang in languages]
+    parser_options = tool_entry.get("parser_options")
+    if isinstance(parser_options, dict) and parser_options:
+        kwargs["parser_options"] = parser_options
+
+    purpose_hint = _resolve_resolve_time_purpose_hint(tool_entry)
+    if purpose_hint:
+        kwargs["purpose_hint"] = purpose_hint
+
+    return ResolveTimeBackend(**kwargs)

--- a/src/gateway/services/resolve_time_backend.py
+++ b/src/gateway/services/resolve_time_backend.py
@@ -2,8 +2,8 @@
 
 A backend the tool-use loop in :mod:`gateway.services.mcp_loop` dispatches to
 whenever the model emits a ``resolve_time(expression=…)`` call. Unlike the
-sandbox / web_search backends, this one is pure local computation — it shells
-out to no service and holds no HTTP client — so its async-context-manager
+sandbox / web_search backends, this one is pure local computation: it shells
+out to no service and holds no HTTP client, so its async-context-manager
 methods are no-ops; it implements them only so the loop can drive it as a
 ``pool`` uniformly.
 
@@ -16,10 +16,10 @@ its workspace policy: the gateway runs the tool, the platform owns the config.
 ``timezone_mode`` reconciles the workspace ``timezone`` with the ``timezone_name``
 the model may pass per call:
 
-* ``request`` — honour the model's per-call timezone; fall back to UTC.
-* ``default`` — honour the model's per-call timezone, else the workspace
+* ``request``: honour the model's per-call timezone; fall back to UTC.
+* ``default``: honour the model's per-call timezone, else the workspace
   ``timezone``, else UTC.
-* ``forced`` — ignore the model entirely; always use the workspace ``timezone``.
+* ``forced``: ignore the model entirely; always use the workspace ``timezone``.
 
 This satisfies the same duck-typed protocol the MCP loop uses for tool dispatch
 (``openai_tools``, ``owns_tool``, ``purpose_hints``, ``call_tool``).
@@ -30,11 +30,15 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, cast
 from zoneinfo import ZoneInfo
 
 import dateparser
+
+# Case-insensitive " to " range separator, with flexible surrounding whitespace.
+_RANGE_SEPARATOR = re.compile(r"\s+to\s+", re.IGNORECASE)
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -54,7 +58,7 @@ _DEFAULT_DATE_ORDER = "MDY"
 _DEFAULT_WEEK_START = "monday"
 
 # Gateway-controlled dateparser settings that an opaque parser_options bag must
-# never override — these are derived from the typed policy fields instead.
+# never override; these are derived from the typed policy fields instead.
 _RESERVED_PARSER_SETTINGS = frozenset({"RELATIVE_BASE", "RETURN_AS_TIMEZONE_AWARE", "PREFER_DATES_FROM", "DATE_ORDER"})
 
 # Defensive bounds mirroring the platform's stored-config caps. In standalone
@@ -198,11 +202,12 @@ class ResolveTimeBackend:
     def _resolve(self, expression: str, tz: timezone | ZoneInfo) -> str:
         now = datetime.now(tz)
 
-        # Explicit range: "X to Y" -> {start, end}
-        if " to " in expression:
-            start_raw, end_raw = expression.split(" to ", maxsplit=1)
-            start_dt = self._parse_expression(start_raw.strip(), now)
-            end_dt = self._parse_expression(end_raw.strip(), now)
+        # Explicit range: "X to Y" -> {start, end}. Case-insensitive on the
+        # " to " separator so "Jan 1 To Jan 2" is still recognised as a range.
+        range_parts = _RANGE_SEPARATOR.split(expression, maxsplit=1)
+        if len(range_parts) == 2:
+            start_dt = self._parse_expression(range_parts[0].strip(), now)
+            end_dt = self._parse_expression(range_parts[1].strip(), now)
             if start_dt is not None and end_dt is not None:
                 start = _floor(start_dt, tz)
                 end = _floor(end_dt, tz) + timedelta(days=1)
@@ -233,7 +238,7 @@ class ResolveTimeBackend:
         )
         try:
             result: datetime | None = dateparser.parse(expr, languages=self._languages, settings=cast(Any, settings))
-        except Exception as exc:  # noqa: BLE001 — dateparser raises broad on bad settings
+        except Exception as exc:  # noqa: BLE001 (dateparser raises broad on bad settings)
             logger.warning("resolve_time: dateparser failed for %r: %s", expr, exc)
             return None
         if result is None:
@@ -293,7 +298,7 @@ def _bounded_parser_options(options: dict[str, Any] | None) -> dict[str, Any]:
     """Clamp a request-supplied parser_options bag to the backend's caps.
 
     Returns at most ``_MAX_PARSER_OPTION_KEYS`` keys, and drops the bag entirely
-    if it can't be serialised or exceeds ``_MAX_PARSER_OPTIONS_BYTES`` — the
+    if it can't be serialised or exceeds ``_MAX_PARSER_OPTIONS_BYTES``; the
     platform applies the same caps when storing config, so this only bites in
     standalone mode where config comes straight from the request.
     """
@@ -301,7 +306,7 @@ def _bounded_parser_options(options: dict[str, Any] | None) -> dict[str, Any]:
         return {}
     bounded = dict(list(options.items())[:_MAX_PARSER_OPTION_KEYS])
     try:
-        if len(json.dumps(bounded, default=str)) > _MAX_PARSER_OPTIONS_BYTES:
+        if len(json.dumps(bounded, default=str).encode("utf-8")) > _MAX_PARSER_OPTIONS_BYTES:
             logger.warning("resolve_time: parser_options exceeds size cap; ignoring")
             return {}
     except (TypeError, ValueError):
@@ -321,10 +326,12 @@ def _is_utc(tz: timezone | ZoneInfo) -> bool:
 
 
 def _fmt(dt: datetime, tz: timezone | ZoneInfo) -> str:
-    """ISO 8601 string — ``Z`` suffix for UTC, numeric offset otherwise."""
+    """ISO 8601 string at second precision: ``Z`` suffix for UTC, numeric offset otherwise."""
     if _is_utc(tz):
         return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
-    return dt.isoformat()
+    # Drop microseconds so the non-UTC path matches the UTC path's precision
+    # (datetime.now() carries microseconds; the floored paths do not).
+    return dt.replace(microsecond=0).isoformat()
 
 
 def _range_json(start: datetime, end: datetime, tz: timezone | ZoneInfo) -> str:

--- a/src/gateway/services/resolve_time_backend.py
+++ b/src/gateway/services/resolve_time_backend.py
@@ -1,0 +1,343 @@
+"""Resolve natural-language time expressions for the ``resolve_time`` tool.
+
+A backend the tool-use loop in :mod:`gateway.services.mcp_loop` dispatches to
+whenever the model emits a ``resolve_time(expression=…)`` call. Unlike the
+sandbox / web_search backends, this one is pure local computation — it shells
+out to no service and holds no HTTP client — so its async-context-manager
+methods are no-ops; it implements them only so the loop can drive it as a
+``pool`` uniformly.
+
+The heavy lifting is the `dateparser` library, with the parsing policy
+(timezone handling, preferred direction, date order, week start, languages,
+and an opaque settings passthrough) supplied per request by the platform's
+``/gateway/resolve-time/resolve`` response. This mirrors how web_search reads
+its workspace policy: the gateway runs the tool, the platform owns the config.
+
+``timezone_mode`` reconciles the workspace ``timezone`` with the ``timezone_name``
+the model may pass per call:
+
+* ``request`` — honour the model's per-call timezone; fall back to UTC.
+* ``default`` — honour the model's per-call timezone, else the workspace
+  ``timezone``, else UTC.
+* ``forced`` — ignore the model entirely; always use the workspace ``timezone``.
+
+This satisfies the same duck-typed protocol the MCP loop uses for tool dispatch
+(``openai_tools``, ``owns_tool``, ``purpose_hints``, ``call_tool``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any, cast
+from zoneinfo import ZoneInfo
+
+import dateparser
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+logger = logging.getLogger(__name__)
+
+RESOLVE_TIME_TOOL_NAME = "resolve_time"
+
+_VALID_TIMEZONE_MODES = frozenset({"request", "default", "forced"})
+_VALID_PREFER_DATES_FROM = frozenset({"past", "future", "current_period"})
+_VALID_DATE_ORDERS = frozenset({"MDY", "DMY", "YMD"})
+_VALID_WEEK_STARTS = frozenset({"monday", "sunday"})
+
+_DEFAULT_TIMEZONE_MODE = "default"
+_DEFAULT_PREFER_DATES_FROM = "past"
+_DEFAULT_DATE_ORDER = "MDY"
+_DEFAULT_WEEK_START = "monday"
+
+# Gateway-controlled dateparser settings that an opaque parser_options bag must
+# never override — these are derived from the typed policy fields instead.
+_RESERVED_PARSER_SETTINGS = frozenset({"RELATIVE_BASE", "RETURN_AS_TIMEZONE_AWARE", "PREFER_DATES_FROM", "DATE_ORDER"})
+
+# Defensive bounds mirroring the platform's stored-config caps. In standalone
+# mode the config comes straight from the request with no platform validation,
+# so the backend clamps it itself: an oversized expression would block the parse
+# thread, and an unbounded parser_options/languages payload is pointless input.
+_MAX_EXPRESSION_LEN = 512
+_MAX_LANGUAGES = 20
+_MAX_PARSER_OPTION_KEYS = 30
+_MAX_PARSER_OPTIONS_BYTES = 4096
+
+_DEFAULT_PURPOSE_HINT = (
+    "Call `resolve_time` to turn any relative or natural-language date "
+    '("last 2 weeks", "yesterday", "since Monday") into exact ISO 8601 '
+    "timestamps before passing them to other tools. Do not compute dates "
+    "yourself. With no argument it returns the current time."
+)
+
+_TOOL_DESCRIPTION = (
+    "Resolve a natural-language time expression to deterministic ISO 8601 "
+    "timestamps. Call with no argument to get the current time. Single points "
+    '("9 days ago", "March 1") return one timestamp; periods and ranges '
+    '("yesterday", "last week", "9 days ago to today") return a JSON '
+    "object with `start` and `end`."
+)
+
+
+class ResolveTimeBackend:
+    """Stateless, local ``resolve_time`` tool backend.
+
+    Duck-types as the MCP loop's ``pool`` parameter. Construction takes the
+    resolved workspace policy; defaults reproduce octonous's behaviour
+    (UTC-fallback, prefer past dates, MDY, Monday week start).
+    """
+
+    def __init__(
+        self,
+        *,
+        timezone_mode: str | None = None,
+        timezone_name: str | None = None,
+        prefer_dates_from: str | None = None,
+        date_order: str | None = None,
+        week_start: str | None = None,
+        languages: list[str] | None = None,
+        parser_options: dict[str, Any] | None = None,
+        purpose_hint: str | None = None,
+    ) -> None:
+        self._timezone_mode = timezone_mode if timezone_mode in _VALID_TIMEZONE_MODES else _DEFAULT_TIMEZONE_MODE
+        self._workspace_tz = _safe_zoneinfo(timezone_name)
+        self._prefer_dates_from = (
+            prefer_dates_from if prefer_dates_from in _VALID_PREFER_DATES_FROM else _DEFAULT_PREFER_DATES_FROM
+        )
+        self._date_order = date_order if date_order in _VALID_DATE_ORDERS else _DEFAULT_DATE_ORDER
+        self._week_start = week_start if week_start in _VALID_WEEK_STARTS else _DEFAULT_WEEK_START
+        self._languages = [str(lang) for lang in languages[:_MAX_LANGUAGES]] if languages else None
+        self._parser_options = _bounded_parser_options(parser_options)
+        self._purpose_hint = purpose_hint or _DEFAULT_PURPOSE_HINT
+
+    async def __aenter__(self) -> ResolveTimeBackend:
+        return self
+
+    async def __aexit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _tb: TracebackType | None,
+    ) -> None:
+        return None
+
+    # ----- duck-typed protocol the MCP loop uses on `pool` -----
+
+    @property
+    def openai_tools(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": RESOLVE_TIME_TOOL_NAME,
+                    "description": _TOOL_DESCRIPTION,
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "expression": {
+                                "type": "string",
+                                "description": (
+                                    'A natural-language time expression, e.g. "last 2 weeks", '
+                                    '"yesterday", "9 days ago", "January 1 to January 15". '
+                                    "Omit to get the current time."
+                                ),
+                            },
+                            "timezone_name": {
+                                "type": "string",
+                                "description": (
+                                    'Optional IANA timezone (e.g. "America/New_York") to resolve '
+                                    "the expression in. May be ignored by workspace policy."
+                                ),
+                            },
+                        },
+                        "required": [],
+                    },
+                },
+            }
+        ]
+
+    def owns_tool(self, name: str) -> bool:
+        return name == RESOLVE_TIME_TOOL_NAME
+
+    def purpose_hints(self) -> list[tuple[str, str]]:
+        return [(RESOLVE_TIME_TOOL_NAME, self._purpose_hint)]
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+        if name != RESOLVE_TIME_TOOL_NAME:
+            raise KeyError(f"ResolveTimeBackend does not own tool {name!r}")
+
+        expression = arguments.get("expression")
+        requested_tz = arguments.get("timezone_name")
+        tz = self._effective_tz(requested_tz if isinstance(requested_tz, str) else None)
+
+        if not isinstance(expression, str) or not expression.strip():
+            return _fmt(datetime.now(tz), tz)
+
+        cleaned = expression.strip()
+        if len(cleaned) > _MAX_EXPRESSION_LEN:
+            return f"Time expression too long (max {_MAX_EXPRESSION_LEN} characters)."
+
+        # dateparser.parse is synchronous and CPU-bound; run it off the event
+        # loop so a slow parse can't stall other requests sharing this worker.
+        return await asyncio.to_thread(self._resolve, cleaned, tz)
+
+    # ----- internals -----
+
+    def _effective_tz(self, requested_tz: str | None) -> timezone | ZoneInfo:
+        """Pick the timezone to resolve in, per ``timezone_mode``."""
+        if self._timezone_mode == "forced":
+            return self._workspace_tz or timezone.utc
+        if self._timezone_mode == "request":
+            return _safe_zoneinfo(requested_tz) or timezone.utc
+        # default: model's per-call tz, then workspace tz, then UTC.
+        return _safe_zoneinfo(requested_tz) or self._workspace_tz or timezone.utc
+
+    def _resolve(self, expression: str, tz: timezone | ZoneInfo) -> str:
+        now = datetime.now(tz)
+
+        # Explicit range: "X to Y" -> {start, end}
+        if " to " in expression:
+            start_raw, end_raw = expression.split(" to ", maxsplit=1)
+            start_dt = self._parse_expression(start_raw.strip(), now)
+            end_dt = self._parse_expression(end_raw.strip(), now)
+            if start_dt is not None and end_dt is not None:
+                start = _floor(start_dt, tz)
+                end = _floor(end_dt, tz) + timedelta(days=1)
+                return _range_json(start, end, tz)
+
+        # Named periods: "yesterday", "last week", etc. -> {start, end}
+        window = self._resolve_common_period_window(expression, now, tz)
+        if window is not None:
+            return _range_json(window[0], window[1], tz)
+
+        # Single point in time: "9 days ago", "March 1" -> bare ISO timestamp
+        parsed = self._parse_expression(expression, now)
+        if parsed is None:
+            return f"Could not parse time expression: {expression!r}"
+        return _fmt(_floor(parsed, tz), tz)
+
+    def _parse_expression(self, expr: str, reference_date: datetime) -> datetime | None:
+        settings: dict[str, Any] = {
+            key: value for key, value in self._parser_options.items() if key not in _RESERVED_PARSER_SETTINGS
+        }
+        settings.update(
+            {
+                "RELATIVE_BASE": reference_date.replace(tzinfo=None),
+                "RETURN_AS_TIMEZONE_AWARE": False,
+                "PREFER_DATES_FROM": self._prefer_dates_from,
+                "DATE_ORDER": self._date_order,
+            }
+        )
+        try:
+            result: datetime | None = dateparser.parse(expr, languages=self._languages, settings=cast(Any, settings))
+        except Exception as exc:  # noqa: BLE001 — dateparser raises broad on bad settings
+            logger.warning("resolve_time: dateparser failed for %r: %s", expr, exc)
+            return None
+        if result is None:
+            return None
+        return result.replace(tzinfo=reference_date.tzinfo or timezone.utc)
+
+    def _resolve_common_period_window(
+        self, expression: str, now: datetime, tz: timezone | ZoneInfo
+    ) -> tuple[datetime, datetime] | None:
+        """Return [start, end) windows for common relative phrases."""
+        expr = expression.strip().lower()
+        today = _floor(now, tz)
+        week_offset = self._weekday_offset(today)
+
+        if expr == "today":
+            return today, today + timedelta(days=1)
+        if expr == "yesterday":
+            start = today - timedelta(days=1)
+            return start, today
+        if expr == "this week":
+            start = today - timedelta(days=week_offset)
+            return start, start + timedelta(days=7)
+        if expr == "last week":
+            this_week_start = today - timedelta(days=week_offset)
+            start = this_week_start - timedelta(days=7)
+            return start, this_week_start
+        if expr == "this month":
+            start = today.replace(day=1)
+            return start, _first_day_next_month(start)
+        if expr == "last month":
+            this_month_start = today.replace(day=1)
+            return _first_day_previous_month(this_month_start), this_month_start
+        return None
+
+    def _weekday_offset(self, day: datetime) -> int:
+        """Days since the start of the week, honouring ``week_start``.
+
+        Python's ``weekday()`` is Monday=0…Sunday=6. For a Sunday-start week,
+        Sunday must map to 0 and Monday…Saturday to 1…6.
+        """
+        if self._week_start == "sunday":
+            return (day.weekday() + 1) % 7
+        return day.weekday()
+
+
+def _safe_zoneinfo(name: str | None) -> ZoneInfo | None:
+    if not name or not name.strip():
+        return None
+    try:
+        return ZoneInfo(name.strip())
+    except (KeyError, ValueError):
+        logger.warning("resolve_time: ignoring invalid timezone %r", name)
+        return None
+
+
+def _bounded_parser_options(options: dict[str, Any] | None) -> dict[str, Any]:
+    """Clamp a request-supplied parser_options bag to the backend's caps.
+
+    Returns at most ``_MAX_PARSER_OPTION_KEYS`` keys, and drops the bag entirely
+    if it can't be serialised or exceeds ``_MAX_PARSER_OPTIONS_BYTES`` — the
+    platform applies the same caps when storing config, so this only bites in
+    standalone mode where config comes straight from the request.
+    """
+    if not options:
+        return {}
+    bounded = dict(list(options.items())[:_MAX_PARSER_OPTION_KEYS])
+    try:
+        if len(json.dumps(bounded, default=str)) > _MAX_PARSER_OPTIONS_BYTES:
+            logger.warning("resolve_time: parser_options exceeds size cap; ignoring")
+            return {}
+    except (TypeError, ValueError):
+        logger.warning("resolve_time: parser_options not serialisable; ignoring")
+        return {}
+    return bounded
+
+
+def _floor(dt: datetime, tz: timezone | ZoneInfo) -> datetime:
+    """Floor a datetime to midnight (start of day) in the given timezone."""
+    return dt.replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=tz)
+
+
+def _is_utc(tz: timezone | ZoneInfo) -> bool:
+    """True for UTC, however it was constructed (timezone.utc or ZoneInfo('UTC'))."""
+    return tz == timezone.utc or getattr(tz, "key", "") in ("UTC", "Etc/UTC")
+
+
+def _fmt(dt: datetime, tz: timezone | ZoneInfo) -> str:
+    """ISO 8601 string — ``Z`` suffix for UTC, numeric offset otherwise."""
+    if _is_utc(tz):
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    return dt.isoformat()
+
+
+def _range_json(start: datetime, end: datetime, tz: timezone | ZoneInfo) -> str:
+    return json.dumps({"start": _fmt(start, tz), "end": _fmt(end, tz)})
+
+
+def _first_day_next_month(dt: datetime) -> datetime:
+    if dt.month == 12:
+        return dt.replace(year=dt.year + 1, month=1, day=1)
+    return dt.replace(month=dt.month + 1, day=1)
+
+
+def _first_day_previous_month(dt: datetime) -> datetime:
+    if dt.month == 1:
+        return dt.replace(year=dt.year - 1, month=12, day=1)
+    return dt.replace(month=dt.month - 1, day=1)

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -1219,3 +1219,184 @@ def test_hybrid_mode_web_search_empty_request_list_keeps_workspace_policy(
     assert merged is not None
     # Empty per-request list did not wipe the workspace allow-list.
     assert merged["allowed_domains"] == ["docs.python.org"]
+
+
+# ---------------------------------------------------------------------------
+# resolve_time hybrid-mode policy resolution
+# ---------------------------------------------------------------------------
+# In hybrid mode an `otari_resolve_time` request consults the platform's
+# `/gateway/resolve-time/resolve` endpoint: if resolve_time is disabled for the
+# workspace the gateway 403s; otherwise the resolved workspace policy is merged
+# into the tool entry (per-request values win) before the local backend runs.
+
+
+class _FakeResolveTimeBackend:
+    """Minimal ResolveTimeBackend duck-type that records the tool_entry it was
+    built from and resolves the tool loop in a single round (no real parsing)."""
+
+    last_tool_entry: dict[str, Any] | None = None
+
+    def __init__(self, *, tool_entry: dict[str, Any]) -> None:
+        type(self).last_tool_entry = dict(tool_entry)
+
+    async def __aenter__(self) -> "_FakeResolveTimeBackend":
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    @property
+    def openai_tools(self) -> list[dict[str, Any]]:
+        return [{"type": "function", "function": {"name": "resolve_time", "description": "", "parameters": {}}}]
+
+    def owns_tool(self, name: str) -> bool:
+        return name == "resolve_time"
+
+    def purpose_hints(self) -> list[tuple[str, str]]:
+        return []
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+        return "2026-02-14T15:30:00Z"
+
+
+def test_hybrid_mode_resolve_time_403_when_disabled(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An `otari_resolve_time` request whose workspace has resolve_time disabled
+    is rejected with 403 before any provider call."""
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _single_attempt_resolve_response(request_id="rt-req-disabled")
+        if url.endswith("/gateway/resolve-time/resolve"):
+            return httpx.Response(200, json={"enabled": False})
+        return httpx.Response(204)
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "otari_resolve_time"}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "resolve_time is not enabled for this workspace"}
+
+
+def test_hybrid_mode_resolve_time_merges_workspace_config(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When enabled, the resolved workspace policy is merged into the tool entry
+    with per-request values winning over workspace defaults."""
+    _FakeResolveTimeBackend.last_tool_entry = None
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _single_attempt_resolve_response(request_id="rt-req-enabled")
+        if url.endswith("/gateway/resolve-time/resolve"):
+            return httpx.Response(
+                200,
+                json={
+                    "enabled": True,
+                    "timezone_mode": "forced",
+                    "timezone": "America/New_York",
+                    "prefer_dates_from": "past",
+                    "date_order": "DMY",
+                    "week_start": "sunday",
+                    "purpose_hint": "workspace hint",
+                    "parser_options": {"STRICT_PARSING": False},
+                },
+            )
+        return httpx.Response(204)
+
+    async def fake_loop_acompletion(**kwargs: Any) -> ChatCompletion:
+        return ChatCompletion(
+            id="cmpl-rt",
+            object="chat.completion",
+            created=0,
+            model="openai:gpt-4o-mini",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="answer"),
+                )
+            ],
+            usage=CompletionUsage(prompt_tokens=3, completion_tokens=2, total_tokens=5),
+        )
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes._pipeline._build_resolve_time_backend", _FakeResolveTimeBackend)
+    monkeypatch.setattr("gateway.services.mcp_loop.acompletion", fake_loop_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            # Per-request timezone_mode=request must win over workspace "forced".
+            "tools": [{"type": "otari_resolve_time", "timezone_mode": "request"}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+    merged = _FakeResolveTimeBackend.last_tool_entry
+    assert merged is not None
+    # Per-request value wins.
+    assert merged["timezone_mode"] == "request"
+    # Workspace defaults fill in the unset keys.
+    assert merged["timezone"] == "America/New_York"
+    assert merged["date_order"] == "DMY"
+    assert merged["week_start"] == "sunday"
+    assert merged["purpose_hint"] == "workspace hint"
+    assert merged["parser_options"] == {"STRICT_PARSING": False}
+
+
+def test_hybrid_mode_resolve_time_conflicts_with_web_search(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """resolve_time shares the single tool-loop pool, so it cannot be combined
+    with another gateway-run tool (otari_web_search here) in one request."""
+    monkeypatch.setenv("GATEWAY_WEB_SEARCH_URL", "http://searxng:8080")
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _single_attempt_resolve_response(request_id="rt-req-conflict")
+        if url.endswith("/gateway/web-search/resolve"):
+            return httpx.Response(200, json={"enabled": True})
+        if url.endswith("/gateway/resolve-time/resolve"):
+            return httpx.Response(200, json={"enabled": True})
+        return httpx.Response(204)
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+
+    # Conflict must be detected regardless of tool order in the request.
+    for tools in (
+        [{"type": "otari_web_search"}, {"type": "otari_resolve_time"}],
+        [{"type": "otari_resolve_time"}, {"type": "otari_web_search"}],
+    ):
+        response = platform_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "anything",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": tools,
+            },
+            headers={"Authorization": "Bearer user_test_token"},
+        )
+        assert response.status_code == 400

--- a/tests/unit/test_pipeline_settlement.py
+++ b/tests/unit/test_pipeline_settlement.py
@@ -53,6 +53,8 @@ def _tool_ctx(**overrides: Any) -> ToolContext:
         "web_search_tool_entry": None,
         "web_search_url": None,
         "web_search_auth_token": None,
+        "use_resolve_time": False,
+        "resolve_time_tool_entry": None,
         "remaining_user_tools": None,
         "max_tool_iterations": 10,
         "tools_header": None,

--- a/tests/unit/test_resolve_time_backend.py
+++ b/tests/unit/test_resolve_time_backend.py
@@ -68,6 +68,12 @@ async def test_explicit_range_inclusive_end() -> None:
 
 
 @pytest.mark.asyncio
+async def test_explicit_range_separator_is_case_insensitive() -> None:
+    out = json.loads(await _call(ResolveTimeBackend(), "9 days ago To today"))
+    assert out == {"start": "2026-02-05T00:00:00Z", "end": "2026-02-15T00:00:00Z"}
+
+
+@pytest.mark.asyncio
 async def test_unparseable_expression_returns_error_string() -> None:
     out = await _call(ResolveTimeBackend(), "zzzz not a date qwerty")
     assert out.startswith("Could not parse time expression")

--- a/tests/unit/test_resolve_time_backend.py
+++ b/tests/unit/test_resolve_time_backend.py
@@ -1,0 +1,222 @@
+"""Unit tests for the local ``resolve_time`` tool backend.
+
+Time is frozen by monkeypatching the module's ``datetime`` with a subclass
+whose ``now()`` returns a fixed instant (Sat 2026-02-14 15:30 UTC), so the
+relative-expression assertions are deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone, tzinfo
+
+import pytest
+
+from gateway.services import resolve_time_backend as backend_module
+from gateway.services.resolve_time_backend import RESOLVE_TIME_TOOL_NAME, ResolveTimeBackend
+
+_FROZEN_NOW = datetime(2026, 2, 14, 15, 30, 0, tzinfo=timezone.utc)  # a Saturday
+
+
+@pytest.fixture(autouse=True)
+def _freeze_now(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz: tzinfo | None = None) -> datetime:  # type: ignore[override]
+            return _FROZEN_NOW.astimezone(tz) if tz is not None else _FROZEN_NOW.replace(tzinfo=None)
+
+    monkeypatch.setattr(backend_module, "datetime", _FrozenDatetime)
+
+
+async def _call(backend: ResolveTimeBackend, expression: str | None = None, **kwargs: str) -> str:
+    args: dict[str, str] = dict(kwargs)
+    if expression is not None:
+        args["expression"] = expression
+    async with backend:
+        return await backend.call_tool(RESOLVE_TIME_TOOL_NAME, args)
+
+
+# ───────────── basics ─────────────
+
+
+@pytest.mark.asyncio
+async def test_no_argument_returns_now_utc() -> None:
+    assert await _call(ResolveTimeBackend()) == "2026-02-14T15:30:00Z"
+
+
+@pytest.mark.asyncio
+async def test_empty_expression_returns_now() -> None:
+    assert await _call(ResolveTimeBackend(), "   ") == "2026-02-14T15:30:00Z"
+
+
+@pytest.mark.asyncio
+async def test_single_point_floors_to_midnight() -> None:
+    assert await _call(ResolveTimeBackend(), "9 days ago") == "2026-02-05T00:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_yesterday_returns_one_day_window() -> None:
+    out = json.loads(await _call(ResolveTimeBackend(), "yesterday"))
+    assert out == {"start": "2026-02-13T00:00:00Z", "end": "2026-02-14T00:00:00Z"}
+
+
+@pytest.mark.asyncio
+async def test_explicit_range_inclusive_end() -> None:
+    out = json.loads(await _call(ResolveTimeBackend(), "9 days ago to today"))
+    # end is floored + 1 day so the window is inclusive of "today".
+    assert out == {"start": "2026-02-05T00:00:00Z", "end": "2026-02-15T00:00:00Z"}
+
+
+@pytest.mark.asyncio
+async def test_unparseable_expression_returns_error_string() -> None:
+    out = await _call(ResolveTimeBackend(), "zzzz not a date qwerty")
+    assert out.startswith("Could not parse time expression")
+
+
+# ───────────── week start ─────────────
+
+
+@pytest.mark.asyncio
+async def test_last_week_monday_start() -> None:
+    out = json.loads(await _call(ResolveTimeBackend(week_start="monday"), "last week"))
+    # Sat 2026-02-14 → this week starts Mon 2026-02-09 → last week is Feb 2..9.
+    assert out == {"start": "2026-02-02T00:00:00Z", "end": "2026-02-09T00:00:00Z"}
+
+
+@pytest.mark.asyncio
+async def test_last_week_sunday_start() -> None:
+    out = json.loads(await _call(ResolveTimeBackend(week_start="sunday"), "last week"))
+    # Sunday-start: this week starts Sun 2026-02-08 → last week is Feb 1..8.
+    assert out == {"start": "2026-02-01T00:00:00Z", "end": "2026-02-08T00:00:00Z"}
+
+
+# ───────────── timezone modes ─────────────
+
+
+@pytest.mark.asyncio
+async def test_forced_mode_uses_workspace_tz_and_ignores_request() -> None:
+    backend = ResolveTimeBackend(timezone_mode="forced", timezone_name="America/New_York")
+    # Even though the model passes UTC, forced mode resolves in New York.
+    out = json.loads(await _call(backend, "yesterday", timezone_name="UTC"))
+    assert out == {"start": "2026-02-13T00:00:00-05:00", "end": "2026-02-14T00:00:00-05:00"}
+
+
+@pytest.mark.asyncio
+async def test_request_mode_honours_model_tz() -> None:
+    backend = ResolveTimeBackend(timezone_mode="request")
+    # No workspace tz configured; request mode resolves in the model-passed tz,
+    # so the floored result carries New York's -05:00 offset.
+    out = await _call(backend, "9 days ago", timezone_name="America/New_York")
+    assert out == "2026-02-05T00:00:00-05:00"
+
+
+@pytest.mark.asyncio
+async def test_request_mode_without_tz_falls_back_to_utc() -> None:
+    backend = ResolveTimeBackend(timezone_mode="request", timezone_name="America/New_York")
+    # request mode ignores the workspace tz when the model passes none → UTC.
+    assert await _call(backend, "9 days ago") == "2026-02-05T00:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_default_mode_prefers_request_then_workspace() -> None:
+    backend = ResolveTimeBackend(timezone_mode="default", timezone_name="America/New_York")
+    # No per-call tz → falls back to workspace New York.
+    assert await _call(backend, "9 days ago") == "2026-02-05T00:00:00-05:00"
+
+
+# ───────────── policy knobs ─────────────
+
+
+@pytest.mark.asyncio
+async def test_invalid_timezone_name_falls_back_to_utc() -> None:
+    backend = ResolveTimeBackend(timezone_mode="forced", timezone_name="Mars/Olympus_Mons")
+    assert await _call(backend, "9 days ago") == "2026-02-05T00:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_zoneinfo_utc_emits_z_suffix() -> None:
+    # timezone="UTC" resolves to ZoneInfo("UTC") (not timezone.utc); the result
+    # must still use the Z suffix, not +00:00, for output consistency.
+    backend = ResolveTimeBackend(timezone_mode="forced", timezone_name="UTC")
+    assert await _call(backend, "9 days ago") == "2026-02-05T00:00:00Z"
+    out = json.loads(await _call(backend, "yesterday"))
+    assert out == {"start": "2026-02-13T00:00:00Z", "end": "2026-02-14T00:00:00Z"}
+
+
+@pytest.mark.asyncio
+async def test_overlong_expression_is_rejected_without_parsing() -> None:
+    out = await _call(ResolveTimeBackend(), "a" * 600)
+    assert "too long" in out
+
+
+@pytest.mark.asyncio
+async def test_today_and_month_windows() -> None:
+    backend = ResolveTimeBackend()
+    assert json.loads(await _call(backend, "today")) == {
+        "start": "2026-02-14T00:00:00Z",
+        "end": "2026-02-15T00:00:00Z",
+    }
+    assert json.loads(await _call(backend, "this month")) == {
+        "start": "2026-02-01T00:00:00Z",
+        "end": "2026-03-01T00:00:00Z",
+    }
+    assert json.loads(await _call(backend, "last month")) == {
+        "start": "2026-01-01T00:00:00Z",
+        "end": "2026-02-01T00:00:00Z",
+    }
+
+
+def test_parser_options_clamped_to_key_cap() -> None:
+    backend = ResolveTimeBackend(parser_options={f"K{i}": i for i in range(50)})
+    assert len(backend._parser_options) == 30
+
+
+def test_oversized_parser_options_dropped() -> None:
+    backend = ResolveTimeBackend(parser_options={"BIG": "x" * 5000})
+    assert backend._parser_options == {}
+
+
+def test_languages_clamped() -> None:
+    backend = ResolveTimeBackend(languages=[f"l{i}" for i in range(40)])
+    assert backend._languages is not None
+    assert len(backend._languages) == 20
+
+
+@pytest.mark.asyncio
+async def test_reserved_parser_options_cannot_override_gateway_settings() -> None:
+    # A caller trying to flip PREFER_DATES_FROM via parser_options must be ignored;
+    # the typed prefer_dates_from policy wins. "9 days ago" is unambiguous, so we
+    # just assert it still resolves deterministically rather than erroring.
+    backend = ResolveTimeBackend(parser_options={"PREFER_DATES_FROM": "future", "RELATIVE_BASE": "garbage"})
+    assert await _call(backend, "9 days ago") == "2026-02-05T00:00:00Z"
+
+
+# ───────────── protocol ─────────────
+
+
+def test_openai_tools_schema_shape() -> None:
+    tools = ResolveTimeBackend().openai_tools
+    assert len(tools) == 1
+    fn = tools[0]["function"]
+    assert fn["name"] == RESOLVE_TIME_TOOL_NAME
+    assert set(fn["parameters"]["properties"]) == {"expression", "timezone_name"}
+    assert fn["parameters"]["required"] == []
+
+
+def test_owns_only_its_own_tool() -> None:
+    backend = ResolveTimeBackend()
+    assert backend.owns_tool(RESOLVE_TIME_TOOL_NAME) is True
+    assert backend.owns_tool("web_search") is False
+
+
+def test_purpose_hint_override() -> None:
+    backend = ResolveTimeBackend(purpose_hint="custom hint")
+    assert backend.purpose_hints() == [(RESOLVE_TIME_TOOL_NAME, "custom hint")]
+
+
+@pytest.mark.asyncio
+async def test_call_tool_rejects_foreign_tool_name() -> None:
+    backend = ResolveTimeBackend()
+    async with backend:
+        with pytest.raises(KeyError):
+            await backend.call_tool("web_search", {})

--- a/tests/unit/test_resolve_time_resolve.py
+++ b/tests/unit/test_resolve_time_resolve.py
@@ -1,0 +1,141 @@
+"""Unit tests for resolving the workspace resolve_time policy via the platform."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from gateway.api.routes import _platform as platform_module
+from gateway.api.routes._platform import _resolve_platform_time
+
+
+def _config(*, base_url: str | None = "https://platform.local") -> Any:
+    cfg = MagicMock()
+    cfg.platform = {"base_url": base_url, "resolve_timeout_ms": 5000} if base_url else {}
+    cfg.platform_token = "gw_test_token"
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_policy_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_post(
+        *, url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["body"] = body
+        return httpx.Response(
+            200,
+            json={
+                "enabled": True,
+                "timezone_mode": "forced",
+                "timezone": "America/New_York",
+                "prefer_dates_from": "past",
+                "date_order": "DMY",
+                "week_start": "sunday",
+                "languages": ["en", "es"],
+                "purpose_hint": "resolve dates first",
+                "parser_options": {"STRICT_PARSING": False},
+            },
+        )
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    out = await _resolve_platform_time(_config(), "tk_user")
+
+    assert out["enabled"] is True
+    assert out["timezone_mode"] == "forced"
+    assert out["timezone"] == "America/New_York"
+    assert out["parser_options"] == {"STRICT_PARSING": False}
+
+    assert captured["url"].endswith("/gateway/resolve-time/resolve")
+    assert captured["headers"]["X-Gateway-Token"] == "gw_test_token"
+    assert captured["headers"]["X-User-Token"] == "tk_user"
+    assert captured["body"] == {}
+
+
+@pytest.mark.asyncio
+async def test_resolve_403_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return httpx.Response(403, json={"detail": "resolve_time disabled"})
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_time(_config(), "tk")
+    assert ei.value.status_code == 403
+    assert ei.value.detail == "resolve_time disabled"
+
+
+@pytest.mark.asyncio
+async def test_resolve_429_passthrough_with_retry_after(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return httpx.Response(429, json={"detail": "slow down"}, headers={"Retry-After": "30"})
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_time(_config(), "tk")
+    assert ei.value.status_code == 429
+    assert ei.value.headers == {"Retry-After": "30"}
+    assert ei.value.detail == "slow down"
+
+
+@pytest.mark.asyncio
+async def test_resolve_5xx_maps_to_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return httpx.Response(503, text="busy")
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_time(_config(), "tk")
+    assert ei.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_resolve_422_collapses_to_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        return httpx.Response(422, json={"detail": "schema mismatch"})
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_time(_config(), "tk")
+    assert ei.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_resolve_network_error_maps_to_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_post(**kwargs: Any) -> httpx.Response:
+        raise httpx.NetworkError("connection refused")
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_time(_config(), "tk")
+    assert ei.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_resolve_misconfigured_platform_500() -> None:
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_platform_time(_config(base_url=None), "tk")
+    assert ei.value.status_code == 500

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 resolution-markers = [
     "sys_platform == 'linux'",
@@ -34,9 +34,7 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/22/a73ccbf9dbd6e26dda0b24d5fd5db7da92ee3383a79f47677ffb834c5c5b/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:915fbb7b41b115192259f8c9ae58f3ddc444d2b5579917270211858e606a4afd", size = 485841, upload-time = "2026-06-07T21:07:19.555Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/b9/57ed8eaf596321c2ad747bd480fb1700dbd7177c60dfc9e4c187f629662e/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:7fb4bdf95b0561a79f259f9d28fbc109728c5ee7f27aff6391f0ca703a329abe", size = 492088, upload-time = "2026-06-07T21:07:21.581Z" },
-    { url = "https://files.pythonhosted.org/packages/78/c0/5ebe5270a7c140d7c6f79dcb018640225f14d406c149e4eec04a7d82fe71/aiohttp-3.14.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:1b9748363260121d2927704f5d4fc498150669ca3ae93625986ee89c8f80dcd4", size = 501564, upload-time = "2026-06-07T21:07:23.388Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/79/e5cc690e9d922a66887ceeaca53a8ffd5a7b0be3816142b7abc433742d89/aiohttp-3.14.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:2a73f487ab8ef5abbb24b7aa9b73e98eaba9e9e031804ff2416f02eca315ccaf", size = 515270, upload-time = "2026-06-07T21:07:17.53Z" },
     { url = "https://files.pythonhosted.org/packages/75/7f/8cdaa24fc7983865e0915153b96a9ac5bcdd3548d64c5a27d17cecccad2d/aiohttp-3.14.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:86a6dab78b0e43e2897a3bbe15745aa60dc5423ca437b7b0b164c069bf91b876", size = 751998, upload-time = "2026-06-07T21:07:25.046Z" },
     { url = "https://files.pythonhosted.org/packages/b2/f4/c4227aacfacc5cb0cc2d119b65301d177912a6842cd64e120c47af76064f/aiohttp-3.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dfd6e47d3c44c2279907607f73a4240b88c69eb8b90da7e2441a8045dfd21da", size = 510918, upload-time = "2026-06-07T21:07:27.28Z" },
     { url = "https://files.pythonhosted.org/packages/ab/01/a2d5f96cd4e74424864d30bc0a7e44d0a12dacdcfa91b5b2d1bd3dca6bf3/aiohttp-3.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:317acd9f8602858dc7d59679812c376c7f0b97bcbbf16e0d6237f54141d8a8a6", size = 508657, upload-time = "2026-06-07T21:07:29.252Z" },
@@ -52,9 +50,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/a1/b0c61e7a137f0d81de49a82023a6df73c3c16d6fefb0f8e4a93d21639002/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:5663ee9257cfa1add7253a7da3035a02f31b6600ec48261585e1800a81533080", size = 1580077, upload-time = "2026-06-07T21:07:50.069Z" },
     { url = "https://files.pythonhosted.org/packages/0b/41/194ea4623693009fcefebef7aef63c141754f153e9cd0d39d3b9e36c175c/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:603a2c834142172ffddc054067f5ec0ca65d57a0aa98a71bc81952573208e345", size = 1791688, upload-time = "2026-06-07T21:07:52.106Z" },
     { url = "https://files.pythonhosted.org/packages/ba/45/4de841f005cfe1fd63e2a2fe011262c515e2a62aa6994b15947e7d717ac9/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cb21957bb8aca671c1765e32f58164cf0c50e6bf41c0bbbd16da20732ecaf588", size = 1761094, upload-time = "2026-06-07T21:07:54.113Z" },
-    { url = "https://files.pythonhosted.org/packages/85/a5/9594ad6289eebbc97d167c44213d557807f90e59115caad24de21ad2c3b1/aiohttp-3.14.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:62a759436b29e677181a9e76bab8b8f689a29cb9c535f45f7c48c9c830d3f8c3", size = 487918, upload-time = "2026-06-07T21:08:06.377Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/61/16a32c36c3c49edec122a3dc811f2057df2f94d3b14aa107c8017d981618/aiohttp-3.14.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:2964cbf553df4d7a57348da44d961d871895fc1ee4e8c322b2a95612c7b17fba", size = 494014, upload-time = "2026-06-07T21:08:08.263Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/89/3ebcf96ed99c05bec9c434aaac6963fd3cbab4a786ae739908a144d9ce44/aiohttp-3.14.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:237651caadc3a59badd39319c54642b5299e9cc98a3a194310e55d5bb9f5e397", size = 502398, upload-time = "2026-06-07T21:08:10.244Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/2e/bfa02f699d87ffc86d5959270b28f1cb410add3ccaced8ed2e0b8a5238fc/aiohttp-3.14.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:20205f7f5ade7aaec9f4b500549bbc071b046453aed72f9c06dcab87896a83e8", size = 514718, upload-time = "2026-06-07T21:08:04.476Z" },
     { url = "https://files.pythonhosted.org/packages/fd/3d/b74870a0c2d40c355928cd5b96c7a11fa821b8a40fc41365e64479b151fb/aiohttp-3.14.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:896e12dfdbbab9d8f7e16d2b28c6769a60126fa92095d1ebf9473d02593a2448", size = 758018, upload-time = "2026-06-07T21:08:12.447Z" },
     { url = "https://files.pythonhosted.org/packages/d3/66/f42f5c984d99e49c6cff5f26f590750f2e2f7ef1fcfb99966ab5be1b632e/aiohttp-3.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d03f281ed22579314ba00821ce20115a7c0ac430660b4cc05704a3f818b3e004", size = 512462, upload-time = "2026-06-07T21:08:14.624Z" },
     { url = "https://files.pythonhosted.org/packages/e9/a7/248e1aebe0c7810b0271e021a0f2a5eb6e78a051885b3c9df49f42a5802d/aiohttp-3.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:07eabb979d236335fed927e137a928c9adfb7df3b9ec7aa31726f133a62be983", size = 512824, upload-time = "2026-06-07T21:08:16.572Z" },
@@ -872,6 +868,7 @@ dependencies = [
     { name = "any-llm-sdk", extra = ["all"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "asyncpg", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "dateparser", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "fastapi", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "markitdown", extra = ["docx", "pdf", "pptx", "xlsx"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "mcp", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -914,6 +911,7 @@ requires-dist = [
     { name = "any-llm-sdk", extras = ["all"], specifier = ">=1.17.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "click", specifier = ">=8.1.0" },
+    { name = "dateparser", specifier = ">=1.2.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "markitdown", extras = ["docx", "pptx", "xlsx", "pdf"], specifier = ">=0.1.0" },
     { name = "mcp", specifier = ">=1.0.0" },
@@ -2408,9 +2406,6 @@ version = "12.2.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
-    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
     { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
     { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
     { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
@@ -2427,9 +2422,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
     { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
     { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
     { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
     { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
     { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },


### PR DESCRIPTION
## Description

Adds an `otari_resolve_time` built-in tool: it resolves natural-language time expressions ("last 2 weeks", "yesterday", "January 1 to January 15") into deterministic ISO 8601 timestamps using `dateparser`, so any model, including open-weight ones, gets reliable relative-date handling instead of doing brittle date math in its head.

Parity with the existing `web_search` built-in tool:

- New `ResolveTimeBackend` implements the `ToolBackend` protocol and runs **locally**, with no upstream provider and no credential (secret-free).
- In **hybrid mode** the per-workspace policy (timezone mode, prefer-dates / date-order / week-start, languages, purpose hint, opaque `parser_options`) is resolved from the platform's new `POST /gateway/resolve-time/resolve` endpoint and merged with per-request overrides.
- In **standalone mode** the request tool entry drives it directly.
- Wired into all three dispatch sites (`dispatch_non_stream`, `open_stream`, platform-fallback streaming). It shares the single tool-loop pool, so it is mutually exclusive with the other gateway-run tools for now (returns 400), matching the existing sandbox / web_search / MCP behaviour.

Hardening: `dateparser.parse` runs off the event loop via `asyncio.to_thread`, the `expression` is length-capped, and `parser_options` / `languages` are clamped in standalone mode (the platform applies the same caps to stored config). `dateparser` was promoted from a transitive to an explicit dependency.

> Companion platform PR (adds the `/gateway/resolve-time/resolve` endpoint, the per-workspace config, and the Time UI): mozilla-ai/otari-ai#1197

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Implements the gateway side of the relative-time tool (cf. mozilla-ai/octonous#1301).

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). (Verified no-op: the tool type adds no schema change.)

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 4.8, via Claude Code.

**Any additional AI details you'd like to share:**

The design was human-directed; the implementation, tests, and this description were written by the agent.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
Added a new built-in time-resolution tool that can turn natural-language date and time phrases into stable ISO 8601 results. It works locally, with workspace policy support in hosted mode, and now appears in the product documentation alongside the other built-in tools.

## Technical notes
- Added `otari_resolve_time` wiring through request handling and stream/tool-loop dispatch.
- Introduced a local resolve-time backend powered by `dateparser`.
- Added platform policy lookup for hybrid mode and request-level overrides.
- Hardened parsing with input limits and background execution.
- Updated dependencies and added unit/integration coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->