### PR TITLE
feat(client): generate Postman collection from OpenAPI spec

### DIFF
--- a/.github/workflows/otari-tests.yml
+++ b/.github/workflows/otari-tests.yml
@@ -76,3 +76,6 @@ jobs:
 
     - name: Verify OpenAPI spec is up to date
       run: make openapi-check
+
+    - name: Verify Postman collection is up to date
+      run: make postman-check

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev test test-unit test-integration lint typecheck openapi-check changelog
+.PHONY: help dev test test-unit test-integration lint typecheck openapi-check postman postman-check changelog
 
 help:
 	@printf "Available targets:\n"
@@ -9,6 +9,8 @@ help:
 	@printf "  lint Run Ruff lint checks\n"
 	@printf "  typecheck Run mypy type checks\n"
 	@printf "  openapi-check Verify the OpenAPI spec is up to date\n"
+	@printf "  postman Regenerate the Postman collection from the OpenAPI spec\n"
+	@printf "  postman-check Verify the Postman collection is up to date\n"
 	@printf "  changelog Preview the generated CHANGELOG.md locally (git-cliff)\n"
 
 dev:
@@ -34,6 +36,12 @@ typecheck:
 
 openapi-check:
 	uv run python scripts/generate_openapi.py --check
+
+postman:
+	uv run python scripts/generate_postman.py
+
+postman-check:
+	uv run python scripts/generate_postman.py --check
 
 # Local preview only. CHANGELOG.md is generated at release time by the
 # otari-release / otari-tag-release workflows; this target is for eyeballing

--- a/README.md
+++ b/README.md
@@ -326,6 +326,17 @@ Embeddings, moderations, rerank, images, audio, batches, and models round out
 the OpenAI-compatible surface. See the full schema in
 `docs/public/openapi.json`.
 
