### PR TITLE
fix(batches): enforce user resolution, budget, rate limiting, and batch ownership

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -748,6 +748,17 @@
             "minItems": 1,
             "title": "Requests",
             "type": "array"
+          },
+          "user": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User"
           }
         },
         "required": [
@@ -3110,7 +3121,7 @@
     },
     "/v1/batches": {
       "get": {
-        "description": "List batches for a provider.",
+        "description": "List batches for a provider.\n\nNon-master keys only see batches they own (plus legacy batches without an\nownership marker); the page is filtered after the provider call, so a page\nmay contain fewer than ``limit`` items.",
         "operationId": "list_batches_v1_batches_get",
         "parameters": [
           {
@@ -3186,7 +3197,7 @@
         ]
       },
       "post": {
-        "description": "Create a batch of LLM requests for asynchronous processing.",
+        "description": "Create a batch of LLM requests for asynchronous processing.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
         "operationId": "create_batch_v1_batches_post",
         "requestBody": {
           "content": {

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -135,7 +135,7 @@
         {
           "name": "List Batches",
           "request": {
-            "description": "List batches for a provider.",
+            "description": "List batches for a provider.\n\nNon-master keys only see batches they own (plus legacy batches without an\nownership marker); the page is filtered after the provider call, so a page\nmay contain fewer than ``limit`` items.",
             "header": [],
             "method": "GET",
             "url": {
@@ -182,7 +182,7 @@
               },
               "raw": "{\n  \"model\": \"string\",\n  \"requests\": [\n    {\n      \"custom_id\": \"string\",\n      \"body\": {}\n    }\n  ]\n}"
             },
-            "description": "Create a batch of LLM requests for asynchronous processing.",
+            "description": "Create a batch of LLM requests for asynchronous processing.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use virtual user created with API key",
             "header": [
               {
                 "key": "Content-Type",

--- a/src/gateway/api/routes/batches.py
+++ b/src/gateway/api/routes/batches.py
@@ -447,12 +447,17 @@ async def retrieve_batch_results(
     """Retrieve the results of a completed batch."""
     api_key, is_master_key = auth_result
     api_key_id = api_key.id if api_key else None
-    user_id = api_key.user_id if api_key else None
 
     provider_enum, provider_kwargs = _resolve_batch_provider(config, provider)
 
     batch = await _retrieve_batch_or_502(provider_enum, batch_id, provider, provider_kwargs)
     _check_batch_ownership(batch, api_key, is_master_key, batch_id)
+
+    # Attribute usage to the batch owner stamped at creation time (so a
+    # master-key retrieval bills the owner, not user_id=None), falling back to
+    # the key's user for legacy batches without the marker.
+    owner = (batch.metadata or {}).get(_OWNER_METADATA_KEY)
+    user_id = owner or (api_key.user_id if api_key else None)
 
     try:
         result = await aretrieve_batch_results(

--- a/src/gateway/api/routes/batches.py
+++ b/src/gateway/api/routes/batches.py
@@ -11,17 +11,32 @@ from any_llm import AnyLLM, LLMProvider
 from any_llm.api import acancel_batch, acreate_batch, alist_batches, aretrieve_batch, aretrieve_batch_results
 from any_llm.exceptions import BatchNotCompleteError, UnsupportedProviderError
 from any_llm.types.batch import Batch
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.api.deps import get_config, get_log_writer, verify_api_key_or_master_key
+from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
+from gateway.api.routes._helpers import resolve_user_id
+from gateway.api.routes.chat import rate_limit_headers
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import APIKey, UsageLog
+from gateway.rate_limit import check_rate_limit
+from gateway.services.budget_service import (
+    reconcile_reservation,
+    refund_reservation,
+    reserve_budget,
+)
 from gateway.services.log_writer import LogWriter
+from gateway.services.pricing_service import find_model_pricing
 from gateway.services.provider_kwargs import get_provider_kwargs, resolve_provider_selector
 
 router = APIRouter(prefix="/v1/batches", tags=["batches"])
+
+# Metadata key stamped on provider batches at creation time so ownership can be
+# checked on retrieve/cancel/results. The gateway stores no batch table, so the
+# provider-side metadata is the ownership anchor.
+_OWNER_METADATA_KEY = "otari_user_id"
 
 
 # ---------------------------------------------------------------------------
@@ -39,6 +54,7 @@ class CreateBatchRequest(BaseModel):
     requests: list[BatchRequestItem] = Field(min_length=1, max_length=10_000)
     completion_window: str = "24h"
     metadata: dict[str, str] | None = None
+    user: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -54,8 +70,12 @@ async def log_batch_usage(
     endpoint: str,
     user_id: str | None = None,
     error: str | None = None,
+    prompt_tokens: int | None = None,
+    completion_tokens: int | None = None,
+    total_tokens: int | None = None,
+    cost: float | None = None,
 ) -> None:
-    """Log batch API usage."""
+    """Log batch API usage, including token counts and cost when derivable."""
     usage_log = UsageLog(
         id=str(uuid.uuid4()),
         api_key_id=api_key_id,
@@ -64,6 +84,10 @@ async def log_batch_usage(
         model=model,
         provider=provider,
         endpoint=endpoint,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+        cost=cost,
         status="success" if error is None else "error",
         error_message=error,
     )
@@ -101,6 +125,59 @@ def _resolve_batch_provider(config: GatewayConfig, provider: str) -> tuple[LLMPr
     return impl, get_provider_kwargs(config, impl)
 
 
+def _owns_batch(batch: Batch, api_key: APIKey | None, is_master_key: bool) -> bool:
+    """Whether the requester may access ``batch``.
+
+    Ownership is anchored on the :data:`_OWNER_METADATA_KEY` metadata entry
+    stamped at creation time. Batches without the marker (created before
+    stamping existed, or via providers that do not round-trip metadata) remain
+    accessible to any authenticated key. The master key may access any batch.
+    """
+    if is_master_key:
+        return True
+    owner = (batch.metadata or {}).get(_OWNER_METADATA_KEY)
+    if owner is None:
+        return True
+    requester = str(api_key.user_id) if api_key and api_key.user_id else None
+    return owner == requester
+
+
+def _check_batch_ownership(batch: Batch, api_key: APIKey | None, is_master_key: bool, batch_id: str) -> None:
+    """Raise 404 when the requester does not own ``batch``.
+
+    404 rather than 403 so a foreign key cannot probe which batch ids exist.
+    """
+    if not _owns_batch(batch, api_key, is_master_key):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Batch '{batch_id}' not found",
+        )
+
+
+async def _retrieve_batch_or_502(
+    provider_enum: LLMProvider,
+    batch_id: str,
+    provider: str,
+    provider_kwargs: dict[str, Any],
+) -> Batch:
+    """Retrieve a batch from the provider, mapping failures to 502."""
+    try:
+        batch: Batch = await aretrieve_batch(
+            provider=provider_enum,
+            batch_id=batch_id,
+            **provider_kwargs,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Batch retrieve failed for %s: %s", provider, e)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="LLM provider error",
+        ) from e
+    return batch
+
+
 # ---------------------------------------------------------------------------
 # Route handlers
 # ---------------------------------------------------------------------------
@@ -109,16 +186,48 @@ def _resolve_batch_provider(config: GatewayConfig, provider: str) -> tuple[LLMPr
 @router.post("", response_model=None)
 async def create_batch(
     raw_request: Request,
+    response: Response,
     background_tasks: BackgroundTasks,
     request: CreateBatchRequest,
     auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
     log_writer: Annotated[LogWriter, Depends(get_log_writer)],
 ) -> dict[str, Any]:
-    """Create a batch of LLM requests for asynchronous processing."""
+    """Create a batch of LLM requests for asynchronous processing.
+
+    Authentication modes:
+    - Master key + user field: Use specified user (must exist)
+    - API key + user field: Use specified user (must exist)
+    - API key without user field: Use virtual user created with API key
+    """
     api_key, is_master_key = auth_result
     api_key_id = api_key.id if api_key else None
-    user_id = api_key.user_id if api_key else None
+
+    user_id = resolve_user_id(
+        user_id_from_request=request.user,
+        api_key=api_key,
+        is_master_key=is_master_key,
+        master_key_error=HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="When using master key, 'user' field is required in request body",
+        ),
+        no_api_key_error=HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key validation failed",
+        ),
+        no_user_error=HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key has no associated user",
+        ),
+        forbidden_user_error=HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="'user' field does not match the authenticated API key's user",
+        ),
+        reject_mismatch=config.reject_user_mismatch,
+    )
+
+    rate_limit_info = check_rate_limit(raw_request, user_id)
 
     try:
         resolved = resolve_provider_selector(config, request.model)
@@ -139,6 +248,15 @@ async def create_batch(
 
     provider_kwargs = resolved.kwargs
 
+    # Batch cost is unknown until results are retrieved, so the reservation
+    # estimate is 0; it still enforces per-user state (user exists, not
+    # blocked, not already over budget), matching the audio routes.
+    reservation = await reserve_budget(db, user_id, 0.0, model=request.model, strategy=config.budget_strategy)
+
+    # Stamp the billed user into the provider-side metadata so ownership can be
+    # enforced on retrieve/cancel/results; a client-supplied value never wins.
+    metadata = {**(request.metadata or {}), _OWNER_METADATA_KEY: user_id}
+
     # Build JSONL temp file from requests
     with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as tmp:
         for req_item in request.requests:
@@ -157,10 +275,11 @@ async def create_batch(
             input_file_path=tmp_path,
             endpoint="/v1/chat/completions",
             completion_window=request.completion_window,
-            metadata=request.metadata,
+            metadata=metadata,
             **provider_kwargs,
         )
     except HTTPException:
+        await refund_reservation(db, reservation)
         raise
     except Exception as e:
         await log_batch_usage(
@@ -172,6 +291,7 @@ async def create_batch(
             user_id=user_id,
             error=str(e),
         )
+        await refund_reservation(db, reservation)
         logger.error("Batch create failed for %s: %s", provider, e)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -190,7 +310,15 @@ async def create_batch(
         provider=resolved.instance,
         endpoint="/v1/batches",
         user_id=user_id,
+        prompt_tokens=0,
+        completion_tokens=0,
+        total_tokens=0,
     )
+    await reconcile_reservation(db, reservation, 0.0)
+
+    if rate_limit_info:
+        for key, value in rate_limit_headers(rate_limit_info).items():
+            response.headers[key] = value
 
     response_data = batch.model_dump()
     response_data["provider"] = resolved.instance
@@ -206,22 +334,11 @@ async def retrieve_batch(
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> dict[str, Any]:
     """Retrieve the status of a batch."""
+    api_key, is_master_key = auth_result
     provider_enum, provider_kwargs = _resolve_batch_provider(config, provider)
 
-    try:
-        batch: Batch = await aretrieve_batch(
-            provider=provider_enum,
-            batch_id=batch_id,
-            **provider_kwargs,
-        )
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error("Batch retrieve failed for %s: %s", provider, e)
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="LLM provider error",
-        ) from e
+    batch = await _retrieve_batch_or_502(provider_enum, batch_id, provider, provider_kwargs)
+    _check_batch_ownership(batch, api_key, is_master_key, batch_id)
 
     response_data = batch.model_dump()
     response_data["provider"] = provider
@@ -237,7 +354,11 @@ async def cancel_batch(
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> dict[str, Any]:
     """Cancel a batch."""
+    api_key, is_master_key = auth_result
     provider_enum, provider_kwargs = _resolve_batch_provider(config, provider)
+
+    existing = await _retrieve_batch_or_502(provider_enum, batch_id, provider, provider_kwargs)
+    _check_batch_ownership(existing, api_key, is_master_key, batch_id)
 
     try:
         batch: Batch = await acancel_batch(
@@ -268,7 +389,13 @@ async def list_batches(
     after: str | None = None,
     limit: int | None = None,
 ) -> dict[str, Any]:
-    """List batches for a provider."""
+    """List batches for a provider.
+
+    Non-master keys only see batches they own (plus legacy batches without an
+    ownership marker); the page is filtered after the provider call, so a page
+    may contain fewer than ``limit`` items.
+    """
+    api_key, is_master_key = auth_result
     provider_enum, provider_kwargs = _resolve_batch_provider(config, provider)
 
     list_kwargs: dict[str, Any] = {**provider_kwargs}
@@ -291,7 +418,13 @@ async def list_batches(
             detail="LLM provider error",
         ) from e
 
-    return {"data": [{**batch.model_dump(), "provider": provider} for batch in batches]}
+    return {
+        "data": [
+            {**batch.model_dump(), "provider": provider}
+            for batch in batches
+            if _owns_batch(batch, api_key, is_master_key)
+        ]
+    }
 
 
 @router.get(
@@ -307,6 +440,7 @@ async def retrieve_batch_results(
     provider: str,
     raw_request: Request,
     auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
     log_writer: Annotated[LogWriter, Depends(get_log_writer)],
 ) -> dict[str, Any]:
@@ -316,6 +450,9 @@ async def retrieve_batch_results(
     user_id = api_key.user_id if api_key else None
 
     provider_enum, provider_kwargs = _resolve_batch_provider(config, provider)
+
+    batch = await _retrieve_batch_or_502(provider_enum, batch_id, provider, provider_kwargs)
+    _check_batch_ownership(batch, api_key, is_master_key, batch_id)
 
     try:
         result = await aretrieve_batch_results(
@@ -347,6 +484,25 @@ async def retrieve_batch_results(
             batch_model = item.result.model
             break
 
+    # Sum per-request token usage so batch spend is visible in usage reporting.
+    prompt_tokens = 0
+    completion_tokens = 0
+    total_tokens = 0
+    for item in result.results:
+        usage = item.result.usage if item.result is not None else None
+        if usage is not None:
+            prompt_tokens += usage.prompt_tokens or 0
+            completion_tokens += usage.completion_tokens or 0
+            total_tokens += usage.total_tokens or 0
+
+    cost: float | None = None
+    if total_tokens:
+        pricing = await find_model_pricing(db, provider_enum.value, batch_model)
+        if pricing:
+            cost = (prompt_tokens / 1_000_000) * pricing.input_price_per_million + (
+                completion_tokens / 1_000_000
+            ) * pricing.output_price_per_million
+
     await log_batch_usage(
         log_writer=log_writer,
         api_key_id=api_key_id,
@@ -354,6 +510,10 @@ async def retrieve_batch_results(
         provider=provider,
         endpoint="/v1/batches/results",
         user_id=user_id,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+        cost=cost,
     )
 
     return {

--- a/tests/integration/test_batches_endpoint.py
+++ b/tests/integration/test_batches_endpoint.py
@@ -1,14 +1,21 @@
 """Tests for the /v1/batches batch API endpoints."""
 
 import os
+from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from any_llm.exceptions import BatchNotCompleteError
 from any_llm.types.batch import BatchResult, BatchResultError, BatchResultItem
+from any_llm.types.completion import CompletionUsage
 from fastapi.testclient import TestClient
 from openai.types.batch import Batch
 from openai.types.batch_request_counts import BatchRequestCounts
+
+from gateway.core.config import API_KEY_HEADER
+
+from .test_rate_limiting import _make_rate_limit_client
 
 
 def _mock_batch(**overrides: Any) -> Batch:
@@ -91,17 +98,28 @@ def test_create_batch_with_master_key(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/batches works with master key."""
+    """POST /v1/batches works with master key naming an existing user."""
     mock_batch = _mock_batch()
 
     class _SupportsBatch:
         SUPPORTS_BATCH = True
 
+    resp = client.post(
+        "/v1/users",
+        json={"user_id": "batch-master-user"},
+        headers=master_key_header,
+    )
+    assert resp.status_code == 200
+
     with (
         patch("gateway.api.routes.batches.acreate_batch", new_callable=AsyncMock, return_value=mock_batch),
         patch("gateway.api.routes.batches.AnyLLM.get_provider_class", return_value=_SupportsBatch),
     ):
-        resp = client.post("/v1/batches", json=_create_batch_body(), headers=master_key_header)
+        resp = client.post(
+            "/v1/batches",
+            json=_create_batch_body(user="batch-master-user"),
+            headers=master_key_header,
+        )
 
     assert resp.status_code == 200
     assert resp.json()["id"] == "batch_abc123"
@@ -282,7 +300,14 @@ def test_cancel_batch(
     """POST /v1/batches/{batch_id}/cancel cancels a batch."""
     mock_batch = _mock_batch(status="cancelling")
 
-    with patch("gateway.api.routes.batches.acancel_batch", new_callable=AsyncMock, return_value=mock_batch):
+    with (
+        patch(
+            "gateway.api.routes.batches.aretrieve_batch",
+            new_callable=AsyncMock,
+            return_value=_mock_batch(status="in_progress"),
+        ),
+        patch("gateway.api.routes.batches.acancel_batch", new_callable=AsyncMock, return_value=mock_batch),
+    ):
         resp = client.post("/v1/batches/batch_abc123/cancel?provider=openai", headers=api_key_header)
 
     assert resp.status_code == 200
@@ -335,6 +360,7 @@ def test_retrieve_batch_results(
     """GET /v1/batches/{batch_id}/results returns per-request results."""
     mock_completion = MagicMock()
     mock_completion.model = "gpt-4o-mini"
+    mock_completion.usage = None
     mock_completion.model_dump.return_value = {"id": "chatcmpl-1", "choices": []}
 
     mock_result = BatchResult(
@@ -346,7 +372,14 @@ def test_retrieve_batch_results(
         ]
     )
 
-    with patch("gateway.api.routes.batches.aretrieve_batch_results", new_callable=AsyncMock, return_value=mock_result):
+    with (
+        patch(
+            "gateway.api.routes.batches.aretrieve_batch",
+            new_callable=AsyncMock,
+            return_value=_mock_batch(status="completed"),
+        ),
+        patch("gateway.api.routes.batches.aretrieve_batch_results", new_callable=AsyncMock, return_value=mock_result),
+    ):
         resp = client.get("/v1/batches/batch_abc123/results?provider=openai", headers=api_key_header)
 
     assert resp.status_code == 200
@@ -367,10 +400,17 @@ def test_retrieve_batch_results_not_complete(
     api_key_header: dict[str, str],
 ) -> None:
     """GET /v1/batches/{batch_id}/results returns 409 when batch is not complete."""
-    with patch(
-        "gateway.api.routes.batches.aretrieve_batch_results",
-        new_callable=AsyncMock,
-        side_effect=BatchNotCompleteError(batch_id="batch_abc123", status="in_progress"),
+    with (
+        patch(
+            "gateway.api.routes.batches.aretrieve_batch",
+            new_callable=AsyncMock,
+            return_value=_mock_batch(status="in_progress"),
+        ),
+        patch(
+            "gateway.api.routes.batches.aretrieve_batch_results",
+            new_callable=AsyncMock,
+            side_effect=BatchNotCompleteError(batch_id="batch_abc123", status="in_progress"),
+        ),
     ):
         resp = client.get("/v1/batches/batch_abc123/results?provider=openai", headers=api_key_header)
 
@@ -391,7 +431,14 @@ def test_retrieve_batch_results_logs_usage(
     mock_result = BatchResult(results=[])
     user_id = api_key_obj["user_id"]
 
-    with patch("gateway.api.routes.batches.aretrieve_batch_results", new_callable=AsyncMock, return_value=mock_result):
+    with (
+        patch(
+            "gateway.api.routes.batches.aretrieve_batch",
+            new_callable=AsyncMock,
+            return_value=_mock_batch(status="completed"),
+        ),
+        patch("gateway.api.routes.batches.aretrieve_batch_results", new_callable=AsyncMock, return_value=mock_result),
+    ):
         resp = client.get("/v1/batches/batch_abc123/results?provider=openai", headers=api_key_header)
 
     assert resp.status_code == 200
@@ -402,6 +449,347 @@ def test_retrieve_batch_results_logs_usage(
     results_logs = [log for log in logs if log["endpoint"] == "/v1/batches/results"]
     assert len(results_logs) >= 1
     assert results_logs[0]["status"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# Enforcement — user resolution, budget, rate limiting, ownership (issue #258)
+# ---------------------------------------------------------------------------
+
+
+class _SupportsBatch:
+    SUPPORTS_BATCH = True
+
+
+def _batch_enforcement_patches() -> tuple[Any, Any]:
+    """Patches for provider calls so enforcement tests never hit a provider."""
+    return (
+        patch("gateway.api.routes.batches.acreate_batch", new_callable=AsyncMock, return_value=_mock_batch()),
+        patch("gateway.api.routes.batches.AnyLLM.get_provider_class", return_value=_SupportsBatch),
+    )
+
+
+def test_create_batch_master_key_requires_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """POST /v1/batches with master key and no user field is rejected with 400."""
+    create_patch, supports_patch = _batch_enforcement_patches()
+    with create_patch as mock_call, supports_patch:
+        resp = client.post("/v1/batches", json=_create_batch_body(), headers=master_key_header)
+
+    assert resp.status_code == 400
+    assert "user" in resp.json()["detail"].lower()
+    mock_call.assert_not_awaited()
+
+
+def test_create_batch_master_key_unknown_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """POST /v1/batches with master key naming a nonexistent user returns 404."""
+    create_patch, supports_patch = _batch_enforcement_patches()
+    with create_patch as mock_call, supports_patch:
+        resp = client.post(
+            "/v1/batches",
+            json=_create_batch_body(user="no-such-user"),
+            headers=master_key_header,
+        )
+
+    assert resp.status_code == 404
+    assert "not found" in resp.json()["detail"].lower()
+    mock_call.assert_not_awaited()
+
+
+def test_create_batch_blocked_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """POST /v1/batches for a blocked user is rejected before the provider call."""
+    resp = client.post(
+        "/v1/users",
+        json={"user_id": "batch-blocked-user", "blocked": True},
+        headers=master_key_header,
+    )
+    assert resp.status_code == 200
+
+    create_patch, supports_patch = _batch_enforcement_patches()
+    with create_patch as mock_call, supports_patch:
+        resp = client.post(
+            "/v1/batches",
+            json=_create_batch_body(user="batch-blocked-user"),
+            headers=master_key_header,
+        )
+
+    assert resp.status_code == 403
+    assert "blocked" in resp.json()["detail"].lower()
+    mock_call.assert_not_awaited()
+
+
+def test_create_batch_over_budget_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """POST /v1/batches for a user over budget is rejected before the provider call."""
+    budget_resp = client.post(
+        "/v1/budgets",
+        json={"max_budget": 0.0},
+        headers=master_key_header,
+    )
+    assert budget_resp.status_code == 200
+    budget_id = budget_resp.json()["budget_id"]
+
+    resp = client.post(
+        "/v1/users",
+        json={"user_id": "batch-broke-user", "budget_id": budget_id},
+        headers=master_key_header,
+    )
+    assert resp.status_code == 200
+
+    create_patch, supports_patch = _batch_enforcement_patches()
+    with create_patch as mock_call, supports_patch:
+        resp = client.post(
+            "/v1/batches",
+            json=_create_batch_body(user="batch-broke-user"),
+            headers=master_key_header,
+        )
+
+    assert resp.status_code == 403
+    assert "exceeded budget" in resp.json()["detail"].lower()
+    mock_call.assert_not_awaited()
+
+
+def test_create_batch_api_key_cannot_bill_other_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """A non-master key naming a user other than its own is rejected."""
+    resp = client.post(
+        "/v1/users",
+        json={"user_id": "batch-victim-user"},
+        headers=master_key_header,
+    )
+    assert resp.status_code == 200
+
+    create_patch, supports_patch = _batch_enforcement_patches()
+    with create_patch as mock_call, supports_patch:
+        resp = client.post(
+            "/v1/batches",
+            json=_create_batch_body(user="batch-victim-user"),
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 403
+    assert "does not match" in resp.json()["detail"].lower()
+    mock_call.assert_not_awaited()
+
+
+def test_create_batch_stamps_owner_metadata(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """The billed user is stamped into batch metadata; a spoofed value never wins."""
+    create_patch, supports_patch = _batch_enforcement_patches()
+    with create_patch as mock_call, supports_patch:
+        resp = client.post(
+            "/v1/batches",
+            json=_create_batch_body(metadata={"team": "ml-ops", "otari_user_id": "spoofed-user"}),
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200
+    metadata = mock_call.call_args.kwargs["metadata"]
+    assert metadata["otari_user_id"] == api_key_obj["user_id"]
+    assert metadata["team"] == "ml-ops"
+
+
+@pytest.fixture
+def batch_rate_limit_client(postgres_url: str) -> Generator[TestClient]:
+    yield from _make_rate_limit_client(postgres_url, rate_limit_rpm=2)
+
+
+def test_create_batch_rate_limited(batch_rate_limit_client: TestClient) -> None:
+    """POST /v1/batches enforces the per-user rate limit."""
+    header = {API_KEY_HEADER: "Bearer test-master-key"}
+    resp = batch_rate_limit_client.post(
+        "/v1/users",
+        json={"user_id": "batch-rl-user"},
+        headers=header,
+    )
+    assert resp.status_code == 200
+
+    create_patch, supports_patch = _batch_enforcement_patches()
+    with create_patch, supports_patch:
+        first = batch_rate_limit_client.post(
+            "/v1/batches",
+            json=_create_batch_body(user="batch-rl-user"),
+            headers=header,
+        )
+        second = batch_rate_limit_client.post(
+            "/v1/batches",
+            json=_create_batch_body(user="batch-rl-user"),
+            headers=header,
+        )
+        third = batch_rate_limit_client.post(
+            "/v1/batches",
+            json=_create_batch_body(user="batch-rl-user"),
+            headers=header,
+        )
+
+    assert first.status_code == 200
+    assert first.headers["X-RateLimit-Limit"] == "2"
+    assert second.status_code == 200
+    assert third.status_code == 429
+    assert "Retry-After" in third.headers
+
+
+def test_retrieve_batch_owned_by_other_user_is_404(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """GET /v1/batches/{batch_id} hides batches owned by another user."""
+    foreign = _mock_batch(metadata={"otari_user_id": "someone-else"})
+
+    with patch("gateway.api.routes.batches.aretrieve_batch", new_callable=AsyncMock, return_value=foreign):
+        resp = client.get("/v1/batches/batch_abc123?provider=openai", headers=api_key_header)
+
+    assert resp.status_code == 404
+    assert "not found" in resp.json()["detail"].lower()
+
+
+def test_retrieve_batch_owned_by_self(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """GET /v1/batches/{batch_id} returns batches owned by the key's user."""
+    own = _mock_batch(metadata={"otari_user_id": api_key_obj["user_id"]})
+
+    with patch("gateway.api.routes.batches.aretrieve_batch", new_callable=AsyncMock, return_value=own):
+        resp = client.get("/v1/batches/batch_abc123?provider=openai", headers=api_key_header)
+
+    assert resp.status_code == 200
+    assert resp.json()["id"] == "batch_abc123"
+
+
+def test_retrieve_batch_master_key_sees_any(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """The master key may retrieve any batch regardless of owner."""
+    foreign = _mock_batch(metadata={"otari_user_id": "someone-else"})
+
+    with patch("gateway.api.routes.batches.aretrieve_batch", new_callable=AsyncMock, return_value=foreign):
+        resp = client.get("/v1/batches/batch_abc123?provider=openai", headers=master_key_header)
+
+    assert resp.status_code == 200
+
+
+def test_cancel_batch_owned_by_other_user_is_404(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/batches/{batch_id}/cancel refuses batches owned by another user."""
+    foreign = _mock_batch(metadata={"otari_user_id": "someone-else"})
+
+    with (
+        patch("gateway.api.routes.batches.aretrieve_batch", new_callable=AsyncMock, return_value=foreign),
+        patch("gateway.api.routes.batches.acancel_batch", new_callable=AsyncMock) as mock_cancel,
+    ):
+        resp = client.post("/v1/batches/batch_abc123/cancel?provider=openai", headers=api_key_header)
+
+    assert resp.status_code == 404
+    mock_cancel.assert_not_awaited()
+
+
+def test_retrieve_batch_results_owned_by_other_user_is_404(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """GET /v1/batches/{batch_id}/results refuses batches owned by another user."""
+    foreign = _mock_batch(metadata={"otari_user_id": "someone-else"})
+
+    with (
+        patch("gateway.api.routes.batches.aretrieve_batch", new_callable=AsyncMock, return_value=foreign),
+        patch("gateway.api.routes.batches.aretrieve_batch_results", new_callable=AsyncMock) as mock_results,
+    ):
+        resp = client.get("/v1/batches/batch_abc123/results?provider=openai", headers=api_key_header)
+
+    assert resp.status_code == 404
+    mock_results.assert_not_awaited()
+
+
+def test_list_batches_filters_foreign_batches(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """GET /v1/batches hides other users' batches but keeps own and legacy ones."""
+    own = _mock_batch(id="batch_own", metadata={"otari_user_id": api_key_obj["user_id"]})
+    foreign = _mock_batch(id="batch_foreign", metadata={"otari_user_id": "someone-else"})
+    legacy = _mock_batch(id="batch_legacy")
+
+    with patch(
+        "gateway.api.routes.batches.alist_batches",
+        new_callable=AsyncMock,
+        return_value=[own, foreign, legacy],
+    ):
+        resp = client.get("/v1/batches?provider=openai", headers=api_key_header)
+
+    assert resp.status_code == 200
+    ids = [item["id"] for item in resp.json()["data"]]
+    assert "batch_own" in ids
+    assert "batch_legacy" in ids
+    assert "batch_foreign" not in ids
+
+
+def test_retrieve_batch_results_records_tokens_and_cost(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """GET /v1/batches/{batch_id}/results records summed tokens and cost."""
+    pricing_resp = client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "openai:gpt-4o-mini",
+            "input_price_per_million": 1.0,
+            "output_price_per_million": 2.0,
+        },
+        headers=master_key_header,
+    )
+    assert pricing_resp.status_code == 200
+
+    mock_completion = MagicMock()
+    mock_completion.model = "gpt-4o-mini"
+    mock_completion.usage = CompletionUsage(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+    mock_completion.model_dump.return_value = {"id": "chatcmpl-1", "choices": []}
+
+    mock_result = BatchResult(results=[BatchResultItem(custom_id="req-1", result=mock_completion, error=None)])
+
+    with (
+        patch(
+            "gateway.api.routes.batches.aretrieve_batch",
+            new_callable=AsyncMock,
+            return_value=_mock_batch(status="completed"),
+        ),
+        patch("gateway.api.routes.batches.aretrieve_batch_results", new_callable=AsyncMock, return_value=mock_result),
+    ):
+        resp = client.get("/v1/batches/batch_abc123/results?provider=openai", headers=api_key_header)
+
+    assert resp.status_code == 200
+
+    usage_resp = client.get(f"/v1/users/{api_key_obj['user_id']}/usage", headers=master_key_header)
+    assert usage_resp.status_code == 200
+    results_logs = [log for log in usage_resp.json() if log["endpoint"] == "/v1/batches/results"]
+    assert len(results_logs) >= 1
+    log = results_logs[0]
+    assert log["prompt_tokens"] == 100
+    assert log["completion_tokens"] == 50
+    assert log["total_tokens"] == 150
+    assert log["cost"] == pytest.approx(100 / 1_000_000 * 1.0 + 50 / 1_000_000 * 2.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_batches_endpoint.py
+++ b/tests/integration/test_batches_endpoint.py
@@ -744,6 +744,36 @@ def test_list_batches_filters_foreign_batches(
     assert "batch_foreign" not in ids
 
 
+def test_retrieve_batch_results_master_key_logs_batch_owner(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """Master-key results retrieval attributes usage to the stamped batch owner."""
+    resp = client.post(
+        "/v1/users",
+        json={"user_id": "batch-owner-user"},
+        headers=master_key_header,
+    )
+    assert resp.status_code == 200
+
+    stamped = _mock_batch(status="completed", metadata={"otari_user_id": "batch-owner-user"})
+    mock_result = BatchResult(results=[])
+
+    with (
+        patch("gateway.api.routes.batches.aretrieve_batch", new_callable=AsyncMock, return_value=stamped),
+        patch("gateway.api.routes.batches.aretrieve_batch_results", new_callable=AsyncMock, return_value=mock_result),
+    ):
+        resp = client.get("/v1/batches/batch_abc123/results?provider=openai", headers=master_key_header)
+
+    assert resp.status_code == 200
+
+    usage_resp = client.get("/v1/users/batch-owner-user/usage", headers=master_key_header)
+    assert usage_resp.status_code == 200
+    results_logs = [log for log in usage_resp.json() if log["endpoint"] == "/v1/batches/results"]
+    assert len(results_logs) == 1
+    assert results_logs[0]["status"] == "success"
+
+
 def test_retrieve_batch_results_records_tokens_and_cost(
     client: TestClient,
     master_key_header: dict[str, str],


### PR DESCRIPTION
## Description

`/v1/batches` was the only billable provider surface that skipped every request gate: a master key silently attributed batches to `user_id=None`, blocked or over-budget users could submit arbitrarily large batch jobs, no rate limit applied, batch usage logs carried no token or cost data, and any authenticated key could retrieve, cancel, or read the results of any batch id.

This PR routes batch creation through the same gates as the sibling provider routes (see `audio.py`):

- `resolve_user_id`: master key requests must name a `user`; a non-master key can only bill its own user, honoring `reject_user_mismatch`.
- `check_rate_limit`, with `X-RateLimit-*` headers on success.
- A zero-estimate `reserve_budget` before the provider call, which rejects unknown (404), blocked (403), and already-over-budget (403) users; the reservation is reconciled on success and refunded on failure.

Ownership is anchored on an `otari_user_id` entry stamped into the provider-side batch metadata at creation time, since the gateway stores no batch table (a client-supplied value never wins). Retrieve, cancel, and results check it and answer 404 for another user's batch so ids cannot be probed; list filters other users' batches out of the page. Batches created before this change, or via providers that do not round-trip metadata, carry no marker and remain accessible; the master key retains full access.

Usage logs now record what is derivable: explicit zero token counts at creation, and summed per-request tokens plus pricing-derived cost when results are retrieved. Folding that cost into `users.spend` is deferred: results can be retrieved repeatedly and without a batch table the charge cannot be deduplicated.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #258

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code (Fable 5)

**Any additional AI details you'd like to share:**

Implementation, tests, and this description were generated by Claude Code working from issue #258, with the new tests verified to fail before the fix and pass after it. The direction and review are @njbrake's.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated **batch creation** to require/resolve the correct user (including stricter handling for master-key requests), validate eligibility (unknown/blocked/over-budget), apply **per-user rate limiting**, and only proceed with provider calls after reserving capacity.
- Added **provider-side ownership tagging** so batches are attributable to the creating user, enabling consistent enforcement across **retrieve, cancel, and results** (non-owners now get “not found” instead of access).
- Improved **batch usage logging** by recording token totals at creation and, when results are fetched, recording aggregated tokens and any applicable pricing-derived cost (with billing application intentionally deferred to avoid double-counting).
- Strengthened **batch listing** so non-master users only see their own batches (while still allowing access to legacy batches that lack ownership metadata).
- Expanded **integration tests** to cover the new enforcement, rate limiting, ownership rules, token/cost logging, and listing behavior.
- Updated the public **Postman documentation** descriptions for batch list and create flows.

## Technical notes

- Batch ownership is stored in provider metadata and checked on retrieve/cancel/results; list filtering happens after the provider call.
- Reservation is started with a **zero estimate** for eligibility enforcement, then reconciled/refunded based on outcomes.
- Rate-limit headers from the batch path are forwarded on the HTTP response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->