### PR TITLE
feat: enforce PERF (perflint) rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ src = ["src", "tests", "scripts"]
 extend-exclude = ["demo/"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I"]
+select = ["E", "F", "I", "PERF"]
 
 [tool.ruff.lint.per-file-ignores]
 "scripts/generate_openapi.py" = ["E402"]

--- a/src/gateway/services/mcp_client.py
+++ b/src/gateway/services/mcp_client.py
@@ -129,9 +129,7 @@ class MCPClientPool:
         if owner is None:
             raise KeyError(f"No MCP server owns tool {name!r}")
         result = await self._servers[owner].session.call_tool(name, arguments)
-        parts: list[str] = []
-        for block in result.content:
-            parts.append(_render_content_block(block))
+        parts = [_render_content_block(block) for block in result.content]
         flattened = "\n".join(p for p in parts if p)
         if result.isError:
             return f"[tool error] {flattened}"

--- a/tests/unit/test_mcp_loop.py
+++ b/tests/unit/test_mcp_loop.py
@@ -499,13 +499,14 @@ async def test_stream_loop_passes_chunks_through_and_terminates(monkeypatch: pyt
 
     monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
 
-    pieces: list[str | None] = []
-    async for c in mcp_tool_loop_stream(
-        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "hi"}]},
-        pool=_FakePool(tool_names=[]),
-        max_iterations=3,
-    ):
-        pieces.append(c.choices[0].delta.content if c.choices else None)
+    pieces = [
+        c.choices[0].delta.content if c.choices else None
+        async for c in mcp_tool_loop_stream(
+            completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "hi"}]},
+            pool=_FakePool(tool_names=[]),
+            max_iterations=3,
+        )
+    ]
     assert pieces == ["hi", " there"]
 
 
@@ -532,14 +533,15 @@ async def test_stream_loop_runs_mcp_tool_and_continues(monkeypatch: pytest.Monke
     monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
 
     pool = _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})
-    finishes: list[str | None] = []
-    async for c in mcp_tool_loop_stream(
-        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
-        pool=pool,
-        max_iterations=5,
-    ):
-        if c.choices and c.choices[0].finish_reason:
-            finishes.append(c.choices[0].finish_reason)
+    finishes = [
+        c.choices[0].finish_reason
+        async for c in mcp_tool_loop_stream(
+            completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+            pool=pool,
+            max_iterations=5,
+        )
+        if c.choices and c.choices[0].finish_reason
+    ]
     # Only the final iteration's `stop` is forwarded; the intermediate
     # `tool_calls` terminal is suppressed.
     assert finishes == ["stop"]
@@ -568,14 +570,15 @@ async def test_stream_loop_forwards_terminal_when_model_emits_foreign_tool(
     monkeypatch.setattr(mcp_loop_module, "acompletion", fake_acompletion)
 
     pool = _FakePool(tool_names=["fetch_url"])  # doesn't own user_tool
-    finishes: list[str | None] = []
-    async for c in mcp_tool_loop_stream(
-        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
-        pool=pool,
-        max_iterations=5,
-    ):
-        if c.choices and c.choices[0].finish_reason:
-            finishes.append(c.choices[0].finish_reason)
+    finishes = [
+        c.choices[0].finish_reason
+        async for c in mcp_tool_loop_stream(
+            completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+            pool=pool,
+            max_iterations=5,
+        )
+        if c.choices and c.choices[0].finish_reason
+    ]
     assert finishes == ["tool_calls"]
     assert pool.calls == []
 

--- a/tests/unit/test_mcp_loop_messages.py
+++ b/tests/unit/test_mcp_loop_messages.py
@@ -575,13 +575,14 @@ async def test_stream_passes_text_events_through_and_terminates(monkeypatch: pyt
 
     monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
 
-    types: list[str] = []
-    async for event in anthropic_tool_loop_stream(
-        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 100},
-        pool=cast(Any, _FakePool(tool_names=[])),
-        max_iterations=3,
-    ):
-        types.append(event.type)
+    types = [
+        event.type
+        async for event in anthropic_tool_loop_stream(
+            completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 100},
+            pool=cast(Any, _FakePool(tool_names=[])),
+            max_iterations=3,
+        )
+    ]
     # All events forwarded — single-iteration path, terminal events included.
     assert types == [
         "message_start",
@@ -628,14 +629,15 @@ async def test_stream_runs_owned_tool_and_continues(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
 
     pool = _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})
-    terminal_types: list[str] = []
-    async for event in anthropic_tool_loop_stream(
-        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}], "max_tokens": 100},
-        pool=cast(Any, pool),
-        max_iterations=5,
-    ):
-        if event.type in {"message_delta", "message_stop"}:
-            terminal_types.append(event.type)
+    terminal_types = [
+        event.type
+        async for event in anthropic_tool_loop_stream(
+            completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}], "max_tokens": 100},
+            pool=cast(Any, pool),
+            max_iterations=5,
+        )
+        if event.type in {"message_delta", "message_stop"}
+    ]
     # Only the FINAL iteration's terminal events are forwarded. The intermediate
     # ``tool_use`` iteration's terminal events are dropped.
     assert terminal_types == ["message_delta", "message_stop"]
