### PR TITLE
feat(config): support full provider/pricing config via environment

### DIFF
--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -47,9 +47,10 @@ Notes:
   Railway's `DATABASE_URL` works without edits.
 - `OTARI_REQUIRE_PRICING=false` is deliberate. The image default is `true`
   (fail-closed), which rejects any model without configured pricing; that would
-  make an env-only deploy unusable until pricing is added. Configuring per-model
-  pricing via env is tracked in
-  [#208](https://github.com/mozilla-ai/otari/issues/208).
+  make an env-only deploy unusable until pricing is added. To serve priced
+  models instead, supply `pricing` (and any other structured config like custom
+  `api_base` or Vertex settings) through `OTARI_CONFIG_YAML` / `OTARI_CONFIG_B64`;
+  see [Full config via environment](../../docs/configuration.md#full-config-via-environment).
 
 ## Deploy
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,13 +82,40 @@ pricing:
 
 The following `OTARI_` variables override config file values for their matching fields. For example, `OTARI_PORT=9000` overrides `port: 8000` in the YAML.
 
-`OTARI_` overrides apply to scalar fields (strings, numbers, booleans). List and dict fields (`cors_allow_origins`, `providers`, `pricing`, and the `platform` block) are not read from `OTARI_` variables; set them in the YAML file instead. The `platform` block also has dedicated `PLATFORM_*` variables (see the otari.ai variables below).
+`OTARI_` overrides apply to scalar fields (strings, numbers, booleans). List and dict fields (`cors_allow_origins`, `providers`, `pricing`, and the `platform` block) are not read from individual `OTARI_` variables; set them in the YAML file, or supply the whole config through the environment with `OTARI_CONFIG_YAML` / `OTARI_CONFIG_B64` (see [Full config via environment](#full-config-via-environment)). The `platform` block also has dedicated `PLATFORM_*` variables (see the otari.ai variables below).
 
 The config file also supports `${ENV_VAR}` interpolation:
 
 ```yaml
 master_key: "${MY_SECRET_KEY}"
 ```
+
+### Full config via environment
+
+On PaaS platforms (Railway, Render, Fly.io, Kubernetes) where mounting a `config.yml` is awkward, you can supply the entire config, including the non-scalar `providers` and `pricing` fields, through the environment. This reaches the full schema with no file mount and no custom image.
+
+| Variable | Description |
+|----------|-------------|
+| `OTARI_CONFIG_YAML` | The full config as raw YAML, parsed exactly like a `config.yml`. |
+| `OTARI_CONFIG_B64` | The same YAML, base64-encoded, for env-var UIs that mangle multiline values. |
+
+The YAML supports the same `${ENV_VAR}` interpolation as a config file, so you can keep secrets in separate variables:
+
+```yaml
+# value of OTARI_CONFIG_YAML
+providers:
+  openai:
+    api_key: ${OPENAI_API_KEY}
+    api_base: https://my-proxy.example/v1
+pricing:
+  openai:gpt-4o:
+    input_price_per_million: 2.5
+    output_price_per_million: 10
+```
+
+Precedence, lowest to highest: the config file, then the env-structured config (`OTARI_CONFIG_YAML` or `OTARI_CONFIG_B64`, with raw YAML winning if both are set), then scalar `OTARI_<FIELD>` overrides. Env-structured keys replace the matching top-level keys from the file. Invalid base64, invalid YAML, or a non-mapping top level fails fast at startup with a clear error.
+
+Note the `require_pricing` interaction: it defaults to `true` (fail-closed), so the gateway rejects any model without configured pricing. An env-only deploy therefore needs either `pricing` entries (as above) or `OTARI_REQUIRE_PRICING=false` to serve unpriced models.
 
 ### Common variables
 

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -1,3 +1,5 @@
+import base64
+import binascii
 import os
 import re
 import types
@@ -23,6 +25,12 @@ PLATFORM_TOKEN_ENV_VARS = (
 # OTARI_PORT). The GATEWAY_ prefix below is the legacy native pydantic prefix,
 # still honored for backward compatibility; OTARI_ wins when both are set.
 OTARI_ENV_PREFIX = "OTARI_"
+# Full structured config supplied through the environment, for PaaS platforms
+# (Railway, Render, Fly.io, Kubernetes) where mounting a config.yml is awkward.
+# These carry the entire YAML schema (providers, pricing, etc.), not just the
+# scalar fields reachable via OTARI_<FIELD>. Raw YAML wins when both are set.
+OTARI_CONFIG_YAML_ENV = "OTARI_CONFIG_YAML"
+OTARI_CONFIG_B64_ENV = "OTARI_CONFIG_B64"
 
 
 class _NonScalarField(Exception):
@@ -309,6 +317,46 @@ class GatewayConfig(BaseSettings):
             raise ValueError(msg)
 
 
+def _load_structured_env_config() -> dict[str, Any] | None:
+    """Parse a full YAML config supplied through the environment.
+
+    Reads ``OTARI_CONFIG_YAML`` (raw YAML) or ``OTARI_CONFIG_B64`` (base64-encoded
+    YAML). This lets PaaS deployments reach the entire config schema, including
+    the non-scalar ``providers`` and ``pricing`` fields, without mounting a
+    ``config.yml``. Raw YAML wins when both are set. ``${VAR}`` references are
+    resolved exactly as in a config file. Returns the parsed mapping, or ``None``
+    when neither variable is set or the content is empty. Raises ``ValueError``
+    with a clear message on invalid base64, invalid YAML, or a non-mapping top
+    level, so startup fails fast.
+    """
+    raw = os.getenv(OTARI_CONFIG_YAML_ENV)
+    source = OTARI_CONFIG_YAML_ENV
+    if not raw:
+        encoded = os.getenv(OTARI_CONFIG_B64_ENV)
+        if not encoded:
+            return None
+        source = OTARI_CONFIG_B64_ENV
+        try:
+            raw = base64.b64decode(encoded, validate=True).decode("utf-8")
+        except (binascii.Error, ValueError, UnicodeDecodeError) as exc:
+            msg = f"{OTARI_CONFIG_B64_ENV} is not valid base64-encoded UTF-8: {exc}"
+            raise ValueError(msg) from exc
+
+    try:
+        parsed = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        msg = f"{source} is not valid YAML: {exc}"
+        raise ValueError(msg) from exc
+
+    if parsed is None:
+        return None
+    if not isinstance(parsed, dict):
+        msg = f"{source} must contain a YAML mapping at the top level, got {type(parsed).__name__}."
+        raise ValueError(msg)
+
+    return _resolve_env_vars(parsed)
+
+
 def load_config(config_path: str | None = None) -> GatewayConfig:
     """Load configuration from file and environment variables.
 
@@ -328,6 +376,10 @@ def load_config(config_path: str | None = None) -> GatewayConfig:
             yaml_config = yaml.safe_load(f)
             if yaml_config:
                 config_dict = _resolve_env_vars(yaml_config)
+
+    structured_env_config = _load_structured_env_config()
+    if structured_env_config:
+        config_dict.update(structured_env_config)
 
     _apply_otari_env_overrides(config_dict)
     _apply_platform_env_overrides(config_dict)

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -336,8 +336,11 @@ def _load_structured_env_config() -> dict[str, Any] | None:
         if not encoded:
             return None
         source = OTARI_CONFIG_B64_ENV
+        # Strip whitespace first: the standard `base64` CLI and many env-var UIs
+        # wrap output at 76 columns, and validate=True would reject those newlines
+        # while still catching genuinely invalid characters.
         try:
-            raw = base64.b64decode(encoded, validate=True).decode("utf-8")
+            raw = base64.b64decode("".join(encoded.split()), validate=True).decode("utf-8")
         except (binascii.Error, ValueError, UnicodeDecodeError) as exc:
             msg = f"{OTARI_CONFIG_B64_ENV} is not valid base64-encoded UTF-8: {exc}"
             raise ValueError(msg) from exc

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -331,9 +331,9 @@ def _load_structured_env_config() -> dict[str, Any] | None:
     """
     raw = os.getenv(OTARI_CONFIG_YAML_ENV)
     source = OTARI_CONFIG_YAML_ENV
-    if not raw:
+    if not (raw and raw.strip()):
         encoded = os.getenv(OTARI_CONFIG_B64_ENV)
-        if not encoded:
+        if not (encoded and encoded.strip()):
             return None
         source = OTARI_CONFIG_B64_ENV
         # Strip whitespace first: the standard `base64` CLI and many env-var UIs

--- a/tests/integration/test_config_env_loading.py
+++ b/tests/integration/test_config_env_loading.py
@@ -251,16 +251,19 @@ def test_load_config_prefers_otari_ai_token_over_legacy_aliases(
     assert config.platform_token == "new-token"
 
 
-def _clear_structured_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def _isolate_structured_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Clear any structured-config vars and run from an empty dir so load_config()
+    # cannot pick up a developer's repo-root .env.
     monkeypatch.delenv("OTARI_CONFIG_YAML", raising=False)
     monkeypatch.delenv("OTARI_CONFIG_B64", raising=False)
+    monkeypatch.chdir(tmp_path)
 
 
 def test_load_config_reads_full_provider_pricing_from_env_yaml_without_file(
-    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # Env-only deploy: full provider + pricing config, no config.yml present.
-    _clear_structured_env(monkeypatch)
+    _isolate_structured_env(monkeypatch, tmp_path)
     monkeypatch.setenv(
         "OTARI_CONFIG_YAML",
         (
@@ -283,9 +286,8 @@ def test_load_config_reads_full_provider_pricing_from_env_yaml_without_file(
     assert config.pricing["openai:gpt-4o"].output_price_per_million == 10
 
 
-def test_load_config_structured_env_base64(monkeypatch: pytest.MonkeyPatch) -> None:
-
-    _clear_structured_env(monkeypatch)
+def test_load_config_structured_env_base64(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _isolate_structured_env(monkeypatch, tmp_path)
     yaml_text = "providers:\n  mistral:\n    api_key: b64-key\n"
     monkeypatch.setenv("OTARI_CONFIG_B64", base64.b64encode(yaml_text.encode("utf-8")).decode("ascii"))
 
@@ -294,9 +296,11 @@ def test_load_config_structured_env_base64(monkeypatch: pytest.MonkeyPatch) -> N
     assert config.providers["mistral"]["api_key"] == "b64-key"
 
 
-def test_load_config_structured_env_base64_tolerates_newline_wrapping(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_config_structured_env_base64_tolerates_newline_wrapping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     # The standard `base64` CLI and many env-var UIs wrap output at 76 columns.
-    _clear_structured_env(monkeypatch)
+    _isolate_structured_env(monkeypatch, tmp_path)
     yaml_text = (
         "providers:\n"
         "  openai:\n"
@@ -311,9 +315,10 @@ def test_load_config_structured_env_base64_tolerates_newline_wrapping(monkeypatc
     assert config.providers["openai"]["api_key"].startswith("a-fairly-long-key")
 
 
-def test_load_config_structured_env_prefers_raw_yaml_over_base64(monkeypatch: pytest.MonkeyPatch) -> None:
-
-    _clear_structured_env(monkeypatch)
+def test_load_config_structured_env_prefers_raw_yaml_over_base64(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolate_structured_env(monkeypatch, tmp_path)
     monkeypatch.setenv("OTARI_CONFIG_YAML", "providers:\n  openai:\n    api_key: from-raw\n")
     monkeypatch.setenv(
         "OTARI_CONFIG_B64",
@@ -325,11 +330,27 @@ def test_load_config_structured_env_prefers_raw_yaml_over_base64(monkeypatch: py
     assert config.providers["openai"]["api_key"] == "from-raw"
 
 
+def test_load_config_structured_env_whitespace_yaml_falls_back_to_base64(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A whitespace-only OTARI_CONFIG_YAML must not suppress the base64 fallback.
+    _isolate_structured_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("OTARI_CONFIG_YAML", "   \n  ")
+    monkeypatch.setenv(
+        "OTARI_CONFIG_B64",
+        base64.b64encode(b"providers:\n  openai:\n    api_key: from-b64\n").decode("ascii"),
+    )
+
+    config = load_config()
+
+    assert config.providers["openai"]["api_key"] == "from-b64"
+
+
 def test_load_config_precedence_file_then_structured_then_scalar(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # file < env-structured < scalar OTARI_<FIELD>
-    _clear_structured_env(monkeypatch)
+    _isolate_structured_env(monkeypatch, tmp_path)
     config_file = tmp_path / "gateway.yml"
     config_file.write_text(
         "budget_strategy: for_update\nproviders:\n  openai:\n    api_key: file-key\n",
@@ -350,8 +371,10 @@ def test_load_config_precedence_file_then_structured_then_scalar(
     assert config.providers["openai"]["api_key"] == "structured-key"
 
 
-def test_load_config_structured_env_resolves_var_references(monkeypatch: pytest.MonkeyPatch) -> None:
-    _clear_structured_env(monkeypatch)
+def test_load_config_structured_env_resolves_var_references(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolate_structured_env(monkeypatch, tmp_path)
     monkeypatch.setenv("MY_OPENAI_KEY", "resolved-secret")
     monkeypatch.setenv("OTARI_CONFIG_YAML", "providers:\n  openai:\n    api_key: ${MY_OPENAI_KEY}\n")
 
@@ -360,24 +383,30 @@ def test_load_config_structured_env_resolves_var_references(monkeypatch: pytest.
     assert config.providers["openai"]["api_key"] == "resolved-secret"
 
 
-def test_load_config_structured_env_invalid_yaml_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
-    _clear_structured_env(monkeypatch)
+def test_load_config_structured_env_invalid_yaml_fails_fast(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolate_structured_env(monkeypatch, tmp_path)
     monkeypatch.setenv("OTARI_CONFIG_YAML", "providers: [unclosed\n")
 
     with pytest.raises(ValueError, match="OTARI_CONFIG_YAML is not valid YAML"):
         load_config()
 
 
-def test_load_config_structured_env_invalid_base64_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
-    _clear_structured_env(monkeypatch)
+def test_load_config_structured_env_invalid_base64_fails_fast(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolate_structured_env(monkeypatch, tmp_path)
     monkeypatch.setenv("OTARI_CONFIG_B64", "not!valid!base64!")
 
     with pytest.raises(ValueError, match="OTARI_CONFIG_B64 is not valid base64"):
         load_config()
 
 
-def test_load_config_structured_env_non_mapping_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
-    _clear_structured_env(monkeypatch)
+def test_load_config_structured_env_non_mapping_fails_fast(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolate_structured_env(monkeypatch, tmp_path)
     monkeypatch.setenv("OTARI_CONFIG_YAML", "- just\n- a\n- list\n")
 
     with pytest.raises(ValueError, match="must contain a YAML mapping"):

--- a/tests/integration/test_config_env_loading.py
+++ b/tests/integration/test_config_env_loading.py
@@ -1,3 +1,4 @@
+import base64
 import os
 from pathlib import Path
 
@@ -248,3 +249,119 @@ def test_load_config_prefers_otari_ai_token_over_legacy_aliases(
 
     assert config.is_hybrid_mode
     assert config.platform_token == "new-token"
+
+
+def _clear_structured_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OTARI_CONFIG_YAML", raising=False)
+    monkeypatch.delenv("OTARI_CONFIG_B64", raising=False)
+
+
+def test_load_config_reads_full_provider_pricing_from_env_yaml_without_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Env-only deploy: full provider + pricing config, no config.yml present.
+    _clear_structured_env(monkeypatch)
+    monkeypatch.setenv(
+        "OTARI_CONFIG_YAML",
+        (
+            "providers:\n"
+            "  openai:\n"
+            "    api_key: env-openai-key\n"
+            "    api_base: https://proxy.example/v1\n"
+            "pricing:\n"
+            "  openai:gpt-4o:\n"
+            "    input_price_per_million: 2.5\n"
+            "    output_price_per_million: 10\n"
+        ),
+    )
+
+    config = load_config()
+
+    assert config.providers["openai"]["api_key"] == "env-openai-key"
+    assert config.providers["openai"]["api_base"] == "https://proxy.example/v1"
+    assert config.pricing["openai:gpt-4o"].input_price_per_million == 2.5
+    assert config.pricing["openai:gpt-4o"].output_price_per_million == 10
+
+
+def test_load_config_structured_env_base64(monkeypatch: pytest.MonkeyPatch) -> None:
+
+    _clear_structured_env(monkeypatch)
+    yaml_text = "providers:\n  mistral:\n    api_key: b64-key\n"
+    monkeypatch.setenv("OTARI_CONFIG_B64", base64.b64encode(yaml_text.encode("utf-8")).decode("ascii"))
+
+    config = load_config()
+
+    assert config.providers["mistral"]["api_key"] == "b64-key"
+
+
+def test_load_config_structured_env_prefers_raw_yaml_over_base64(monkeypatch: pytest.MonkeyPatch) -> None:
+
+    _clear_structured_env(monkeypatch)
+    monkeypatch.setenv("OTARI_CONFIG_YAML", "providers:\n  openai:\n    api_key: from-raw\n")
+    monkeypatch.setenv(
+        "OTARI_CONFIG_B64",
+        base64.b64encode(b"providers:\n  openai:\n    api_key: from-b64\n").decode("ascii"),
+    )
+
+    config = load_config()
+
+    assert config.providers["openai"]["api_key"] == "from-raw"
+
+
+def test_load_config_precedence_file_then_structured_then_scalar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # file < env-structured < scalar OTARI_<FIELD>
+    _clear_structured_env(monkeypatch)
+    config_file = tmp_path / "gateway.yml"
+    config_file.write_text(
+        "budget_strategy: for_update\nproviders:\n  openai:\n    api_key: file-key\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv(
+        "OTARI_CONFIG_YAML",
+        "budget_strategy: cas\nproviders:\n  openai:\n    api_key: structured-key\n",
+    )
+    monkeypatch.setenv("OTARI_BUDGET_STRATEGY", "disabled")
+
+    config = load_config(str(config_file))
+
+    # Scalar OTARI_<FIELD> wins over both file and env-structured.
+    assert config.budget_strategy == "disabled"
+    # env-structured providers win over the file's providers.
+    assert config.providers["openai"]["api_key"] == "structured-key"
+
+
+def test_load_config_structured_env_resolves_var_references(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_structured_env(monkeypatch)
+    monkeypatch.setenv("MY_OPENAI_KEY", "resolved-secret")
+    monkeypatch.setenv("OTARI_CONFIG_YAML", "providers:\n  openai:\n    api_key: ${MY_OPENAI_KEY}\n")
+
+    config = load_config()
+
+    assert config.providers["openai"]["api_key"] == "resolved-secret"
+
+
+def test_load_config_structured_env_invalid_yaml_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_structured_env(monkeypatch)
+    monkeypatch.setenv("OTARI_CONFIG_YAML", "providers: [unclosed\n")
+
+    with pytest.raises(ValueError, match="OTARI_CONFIG_YAML is not valid YAML"):
+        load_config()
+
+
+def test_load_config_structured_env_invalid_base64_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_structured_env(monkeypatch)
+    monkeypatch.setenv("OTARI_CONFIG_B64", "not!valid!base64!")
+
+    with pytest.raises(ValueError, match="OTARI_CONFIG_B64 is not valid base64"):
+        load_config()
+
+
+def test_load_config_structured_env_non_mapping_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_structured_env(monkeypatch)
+    monkeypatch.setenv("OTARI_CONFIG_YAML", "- just\n- a\n- list\n")
+
+    with pytest.raises(ValueError, match="must contain a YAML mapping"):
+        load_config()

--- a/tests/integration/test_config_env_loading.py
+++ b/tests/integration/test_config_env_loading.py
@@ -294,6 +294,23 @@ def test_load_config_structured_env_base64(monkeypatch: pytest.MonkeyPatch) -> N
     assert config.providers["mistral"]["api_key"] == "b64-key"
 
 
+def test_load_config_structured_env_base64_tolerates_newline_wrapping(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The standard `base64` CLI and many env-var UIs wrap output at 76 columns.
+    _clear_structured_env(monkeypatch)
+    yaml_text = (
+        "providers:\n"
+        "  openai:\n"
+        "    api_key: a-fairly-long-key-value-to-force-base64-line-wrapping-aaaaaaaaaaaaaa\n"
+    )
+    wrapped = base64.encodebytes(yaml_text.encode("utf-8")).decode("ascii")
+    assert "\n" in wrapped.strip()
+    monkeypatch.setenv("OTARI_CONFIG_B64", wrapped)
+
+    config = load_config()
+
+    assert config.providers["openai"]["api_key"].startswith("a-fairly-long-key")
+
+
 def test_load_config_structured_env_prefers_raw_yaml_over_base64(monkeypatch: pytest.MonkeyPatch) -> None:
 
     _clear_structured_env(monkeypatch)


### PR DESCRIPTION
## Description

Otari already layers `OTARI_<FIELD>` overrides on every scalar config field, but `providers` and `pricing` are dict fields that `_coerce_scalar_env` rejects, so they could only be set from a mounted `config.yml`. That makes PaaS deploys (Railway, Render, Fly.io, Kubernetes) awkward: reaching custom `api_base`, `client_args`, Vertex settings, or per-model pricing meant baking a custom image or adding a wrapper entrypoint, undercutting the "pull the published image and set env vars" story.

This adds two env vars that carry the entire YAML schema, reusing the existing config-file path and pydantic validation (the issue's recommended option 1):

- `OTARI_CONFIG_YAML`: the full config as raw YAML.
- `OTARI_CONFIG_B64`: the same YAML base64-encoded, for env-var UIs that mangle multiline values.

`${VAR}` references resolve exactly as in a config file. Precedence, lowest to highest: config file, env-structured config (raw YAML wins over base64), then scalar `OTARI_<FIELD>` overrides. Env-structured keys replace the matching top-level keys from the file. Invalid base64, invalid YAML, or a non-mapping top level fail fast at startup with a clear error.

Option 2 from the issue (`OTARI_PROVIDERS` / `OTARI_PRICING` JSON) was intentionally not implemented: option 1 satisfies every acceptance criterion with less surface area.

### Acceptance criteria

- [x] Runs with full provider + pricing config and no `config.yml`, configured entirely via env.
- [x] Precedence documented and tested (file < env-structured < scalar `OTARI_<FIELD>`).
- [x] Invalid YAML/base64 fails fast with a clear startup error.
- [x] Docs note the PaaS use case and the `require_pricing=true` interaction.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #208

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

No API contract changed (config loading only); OpenAPI spec confirmed up to date. New tests live in `tests/integration/test_config_env_loading.py`.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:** Drafted via the fix-github-issue workflow; reasoning and decisions are @njbrake's.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Added support for loading full gateway configuration from environment variables, including structured provider and pricing settings.
- Documented the new env-based configuration flow for PaaS deployments and clarified how pricing requirements behave when pricing is not provided.
- Added integration coverage for raw YAML, base64 YAML, config precedence, env interpolation, and fast-fail validation for invalid structured input.

## Technical notes
- New env vars: `OTARI_CONFIG_YAML` and `OTARI_CONFIG_B64`.
- Precedence is now: config file → structured env config → scalar `OTARI_<FIELD>` overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->