### PR TITLE
docs: update claude code and open code guides

### DIFF
--- a/docs/use-with-claude-code.md
+++ b/docs/use-with-claude-code.md
@@ -9,6 +9,12 @@ without changing how you use the CLI.
 
 ## Quick start
 
+Claude Code appends `/v1/messages` and `/v1/messages/count_tokens` to
+`ANTHROPIC_BASE_URL` itself, so the base URL must be the Otari root, not
+`/v1`. For local development, use `http://localhost:8000`.
+
+### Connected to otari.ai
+
 ```bash
 export ANTHROPIC_BASE_URL="https://api.otari.ai"   # your Otari base URL, no /v1
 export ANTHROPIC_AUTH_TOKEN="tk_your_otari_token"  # sent as Authorization: Bearer
@@ -16,19 +22,26 @@ export ANTHROPIC_MODEL="anthropic:claude-sonnet-4-6"
 claude
 ```
 
-Claude Code appends `/v1/messages` and `/v1/messages/count_tokens` to
-`ANTHROPIC_BASE_URL` itself, so the base URL must be the Otari root (for local
-development, `http://localhost:8000`).
-
-### Standalone mode: allow Claude Code's user_id
+### Standalone
 
 Claude Code attaches its own `metadata.user_id` to every request. In standalone
 mode Otari binds spend to the API key's own user and, by default, rejects a
 request that names a different user (`403 permission_error`). Set
 `reject_user_mismatch: false` in your config so Claude Code's `user_id` is
-ignored and spend is bound to the key. (Hybrid mode authenticates via
-the user token and does not compare `metadata.user_id`, so this setting does not
-apply there.)
+ignored and spend is still bound to the key's user.
+
+```yaml
+reject_user_mismatch: false
+```
+
+Then run Claude Code against your local Otari:
+
+```bash
+export ANTHROPIC_BASE_URL="http://localhost:8000"
+export ANTHROPIC_AUTH_TOKEN="<your-otari-api-key>"
+export ANTHROPIC_MODEL="anthropic:claude-sonnet-4-6"
+claude
+```
 
 Use `ANTHROPIC_AUTH_TOKEN` (not `ANTHROPIC_API_KEY`): it is sent as
 `Authorization: Bearer <token>`, which is the scheme Otari accepts for
@@ -38,7 +51,8 @@ both standalone API keys and connected user tokens. `ANTHROPIC_API_KEY` sends an
 ### settings.json
 
 The same configuration works in `~/.claude/settings.json` (or a project-level
-`.claude/settings.json`):
+`.claude/settings.json`). Replace the values with your deployment's URL, token,
+and model defaults:
 
 ```json
 {
@@ -52,60 +66,34 @@ The same configuration works in `~/.claude/settings.json` (or a project-level
 }
 ```
 
-## You are not limited to Claude models
+## Choosing a model
 
