### PR TITLE
feat(models): config-level model aliases that map to real selectors

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -98,3 +98,14 @@ providers:
   # openai:gpt-5:
     # input_price_per_million: 0.25
     # output_price_per_million: 1.00
+
+# Model aliases (optional): expose a friendly display name that maps to a real
+# selector, hiding the underlying provider/model. Format: name -> target
+# ("provider:model" or a named "instance:model"). The alias is what users see in
+# /v1/models and in response `model` fields; pricing, budgets, and usage key on
+# the resolved target. Set `model_discovery: false` to expose only these curated
+# names. Standalone-mode only.
+# aliases:
+#   myopusmodel: anthropic:claude-opus-4
+#   fastmodel: openai:gpt-5
+#   housemodel: home_lab:qwen3

--- a/docs/models.md
+++ b/docs/models.md
@@ -195,8 +195,9 @@ discovered models.
 
 Constraints, checked at startup: a target must be of the form `instance:model` or
 `provider:model` whose prefix is a configured instance or a known provider; an
-alias name must not collide with a provider instance name; and an alias target
-must not be another alias (no chaining).
+alias name must not contain `:` or `/` (a selector-shaped name would silently
+reroute requests for the real model) and must not collide with a provider
+instance name; and an alias target must not be another alias (no chaining).
 
 Like named instances, aliases are a standalone-mode feature. In hybrid mode model
 resolution and routing are owned by the otari.ai platform, so the local `aliases`

--- a/docs/models.md
+++ b/docs/models.md
@@ -161,6 +161,47 @@ providers:
 The declared `models` are listed as `edge_box:<model>`. Direct requests work
 with or without this list; it only affects discovery.
 
+## Model aliases
+
+An alias is a display name that maps to a real selector, so you can expose a
+friendly, stable model name and keep the underlying provider/model hidden.
+Aliases are configured in a top-level `aliases` map (display name to target):
+
+```yaml
+aliases:
+  myopusmodel: anthropic:claude-opus-4
+  fastmodel: openai:gpt-5
+  housemodel: home_lab:qwen3     # target may be a named instance
+```
+
+A request whose `model` is an alias routes to its target. The alias is what
+callers see:
+
+- `GET /v1/models` lists the alias id (and `GET /v1/models/{alias}` resolves it),
+  with pricing read from the target so the real price shows without revealing the
+  model. Aliased entries report `owned_by: otari`.
+- The response `model` field (streaming and non-streaming) is relabeled to the
+  alias, so the underlying model name never appears on the wire.
+
+Pricing, budgets, and usage logs key on the resolved target, not the alias:
+configure pricing once for `anthropic:claude-opus-4` and every alias pointing at
+it inherits that price. An alias with no pricing on its target fails closed under
+`require_pricing`, exactly as the real model would.
+
+To expose only your curated alias names, set `model_discovery: false` so the full
+provider catalog is not listed; the listing then shows just the aliases (plus any
+models you priced explicitly). With discovery on, aliases appear alongside the
+discovered models.
+
+Constraints, checked at startup: a target must be of the form `instance:model` or
+`provider:model` whose prefix is a configured instance or a known provider; an
+alias name must not collide with a provider instance name; and an alias target
+must not be another alias (no chaining).
+
+Like named instances, aliases are a standalone-mode feature. In hybrid mode model
+resolution and routing are owned by the otari.ai platform, so the local `aliases`
+map does not apply.
+
 ## Listing available models
 
 Query Otari to see which models are available:

--- a/docs/models.md
+++ b/docs/models.md
@@ -189,9 +189,12 @@ it inherits that price. An alias with no pricing on its target fails closed unde
 `require_pricing`, exactly as the real model would.
 
 To expose only your curated alias names, set `model_discovery: false` so the full
-provider catalog is not listed; the listing then shows just the aliases (plus any
-models you priced explicitly). With discovery on, aliases appear alongside the
-discovered models.
+provider catalog is not listed; the listing then shows just the aliases, plus any
+models you priced explicitly that no alias points at. Pricing an alias target does
+not republish it: the alias entry already carries that price, so pricing a target
+never puts the hidden name back in the listing. Whether real models are listed is
+governed by `model_discovery` alone. With discovery on, aliases appear alongside
+the discovered models, including any target you aliased.
 
 Constraints, checked at startup: a target must be of the form `instance:model` or
 `provider:model` whose prefix is a configured instance or a known provider; an

--- a/docs/models.md
+++ b/docs/models.md
@@ -183,6 +183,14 @@ callers see:
 - The response `model` field (streaming and non-streaming) is relabeled to the
   alias, so the underlying model name never appears on the wire.
 
+Alias routing is applied wherever a model selector is resolved, so an alias is
+accepted on every model-taking endpoint. The response `model` field is relabeled
+on `/v1/chat/completions`, `/v1/messages`, `/v1/responses`, `/v1/embeddings`,
+`/v1/moderations`, and `/v1/rerank`. Other surfaces (`/v1/images`,
+`/v1/audio/*`, `/v1/batches`) route aliases but return the provider payload as-is;
+those payloads carry no `model` field today, so nothing leaks, but a provider that
+started returning one would echo the target rather than the alias.
+
 Pricing, budgets, and usage logs key on the resolved target, not the alias:
 configure pricing once for `anthropic:claude-opus-4` and every alias pointing at
 it inherits that price. An alias with no pricing on its target fails closed under

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -81,6 +81,7 @@ from gateway.core.env import otari_env
 from gateway.core.usage import cache_read_tokens_of, cache_write_tokens_of
 from gateway.log_config import logger
 from gateway.metrics import record_cost, record_tokens
+from gateway.model_labeling import relabel_model
 from gateway.models.entities import UsageLog
 from gateway.models.guardrails import GuardrailConfig
 from gateway.models.mcp import McpServerConfig
@@ -110,7 +111,6 @@ from gateway.streaming import (
     StreamFormat,
     StreamingAttemptFailure,
     iterate_streaming_attempts,
-    relabel_model,
     streaming_generator,
 )
 

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -110,6 +110,7 @@ from gateway.streaming import (
     StreamFormat,
     StreamingAttemptFailure,
     iterate_streaming_attempts,
+    relabel_model,
     streaming_generator,
 )
 
@@ -1174,6 +1175,7 @@ def build_streaming_response(
     platform_correlation_id: str | None = None,
     platform_request_id: str | None = None,
     session_label: str | None = None,
+    display_model: str | None = None,
 ) -> StreamingResponse:
     """Wrap an already-opened upstream stream in an SSE response.
 
@@ -1306,6 +1308,7 @@ def build_streaming_response(
             label=f"{provider}:{model}",
             on_no_usage=_on_no_usage,
             on_incomplete=_on_incomplete,
+            display_model=display_model,
         ),
         media_type="text/event-stream",
         headers=headers,
@@ -1375,6 +1378,7 @@ async def run_single_attempt_stream(
     platform_correlation_id: str | None = None,
     platform_request_id: str | None = None,
     session_label: str | None = None,
+    display_model: str | None = None,
 ) -> StreamingResponse:
     """Open a single-attempt stream and wrap it with settlement callbacks.
 
@@ -1420,6 +1424,7 @@ async def run_single_attempt_stream(
         platform_correlation_id=platform_correlation_id,
         platform_request_id=platform_request_id,
         session_label=session_label,
+        display_model=display_model,
     )
 
 
@@ -1738,12 +1743,17 @@ async def run_standalone_non_stream(
     call_kwargs: dict[str, Any],
     provider: Any,
     model: str,
+    display_model: str | None = None,
 ) -> ResultT:
     """Standalone-mode non-streaming dispatch with reservation settlement.
 
     Success writes the usage log (per the adapter's no-usage policy) and
     reconciles the reservation against actual cost; every failure path refunds
     the reservation before mapping the error to the format's wire envelope.
+
+    ``display_model`` (a configured alias) relabels the result's ``model`` field
+    before returning, so the underlying provider/model stays hidden; billing and
+    logging above still key on the resolved target ``model``/``provider``.
     """
     try:
         result = await dispatch_non_stream(adapter=adapter, tool_ctx=tool_ctx, call_kwargs=call_kwargs)
@@ -1763,6 +1773,8 @@ async def run_standalone_non_stream(
                 )
             if ctx.reservation is not None:
                 await reconcile_reservation(ctx.db, ctx.reservation, actual_cost or 0.0)
+        if display_model is not None:
+            relabel_model(result, display_model)
         return result
     except HTTPException:
         await release_reservation(ctx)

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -399,6 +399,7 @@ async def chat_completions(
             call_kwargs=call_kwargs,
             provider=resolved.instance,
             model=resolved.model,
+            display_model=resolved.alias,
         )
 
     # ------------------------------------------------------------------
