### PR TITLE
docs(render): mention Otari Gateway Tester for browser smoke tests

### DIFF
--- a/deploy/render/README.md
+++ b/deploy/render/README.md
@@ -95,11 +95,7 @@ For a longer-lived deployment, use `OTARI_MASTER_KEY` to create a named API key,
 
 ### Otari Gateway Tester
 
-For a browser chat UI against the gateway (instead of `curl`), deploy the companion [Otari Tester](https://github.com/ojusave/otari-tester) app on Render:
-
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/ojusave/otari-tester)
-
-Point `OTARI_BASE_URL` at your Otari service URL and paste the bootstrap `gw-…` key from the Otari logs (or set `OTARI_API_KEY` in the tester Blueprint). The UI loads models from `GET /v1/models` when the gateway catalog is available.
+For a browser chat UI against the gateway (instead of `curl`), use the companion [Otari Tester](https://github.com/ojusave/otari-tester). Point it at your Otari service URL and paste the bootstrap `gw-…` key from the Otari logs. The UI loads models from `GET /v1/models` when the gateway catalog is available.
 
 ## Upgrade for production
 

--- a/deploy/render/README.md
+++ b/deploy/render/README.md
@@ -93,6 +93,14 @@ Use a `provider:model` value that matches a credential you supplied. Clients sho
 
 For a longer-lived deployment, use `OTARI_MASTER_KEY` to create a named API key, then revoke the bootstrap key through the key-management API.
 
+### Otari Gateway Tester
+
+For a browser chat UI against the gateway (instead of `curl`), deploy the companion [Otari Tester](https://github.com/ojusave/otari-tester) app on Render:
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/ojusave/otari-tester)
+
+Point `OTARI_BASE_URL` at your Otari service URL and paste the bootstrap `gw-…` key from the Otari logs (or set `OTARI_API_KEY` in the tester Blueprint). The UI loads models from `GET /v1/models` when the gateway catalog is available.
+
 ## Upgrade for production
 
 Before the free database expires, change the web-service plan to `starter` and the database plan to `basic-256mb` or higher. Paid web services do not spin down when idle, and paid Render Postgres adds continuous backups and point-in-time recovery.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,6 +38,8 @@ The Blueprint, upgrade instructions, and full env table are available at [`deplo
 
 This Blueprint deploys standalone mode with a local Postgres database. Render also has a hybrid-mode Blueprint connected to otari.ai — see [Hybrid mode](https://github.com/mozilla-ai/otari/tree/main/deploy/render#hybrid-mode) in the Render docs, or [Connect to otari.ai](#connect-to-otariai) below for the general Docker instructions.
 
+To smoke-test the deployed gateway from a browser, use the [Otari Gateway Tester](https://github.com/ojusave/otari-tester) (documented under [Verify → Otari Gateway Tester](https://github.com/mozilla-ai/otari/blob/main/deploy/render/README.md#otari-gateway-tester)).
+
 ## Deploy on Railway
 
 For a hosted standalone deployment without local setup, use the one-click


### PR DESCRIPTION
## Summary
- Document the companion [Otari Gateway Tester](https://github.com/ojusave/otari-tester) under Verify in `deploy/render/README.md` (repo link only; no Deploy button)
- Link to it from `docs/deployment.md` so Render deploy readers can smoke-test via a chat UI instead of curl only

## Test plan
- [ ] Confirm the Otari Tester link resolves to https://github.com/ojusave/otari-tester
- [ ] Confirm no Deploy to Render button for the tester in the Render docs
- [ ] Skim tone against existing Verify / Hybrid sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added instructions for verifying a deployed gateway with the Otari Gateway Tester browser interface.
  - Explained how to connect the tester to the service, provide the bootstrap key, and load available models.
  - Added a link to the relevant deployment verification guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->