### PR TITLE
feat(hybrid): forward request session_label to platform usage report

### DIFF
--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -263,11 +263,27 @@ Content-Type: application/json
     "cache_read_tokens": 8,            // provider cache-read input tokens
     "cache_write_tokens": 0           // cache-write (creation) input tokens; Anthropic only
   },
-  "error_class": "http_401"            // optional on error; omitted when the
+  "error_class": "http_401",           // optional on error; omitted when the
                                        // Otari can't classify the failure
                                        // (e.g. mid-stream errors). See below.
+  "session_label": "my-run-personas"   // optional; the caller's cost-attribution
+                                       // label (see below). Omitted when absent.
 }
 ```
+
+`session_label` is an optional caller-supplied label for cost attribution (per
+run, experiment, or conversation). A caller sets it on the request body
+(`session_label` on the chat/messages/responses request); Otari strips it before
+the upstream provider call and forwards it here so the platform can attribute the
+attempt's spend to that session without the caller standing up OpenTelemetry. It
+is trimmed and omitted when blank; Otari caps it at 255 characters at the request
+boundary so the platform never has to truncate. All attempts of one request carry
+the same label.
+
+> **`user` is not used for cost attribution in hybrid mode.** The OpenAI-standard
+> `user` field is stripped before the upstream call and is not forwarded on the
+> usage report, so it does not segment spend here. Callers who want per-run cost
+> breakdown must use `session_label`.
 
 `cache_read_tokens` and `cache_write_tokens` are additive fields carrying the
 provider cached-token counts (default `0` when a provider reports none). Their

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -449,6 +449,19 @@
             ],
             "title": "Seed"
           },
+          "session_label": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional caller-supplied label for cost attribution (per run, experiment, or conversation). In hybrid mode it is forwarded onto the platform usage report so spend can be sliced by session without standing up OpenTelemetry. Stripped before the request is forwarded upstream to the provider.",
+            "title": "Session Label"
+          },
           "stop": {
             "anyOf": [
               {
@@ -1401,6 +1414,19 @@
             "title": "Model",
             "type": "string"
           },
+          "session_label": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional caller-supplied label for cost attribution (per run, experiment, or conversation). In hybrid mode it is forwarded onto the platform usage report so spend can be sliced by session without standing up OpenTelemetry. Stripped before the request is forwarded upstream to the provider.",
+            "title": "Session Label"
+          },
           "stop_sequences": {
             "anyOf": [
               {
@@ -2116,6 +2142,19 @@
               }
             ],
             "title": "Service Tier"
+          },
+          "session_label": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional caller-supplied label for cost attribution (per run, experiment, or conversation). In hybrid mode it is forwarded onto the platform usage report so spend can be sliced by session without standing up OpenTelemetry. Stripped before the request is forwarded upstream to the provider.",
+            "title": "Session Label"
           },
           "store": {
             "anyOf": [

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -459,7 +459,7 @@
                 "type": "null"
               }
             ],
-            "description": "Optional caller-supplied label for cost attribution (per run, experiment, or conversation). In hybrid mode it is forwarded onto the platform usage report so spend can be sliced by session without standing up OpenTelemetry. Stripped before the request is forwarded upstream to the provider.",
+            "description": "Optional caller-supplied label for cost attribution (per run, experiment, or conversation). In hybrid mode it is forwarded onto the platform usage report so spend can be sliced by session without standing up OpenTelemetry. Stripped before the request is forwarded upstream to the provider. Has no effect in standalone mode, where there is no platform to report it to.",
             "title": "Session Label"
           },
           "stop": {
@@ -1424,7 +1424,7 @@
                 "type": "null"
               }
             ],
-            "description": "Optional caller-supplied label for cost attribution (per run, experiment, or conversation). In hybrid mode it is forwarded onto the platform usage report so spend can be sliced by session without standing up OpenTelemetry. Stripped before the request is forwarded upstream to the provider.",
+            "description": "Optional caller-supplied label for cost attribution (per run, experiment, or conversation). In hybrid mode it is forwarded onto the platform usage report so spend can be sliced by session without standing up OpenTelemetry. Stripped before the request is forwarded upstream to the provider. Has no effect in standalone mode, where there is no platform to report it to.",
             "title": "Session Label"
           },
           "stop_sequences": {
@@ -2153,7 +2153,7 @@
                 "type": "null"
               }
             ],
-            "description": "Optional caller-supplied label for cost attribution (per run, experiment, or conversation). In hybrid mode it is forwarded onto the platform usage report so spend can be sliced by session without standing up OpenTelemetry. Stripped before the request is forwarded upstream to the provider.",
+            "description": "Optional caller-supplied label for cost attribution (per run, experiment, or conversation). In hybrid mode it is forwarded onto the platform usage report so spend can be sliced by session without standing up OpenTelemetry. Stripped before the request is forwarded upstream to the provider. Has no effect in standalone mode, where there is no platform to report it to.",
             "title": "Session Label"
           },
           "store": {

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -1101,6 +1101,7 @@ def build_streaming_response(
     reservation: ReservationHandle | None,
     platform_correlation_id: str | None = None,
     platform_request_id: str | None = None,
+    session_label: str | None = None,
 ) -> StreamingResponse:
     """Wrap an already-opened upstream stream in an SSE response.
 
@@ -1127,6 +1128,7 @@ def build_streaming_response(
                     correlation_id=platform_correlation_id,
                     outcome="success",
                     usage=usage_data,
+                    session_label=session_label,
                 )
             )
             return
@@ -1187,6 +1189,7 @@ def build_streaming_response(
                     correlation_id=platform_correlation_id,
                     outcome="error",
                     usage=None,
+                    session_label=session_label,
                 )
             )
             return
@@ -1280,6 +1283,7 @@ async def run_single_attempt_stream(
     model: str,
     platform_correlation_id: str | None = None,
     platform_request_id: str | None = None,
+    session_label: str | None = None,
 ) -> StreamingResponse:
     """Open a single-attempt stream and wrap it with settlement callbacks.
 
@@ -1324,6 +1328,7 @@ async def run_single_attempt_stream(
         reservation=ctx.reservation,
         platform_correlation_id=platform_correlation_id,
         platform_request_id=platform_request_id,
+        session_label=session_label,
     )
 
 
@@ -1331,6 +1336,7 @@ async def _flush_pending_usage_reports(
     config: GatewayConfig,
     pending_error_reports: list[tuple[str, str, Any, str | None]],
     request_id: str,
+    session_label: str | None = None,
 ) -> None:
     """Send the per-attempt error reports inline on the all-failed path.
 
@@ -1353,7 +1359,7 @@ async def _flush_pending_usage_reports(
         results = await asyncio.wait_for(
             asyncio.gather(
                 *(
-                    _report_platform_usage(config, attempt_id, outcome, usage, error_class)
+                    _report_platform_usage(config, attempt_id, outcome, usage, error_class, session_label)
                     for attempt_id, outcome, usage, error_class in pending_error_reports
                 ),
                 return_exceptions=True,
@@ -1386,6 +1392,7 @@ async def run_streaming_with_fallback(
     background_tasks: BackgroundTasks,
     rate_limit_info: RateLimitInfo | None,
     tool_ctx: ToolContext,
+    session_label: str | None = None,
 ) -> StreamingResponse:
     """Multi-attempt streaming for hybrid-mode requests.
 
@@ -1464,6 +1471,7 @@ async def run_streaming_with_fallback(
             "error",
             None,
             failure.error_class,
+            session_label,
         )
         pending_error_reports.append((attempt.attempt_id, "error", None, failure.error_class))
         logger.warning(
@@ -1492,7 +1500,9 @@ async def run_streaming_with_fallback(
         # if the flush raises or is interrupted.
         try:
             if not isinstance(exc, asyncio.CancelledError):
-                await _flush_pending_usage_reports(config, pending_error_reports, route.request_id)
+                await _flush_pending_usage_reports(
+                    config, pending_error_reports, route.request_id, session_label
+                )
         finally:
             await backend_stack.aclose()
         raise
@@ -1524,6 +1534,7 @@ async def run_streaming_with_fallback(
         reservation=None,
         platform_correlation_id=chosen.attempt_id,
         platform_request_id=route.request_id,
+        session_label=session_label,
     )
 
 
@@ -1548,6 +1559,7 @@ async def run_platform_non_stream(
     background_tasks: BackgroundTasks,
     config: GatewayConfig,
     rate_limit_info: RateLimitInfo | None,
+    session_label: str | None = None,
 ) -> ResultT:
     """Drive the multi-attempt hybrid-mode non-streaming path via the shared
     ``run_platform_attempts`` runner, dispatching each attempt through the
@@ -1591,6 +1603,7 @@ async def run_platform_non_stream(
             outcome,
             usage,
             error_class,
+            session_label,
         )
         if outcome != "success":
             pending_error_reports.append((attempt.attempt_id, outcome, usage, error_class))
@@ -1620,7 +1633,7 @@ async def run_platform_non_stream(
         # branch only catches HTTPException (what the runner raises on the
         # all-failed path); a CancelledError propagates without doing reporting
         # I/O during teardown.
-        await _flush_pending_usage_reports(config, pending_error_reports, route.request_id)
+        await _flush_pending_usage_reports(config, pending_error_reports, route.request_id, session_label)
         raise
 
 

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -668,6 +668,7 @@ async def _report_platform_usage(
     outcome: str,
     usage: CompletionUsage | None,
     error_class: str | None = None,
+    session_label: str | None = None,
 ) -> None:
     """POST a usage record back to the platform with bounded retries.
 
@@ -686,6 +687,12 @@ async def _report_platform_usage(
     headers = {"X-Gateway-Token": config.platform_token or ""}
 
     payload: dict[str, Any] = {"correlation_id": correlation_id, "status": outcome}
+    # Forward the caller's session label so the platform can attribute this
+    # attempt's spend. Blank is treated as absent; the body field already caps
+    # length, so the platform never has to truncate.
+    normalized_label = (session_label or "").strip()
+    if normalized_label:
+        payload["session_label"] = normalized_label
     if outcome == "success":
         token_usage = usage or CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
         payload["usage"] = {

--- a/src/gateway/api/routes/_schema_derive.py
+++ b/src/gateway/api/routes/_schema_derive.py
@@ -39,6 +39,18 @@ PARAM_FIELD_RENAMES: dict[str, str] = {"model_id": "model"}
 # are also stripped before forwarding (see ``_tools._strip_gateway_fields``) to
 # cover schemas that allow extra fields (the Responses request uses
 # ``extra="allow"``).
+# Shared definition for the optional ``session_label`` body field on the chat,
+# messages, and responses request schemas. Capped at 255 to match the platform's
+# indexed session-label keyword so the value is never truncated downstream.
+SESSION_LABEL_MAX_LENGTH = 255
+SESSION_LABEL_DESC = (
+    "Optional caller-supplied label for cost attribution (per run, experiment, "
+    "or conversation). In hybrid mode it is forwarded onto the platform usage "
+    "report so spend can be sliced by session without standing up OpenTelemetry. "
+    "Stripped before the request is forwarded upstream to the provider."
+)
+
+
 SENSITIVE_PARAM_FIELDS: frozenset[str] = frozenset(
     {
         "api_key",

--- a/src/gateway/api/routes/_schema_derive.py
+++ b/src/gateway/api/routes/_schema_derive.py
@@ -39,18 +39,6 @@ PARAM_FIELD_RENAMES: dict[str, str] = {"model_id": "model"}
 # are also stripped before forwarding (see ``_tools._strip_gateway_fields``) to
 # cover schemas that allow extra fields (the Responses request uses
 # ``extra="allow"``).
-# Shared definition for the optional ``session_label`` body field on the chat,
-# messages, and responses request schemas. Capped at 255 to match the platform's
-# indexed session-label keyword so the value is never truncated downstream.
-SESSION_LABEL_MAX_LENGTH = 255
-SESSION_LABEL_DESC = (
-    "Optional caller-supplied label for cost attribution (per run, experiment, "
-    "or conversation). In hybrid mode it is forwarded onto the platform usage "
-    "report so spend can be sliced by session without standing up OpenTelemetry. "
-    "Stripped before the request is forwarded upstream to the provider."
-)
-
-
 SENSITIVE_PARAM_FIELDS: frozenset[str] = frozenset(
     {
         "api_key",
@@ -64,6 +52,17 @@ SENSITIVE_PARAM_FIELDS: frozenset[str] = frozenset(
         "aws_access_key_id",
         "aws_secret_access_key",
     }
+)
+
+# Shared definition for the optional ``session_label`` body field on the chat,
+# messages, and responses request schemas. Capped at 255 to match the platform's
+# indexed session-label keyword so the value is never truncated downstream.
+SESSION_LABEL_MAX_LENGTH = 255
+SESSION_LABEL_DESC = (
+    "Optional caller-supplied label for cost attribution (per run, experiment, "
+    "or conversation). In hybrid mode it is forwarded onto the platform usage "
+    "report so spend can be sliced by session without standing up OpenTelemetry. "
+    "Stripped before the request is forwarded upstream to the provider."
 )
 
 

--- a/src/gateway/api/routes/_schema_derive.py
+++ b/src/gateway/api/routes/_schema_derive.py
@@ -62,7 +62,8 @@ SESSION_LABEL_DESC = (
     "Optional caller-supplied label for cost attribution (per run, experiment, "
     "or conversation). In hybrid mode it is forwarded onto the platform usage "
     "report so spend can be sliced by session without standing up OpenTelemetry. "
-    "Stripped before the request is forwarded upstream to the provider."
+    "Stripped before the request is forwarded upstream to the provider. Has no "
+    "effect in standalone mode, where there is no platform to report it to."
 )
 
 

--- a/src/gateway/api/routes/_tools.py
+++ b/src/gateway/api/routes/_tools.py
@@ -78,6 +78,7 @@ _GATEWAY_INTERNAL_FIELDS = (
     "guardrails",
     "tools_header",
     "max_tool_iterations",
+    "session_label",
     "user",
 )
 

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -39,7 +39,7 @@ from gateway.api.routes._pipeline import (
     run_streaming_with_fallback,
 )
 from gateway.api.routes._platform import ResolvedAttempt
-from gateway.api.routes._schema_derive import derive_request_base
+from gateway.api.routes._schema_derive import SESSION_LABEL_DESC, SESSION_LABEL_MAX_LENGTH, derive_request_base
 from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
 from gateway.core.usage import GatewayUsage
@@ -114,6 +114,7 @@ class ChatCompletionRequest(derive_request_base(CompletionParams)):  # type: ign
         ),
     )
     max_tool_iterations: int | None = Field(default=None, ge=1, le=MAX_TOOL_ITERATIONS_CAP)
+    session_label: str | None = Field(default=None, max_length=SESSION_LABEL_MAX_LENGTH, description=SESSION_LABEL_DESC)
 
 
 class _ChatAdapter:
@@ -344,6 +345,7 @@ async def chat_completions(
                     background_tasks=background_tasks,
                     rate_limit_info=ctx.rate_limit_info,
                     tool_ctx=tool_ctx,
+                    session_label=request.session_label,
                 )
             except HTTPException:
                 raise
@@ -421,6 +423,7 @@ async def chat_completions(
             background_tasks=background_tasks,
             config=config,
             rate_limit_info=ctx.rate_limit_info,
+            session_label=request.session_label,
         )
 
     resolved = resolve_provider_selector(config, request.model)

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -45,7 +45,7 @@ from gateway.api.routes._platform import (
     _extract_platform_user_token,
     _resolve_platform_credentials,
 )
-from gateway.api.routes._schema_derive import derive_request_base
+from gateway.api.routes._schema_derive import SESSION_LABEL_DESC, SESSION_LABEL_MAX_LENGTH, derive_request_base
 from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
 from gateway.core.usage import GatewayUsage
@@ -92,6 +92,7 @@ class MessagesRequest(derive_request_base(MessagesParams)):  # type: ignore[misc
     guardrails: list[GuardrailConfig] | None = Field(default=None, max_length=8)
     tools_header: str | None = None
     max_tool_iterations: int | None = Field(default=None, ge=1, le=MAX_TOOL_ITERATIONS_CAP)
+    session_label: str | None = Field(default=None, max_length=SESSION_LABEL_MAX_LENGTH, description=SESSION_LABEL_DESC)
 
 
 class CountTokensRequest(BaseModel):
@@ -424,6 +425,7 @@ async def create_message(
                     background_tasks=background_tasks,
                     rate_limit_info=ctx.rate_limit_info,
                     tool_ctx=tool_ctx,
+                    session_label=request.session_label,
                 )
             except HTTPException as exc:
                 # Hybrid terminal failures arrive as format-agnostic plain-string
@@ -492,6 +494,7 @@ async def create_message(
             model=model,
             platform_correlation_id=platform_correlation_id,
             platform_request_id=platform_request_id,
+            session_label=request.session_label,
         )
 
     # ------------------------------------------------------------------
@@ -510,6 +513,7 @@ async def create_message(
                 background_tasks=background_tasks,
                 config=config,
                 rate_limit_info=ctx.rate_limit_info,
+                session_label=request.session_label,
             )
         except HTTPException as exc:
             # Hybrid terminal failures arrive as format-agnostic plain-string

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -38,7 +38,7 @@ from gateway.api.routes._pipeline import (
     run_streaming_with_fallback,
 )
 from gateway.api.routes._platform import ResolvedAttempt
-from gateway.api.routes._schema_derive import derive_request_base
+from gateway.api.routes._schema_derive import SESSION_LABEL_DESC, SESSION_LABEL_MAX_LENGTH, derive_request_base
 from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
 from gateway.core.usage import GatewayUsage
@@ -94,6 +94,7 @@ class ResponsesRequest(derive_request_base(ResponsesParams)):  # type: ignore[mi
     guardrails: list[GuardrailConfig] | None = Field(default=None, max_length=8)
     tools_header: str | None = None
     max_tool_iterations: int | None = Field(default=None, ge=1, le=MAX_TOOL_ITERATIONS_CAP)
+    session_label: str | None = Field(default=None, max_length=SESSION_LABEL_MAX_LENGTH, description=SESSION_LABEL_DESC)
 
 
 def _responses_input_text(value: Any) -> str:
@@ -401,6 +402,7 @@ async def create_response(
                     background_tasks=background_tasks,
                     rate_limit_info=ctx.rate_limit_info,
                     tool_ctx=tool_ctx,
+                    session_label=request_body.session_label,
                 )
             except HTTPException:
                 raise
@@ -456,6 +458,7 @@ async def create_response(
             model=model,
             platform_correlation_id=platform_correlation_id,
             platform_request_id=platform_request_id,
+            session_label=request_body.session_label,
         )
 
     # ------------------------------------------------------------------
@@ -474,6 +477,7 @@ async def create_response(
                 background_tasks=background_tasks,
                 config=config,
                 rate_limit_info=ctx.rate_limit_info,
+                session_label=request_body.session_label,
             )
         except HTTPException:
             raise

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -222,6 +222,11 @@ def test_hybrid_mode_forwards_session_label_and_strips_it_upstream(
     )
 
     assert response.status_code == 200
+    # Exactly one provider call and one usage report — pin the counts so a
+    # regression that double-reports or double-dispatches this single-attempt
+    # request is caught rather than masked by indexing the first entry.
+    assert len(upstream_kwargs) == 1
+    assert len(usage_reports) == 1
     # The label rides the usage report ...
     assert usage_reports[0]["session_label"] == "my-run-personas"
     # ... but never leaks to the upstream provider call.

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -153,6 +153,81 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
     ]
 
 
+def test_hybrid_mode_forwards_session_label_and_strips_it_upstream(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A request-body ``session_label`` reaches the platform usage report (for
+    cost attribution) but is stripped before the provider call."""
+    usage_reports: list[dict[str, Any]] = []
+    upstream_kwargs: list[dict[str, Any]] = []
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json={
+                    "request_id": "7af2c39d-4eb8-4b3f-8242-46a97f7d5e68",
+                    "fallback_enabled": False,
+                    "attempts": [
+                        {
+                            "attempt_id": "7af2c39d-4eb8-4b3f-8242-46a97f7d5e68",
+                            "position": 0,
+                            "provider": "openai",
+                            "model": "gpt-4o-mini",
+                            "api_key": "sk-platform-key",
+                            "api_base": "https://api.openai.com/v1",
+                            "managed": True,
+                        }
+                    ],
+                },
+            )
+
+        usage_reports.append(body)
+        return httpx.Response(204)
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        upstream_kwargs.append(kwargs)
+        return ChatCompletion(
+            id="chatcmpl-platform",
+            object="chat.completion",
+            created=1700000000,
+            model="gpt-4o-mini",
+            choices=[
+                Choice(
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="hello"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=CompletionUsage(prompt_tokens=10, completion_tokens=7, total_tokens=17),
+        )
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.acompletion", fake_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hi"}],
+            "session_label": "my-run-personas",
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+    # The label rides the usage report ...
+    assert usage_reports[0]["session_label"] == "my-run-personas"
+    # ... but never leaks to the upstream provider call.
+    assert "session_label" not in upstream_kwargs[0]
+
+
 def test_hybrid_mode_accepts_legacy_resolve_shape(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_hybrid_mode_messages.py
+++ b/tests/integration/test_hybrid_mode_messages.py
@@ -801,6 +801,77 @@ def test_hybrid_mode_tool_loop_streaming_sets_correlation_id_and_reports_usage(
     assert success_reports[0]["correlation_id"] == "stream-att-1"
 
 
+def test_hybrid_mode_tool_loop_streaming_forwards_session_label(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The streaming success closure (``build_streaming_response._on_complete``)
+    on the ``run_single_attempt_stream`` hybrid path (used by messages/responses
+    for tool-loop streaming, which chat does not take) must carry the caller's
+    session_label onto the usage report."""
+    usage_reports: list[dict[str, Any]] = []
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json=_resolve_payload([_attempt(0, "stream-att-1", "claude-3-5-sonnet-20241022", "sk-platform")]),
+            )
+        usage_reports.append(body)
+        return httpx.Response(204)
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+
+    from unittest.mock import AsyncMock, patch
+
+    from any_llm.types.messages import MessageDelta, MessageDeltaEvent, MessageDeltaUsage
+
+    async def fake_loop_stream(**_kwargs: Any) -> Any:
+        yield MessageDeltaEvent(
+            type="message_delta",
+            delta=MessageDelta(stop_reason=cast(Any, "end_turn"), stop_sequence=None),
+            usage=MessageDeltaUsage(
+                input_tokens=3,
+                output_tokens=5,
+                cache_creation_input_tokens=None,
+                cache_read_input_tokens=None,
+                server_tool_use=None,
+            ),
+        )
+
+    with (
+        patch("gateway.api.routes.messages.anthropic_tool_loop_stream", new=fake_loop_stream),
+        patch(
+            "gateway.services.mcp_client.MCPClientPool.__aenter__",
+            new=AsyncMock(return_value=AsyncMock(purpose_hints=lambda: [])),
+        ),
+        patch("gateway.services.mcp_client.MCPClientPool.__aexit__", new=AsyncMock(return_value=None)),
+    ):
+        with platform_client.stream(
+            "POST",
+            "/v1/messages",
+            json={
+                "model": "claude-3-5-sonnet-20241022",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 100,
+                "stream": True,
+                "session_label": "my-run-personas",
+                "mcp_servers": [{"name": "test", "url": "http://127.0.0.1:18080/mcp"}],
+            },
+            headers={"Authorization": "Bearer user_test_token"},
+        ) as response:
+            assert response.status_code == 200, response.read().decode()
+            # Consume the stream so on_complete fires.
+            for _ in response.iter_bytes():
+                pass
+
+    success_reports = [r for r in usage_reports if r.get("status") == "success"]
+    assert success_reports, "expected a success usage report for the hybrid-mode tool-loop stream"
+    assert success_reports[0]["session_label"] == "my-run-personas"
+
+
 def test_hybrid_mode_count_tokens_requires_authorization_header(
     platform_client: TestClient,
 ) -> None:

--- a/tests/unit/test_flush_pending_usage_reports.py
+++ b/tests/unit/test_flush_pending_usage_reports.py
@@ -12,10 +12,17 @@ from gateway.core.config import GatewayConfig
 
 
 def test_flush_delivers_all_reports_when_fast(monkeypatch: pytest.MonkeyPatch) -> None:
-    sent: list[tuple[str, str, str | None]] = []
+    sent: list[tuple[str, str, str | None, str | None]] = []
 
-    async def fake_report(config: Any, cid: str, outcome: str, usage: Any, error_class: str | None) -> None:
-        sent.append((cid, outcome, error_class))
+    async def fake_report(
+        config: Any,
+        cid: str,
+        outcome: str,
+        usage: Any,
+        error_class: str | None,
+        session_label: str | None = None,
+    ) -> None:
+        sent.append((cid, outcome, error_class, session_label))
 
     monkeypatch.setattr(_pipeline, "_report_platform_usage", fake_report)
     config = GatewayConfig(platform={"base_url": "http://platform.test"})
@@ -25,10 +32,15 @@ def test_flush_delivers_all_reports_when_fast(monkeypatch: pytest.MonkeyPatch) -
             config,
             [("att-1", "error", None, "http_500"), ("att-2", "error", None, "http_429")],
             "req-1",
+            "my-run-personas",
         )
     )
 
-    assert sorted(sent) == [("att-1", "error", "http_500"), ("att-2", "error", "http_429")]
+    # Every flushed report carries the per-request session label.
+    assert sorted(sent) == [
+        ("att-1", "error", "http_500", "my-run-personas"),
+        ("att-2", "error", "http_429", "my-run-personas"),
+    ]
 
 
 def test_flush_is_bounded_and_does_not_wait_for_a_slow_report(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -39,7 +51,14 @@ def test_flush_is_bounded_and_does_not_wait_for_a_slow_report(monkeypatch: pytes
     """
     completed: list[str] = []
 
-    async def slow_report(config: Any, cid: str, outcome: str, usage: Any, error_class: str | None) -> None:
+    async def slow_report(
+        config: Any,
+        cid: str,
+        outcome: str,
+        usage: Any,
+        error_class: str | None,
+        session_label: str | None = None,
+    ) -> None:
         await asyncio.sleep(10)
         completed.append(cid)
 

--- a/tests/unit/test_run_platform_attempts.py
+++ b/tests/unit/test_run_platform_attempts.py
@@ -77,3 +77,40 @@ async def test_report_platform_usage_does_not_retry_on_402(monkeypatch: pytest.M
     # behaviour: 402 must stay in the non-retryable set even if the >= 500 retry
     # predicate changes.
     assert 402 in _platform._USAGE_NON_RETRYABLE_STATUS_CODES
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("session_label", "expected"),
+    [
+        ("my-run-personas", "my-run-personas"),
+        ("  spaced-out  ", "spaced-out"),  # trimmed
+        (None, None),  # omitted
+        ("   ", None),  # blank treated as absent
+    ],
+)
+async def test_report_platform_usage_forwards_session_label(
+    monkeypatch: pytest.MonkeyPatch,
+    session_label: str | None,
+    expected: str | None,
+) -> None:
+    """The caller's session label rides the usage report so the platform can
+    attribute spend; blank/absent labels are omitted from the payload."""
+    config = cast(
+        GatewayConfig,
+        SimpleNamespace(
+            platform={"base_url": "http://platform", "usage_max_retries": 3},
+            platform_token="gw-test",
+        ),
+    )
+
+    post_mock = AsyncMock(return_value=httpx.Response(204))
+    monkeypatch.setattr(_platform, "_post_platform", post_mock)
+
+    await _platform._report_platform_usage(config, "corr-1", "success", None, session_label=session_label)
+
+    body = post_mock.call_args.kwargs["body"]
+    if expected is None:
+        assert "session_label" not in body
+    else:
+        assert body["session_label"] == expected


### PR DESCRIPTION
## Description

In hybrid (platform) mode, callers had **no way to attribute gateway-routed spend to a session** without standing up a full OpenTelemetry SDK + OTLP exporter just to set one attribute, which is disproportionate for a batch inference script or a simple agent loop.

This adds an optional `session_label` so a caller can tag a run / experiment / conversation, and Otari forwards it onto the `/gateway/usage` report. The platform attributes the attempt's spend to that session (companion PR below), making gateway-mode cost filterable / groupable in the Usage UI without OTel.

How:

- **Body field** `session_label` on the chat, messages, and responses request schemas (shared `SESSION_LABEL_DESC` / `_MAX_LENGTH` in `_schema_derive.py`, capped at 255). Because the schemas drive the OpenAPI spec, **generated SDKs pick the field up automatically** (no manual SDK changes).
- **Stripped before the upstream provider call** (added to `_GATEWAY_INTERNAL_FIELDS`, same path as the existing `user` / `mcp_servers` / `guardrails` gateway-internal fields), so it never leaks to the provider.
- **Threaded onto every usage-report path** in `_pipeline.py`: streaming success/error (`build_streaming_response`), single-attempt streaming, non-streaming fallback (`run_platform_non_stream`), and the inline all-failed flush (`_flush_pending_usage_reports`). `_report_platform_usage` adds it to the POST body, trimmed, with blank treated as absent. The 255 cap matches the platform's indexed session-label keyword so the value is never truncated downstream.
- **`user` no-op documented** in `docs/hybrid-mode-protocol.md`: the OpenAI-standard `user` field is not used for cost attribution in hybrid mode (it is stripped and not reported), so callers reach for `session_label` instead.
- Regenerated `docs/public/openapi.json`.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Addresses the gateway/SDK portion of mozilla-ai/otari-ai#1161. Companion to platform-side PR mozilla-ai/otari-ai#1231 (accepts `session_label` on `GatewayUsageReport` and lands it on the synthetic Usage span).

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). Note: `make lint` and `make typecheck` pass; for tests I ran the full `tests/unit` suite plus the hybrid-mode integration files (`601 passed`). The complete `tests/integration` suite needs Docker/testcontainers, which is unavailable in this environment, so it will be validated by CI.
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:**

Authored with Claude Code. The maintainer (repo owner) reviewed the design decisions (body field vs header, consistency with the platform-side contract) before implementation.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Created with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
Added an optional `session_label` field to hybrid-mode chat, messages, and responses requests so callers can tag usage by session for billing and reporting. The gateway preserves the label for its internal usage reporting, strips it before sending requests upstream, and includes it in `/gateway/usage` so platform data can be attributed and filtered by session. Docs were updated to clarify that the standard `user` field is not used for cost attribution in hybrid mode, and that `session_label` has no effect in standalone mode.

## Technical notes
- Added `session_label` (optional, max 255 characters) to chat, messages, and responses request schemas.
- Trimmed whitespace and treated blank values as absent.
- Threaded `session_label` through hybrid streaming and non-streaming execution paths, ensuring it’s included in platform usage-report payloads.
- Stripped `session_label` before forwarding upstream provider requests.
- Regenerated OpenAPI so SDKs pick up the new field automatically.
- Updated/added tests for forwarding, trimming/omission, stripping upstream, and correct inclusion in success usage reports (including streaming-specific coverage and stricter call/report count checks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->