### PR TITLE
fix(pricing): warn and skip instead of crashing for unlisted providers

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,6 +194,8 @@ pricing:
 
 Config pricing sets initial values. Pricing set via the `/v1/pricing` API takes precedence.
 
+A pricing entry whose provider is not listed in the `providers` section is skipped at startup with a warning, not treated as a fatal error: the provider may still be reachable through environment credentials (any-llm reads keys like `OPENAI_API_KEY`), so a pricing/provider mismatch should not abort the gateway. To have such an entry take effect, add the provider to the `providers` section.
+
 ### Default pricing
 
 Default pricing is **off by default**. When you enable it (`default_pricing: true` in `config.yml`, or

--- a/src/gateway/services/pricing_init_service.py
+++ b/src/gateway/services/pricing_init_service.py
@@ -55,11 +55,15 @@ async def initialize_pricing_from_config(config: GatewayConfig, db: AsyncSession
         model_key = f"{provider.value}:{model_name}"
 
         if provider.value not in config.providers:
-            msg = (
-                f"Cannot set pricing for model '{model_key}': "
-                f"provider '{provider}' is not configured in the providers section"
+            logger.warning(
+                "Skipping pricing for '%s': provider '%s' is not listed in the providers section. "
+                "The provider may still work if its credentials come from the environment, but its "
+                "pricing is ignored. Add '%s' to the providers section, or remove this pricing entry.",
+                model_key,
+                provider.value,
+                provider.value,
             )
-            raise ValueError(msg)
+            continue
 
         input_price = pricing_config.input_price_per_million
         output_price = pricing_config.output_price_per_million

--- a/tests/integration/test_pricing_config.py
+++ b/tests/integration/test_pricing_config.py
@@ -1,5 +1,6 @@
 """Tests for pricing configuration from config file."""
 
+import logging
 from datetime import UTC, datetime
 
 import pytest
@@ -132,9 +133,16 @@ def test_database_pricing_takes_precedence(postgres_url: str, test_db: Session) 
         dispose_override()
 
 
-def test_pricing_validation_requires_configured_provider(postgres_url: str) -> None:
-    """Test that pricing initialization fails if provider is not configured."""
-    # Config with pricing for a provider that's not in providers list
+def test_pricing_for_unlisted_provider_is_skipped_not_fatal(
+    postgres_url: str,
+    test_db: Session,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Pricing for a provider absent from `providers:` is skipped with a warning, not a crash.
+
+    The provider may still be reachable via environment credentials, so a pricing/provider
+    mismatch must not abort startup (see issue #191).
+    """
     config = GatewayConfig(
         database_url=postgres_url,
         master_key="test-master-key",
@@ -142,19 +150,47 @@ def test_pricing_validation_requires_configured_provider(postgres_url: str) -> N
         port=8000,
         providers={"openai": {"api_key": "test-key"}},
         pricing={
+            # Unlisted provider: should be skipped.
             "anthropic:claude-3-opus": PricingConfig(
                 input_price_per_million=15.0,
                 output_price_per_million=75.0,
             ),
+            # Listed provider: should still be loaded.
+            "openai:gpt-4": PricingConfig(
+                input_price_per_million=30.0,
+                output_price_per_million=60.0,
+            ),
         },
     )
 
-    # Should raise ValueError when trying to initialize pricing
     app = create_app(config)
+    override_get_db, dispose_override = build_async_session_override(postgres_url)
+    app.dependency_overrides[get_db] = override_get_db
 
-    with pytest.raises(ValueError, match="provider 'anthropic' is not configured"):
-        with TestClient(app):
-            pass
+    # The gateway logger does not propagate to the root logger, so caplog's
+    # root handler never sees its records; attach caplog's handler directly.
+    gateway_logger = logging.getLogger("gateway")
+    gateway_logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.WARNING, logger="gateway"):
+            with TestClient(app):
+                # Startup succeeded: the unlisted provider's pricing was skipped, not fatal.
+                skipped = test_db.query(ModelPricing).filter(
+                    ModelPricing.model_key == "anthropic:claude-3-opus"
+                ).first()
+                assert skipped is None, "Pricing for an unlisted provider should be skipped"
+
+                # The listed provider's pricing is still loaded.
+                loaded = test_db.query(ModelPricing).filter(ModelPricing.model_key == "openai:gpt-4").first()
+                assert loaded is not None, "Pricing for a listed provider should still be loaded"
+                assert loaded.input_price_per_million == 30.0
+    finally:
+        gateway_logger.removeHandler(caplog.handler)
+        dispose_override()
+
+    assert any(
+        "Skipping pricing" in record.message and "anthropic" in record.message for record in caplog.records
+    ), "Expected a warning that anthropic pricing was skipped"
 
 
 def test_pricing_loaded_from_config_normalizes_legacy_slash_format(postgres_url: str, test_db: Session) -> None:


### PR DESCRIPTION
## Description

`initialize_pricing_from_config` raised a fatal `ValueError` when a model in the `pricing:` block had a provider not enumerated in `providers:`, crash-looping the gateway at startup (heavy under `restart: unless-stopped`). The provider is often still reachable via environment credentials (any-llm reads keys like `OPENAI_API_KEY`), so a pricing/provider mismatch should not take the gateway down.

This implements option 2 from the issue (warn and skip): log a warning and skip the offending entry instead of aborting. Other pricing entries still load, and the message tells operators how to fix it (add the provider to `providers:`, or remove the entry). The typo-catching signal is preserved without the crash.

New warning:

> Skipping pricing for 'anthropic:claude-3-opus': provider 'anthropic' is not listed in the providers section. The provider may still work if its credentials come from the environment, but its pricing is ignored. Add 'anthropic' to the providers section, or remove this pricing entry.

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #191

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). (No API contract change.)

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 4.8 via Claude Code.

**Any additional AI details you'd like to share:**

Implemented by Claude Code through back-and-forth with @njbrake; the decision (option 2, warn and skip) is his.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)