+### Postman collection
+
+For poking at a running server (managing keys, users, budgets, and pricing, or
+firing off chat/messages/responses requests) without a separate client, import
+`docs/public/otari.postman_collection.json` into Postman. Set the `baseUrl` and
+`otariKey` collection variables; the `Otari-Key` auth header is sent on every
+request. The collection is generated from the OpenAPI spec
+(`scripts/generate_postman.py`) and kept in sync in CI, so it tracks the API as
+it changes. The built-in Swagger UI at `http://localhost:8000/docs` is the
+zero-install alternative.
+
 ## Useful CLI commands
 
 ```bash
@@ -333,6 +344,7 @@ uv run otari init-db --config config.yml
 uv run otari migrate --config config.yml
 uv run otari migrate --config config.yml --revision <rev>
 uv run python scripts/generate_openapi.py --check
+uv run python scripts/generate_postman.py --check
 ```
 
 ## Documentation

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -1,0 +1,1595 @@
+{
+  "auth": {
+    "apikey": [
+      {
+        "key": "key",
+        "type": "string",
+        "value": "Otari-Key"
+      },
+      {
+        "key": "value",
+        "type": "string",
+        "value": "{{otariKey}}"
+      },
+      {
+        "key": "in",
+        "type": "string",
+        "value": "header"
+      }
+    ],
+    "type": "apikey"
+  },
+  "info": {
+    "description": "otari management + inference collection, generated from the OpenAPI spec by scripts/generate_postman.py. Stopgap client for driving a running Otari server until the web UI lands.\n\nSet the `baseUrl` and `otariKey` collection variables (or override them with a Postman environment). Auth is sent as the `Otari-Key` header on every request via collection-level auth.",
+    "name": "otari API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "item": [
+        {
+          "name": "Health Check",
+          "request": {
+            "description": "General health check endpoint.\n\nReturns basic health status. For infrastructure monitoring,\nuse /health/readiness or /health/liveness instead.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "health"
+              ],
+              "raw": "{{baseUrl}}/health"
+            }
+          }
+        },
+        {
+          "name": "Health Liveness",
+          "request": {
+            "description": "Liveness probe endpoint.\n\nSimple check to verify the process is alive and responding.\nUsed by Kubernetes/container orchestrators for liveness probes.\n\nReturns:\n    Plain text \"I'm alive!\" message",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "health",
+                "liveness"
+              ],
+              "raw": "{{baseUrl}}/health/liveness"
+            }
+          }
+        },
+        {
+          "name": "Health Readiness",
+          "request": {
+            "description": "Readiness probe endpoint.\n\nChecks if the gateway is ready to serve requests by validating:\n- Database connectivity\n- Service availability\n\nUsed by Kubernetes/container orchestrators for readiness probes.\nReturns HTTP 503 if any dependency is unavailable.\n\nReturns:\n    dict: Status object with health details\n\nRaises:\n    HTTPException: 503 if service is not ready",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "health",
+                "readiness"
+              ],
+              "raw": "{{baseUrl}}/health/readiness"
+            }
+          }
+        }
+      ],
+      "name": "health"
+    },
+    {
+      "item": [
+        {
+          "name": "Create Speech",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"model\": \"string\",\n  \"input\": \"string\",\n  \"voice\": \"string\"\n}"
+            },
+            "description": "OpenAI-compatible audio speech (TTS) endpoint.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "audio",
+                "speech"
+              ],
+              "raw": "{{baseUrl}}/v1/audio/speech"
+            }
+          }
+        },
+        {
+          "name": "Create Transcription",
+          "request": {
+            "description": "OpenAI-compatible audio transcription endpoint.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
+            "header": [],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "audio",
+                "transcriptions"
+              ],
+              "raw": "{{baseUrl}}/v1/audio/transcriptions"
+            }
+          }
+        }
+      ],
+      "name": "audio"
+    },
+    {
+      "item": [
+        {
+          "name": "List Batches",
+          "request": {
+            "description": "List batches for a provider.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "batches"
+              ],
+              "query": [
+                {
+                  "description": "",
+                  "disabled": false,
+                  "key": "provider",
+                  "value": ""
+                },
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "after",
+                  "value": ""
+                },
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "limit",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/batches?provider=&after=&limit="
+            }
+          }
+        },
+        {
+          "name": "Create Batch",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"model\": \"string\",\n  \"requests\": [\n    {\n      \"custom_id\": \"string\",\n      \"body\": {}\n    }\n  ]\n}"
+            },
+            "description": "Create a batch of LLM requests for asynchronous processing.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "batches"
+              ],
+              "raw": "{{baseUrl}}/v1/batches"
+            }
+          }
+        },
+        {
+          "name": "Retrieve Batch",
+          "request": {
+            "description": "Retrieve the status of a batch.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "batches",
+                ":batch_id"
+              ],
+              "query": [
+                {
+                  "description": "",
+                  "disabled": false,
+                  "key": "provider",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/batches/:batch_id?provider=",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "batch_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Cancel Batch",
+          "request": {
+            "description": "Cancel a batch.",
+            "header": [],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "batches",
+                ":batch_id",
+                "cancel"
+              ],
+              "query": [
+                {
+                  "description": "",
+                  "disabled": false,
+                  "key": "provider",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/batches/:batch_id/cancel?provider=",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "batch_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Retrieve Batch Results",
+          "request": {
+            "description": "Retrieve the results of a completed batch.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "batches",
+                ":batch_id",
+                "results"
+              ],
+              "query": [
+                {
+                  "description": "",
+                  "disabled": false,
+                  "key": "provider",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/batches/:batch_id/results?provider=",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "batch_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "name": "batches"
+    },
+    {
+      "item": [
+        {
+          "name": "List Budgets",
+          "request": {
+            "description": "List all budgets with pagination.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "budgets"
+              ],
+              "query": [
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "skip",
+                  "value": ""
+                },
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "limit",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/budgets?skip=&limit="
+            }
+          }
+        },
+        {
+          "name": "Create Budget",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"budget_duration_sec\": 0,\n  \"max_budget\": 0\n}"
+            },
+            "description": "Create a new budget.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "budgets"
+              ],
+              "raw": "{{baseUrl}}/v1/budgets"
+            }
+          }
+        },
+        {
+          "name": "Get Budget",
+          "request": {
+            "description": "Get details of a specific budget.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "budgets",
+                ":budget_id"
+              ],
+              "raw": "{{baseUrl}}/v1/budgets/:budget_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "budget_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Update Budget",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"budget_duration_sec\": 0,\n  \"max_budget\": 0\n}"
+            },
+            "description": "Update a budget.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "PATCH",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "budgets",
+                ":budget_id"
+              ],
+              "raw": "{{baseUrl}}/v1/budgets/:budget_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "budget_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Budget",
+          "request": {
+            "description": "Delete a budget.",
+            "header": [],
+            "method": "DELETE",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "budgets",
+                ":budget_id"
+              ],
+              "raw": "{{baseUrl}}/v1/budgets/:budget_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "budget_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "name": "budgets"
+    },
+    {
+      "item": [
+        {
+          "name": "Chat Completions",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"model\": \"openai:gpt-4o-mini\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Hello from Otari!\"\n    }\n  ]\n}"
+            },
+            "description": "OpenAI-compatible chat completions endpoint.\n\nSupports both streaming and non-streaming responses.\nHandles reasoning content from otari providers.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ],
+              "raw": "{{baseUrl}}/v1/chat/completions"
+            }
+          }
+        }
+      ],
+      "name": "chat"
+    },
+    {
+      "item": [
+        {
+          "name": "Create Embedding",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"model\": \"string\",\n  \"input\": \"string\"\n}"
+            },
+            "description": "OpenAI-compatible embeddings endpoint.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "embeddings"
+              ],
+              "raw": "{{baseUrl}}/v1/embeddings"
+            }
+          }
+        }
+      ],
+      "name": "embeddings"
+    },
+    {
+      "item": [
+        {
+          "name": "List Files",
+          "request": {
+            "description": "List the authenticated user's uploaded files.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "files"
+              ],
+              "query": [
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "user",
+                  "value": ""
+                },
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "purpose",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/files?user=&purpose="
+            }
+          }
+        },
+        {
+          "name": "Create File",
+          "request": {
+            "description": "OpenAI-compatible file upload endpoint.",
+            "header": [],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "files"
+              ],
+              "raw": "{{baseUrl}}/v1/files"
+            }
+          }
+        },
+        {
+          "name": "Get File",
+          "request": {
+            "description": "Retrieve metadata for a single file.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "files",
+                ":file_id"
+              ],
+              "query": [
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "user",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/files/:file_id?user=",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "file_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete File",
+          "request": {
+            "description": "Soft-delete a file's metadata and remove its bytes from the backend.",
+            "header": [],
+            "method": "DELETE",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "files",
+                ":file_id"
+              ],
+              "query": [
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "user",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/files/:file_id?user=",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "file_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Get File Content",
+          "request": {
+            "description": "Download the raw bytes of a file.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "files",
+                ":file_id",
+                "content"
+              ],
+              "query": [
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "user",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/files/:file_id/content?user=",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "file_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "name": "files"
+    },
+    {
+      "item": [
+        {
+          "name": "Create Image",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"model\": \"string\",\n  \"prompt\": \"string\"\n}"
+            },
+            "description": "OpenAI-compatible image generation endpoint.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "images",
+                "generations"
+              ],
+              "raw": "{{baseUrl}}/v1/images/generations"
+            }
+          }
+        }
+      ],
+      "name": "images"
+    },
+    {
+      "item": [
+        {
+          "name": "List Keys",
+          "request": {
+            "description": "List all API keys.\n\nRequires master key authentication.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "keys"
+              ],
+              "query": [
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "skip",
+                  "value": ""
+                },
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "limit",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/keys?skip=&limit="
+            }
+          }
+        },
+        {
+          "name": "Create Key",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"expires_at\": \"2024-01-01T00:00:00Z\",\n  \"key_name\": \"string\",\n  \"metadata\": {},\n  \"user_id\": \"string\"\n}"
+            },
+            "description": "Create a new API key.\n\nRequires master key authentication.\n\nIf user_id is provided, the key will be associated with that user (creates user if it doesn't exist).\nIf user_id is not provided, a new user will be created automatically and the key will be associated with it.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "keys"
+              ],
+              "raw": "{{baseUrl}}/v1/keys"
+            }
+          }
+        },
+        {
+          "name": "Get Key",
+          "request": {
+            "description": "Get details of a specific API key.\n\nRequires master key authentication.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "keys",
+                ":key_id"
+              ],
+              "raw": "{{baseUrl}}/v1/keys/:key_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "key_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Update Key",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"expires_at\": \"2024-01-01T00:00:00Z\",\n  \"is_active\": false,\n  \"key_name\": \"string\",\n  \"metadata\": {}\n}"
+            },
+            "description": "Update an API key.\n\nRequires master key authentication.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "PATCH",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "keys",
+                ":key_id"
+              ],
+              "raw": "{{baseUrl}}/v1/keys/:key_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "key_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Key",
+          "request": {
+            "description": "Delete (revoke) an API key.\n\nRequires master key authentication.",
+            "header": [],
+            "method": "DELETE",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "keys",
+                ":key_id"
+              ],
+              "raw": "{{baseUrl}}/v1/keys/:key_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "key_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "name": "keys"
+    },
+    {
+      "item": [
+        {
+          "name": "Create Message",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"model\": \"anthropic:claude-haiku-4-5\",\n  \"max_tokens\": 1024,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Hello from Otari!\"\n    }\n  ]\n}"
+            },
+            "description": "Anthropic Messages API-compatible endpoint.\n\nSupports MCP tool-use loops, sandboxed code execution, and SearXNG\nweb_search in both standalone mode and hybrid mode. Hybrid-mode\nrequests resolve credentials via the platform service and (for\nnon-tool-loop requests) get multi-attempt fallback across the resolved\nroute. Tool-loop requests collapse to a single attempt \u2014 once\n``on_first_response`` lock-in plumbing lands across the codebase, a\nfollow-up will enable pre-lock-in fallback for tool-loop requests too.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "messages"
+              ],
+              "raw": "{{baseUrl}}/v1/messages"
+            }
+          }
+        },
+        {
+          "name": "Count Message Tokens",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"model\": \"string\",\n  \"messages\": [\n    {}\n  ]\n}"
+            },
+            "description": "Anthropic ``/v1/messages/count_tokens``-compatible endpoint.\n\nReturns ``{\"input_tokens\": N}`` without contacting an upstream provider:\ncounting is local, so there is no budget reservation, pricing, or usage\nlogging. Authentication mirrors :func:`create_message` \u2014 hybrid mode\nresolves the caller's token against the platform, standalone mode validates\nthe API key \u2014 so the endpoint is not an open token-counting oracle.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "messages",
+                "count_tokens"
+              ],
+              "raw": "{{baseUrl}}/v1/messages/count_tokens"
+            }
+          }
+        }
+      ],
+      "name": "messages"
+    },
+    {
+      "item": [
+        {
+          "name": "List Models",
+          "request": {
+            "description": "List all available models.\n\nReturns models auto-discovered from configured providers, enriched with\npricing data from the model_pricing table when available. Models that only\nexist in the pricing table are also included for backward compatibility.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "models"
+              ],
+              "query": [
+                {
+                  "description": "Filter models by provider name",
+                  "disabled": true,
+                  "key": "provider",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/models?provider="
+            }
+          }
+        },
+        {
+          "name": "Get Model",
+          "request": {
+            "description": "Get details for a specific model.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "models",
+                ":model_id"
+              ],
+              "raw": "{{baseUrl}}/v1/models/:model_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "model_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "name": "models"
+    },
+    {
+      "item": [
+        {
+          "name": "Create Moderation",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"model\": \"string\",\n  \"input\": \"string\"\n}"
+            },
+            "description": "OpenAI-compatible moderations endpoint.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "moderations"
+              ],
+              "query": [
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "include_raw",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/moderations?include_raw="
+            }
+          }
+        }
+      ],
+      "name": "moderations"
+    },
+    {
+      "item": [
+        {
+          "name": "List Pricing",
+          "request": {
+            "description": "List all model pricing.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "pricing"
+              ],
+              "query": [
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "skip",
+                  "value": ""
+                },
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "limit",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/pricing?skip=&limit="
+            }
+          }
+        },
+        {
+          "name": "Set Pricing",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"model_key\": \"string\",\n  \"input_price_per_million\": 0,\n  \"output_price_per_million\": 0\n}"
+            },
+            "description": "Set or update pricing for a model.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "pricing"
+              ],
+              "raw": "{{baseUrl}}/v1/pricing"
+            }
+          }
+        },
+        {
+          "name": "Get Pricing",
+          "request": {
+            "description": "Get pricing for a specific model as of a timestamp.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "pricing",
+                ":model_key"
+              ],
+              "query": [
+                {
+                  "description": "ISO datetime for effective lookup",
+                  "disabled": true,
+                  "key": "as_of",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/pricing/:model_key?as_of=",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "model_key",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Pricing",
+          "request": {
+            "description": "Delete pricing entries for a model.",
+            "header": [],
+            "method": "DELETE",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "pricing",
+                ":model_key"
+              ],
+              "query": [
+                {
+                  "description": "ISO datetime identifying a specific pricing row to delete",
+                  "disabled": true,
+                  "key": "effective_at",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/pricing/:model_key?effective_at=",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "model_key",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Get Pricing History",
+          "request": {
+            "description": "Return the full pricing history for a model.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "pricing",
+                ":model_key",
+                "history"
+              ],
+              "raw": "{{baseUrl}}/v1/pricing/:model_key/history",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "model_key",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "name": "pricing"
+    },
+    {
+      "item": [
+        {
+          "name": "Create Rerank",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"model\": \"string\",\n  \"query\": \"string\",\n  \"documents\": [\n    \"string\"\n  ]\n}"
+            },
+            "description": "Rerank documents by relevance to a query.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "rerank"
+              ],
+              "raw": "{{baseUrl}}/v1/rerank"
+            }
+          }
+        }
+      ],
+      "name": "rerank"
+    },
+    {
+      "item": [
+        {
+          "name": "Create Response",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"model\": \"openai:gpt-4o-mini\",\n  \"input\": \"Hello from Otari!\"\n}"
+            },
+            "description": "OpenAI-compatible Responses endpoint.\n\nSupports MCP tool-use loops, sandboxed code execution, and SearXNG\nweb_search in both standalone mode and hybrid mode. Hybrid-mode\nrequests resolve credentials via the platform service and (for\nnon-tool-loop requests) get multi-attempt fallback across the resolved\nroute. Tool-loop requests collapse to a single attempt \u2014 once\n``on_first_response`` lock-in plumbing lands across the codebase, a\nfollow-up will enable pre-lock-in fallback for tool-loop requests too.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ],
+              "raw": "{{baseUrl}}/v1/responses"
+            }
+          }
+        }
+      ],
+      "name": "responses"
+    },
+    {
+      "item": [
+        {
+          "name": "List Usage",
+          "request": {
+            "description": "List usage logs ordered by timestamp (most recent first).\n\nSupports optional filters for time range and user. Paginated via skip/limit.\nTimestamps accept either ISO 8601 strings or Unix epoch seconds (numeric).",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "usage"
+              ],
+              "query": [
+                {
+                  "description": "Return logs with timestamp >= start_date (ISO 8601 or Unix epoch seconds)",
+                  "disabled": true,
+                  "key": "start_date",
+                  "value": ""
+                },
+                {
+                  "description": "Return logs with timestamp < end_date (ISO 8601 or Unix epoch seconds)",
+                  "disabled": true,
+                  "key": "end_date",
+                  "value": ""
+                },
+                {
+                  "description": "Filter to a single user",
+                  "disabled": true,
+                  "key": "user_id",
+                  "value": ""
+                },
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "skip",
+                  "value": ""
+                },
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "limit",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/usage?start_date=&end_date=&user_id=&skip=&limit="
+            }
+          }
+        }
+      ],
+      "name": "usage"
+    },
+    {
+      "item": [
+        {
+          "name": "List Users",
+          "request": {
+            "description": "List all users with pagination.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users"
+              ],
+              "query": [
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "skip",
+                  "value": ""
+                },
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "limit",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/users?skip=&limit="
+            }
+          }
+        },
+        {
+          "name": "Create User",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"user_id\": \"string\"\n}"
+            },
+            "description": "Create a new user.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users"
+              ],
+              "raw": "{{baseUrl}}/v1/users"
+            }
+          }
+        },
+        {
+          "name": "Get User",
+          "request": {
+            "description": "Get details of a specific user.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                ":user_id"
+              ],
+              "raw": "{{baseUrl}}/v1/users/:user_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "user_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Update User",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"alias\": \"string\",\n  \"blocked\": false,\n  \"budget_id\": \"string\",\n  \"metadata\": {}\n}"
+            },
+            "description": "Update a user.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "PATCH",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                ":user_id"
+              ],
+              "raw": "{{baseUrl}}/v1/users/:user_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "user_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete User",
+          "request": {
+            "description": "Delete a user.",
+            "header": [],
+            "method": "DELETE",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                ":user_id"
+              ],
+              "raw": "{{baseUrl}}/v1/users/:user_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "user_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Get User Usage",
+          "request": {
+            "description": "Get usage history for a specific user.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "users",
+                ":user_id",
+                "usage"
+              ],
+              "query": [
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "skip",
+                  "value": ""
+                },
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "limit",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/users/:user_id/usage?skip=&limit=",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "user_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "name": "users"
+    }
+  ],
+  "variable": [
+    {
+      "key": "baseUrl",
+      "type": "string",
+      "value": "http://localhost:8000"
+    },
+    {
+      "key": "otariKey",
+      "type": "string",
+      "value": ""
+    }
+  ]
+}

