### PR TITLE
fix: Minor fixes to example config file

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -3,7 +3,7 @@
 # Database connection URL.
 # PostgreSQL is used by the full docker compose stack (postgres service is defined in docker-compose.yml).
 # For local development without Docker, switch to SQLite:
-#   database_url: "sqlite+aiosqlite:///./otari.db"
+#   database_url: "sqlite:///./otari.db"
 database_url: "postgresql://otari:otari@postgres:5432/otari"
 
 # Server configuration - if you want to use a different port, change it here and in the docker-compose.yml file.
@@ -90,7 +90,7 @@ providers:
 # Format: "provider:model" -> input/output price per million tokens
 # Database pricing takes precedence - config only sets initial values
 # Prices are in USD per million tokens
-pricing:
+# pricing:
   # See https://cloud.google.com/vertex-ai/generative-ai/pricing
   # vertexai:Qwen3-235B-A22B-Instruct-2507:
   #   input_price_per_million: 0.25


### PR DESCRIPTION
## Description

Two minor fixes:

- removed `+aiosqlite` from sqlite config (otherwise it clashes with alembic's sync driver). Otari seems to be converting it to sqlite+aiosqlite internally anyway for the app engine (_to_async_url in core/database.py)
- fixed pydantic validation error on pricing. The `pricing:` key is uncommented but every child under it is commented out. YAML parses that as pricing: null, and the config model declares pricing: dict[str, PricingConfig], so pydantic rejects null:
```
  1 validation error for GatewayConfig
  pricing  ... dict_type
```
The fix comments the "pricing" key too (tested and working, actually Otari does not seem to require pricing anymore and can run with models not already defined in the pricing section which is good from a UX pov)

## PR Type

- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the example config to better match how the app actually runs: the SQLite example now uses the standard local database URL, and the pricing example is fully disabled so it won’t trigger config validation issues. This makes the sample config easier to use out of the box and avoids confusion for setups that don’t define pricing entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->