### PR TITLE
fix(client): send Postman auth as Authorization Bearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,8 +331,8 @@ the OpenAI-compatible surface. See the full schema in
 For poking at a running server (managing keys, users, budgets, and pricing, or
 firing off chat/messages/responses requests) without a separate client, import
 `docs/public/otari.postman_collection.json` into Postman. Set the `baseUrl` and
-`otariKey` collection variables; the `Otari-Key` auth header is sent on every
-request. The collection is generated from the OpenAPI spec
+`otariKey` collection variables; the key is sent as an `Authorization: Bearer`
+header on every request. The collection is generated from the OpenAPI spec
 (`scripts/generate_postman.py`) and kept in sync in CI, so it tracks the API as
 it changes. The built-in Swagger UI at `http://localhost:8000/docs` is the
 zero-install alternative.

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -1,26 +1,16 @@
 {
   "auth": {
-    "apikey": [
+    "bearer": [
       {
-        "key": "key",
-        "type": "string",
-        "value": "Otari-Key"
-      },
-      {
-        "key": "value",
+        "key": "token",
         "type": "string",
         "value": "{{otariKey}}"
-      },
-      {
-        "key": "in",
-        "type": "string",
-        "value": "header"
       }
     ],
-    "type": "apikey"
+    "type": "bearer"
   },
   "info": {
-    "description": "otari management + inference collection, generated from the OpenAPI spec by scripts/generate_postman.py. Stopgap client for driving a running Otari server until the web UI lands.\n\nSet the `baseUrl` and `otariKey` collection variables (or override them with a Postman environment). Auth is sent as the `Otari-Key` header on every request via collection-level auth.",
+    "description": "otari management + inference collection, generated from the OpenAPI spec by scripts/generate_postman.py. Stopgap client for driving a running Otari server until the web UI lands.\n\nSet the `baseUrl` and `otariKey` collection variables (or override them with a Postman environment). Auth is sent as an `Authorization: Bearer <otariKey>` header on every request via collection-level auth.",
     "name": "otari API",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },

--- a/scripts/generate_postman.py
+++ b/scripts/generate_postman.py
@@ -25,9 +25,12 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_SPEC = REPO_ROOT / "docs" / "public" / "openapi.json"
 DEFAULT_OUTPUT = REPO_ROOT / "docs" / "public" / "otari.postman_collection.json"
 
-# The canonical auth header (see API_KEY_HEADER in src/gateway/core/config.py).
 # The OpenAPI spec does not declare a security scheme, so we inject it here.
-API_KEY_HEADER = "Otari-Key"
+# The gateway accepts the key as a Bearer token via the standard Authorization
+# header (it also accepts the legacy Otari-Key header, but only when the value
+# is itself prefixed with "Bearer "; see _extract_bearer_token in
+# src/gateway/api/deps.py). Using standard Bearer auth keeps the collection
+# aligned with the documented curl examples.
 DEFAULT_BASE_URL = "http://localhost:8000"
 
 # Methods that carry a JSON request body worth templating.
@@ -273,8 +276,9 @@ def build_collection(spec: dict[str, Any]) -> dict[str, Any]:
         "spec by scripts/generate_postman.py. Stopgap client for driving a running "
         "Otari server until the web UI lands.\n\n"
         f"Set the `baseUrl` and `otariKey` collection variables (or override them "
-        "with a Postman environment). Auth is sent as the "
-        f"`{API_KEY_HEADER}` header on every request via collection-level auth."
+        "with a Postman environment). Auth is sent as an "
+        "`Authorization: Bearer <otariKey>` header on every request via "
+        "collection-level auth."
     )
 
     return {
@@ -284,11 +288,9 @@ def build_collection(spec: dict[str, Any]) -> dict[str, Any]:
             "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         },
         "auth": {
-            "type": "apikey",
-            "apikey": [
-                {"key": "key", "value": API_KEY_HEADER, "type": "string"},
-                {"key": "value", "value": "{{otariKey}}", "type": "string"},
-                {"key": "in", "value": "header", "type": "string"},
+            "type": "bearer",
+            "bearer": [
+                {"key": "token", "value": "{{otariKey}}", "type": "string"},
             ],
         },
         "variable": [


### PR DESCRIPTION
## Description

The Postman collection merged in #216 fails to authenticate. It sends the API key as a raw `Otari-Key` header, but the gateway routes every auth header (including `Otari-Key`) through `_extract_bearer_token` (`src/gateway/api/deps.py`), which requires a `Bearer ` prefix. A raw `Otari-Key: gw-...` value is rejected with a 401 "Invalid header format. Expected 'Bearer <token>'".

This switches the generator to Postman's native `bearer` auth type, which emits the standard `Authorization: Bearer <otariKey>` header, matching the documented curl examples.

- `scripts/generate_postman.py`: auth block is now `type: bearer`; updated comment and collection description.
- `docs/public/otari.postman_collection.json`: regenerated (`make postman-check` passes).
- `README.md`: updated the Postman section wording.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Follow-up to #216.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

No test was added: the collection is generated artifact JSON, and the maintainer opted out of an auth-integration test for this fix.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Claude Opus 4.8)

**Any additional AI details you'd like to share:** Generated via back-and-forth with @njbrake; the diagnosis and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)