-Claude Code speaks the Anthropic *wire format*, but the `model` field is just a
+Claude Code speaks the Anthropic wire format, but the `model` field is just a
 string Otari forwards to [any-llm](https://github.com/mozilla-ai/any-llm).
-any-llm translates the Messages format to and from each provider's native API, so
-**any model in the catalog works** — OpenAI, Mistral, Mozilla.ai inference
-models, Moonshot, and so on — not just Anthropic's Opus/Sonnet/Haiku.
+Examples in this page use `provider:model`; Otari also accepts
+`provider/model` in both standalone and connected mode.
 
-Set the model strings to whatever your deployment expects:
+- **Claude models:** `anthropic:claude-sonnet-4-6`,
+  `anthropic:claude-opus-4-8`, `anthropic:claude-haiku-4-5`
+- **Standalone, any configured provider:** `openai:gpt-4o`,
+  `mistral:mistral-large-latest`, `anthropic:claude-sonnet-4-6`
+- **Connected to otari.ai, managed models:** `mzai:<catalog-id>`, for example
+  `mzai:moonshotai/Kimi-K2.6`. These run only through otari.ai's hosted gateway.
+- **Connected to otari.ai, your own provider keys:** `openai:gpt-4o`,
+  `mistral:mistral-large-latest`, `anthropic:claude-sonnet-4-6`
 
-- **Connected to otari.ai:** use `mzai:<catalog-id>` for a
-  managed open-weight model (e.g. `mzai:moonshotai/Kimi-K2.6`), or
-  `provider/model` for one of your own provider keys (e.g. `openai/gpt-4o`,
-  `anthropic/claude-sonnet-4-6`). An `mzai:` prefix selects the managed catalog,
-  so adding it to a proprietary model routes it there instead of your key and it
-  will not resolve.
-- **Standalone:** use `provider:model`, e.g. `openai:gpt-4o`,
-  `mistral:mistral-large-latest`, or `anthropic:claude-sonnet-4-6`.
+If you use Claude Code's `opus`, `sonnet`, or `haiku` aliases, set the matching
+`ANTHROPIC_DEFAULT_*_MODEL` variables so Claude Code does not fall back to a
+model your Otari deployment does not serve.
 
-Claude Code uses two tiers you can point independently: a primary model for the
-agent loop (`ANTHROPIC_MODEL`, or the `ANTHROPIC_DEFAULT_*_MODEL` tier the
-`opus`/`sonnet`/`haiku` aliases resolve to) and a small/fast model for background
-work like title generation (`ANTHROPIC_DEFAULT_HAIKU_MODEL`). Set both so neither
-tier falls back to a model your Otari instance does not serve. For example, to run the
-CLI entirely on managed open-weight models (a capable main model and a smaller
-background model):
+### Non-Claude models
 
-```bash
-export ANTHROPIC_BASE_URL="https://api.otari.ai"
-export ANTHROPIC_AUTH_TOKEN="tk_your_otari_token"
-export ANTHROPIC_DEFAULT_OPUS_MODEL="mzai:moonshotai/Kimi-K2.6"
-export ANTHROPIC_DEFAULT_SONNET_MODEL="mzai:moonshotai/Kimi-K2.6"
-export ANTHROPIC_DEFAULT_HAIKU_MODEL="mzai:Qwen/Qwen3-32B"
-claude
-```
+Otari can route Claude Code to non-Claude models, but Claude Code is tuned for
+Claude. Expect weaker tool use on some models, and expect Anthropic-specific
+features such as extended thinking or prompt caching to be dropped when the
+target provider does not support them.
 
-### Caveats with non-Claude models
+## See also
 
-Routing works at the protocol level, but quality does not transfer
-automatically. Claude Code's prompts and tool-use loop are tuned for Claude
-models; other models run through the same Otari path but may produce weaker
-tool calling and agentic behavior. Anthropic-only features (extended thinking,
-prompt caching via `cache_control`) have no equivalent on most providers and are
-dropped in translation. Treat non-Claude models as usable, not equivalent.
-
-## What Otari provides
-
-- **`POST /v1/messages`** — the Anthropic Messages endpoint Claude Code drives,
-  with streaming and tool use.
-- **`POST /v1/messages/count_tokens`** — Claude Code calls this every turn to keep
-  the prompt within the context window. Otari counts locally (no provider
-  call, no budget debit) and returns `{"input_tokens": N}`. The count is an
-  approximation; it is used only to gauge headroom, not for billing.
-
-Token usage and cost from `/v1/messages` are recorded and reconciled exactly as
-for `/v1/chat/completions`, so Claude Code sessions show up in usage and budgets
-like any other client.
+- [Modes](modes.md) for standalone vs connected behavior
+- [API reference](api-reference.md) for the Messages endpoints and auth rules

--- a/docs/use-with-opencode.md
+++ b/docs/use-with-opencode.md
@@ -25,8 +25,10 @@ Add Otari as a provider in your `opencode.jsonc`:
 ```
 
 `baseURL` is the Otari root plus `/v1` (opencode appends `/chat/completions`
-itself). Point it at your Otari: `http://localhost:8000/v1` for local
-development, or `https://api.otari.ai/v1` when connected to otari.ai.
+itself). Point it at the gateway you are actually using: `http://localhost:8000/v1`
+for local standalone development, your self-hosted gateway URL plus `/v1` when
+connected to otari.ai, or `https://api.otari.ai/v1` when using otari.ai's
+hosted gateway.
 
 Export your key so opencode reads it from the environment instead of the config
 file, then run with a model:
@@ -44,12 +46,15 @@ accepts for both standalone API keys and connected user tokens.
 The provider id is `otari` (from your config) and the model selector is whatever
 your deployment expects:
 
-- **Standalone:** `provider:model`, e.g. `otari/openai:gpt-4o`,
+- **Standalone, any configured provider:** `provider:model`, e.g. `otari/openai:gpt-4o`,
   `otari/anthropic:claude-sonnet-4-6`, `otari/mistral:mistral-large-latest`.
-- **Connected to otari.ai:** `otari/mzai:<catalog-id>` for a managed open-weight
-  model (e.g. `otari/mzai:moonshotai/Kimi-K2.6`), or `otari/provider/model` for
-  one of your own provider keys (e.g. `otari/openai/gpt-4o`). An `mzai:` prefix
-  selects the managed catalog, so adding it to a proprietary model misroutes it.
+- **Connected to otari.ai, managed models:** `otari/mzai:<catalog-id>`, for
+  example `otari/mzai:moonshotai/Kimi-K2.6`. These run only through otari.ai's
+  hosted gateway.
+- **Connected to otari.ai, your own provider keys:** `otari/openai:gpt-4o` or
+  `otari/openai/gpt-4o`, plus the equivalent Anthropic or Mistral forms. An
+  `mzai:` prefix selects the managed catalog, so adding it to a proprietary
+  model misroutes it.
 
 Any model in the catalog works; Otari routes the request to the right
 provider and records usage and cost for it the same way as any other client.


### PR DESCRIPTION
## Description
This PR updates Claude Code and Open Code guides. 

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [X] Documentation
- [ ] Infrastructure / CI

## Checklist

- [X] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [X] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [X] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**


**Any additional AI details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
Updated the Claude Code and Open Code documentation to make setup and model selection clearer. The guides now better explain the correct Otari base URLs, how to configure Claude Code to work with the service, and how to choose between supported model/provider formats.

### Technical notes
- Clarified Claude Code quick-start and standalone configuration details, including user binding behavior.
- Reworked model guidance to separate Claude, standalone, managed, and connected-provider options.
- Added clearer routing guidance for Open Code, including hosted vs local gateway URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->