### PR TITLE
ci(security): pin GitHub Actions to commit SHAs and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions current. Without this, pinned SHAs go
+  # stale and miss upstream security patches; Dependabot bumps both the SHA and
+  # the trailing version comment as new releases ship.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      # One PR per week for routine minor/patch bumps to cut review noise;
+      # major bumps still arrive as individual PRs so they get scrutiny.
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/otari-docker.yml
+++ b/.github/workflows/otari-docker.yml
@@ -32,19 +32,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Truncate commit SHA
         run: echo "GITHUB_SHA_SHORT=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -61,7 +61,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Build Docker image for testing
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile
@@ -76,7 +76,7 @@ jobs:
         run: ./scripts/docker_liveness_check.sh otari-test:${{ github.sha }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Dockerfile
@@ -104,10 +104,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@v5
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -121,7 +121,7 @@ jobs:
     steps:
       - name: Generate App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.PLATFORM_DISPATCH_APP_ID }}
           private-key: ${{ secrets.PLATFORM_DISPATCH_APP_PRIVATE_KEY }}

--- a/.github/workflows/otari-lint.yml
+++ b/.github/workflows/otari-lint.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         python-version: 3.14
         activate-environment: true

--- a/.github/workflows/otari-release.yml
+++ b/.github/workflows/otari-release.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       VERSION: ${{ github.event.inputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
           # git-cliff walks tag history to render the changelog, so it needs
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: 3.14
 

--- a/.github/workflows/otari-sdk-codegen-check.yml
+++ b/.github/workflows/otari-sdk-codegen-check.yml
@@ -35,14 +35,14 @@ jobs:
         language: [python, typescript, go, rust]
     steps:
       - name: Checkout Otari
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Read-only job: it generates clients and opens no PRs, so the checkout
           # credential is unused. Drop it rather than leave a token in .git/config
           # while the generator and project code run.
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: 3.14
           activate-environment: true
@@ -51,7 +51,7 @@ jobs:
         run: uv sync --dev --frozen
 
       - name: Set up Java (OpenAPI Generator runtime)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: '17'

--- a/.github/workflows/otari-sdk-codegen.yml
+++ b/.github/workflows/otari-sdk-codegen.yml
@@ -55,9 +55,9 @@ jobs:
 
     steps:
       - name: Checkout Otari
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: 3.14
           activate-environment: true
@@ -66,7 +66,7 @@ jobs:
         run: uv sync --dev --frozen
 
       - name: Set up Java (OpenAPI Generator runtime)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: '17'
@@ -99,7 +99,7 @@ jobs:
           uv run python scripts/sdk_codegen/generate.py "${args[@]}"
 
       - name: Checkout ${{ matrix.sdk_repo }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ matrix.sdk_repo }}
           token: ${{ secrets.SDK_CODEGEN_TOKEN }}
@@ -113,7 +113,7 @@ jobs:
           cp -r "dist/${{ matrix.language }}" "$target"
 
       - name: Open PR on ${{ matrix.sdk_repo }}
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ secrets.SDK_CODEGEN_TOKEN }}
           path: sdk-repo

--- a/.github/workflows/otari-tag-release.yml
+++ b/.github/workflows/otari-tag-release.yml
@@ -26,13 +26,13 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: 3.14
 

--- a/.github/workflows/otari-tests.yml
+++ b/.github/workflows/otari-tests.yml
@@ -31,9 +31,9 @@ jobs:
     environment: integration-tests
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         python-version: 3.14
         activate-environment: true
@@ -55,7 +55,7 @@ jobs:
         uv run pytest tests/integration -v --cov --cov-report=xml --cov-append -n auto
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
       with:
         file: ./coverage.xml
         fail_ci_if_error: false
@@ -64,9 +64,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         python-version: 3.14
         activate-environment: true

--- a/.github/workflows/otari-typecheck.yml
+++ b/.github/workflows/otari-typecheck.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-    - uses: astral-sh/setup-uv@v7
+    - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         python-version: 3.14
         activate-environment: true

--- a/.github/workflows/sdk-regen-staleness.yml
+++ b/.github/workflows/sdk-regen-staleness.yml
@@ -33,11 +33,11 @@ jobs:
         # The script authenticates via the gh CLI using the env tokens below, so
         # the checkout's persisted git credential is unused; drop it to avoid
         # leaving GITHUB_TOKEN in .git/config while repository code runs.
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: 3.14
 


### PR DESCRIPTION
## Description

_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose and edits are Claude's._

Floating major-version tags (for example `actions/checkout@v6`) can be re-pointed by whoever controls the action's repository, so a compromised or malicious release silently flows into our CI, which runs with repository secrets and write tokens. Pinning each action to a full commit SHA removes that vector: the SHA is immutable, so a new release cannot change what runs until we deliberately bump it.

This pins all 12 floating action references to full 40-character commit SHAs with a trailing `# vX.Y.Z` comment, matching the pattern already used by `actions/github-script`, `dtolnay/rust-toolchain`, and `amannn/action-semantic-pull-request`. Each precise version comment was verified to dereference to the same commit as the major tag it replaces.

It also adds `.github/dependabot.yml` with the `github-actions` ecosystem so the pinned SHAs (and their version comments) stay current instead of going stale and missing upstream security patches. Routine minor/patch bumps are grouped into one weekly PR; major bumps still arrive individually so they get scrutiny.

Actions pinned: `actions/checkout`, `astral-sh/setup-uv`, `actions/setup-java`, `actions/create-github-app-token`, `codecov/codecov-action`, `peter-evans/create-pull-request`, `peter-evans/dockerhub-description`, `docker/setup-qemu-action`, `docker/setup-buildx-action`, `docker/login-action`, `docker/metadata-action`, `docker/build-push-action`.

Validation: `actionlint` passes clean on all workflows and every file parses as valid YAML. There is no application code change.

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

Closes #167

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). (N/A: CI workflow configuration only, no application code; validated with `actionlint`.)
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). (N/A for a CI-config-only change; ran `actionlint` and YAML parse instead.)
- [x] Documentation was updated where necessary. (None needed.)
- [x] If the API contract changed, I regenerated the OpenAPI spec. (No API contract change.)

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:** SHAs were resolved from the GitHub API and each precise version comment was checked to point at the same commit as the major tag it replaced.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
