### PR TITLE
docs(render): fix Deploy to Render URL path query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ This starts Otari on port 8000 backed by a Postgres container, so keys, budgets,
 
 Deploy Otari with fully managed Postgres on Render for free. Just add your provider credentials; Render provisions and connects your services automatically.
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/mozilla-ai/otari&blueprintPath=deploy/render/render.yaml)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/mozilla-ai/otari&path=deploy/render/render.yaml)
 
 Read [`the docs`](deploy/render/README.md) for more details, including a hybrid-mode Blueprint connected to otari.ai.
 

--- a/deploy/render/README.md
+++ b/deploy/render/README.md
@@ -2,7 +2,7 @@
 
 Deploy Otari and Render Postgres from a Blueprint ([`render.yaml`](./render.yaml)). Render pulls the published Otari image rather than building this repository. For hybrid mode instead, connected to otari.ai, see [Hybrid mode](#hybrid-mode) below.
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/mozilla-ai/otari&blueprintPath=deploy/render/render.yaml)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/mozilla-ai/otari&path=deploy/render/render.yaml)
 
 ## What gets deployed
 
@@ -55,7 +55,7 @@ The Blueprint sets `OTARI_REQUIRE_PRICING=true` (fail closed) and
 
 ## Deploy
 
-1. Click **Deploy to Render** above. The button passes `blueprintPath=deploy/render/render.yaml` so Render loads this Blueprint instead of looking for a root `render.yaml`.
+1. Click **Deploy to Render** above. The button passes `path=deploy/render/render.yaml` so Render loads this Blueprint instead of looking for a root `render.yaml`.
 2. If you create the Blueprint from the Dashboard instead (**New → Blueprint**), set **Blueprint Path** to:
 
    ```text
@@ -105,7 +105,7 @@ The Blueprint above deploys Otari in standalone mode with its own database. Otar
 
 A separate Blueprint, [`render.hybrid.yaml`](./render.hybrid.yaml), deploys hybrid mode:
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/mozilla-ai/otari&blueprintPath=deploy/render/render.hybrid.yaml)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/mozilla-ai/otari&path=deploy/render/render.hybrid.yaml)
 
 ### What gets deployed
 
@@ -127,7 +127,7 @@ No database is created. Otari keeps no local state in hybrid mode: users, budget
 
 ### Deploy
 
-1. Click **Deploy to Render** above. The button passes `blueprintPath=deploy/render/render.hybrid.yaml`.
+1. Click **Deploy to Render** above. The button passes `path=deploy/render/render.hybrid.yaml`.
 2. Enter your `OTARI_AI_TOKEN`.
 3. Review the single free web service, then apply the Blueprint.
 4. Wait for `otari-hybrid` to become live, then copy its `*.onrender.com` URL from the Dashboard.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -28,7 +28,7 @@ It deploys the published Otari image (`docker.io/mzdotai/otari:0.2.0`) as a free
 - On Apply, provide whichever provider credentials you use. Render provisions the web service and Postgres, injects the database’s internal connection string as `OTARI_DATABASE_URL`, generates `OTARI_MASTER_KEY`, sets `PORT` and `OTARI_PORT` to `8000`, enables fail-closed bundled pricing (`OTARI_REQUIRE_PRICING` and `OTARI_DEFAULT_PRICING`), and checks `/health/readiness`.
 - On Otari startup, the app runs database migrations and creates the bootstrap API key (printed once in the service logs).
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/mozilla-ai/otari&blueprintPath=deploy/render/render.yaml)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/mozilla-ai/otari&path=deploy/render/render.yaml)
 
 If you create the Blueprint from the Dashboard (**New → Blueprint**) instead of the button, set **Blueprint Path** to `deploy/render/render.yaml`.
 


### PR DESCRIPTION
## Description

Fix Deploy to Render button URLs so nested Blueprints load on apply.

Render's Blueprint create flow accepts a `path` query param (not `blueprintPath`). Update standalone and hybrid buttons:

- Standalone: `path=deploy/render/render.yaml`
- Hybrid: `path=deploy/render/render.hybrid.yaml`

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues
<!-- e.g. "Fixes #123" -->

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Cursor Agent


**Any additional AI details you'd like to share:** Assisted with searching the correct Deploy to Render query param and drafting the docs URL updates.


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)

## Test plan
- [ ] Click Deploy to Render from README; confirm Blueprint Path is prefilled to `deploy/render/render.yaml`
- [ ] Same for hybrid button → `deploy/render/render.hybrid.yaml`