### PR TITLE
fix(openapi): add ApiKeyAuth security scheme to schema definition

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -2892,6 +2892,14 @@
         "title": "ValidationError",
         "type": "object"
       }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "description": "Enter your API key here (sent as Otari-Key header).",
+        "in": "header",
+        "name": "Otari-Key",
+        "type": "apiKey"
+      }
     }
   },
   "info": {
@@ -2944,6 +2952,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Health Liveness",
         "tags": [
           "health"
@@ -2968,6 +2981,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Health Readiness",
         "tags": [
           "health"
@@ -3044,6 +3062,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Create Speech",
         "tags": [
           "audio"
@@ -3084,6 +3107,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Create Transcription",
         "tags": [
           "audio"
@@ -3157,6 +3185,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "List Batches",
         "tags": [
           "batches"
@@ -3195,6 +3228,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Create Batch",
         "tags": [
           "batches"
@@ -3245,6 +3283,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Retrieve Batch",
         "tags": [
           "batches"
@@ -3295,6 +3338,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Cancel Batch",
         "tags": [
           "batches"
@@ -3351,6 +3399,11 @@
             "description": "LLM provider error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Retrieve Batch Results",
         "tags": [
           "batches"
@@ -3412,6 +3465,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "List Budgets",
         "tags": [
           "budgets"
@@ -3452,6 +3510,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Create Budget",
         "tags": [
           "budgets"
@@ -3488,6 +3551,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Delete Budget",
         "tags": [
           "budgets"
@@ -3529,6 +3597,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Get Budget",
         "tags": [
           "budgets"
@@ -3580,6 +3653,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Update Budget",
         "tags": [
           "budgets"
@@ -3620,6 +3698,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Chat Completions",
         "tags": [
           "chat"
@@ -3660,6 +3743,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Create Embedding",
         "tags": [
           "embeddings"
@@ -3728,6 +3816,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "List Files",
         "tags": [
           "files"
@@ -3770,6 +3863,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Create File",
         "tags": [
           "files"
@@ -3831,6 +3929,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Delete File",
         "tags": [
           "files"
@@ -3890,6 +3993,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Get File",
         "tags": [
           "files"
@@ -3947,6 +4055,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Get File Content",
         "tags": [
           "files"
@@ -3987,6 +4100,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Create Image",
         "tags": [
           "images"
@@ -4048,6 +4166,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "List Keys",
         "tags": [
           "keys"
@@ -4088,6 +4211,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Create Key",
         "tags": [
           "keys"
@@ -4124,6 +4252,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Delete Key",
         "tags": [
           "keys"
@@ -4165,6 +4298,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Get Key",
         "tags": [
           "keys"
@@ -4216,6 +4354,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Update Key",
         "tags": [
           "keys"
@@ -4256,6 +4399,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Create Message",
         "tags": [
           "messages"
@@ -4298,6 +4446,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Count Message Tokens",
         "tags": [
           "messages"
@@ -4350,6 +4503,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "List Models",
         "tags": [
           "models"
@@ -4393,6 +4551,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Get Model",
         "tags": [
           "models"
@@ -4447,6 +4610,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Create Moderation",
         "tags": [
           "moderations"
@@ -4508,6 +4676,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "List Pricing",
         "tags": [
           "pricing"
@@ -4548,6 +4721,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Set Pricing",
         "tags": [
           "pricing"
@@ -4603,6 +4781,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Delete Pricing",
         "tags": [
           "pricing"
@@ -4663,6 +4846,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Get Pricing",
         "tags": [
           "pricing"
@@ -4710,6 +4898,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Get Pricing History",
         "tags": [
           "pricing"
@@ -4750,6 +4943,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Create Rerank",
         "tags": [
           "rerank"
@@ -4790,6 +4988,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Create Response",
         "tags": [
           "responses"
@@ -4907,6 +5110,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "List Usage",
         "tags": [
           "usage"
@@ -4968,6 +5176,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "List Users",
         "tags": [
           "users"
@@ -5008,6 +5221,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Create User",
         "tags": [
           "users"
@@ -5044,6 +5262,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Delete User",
         "tags": [
           "users"
@@ -5085,6 +5308,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Get User",
         "tags": [
           "users"
@@ -5136,6 +5364,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Update User",
         "tags": [
           "users"
@@ -5206,6 +5439,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "summary": "Get User Usage",
         "tags": [
           "users"

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -2952,11 +2952,6 @@
             "description": "Successful Response"
           }
         },
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
         "summary": "Health Liveness",
         "tags": [
           "health"
@@ -2981,11 +2976,6 @@
             "description": "Successful Response"
           }
         },
-        "security": [
-          {
-            "ApiKeyAuth": []
-          }
-        ],
         "summary": "Health Readiness",
         "tags": [
           "health"

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -107,9 +107,6 @@ def create_app(config: GatewayConfig) -> FastAPI:
         lifespan=_create_lifespan(config),
     )
 
-    # Addition of a cosmetic fix for the openapi schema, this just adds the
-    # ApiKeyAuth security scheme to the openapi schema and applies it to all the
-    # openapi paths
     def custom_openapi() -> dict[str, Any]:
         if app.openapi_schema:
             return app.openapi_schema
@@ -136,7 +133,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
         }
 
         for path, path_item in openapi_schema.get("paths", {}).items():
-            if path in _PUBLIC_PREFIXES:
+            if path.startswith(_PUBLIC_PREFIXES):
                 continue
             for operation in path_item.values():
                 if isinstance(operation, dict):

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -144,7 +144,6 @@ def create_app(config: GatewayConfig) -> FastAPI:
 
     app.openapi = custom_openapi  # type: ignore[method-assign]
 
-
     @app.get("/", response_class=HTMLResponse, include_in_schema=False)
     async def root_tutorial() -> str:
         return ROOT_TUTORIAL_HTML

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -107,6 +107,47 @@ def create_app(config: GatewayConfig) -> FastAPI:
         lifespan=_create_lifespan(config),
     )
 
+    # Addition of a cosmetic fix for the openapi schema, this just adds the
+    # ApiKeyAuth security scheme to the openapi schema and applies it to all the
+    # openapi paths
+    def custom_openapi() -> dict[str, Any]:
+        if app.openapi_schema:
+            return app.openapi_schema
+
+        from fastapi.openapi.utils import get_openapi
+
+        openapi_schema = get_openapi(
+            title=app.title,
+            version=app.version,
+            description=app.description,
+            routes=app.routes,
+        )
+
+        if "components" not in openapi_schema:
+            openapi_schema["components"] = {}
+        if "securitySchemes" not in openapi_schema["components"]:
+            openapi_schema["components"]["securitySchemes"] = {}
+
+        openapi_schema["components"]["securitySchemes"]["ApiKeyAuth"] = {
+            "type": "apiKey",
+            "in": "header",
+            "name": API_KEY_HEADER,
+            "description": f"Enter your API key here (sent as {API_KEY_HEADER} header).",
+        }
+
+        for path, path_item in openapi_schema.get("paths", {}).items():
+            if path in _PUBLIC_PREFIXES:
+                continue
+            for operation in path_item.values():
+                if isinstance(operation, dict):
+                    operation["security"] = [{"ApiKeyAuth": []}]
+
+        app.openapi_schema = openapi_schema
+        return app.openapi_schema
+
+    app.openapi = custom_openapi  # type: ignore[method-assign]
+
+
     @app.get("/", response_class=HTMLResponse, include_in_schema=False)
     async def root_tutorial() -> str:
         return ROOT_TUTORIAL_HTML


### PR DESCRIPTION
## Description
Adds the ApiKeyAuth security scheme to the OpenAPI schema, applying it to all non-public endpoints. This displays the authorization/lock symbol in the Swagger UI and OpenAPI documentation. This is to solve the issue 217 .


## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
Fixes #217

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [ ] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**
Gemini 3.5 Flash via Antigravity Agent

**Any additional AI details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added an API key security definition to the OpenAPI schema (using the `Otari-Key` header).
- Updated the generated OpenAPI so every non-public route requires that API key in Swagger UI “Try it out” requests (everything except `/health`).
- Left existing request authentication/middleware behavior unchanged.

## Technical notes

- In `src/gateway/main.py`, `create_app()` overrides FastAPI’s OpenAPI generation with a cached `custom_openapi()` that injects an `ApiKeyAuth` `apiKey` scheme into `components.securitySchemes` and sets per-operation `security: [{"ApiKeyAuth": []}]` for paths not starting with `/health`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->