--- a/scripts/generate_postman.py
+++ b/scripts/generate_postman.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""Generate a Postman collection for Otari from the OpenAPI spec.
+
+This is a stopgap client for managing a running Otari server (keys, users,
+budgets, usage, pricing) and exercising the inference endpoints, until the
+streamlined web UI lands. The collection is derived entirely from
+``docs/public/openapi.json`` so it stays in sync with the API surface.
+
+Two modes:
+- Generate mode (default): writes the collection JSON.
+- Check mode (--check): regenerates and compares against the existing file,
+  exiting non-zero if they differ (for CI/CD, mirroring generate_openapi.py).
+
+The OpenAPI spec is the source of truth here; regenerate it first with
+``python scripts/generate_openapi.py`` if the API changed.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SPEC = REPO_ROOT / "docs" / "public" / "openapi.json"
+DEFAULT_OUTPUT = REPO_ROOT / "docs" / "public" / "otari.postman_collection.json"
+
+# The canonical auth header (see API_KEY_HEADER in src/gateway/core/config.py).
+# The OpenAPI spec does not declare a security scheme, so we inject it here.
+API_KEY_HEADER = "Otari-Key"
+DEFAULT_BASE_URL = "http://localhost:8000"
+
+# Methods that carry a JSON request body worth templating.
+BODY_METHODS = {"post", "put", "patch"}
+HTTP_METHODS = ("get", "post", "put", "patch", "delete")
+
+# A few inference endpoints type their payloads as free-form objects in the
+# spec (e.g. ``messages`` is just ``{type: object}``), so a derived example
+# collapses to ``[{}]`` and is not runnable. For those, supply a curated,
+# working example body keyed by (METHOD, path). Everything else stays derived
+# from the schema. Models use the provider-prefixed form Otari expects.
+EXAMPLE_BODY_OVERRIDES: dict[tuple[str, str], dict[str, Any]] = {
+    ("POST", "/v1/chat/completions"): {
+        "model": "openai:gpt-4o-mini",
+        "messages": [{"role": "user", "content": "Hello from Otari!"}],
+    },
+    ("POST", "/v1/messages"): {
+        "model": "anthropic:claude-haiku-4-5",
+        "max_tokens": 1024,
+        "messages": [{"role": "user", "content": "Hello from Otari!"}],
+    },
+    ("POST", "/v1/responses"): {
+        "model": "openai:gpt-4o-mini",
+        "input": "Hello from Otari!",
+    },
+}
+
+
+def load_spec(spec_path: Path) -> dict[str, Any]:
+    """Load the OpenAPI spec JSON."""
+    with open(spec_path, encoding="utf-8") as f:
+        spec: dict[str, Any] = json.load(f)
+        return spec
+
+
+def resolve_ref(ref: str, spec: dict[str, Any]) -> dict[str, Any]:
+    """Resolve a local ``#/...`` JSON pointer within the spec."""
+    node: Any = spec
+    for part in ref.lstrip("#/").split("/"):
+        node = node[part]
+    return cast(dict[str, Any], node)
+
+
+def example_for_schema(
+    schema: dict[str, Any],
+    spec: dict[str, Any],
+    *,
+    depth: int = 0,
+    seen: frozenset[str] = frozenset(),
+) -> Any:
+    """Build a minimal example value from a JSON schema node.
+
+    Prefers explicit ``example``/``default``; otherwise constructs a value from
+    the schema's structure. Objects include only required properties (falling
+    back to all properties when none are required) to keep bodies usable rather
+    than exhaustive. Recursion is bounded to avoid blowing up on self-referential
+    schemas.
+    """
+    if depth > 6:
+        return None
+
+    if "$ref" in schema:
+        ref = schema["$ref"]
+        if ref in seen:
+            return None
+        return example_for_schema(
+            resolve_ref(ref, spec), spec, depth=depth, seen=seen | {ref}
+        )
+
+    if "example" in schema:
+        return schema["example"]
+    if "default" in schema:
+        return schema["default"]
+
+    for combiner in ("allOf", "anyOf", "oneOf"):
+        if combiner in schema and schema[combiner]:
+            if combiner == "allOf":
+                merged: dict[str, Any] = {}
+                for sub in schema["allOf"]:
+                    value = example_for_schema(sub, spec, depth=depth + 1, seen=seen)
+                    if isinstance(value, dict):
+                        merged.update(value)
+                return merged
+            return example_for_schema(
+                schema[combiner][0], spec, depth=depth + 1, seen=seen
+            )
+
+    if "enum" in schema and schema["enum"]:
+        return schema["enum"][0]
+
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        schema_type = next((t for t in schema_type if t != "null"), None)
+
+    if schema_type == "object" or "properties" in schema:
+        props: dict[str, Any] = schema.get("properties", {})
+        required = schema.get("required", [])
+        keys = required if required else list(props)
+        return {
+            name: example_for_schema(props[name], spec, depth=depth + 1, seen=seen)
+            for name in keys
+            if name in props
+        }
+
+    if schema_type == "array":
+        items = schema.get("items", {})
+        return [example_for_schema(items, spec, depth=depth + 1, seen=seen)]
+
+    if schema_type == "string":
+        fmt = schema.get("format")
+        if fmt == "date-time":
+            return "2024-01-01T00:00:00Z"
+        if fmt == "date":
+            return "2024-01-01"
+        if fmt == "uuid":
+            return "00000000-0000-0000-0000-000000000000"
+        return "string"
+    if schema_type == "integer":
+        return 0
+    if schema_type == "number":
+        return 0
+    if schema_type == "boolean":
+        return False
+
+    return None
+
+
+def request_body_example(operation: dict[str, Any], spec: dict[str, Any]) -> Any:
+    """Return the JSON example for an operation's request body, if any."""
+    content = operation.get("requestBody", {}).get("content", {})
+    schema = content.get("application/json", {}).get("schema")
+    if schema is None:
+        return None
+    return example_for_schema(schema, spec)
+
+
+def build_url(path: str, operation: dict[str, Any]) -> dict[str, Any]:
+    """Build a Postman URL object with path variables and query params."""
+    # Postman represents path params as ``:name`` segments.
+    raw_path = path
+    segments: list[str] = []
+    variables: list[dict[str, Any]] = []
+    for seg in path.strip("/").split("/"):
+        if seg.startswith("{") and seg.endswith("}"):
+            name = seg[1:-1]
+            segments.append(f":{name}")
+            variables.append({"key": name, "value": "", "description": "path parameter"})
+        else:
+            segments.append(seg)
+    raw_path = "/" + "/".join(segments) if segments else ""
+
+    query: list[dict[str, Any]] = []
+    for param in operation.get("parameters", []):
+        if param.get("in") != "query":
+            continue
+        query.append(
+            {
+                "key": param["name"],
+                "value": "",
+                "description": param.get("description", ""),
+                # Optional params start disabled so the request runs clean.
+                "disabled": not param.get("required", False),
+            }
+        )
+
+    raw = "{{baseUrl}}" + raw_path
+    if query:
+        raw += "?" + "&".join(f"{q['key']}=" for q in query)
+
+    url: dict[str, Any] = {
+        "raw": raw,
+        "host": ["{{baseUrl}}"],
+        "path": [s for s in segments],
+    }
+    if query:
+        url["query"] = query
+    if variables:
+        url["variable"] = variables
+    return url
+
+
+def build_item(path: str, method: str, operation: dict[str, Any], spec: dict[str, Any]) -> dict[str, Any]:
+    """Build a single Postman request item from an operation."""
+    name = operation.get("summary") or operation.get("operationId") or f"{method.upper()} {path}"
+
+    headers: list[dict[str, Any]] = []
+    request: dict[str, Any] = {
+        "method": method.upper(),
+        "header": headers,
+        "url": build_url(path, operation),
+    }
+
+    description = operation.get("description")
+    if description:
+        request["description"] = description
+
+    if method in BODY_METHODS:
+        body = EXAMPLE_BODY_OVERRIDES.get(
+            (method.upper(), path)
+        ) or request_body_example(operation, spec)
+        if body is not None:
+            headers.append({"key": "Content-Type", "value": "application/json"})
+            request["body"] = {
+                "mode": "raw",
+                "raw": json.dumps(body, indent=2),
+                "options": {"raw": {"language": "json"}},
+            }
+
+    return {"name": name, "request": request}
+
+
+def build_collection(spec: dict[str, Any]) -> dict[str, Any]:
+    """Build the full Postman collection from an OpenAPI spec."""
+    info = spec.get("info", {})
+    title = info.get("title", "Otari")
+
+    # Group operations by their first tag, preserving spec tag order.
+    declared_tags = [t["name"] for t in spec.get("tags", []) if "name" in t]
+    folders: dict[str, list[dict[str, Any]]] = {}
+    folder_order: list[str] = list(declared_tags)
+
+    for path in spec.get("paths", {}):
+        for method in HTTP_METHODS:
+            operation = spec["paths"][path].get(method)
+            if operation is None:
+                continue
+            tags = operation.get("tags") or ["default"]
+            tag = tags[0]
+            if tag not in folders:
+                folders[tag] = []
+                if tag not in folder_order:
+                    folder_order.append(tag)
+            folders[tag].append(build_item(path, method, operation, spec))
+
+    items = [
+        {"name": tag, "item": folders[tag]}
+        for tag in folder_order
+        if tag in folders
+    ]
+
+    description = (
+        f"{title} management + inference collection, generated from the OpenAPI "
+        "spec by scripts/generate_postman.py. Stopgap client for driving a running "
+        "Otari server until the web UI lands.\n\n"
+        f"Set the `baseUrl` and `otariKey` collection variables (or override them "
+        "with a Postman environment). Auth is sent as the "
+        f"`{API_KEY_HEADER}` header on every request via collection-level auth."
+    )
+
+    return {
+        "info": {
+            "name": f"{title} API",
+            "description": description,
+            "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        },
+        "auth": {
+            "type": "apikey",
+            "apikey": [
+                {"key": "key", "value": API_KEY_HEADER, "type": "string"},
+                {"key": "value", "value": "{{otariKey}}", "type": "string"},
+                {"key": "in", "value": "header", "type": "string"},
+            ],
+        },
+        "variable": [
+            {"key": "baseUrl", "value": DEFAULT_BASE_URL, "type": "string"},
+            {"key": "otariKey", "value": "", "type": "string"},
+        ],
+        "item": items,
+    }
+
+
+def serialize(collection: dict[str, Any]) -> str:
+    """Serialize a collection deterministically for stable diffs."""
+    return json.dumps(collection, indent=2, sort_keys=True) + "\n"
+
+
+def main() -> int:
+    """Generate or check the Postman collection."""
+    parser = argparse.ArgumentParser(description="Generate Otari Postman collection")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check if the generated collection matches the existing file (for CI/CD)",
+    )
+    parser.add_argument(
+        "--spec",
+        type=Path,
+        default=DEFAULT_SPEC,
+        help=f"Path to the OpenAPI spec (default: {DEFAULT_SPEC})",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Output path for the collection (default: {DEFAULT_OUTPUT})",
+    )
+    args = parser.parse_args()
+
+    if not args.spec.exists():
+        print(f"Error: {args.spec} does not exist", file=sys.stderr)
+        print("Run 'python scripts/generate_openapi.py' first", file=sys.stderr)
+        return 1
+
+    print("Generating Postman collection...")
+    collection = build_collection(load_spec(args.spec))
+    generated = serialize(collection)
+
+    if args.check:
+        print(f"Checking if {args.output} is up to date...")
+        if not args.output.exists():
+            print(f"✗ {args.output} does not exist", file=sys.stderr)
+            return 1
+        existing = args.output.read_text(encoding="utf-8")
+        if existing == generated:
+            print("✓ Postman collection is up to date")
+            return 0
+        print("✗ Postman collection is out of date", file=sys.stderr)
+        print("Run 'python scripts/generate_postman.py' to update it", file=sys.stderr)
+        return 1
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(generated, encoding="utf-8")
+    print(f"✓ Postman collection written to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

Adds a stopgap Postman collection for driving a running Otari server (managing keys, users, budgets, pricing, usage) and exercising the inference endpoints, until the streamlined web UI lands.

- **`docs/public/otari.postman_collection.json`**: 47 requests across 17 folders (every path/method in the spec), grouped by tag. Collection-level `Otari-Key` auth plus `baseUrl` and `otariKey` variables, so you import it, paste a key once, and go.
- **`scripts/generate_postman.py`**: derives the collection from `docs/public/openapi.json`, with a `--check` mode mirroring `generate_openapi.py`. Request bodies are built from the schemas; the three free-form inference endpoints (chat, messages, responses) get curated, runnable example bodies since the spec types their payloads as opaque objects.
- **Makefile**: `make postman` (regenerate) and `make postman-check` (verify fresh).
- **CI**: a "Verify Postman collection is up to date" step in the existing `openapi-spec` job, right after the OpenAPI check, so the committed collection cannot drift from the spec.
- **README**: a short "Postman collection" subsection, plus the `--check` command. Points at the built-in Swagger UI at `/docs` as the zero-install alternative.

Because the collection is generated from the OpenAPI spec and checked in CI, it tracks the API surface as it changes rather than drifting.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

Related: #217 (follow-up; not fixed here). The Swagger UI at `/docs` is currently browse-only because it has no Otari-Key auth scheme, which is part of why this Postman collection is a useful stopgap.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). The generator is exercised by the `postman-check` CI step rather than a unit test.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`; `postman-check` and `openapi-check` pass).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). No API contract change; the collection is generated from the existing spec.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 4.8 via Claude Code.

**Any additional AI details you'd like to share:**

Generated through back-and-forth with @njbrake; the design decisions (generate from the OpenAPI spec, keep it in sync via a CI check, curated example bodies for the free-form inference endpoints) are his.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)