### PR TITLE
fix(metrics): label requests by route template, not raw path

### DIFF
--- a/src/gateway/metrics.py
+++ b/src/gateway/metrics.py
@@ -103,6 +103,25 @@ LOG_WRITER_ROWS = Counter(
 
 _PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
 
+_UNMATCHED_ENDPOINT = "unmatched"
+
+
+def _endpoint_label(scope: Scope) -> str:
+    """Return the matched route template for a request, or a bounded fallback.
+
+    Labeling metrics with the raw ``scope["path"]`` mints a new Prometheus
+    series per distinct path parameter value (file id, batch id, per-user
+    lookups, ...), which is unbounded label cardinality. FastAPI records the
+    matched route on the scope once routing finishes, so its ``path`` template
+    (for example ``/v1/files/{file_id}``) collapses those into a single series.
+    Requests that match no route land in the ``unmatched`` bucket.
+    """
+    route = scope.get("route")
+    template = getattr(route, "path", None)
+    if isinstance(template, str) and template:
+        return template
+    return _UNMATCHED_ENDPOINT
+
 
 async def metrics_endpoint(request: Request) -> Response:
     """Serve Prometheus metrics."""
@@ -142,8 +161,9 @@ class MetricsMiddleware:
         finally:
             duration = time.monotonic() - start
             ACTIVE_REQUESTS.dec()
-            REQUESTS.labels(method=method, endpoint=path, status=str(status_code)).inc()
-            REQUEST_DURATION_SECONDS.labels(method=method, endpoint=path).observe(duration)
+            endpoint = _endpoint_label(scope)
+            REQUESTS.labels(method=method, endpoint=endpoint, status=str(status_code)).inc()
+            REQUEST_DURATION_SECONDS.labels(method=method, endpoint=endpoint).observe(duration)
 
 
 def record_tokens(provider: str, model: str, prompt_tokens: int, completion_tokens: int) -> None:

--- a/tests/unit/test_gateway_metrics.py
+++ b/tests/unit/test_gateway_metrics.py
@@ -144,6 +144,38 @@ def test_middleware_tracks_error_status_codes() -> None:
     assert _sample("gateway_requests_total", labels) - before == 1.0
 
 
+def test_middleware_labels_parameterized_route_with_template() -> None:
+    """Different path params collapse to one series; unknown paths bucket as 'unmatched'."""
+    app = FastAPI()
+
+    @app.get("/v1/files/{file_id}")
+    async def get_file(file_id: str) -> dict[str, str]:
+        return {"id": file_id}
+
+    app.add_middleware(MetricsMiddleware)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    template_labels = {"method": "GET", "endpoint": "/v1/files/{file_id}", "status": "200"}
+    raw_labels_a = {"method": "GET", "endpoint": "/v1/files/aaa", "status": "200"}
+    raw_labels_b = {"method": "GET", "endpoint": "/v1/files/bbb", "status": "200"}
+    unmatched_labels = {"method": "GET", "endpoint": "unmatched", "status": "404"}
+
+    before_template = _sample("gateway_requests_total", template_labels)
+    before_unmatched = _sample("gateway_requests_total", unmatched_labels)
+
+    assert client.get("/v1/files/aaa").status_code == 200
+    assert client.get("/v1/files/bbb").status_code == 200
+    assert client.get("/no/such/route").status_code == 404
+
+    # Two distinct ids produce a single labeled series keyed by the route template.
+    assert _sample("gateway_requests_total", template_labels) - before_template == 2.0
+    # The raw per-id paths must never appear as their own series.
+    assert _sample("gateway_requests_total", raw_labels_a) == 0.0
+    assert _sample("gateway_requests_total", raw_labels_b) == 0.0
+    # Paths that match no route land in the bounded fallback bucket.
+    assert _sample("gateway_requests_total", unmatched_labels) - before_unmatched == 1.0
+
+
 def test_middleware_skips_metrics_endpoint() -> None:
     app = _make_test_app()
     client = TestClient(app)


### PR DESCRIPTION
## Description

The metrics middleware labeled `REQUESTS` and `REQUEST_DURATION_SECONDS` with the
raw `scope["path"]`. Parameterized routes (for example `GET /v1/files/{file_id}`,
per-batch GETs, per-user lookups) minted a new Prometheus time series for every
distinct id, which is unbounded label cardinality that bloats the client registry
and eventually hurts the scraper and TSDB.

This change resolves the matched route template instead. FastAPI records the matched
route on the ASGI scope once routing finishes, so reading `scope["route"].path` after
the app processes the request collapses path parameters into one series per route.
Requests that match no route fall into a bounded `unmatched` bucket, so 404 floods
cannot grow the label set either.

New unit test: two requests to `/v1/files/{file_id}` with different ids produce a
single template-labeled series (and no raw per-id series), and an unknown path lands
in the `unmatched` bucket. The test fails on the pre-fix code.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #264

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code

**Any additional AI details you'd like to share:**

Drafted via back-and-forth with @njbrake; the reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Group request metrics by route pattern instead of individual URLs.
- Add an `unmatched` group for unknown routes.
- Add coverage for parameterized routes and unknown paths.

This keeps metric series bounded and prevents unnecessary growth from URL parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->