### PR TITLE
add Render Blueprint + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ This starts Otari on port 8000 backed by a Postgres container, so keys, budgets,
 
 ## Other ways to run
 
+### Render
+
+Run standalone Otari on [Render](https://render.com) from the repo Blueprint: a Starter web service on the published `mzdotai/otari` image plus managed Postgres 16 on the private network. On Apply you can fill OpenAI, Anthropic, Mistral, and/or Gemini keys (leave unused ones blank); Render generates `OTARI_MASTER_KEY`, runs migrations, and prints a bootstrap `gw-…` key in the logs.
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/mozilla-ai/otari)
+
+See [`deploy/render/`](deploy/render/README.md) for the env table, why `PORT`/`OTARI_PORT` are both set, and a short smoke-test list.
+
 ### Railway
 
 Want a hosted gateway with no local setup? Deploy Otari plus a managed Postgres on [Railway](https://railway.com) in one click. Bring a provider key (OpenAI, Anthropic, Mistral, or Gemini) and you get a running gateway with virtual keys, budgets, and usage tracking.

--- a/deploy/render/README.md
+++ b/deploy/render/README.md
@@ -1,0 +1,101 @@
+# Deploy Otari on Render
+
+[`render.yaml`](../../render.yaml) at the repo root is the Blueprint. This page
+is how to use it and what to check after Apply.
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/mozilla-ai/otari)
+
+## Resources
+
+| Name | Plan / kind | Notes |
+| --- | --- | --- |
+| `otari` | Web, Starter | `docker.io/mzdotai/otari:0.2.0`, `/health`, Oregon |
+| `otari-db` | Postgres 16, basic-256mb | User/db `otari`, `ipAllowList: []` (private only) |
+
+Render does not build from this tree. It pulls the published image. On first
+boot, `OTARI_AUTO_MIGRATE` runs Alembic and `OTARI_BOOTSTRAP_API_KEY` prints a
+`gw-…` client key once in the service logs.
+
+Postgres 16 matches the `postgres:16-alpine` service in
+[`docker-compose.yml`](../../docker-compose.yml). Otari is not locked to that
+major; change `postgresMajorVersion` in the Blueprint if you prefer another.
+
+## Env vars
+
+Otari’s own settings are `OTARI_<FIELD>`. Upstream provider SDKs (through
+[any-llm](https://github.com/mozilla-ai/any-llm)) read their usual key names.
+
+| Variable | Set how | Notes |
+| --- | --- | --- |
+| `PORT`, `OTARI_PORT` | both `8000` | Otari listens on `OTARI_PORT`. Render’s health check and routing use `PORT`. They have to agree. |
+| `OTARI_HOST` | `0.0.0.0` | Without this, the process only binds localhost inside the container. |
+| `OTARI_DATABASE_URL` | from `otari-db` | Keys, budgets, usage. |
+| `OTARI_MASTER_KEY` | generated | Management APIs. Copy it from the Environment tab after deploy. |
+| `OTARI_REQUIRE_PRICING` | `false` | Image default is `true`. With no pricing table yet, that rejects every model. |
+| `OTARI_AUTO_MIGRATE` | `true` | |
+| `OTARI_BOOTSTRAP_API_KEY` | `true` | |
+
+Apply also prompts for four provider keys, all optional in the form:
+
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+- `MISTRAL_API_KEY`
+- `GEMINI_API_KEY`
+
+Fill the ones you will call; leave the others empty. Chat completions need at
+least one. Anything else from [`docs/models.md`](../../docs/models.md) can be
+added later on the service Environment tab under its native name.
+
+When you do want priced models, put pricing (and the rest of structured config)
+in `OTARI_CONFIG_YAML` or `OTARI_CONFIG_B64`. See
+[Full config via environment](../../docs/configuration.md#full-config-via-environment).
+
+Render’s `postgresql://` URL is fine as-is. Otari rewrites it to the async
+driver on its own.
+
+## Deploy
+
+1. Use the button above (or the same link in the root README).
+2. On Apply, enter whatever provider keys you need.
+3. Wait until `otari` and `otari-db` are live, then grab the `*.onrender.com` URL
+   from the Dashboard.
+
+## Test it
+
+```bash
+export OTARI_URL=https://<your-service>.onrender.com
+
+curl "$OTARI_URL/health"
+curl "$OTARI_URL/health/readiness"
+```
+
+Readiness should show the database connected. Pull the bootstrap `gw-…` key out
+of the **otari** logs (first boot only):
+
+```bash
+curl "$OTARI_URL/v1/chat/completions" \
+  -H "Authorization: Bearer <gw-key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "openai:gpt-4o-mini",
+    "messages": [{"role": "user", "content": "ping"}]
+  }'
+```
+
+Use a `provider:model` string that matches a key you actually set.
+
+Quick checks:
+
+- [ ] Web + Postgres both live
+- [ ] `/health` OK
+- [ ] `/health/readiness` → database connected
+- [ ] `gw-…` key in logs
+- [ ] Chat completion returns 200
+- [ ] Clients talk to `$OTARI_URL/v1` — the image’s sample page still hardcodes `http://localhost:8000/v1`
+
+## Editing the Blueprint
+
+Change [`render.yaml`](../../render.yaml), keep the image tag pinned unless you
+mean to float, then apply it on a throwaway Render project and run the checks
+above. If the Deploy button’s repo URL moves, update this README, the root
+README, and `docs/deployment.md` together.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -19,6 +19,23 @@ When turning that setup into a longer-lived deployment:
 - Add `pricing` entries for every model you want budget enforcement on.
 - Point container health checks at `/health` and `/health/readiness`.
 
+## Deploy on Render
+
+The repo-root [`render.yaml`](../render.yaml) Blueprint deploys Otari as an
+image-backed web service (`docker.io/mzdotai/otari:0.2.0`) with Render-managed
+Postgres 16. `OTARI_DATABASE_URL` comes from the database connection string.
+Both `PORT` and `OTARI_PORT` are set to `8000` because Otari listens on
+`OTARI_PORT`, not Render's injected `PORT` alone. Health checks use `/health`.
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/mozilla-ai/otari)
+
+On Apply, Render prompts for `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+`MISTRAL_API_KEY`, and `GEMINI_API_KEY`. Set whichever providers you need; leave
+the others empty. `OTARI_MASTER_KEY` is generated for you, and
+`OTARI_REQUIRE_PRICING=false` keeps an env-only deploy usable before you add
+pricing. Smoke tests and the full env table are in
+[`deploy/render/`](https://github.com/mozilla-ai/otari/tree/main/deploy/render).
+
 ## Deploy on Railway
 
 For a hosted standalone deployment without local setup, use the one-click

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,69 @@
+# yaml-language-server: $schema=https://render.com/schema/render.yaml.json
+#
+# Otari on Render — Blueprint for one-click deploy
+# Docs: deploy/render/README.md
+# Image: https://hub.docker.com/r/mzdotai/otari
+#
+# Pattern: image-wrapper (official mzdotai/otari image; no source build on Render)
+# Env-only standalone: Otari web + managed Postgres (auto_migrate + bootstrap key).
+
+previews:
+  generation: off
+
+projects:
+  - name: otari
+    environments:
+      - name: production
+        services:
+          - type: web
+            name: otari
+            runtime: image
+            plan: starter
+            region: oregon
+            image:
+              url: docker.io/mzdotai/otari:0.2.0
+            healthCheckPath: /health
+            envVars:
+              # Otari binds OTARI_PORT (default 8000), not Render's PORT.
+              # Pin both so Render's port scanner and the process agree.
+              - key: PORT
+                value: "8000"
+              - key: OTARI_PORT
+                value: "8000"
+              - key: OTARI_HOST
+                value: "0.0.0.0"
+              - key: OTARI_DATABASE_URL
+                fromDatabase:
+                  name: otari-db
+                  property: connectionString
+              - key: OTARI_MASTER_KEY
+                generateValue: true
+              # Image default is require_pricing=true (fail-closed). An env-only
+              # deploy has no pricing table, so disable until you add pricing via
+              # OTARI_CONFIG_YAML or the /v1/pricing API.
+              - key: OTARI_REQUIRE_PRICING
+                value: "false"
+              - key: OTARI_AUTO_MIGRATE
+                value: "true"
+              - key: OTARI_BOOTSTRAP_API_KEY
+                value: "true"
+              # Provider credentials (any-llm). Prompted on initial Blueprint
+              # create so deployers can fill whichever providers they use.
+              # At least one is needed to serve traffic; leave unused keys blank.
+              - key: OPENAI_API_KEY
+                sync: false
+              - key: ANTHROPIC_API_KEY
+                sync: false
+              - key: MISTRAL_API_KEY
+                sync: false
+              - key: GEMINI_API_KEY
+                sync: false
+
+        databases:
+          - name: otari-db
+            plan: basic-256mb
+            region: oregon
+            databaseName: otari
+            user: otari
+            postgresMajorVersion: "16"
+            ipAllowList: []


### PR DESCRIPTION
Ship render.yaml (Otari image + Postgres), deploy/render notes, and README / deployment links. Apply prompts for OpenAI, Anthropic, Mistral, and Gemini.

**Files changed:**
- `render.yaml` — Otari web service (`mzdotai/otari:0.2.0`) + Postgres 16
- `deploy/render/README.md` — operator docs for the Blueprint
- `docs/deployment.md` — Render section
- `README.md` — Deploy to Render link and quickstart pointer

## Description
<!-- What does this PR do and why? -->


## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
<!-- e.g. "Fixes #123" -->

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [ ] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**


**Any additional AI details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)
