### PR TITLE
docs(models): document the HuggingFace pinned-backend selector grammar

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -15,6 +15,19 @@ vertexai:gemini-2.0-flash
 
 The `provider` prefix tells Otari which backend to route to. The `model_name` is passed directly to that provider's API.
 
+### Pinning a HuggingFace inference backend
+
+HuggingFace Inference Providers is a router: the same model id (for example `zai-org/GLM-4.6`) can be served by several backends (Together, Novita, and others), and in the default "auto" mode the backend, and therefore the price, is chosen at request time. To route (and price) deterministically, pin a backend with a `:<backend>` suffix on the model id, which the HuggingFace router honors server side:
+
+```
+huggingface:zai-org/GLM-4.6:together
+huggingface:zai-org/GLM-4.6:novita
+```
+
+The pinned-selector grammar is `huggingface:<model>:<backend>`. Otari splits the provider off the first `:`, so everything after it (`<model>:<backend>`) is forwarded as the model id and the `:<backend>` suffix reaches the router unchanged. The router also accepts policy suffixes such as `:cheapest`, `:fastest`, `:preferred`, and `:auto`.
+
+This grammar is the contract consumers build against. The otari.ai platform's pricing UI, for instance, offers each priceable backend as a pinned `huggingface:<model>:<backend>` selector, because a pinned selector resolves to a single backend, which is what makes a HuggingFace model priceable (auto mode cannot be priced from the model id alone).
+
 ## Supported providers
 
 Otari depends on `any-llm-sdk[all]`. Provider support can change as the SDK evolves.
@@ -36,7 +49,7 @@ Use this list as a quick reference for common providers supported by the current
 | Fireworks | `fireworks` | `fireworks:llama-v3-70b` | |
 | Gemini | `gemini` | `gemini:gemini-2.0-flash` | |
 | Groq | `groq` | `groq:llama3-70b-8192` | |
-| HuggingFace | `huggingface` | `huggingface:meta-llama/Llama-3-70b` | |
+| HuggingFace | `huggingface` | `huggingface:meta-llama/Llama-3-70b` | Pin a backend with `:<backend>` (see [Pinning a HuggingFace inference backend](#pinning-a-huggingface-inference-backend)) |
 | Inception | `inception` | `inception:mercury-coder-small` | |
 | Llama.cpp | `llamacpp` | `llamacpp:default` | Local server |
 | Llamafile | `llamafile` | `llamafile:default` | Local server |

--- a/docs/models.md
+++ b/docs/models.md
@@ -19,7 +19,7 @@ The `provider` prefix tells Otari which backend to route to. The `model_name` is
 
 HuggingFace Inference Providers is a router: the same model id (for example `zai-org/GLM-4.6`) can be served by several backends (Together, Novita, and others), and in the default "auto" mode the backend, and therefore the price, is chosen at request time. To route (and price) deterministically, pin a backend with a `:<backend>` suffix on the model id, which the HuggingFace router honors server side:
 
-```
+```text
 huggingface:zai-org/GLM-4.6:together
 huggingface:zai-org/GLM-4.6:novita
 ```


### PR DESCRIPTION
## Description

Documents the HuggingFace **pinned-backend selector grammar** in the model reference: `huggingface:<model>:<backend>` (the `:<backend>` suffix the HuggingFace router honors server-side, plus the `:cheapest`/`:fastest`/`:preferred`/`:auto` policy suffixes).

HuggingFace "auto" routing can't be priced from the model id alone, so a pinned backend is what makes a HuggingFace model deterministic and priceable. Downstream consumers (the otari.ai platform's pricing UI builds these pinned selectors) currently hardcode this format with no documented contract; this gives them a canonical reference. Linked from the HuggingFace provider row.

Surfaced during review of the platform's HuggingFace pinned-combos work (mozilla-ai/otari-ai#1174), where the grammar was being encoded independently in several places.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Relates to mozilla-ai/otari-ai#1158

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change. (Docs-only; no tests.)
- [x] I ran the Definition of Done checks locally. (Docs-only change.)
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec. (No API change.)

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code (Claude Opus 4.8)

**Any additional AI details you'd like to share:**

Drafted with Claude Code while addressing the review on the related platform PR.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated `docs/models.md` to document how to “pin” a deterministic HuggingFace backend so routing is consistent and models can be priced reliably. Added a clear, canonical selector format (`huggingface:<model>:<backend>`) including the supported backend-policy suffix options, and noted the pinning hint directly in the HuggingFace row of the “Supported providers” table for easier discovery by downstream consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->