### PR TITLE
feat: opt-in first-chunk grace for the final streaming attempt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ otari-gateway.db
 otari.db
 
 .DS_Store
+
+.idea/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,6 +153,7 @@ These are only relevant when running connected to [otari.ai](https://otari.ai). 
 | `PLATFORM_USAGE_TIMEOUT_MS` | `5000` | Timeout for usage reporting calls |
 | `PLATFORM_USAGE_MAX_RETRIES` | `3` | Max retries for transient usage reporting failures |
 | `STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS` | `2000` | Per-attempt timeout waiting for first streamed chunk |
+| `STREAMING_FALLBACK_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS` | `0` | Extra first-chunk grace for the sole/final attempt, added on top of the per-attempt budget. `0` = no grace (unchanged) |
 
 ## Provider configuration
 

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -343,8 +343,12 @@ The mechanism is a per-attempt **first-chunk gate**. For each attempt:
    — provider returned `401` / `5xx` / network error before the stream even
    opened — classify the error: retryable failures move to the next attempt;
    non-retryable failures propagate.
-2. Wait for the first chunk with a bounded timeout
-   (`STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS`, default 2000 ms). If the
+2. Wait for the first chunk with a bounded timeout. Non-final attempts use the
+   per-attempt failover budget (`STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS`,
+   default 2000 ms). The sole/final attempt has no next attempt to fall over to,
+   so it additionally gets `STREAMING_FALLBACK_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS`
+   of grace on top of the budget (default 0, i.e. unchanged), so a slow-but-valid
+   first token is not turned into a timeout, while the wait stays bounded. If the
    upstream raises before yielding or the wait times out, move to the next
    attempt.
 3. Once a first chunk is in hand, commit. Stitch it back onto the iterator
@@ -352,8 +356,8 @@ The mechanism is a per-attempt **first-chunk gate**. For each attempt:
 
 **Latency contract:** zero added latency in the success case — the first
 chunk is held only for the microseconds it takes to call the SSE response
-builder. In the failure case, each abandoned attempt costs at most
-`first_chunk_timeout_seconds`.
+builder. In the failure case, each abandoned non-final attempt costs at most the
+failover budget; the final attempt costs at most budget + grace.
 
 **What this catches:** auth errors (`401`/`403`), rate-limits (`429`),
 upstream `5xx`, connection failures, hung connections, "stream opens but
@@ -378,3 +382,4 @@ flag.
 | `PLATFORM_USAGE_TIMEOUT_MS` | `5000` | Per-usage-report timeout. |
 | `PLATFORM_USAGE_MAX_RETRIES` | `3` | Max retries for transient usage-report failures. |
 | `STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS` | `2000` | Per-attempt budget for the streaming first-chunk gate. |
+| `STREAMING_FALLBACK_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS` | `0` | Extra first-chunk grace for the sole/final attempt, on top of the budget. `0` = unchanged. |

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -53,8 +53,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from gateway.api.deps import verify_api_key_or_master_key
 from gateway.api.routes._helpers import apply_input_guardrails, resolve_user_id
 from gateway.api.routes._platform import (
+    _DEFAULT_STREAM_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS,
     _DEFAULT_STREAM_FIRST_CHUNK_TIMEOUT_MS,
     _DEFAULT_STREAM_FIRST_CHUNK_TIMEOUT_MS_TOOL_LOOP,
+    _STREAM_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS_KEY,
     _STREAM_FIRST_CHUNK_TIMEOUT_MS_KEY,
     _STREAM_FIRST_CHUNK_TIMEOUT_MS_TOOL_LOOP_KEY,
     ResolvedAttempt,
@@ -1268,6 +1270,25 @@ def stream_first_chunk_timeout_seconds(config: GatewayConfig, *, tool_mode: bool
     )
 
 
+def stream_final_attempt_extra_seconds(config: GatewayConfig) -> float:
+    """Extra first-chunk grace granted only to the sole/final streaming attempt.
+
+    Added on top of the per-attempt failover budget for the terminal attempt,
+    which has no next entry in the routing policy to fall over to. Keeps that
+    attempt's wait bounded while not converting a slow-but-valid first token into
+    a timeout. Mode-agnostic (applies on top of the plain or tool-loop budget).
+    """
+    return (
+        int(
+            config.platform.get(
+                _STREAM_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS_KEY,
+                _DEFAULT_STREAM_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS,
+            )
+        )
+        / 1000
+    )
+
+
 # ---------------------------------------------------------------------------
 # Shared request runners
 # ---------------------------------------------------------------------------
@@ -1411,6 +1432,7 @@ async def run_streaming_with_fallback(
     """
     tool_mode = tool_ctx.use_tool_loop
     first_chunk_timeout = stream_first_chunk_timeout_seconds(config, tool_mode=tool_mode)
+    final_attempt_extra = stream_final_attempt_extra_seconds(config)
 
     backend_stack = AsyncExitStack()
     pool_for_loop: Any = None
@@ -1490,6 +1512,7 @@ async def run_streaming_with_fallback(
             classify_error=_classify_upstream_error,
             on_attempt_failed=_on_attempt_failed,
             first_chunk_timeout_seconds=first_chunk_timeout,
+            final_attempt_extra_seconds=final_attempt_extra,
         )
     except BaseException as exc:
         # No attempt yielded a first chunk: the request ends in an error

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -65,6 +65,19 @@ _DEFAULT_STREAM_FIRST_CHUNK_TIMEOUT_MS_TOOL_LOOP = 30000
 _STREAM_FIRST_CHUNK_TIMEOUT_MS_KEY = "streaming_first_chunk_timeout_ms"
 _STREAM_FIRST_CHUNK_TIMEOUT_MS_TOOL_LOOP_KEY = "streaming_first_chunk_timeout_ms_tool_loop"
 
+# Extra first-chunk grace added ONLY to the sole/final attempt, on top of the
+# per-attempt budget above. That budget is a failover trigger: it abandons a slow
+# attempt so the next entry in the routing policy can be tried. The final attempt
+# has no next entry, so a tight cap there only turns a slow-but-valid first token
+# into a 504 with nothing to fall over to. Granting grace keeps the terminal wait
+# bounded (a genuinely hung upstream still times out at budget + grace) while not
+# failing valid slow-to-start responses. Applied on top of whichever base budget
+# is in effect (plain or tool-loop). Defaults to 0 (no grace), so behavior is
+# unchanged unless an operator opts in via ``config.platform`` (v1.2 will move
+# these onto the routing_policy schema).
+_DEFAULT_STREAM_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS = 0
+_STREAM_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS_KEY = "streaming_final_attempt_extra_first_chunk_timeout_ms"
+
 
 class ResolvedAttempt(BaseModel):
     """A single resolution attempt returned by the platform."""

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -378,6 +378,27 @@ class GatewayConfig(BaseSettings):
             raise ValueError(msg)
         return normalized
 
+    @field_validator("platform")
+    @classmethod
+    def _validate_platform_streaming_timeouts(cls, platform: dict[str, Any]) -> dict[str, Any]:
+        """Reject non-sensical streaming first-chunk timeout settings at load time.
+
+        The per-attempt first-chunk budgets must be positive: a zero or negative
+        wait would treat every attempt as instantly hung. The terminal-attempt
+        extra grace must be non-negative, since it is added on top of the budget.
+        """
+        positive_ms_keys = (
+            "streaming_first_chunk_timeout_ms",
+            "streaming_first_chunk_timeout_ms_tool_loop",
+        )
+        for key in positive_ms_keys:
+            if key in platform and float(platform[key]) <= 0:
+                raise ValueError(f"{key} must be > 0, got {platform[key]}")
+        extra_key = "streaming_final_attempt_extra_first_chunk_timeout_ms"
+        if extra_key in platform and float(platform[extra_key]) < 0:
+            raise ValueError(f"{extra_key} must be >= 0, got {platform[extra_key]}")
+        return platform
+
     def validate_mode_selection(self) -> None:
         configured_mode = self.mode.strip().lower()
         # "platform" is the legacy alias for "hybrid" (the otari.ai-connected
@@ -537,6 +558,15 @@ def _apply_platform_env_overrides(config: dict[str, Any]) -> None:
         # control.
         "STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS": (
             "streaming_first_chunk_timeout_ms",
+            int,
+        ),
+        # Extra first-chunk grace for the sole/final streaming attempt, added on
+        # top of the per-attempt budget above. The failover budget exists to move
+        # to the next routing-policy entry when an attempt is slow; the final
+        # attempt has no next entry, so this keeps its wait bounded without cutting
+        # off a slow-but-valid first token.
+        "STREAMING_FALLBACK_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS": (
+            "streaming_final_attempt_extra_first_chunk_timeout_ms",
             int,
         ),
     }

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -161,6 +161,7 @@ async def iterate_streaming_attempts(
     classify_error: Callable[[BaseException], tuple[bool, str]],
     on_attempt_failed: Callable[[A, StreamingAttemptFailure], Awaitable[None]],
     first_chunk_timeout_seconds: float = DEFAULT_FIRST_CHUNK_TIMEOUT_SECONDS,
+    final_attempt_extra_seconds: float = 0.0,
 ) -> tuple[A, AsyncIterator[C]]:
     """Iterate over ``attempts`` until one yields its first chunk; return that
     attempt and an iterator that re-emits the chunk followed by the rest of
@@ -173,9 +174,15 @@ async def iterate_streaming_attempts(
        so the caller can record per-attempt failure metadata (regardless of
        whether the error is retryable), then retryable errors continue to the
        next attempt and non-retryable errors propagate.
-    2. The first chunk is awaited with a ``first_chunk_timeout_seconds`` cap.
-       If the timeout fires or the upstream raises before yielding, the same
-       classification + ``on_attempt_failed`` logic applies.
+    2. The first chunk is awaited under a per-attempt cap. For non-final
+       attempts the cap is ``first_chunk_timeout_seconds``, a failover trigger
+       that abandons a slow attempt so the next one in the plan is tried. The
+       final (or sole) attempt has nothing to fall over to, so it gets
+       ``first_chunk_timeout_seconds + final_attempt_extra_seconds``: extra grace
+       on top of the failover budget so a slow-but-valid first token still
+       streams, while the wait stays bounded (a genuinely hung upstream still
+       times out). If the wait times out or the upstream raises before yielding,
+       the same classification + ``on_attempt_failed`` logic applies.
     3. Once a first chunk is in hand, we commit — the function returns and
        the caller flushes the response. Errors after this point reach the
        client; they cannot be hidden without buffering the entire stream.
@@ -188,12 +195,15 @@ async def iterate_streaming_attempts(
 
     Latency contract: zero added latency in the success case — we hold the
     first chunk only long enough to call this function's caller. In the
-    failure case, each abandoned attempt costs at most
-    ``first_chunk_timeout_seconds``.
+    failure case, each abandoned non-final attempt costs at most
+    ``first_chunk_timeout_seconds``; the final attempt costs at most
+    ``first_chunk_timeout_seconds + final_attempt_extra_seconds``.
     """
     last_exception: BaseException | None = None
+    final_index = len(attempts) - 1
 
-    for attempt in attempts:
+    for index, attempt in enumerate(attempts):
+        is_final_attempt = index == final_index
         try:
             stream = await build_stream(attempt)
         except BaseException as exc:
@@ -204,10 +214,18 @@ async def iterate_streaming_attempts(
                 raise
             continue
 
+        # The failover cap only buys something when a next attempt exists, so the
+        # sole/final attempt gets extra grace on top of it rather than being cut
+        # off with nothing to fall over to.
+        attempt_timeout = first_chunk_timeout_seconds
+        if is_final_attempt:
+            attempt_timeout += final_attempt_extra_seconds
+
+        first_chunk: C
         try:
-            first_chunk: C = await asyncio.wait_for(
+            first_chunk = await asyncio.wait_for(
                 stream.__anext__(),
-                timeout=first_chunk_timeout_seconds,
+                timeout=attempt_timeout,
             )
         except StopAsyncIteration:
             # Stream completed without yielding. Unusual but valid — commit

--- a/tests/unit/test_platform_timeout_config.py
+++ b/tests/unit/test_platform_timeout_config.py
@@ -1,0 +1,58 @@
+"""Validation of the streaming first-chunk timeout settings in ``GatewayConfig``.
+
+The per-attempt failover budgets must be positive; the terminal-attempt extra
+grace must be non-negative (it is added on top of the budget). Bad values are
+rejected at config-load time rather than silently breaking every request.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from gateway.core.config import GatewayConfig
+
+
+def test_valid_streaming_timeouts_are_accepted() -> None:
+    config = GatewayConfig(
+        platform={
+            "streaming_first_chunk_timeout_ms": 2000,
+            "streaming_first_chunk_timeout_ms_tool_loop": 30000,
+            "streaming_final_attempt_extra_first_chunk_timeout_ms": 58000,
+        }
+    )
+    assert config.platform["streaming_final_attempt_extra_first_chunk_timeout_ms"] == 58000
+
+
+def test_zero_extra_grace_is_allowed() -> None:
+    config = GatewayConfig(platform={"streaming_final_attempt_extra_first_chunk_timeout_ms": 0})
+    assert config.platform["streaming_final_attempt_extra_first_chunk_timeout_ms"] == 0
+
+
+def test_absent_keys_are_accepted() -> None:
+    config = GatewayConfig(platform={})
+    assert config.platform == {}
+
+
+@pytest.mark.parametrize("bad_value", [0, -1, -2000])
+def test_non_positive_first_chunk_budget_is_rejected(bad_value: int) -> None:
+    with pytest.raises(ValidationError, match="streaming_first_chunk_timeout_ms must be > 0"):
+        GatewayConfig(platform={"streaming_first_chunk_timeout_ms": bad_value})
+
+
+@pytest.mark.parametrize("bad_value", [0, -1])
+def test_non_positive_tool_loop_budget_is_rejected(bad_value: int) -> None:
+    with pytest.raises(ValidationError, match="streaming_first_chunk_timeout_ms_tool_loop must be > 0"):
+        GatewayConfig(platform={"streaming_first_chunk_timeout_ms_tool_loop": bad_value})
+
+
+@pytest.mark.parametrize("bad_value", [-1, -0.5])
+def test_negative_extra_grace_is_rejected(bad_value: float) -> None:
+    with pytest.raises(ValidationError, match="must be >= 0"):
+        GatewayConfig(platform={"streaming_final_attempt_extra_first_chunk_timeout_ms": bad_value})
+
+
+def test_default_terminal_grace_is_zero() -> None:
+    """Unconfigured, the terminal grace resolves to 0.0 so the sole/final attempt
+    keeps the historical cap; the setting is opt-in and changes no default."""
+    from gateway.api.routes._pipeline import stream_final_attempt_extra_seconds
+
+    assert stream_final_attempt_extra_seconds(GatewayConfig()) == 0.0

--- a/tests/unit/test_streaming_attempts.py
+++ b/tests/unit/test_streaming_attempts.py
@@ -1,0 +1,179 @@
+"""Unit tests for the first-chunk timeout policy in ``iterate_streaming_attempts``.
+
+The first-chunk timeout is a failover trigger: it abandons a slow attempt so the
+next one in the prioritized fallback plan can be tried. Non-final attempts get the
+tight failover budget; the sole/final attempt has nothing to fall over to, so it
+gets ``final_attempt_extra_seconds`` of grace on top of the budget. That grace lets
+a slow-but-valid first token stream through, while keeping the wait bounded, so a
+genuinely hung upstream still times out at ``budget + grace``.
+"""
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from gateway.streaming import StreamingAttemptFailure, iterate_streaming_attempts
+
+# Small, well-separated durations keep the tests fast while staying robust on a
+# loaded CI box. Failover budget is tight; the terminal grace extends it.
+_BUDGET_SECONDS = 0.05
+_GRACE_SECONDS = 0.25  # terminal budget = 0.30
+_WITHIN_GRACE_DELAY = 0.15  # > budget, < budget + grace
+_BEYOND_GRACE_DELAY = 0.45  # > budget + grace
+
+
+class _RetryableError(Exception):
+    """A build-time upstream failure the classifier treats as retryable."""
+
+
+async def _stream(delay: float, chunks: tuple[str, ...]) -> AsyncIterator[str]:
+    """Async stream whose first ``__anext__`` blocks for ``delay`` seconds."""
+    import asyncio
+
+    if delay:
+        await asyncio.sleep(delay)
+    for chunk in chunks:
+        yield chunk
+
+
+def _attempt(
+    name: str,
+    *,
+    delay: float = 0.0,
+    chunks: tuple[str, ...] = ("chunk",),
+    build_error: Exception | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(name=name, delay=delay, chunks=chunks, build_error=build_error)
+
+
+def _harness() -> tuple[Any, Any, Any, list[tuple[str, str]]]:
+    """Build the ``build_stream`` / ``classify_error`` / ``on_attempt_failed``
+    callbacks plus the list that records abandoned attempts."""
+    failures: list[tuple[str, str]] = []
+
+    async def build_stream(attempt: SimpleNamespace) -> AsyncIterator[str]:
+        if attempt.build_error is not None:
+            raise attempt.build_error
+        return _stream(attempt.delay, attempt.chunks)
+
+    def classify_error(exc: BaseException) -> tuple[bool, str]:
+        return True, type(exc).__name__
+
+    async def on_attempt_failed(attempt: SimpleNamespace, failure: StreamingAttemptFailure) -> None:
+        failures.append((attempt.name, failure.error_class))
+
+    return build_stream, classify_error, on_attempt_failed, failures
+
+
+async def _drain(stream: AsyncIterator[str]) -> list[str]:
+    return [chunk async for chunk in stream]
+
+
+@pytest.mark.asyncio
+async def test_sole_attempt_slow_first_chunk_within_grace_streams() -> None:
+    """A single-attempt request whose first chunk exceeds the failover budget but
+    lands within the terminal grace must stream, not 504."""
+    build_stream, classify_error, on_attempt_failed, failures = _harness()
+    attempts = [_attempt("only", delay=_WITHIN_GRACE_DELAY, chunks=("hi", "there"))]
+
+    chosen, stream = await iterate_streaming_attempts(
+        attempts=attempts,
+        build_stream=build_stream,
+        classify_error=classify_error,
+        on_attempt_failed=on_attempt_failed,
+        first_chunk_timeout_seconds=_BUDGET_SECONDS,
+        final_attempt_extra_seconds=_GRACE_SECONDS,
+    )
+
+    assert chosen.name == "only"
+    assert await _drain(stream) == ["hi", "there"]
+    assert failures == []  # not abandoned: within budget + grace
+
+
+@pytest.mark.asyncio
+async def test_sole_attempt_beyond_grace_still_times_out() -> None:
+    """The terminal grace is bounded: a first chunk slower than budget + grace
+    still times out, so a genuinely hung upstream cannot hang forever."""
+    build_stream, classify_error, on_attempt_failed, failures = _harness()
+    attempts = [_attempt("only", delay=_BEYOND_GRACE_DELAY)]
+
+    with pytest.raises(TimeoutError):
+        await iterate_streaming_attempts(
+            attempts=attempts,
+            build_stream=build_stream,
+            classify_error=classify_error,
+            on_attempt_failed=on_attempt_failed,
+            first_chunk_timeout_seconds=_BUDGET_SECONDS,
+            final_attempt_extra_seconds=_GRACE_SECONDS,
+        )
+
+    assert failures == [("only", "timeout")]
+
+
+@pytest.mark.asyncio
+async def test_non_final_slow_attempt_fails_over_at_the_budget() -> None:
+    """A non-final attempt is capped at the failover budget (grace does not apply)
+    and fails over even for a delay the terminal grace would have tolerated."""
+    build_stream, classify_error, on_attempt_failed, failures = _harness()
+    attempts = [
+        _attempt("primary", delay=_WITHIN_GRACE_DELAY, chunks=("primary-chunk",)),
+        _attempt("fallback", delay=0.0, chunks=("fallback-chunk",)),
+    ]
+
+    chosen, stream = await iterate_streaming_attempts(
+        attempts=attempts,
+        build_stream=build_stream,
+        classify_error=classify_error,
+        on_attempt_failed=on_attempt_failed,
+        first_chunk_timeout_seconds=_BUDGET_SECONDS,
+        final_attempt_extra_seconds=_GRACE_SECONDS,
+    )
+
+    assert chosen.name == "fallback"
+    assert await _drain(stream) == ["fallback-chunk"]
+    assert failures == [("primary", "timeout")]
+
+
+@pytest.mark.asyncio
+async def test_final_attempt_of_chain_gets_the_grace() -> None:
+    """The last attempt in a chain has no successor, so it gets the terminal grace
+    even though an earlier attempt failed over into it."""
+    build_stream, classify_error, on_attempt_failed, failures = _harness()
+    attempts = [
+        _attempt("primary", build_error=_RetryableError("primary down")),
+        _attempt("fallback", delay=_WITHIN_GRACE_DELAY, chunks=("fallback-chunk",)),
+    ]
+
+    chosen, stream = await iterate_streaming_attempts(
+        attempts=attempts,
+        build_stream=build_stream,
+        classify_error=classify_error,
+        on_attempt_failed=on_attempt_failed,
+        first_chunk_timeout_seconds=_BUDGET_SECONDS,
+        final_attempt_extra_seconds=_GRACE_SECONDS,
+    )
+
+    assert chosen.name == "fallback"
+    assert await _drain(stream) == ["fallback-chunk"]
+    assert failures == [("primary", "_RetryableError")]
+
+
+@pytest.mark.asyncio
+async def test_default_extra_is_zero_preserves_uniform_cap() -> None:
+    """With no grace passed, every attempt (including the sole one) is capped at
+    the failover budget, the historical uniform-cap behavior."""
+    build_stream, classify_error, on_attempt_failed, failures = _harness()
+    attempts = [_attempt("only", delay=_WITHIN_GRACE_DELAY)]
+
+    with pytest.raises(TimeoutError):
+        await iterate_streaming_attempts(
+            attempts=attempts,
+            build_stream=build_stream,
+            classify_error=classify_error,
+            on_attempt_failed=on_attempt_failed,
+            first_chunk_timeout_seconds=_BUDGET_SECONDS,
+        )
+
+    assert failures == [("only", "timeout")]


### PR DESCRIPTION
## Description

The per-attempt first-chunk timeout in `iterate_streaming_attempts` is a failover trigger: it abandons a slow attempt so the next entry in the plan can be tried. Applied uniformly it also caps the **sole/final** attempt, which has no successor to fall over to, turning a slow-but-valid first token into a timeout (a 504 for single-attempt streaming).

This adds an **opt-in, bounded** terminal-attempt grace:

- `iterate_streaming_attempts` gains `final_attempt_extra_seconds` (default `0.0`, so existing behavior is unchanged): the sole/final attempt is time-boxed at `first_chunk_timeout_seconds + extra` instead of just the budget. Additive keeps `final >= budget` by construction, and the wait stays bounded so a genuinely hung upstream still times out.
- New operator setting `STREAMING_FALLBACK_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS` (`config.platform.streaming_final_attempt_extra_first_chunk_timeout_ms`), defaulting to `0`, with no behavior change unless an operator opts in.
- A `@field_validator("platform")` rejects a non-positive first-chunk budget or a negative grace at config-load time (fail fast, not per-request).

Keeping the default at `0` makes this a purely additive capability; operators (or a deployment) opt in by setting the grace. Happy to align the setting name with the planned move of these timeouts onto the `routing_policy` schema.

Also includes a small chore commit adding `.idea/` to `.gitignore`.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Addresses #237.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). <!-- no API contract change in this PR -->

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Claude (Claude Code)


**Any additional AI details you'd like to share:**
Claude was used for pairing on the investigation and the fix, under heavy direction and review from me.


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)