@@ -435,6 +436,7 @@ async def chat_completions(
         call_kwargs=call_kwargs,
         provider=resolved.instance,
         model=resolved.model,
+        display_model=resolved.alias,
     )
 
     if ctx.rate_limit_info:

--- a/src/gateway/api/routes/embeddings.py
+++ b/src/gateway/api/routes/embeddings.py
@@ -26,6 +26,7 @@ from gateway.services.budget_service import (
 from gateway.services.log_writer import LogWriter
 from gateway.services.pricing_service import find_model_pricing, pricing_required_but_missing
 from gateway.services.provider_kwargs import resolve_provider_selector
+from gateway.streaming import relabel_model
 
 router = APIRouter(prefix="/v1", tags=["embeddings"])
 
@@ -172,4 +173,6 @@ async def create_embedding(
         for key, value in rate_limit_headers(rate_limit_info).items():
             response.headers[key] = value
 
+    if resolved.alias is not None:
+        relabel_model(result, resolved.alias)
     return result

--- a/src/gateway/api/routes/embeddings.py
+++ b/src/gateway/api/routes/embeddings.py
@@ -15,6 +15,7 @@ from gateway.api.routes._helpers import resolve_user_id
 from gateway.api.routes.chat import rate_limit_headers
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
+from gateway.model_labeling import relabel_model
 from gateway.models.entities import APIKey, UsageLog
 from gateway.rate_limit import check_rate_limit
 from gateway.services.budget_service import (
@@ -26,7 +27,6 @@ from gateway.services.budget_service import (
 from gateway.services.log_writer import LogWriter
 from gateway.services.pricing_service import find_model_pricing, pricing_required_but_missing
 from gateway.services.provider_kwargs import resolve_provider_selector
-from gateway.streaming import relabel_model
 
 router = APIRouter(prefix="/v1", tags=["embeddings"])
 
@@ -104,7 +104,7 @@ async def create_embedding(
         await refund_reservation(db, reservation)
         raise HTTPException(
             status_code=status.HTTP_402_PAYMENT_REQUIRED,
-            detail=f"No pricing configured for model '{resolved.instance}:{model}'",
+            detail=f"No pricing configured for model '{request.model}'",
         )
 
     provider_kwargs = resolved.kwargs

--- a/src/gateway/api/routes/images.py
+++ b/src/gateway/api/routes/images.py
@@ -106,7 +106,7 @@ async def create_image(
         await refund_reservation(db, reservation)
         raise HTTPException(
             status_code=status.HTTP_402_PAYMENT_REQUIRED,
-            detail=f"No pricing configured for model '{resolved.instance}:{model}'",
+            detail=f"No pricing configured for model '{request.model}'",
         )
 
     provider_kwargs = resolved.kwargs

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -479,11 +479,13 @@ async def create_message(
             platform_correlation_id = attempt.attempt_id
             platform_request_id = route.request_id
             billing_provider: Any = LLMProvider(attempt.provider)
+            display_model: str | None = None
         else:
             resolved = resolve_dispatch_provider(ctx, config, request.model)
             model = resolved.model
             call_kwargs = {**resolved.kwargs, **request_fields, "model": resolved.dispatch_model}
             billing_provider = resolved.instance
+            display_model = resolved.alias
 
         return await run_single_attempt_stream(
             adapter=_ADAPTER,
@@ -495,6 +497,7 @@ async def create_message(
             platform_correlation_id=platform_correlation_id,
             platform_request_id=platform_request_id,
             session_label=request.session_label,
+            display_model=display_model,
         )
 
     # ------------------------------------------------------------------
@@ -549,6 +552,7 @@ async def create_message(
         call_kwargs=call_kwargs,
         provider=resolved.instance,
         model=resolved.model,
+        display_model=resolved.alias,
     )
 
     if ctx.rate_limit_info:

--- a/src/gateway/api/routes/models.py
+++ b/src/gateway/api/routes/models.py
@@ -85,6 +85,11 @@ def _alias_model(config: GatewayConfig, alias: str, pricing_lookup: dict[str, Mo
     )
 
 
+def _alias_target_keys(config: GatewayConfig) -> set[str]:
+    """Canonical pricing keys of every configured alias target."""
+    return {normalize_pricing_key(config, target) for target in config.aliases.values()}
+
+
 async def _get_pricing_map(db: AsyncSession, provider_filter: str | None = None) -> dict[str, ModelPricing]:
     """Load latest pricing per model_key, optionally filtered by provider prefix."""
     latest_effective = (
@@ -154,9 +159,15 @@ async def list_models(
             )
 
     # Phase 2: pricing-only models (not discovered but have pricing entries).
+    # An alias target is skipped: billing keys on the real model, so aliasing one
+    # forces a pricing entry for it, and publishing that entry here would expose
+    # the very name the alias exists to hide. Whether real models are listed is
+    # governed by ``model_discovery`` (phase 1), never by pricing config.
+    alias_targets = _alias_target_keys(config)
     for model_key, pricing in pricing_map.items():
-        if model_key not in merged:
-            merged[model_key] = _model_from_pricing(pricing)
+        if model_key in merged or normalize_pricing_key(config, model_key) in alias_targets:
+            continue
+        merged[model_key] = _model_from_pricing(pricing)
 
     # Phase 3: configured aliases. An alias is a display name, not a provider, so
     # it is only listed for the unfiltered listing; a ``?provider=`` filter asks

--- a/src/gateway/api/routes/models.py
+++ b/src/gateway/api/routes/models.py
@@ -13,8 +13,14 @@ from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import ModelPricing
 from gateway.services.model_discovery_service import discover_all_models, get_model_cache
+from gateway.services.provider_kwargs import normalize_pricing_key
 
 router = APIRouter(prefix="/v1", tags=["models"])
+
+# ``owned_by`` reported for alias entries. Aliases intentionally hide the
+# underlying provider, so the gateway itself is named as the owner rather than
+# the real upstream.
+ALIAS_OWNED_BY = "otari"
 
 
 class ModelPricingInfo(BaseModel):
@@ -57,6 +63,28 @@ def _model_from_pricing(pricing: ModelPricing) -> ModelObject:
     )
 
 
+def _alias_model(config: GatewayConfig, alias: str, pricing_lookup: dict[str, ModelPricing]) -> ModelObject:
+    """Build a ModelObject for a configured alias.
+
+    The alias id is what the caller sees; pricing is looked up from the resolved
+    target's canonical key so an alias shows the real model's price without
+    revealing the provider/model behind it.
+    """
+    target = config.aliases[alias]
+    pricing = pricing_lookup.get(normalize_pricing_key(config, target))
+    return ModelObject(
+        id=alias,
+        created=0,
+        owned_by=ALIAS_OWNED_BY,
+        pricing=ModelPricingInfo(
+            input_price_per_million=pricing.input_price_per_million,
+            output_price_per_million=pricing.output_price_per_million,
+        )
+        if pricing
+        else None,
+    )
+
+
 async def _get_pricing_map(db: AsyncSession, provider_filter: str | None = None) -> dict[str, ModelPricing]:
     """Load latest pricing per model_key, optionally filtered by provider prefix."""
     latest_effective = (
@@ -96,6 +124,9 @@ async def list_models(
     exist in the pricing table are also included for backward compatibility.
     """
     pricing_map = await _get_pricing_map(db, provider_filter=provider)
+    # Snapshot before phase 1 mutates ``pricing_map`` (it pops matched keys), so
+    # alias pricing can still be looked up by the target's canonical key.
+    pricing_lookup = dict(pricing_map)
 
     merged: dict[str, ModelObject] = {}
 
@@ -127,6 +158,13 @@ async def list_models(
         if model_key not in merged:
             merged[model_key] = _model_from_pricing(pricing)
 
+    # Phase 3: configured aliases. An alias is a display name, not a provider, so
+    # it is only listed for the unfiltered listing; a ``?provider=`` filter asks
+    # for one provider's real models and must not leak the alias mapping.
+    if provider is None:
+        for alias in config.aliases:
+            merged[alias] = _alias_model(config, alias, pricing_lookup)
+
     sorted_models = sorted(merged.values(), key=lambda m: m.id)
     return ModelListResponse(data=sorted_models)
 
@@ -138,6 +176,12 @@ async def get_model(
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> ModelObject:
     """Get details for a specific model."""
+    # A configured alias resolves to its own entry, with pricing read from the
+    # resolved target so the underlying provider/model stays hidden.
+    if model_id in config.aliases:
+        pricing_lookup = await _get_pricing_map(db)
+        return _alias_model(config, model_id, pricing_lookup)
+
     # Check the pricing table first.
     stmt = (
         select(ModelPricing)

--- a/src/gateway/api/routes/models.py
+++ b/src/gateway/api/routes/models.py
@@ -1,6 +1,7 @@
 """OpenAI-compatible models listing endpoint with auto-discovery."""
 
 import calendar
+from collections.abc import Sequence
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -90,8 +91,27 @@ def _alias_target_keys(config: GatewayConfig) -> set[str]:
     return {normalize_pricing_key(config, target) for target in config.aliases.values()}
 
 
-async def _get_pricing_map(db: AsyncSession, provider_filter: str | None = None) -> dict[str, ModelPricing]:
-    """Load latest pricing per model_key, optionally filtered by provider prefix."""
+def _pricing_key_candidates(config: GatewayConfig, target: str) -> list[str]:
+    """Stored key forms that could hold pricing for ``target``.
+
+    Keys are canonicalized on write, but rows predating that may still use the
+    legacy ``provider/model`` separator, so both forms are offered.
+    """
+    canonical = normalize_pricing_key(config, target)
+    return sorted({target, canonical, canonical.replace(":", "/", 1)})
+
+
+def _normalized_pricing_lookup(config: GatewayConfig, pricing_map: dict[str, ModelPricing]) -> dict[str, ModelPricing]:
+    """Re-key a pricing map by canonical model key, matching how targets resolve."""
+    return {normalize_pricing_key(config, key): row for key, row in pricing_map.items()}
+
+
+async def _get_pricing_map(
+    db: AsyncSession,
+    provider_filter: str | None = None,
+    model_keys: Sequence[str] | None = None,
+) -> dict[str, ModelPricing]:
+    """Load latest pricing per model_key, optionally filtered by provider prefix or key set."""
     latest_effective = (
         select(
             ModelPricing.model_key.label("model_key"),
@@ -109,6 +129,9 @@ async def _get_pricing_map(db: AsyncSession, provider_filter: str | None = None)
 
     if provider_filter:
         stmt = stmt.where(ModelPricing.model_key.startswith(f"{provider_filter}:"))
+
+    if model_keys is not None:
+        stmt = stmt.where(ModelPricing.model_key.in_(model_keys))
 
     stmt = stmt.order_by(ModelPricing.model_key)
     result = await db.execute(stmt)
@@ -130,8 +153,12 @@ async def list_models(
     """
     pricing_map = await _get_pricing_map(db, provider_filter=provider)
     # Snapshot before phase 1 mutates ``pricing_map`` (it pops matched keys), so
-    # alias pricing can still be looked up by the target's canonical key.
-    pricing_lookup = dict(pricing_map)
+    # alias pricing can still be looked up by the target's canonical key. Keys are
+    # canonicalized because an alias target is always canonical while a stored row
+    # may use the legacy "provider/model" form; without this a legacy-form row
+    # would be withheld from the listing by phase 2 yet never match its alias, so
+    # its price would show nowhere.
+    pricing_lookup = _normalized_pricing_lookup(config, pricing_map)
 
     merged: dict[str, ModelObject] = {}
 
@@ -188,10 +215,13 @@ async def get_model(
 ) -> ModelObject:
     """Get details for a specific model."""
     # A configured alias resolves to its own entry, with pricing read from the
-    # resolved target so the underlying provider/model stays hidden.
+    # resolved target so the underlying provider/model stays hidden. Only the
+    # target's own rows are loaded rather than the whole pricing table.
     if model_id in config.aliases:
-        pricing_lookup = await _get_pricing_map(db)
-        return _alias_model(config, model_id, pricing_lookup)
+        pricing_map = await _get_pricing_map(
+            db, model_keys=_pricing_key_candidates(config, config.aliases[model_id])
+        )
+        return _alias_model(config, model_id, _normalized_pricing_lookup(config, pricing_map))
 
     # Check the pricing table first.
     stmt = (

--- a/src/gateway/api/routes/moderations.py
+++ b/src/gateway/api/routes/moderations.py
@@ -24,6 +24,7 @@ from gateway.services.budget_service import (
 from gateway.services.log_writer import LogWriter
 from gateway.services.pricing_service import find_model_pricing
 from gateway.services.provider_kwargs import resolve_provider_selector
+from gateway.streaming import relabel_model
 from gateway.types.moderation import ModerationResponse
 
 # Locked phrasing — cross-SDK error contract. Do not reword.
@@ -186,4 +187,6 @@ async def create_moderation(
         for key, value in rate_limit_headers(rate_limit_info).items():
             response.headers[key] = value
 
+    if resolved.alias is not None:
+        relabel_model(result, resolved.alias)
     return result

--- a/src/gateway/api/routes/moderations.py
+++ b/src/gateway/api/routes/moderations.py
@@ -14,6 +14,7 @@ from gateway.api.routes._helpers import resolve_user_id
 from gateway.api.routes.chat import rate_limit_headers
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
+from gateway.model_labeling import relabel_model
 from gateway.models.entities import APIKey, UsageLog
 from gateway.rate_limit import check_rate_limit
 from gateway.services.budget_service import (
@@ -24,7 +25,6 @@ from gateway.services.budget_service import (
 from gateway.services.log_writer import LogWriter
 from gateway.services.pricing_service import find_model_pricing
 from gateway.services.provider_kwargs import resolve_provider_selector
-from gateway.streaming import relabel_model
 from gateway.types.moderation import ModerationResponse
 
 # Locked phrasing — cross-SDK error contract. Do not reword.

--- a/src/gateway/api/routes/rerank.py
+++ b/src/gateway/api/routes/rerank.py
@@ -14,6 +14,7 @@ from gateway.api.routes._helpers import resolve_user_id
 from gateway.api.routes.chat import rate_limit_headers
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
+from gateway.model_labeling import relabel_model
 from gateway.models.entities import APIKey, UsageLog
 from gateway.rate_limit import check_rate_limit
 from gateway.services.budget_service import (
@@ -101,7 +102,7 @@ async def create_rerank(
         await refund_reservation(db, reservation)
         raise HTTPException(
             status_code=status.HTTP_402_PAYMENT_REQUIRED,
-            detail=f"No pricing configured for model '{resolved.instance}:{model}'",
+            detail=f"No pricing configured for model '{request.model}'",
         )
 
     provider_kwargs = resolved.kwargs
@@ -173,4 +174,9 @@ async def create_rerank(
         for key, value in rate_limit_headers(rate_limit_info).items():
             response.headers[key] = value
 
+    # Rerank results are returned verbatim and some providers (Voyage, Jina)
+    # carry ``model``, which would echo the target an alias exists to hide. The
+    # call is a no-op on results without the field.
+    if resolved.alias is not None:
+        relabel_model(result, resolved.alias)
     return result

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -445,9 +445,11 @@ async def create_response(
             platform_correlation_id = attempt.attempt_id
             platform_request_id = route.request_id
             stream_billing: Any = provider
+            display_model: str | None = None
         else:
             call_kwargs = {**provider_kwargs, **base_request_fields, "model": model}
             stream_billing = billing_instance
+            display_model = resolved.alias
 
         return await run_single_attempt_stream(
             adapter=_ADAPTER,
@@ -459,6 +461,7 @@ async def create_response(
             platform_correlation_id=platform_correlation_id,
             platform_request_id=platform_request_id,
             session_label=request_body.session_label,
+            display_model=display_model,
         )
 
     # ------------------------------------------------------------------
@@ -504,6 +507,7 @@ async def create_response(
         call_kwargs=call_kwargs,
         provider=billing_instance,
         model=model,
+        display_model=resolved.alias,
     )
 
     if ctx.rate_limit_info:

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -351,12 +351,18 @@ class GatewayConfig(BaseSettings):
         Each alias must name a non-empty target selector with a usable
         ``instance``/``provider`` prefix; the prefix must resolve to a configured
         provider instance or a known any-llm implementation. An alias name must
-        not collide with a configured provider instance (that would be ambiguous)
-        and its target must not itself be an alias (no chaining for now).
+        not contain a selector delimiter (``:`` or ``/``): alias lookup runs
+        before selector resolution, so such a name would silently reroute
+        requests for a real ``provider:model``. It must also not collide with a
+        configured provider instance (that would be ambiguous), and its target
+        must not itself be an alias (no chaining for now).
         """
         for name, target in self.aliases.items():
             if not name:
                 msg = "alias name must not be empty."
+                raise ValueError(msg)
+            if ":" in name or "/" in name:
+                msg = f"alias name '{name}' must not contain ':' or '/' (it would shadow a real model selector)."
                 raise ValueError(msg)
             if name in self.providers:
                 msg = f"alias '{name}' collides with a configured provider instance name."

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -143,6 +143,16 @@ class GatewayConfig(BaseSettings):
             "list declares model ids for instances whose backend has no /v1/models."
         ),
     )
+    aliases: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Model name aliases (display name -> target selector). A request naming an alias "
+            "is routed to its target ('instance:model' or 'provider:model'), and the alias is "
+            "what users see in GET /v1/models and in response 'model' fields, so the underlying "
+            "provider/model can stay hidden. Pricing, budgets, and usage logs key on the resolved "
+            "target. Standalone-mode only (hybrid resolves models against the platform)."
+        ),
+    )
     pricing: dict[str, PricingConfig] = Field(
         default_factory=dict,
         description=(
@@ -324,6 +334,56 @@ class GatewayConfig(BaseSettings):
                 return PROVIDER_TYPE_ALIASES.get(declared, declared)
         return instance
 
+    def resolve_alias(self, name: str) -> str | None:
+        """Return the target selector for a configured alias, or None.
+
+        The alias is a display name (e.g. ``myopusmodel``) that maps to a real
+        selector (``instance:model`` / ``provider:model``). Returns ``None`` when
+        ``name`` is not a configured alias, so callers fall through to ordinary
+        selector resolution.
+        """
+        target = self.aliases.get(name)
+        return target if isinstance(target, str) and target else None
+
+    def validate_aliases(self) -> None:
+        """Validate the ``aliases`` map at startup so misconfig fails fast.
+
+        Each alias must name a non-empty target selector with a usable
+        ``instance``/``provider`` prefix; the prefix must resolve to a configured
+        provider instance or a known any-llm implementation. An alias name must
+        not collide with a configured provider instance (that would be ambiguous)
+        and its target must not itself be an alias (no chaining for now).
+        """
+        for name, target in self.aliases.items():
+            if not name:
+                msg = "alias name must not be empty."
+                raise ValueError(msg)
+            if name in self.providers:
+                msg = f"alias '{name}' collides with a configured provider instance name."
+                raise ValueError(msg)
+            if not isinstance(target, str) or not target:
+                msg = f"aliases.{name} must be a non-empty target selector string."
+                raise ValueError(msg)
+            colon, slash = target.find(":"), target.find("/")
+            cut = colon if colon != -1 and (slash == -1 or colon < slash) else slash
+            if cut <= 0 or cut == len(target) - 1:
+                msg = f"aliases.{name} target '{target}' must be of the form 'instance:model' or 'provider:model'."
+                raise ValueError(msg)
+            prefix = target[:cut]
+            if prefix in self.aliases:
+                msg = f"aliases.{name} target '{target}' points at another alias; alias chaining is not supported."
+                raise ValueError(msg)
+            if prefix in self.providers:
+                continue
+            try:
+                LLMProvider(PROVIDER_TYPE_ALIASES.get(prefix, prefix))
+            except ValueError as exc:
+                msg = (
+                    f"aliases.{name} target '{target}' prefix '{prefix}' is neither a configured "
+                    "provider instance nor a known provider implementation."
+                )
+                raise ValueError(msg) from exc
+
     def validate_provider_instances(self) -> None:
         """Validate per-instance ``provider_type`` / ``models`` declarations.
 
@@ -489,6 +549,7 @@ def load_config(config_path: str | None = None) -> GatewayConfig:
     config = GatewayConfig(**config_dict)
     config.validate_mode_selection()
     config.validate_provider_instances()
+    config.validate_aliases()
     return config
 
 

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -381,8 +381,13 @@ class GatewayConfig(BaseSettings):
                 raise ValueError(msg)
             if prefix in self.providers:
                 continue
+            # No PROVIDER_TYPE_ALIASES mapping here: that normalizes an instance's
+            # declared provider_type, not a selector prefix. Request-time routing
+            # splits the selector through any-llm, which knows no such mapping, so
+            # accepting "openai-compatible:model" would pass startup and then fail
+            # on the first request.
             try:
-                LLMProvider(PROVIDER_TYPE_ALIASES.get(prefix, prefix))
+                LLMProvider(prefix)
             except ValueError as exc:
                 msg = (
                     f"aliases.{name} target '{target}' prefix '{prefix}' is neither a configured "

--- a/src/gateway/model_labeling.py
+++ b/src/gateway/model_labeling.py
@@ -1,0 +1,24 @@
+"""Relabeling of the ``model`` field on provider results and stream chunks."""
+
+from typing import Any
+
+__all__ = ["relabel_model"]
+
+
+def relabel_model(obj: Any, display_model: str) -> Any:
+    """Rewrite the ``model`` field on a result or stream chunk in place.
+
+    Used to echo a configured alias back to the caller instead of the real
+    upstream model. Handles the top-level ``model`` field (OpenAI chat chunks and
+    every non-streaming result object) plus the nested locations streaming start
+    events carry it in: Anthropic ``message_start`` (``.message.model``) and the
+    Responses events (``.response.model``). Chunks with no model field anywhere
+    are left untouched, so this is safe to call on every chunk of any format.
+    """
+    for holder in (obj, getattr(obj, "message", None), getattr(obj, "response", None)):
+        if holder is not None and hasattr(holder, "model"):
+            try:
+                holder.model = display_model
+            except (AttributeError, ValueError):  # frozen / validated field, leave as-is
+                pass
+    return obj

--- a/src/gateway/services/provider_kwargs.py
+++ b/src/gateway/services/provider_kwargs.py
@@ -82,6 +82,13 @@ class ResolvedProvider:
     """Bare model name (no instance/provider prefix)."""
     kwargs: dict[str, Any]
     """Credentials / client args for the any-llm call."""
+    alias: str | None = None
+    """Display name the caller used when the selector was a configured alias.
+
+    ``None`` for an ordinary selector. When set, response ``model`` fields are
+    relabeled to this so the underlying provider/model stays hidden; pricing,
+    budgets, and usage logs still key on the resolved target.
+    """
 
     @property
     def dispatch_model(self) -> str:
@@ -116,11 +123,18 @@ def resolve_provider_selector(config: GatewayConfig, model_selector: str) -> Res
     selector is split by any-llm directly, so unconfigured selectors and the
     legacy ``provider/model`` form keep working exactly as before.
 
+    A selector that names a configured alias is first substituted with the
+    alias target, then resolved as usual; the resulting ``ResolvedProvider``
+    carries ``alias`` so response ``model`` fields can be relabeled.
+
     Raises ``ValueError`` / ``AnyLLMError`` (from any-llm) for a selector that
     names neither a configured instance nor a known provider, mirroring the
     prior ``AnyLLM.split_model_provider`` behavior.
     """
-    split = split_selector(model_selector)
+    alias = config.resolve_alias(model_selector)
+    selector = alias if alias is not None else model_selector
+
+    split = split_selector(selector)
     if split is not None and split[0] in config.providers:
         instance, model = split
         provider = LLMProvider(config.provider_instance_type(instance))
@@ -129,14 +143,16 @@ def resolve_provider_selector(config: GatewayConfig, model_selector: str) -> Res
             provider=provider,
             model=model,
             kwargs=get_provider_kwargs(config, provider, instance=instance),
+            alias=model_selector if alias is not None else None,
         )
 
-    provider, model = AnyLLM.split_model_provider(model_selector)
+    provider, model = AnyLLM.split_model_provider(selector)
     return ResolvedProvider(
         instance=provider.value,
         provider=provider,
         model=model,
         kwargs=get_provider_kwargs(config, provider, instance=provider.value),
+        alias=model_selector if alias is not None else None,
     )
 
 

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -60,6 +60,25 @@ ANTHROPIC_STREAM_FORMAT = StreamFormat(
 )
 
 
+def relabel_model(obj: Any, display_model: str) -> Any:
+    """Rewrite the ``model`` field on a result or stream chunk in place.
+
+    Used to echo a configured alias back to the caller instead of the real
+    upstream model. Handles the top-level ``model`` field (OpenAI chat chunks and
+    every non-streaming result object) plus the nested locations streaming start
+    events carry it in: Anthropic ``message_start`` (``.message.model``) and the
+    Responses events (``.response.model``). Chunks with no model field anywhere
+    are left untouched, so this is safe to call on every chunk of any format.
+    """
+    for holder in (obj, getattr(obj, "message", None), getattr(obj, "response", None)):
+        if holder is not None and hasattr(holder, "model"):
+            try:
+                holder.model = display_model
+            except (AttributeError, ValueError):  # frozen / validated field — leave as-is
+                pass
+    return obj
+
+
 def _merge_usage(current: CompletionUsage, update: CompletionUsage) -> CompletionUsage:
     """Merge usage data, keeping the last non-zero value for each field."""
     return GatewayUsage(
@@ -81,6 +100,7 @@ async def streaming_generator(
     label: str,
     on_no_usage: Callable[[], Awaitable[None]] | None = None,
     on_incomplete: Callable[[], Awaitable[None]] | None = None,
+    display_model: str | None = None,
 ) -> AsyncGenerator[str, None]:
     """Shared SSE streaming generator with usage tracking and error handling.
 
@@ -89,6 +109,9 @@ async def streaming_generator(
         format_chunk: Formats a chunk into an SSE string
         extract_usage: Extracts usage from a chunk, or returns None if no usage present
         fmt: SSE format configuration (done marker, error payload, etc.)
+        display_model: When set (a configured alias was used), each chunk's
+            ``model`` field is relabeled to this before formatting, so the
+            underlying provider/model never appears on the wire.
         on_complete: Called with aggregated usage after successful streaming that
             included usage data
         on_error: Called with error message on failure
@@ -112,6 +135,8 @@ async def streaming_generator(
             if chunk_usage:
                 usage = _merge_usage(usage, chunk_usage)
                 has_usage = True
+            if display_model is not None:
+                chunk = relabel_model(chunk, display_model)
             yield format_chunk(chunk)
         yield fmt.done_marker
 

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -74,7 +74,7 @@ def relabel_model(obj: Any, display_model: str) -> Any:
         if holder is not None and hasattr(holder, "model"):
             try:
                 holder.model = display_model
-            except (AttributeError, ValueError):  # frozen / validated field — leave as-is
+            except (AttributeError, ValueError):  # frozen / validated field, leave as-is
                 pass
     return obj
 

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -11,6 +11,7 @@ from any_llm.types.completion import CompletionUsage
 
 from gateway.core.usage import GatewayUsage, cache_read_tokens_of, cache_write_tokens_of
 from gateway.log_config import logger
+from gateway.model_labeling import relabel_model
 
 A = TypeVar("A")  # Attempt-like, opaque to this module
 C = TypeVar("C")  # Chunk type emitted by the upstream stream
@@ -58,25 +59,6 @@ ANTHROPIC_STREAM_FORMAT = StreamFormat(
     error_payload=f"event: error\ndata: {_ANTHROPIC_ERROR}\n\n",
     yield_done_on_error=False,
 )
-
-
-def relabel_model(obj: Any, display_model: str) -> Any:
-    """Rewrite the ``model`` field on a result or stream chunk in place.
-
-    Used to echo a configured alias back to the caller instead of the real
-    upstream model. Handles the top-level ``model`` field (OpenAI chat chunks and
-    every non-streaming result object) plus the nested locations streaming start
-    events carry it in: Anthropic ``message_start`` (``.message.model``) and the
-    Responses events (``.response.model``). Chunks with no model field anywhere
-    are left untouched, so this is safe to call on every chunk of any format.
-    """
-    for holder in (obj, getattr(obj, "message", None), getattr(obj, "response", None)):
-        if holder is not None and hasattr(holder, "model"):
-            try:
-                holder.model = display_model
-            except (AttributeError, ValueError):  # frozen / validated field, leave as-is
-                pass
-    return obj
 
 
 def _merge_usage(current: CompletionUsage, update: CompletionUsage) -> CompletionUsage:

--- a/tests/integration/test_model_aliases.py
+++ b/tests/integration/test_model_aliases.py
@@ -6,12 +6,20 @@ routes to the target with the target's credentials, billing keys on the target,
 and the alias is what appears in GET /v1/models and in the response ``model``.
 """
 
-from collections.abc import Generator
+from collections.abc import AsyncIterator, Generator
 from typing import Any
 from unittest.mock import patch
 
 import pytest
-from any_llm.types.completion import ChatCompletion, ChatCompletionMessage, Choice, CompletionUsage
+from any_llm.types.completion import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    ChatCompletionMessage,
+    Choice,
+    ChoiceDelta,
+    ChunkChoice,
+    CompletionUsage,
+)
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, text
 
@@ -205,3 +213,40 @@ async def test_response_model_echoes_alias(client: TestClient) -> None:
     assert resp.status_code == 200
     # The caller sees the alias they sent, not the underlying model name.
     assert resp.json()["model"] == "myopusmodel"
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_model_echoes_alias(client: TestClient) -> None:
+    _create_user(client)
+
+    async def chunk_stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield ChatCompletionChunk(
+            id="chatcmpl-alias",
+            object="chat.completion.chunk",
+            created=0,
+            model="claude-opus-4",  # what the provider streams back
+            choices=[
+                ChunkChoice(index=0, delta=ChoiceDelta(role="assistant", content="hi"), finish_reason="stop")
+            ],
+            usage=CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+        )
+
+    async def mock_acompletion(**kwargs: Any) -> AsyncIterator[ChatCompletionChunk]:
+        return chunk_stream()
+
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "myopusmodel",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "user": "test-user",
+                "stream": True,
+            },
+            headers=HEADERS,
+        )
+    assert resp.status_code == 200
+    body = resp.text
+    # The streamed chunks carry the alias, never the underlying model name.
+    assert "myopusmodel" in body
+    assert "claude-opus-4" not in body

--- a/tests/integration/test_model_aliases.py
+++ b/tests/integration/test_model_aliases.py
@@ -128,6 +128,42 @@ def test_alias_listing_surfaces_target_pricing(client: TestClient) -> None:
     assert entry["pricing"]["output_price_per_million"] == 75.0
 
 
+def test_pricing_on_alias_target_does_not_expose_it(client: TestClient) -> None:
+    # Aliasing a model forces a pricing entry on the real target (billing keys
+    # there), and that entry must not put the hidden name back in the listing.
+    client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "home_lab:qwen3",
+            "input_price_per_million": 1.0,
+            "output_price_per_million": 2.0,
+        },
+        headers=HEADERS,
+    )
+    resp = client.get("/v1/models", headers=HEADERS)
+    assert resp.status_code == 200
+    ids = {m["id"] for m in resp.json()["data"]}
+    assert ids == {"myopusmodel", "housemodel"}
+
+
+def test_pricing_on_unaliased_model_still_lists_it(client: TestClient) -> None:
+    # Only alias targets are withheld; a priced model nothing points at is still
+    # listed, preserving the pricing-only listing behavior.
+    client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "anthropic:claude-haiku-4",
+            "input_price_per_million": 1.0,
+            "output_price_per_million": 5.0,
+        },
+        headers=HEADERS,
+    )
+    resp = client.get("/v1/models", headers=HEADERS)
+    assert resp.status_code == 200
+    ids = {m["id"] for m in resp.json()["data"]}
+    assert ids == {"myopusmodel", "housemodel", "anthropic:claude-haiku-4"}
+
+
 def test_provider_filter_excludes_aliases(client: TestClient) -> None:
     # A ?provider= filter asks for one provider's real models and must not leak
     # the alias mapping.

--- a/tests/integration/test_model_aliases.py
+++ b/tests/integration/test_model_aliases.py
@@ -8,7 +8,7 @@ and the alias is what appears in GET /v1/models and in the response ``model``.
 
 from collections.abc import AsyncIterator, Generator
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from any_llm.types.completion import (
@@ -19,6 +19,9 @@ from any_llm.types.completion import (
     ChoiceDelta,
     ChunkChoice,
     CompletionUsage,
+    CreateEmbeddingResponse,
+    Embedding,
+    Usage,
 )
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, text
@@ -26,6 +29,7 @@ from sqlalchemy import create_engine, text
 from gateway.core.config import API_KEY_HEADER, GatewayConfig
 from gateway.db import Base, get_db
 from gateway.main import create_app
+from gateway.types.moderation import ModerationResponse, ModerationResult
 
 from .conftest import _run_alembic_migrations, build_async_session_override
 
@@ -250,3 +254,57 @@ async def test_streaming_response_model_echoes_alias(client: TestClient) -> None
     # The streamed chunks carry the alias, never the underlying model name.
     assert "myopusmodel" in body
     assert "claude-opus-4" not in body
+
+
+# ---------------------------------------------------------------------------
+# Non-chat surfaces whose responses carry a ``model`` field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_embeddings_response_model_echoes_alias(client: TestClient) -> None:
+    _create_user(client)
+
+    mock_response = CreateEmbeddingResponse(
+        data=[Embedding(embedding=[0.1, 0.2], index=0, object="embedding")],
+        model="qwen3",  # what the provider returns
+        object="list",
+        usage=Usage(prompt_tokens=5, total_tokens=5),
+    )
+
+    with patch("gateway.api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_response):
+        resp = client.post(
+            "/v1/embeddings",
+            json={"model": "housemodel", "input": "hello", "user": "test-user"},
+            headers=HEADERS,
+        )
+    assert resp.status_code == 200
+    # The caller sees the alias they sent, not the underlying model name.
+    assert resp.json()["model"] == "housemodel"
+
+
+@pytest.mark.asyncio
+async def test_moderations_response_model_echoes_alias(client: TestClient) -> None:
+    _create_user(client)
+
+    mock_response = ModerationResponse(
+        id="modr-alias",
+        model="claude-opus-4",  # what the provider returns
+        results=[
+            ModerationResult(
+                flagged=False,
+                categories={"violence": False},
+                category_scores={"violence": 0.01},
+            )
+        ],
+    )
+
+    with patch("gateway.api.routes.moderations.amoderation", new_callable=AsyncMock, return_value=mock_response):
+        resp = client.post(
+            "/v1/moderations",
+            json={"model": "myopusmodel", "input": "hello", "user": "test-user"},
+            headers=HEADERS,
+        )
+    assert resp.status_code == 200
+    # The caller sees the alias they sent, not the underlying model name.
+    assert resp.json()["model"] == "myopusmodel"

--- a/tests/integration/test_model_aliases.py
+++ b/tests/integration/test_model_aliases.py
@@ -1,0 +1,207 @@
+"""End-to-end behavior for model aliases (mozilla-ai/otari#228).
+
+An alias is a display name (e.g. ``myopusmodel``) that maps to a real selector
+(``provider:model`` or a named ``instance:model``). A request naming the alias
+routes to the target with the target's credentials, billing keys on the target,
+and the alias is what appears in GET /v1/models and in the response ``model``.
+"""
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from any_llm.types.completion import ChatCompletion, ChatCompletionMessage, Choice, CompletionUsage
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+
+from gateway.core.config import API_KEY_HEADER, GatewayConfig
+from gateway.db import Base, get_db
+from gateway.main import create_app
+
+from .conftest import _run_alembic_migrations, build_async_session_override
+
+
+class _MockCompletionError(Exception):
+    """Raised to short-circuit the mocked acompletion after capturing kwargs."""
+
+
+@pytest.fixture
+def alias_config(postgres_url: str) -> GatewayConfig:
+    return GatewayConfig(
+        database_url=postgres_url,
+        master_key="test-master-key",
+        host="127.0.0.1",
+        port=8000,
+        auto_migrate=False,
+        require_pricing=False,
+        # Discovery off so the listing exposes only the curated alias names plus
+        # any explicitly-priced models, not the full provider catalog.
+        model_discovery=False,
+        providers={
+            "anthropic": {"api_key": "sk-ant"},
+            "home_lab": {
+                "provider_type": "openai",
+                "api_base": "https://box.ts.net/v1",
+                "api_key": "home-lab-token",
+            },
+        },
+        aliases={
+            "myopusmodel": "anthropic:claude-opus-4",
+            "housemodel": "home_lab:qwen3",
+        },
+    )
+
+
+@pytest.fixture
+def client(alias_config: GatewayConfig) -> Generator[TestClient]:
+    _run_alembic_migrations(alias_config.database_url)
+    engine = create_engine(alias_config.database_url, pool_pre_ping=True)
+    app = create_app(alias_config)
+    override_get_db, dispose_override = build_async_session_override(alias_config.database_url)
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        with TestClient(app) as test_client:
+            yield test_client
+    finally:
+        dispose_override()
+        Base.metadata.drop_all(bind=engine)
+        with engine.connect() as conn:
+            conn.execute(text("DROP TABLE IF EXISTS alembic_version CASCADE"))
+            conn.commit()
+
+
+HEADERS = {API_KEY_HEADER: "Bearer test-master-key"}
+
+
+def _create_user(client: TestClient) -> None:
+    resp = client.post("/v1/users", json={"user_id": "test-user", "alias": "Test User"}, headers=HEADERS)
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Listing
+# ---------------------------------------------------------------------------
+
+
+def test_list_models_shows_aliases_only_with_discovery_off(client: TestClient) -> None:
+    resp = client.get("/v1/models", headers=HEADERS)
+    assert resp.status_code == 200
+    ids = {m["id"] for m in resp.json()["data"]}
+    # Only the curated alias names are exposed; the real provider/model is hidden.
+    assert ids == {"myopusmodel", "housemodel"}
+
+
+def test_alias_listing_owned_by_is_gateway(client: TestClient) -> None:
+    resp = client.get("/v1/models", headers=HEADERS)
+    entry = next(m for m in resp.json()["data"] if m["id"] == "myopusmodel")
+    assert entry["owned_by"] == "otari"
+    assert entry["object"] == "model"
+
+
+def test_alias_listing_surfaces_target_pricing(client: TestClient) -> None:
+    # Pricing is configured on the real target; the alias inherits it in listing.
+    client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "anthropic:claude-opus-4",
+            "input_price_per_million": 15.0,
+            "output_price_per_million": 75.0,
+        },
+        headers=HEADERS,
+    )
+    resp = client.get("/v1/models", headers=HEADERS)
+    entry = next(m for m in resp.json()["data"] if m["id"] == "myopusmodel")
+    assert entry["pricing"]["input_price_per_million"] == 15.0
+    assert entry["pricing"]["output_price_per_million"] == 75.0
+
+
+def test_provider_filter_excludes_aliases(client: TestClient) -> None:
+    # A ?provider= filter asks for one provider's real models and must not leak
+    # the alias mapping.
+    resp = client.get("/v1/models", params={"provider": "anthropic"}, headers=HEADERS)
+    assert resp.status_code == 200
+    ids = {m["id"] for m in resp.json()["data"]}
+    assert "myopusmodel" not in ids
+
+
+def test_get_model_by_alias(client: TestClient) -> None:
+    resp = client.get("/v1/models/housemodel", headers=HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == "housemodel"
+    assert data["owned_by"] == "otari"
+
+
+# ---------------------------------------------------------------------------
+# Request routing
+# ---------------------------------------------------------------------------
+
+
+def _post_chat_capture(client: TestClient, model: str) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    async def mock_acompletion(**kwargs: Any) -> None:
+        captured.update(kwargs)
+        raise _MockCompletionError
+
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
+        client.post(
+            "/v1/chat/completions",
+            json={"model": model, "messages": [{"role": "user", "content": "Hi"}], "user": "test-user"},
+            headers=HEADERS,
+        )
+    assert captured, f"acompletion was never called for {model!r}"
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_alias_routes_to_provider_target(client: TestClient) -> None:
+    _create_user(client)
+    captured = _post_chat_capture(client, "myopusmodel")
+    # any-llm sees the real model, with the target provider's credentials.
+    assert captured["model"] == "anthropic:claude-opus-4"
+    assert captured["api_key"] == "sk-ant"
+
+
+@pytest.mark.asyncio
+async def test_alias_routes_to_named_instance_target(client: TestClient) -> None:
+    _create_user(client)
+    captured = _post_chat_capture(client, "housemodel")
+    # Alias -> named instance -> implementation, with the instance's credentials.
+    assert captured["model"] == "openai:qwen3"
+    assert captured["api_base"] == "https://box.ts.net/v1"
+    assert captured["api_key"] == "home-lab-token"
+
+
+@pytest.mark.asyncio
+async def test_response_model_echoes_alias(client: TestClient) -> None:
+    _create_user(client)
+
+    mock_response = ChatCompletion(
+        id="chatcmpl-alias",
+        object="chat.completion",
+        created=0,
+        model="claude-opus-4",  # what the provider returns
+        choices=[
+            Choice(
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content="hi"),
+                finish_reason="stop",
+            )
+        ],
+        usage=CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+    )
+
+    async def mock_acompletion(**kwargs: Any) -> ChatCompletion:
+        return mock_response
+
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"model": "myopusmodel", "messages": [{"role": "user", "content": "Hi"}], "user": "test-user"},
+            headers=HEADERS,
+        )
+    assert resp.status_code == 200
+    # The caller sees the alias they sent, not the underlying model name.
+    assert resp.json()["model"] == "myopusmodel"

--- a/tests/integration/test_model_aliases.py
+++ b/tests/integration/test_model_aliases.py
@@ -92,6 +92,40 @@ def _create_user(client: TestClient) -> None:
 
 
 # ---------------------------------------------------------------------------
+# require_pricing rejection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        ("/v1/embeddings", {"input": "hello"}),
+        ("/v1/rerank", {"query": "q", "documents": ["a", "b"]}),
+        ("/v1/images/generations", {"prompt": "a cat"}),
+    ],
+)
+def test_unpriced_alias_402_echoes_alias_not_target(
+    client: TestClient,
+    alias_config: GatewayConfig,
+    path: str,
+    payload: dict[str, Any],
+) -> None:
+    # The app holds this config object, so the gate reads the flipped flag. With
+    # no pricing on the target, the 402 must name the alias: echoing
+    # "{instance}:{model}" would hand back the string aliases exist to hide.
+    alias_config.require_pricing = True
+    _create_user(client)
+
+    resp = client.post(path, json={"model": "myopusmodel", "user": "test-user", **payload}, headers=HEADERS)
+
+    assert resp.status_code == 402
+    detail = resp.json()["detail"]
+    assert "myopusmodel" in detail
+    assert "claude-opus-4" not in detail
+    assert "anthropic" not in detail
+
+
+# ---------------------------------------------------------------------------
 # Listing
 # ---------------------------------------------------------------------------
 
@@ -126,6 +160,53 @@ def test_alias_listing_surfaces_target_pricing(client: TestClient) -> None:
     entry = next(m for m in resp.json()["data"] if m["id"] == "myopusmodel")
     assert entry["pricing"]["input_price_per_million"] == 15.0
     assert entry["pricing"]["output_price_per_million"] == 75.0
+
+
+def test_legacy_form_pricing_row_still_prices_alias(client: TestClient, alias_config: GatewayConfig) -> None:
+    # Keys are canonicalized on write, but a row predating that may still use the
+    # legacy "provider/model" separator. It must price the alias and must not put
+    # the target back in the listing: withholding it while failing to match the
+    # alias would show the price nowhere.
+    engine = create_engine(alias_config.database_url)
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO model_pricing "
+                    "(model_key, effective_at, input_price_per_million, output_price_per_million, "
+                    " created_at, updated_at) "
+                    "VALUES ('anthropic/claude-opus-4', NOW(), 15.0, 75.0, NOW(), NOW())"
+                ),
+            )
+            conn.commit()
+    finally:
+        engine.dispose()
+
+    resp = client.get("/v1/models", headers=HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert {m["id"] for m in data} == {"myopusmodel", "housemodel"}
+    entry = next(m for m in data if m["id"] == "myopusmodel")
+    assert entry["pricing"]["input_price_per_million"] == 15.0
+
+    # The single-model endpoint reads the same row through its filtered query.
+    single = client.get("/v1/models/myopusmodel", headers=HEADERS)
+    assert single.json()["pricing"]["input_price_per_million"] == 15.0
+
+
+def test_get_model_alias_surfaces_target_pricing(client: TestClient) -> None:
+    client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "home_lab:qwen3",
+            "input_price_per_million": 1.0,
+            "output_price_per_million": 2.0,
+        },
+        headers=HEADERS,
+    )
+    resp = client.get("/v1/models/housemodel", headers=HEADERS)
+    assert resp.status_code == 200
+    assert resp.json()["pricing"] == {"input_price_per_million": 1.0, "output_price_per_million": 2.0}
 
 
 def test_pricing_on_alias_target_does_not_expose_it(client: TestClient) -> None:

--- a/tests/unit/test_model_aliases.py
+++ b/tests/unit/test_model_aliases.py
@@ -60,6 +60,25 @@ def test_validate_rejects_unknown_provider_prefix() -> None:
         GatewayConfig(aliases={"a": "not_a_provider:model"}).validate_aliases()
 
 
+@pytest.mark.parametrize("prefix", ["openai-compatible", "openai_compatible"])
+def test_validate_rejects_provider_type_alias_prefix(prefix: str) -> None:
+    # A provider_type alias names an instance's implementation, not a selector
+    # prefix: any-llm does not know it, so request-time routing would raise. It
+    # must fail at startup rather than on the first request.
+    with pytest.raises(ValueError, match="neither a configured"):
+        GatewayConfig(aliases={"fastmodel": f"{prefix}:gpt-4o"}).validate_aliases()
+
+
+def test_validate_accepts_instance_named_like_provider_type_alias() -> None:
+    # The prefix is a configured instance here, so it stays valid: only the
+    # unconfigured provider_type-alias prefix is rejected.
+    config = GatewayConfig(
+        providers={"openai-compatible": {"provider_type": "openai", "api_base": "http://x/v1"}},
+        aliases={"fastmodel": "openai-compatible:gpt-4o"},
+    )
+    config.validate_aliases()  # no raise
+
+
 @pytest.mark.parametrize("name", ["openai:gpt-4o", "openai/gpt-4o", "my:model"])
 def test_validate_rejects_selector_shaped_name(name: str) -> None:
     # Alias lookup runs before selector resolution, so a name containing a

--- a/tests/unit/test_model_aliases.py
+++ b/tests/unit/test_model_aliases.py
@@ -7,8 +7,8 @@ from any_llm import LLMProvider
 
 from gateway.api.routes.models import _alias_target_keys
 from gateway.core.config import GatewayConfig
+from gateway.model_labeling import relabel_model
 from gateway.services.provider_kwargs import normalize_pricing_key, resolve_provider_selector
-from gateway.streaming import relabel_model
 
 # ---------------------------------------------------------------------------
 # config.resolve_alias

--- a/tests/unit/test_model_aliases.py
+++ b/tests/unit/test_model_aliases.py
@@ -1,0 +1,170 @@
+"""Unit tests for model aliases (display name -> target selector)."""
+
+from __future__ import annotations
+
+import pytest
+from any_llm import LLMProvider
+
+from gateway.core.config import GatewayConfig
+from gateway.services.provider_kwargs import resolve_provider_selector
+from gateway.streaming import relabel_model
+
+# ---------------------------------------------------------------------------
+# config.resolve_alias
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_alias_returns_target() -> None:
+    config = GatewayConfig(aliases={"myopusmodel": "anthropic:claude-opus-4"})
+    assert config.resolve_alias("myopusmodel") == "anthropic:claude-opus-4"
+
+
+def test_resolve_alias_unknown_returns_none() -> None:
+    assert GatewayConfig().resolve_alias("nope") is None
+
+
+def test_resolve_alias_empty_target_returns_none() -> None:
+    assert GatewayConfig(aliases={"x": ""}).resolve_alias("x") is None
+
+
+# ---------------------------------------------------------------------------
+# config.validate_aliases
+# ---------------------------------------------------------------------------
+
+
+def test_validate_accepts_provider_target() -> None:
+    GatewayConfig(aliases={"fastmodel": "openai:gpt-5"}).validate_aliases()  # no raise
+
+
+def test_validate_accepts_named_instance_target() -> None:
+    config = GatewayConfig(
+        providers={"home_lab": {"provider_type": "openai", "api_base": "http://x/v1"}},
+        aliases={"housemodel": "home_lab:qwen3"},
+    )
+    config.validate_aliases()  # no raise
+
+
+def test_validate_rejects_empty_target() -> None:
+    with pytest.raises(ValueError, match="non-empty target"):
+        GatewayConfig(aliases={"a": ""}).validate_aliases()
+
+
+def test_validate_rejects_target_without_prefix() -> None:
+    with pytest.raises(ValueError, match="instance:model"):
+        GatewayConfig(aliases={"a": "gpt-5"}).validate_aliases()
+
+
+def test_validate_rejects_unknown_provider_prefix() -> None:
+    with pytest.raises(ValueError, match="neither a configured"):
+        GatewayConfig(aliases={"a": "not_a_provider:model"}).validate_aliases()
+
+
+def test_validate_rejects_collision_with_provider_instance() -> None:
+    config = GatewayConfig(
+        providers={"openai": {"api_key": "sk"}},
+        aliases={"openai": "anthropic:claude-opus-4"},
+    )
+    with pytest.raises(ValueError, match="collides with a configured provider"):
+        config.validate_aliases()
+
+
+def test_validate_rejects_alias_chaining() -> None:
+    config = GatewayConfig(
+        aliases={"a": "anthropic:claude-opus-4", "b": "a:whatever"},
+    )
+    with pytest.raises(ValueError, match="alias chaining is not supported"):
+        config.validate_aliases()
+
+
+# ---------------------------------------------------------------------------
+# resolve_provider_selector with aliases
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_alias_to_provider_model() -> None:
+    config = GatewayConfig(
+        providers={"anthropic": {"api_key": "sk-ant"}},
+        aliases={"myopusmodel": "anthropic:claude-opus-4"},
+    )
+    resolved = resolve_provider_selector(config, "myopusmodel")
+    # Dispatch + billing target the real model...
+    assert resolved.provider == LLMProvider.ANTHROPIC
+    assert resolved.model == "claude-opus-4"
+    assert resolved.instance == "anthropic"
+    assert resolved.dispatch_model == "anthropic:claude-opus-4"
+    assert resolved.kwargs["api_key"] == "sk-ant"
+    # ...but the alias is carried for response relabeling.
+    assert resolved.alias == "myopusmodel"
+
+
+def test_resolve_alias_to_named_instance() -> None:
+    config = GatewayConfig(
+        providers={"home_lab": {"provider_type": "openai", "api_base": "http://x/v1", "api_key": "ht"}},
+        aliases={"housemodel": "home_lab:qwen3"},
+    )
+    resolved = resolve_provider_selector(config, "housemodel")
+    assert resolved.provider == LLMProvider.OPENAI
+    assert resolved.instance == "home_lab"
+    assert resolved.dispatch_model == "openai:qwen3"
+    assert resolved.kwargs["api_base"] == "http://x/v1"
+    assert resolved.alias == "housemodel"
+
+
+def test_resolve_non_alias_has_no_alias() -> None:
+    config = GatewayConfig(
+        providers={"openai": {"api_key": "sk"}},
+        aliases={"fastmodel": "openai:gpt-5"},
+    )
+    resolved = resolve_provider_selector(config, "openai:gpt-4o")
+    assert resolved.alias is None
+
+
+# ---------------------------------------------------------------------------
+# relabel_model
+# ---------------------------------------------------------------------------
+
+
+class _HasModel:
+    def __init__(self, model: str) -> None:
+        self.model = model
+
+
+class _MessageEvent:
+    """Mimics an Anthropic ``message_start`` event (nested ``.message.model``)."""
+
+    def __init__(self, model: str) -> None:
+        self.message = _HasModel(model)
+
+
+class _ResponseEvent:
+    """Mimics a Responses stream event (nested ``.response.model``)."""
+
+    def __init__(self, model: str) -> None:
+        self.response = _HasModel(model)
+
+
+def test_relabel_top_level_model() -> None:
+    obj = _HasModel("anthropic:claude-opus-4")
+    relabel_model(obj, "myopusmodel")
+    assert obj.model == "myopusmodel"
+
+
+def test_relabel_nested_message_model() -> None:
+    chunk = _MessageEvent("claude-opus-4")
+    relabel_model(chunk, "myopusmodel")
+    assert chunk.message.model == "myopusmodel"
+
+
+def test_relabel_nested_response_model() -> None:
+    event = _ResponseEvent("gpt-5")
+    relabel_model(event, "fastmodel")
+    assert event.response.model == "fastmodel"
+
+
+def test_relabel_no_model_field_is_noop() -> None:
+    class _Bare:
+        pass
+
+    obj = _Bare()
+    relabel_model(obj, "fastmodel")  # must not raise
+    assert not hasattr(obj, "model")

--- a/tests/unit/test_model_aliases.py
+++ b/tests/unit/test_model_aliases.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import pytest
 from any_llm import LLMProvider
 
+from gateway.api.routes.models import _alias_target_keys
 from gateway.core.config import GatewayConfig
-from gateway.services.provider_kwargs import resolve_provider_selector
+from gateway.services.provider_kwargs import normalize_pricing_key, resolve_provider_selector
 from gateway.streaming import relabel_model
 
 # ---------------------------------------------------------------------------
@@ -150,6 +151,18 @@ class _ResponseEvent:
 
     def __init__(self, model: str) -> None:
         self.response = _HasModel(model)
+
+
+def test_alias_target_keys_are_canonical() -> None:
+    # Targets are collected in canonical "instance:model" form so a pricing row
+    # written in the legacy "provider/model" shape still matches its alias and is
+    # withheld from the listing.
+    config = GatewayConfig(
+        providers={"anthropic": {"api_key": "sk-ant"}},
+        aliases={"myopusmodel": "anthropic:claude-opus-4"},
+    )
+    assert _alias_target_keys(config) == {"anthropic:claude-opus-4"}
+    assert normalize_pricing_key(config, "anthropic/claude-opus-4") in _alias_target_keys(config)
 
 
 def test_relabel_top_level_model() -> None:

--- a/tests/unit/test_model_aliases.py
+++ b/tests/unit/test_model_aliases.py
@@ -59,6 +59,15 @@ def test_validate_rejects_unknown_provider_prefix() -> None:
         GatewayConfig(aliases={"a": "not_a_provider:model"}).validate_aliases()
 
 
+@pytest.mark.parametrize("name", ["openai:gpt-4o", "openai/gpt-4o", "my:model"])
+def test_validate_rejects_selector_shaped_name(name: str) -> None:
+    # Alias lookup runs before selector resolution, so a name containing a
+    # delimiter would silently reroute requests for a real provider:model.
+    config = GatewayConfig(aliases={name: "anthropic:claude-opus-4"})
+    with pytest.raises(ValueError, match="must not contain"):
+        config.validate_aliases()
+
+
 def test_validate_rejects_collision_with_provider_instance() -> None:
     config = GatewayConfig(
         providers={"openai": {"api_key": "sk"}},


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

Closes #228. Builds on named provider instances (#219).

## What

Adds a top-level `aliases` map (display name to target selector) so an operator can expose a friendly, stable model name and keep the underlying provider/model hidden:

```yaml
aliases:
  myopusmodel: anthropic:claude-opus-4
  fastmodel: openai:gpt-5
  housemodel: home_lab:qwen3     # target may be a named instance from #219
```

A request whose `model` is an alias routes to its target. The alias is what callers see in `GET /v1/models` and in the response `model` field; the real model name never appears on the wire.

## Design decisions

1. **Billing keys on the real target.** Aliases are pure naming indirection: usage logs, pricing, and budgets key on the resolved `instance:model`. Configure pricing once for the real model and every alias pointing at it inherits it.
2. **Listing is additive.** Alias entries appear in `GET /v1/models` (and `GET /v1/models/{id}`) with pricing read from the target, reported as `owned_by: otari`. Only on the unfiltered listing; a `?provider=` filter will not leak the mapping. To expose only curated alias names, set `model_discovery: false`.
3. **Response model is relabeled to the alias.** The `model` field on both non-streaming results and streaming chunks is rewritten to the alias the caller used.

Aliases are standalone-mode only, like named instances: in hybrid mode model resolution and routing are owned by the otari.ai platform.

## Implementation

- `core/config.py`: `aliases` field, `resolve_alias()`, and `validate_aliases()` (called at load). Fails fast on empty or prefix-less targets, unknown provider prefixes, names colliding with a provider instance, and alias chaining.
- `services/provider_kwargs.py`: alias substitution in `resolve_provider_selector` (the single chokepoint used by every route), with the alias carried on `ResolvedProvider` for relabeling.
- `api/routes/models.py`: alias entries in the listing and single-model endpoints, pricing looked up from the resolved target.
- `streaming.py` + `_pipeline.py`: a `relabel_model()` helper threaded as `display_model` through the standalone non-stream and stream run paths. Inert for non-alias requests.
- Docs: `docs/models.md` and `config.example.yml`.

## Out of scope (v1)

Alias chaining, per-alias independent pricing, and a flag to hide aliased real models while discovery is on.

## Testing

- 17 unit tests (resolution, validation, relabeling) and 8 integration tests (listing, routing to provider and named-instance targets, response echo, provider-filter exclusion).
- `ruff`, `mypy --strict`, and the OpenAPI freshness check pass. Full unit suite: 555 passed. The alias integration suite and related route/streaming/usage suites pass against PostgreSQL.

## Reviewer note

I chose `owned_by: "otari"` for aliased listing entries to avoid leaking the real provider. Happy to make this configurable per alias if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## PR Type

- [x] New Feature

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (no API contract change).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a new “model aliases” feature that lets callers use friendly, vendor-neutral model names.
- Aliases are resolved at startup and then applied consistently across model routing and API responses (chat, embeddings, moderations), including both streaming and non-streaming.
- Updated `/v1/models` so alias models appear in listings (with inherited pricing from the real target) and `/v1/models/{alias}` returns metadata for the alias.
- Updated documentation and the example config to describe alias behavior, limitations (standalone mode only, no alias chaining), and discovery controls.
- Added unit and integration tests covering alias resolution, response relabeling, listing behavior, routing to provider instances, and validation failures.

## Technical notes

- API responses echo the caller’s alias as the `model` field, while pricing/usage/budgets/billing remain tied to the resolved underlying target.
- Aliases are validated at startup, including format/collision checks and rejecting unsupported alias target prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->