@@ -665,14 +667,15 @@ async def test_stream_forwards_terminal_when_model_emits_foreign_tool(monkeypatc
     monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
 
     pool = _FakePool(tool_names=["fetch_url"])  # doesn't own user_tool
-    terminal_types: list[str] = []
-    async for event in anthropic_tool_loop_stream(
-        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}], "max_tokens": 100},
-        pool=cast(Any, pool),
-        max_iterations=5,
-    ):
-        if event.type in {"message_delta", "message_stop"}:
-            terminal_types.append(event.type)
+    terminal_types = [
+        event.type
+        async for event in anthropic_tool_loop_stream(
+            completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}], "max_tokens": 100},
+            pool=cast(Any, pool),
+            max_iterations=5,
+        )
+        if event.type in {"message_delta", "message_stop"}
+    ]
     assert terminal_types == ["message_delta", "message_stop"]
     assert pool.calls == []
 

--- a/tests/unit/test_mcp_loop_responses.py
+++ b/tests/unit/test_mcp_loop_responses.py
@@ -560,13 +560,14 @@ async def test_stream_passes_text_events_through_and_terminates(monkeypatch: pyt
 
     monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
 
-    types: list[str] = []
-    async for event in responses_tool_loop_stream(
-        completion_kwargs={"model": "fake", "input_data": "hi"},
-        pool=cast(Any, _FakePool(tool_names=[])),
-        max_iterations=3,
-    ):
-        types.append(event.type)
+    types = [
+        event.type
+        async for event in responses_tool_loop_stream(
+            completion_kwargs={"model": "fake", "input_data": "hi"},
+            pool=cast(Any, _FakePool(tool_names=[])),
+            max_iterations=3,
+        )
+    ]
     assert types == [
         "response.output_text.delta",
         "response.output_text.delta",
@@ -642,13 +643,14 @@ async def test_stream_foreign_function_call_forwards_terminal_and_exits(
     monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
 
     pool = _FakePool(tool_names=["fetch_url"])  # doesn't own user_tool
-    types: list[str] = []
-    async for event in responses_tool_loop_stream(
-        completion_kwargs={"model": "fake", "input_data": "go"},
-        pool=cast(Any, pool),
-        max_iterations=5,
-    ):
-        types.append(event.type)
+    types = [
+        event.type
+        async for event in responses_tool_loop_stream(
+            completion_kwargs={"model": "fake", "input_data": "go"},
+            pool=cast(Any, pool),
+            max_iterations=5,
+        )
+    ]
     assert "response.completed" in types
     assert pool.calls == []
 

--- a/tests/unit/test_streaming_generator.py
+++ b/tests/unit/test_streaming_generator.py
@@ -40,17 +40,18 @@ async def test_streaming_generator_success_with_usage() -> None:
     async def on_error(error: str) -> None:
         pytest.fail("on_error should not be called")
 
-    events: list[str] = []
-    async for event in streaming_generator(
-        stream=_items("hello", "usage"),
-        format_chunk=_format_chunk,
-        extract_usage=_extract_usage,
-        fmt=OPENAI_STREAM_FORMAT,
-        on_complete=on_complete,
-        on_error=on_error,
-        label="test:model",
-    ):
-        events.append(event)
+    events = [
+        event
+        async for event in streaming_generator(
+            stream=_items("hello", "usage"),
+            format_chunk=_format_chunk,
+            extract_usage=_extract_usage,
+            fmt=OPENAI_STREAM_FORMAT,
+            on_complete=on_complete,
+            on_error=on_error,
+            label="test:model",
+        )
+    ]
 
     assert events == ["data: hello\n\n", "data: usage\n\n", "data: [DONE]\n\n"]
     assert len(completed_usage) == 1
@@ -69,17 +70,18 @@ async def test_streaming_generator_no_usage_skips_on_complete() -> None:
     async def on_error(error: str) -> None:
         pytest.fail("on_error should not be called")
 
-    events: list[str] = []
-    async for event in streaming_generator(
-        stream=_items("hello"),
-        format_chunk=_format_chunk,
-        extract_usage=lambda _: None,
-        fmt=OPENAI_STREAM_FORMAT,
-        on_complete=on_complete,
-        on_error=on_error,
-        label="test:model",
-    ):
-        events.append(event)
+    events = [
+        event
+        async for event in streaming_generator(
+            stream=_items("hello"),
+            format_chunk=_format_chunk,
+            extract_usage=lambda _: None,
+            fmt=OPENAI_STREAM_FORMAT,
+            on_complete=on_complete,
+            on_error=on_error,
+            label="test:model",
+        )
+    ]
 
     assert events == ["data: hello\n\n", "data: [DONE]\n\n"]
     assert not completed
@@ -102,18 +104,19 @@ async def test_streaming_generator_no_usage_invokes_on_no_usage() -> None:
         nonlocal no_usage_called
         no_usage_called = True
 
-    events: list[str] = []
-    async for event in streaming_generator(
-        stream=_items("hello"),
-        format_chunk=_format_chunk,
-        extract_usage=lambda _: None,
-        fmt=OPENAI_STREAM_FORMAT,
-        on_complete=on_complete,
-        on_error=on_error,
-        label="test:model",
-        on_no_usage=on_no_usage,
-    ):
-        events.append(event)
+    events = [
+        event
+        async for event in streaming_generator(
+            stream=_items("hello"),
+            format_chunk=_format_chunk,
+            extract_usage=lambda _: None,
+            fmt=OPENAI_STREAM_FORMAT,
+            on_complete=on_complete,
+            on_error=on_error,
+            label="test:model",
+            on_no_usage=on_no_usage,
+        )
+    ]
 
     assert events == ["data: hello\n\n", "data: [DONE]\n\n"]
     assert not completed
@@ -176,17 +179,18 @@ async def test_streaming_generator_error_openai_format() -> None:
         yield "hello"
         raise RuntimeError(_PROVIDER_CRASHED)
 
-    events: list[str] = []
-    async for event in streaming_generator(
-        stream=_failing_stream(),
-        format_chunk=_format_chunk,
-        extract_usage=lambda _: None,
-        fmt=OPENAI_STREAM_FORMAT,
-        on_complete=on_complete,
-        on_error=on_error,
-        label="test:model",
-    ):
-        events.append(event)
+    events = [
+        event
+        async for event in streaming_generator(
+            stream=_failing_stream(),
+            format_chunk=_format_chunk,
+            extract_usage=lambda _: None,
+            fmt=OPENAI_STREAM_FORMAT,
+            on_complete=on_complete,
+            on_error=on_error,
+            label="test:model",
+        )
+    ]
 
     assert events[0] == "data: hello\n\n"
     assert "server_error" in events[1]
@@ -208,17 +212,18 @@ async def test_streaming_generator_error_anthropic_format() -> None:
         raise RuntimeError(_PROVIDER_CRASHED)
         yield  # pragma: no cover
 
-    events: list[str] = []
-    async for event in streaming_generator(
-        stream=_failing_stream(),
-        format_chunk=_format_chunk,
-        extract_usage=lambda _: None,
-        fmt=ANTHROPIC_STREAM_FORMAT,
-        on_complete=on_complete,
-        on_error=on_error,
-        label="test:model",
-    ):
-        events.append(event)
+    events = [
+        event
+        async for event in streaming_generator(
+            stream=_failing_stream(),
+            format_chunk=_format_chunk,
+            extract_usage=lambda _: None,
+            fmt=ANTHROPIC_STREAM_FORMAT,
+            on_complete=on_complete,
+            on_error=on_error,
+            label="test:model",
+        )
+    ]
 
     assert len(events) == 1
     assert "api_error" in events[0]
@@ -238,17 +243,18 @@ async def test_streaming_generator_error_logging_failure_is_swallowed() -> None:
         raise RuntimeError(_PROVIDER_CRASHED)
         yield  # pragma: no cover
 
-    events: list[str] = []
-    async for event in streaming_generator(
-        stream=_failing_stream(),
-        format_chunk=_format_chunk,
-        extract_usage=lambda _: None,
-        fmt=OPENAI_STREAM_FORMAT,
-        on_complete=on_complete,
-        on_error=on_error,
-        label="test:model",
-    ):
-        events.append(event)
+    events = [
+        event
+        async for event in streaming_generator(
+            stream=_failing_stream(),
+            format_chunk=_format_chunk,
+            extract_usage=lambda _: None,
+            fmt=OPENAI_STREAM_FORMAT,
+            on_complete=on_complete,
+            on_error=on_error,
+            label="test:model",
+        )
+    ]
 
     assert "server_error" in events[0]
     assert events[1] == "data: [DONE]\n\n"


### PR DESCRIPTION
## Description

*_NOTE:_ I did run the _"Definition of Done checks locally (`make lint`, `make typecheck`, `make test`)."_ , however I'm seeing failures in `make test`, which I don't believe are related to my changes.  

Enforce PERF (perflint) rules. By enforcing it, and fixing all flagged items, we can speed up the code/tests, and lower compute costs for all users.


## PR Type
<!-- Check all that apply -->

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Relates-to: https://github.com/mozilla-ai/otari/issues/244 

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [X] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**

Claude Sonnet 4.6 

**Any additional AI details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Enabled Ruff PERF checks across the codebase to catch performance-related patterns.
- Simplified several MCP and streaming tests by using list comprehensions to collect streamed values instead of manual append loops.
- Refactored one MCP tool-call path to build rendered content parts more directly.

## Technical notes
- `pyproject.toml` now includes the `PERF` Ruff rule set.
- The code and test changes are behavior-preserving; they mainly reduce boilerplate and align the codebase with the new lint rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->