### PR TITLE
docs: add GitHub community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and usage help
+    url: https://github.com/mozilla-ai/otari/discussions
+    about: Ask setup and configuration questions in Discussions. Please don't open an issue for these.
+  - name: Discord
+    url: https://discord.gg/ZfZPfTdtSe
+    about: Chat with the community and maintainers in real time.
+  - name: Documentation
+    url: https://github.com/mozilla-ai/otari/blob/main/docs/index.md
+    about: Quickstart, configuration, and API reference.

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build/
 
 .env
 config.yml
+!.github/ISSUE_TEMPLATE/config.yml
 config.yaml
 service_account.json
 gateway.db

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the team at mozilla.ai. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,60 @@
+# Governance
+
+This document describes how the Otari open-source project is run, who makes
+decisions, and how to get involved. It covers the open-source gateway in this
+repository, not the hosted otari.ai service.
+
+## Overview
+
+Otari is an open-source project stewarded by [Mozilla.ai](https://mozilla.ai).
+Development happens in the open on GitHub. Anyone can use Otari, file issues,
+open pull requests, and take part in discussions.
+
+## Roles
+
+**Users** run Otari and report bugs, request features, and ask questions through
+issues and Discussions.
+
+**Contributors** open pull requests. Contributions of any size are welcome, from
+documentation fixes to new features. See [CONTRIBUTING.md](CONTRIBUTING.md) to
+get started.
+
+**Maintainers** review and merge pull requests, triage issues, cut releases, and
+set technical direction. Maintainers are the people with merge access to the
+repository. They are responsible for keeping the project healthy and for
+upholding the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## How decisions are made
+
+Most decisions happen in the open through issues and pull requests, by maintainer
+consensus. Routine changes are merged once a maintainer approves and CI passes.
+
+Larger changes, such as new public APIs, breaking changes, or shifts in scope,
+are discussed in an issue or Discussion first so the reasoning is on the record
+and the community can weigh in. When maintainers disagree and consensus isn't
+reached, the decision escalates to the Mozilla.ai team that stewards the project.
+
+## Becoming a maintainer
+
+Maintainers are invited from the contributor community based on a sustained track
+record: quality contributions over time, helpful review and triage, and good
+judgment in discussions. There is no fixed quota. If you want to grow into the
+role, the path is to keep contributing and engaging; existing maintainers will
+reach out.
+
+## Relationship to Mozilla.ai and otari.ai
+
+Mozilla.ai develops both the open-source Otari gateway and the hosted otari.ai
+platform. The two share concepts and a wire protocol, but the gateway in this
+repository is and will remain open source under its existing license. It is a
+standalone product you can run with no dependency on the hosted service and no
+account required.
+
+We develop the gateway in the open, keep its roadmap public, and accept outside
+contributions on equal terms. The open-source project is not a funnel for the
+hosted product.
+
+## Changing this document
+
+Changes to governance are proposed through a pull request and require maintainer
+consensus to merge.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,28 @@
+# Support
+
+Need help with Otari? Here's where to go.
+
+## Questions and usage help
+
+Use [GitHub Discussions](https://github.com/mozilla-ai/otari/discussions) for
+setup questions, configuration help, and "how do I do X" questions. Search
+existing threads first, since someone may have hit the same thing.
+
+For real-time conversation, join the
+[Discord](https://discord.gg/ZfZPfTdtSe).
+
+## Documentation
+
+Most setup and configuration questions are answered in the docs. Start with the
+[Quickstart](docs/quickstart.md), then [Configuration](config.example.yml) and
+the [API reference](docs/api-reference.md).
+
+## Bugs and feature requests
+
+Open a GitHub issue using the bug report or feature request template. A minimal
+reproduction (config and the exact request) gets a bug fixed far faster.
+
+## Security issues
+
+Do not open a public issue for a vulnerability. Follow the process in
+[SECURITY.md](SECURITY.md) instead.


### PR DESCRIPTION
## Description
Add GitHub community health files for the Otari repo.

Specific additions: 
- GitHub issue template config to disable blank issues and route support questions to Discussions, Discord, and docs
- `SUPPORT.md`, `CODE_OF_CONDUCT.md`, and `GOVERNANCE.md`
- a narrow `.gitignore` exception so `.github/ISSUE_TEMPLATE/config.yml` is tracked



## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [X] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [X] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [X] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [X] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**


**Any additional AI details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added GitHub community health files for the repository, including guidance for asking questions and getting help, a code of conduct, and project governance rules. Also updated issue templates to direct support requests away from blank issues and adjusted gitignore so the issue template config is tracked. This should make the project easier to navigate and support more consistently.

Technical notes:
- Added `.github/ISSUE_TEMPLATE/config.yml` with blank issue creation disabled and links to Discussions, Discord, and documentation.
- Added `SUPPORT.md`, `CODE_OF_CONDUCT.md`, and `GOVERNANCE.md`.
- Updated `.gitignore` with an exception for the issue template config file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->