### PR TITLE
refactor(api): consolidate pass-through provider routes onto a shared pipeline helper

### DIFF
--- a/src/gateway/api/routes/_passthrough.py
+++ b/src/gateway/api/routes/_passthrough.py
@@ -1,0 +1,250 @@
+"""Shared request scaffold for the pass-through provider routes.
+
+The pass-through endpoints (audio, images, embeddings, moderations, rerank)
+follow one scaffold: resolve the billed user, rate limit, resolve the provider
+selector, reserve budget, call the provider, write a usage log, and reconcile
+(success) or refund (failure) the reservation. :func:`run_passthrough` owns
+that scaffold; each route supplies only its endpoint-specific pieces (budget
+estimate, provider call, token extraction, cost computation) as callbacks.
+
+Provider failures are classified with the same helper the hybrid fallback path
+uses (``_classify_upstream_error``) and surface as HTTP 502: an upstream outage
+is an upstream failure, not a gateway bug, matching the chat, messages, and
+responses routes. The raw provider message is never included in the response
+detail (it is preserved on the usage log's ``error_message``).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Generic, TypeVar
+
+from fastapi import HTTPException, Request, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.api.routes._helpers import resolve_user_id
+from gateway.api.routes._pipeline import rate_limit_headers
+from gateway.api.routes._platform import _classify_upstream_error
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger
+from gateway.model_labeling import relabel_model
+from gateway.models.entities import APIKey, ModelPricing, UsageLog
+from gateway.rate_limit import check_rate_limit
+from gateway.services.budget_service import (
+    reconcile_reservation,
+    refund_reservation,
+    reserve_budget,
+)
+from gateway.services.log_writer import LogWriter
+from gateway.services.pricing_service import find_model_pricing, pricing_required_but_missing
+from gateway.services.provider_kwargs import ResolvedProvider, resolve_provider_selector
+
+ResultT = TypeVar("ResultT")
+
+PASSTHROUGH_PROVIDER_ERROR_DETAIL = "The request could not be completed by the provider"
+
+
+def resolve_passthrough_user_id(
+    auth_result: tuple[APIKey | None, bool],
+    user: str | None,
+    *,
+    reject_mismatch: bool,
+) -> str:
+    """Resolve the billed user with the standard pass-through error responses."""
+    api_key, is_master_key = auth_result
+    return resolve_user_id(
+        user_id_from_request=user,
+        api_key=api_key,
+        is_master_key=is_master_key,
+        master_key_error=HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="When using master key, 'user' field is required in request body",
+        ),
+        no_api_key_error=HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key validation failed",
+        ),
+        no_user_error=HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="API key has no associated user",
+        ),
+        forbidden_user_error=HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="'user' field does not match the authenticated API key's user",
+        ),
+        reject_mismatch=reject_mismatch,
+    )
+
+
+@dataclass
+class PassthroughOutcome(Generic[ResultT]):
+    """A successful pass-through provider call plus response metadata."""
+
+    result: ResultT
+    """The provider result, relabeled to the request alias when applicable."""
+    resolved: ResolvedProvider
+    """The resolved selector the call was dispatched against."""
+    headers: dict[str, str]
+    """Rate-limit headers for routes that build their own response object."""
+
+
+async def run_passthrough(
+    *,
+    endpoint: str,
+    raw_request: Request,
+    response: Response | None,
+    auth_result: tuple[APIKey | None, bool],
+    db: AsyncSession,
+    config: GatewayConfig,
+    log_writer: LogWriter,
+    model: str,
+    user: str | None,
+    call_provider: Callable[[ResolvedProvider], Awaitable[ResultT]],
+    lookup_pricing: bool = True,
+    estimate: Callable[[ModelPricing | None], float] | None = None,
+    enforce_require_pricing: bool = False,
+    usage_tokens: Callable[[ResultT], tuple[int | None, int | None, int | None]] | None = None,
+    compute_cost: Callable[[ResultT, ModelPricing | None], float | None] | None = None,
+    map_provider_error: Callable[[Exception], HTTPException | None] | None = None,
+    reserve_before_resolve: bool = False,
+    relabel: bool = True,
+) -> PassthroughOutcome[ResultT]:
+    """Run the shared pass-through scaffold around a single provider call.
+
+    Steps: resolve the billed user (honoring ``config.reject_user_mismatch``),
+    rate limit, resolve the provider selector, look up pricing, reserve the
+    estimated cost, invoke ``call_provider``, write the usage log, and
+    reconcile (success) or refund (failure) the reservation.
+
+    Args:
+        endpoint: Path recorded on usage log rows (e.g. ``"/v1/embeddings"``).
+        raw_request: Incoming request, used for rate limiting.
+        response: When given, rate-limit headers are set on it. Routes that
+            return their own response object pass ``None`` and read
+            ``PassthroughOutcome.headers`` instead.
+        auth_result: The ``verify_api_key_or_master_key`` dependency result.
+        model: The raw request selector; used for the reservation and error
+            text, while the resolved short name reaches the provider and logs.
+        user: The request's ``user`` field, if any.
+        call_provider: Awaits the provider call for the resolved selector. An
+            ``HTTPException`` raised here (e.g. an upload size check) refunds
+            the reservation and propagates unchanged.
+        lookup_pricing: Whether to resolve :class:`ModelPricing` for the model.
+            Audio has no measurable cost unit yet and skips the lookup.
+        estimate: Maps the pricing row to the reservation estimate in USD.
+            Defaults to 0.0, which still enforces per-user state (user exists,
+            not blocked, not already over budget).
+        enforce_require_pricing: When True and ``config.require_pricing`` is
+            set, reject unpriced models with 402. The check runs after the
+            reservation (so its 404/403 rejections take precedence) and the
+            reservation is refunded before raising.
+        usage_tokens: Maps the provider result to ``(prompt, completion,
+            total)`` token counts for the usage log. Defaults to ``(0, 0, 0)``.
+        compute_cost: Maps the result and pricing to the final USD cost, or
+            ``None`` to leave the log's cost unset and reconcile at 0.0.
+        map_provider_error: Route-specific provider-exception mapping checked
+            before the generic 502 (the error log and refund happen either way).
+        reserve_before_resolve: Preserve the audio routes' historical ordering,
+            reserving budget before the selector is resolved. Routes that need
+            pricing resolve first (the pricing key is the resolved instance).
+        relabel: Rewrite the result's ``model`` field to the configured alias
+            the caller used, so responses do not echo the aliased target.
+
+    Returns:
+        The provider result plus the resolved selector and rate-limit headers.
+    """
+    api_key, is_master_key = auth_result
+    api_key_id = api_key.id if api_key else None
+
+    user_id = resolve_passthrough_user_id(auth_result, user, reject_mismatch=config.reject_user_mismatch)
+
+    rate_limit_info = check_rate_limit(raw_request, user_id)
+
+    pricing: ModelPricing | None = None
+    if reserve_before_resolve:
+        reservation = await reserve_budget(
+            db, user_id, estimate(None) if estimate else 0.0, model=model, strategy=config.budget_strategy
+        )
+        resolved = resolve_provider_selector(config, model)
+    else:
+        resolved = resolve_provider_selector(config, model)
+        if lookup_pricing:
+            pricing = await find_model_pricing(db, resolved.instance, resolved.model)
+        # Reserve first so user/blocked/budget rejections (404/403) precede the
+        # missing-pricing rejection (402); refund if we then reject for no pricing.
+        reservation = await reserve_budget(
+            db, user_id, estimate(pricing) if estimate else 0.0, model=model, strategy=config.budget_strategy
+        )
+        if enforce_require_pricing and pricing_required_but_missing(pricing, require_pricing=config.require_pricing):
+            await refund_reservation(db, reservation)
+            raise HTTPException(
+                status_code=status.HTTP_402_PAYMENT_REQUIRED,
+                detail=f"No pricing configured for model '{model}'",
+            )
+
+    try:
+        result = await call_provider(resolved)
+
+        prompt_tokens, completion_tokens, total_tokens = usage_tokens(result) if usage_tokens else (0, 0, 0)
+        usage_log = UsageLog(
+            id=str(uuid.uuid4()),
+            api_key_id=api_key_id,
+            user_id=user_id,
+            timestamp=datetime.now(UTC),
+            model=resolved.model,
+            provider=resolved.instance,
+            endpoint=endpoint,
+            status="success",
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+        )
+
+        cost = compute_cost(result, pricing) if compute_cost else None
+        if cost is not None:
+            usage_log.cost = cost
+
+        await log_writer.put(usage_log)
+        await reconcile_reservation(db, reservation, cost if cost is not None else 0.0)
+
+    except HTTPException:
+        await refund_reservation(db, reservation)
+        raise
+    except Exception as e:
+        error_log = UsageLog(
+            id=str(uuid.uuid4()),
+            api_key_id=api_key_id,
+            user_id=user_id,
+            timestamp=datetime.now(UTC),
+            model=resolved.model,
+            provider=resolved.instance,
+            endpoint=endpoint,
+            status="error",
+            error_message=str(e),
+        )
+        await log_writer.put(error_log)
+        await refund_reservation(db, reservation)
+
+        mapped = map_provider_error(e) if map_provider_error else None
+        if mapped is not None:
+            raise mapped from e
+
+        _, error_class = _classify_upstream_error(e)
+        logger.error("Provider call failed for %s:%s (%s): %s", resolved.provider, resolved.model, error_class, e)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=PASSTHROUGH_PROVIDER_ERROR_DETAIL,
+        ) from e
+
+    headers = rate_limit_headers(rate_limit_info) if rate_limit_info else {}
+    if response is not None:
+        for key, value in headers.items():
+            response.headers[key] = value
+
+    if relabel and resolved.alias is not None:
+        relabel_model(result, resolved.alias)
+
+    return PassthroughOutcome(result=result, resolved=resolved, headers=headers)

--- a/src/gateway/api/routes/audio.py
+++ b/src/gateway/api/routes/audio.py
@@ -1,7 +1,5 @@
 """OpenAI-compatible audio transcription and speech endpoints."""
 
-import uuid
-from datetime import UTC, datetime
 from typing import Annotated, Any
 
 from any_llm import aspeech, atranscription
@@ -11,21 +9,13 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
-from gateway.api.routes._helpers import resolve_user_id
+from gateway.api.routes._passthrough import run_passthrough
 from gateway.api.routes._schema_derive import derive_request_base
 from gateway.api.routes._tools import _strip_gateway_fields
-from gateway.api.routes.chat import rate_limit_headers
 from gateway.core.config import GatewayConfig
-from gateway.log_config import logger
-from gateway.models.entities import APIKey, UsageLog
-from gateway.rate_limit import check_rate_limit
-from gateway.services.budget_service import (
-    reconcile_reservation,
-    refund_reservation,
-    reserve_budget,
-)
+from gateway.models.entities import APIKey
 from gateway.services.log_writer import LogWriter
-from gateway.services.provider_kwargs import resolve_provider_selector
+from gateway.services.provider_kwargs import ResolvedProvider
 
 router = APIRouter(prefix="/v1", tags=["audio"])
 
@@ -67,118 +57,52 @@ async def create_transcription(
     - API key + user field: Use specified user (must exist)
     - API key without user field: Use virtual user created with API key
     """
-    api_key, is_master_key = auth_result
-    api_key_id = api_key.id if api_key else None
 
-    user_id = resolve_user_id(
-        user_id_from_request=user,
-        api_key=api_key,
-        is_master_key=is_master_key,
-        master_key_error=HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="When using master key, 'user' field is required in request body",
-        ),
-        no_api_key_error=HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="API key validation failed",
-        ),
-        no_user_error=HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="API key has no associated user",
-        ),
-        forbidden_user_error=HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="'user' field does not match the authenticated API key's user",
-        ),
-        reject_mismatch=config.reject_user_mismatch,
+    async def call_provider(resolved: ResolvedProvider) -> Transcription:
+        file_bytes = await file.read()
+        if len(file_bytes) > _MAX_AUDIO_UPLOAD_BYTES:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=f"Audio file exceeds maximum upload size of {_MAX_AUDIO_UPLOAD_BYTES // (1024 * 1024)} MB",
+            )
+
+        transcription_kwargs: dict[str, Any] = {
+            "model": resolved.model,
+            "file": file_bytes,
+            "provider": resolved.provider,
+            **resolved.kwargs,
+        }
+        if language is not None:
+            transcription_kwargs["language"] = language
+        if prompt is not None:
+            transcription_kwargs["prompt"] = prompt
+        if response_format is not None:
+            transcription_kwargs["response_format"] = response_format
+        if temperature is not None:
+            transcription_kwargs["temperature"] = temperature
+
+        return await atranscription(**transcription_kwargs)
+
+    # Audio is exempt from require_pricing and has no measurable cost unit yet
+    # (tokens, seconds, etc.), so the reservation estimate is 0 and cost stays
+    # unset; the reservation still enforces existing per-user state (user
+    # exists, not blocked, not already over budget).
+    outcome = await run_passthrough(
+        endpoint="/v1/audio/transcriptions",
+        raw_request=raw_request,
+        response=response,
+        auth_result=auth_result,
+        db=db,
+        config=config,
+        log_writer=log_writer,
+        model=model,
+        user=user,
+        call_provider=call_provider,
+        lookup_pricing=False,
+        reserve_before_resolve=True,
+        relabel=False,
     )
-
-    rate_limit_info = check_rate_limit(raw_request, user_id)
-
-    # Audio is exempt from require_pricing and has no measurable cost unit yet,
-    # so the reservation estimate is 0 — it still enforces existing per-user
-    # state (user exists, not blocked, not already over budget).
-    reservation = await reserve_budget(db, user_id, 0.0, model=model, strategy=config.budget_strategy)
-
-    resolved = resolve_provider_selector(config, model)
-    provider, model_name = resolved.provider, resolved.model
-
-    provider_kwargs = resolved.kwargs
-
-    file_bytes = await file.read()
-    if len(file_bytes) > _MAX_AUDIO_UPLOAD_BYTES:
-        raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-            detail=f"Audio file exceeds maximum upload size of {_MAX_AUDIO_UPLOAD_BYTES // (1024 * 1024)} MB",
-        )
-
-    transcription_kwargs: dict[str, Any] = {
-        "model": model_name,
-        "file": file_bytes,
-        "provider": provider,
-        **provider_kwargs,
-    }
-    if language is not None:
-        transcription_kwargs["language"] = language
-    if prompt is not None:
-        transcription_kwargs["prompt"] = prompt
-    if response_format is not None:
-        transcription_kwargs["response_format"] = response_format
-    if temperature is not None:
-        transcription_kwargs["temperature"] = temperature
-
-    try:
-        result: Transcription = await atranscription(**transcription_kwargs)
-
-        usage_log = UsageLog(
-            id=str(uuid.uuid4()),
-            api_key_id=api_key_id,
-            user_id=user_id,
-            timestamp=datetime.now(UTC),
-            model=model_name,
-            provider=resolved.instance,
-            endpoint="/v1/audio/transcriptions",
-            status="success",
-            prompt_tokens=0,
-            completion_tokens=0,
-            total_tokens=0,
-        )
-
-        # Audio transcription lacks a measurable usage unit (tokens, seconds, etc.)
-        # so cost is left unset until a dedicated pricing metric is available.
-
-        await log_writer.put(usage_log)
-        await reconcile_reservation(db, reservation, 0.0)
-
-    except HTTPException:
-        await refund_reservation(db, reservation)
-        raise
-    except Exception as e:
-        error_log = UsageLog(
-            id=str(uuid.uuid4()),
-            api_key_id=api_key_id,
-            user_id=user_id,
-            timestamp=datetime.now(UTC),
-            model=model_name,
-            provider=resolved.instance,
-            endpoint="/v1/audio/transcriptions",
-            status="error",
-            error_message=str(e),
-        )
-        await log_writer.put(error_log)
-        await refund_reservation(db, reservation)
-
-        logger.error("Provider call failed for %s:%s: %s", provider, model_name, e)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="The request could not be completed by the provider",
-        ) from e
-
-    if rate_limit_info:
-        for key, value in rate_limit_headers(rate_limit_info).items():
-            response.headers[key] = value
-
-    return result.model_dump()
+    return outcome.result.model_dump()
 
 
 class AudioSpeechRequest(derive_request_base(AudioSpeechParams)):  # type: ignore[misc]
@@ -229,112 +153,45 @@ async def create_speech(
     - API key + user field: Use specified user (must exist)
     - API key without user field: Use virtual user created with API key
     """
-    api_key, is_master_key = auth_result
-    api_key_id = api_key.id if api_key else None
 
-    user_id = resolve_user_id(
-        user_id_from_request=request.user,
-        api_key=api_key,
-        is_master_key=is_master_key,
-        master_key_error=HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="When using master key, 'user' field is required in request body",
-        ),
-        no_api_key_error=HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="API key validation failed",
-        ),
-        no_user_error=HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="API key has no associated user",
-        ),
-        forbidden_user_error=HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="'user' field does not match the authenticated API key's user",
-        ),
-        reject_mismatch=config.reject_user_mismatch,
+    async def call_provider(resolved: ResolvedProvider) -> bytes:
+        # Forward every field the schema accepts (it is derived from
+        # AudioSpeechParams), so a new any-llm param is passed through without a
+        # code change. `model` is replaced by the split short name passed
+        # explicitly; gateway-internal (`user`) and sensitive fields are stripped.
+        forward = _strip_gateway_fields(request.model_dump(exclude_unset=True))
+        forward.pop("model", None)
+        speech_kwargs: dict[str, Any] = {
+            "model": resolved.model,
+            "provider": resolved.provider,
+            **resolved.kwargs,
+            **forward,
+        }
+        return await aspeech(**speech_kwargs)
+
+    # Audio is exempt from require_pricing and has no measurable cost unit yet
+    # (tokens, seconds, characters, etc.), so the reservation estimate is 0 and
+    # cost stays unset; the reservation still enforces existing per-user state.
+    outcome = await run_passthrough(
+        endpoint="/v1/audio/speech",
+        raw_request=raw_request,
+        response=None,
+        auth_result=auth_result,
+        db=db,
+        config=config,
+        log_writer=log_writer,
+        model=request.model,
+        user=request.user,
+        call_provider=call_provider,
+        lookup_pricing=False,
+        reserve_before_resolve=True,
+        relabel=False,
     )
-
-    rate_limit_info = check_rate_limit(raw_request, user_id)
-
-    # Audio is exempt from require_pricing and has no measurable cost unit yet,
-    # so the reservation estimate is 0 — it still enforces existing per-user
-    # state (user exists, not blocked, not already over budget).
-    reservation = await reserve_budget(db, user_id, 0.0, model=request.model, strategy=config.budget_strategy)
-
-    resolved = resolve_provider_selector(config, request.model)
-    provider, model_name = resolved.provider, resolved.model
-
-    provider_kwargs = resolved.kwargs
-
-    # Forward every field the schema accepts (it is derived from
-    # AudioSpeechParams), so a new any-llm param is passed through without a code
-    # change. `model` is replaced by the split short name passed explicitly;
-    # gateway-internal (`user`) and sensitive fields are stripped.
-    forward = _strip_gateway_fields(request.model_dump(exclude_unset=True))
-    forward.pop("model", None)
-    speech_kwargs: dict[str, Any] = {
-        "model": model_name,
-        "provider": provider,
-        **provider_kwargs,
-        **forward,
-    }
-
-    try:
-        audio_bytes: bytes = await aspeech(**speech_kwargs)
-
-        usage_log = UsageLog(
-            id=str(uuid.uuid4()),
-            api_key_id=api_key_id,
-            user_id=user_id,
-            timestamp=datetime.now(UTC),
-            model=model_name,
-            provider=resolved.instance,
-            endpoint="/v1/audio/speech",
-            status="success",
-            prompt_tokens=0,
-            completion_tokens=0,
-            total_tokens=0,
-        )
-
-        # Audio speech lacks a measurable usage unit (tokens, seconds, characters, etc.)
-        # so cost is left unset until a dedicated pricing metric is available.
-
-        await log_writer.put(usage_log)
-        await reconcile_reservation(db, reservation, 0.0)
-
-    except HTTPException:
-        await refund_reservation(db, reservation)
-        raise
-    except Exception as e:
-        error_log = UsageLog(
-            id=str(uuid.uuid4()),
-            api_key_id=api_key_id,
-            user_id=user_id,
-            timestamp=datetime.now(UTC),
-            model=model_name,
-            provider=resolved.instance,
-            endpoint="/v1/audio/speech",
-            status="error",
-            error_message=str(e),
-        )
-        await log_writer.put(error_log)
-        await refund_reservation(db, reservation)
-
-        logger.error("Provider call failed for %s:%s: %s", provider, model_name, e)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="The request could not be completed by the provider",
-        ) from e
 
     content_type = _SPEECH_CONTENT_TYPES.get(request.response_format, "audio/mpeg")
 
-    headers: dict[str, str] = {}
-    if rate_limit_info:
-        headers.update(rate_limit_headers(rate_limit_info))
-
     return StreamingResponse(
-        content=iter([audio_bytes]),
+        content=iter([outcome.result]),
         media_type=content_type,
-        headers=headers,
+        headers=outcome.headers,
     )

--- a/src/gateway/api/routes/embeddings.py
+++ b/src/gateway/api/routes/embeddings.py
@@ -1,32 +1,21 @@
 """OpenAI-compatible embeddings endpoint."""
 
-import uuid
-from datetime import UTC, datetime
 from typing import Annotated, Any
 
 from any_llm import aembedding
 from any_llm.types.completion import CreateEmbeddingResponse
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, Request, Response
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
-from gateway.api.routes._helpers import resolve_user_id
-from gateway.api.routes.chat import rate_limit_headers
+from gateway.api.routes._passthrough import run_passthrough
 from gateway.core.config import GatewayConfig
-from gateway.log_config import logger
-from gateway.model_labeling import relabel_model
-from gateway.models.entities import APIKey, UsageLog
-from gateway.rate_limit import check_rate_limit
-from gateway.services.budget_service import (
-    estimate_cost,
-    reconcile_reservation,
-    refund_reservation,
-    reserve_budget,
-)
+from gateway.models.entities import APIKey, ModelPricing
+from gateway.services.budget_service import estimate_cost
 from gateway.services.log_writer import LogWriter
-from gateway.services.pricing_service import find_model_pricing, pricing_required_but_missing
-from gateway.services.provider_kwargs import resolve_provider_selector
+from gateway.services.pricing_service import input_token_cost
+from gateway.services.provider_kwargs import ResolvedProvider
 
 router = APIRouter(prefix="/v1", tags=["embeddings"])
 
@@ -58,121 +47,51 @@ async def create_embedding(
     - API key + user field: Use specified user (must exist)
     - API key without user field: Use virtual user created with API key
     """
-    api_key, is_master_key = auth_result
-    api_key_id = api_key.id if api_key else None
-
-    user_id = resolve_user_id(
-        user_id_from_request=request.user,
-        api_key=api_key,
-        is_master_key=is_master_key,
-        master_key_error=HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="When using master key, 'user' field is required in request body",
-        ),
-        no_api_key_error=HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="API key validation failed",
-        ),
-        no_user_error=HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="API key has no associated user",
-        ),
-        forbidden_user_error=HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="'user' field does not match the authenticated API key's user",
-        ),
-        reject_mismatch=config.reject_user_mismatch,
-    )
-
-    rate_limit_info = check_rate_limit(raw_request, user_id)
-
-    resolved = resolve_provider_selector(config, request.model)
-    provider, model = resolved.provider, resolved.model
-
-    # Resolve pricing for the reservation estimate and the final cost.
-    pricing = await find_model_pricing(db, resolved.instance, model)
-
     # Embeddings have no generated output, so only the prompt contributes cost.
     prompt_chars = sum(len(s) for s in request.input) if isinstance(request.input, list) else len(request.input)
-    estimate = estimate_cost(pricing, prompt_chars=prompt_chars, max_output_tokens=None, default_output_tokens=0)
-    # Reserve first so user/blocked/budget rejections (404/403) precede the
-    # missing-pricing rejection (402); refund if we then reject for no pricing.
-    reservation = await reserve_budget(
-        db, user_id, estimate, model=request.model, strategy=config.budget_strategy
-    )
-    if pricing_required_but_missing(pricing, require_pricing=config.require_pricing):
-        await refund_reservation(db, reservation)
-        raise HTTPException(
-            status_code=status.HTTP_402_PAYMENT_REQUIRED,
-            detail=f"No pricing configured for model '{request.model}'",
+
+    def estimate(pricing: ModelPricing | None) -> float:
+        return estimate_cost(pricing, prompt_chars=prompt_chars, max_output_tokens=None, default_output_tokens=0)
+
+    def usage_tokens(result: CreateEmbeddingResponse) -> tuple[int | None, int | None, int | None]:
+        return (
+            result.usage.prompt_tokens if result.usage else None,
+            0,
+            result.usage.total_tokens if result.usage else None,
         )
 
-    provider_kwargs = resolved.kwargs
-
-    embedding_kwargs: dict[str, Any] = {
-        "model": model,
-        "inputs": request.input,
-        "provider": provider,
-        **provider_kwargs,
-    }
-    if request.encoding_format is not None:
-        embedding_kwargs["encoding_format"] = request.encoding_format
-    if request.dimensions is not None:
-        embedding_kwargs["dimensions"] = request.dimensions
-
-    try:
-        result = await aembedding(**embedding_kwargs)
-
-        usage_log = UsageLog(
-            id=str(uuid.uuid4()),
-            api_key_id=api_key_id,
-            user_id=user_id,
-            timestamp=datetime.now(UTC),
-            model=model,
-            provider=resolved.instance,
-            endpoint="/v1/embeddings",
-            status="success",
-            prompt_tokens=result.usage.prompt_tokens if result.usage else None,
-            completion_tokens=0,
-            total_tokens=result.usage.total_tokens if result.usage else None,
-        )
-
-        cost = 0.0
+    def compute_cost(result: CreateEmbeddingResponse, pricing: ModelPricing | None) -> float | None:
         if result.usage and pricing:
-            cost = (result.usage.prompt_tokens / 1_000_000) * pricing.input_price_per_million
-            usage_log.cost = cost
+            return input_token_cost(result.usage.prompt_tokens, pricing)
+        return None
 
-        await log_writer.put(usage_log)
-        await reconcile_reservation(db, reservation, cost)
+    async def call_provider(resolved: ResolvedProvider) -> CreateEmbeddingResponse:
+        embedding_kwargs: dict[str, Any] = {
+            "model": resolved.model,
+            "inputs": request.input,
+            "provider": resolved.provider,
+            **resolved.kwargs,
+        }
+        if request.encoding_format is not None:
+            embedding_kwargs["encoding_format"] = request.encoding_format
+        if request.dimensions is not None:
+            embedding_kwargs["dimensions"] = request.dimensions
+        return await aembedding(**embedding_kwargs)
 
-    except HTTPException:
-        await refund_reservation(db, reservation)
-        raise
-    except Exception as e:
-        error_log = UsageLog(
-            id=str(uuid.uuid4()),
-            api_key_id=api_key_id,
-            user_id=user_id,
-            timestamp=datetime.now(UTC),
-            model=model,
-            provider=resolved.instance,
-            endpoint="/v1/embeddings",
-            status="error",
-            error_message=str(e),
-        )
-        await log_writer.put(error_log)
-        await refund_reservation(db, reservation)
-
-        logger.error("Provider call failed for %s:%s: %s", provider, model, e)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="The request could not be completed by the provider",
-        ) from e
-
-    if rate_limit_info:
-        for key, value in rate_limit_headers(rate_limit_info).items():
-            response.headers[key] = value
-
-    if resolved.alias is not None:
-        relabel_model(result, resolved.alias)
-    return result
+    outcome = await run_passthrough(
+        endpoint="/v1/embeddings",
+        raw_request=raw_request,
+        response=response,
+        auth_result=auth_result,
+        db=db,
+        config=config,
+        log_writer=log_writer,
+        model=request.model,
+        user=request.user,
+        call_provider=call_provider,
+        estimate=estimate,
+        enforce_require_pricing=True,
+        usage_tokens=usage_tokens,
+        compute_cost=compute_cost,
+    )
+    return outcome.result

--- a/src/gateway/api/routes/files.py
+++ b/src/gateway/api/routes/files.py
@@ -36,6 +36,7 @@ _DEFAULT_PURPOSE = "user_data"
 def _resolve_user(
     auth_result: tuple[APIKey | None, bool],
     user: str | None,
+    config: GatewayConfig,
 ) -> str:
     api_key, is_master_key = auth_result
     return resolve_user_id(
@@ -58,6 +59,7 @@ def _resolve_user(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="'user' field does not match the authenticated API key's user",
         ),
+        reject_mismatch=config.reject_user_mismatch,
     )
 
 
@@ -123,7 +125,7 @@ async def create_file(
     if not config.files_enabled:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File uploads are disabled")
 
-    user_id = _resolve_user(auth_result, user)
+    user_id = _resolve_user(auth_result, user, config)
 
     data = await _read_capped(file, config.files_max_bytes)
     if not data:
@@ -177,7 +179,7 @@ async def list_files(
     if not config.files_enabled:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File uploads are disabled")
 
-    user_id = _resolve_user(auth_result, user)
+    user_id = _resolve_user(auth_result, user, config)
     stmt = select(FileObject).where(
         FileObject.user_id == user_id,
         FileObject.deleted_at.is_(None),
@@ -203,7 +205,7 @@ async def get_file(
     if not config.files_enabled:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File uploads are disabled")
 
-    user_id = _resolve_user(auth_result, user)
+    user_id = _resolve_user(auth_result, user, config)
     record = await fetch_file(db, file_id, user_id)
     if record is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
@@ -223,7 +225,7 @@ async def get_file_content(
     if not config.files_enabled:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File uploads are disabled")
 
-    user_id = _resolve_user(auth_result, user)
+    user_id = _resolve_user(auth_result, user, config)
     record = await fetch_file(db, file_id, user_id)
     if record is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
@@ -249,7 +251,7 @@ async def delete_file(
     if not config.files_enabled:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File uploads are disabled")
 
-    user_id = _resolve_user(auth_result, user)
+    user_id = _resolve_user(auth_result, user, config)
     record = await fetch_file(db, file_id, user_id)
     if record is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")

--- a/src/gateway/api/routes/images.py
+++ b/src/gateway/api/routes/images.py
@@ -1,31 +1,21 @@
 """OpenAI-compatible image generation endpoint."""
 
-import uuid
-from datetime import UTC, datetime
 from typing import Annotated, Any
 
 from any_llm import aimage_generation
 from any_llm.types.image import ImageGenerationParams, ImagesResponse
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, Request, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
-from gateway.api.routes._helpers import resolve_user_id
+from gateway.api.routes._passthrough import run_passthrough
 from gateway.api.routes._schema_derive import derive_request_base
 from gateway.api.routes._tools import _strip_gateway_fields
-from gateway.api.routes.chat import rate_limit_headers
 from gateway.core.config import GatewayConfig
-from gateway.log_config import logger
-from gateway.models.entities import APIKey, UsageLog
-from gateway.rate_limit import check_rate_limit
-from gateway.services.budget_service import (
-    reconcile_reservation,
-    refund_reservation,
-    reserve_budget,
-)
+from gateway.models.entities import APIKey, ModelPricing
 from gateway.services.log_writer import LogWriter
-from gateway.services.pricing_service import find_model_pricing, pricing_required_but_missing
-from gateway.services.provider_kwargs import resolve_provider_selector
+from gateway.services.pricing_service import per_image_cost
+from gateway.services.provider_kwargs import ResolvedProvider
 
 router = APIRouter(prefix="/v1", tags=["images"])
 
@@ -60,124 +50,48 @@ async def create_image(
     - API key + user field: Use specified user (must exist)
     - API key without user field: Use virtual user created with API key
     """
-    api_key, is_master_key = auth_result
-    api_key_id = api_key.id if api_key else None
-
-    user_id = resolve_user_id(
-        user_id_from_request=request.user,
-        api_key=api_key,
-        is_master_key=is_master_key,
-        master_key_error=HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="When using master key, 'user' field is required in request body",
-        ),
-        no_api_key_error=HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="API key validation failed",
-        ),
-        no_user_error=HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="API key has no associated user",
-        ),
-        forbidden_user_error=HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="'user' field does not match the authenticated API key's user",
-        ),
-        reject_mismatch=config.reject_user_mismatch,
-    )
-
-    rate_limit_info = check_rate_limit(raw_request, user_id)
-
-    resolved = resolve_provider_selector(config, request.model)
-    provider, model = resolved.provider, resolved.model
-
-    # Image pricing repurposes input_price_per_million as price-per-image.
-    pricing = await find_model_pricing(db, resolved.instance, model)
-
     # Reserve for the requested image count; reconciled to the actual count below.
     # `is None` (not `or`) so an explicit n=0 isn't silently treated as 1.
     requested_images = request.n if request.n is not None else 1
-    estimate = requested_images * pricing.input_price_per_million if pricing else 0.0
-    # Reserve first so 404/403 precede the missing-pricing 402; refund on reject.
-    reservation = await reserve_budget(
-        db, user_id, estimate, model=request.model, strategy=config.budget_strategy
-    )
-    if pricing_required_but_missing(pricing, require_pricing=config.require_pricing):
-        await refund_reservation(db, reservation)
-        raise HTTPException(
-            status_code=status.HTTP_402_PAYMENT_REQUIRED,
-            detail=f"No pricing configured for model '{request.model}'",
-        )
 
-    provider_kwargs = resolved.kwargs
+    def estimate(pricing: ModelPricing | None) -> float:
+        return per_image_cost(requested_images, pricing) if pricing else 0.0
 
-    # Forward every field the schema accepts (it is derived from
-    # ImageGenerationParams), so a new any-llm param is passed through without a
-    # code change. `model` is replaced by the split short name passed explicitly;
-    # gateway-internal (`user`) and sensitive fields are stripped.
-    forward = _strip_gateway_fields(request.model_dump(exclude_unset=True))
-    forward.pop("model", None)
-    image_kwargs: dict[str, Any] = {
-        "model": model,
-        "provider": provider,
-        **provider_kwargs,
-        **forward,
-    }
-
-    try:
-        result: ImagesResponse = await aimage_generation(**image_kwargs)
-
+    def compute_cost(result: ImagesResponse, pricing: ModelPricing | None) -> float | None:
+        if pricing is None:
+            return None
         n_images = len(result.data) if result.data else requested_images
+        return per_image_cost(n_images, pricing)
 
-        usage_log = UsageLog(
-            id=str(uuid.uuid4()),
-            api_key_id=api_key_id,
-            user_id=user_id,
-            timestamp=datetime.now(UTC),
-            model=model,
-            provider=resolved.instance,
-            endpoint="/v1/images/generations",
-            status="success",
-            prompt_tokens=0,
-            completion_tokens=0,
-            total_tokens=0,
-        )
+    async def call_provider(resolved: ResolvedProvider) -> ImagesResponse:
+        # Forward every field the schema accepts (it is derived from
+        # ImageGenerationParams), so a new any-llm param is passed through without
+        # a code change. `model` is replaced by the split short name passed
+        # explicitly; gateway-internal (`user`) and sensitive fields are stripped.
+        forward = _strip_gateway_fields(request.model_dump(exclude_unset=True))
+        forward.pop("model", None)
+        image_kwargs: dict[str, Any] = {
+            "model": resolved.model,
+            "provider": resolved.provider,
+            **resolved.kwargs,
+            **forward,
+        }
+        return await aimage_generation(**image_kwargs)
 
-        # Image pricing: repurpose input_price_per_million as price-per-image
-        cost = 0.0
-        if pricing:
-            cost = n_images * pricing.input_price_per_million
-            usage_log.cost = cost
-
-        await log_writer.put(usage_log)
-        await reconcile_reservation(db, reservation, cost)
-
-    except HTTPException:
-        await refund_reservation(db, reservation)
-        raise
-    except Exception as e:
-        error_log = UsageLog(
-            id=str(uuid.uuid4()),
-            api_key_id=api_key_id,
-            user_id=user_id,
-            timestamp=datetime.now(UTC),
-            model=model,
-            provider=resolved.instance,
-            endpoint="/v1/images/generations",
-            status="error",
-            error_message=str(e),
-        )
-        await log_writer.put(error_log)
-        await refund_reservation(db, reservation)
-
-        logger.error("Provider call failed for %s:%s: %s", provider, model, e)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="The request could not be completed by the provider",
-        ) from e
-
-    if rate_limit_info:
-        for key, value in rate_limit_headers(rate_limit_info).items():
-            response.headers[key] = value
-
-    return result.model_dump()
+    outcome = await run_passthrough(
+        endpoint="/v1/images/generations",
+        raw_request=raw_request,
+        response=response,
+        auth_result=auth_result,
+        db=db,
+        config=config,
+        log_writer=log_writer,
+        model=request.model,
+        user=request.user,
+        call_provider=call_provider,
+        estimate=estimate,
+        enforce_require_pricing=True,
+        compute_cost=compute_cost,
+        relabel=False,
+    )
+    return outcome.result.model_dump()

--- a/src/gateway/api/routes/moderations.py
+++ b/src/gateway/api/routes/moderations.py
@@ -1,7 +1,5 @@
 """OpenAI-compatible moderations endpoint."""
 
-import uuid
-from datetime import UTC, datetime
 from typing import Annotated, Any
 
 from any_llm import amoderation
@@ -10,21 +8,12 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
-from gateway.api.routes._helpers import resolve_user_id
-from gateway.api.routes.chat import rate_limit_headers
+from gateway.api.routes._passthrough import run_passthrough
 from gateway.core.config import GatewayConfig
-from gateway.log_config import logger
-from gateway.model_labeling import relabel_model
-from gateway.models.entities import APIKey, UsageLog
-from gateway.rate_limit import check_rate_limit
-from gateway.services.budget_service import (
-    reconcile_reservation,
-    refund_reservation,
-    reserve_budget,
-)
+from gateway.models.entities import APIKey, ModelPricing
 from gateway.services.log_writer import LogWriter
-from gateway.services.pricing_service import find_model_pricing
-from gateway.services.provider_kwargs import resolve_provider_selector
+from gateway.services.pricing_service import flat_request_cost
+from gateway.services.provider_kwargs import ResolvedProvider
 from gateway.types.moderation import ModerationResponse
 
 # Locked phrasing — cross-SDK error contract. Do not reword.
@@ -41,6 +30,16 @@ class ModerationRequest(BaseModel):
         description="Text, list of texts, or list of content-part dicts to moderate",
     )
     user: str | None = None
+
+
+def _map_unsupported_moderation(e: Exception) -> HTTPException | None:
+    """Surface any-llm's "provider does not support moderation" as a 400."""
+    if isinstance(e, NotImplementedError) and UNSUPPORTED_MODERATION_SUBSTRING in str(e):
+        return HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+    return None
 
 
 @router.post("/moderations", response_model=ModerationResponse)
@@ -61,132 +60,41 @@ async def create_moderation(
     - API key + user field: Use specified user (must exist)
     - API key without user field: Use virtual user created with API key
     """
-    api_key, is_master_key = auth_result
-    api_key_id = api_key.id if api_key else None
-
-    user_id = resolve_user_id(
-        user_id_from_request=request.user,
-        api_key=api_key,
-        is_master_key=is_master_key,
-        master_key_error=HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="When using master key, 'user' field is required in request body",
-        ),
-        no_api_key_error=HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="API key validation failed",
-        ),
-        no_user_error=HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="API key has no associated user",
-        ),
-        forbidden_user_error=HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="'user' field does not match the authenticated API key's user",
-        ),
-        reject_mismatch=config.reject_user_mismatch,
-    )
-
-    rate_limit_info = check_rate_limit(raw_request, user_id)
-
-    resolved = resolve_provider_selector(config, request.model)
-    provider, model = resolved.provider, resolved.model
 
     # Moderations is exempt from require_pricing: it is free at most providers
-    # and is intentionally treated as $0 when unpriced (see below). Pricing, when
-    # present, is a flat per-request rate stored in input_price_per_million.
-    pricing = await find_model_pricing(db, resolved.instance, model)
-    flat_cost = (pricing.input_price_per_million / 1_000_000) if pricing and pricing.input_price_per_million else 0.0
-    reservation = await reserve_budget(
-        db, user_id, flat_cost, model=request.model, strategy=config.budget_strategy
+    # and is intentionally treated as $0 when unpriced (no "No pricing
+    # configured" warning). Pricing, when present, is a flat per-request rate
+    # (see flat_request_cost); moderation has no token usage.
+    def compute_cost(result: ModerationResponse, pricing: ModelPricing | None) -> float:
+        return flat_request_cost(pricing)
+
+    def usage_tokens(result: ModerationResponse) -> tuple[int | None, int | None, int | None]:
+        return (None, 0, None)
+
+    async def call_provider(resolved: ResolvedProvider) -> ModerationResponse:
+        moderation_kwargs: dict[str, Any] = {
+            "model": resolved.model,
+            "input": request.input,
+            "provider": resolved.provider,
+            "include_raw": include_raw,
+            **resolved.kwargs,
+        }
+        return await amoderation(**moderation_kwargs)
+
+    outcome = await run_passthrough(
+        endpoint="/v1/moderations",
+        raw_request=raw_request,
+        response=response,
+        auth_result=auth_result,
+        db=db,
+        config=config,
+        log_writer=log_writer,
+        model=request.model,
+        user=request.user,
+        call_provider=call_provider,
+        estimate=flat_request_cost,
+        usage_tokens=usage_tokens,
+        compute_cost=compute_cost,
+        map_provider_error=_map_unsupported_moderation,
     )
-
-    provider_kwargs = resolved.kwargs
-
-    moderation_kwargs: dict[str, Any] = {
-        "model": model,
-        "input": request.input,
-        "provider": provider,
-        "include_raw": include_raw,
-        **provider_kwargs,
-    }
-
-    try:
-        result = await amoderation(**moderation_kwargs)
-
-        usage_log = UsageLog(
-            id=str(uuid.uuid4()),
-            api_key_id=api_key_id,
-            user_id=user_id,
-            timestamp=datetime.now(UTC),
-            model=model,
-            provider=resolved.instance,
-            endpoint="/v1/moderations",
-            status="success",
-            prompt_tokens=None,
-            completion_tokens=0,
-            total_tokens=None,
-        )
-
-        # Flat per-request rate (moderation has no token usage); intentionally
-        # no "No pricing configured" warning here — free at most providers.
-        usage_log.cost = flat_cost
-
-        await log_writer.put(usage_log)
-        await reconcile_reservation(db, reservation, flat_cost)
-
-    except HTTPException:
-        await refund_reservation(db, reservation)
-        raise
-    except NotImplementedError as e:
-        error_log = UsageLog(
-            id=str(uuid.uuid4()),
-            api_key_id=api_key_id,
-            user_id=user_id,
-            timestamp=datetime.now(UTC),
-            model=model,
-            provider=resolved.instance,
-            endpoint="/v1/moderations",
-            status="error",
-            error_message=str(e),
-        )
-        await log_writer.put(error_log)
-        await refund_reservation(db, reservation)
-        if UNSUPPORTED_MODERATION_SUBSTRING in str(e):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=str(e),
-            ) from e
-        logger.error("Provider implementation gap for %s:%s: %s", provider, model, e)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="The request could not be completed by the provider",
-        ) from e
-    except Exception as e:
-        error_log = UsageLog(
-            id=str(uuid.uuid4()),
-            api_key_id=api_key_id,
-            user_id=user_id,
-            timestamp=datetime.now(UTC),
-            model=model,
-            provider=resolved.instance,
-            endpoint="/v1/moderations",
-            status="error",
-            error_message=str(e),
-        )
-        await log_writer.put(error_log)
-        await refund_reservation(db, reservation)
-
-        logger.error("Provider call failed for %s:%s: %s", provider, model, e)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="The request could not be completed by the provider",
-        ) from e
-
-    if rate_limit_info:
-        for key, value in rate_limit_headers(rate_limit_info).items():
-            response.headers[key] = value
-
-    if resolved.alias is not None:
-        relabel_model(result, resolved.alias)
-    return result
+    return outcome.result

--- a/src/gateway/api/routes/rerank.py
+++ b/src/gateway/api/routes/rerank.py
@@ -1,31 +1,21 @@
 """Rerank endpoint — reorder documents by relevance to a query."""
 
-import uuid
-from datetime import UTC, datetime
 from typing import Annotated, Any
 
 from any_llm import arerank
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from any_llm.types.rerank import RerankResponse
+from fastapi import APIRouter, Depends, Request, Response
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
-from gateway.api.routes._helpers import resolve_user_id
-from gateway.api.routes.chat import rate_limit_headers
+from gateway.api.routes._passthrough import run_passthrough
 from gateway.core.config import GatewayConfig
-from gateway.log_config import logger
-from gateway.model_labeling import relabel_model
-from gateway.models.entities import APIKey, UsageLog
-from gateway.rate_limit import check_rate_limit
-from gateway.services.budget_service import (
-    estimate_cost,
-    reconcile_reservation,
-    refund_reservation,
-    reserve_budget,
-)
+from gateway.models.entities import APIKey, ModelPricing
+from gateway.services.budget_service import estimate_cost
 from gateway.services.log_writer import LogWriter
-from gateway.services.pricing_service import find_model_pricing, pricing_required_but_missing
-from gateway.services.provider_kwargs import resolve_provider_selector
+from gateway.services.pricing_service import input_token_cost
+from gateway.services.provider_kwargs import ResolvedProvider
 
 router = APIRouter(prefix="/v1", tags=["rerank"])
 
@@ -58,125 +48,53 @@ async def create_rerank(
     - API key + user field: Use specified user (must exist)
     - API key without user field: Use virtual user created with API key
     """
-    api_key, is_master_key = auth_result
-    api_key_id = api_key.id if api_key else None
-
-    user_id = resolve_user_id(
-        user_id_from_request=request.user,
-        api_key=api_key,
-        is_master_key=is_master_key,
-        master_key_error=HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="When using master key, 'user' field is required in request body",
-        ),
-        no_api_key_error=HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="API key validation failed",
-        ),
-        no_user_error=HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="API key has no associated user",
-        ),
-        forbidden_user_error=HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="'user' field does not match the authenticated API key's user",
-        ),
-        reject_mismatch=config.reject_user_mismatch,
-    )
-
-    rate_limit_info = check_rate_limit(raw_request, user_id)
-
-    resolved = resolve_provider_selector(config, request.model)
-    provider, model = resolved.provider, resolved.model
-
-    pricing = await find_model_pricing(db, resolved.instance, model)
-
     # Rerank bills on total tokens (input only). Estimate from query + documents.
     prompt_chars = len(request.query) + sum(len(doc) for doc in request.documents)
-    estimate = estimate_cost(pricing, prompt_chars=prompt_chars, max_output_tokens=None, default_output_tokens=0)
-    # Reserve first so 404/403 precede the missing-pricing 402; refund on reject.
-    reservation = await reserve_budget(
-        db, user_id, estimate, model=request.model, strategy=config.budget_strategy
-    )
-    if pricing_required_but_missing(pricing, require_pricing=config.require_pricing):
-        await refund_reservation(db, reservation)
-        raise HTTPException(
-            status_code=status.HTTP_402_PAYMENT_REQUIRED,
-            detail=f"No pricing configured for model '{request.model}'",
-        )
 
-    provider_kwargs = resolved.kwargs
+    def estimate(pricing: ModelPricing | None) -> float:
+        return estimate_cost(pricing, prompt_chars=prompt_chars, max_output_tokens=None, default_output_tokens=0)
 
-    rerank_kwargs: dict[str, Any] = {
-        "model": model,
-        "query": request.query,
-        "documents": request.documents,
-        "provider": provider,
-        **provider_kwargs,
-    }
-    if request.top_n is not None:
-        rerank_kwargs["top_n"] = request.top_n
-    if request.max_tokens_per_doc is not None:
-        rerank_kwargs["max_tokens_per_doc"] = request.max_tokens_per_doc
-
-    try:
-        result = await arerank(**rerank_kwargs)
-
+    def usage_tokens(result: RerankResponse) -> tuple[int | None, int | None, int | None]:
         total_tokens = result.usage.total_tokens if result.usage else None
+        return (total_tokens, 0, total_tokens)
 
-        usage_log = UsageLog(
-            id=str(uuid.uuid4()),
-            api_key_id=api_key_id,
-            user_id=user_id,
-            timestamp=datetime.now(UTC),
-            model=model,
-            provider=resolved.instance,
-            endpoint="/v1/rerank",
-            status="success",
-            prompt_tokens=total_tokens,
-            completion_tokens=0,
-            total_tokens=total_tokens,
-        )
-
-        cost = 0.0
+    def compute_cost(result: RerankResponse, pricing: ModelPricing | None) -> float | None:
+        total_tokens = result.usage.total_tokens if result.usage else None
         if result.usage and pricing and total_tokens:
-            cost = (total_tokens / 1_000_000) * pricing.input_price_per_million
-            usage_log.cost = cost
+            return input_token_cost(total_tokens, pricing)
+        return None
 
-        await log_writer.put(usage_log)
-        await reconcile_reservation(db, reservation, cost)
-
-    except HTTPException:
-        await refund_reservation(db, reservation)
-        raise
-    except Exception as e:
-        error_log = UsageLog(
-            id=str(uuid.uuid4()),
-            api_key_id=api_key_id,
-            user_id=user_id,
-            timestamp=datetime.now(UTC),
-            model=model,
-            provider=resolved.instance,
-            endpoint="/v1/rerank",
-            status="error",
-            error_message=str(e),
-        )
-        await log_writer.put(error_log)
-        await refund_reservation(db, reservation)
-
-        logger.error("Provider call failed for %s:%s: %s", provider, model, e)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="The request could not be completed by the provider",
-        ) from e
-
-    if rate_limit_info:
-        for key, value in rate_limit_headers(rate_limit_info).items():
-            response.headers[key] = value
+    async def call_provider(resolved: ResolvedProvider) -> RerankResponse:
+        rerank_kwargs: dict[str, Any] = {
+            "model": resolved.model,
+            "query": request.query,
+            "documents": request.documents,
+            "provider": resolved.provider,
+            **resolved.kwargs,
+        }
+        if request.top_n is not None:
+            rerank_kwargs["top_n"] = request.top_n
+        if request.max_tokens_per_doc is not None:
+            rerank_kwargs["max_tokens_per_doc"] = request.max_tokens_per_doc
+        return await arerank(**rerank_kwargs)
 
     # Rerank results are returned verbatim and some providers (Voyage, Jina)
     # carry ``model``, which would echo the target an alias exists to hide. The
-    # call is a no-op on results without the field.
-    if resolved.alias is not None:
-        relabel_model(result, resolved.alias)
-    return result
+    # relabeling is a no-op on results without the field.
+    outcome = await run_passthrough(
+        endpoint="/v1/rerank",
+        raw_request=raw_request,
+        response=response,
+        auth_result=auth_result,
+        db=db,
+        config=config,
+        log_writer=log_writer,
+        model=request.model,
+        user=request.user,
+        call_provider=call_provider,
+        estimate=estimate,
+        enforce_require_pricing=True,
+        usage_tokens=usage_tokens,
+        compute_cost=compute_cost,
+    )
+    return outcome.result

--- a/src/gateway/services/pricing_service.py
+++ b/src/gateway/services/pricing_service.py
@@ -176,6 +176,44 @@ async def find_model_pricing(
     return pricing
 
 
+# ``ModelPricing`` only has per-million-token rate columns, so endpoints whose
+# billable unit is not a token overload ``input_price_per_million`` with a
+# different unit convention. Each convention gets a named helper below so the
+# unit is visible at the call site instead of an anonymous expression that can
+# be miscopied into a new route and misbill by a factor of a million. Dedicated
+# per-unit columns would need a schema migration (deferred; see issue #259).
+
+
+def input_token_cost(tokens: int, pricing: ModelPricing) -> float:
+    """USD cost of ``tokens`` input tokens at the per-million-token rate.
+
+    The standard convention: ``input_price_per_million`` is USD per million
+    input tokens. Used by embeddings and rerank, which bill input tokens only.
+    """
+    return (tokens / 1_000_000) * pricing.input_price_per_million
+
+
+def flat_request_cost(pricing: ModelPricing | None) -> float:
+    """Flat USD cost of one request for a model priced per request.
+
+    Moderations convention: ``input_price_per_million`` stores the per-request
+    rate scaled by 1e6 (USD per million requests), so one request costs the
+    stored rate divided by 1e6. Unpriced models are treated as free.
+    """
+    if pricing is None or not pricing.input_price_per_million:
+        return 0.0
+    return pricing.input_price_per_million / 1_000_000
+
+
+def per_image_cost(n_images: int, pricing: ModelPricing) -> float:
+    """USD cost of ``n_images`` generated images.
+
+    Images convention: despite the name, ``input_price_per_million`` stores raw
+    USD per image (no scaling, no division).
+    """
+    return n_images * pricing.input_price_per_million
+
+
 def pricing_required_but_missing(pricing: ModelPricing | None, *, require_pricing: bool) -> bool:
     """Return True when the request must be rejected for lacking pricing.
 

--- a/tests/integration/test_audio_endpoint.py
+++ b/tests/integration/test_audio_endpoint.py
@@ -85,7 +85,7 @@ def test_transcription_provider_error(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/audio/transcriptions returns 500 when the provider fails."""
+    """POST /v1/audio/transcriptions returns 502 when the provider fails."""
     with patch(
         "gateway.api.routes.audio.atranscription",
         new_callable=AsyncMock,
@@ -97,7 +97,7 @@ def test_transcription_provider_error(
             data={"model": "openai:whisper-1"},
             headers=api_key_header,
         )
-    assert resp.status_code == 500
+    assert resp.status_code == 502
     assert "provider" in resp.json()["detail"].lower()
 
 
@@ -149,7 +149,7 @@ def test_transcription_logs_error_on_failure(
             data={"model": "openai:whisper-1"},
             headers=api_key_header,
         )
-    assert resp.status_code == 500
+    assert resp.status_code == 502
 
     usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
     assert usage_resp.status_code == 200
@@ -269,7 +269,7 @@ def test_speech_provider_error(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/audio/speech returns 500 when the provider fails."""
+    """POST /v1/audio/speech returns 502 when the provider fails."""
     with patch(
         "gateway.api.routes.audio.aspeech",
         new_callable=AsyncMock,
@@ -280,7 +280,7 @@ def test_speech_provider_error(
             json={"model": "openai:tts-1", "input": "Hello", "voice": "alloy"},
             headers=api_key_header,
         )
-    assert resp.status_code == 500
+    assert resp.status_code == 502
     assert "provider" in resp.json()["detail"].lower()
 
 
@@ -329,7 +329,7 @@ def test_speech_logs_error_on_failure(
             json={"model": "openai:tts-1", "input": "Hello", "voice": "alloy"},
             headers=api_key_header,
         )
-    assert resp.status_code == 500
+    assert resp.status_code == 502
 
     usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
     assert usage_resp.status_code == 200

--- a/tests/integration/test_embeddings_endpoint.py
+++ b/tests/integration/test_embeddings_endpoint.py
@@ -97,7 +97,7 @@ def test_embeddings_provider_error(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/embeddings returns 500 when the provider fails."""
+    """POST /v1/embeddings returns 502 when the provider fails."""
     with patch(
         "gateway.api.routes.embeddings.aembedding",
         new_callable=AsyncMock,
@@ -108,7 +108,7 @@ def test_embeddings_provider_error(
             json={"model": "openai:text-embedding-3-small", "input": "hello"},
             headers=api_key_header,
         )
-    assert resp.status_code == 500
+    assert resp.status_code == 502
     assert "provider" in resp.json()["detail"].lower()
 
 
@@ -159,7 +159,7 @@ def test_embeddings_logs_error_on_failure(
             json={"model": "openai:text-embedding-3-small", "input": "hello"},
             headers=api_key_header,
         )
-    assert resp.status_code == 500
+    assert resp.status_code == 502
 
     usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
     assert usage_resp.status_code == 200

--- a/tests/integration/test_files_endpoint.py
+++ b/tests/integration/test_files_endpoint.py
@@ -377,3 +377,49 @@ def test_vision_describe_side_call_is_billed(
     # ...and the describe side-call's cost (1000/1e6*2.5 + 500/1e6*10) was billed.
     user = client.get("/v1/users/vision-user", headers=master_key_header).json()
     assert user["spend"] == pytest.approx(0.0075)
+
+
+def test_files_user_mismatch_rejected_by_default(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    tmp_file_store: None,
+) -> None:
+    """Strict default: a non-master key naming a different 'user' is rejected."""
+    resp = client.post(
+        "/v1/files",
+        headers=api_key_header,
+        files={"file": ("a.txt", b"hello", "text/plain")},
+        data={"user": "someone-else"},
+    )
+    assert resp.status_code == 403
+    assert "does not match" in resp.json()["detail"]
+
+
+def test_files_user_mismatch_ignored_when_lenient(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+    tmp_file_store: None,
+    test_config: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With reject_user_mismatch=False, a mismatched 'user' is ignored.
+
+    The upload succeeds and ownership still binds to the key's own user, like
+    every other pass-through route.
+    """
+    monkeypatch.setattr(test_config, "reject_user_mismatch", False)
+    resp = client.post(
+        "/v1/files",
+        headers=api_key_header,
+        files={"file": ("a.txt", b"hello", "text/plain")},
+        data={"user": "someone-else"},
+    )
+    assert resp.status_code == 200, resp.text
+    file_id = resp.json()["id"]
+
+    # The file is scoped to the key's user, not the mismatched name: listing
+    # with the key (which resolves to its own user) returns it.
+    listing = client.get("/v1/files", headers=api_key_header)
+    assert listing.status_code == 200
+    assert any(f["id"] == file_id for f in listing.json()["data"])

--- a/tests/integration/test_images_endpoint.py
+++ b/tests/integration/test_images_endpoint.py
@@ -89,7 +89,7 @@ def test_images_provider_error(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/images/generations returns 500 when the provider fails."""
+    """POST /v1/images/generations returns 502 when the provider fails."""
     with patch(
         "gateway.api.routes.images.aimage_generation",
         new_callable=AsyncMock,
@@ -100,7 +100,7 @@ def test_images_provider_error(
             json={"model": "openai:dall-e-3", "prompt": "a cute cat"},
             headers=api_key_header,
         )
-    assert resp.status_code == 500
+    assert resp.status_code == 502
     assert "provider" in resp.json()["detail"].lower()
 
 
@@ -151,7 +151,7 @@ def test_images_logs_error_on_failure(
             json={"model": "openai:dall-e-3", "prompt": "a cute cat"},
             headers=api_key_header,
         )
-    assert resp.status_code == 500
+    assert resp.status_code == 502
 
     usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
     assert usage_resp.status_code == 200

--- a/tests/integration/test_moderations_endpoint.py
+++ b/tests/integration/test_moderations_endpoint.py
@@ -153,7 +153,7 @@ def test_moderations_provider_error(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/moderations returns 500 when the provider fails."""
+    """POST /v1/moderations returns 502 when the provider fails."""
     with patch(
         "gateway.api.routes.moderations.amoderation",
         new_callable=AsyncMock,
@@ -164,7 +164,7 @@ def test_moderations_provider_error(
             json={"model": "openai:omni-moderation-latest", "input": "hello"},
             headers=api_key_header,
         )
-    assert resp.status_code == 500
+    assert resp.status_code == 502
     assert "could not be completed" in resp.json()["detail"].lower()
 
 
@@ -188,11 +188,11 @@ def test_moderations_unsupported_provider_returns_400(
     assert resp.json() == {"detail": "Provider anthropic does not support moderation"}
 
 
-def test_moderations_generic_not_implemented_returns_500(
+def test_moderations_generic_not_implemented_returns_502(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """Generic NotImplementedError (without locked phrasing) returns 500."""
+    """Generic NotImplementedError (without locked phrasing) returns 502."""
     with patch(
         "gateway.api.routes.moderations.amoderation",
         new_callable=AsyncMock,
@@ -203,7 +203,7 @@ def test_moderations_generic_not_implemented_returns_500(
             json={"model": "openai:omni-moderation-latest", "input": "hello"},
             headers=api_key_header,
         )
-    assert resp.status_code == 500
+    assert resp.status_code == 502
     assert "could not be completed" in resp.json()["detail"].lower()
 
 
@@ -263,7 +263,7 @@ def test_moderations_logs_error_on_failure(
             json={"model": "openai:omni-moderation-latest", "input": "hello"},
             headers=api_key_header,
         )
-    assert resp.status_code == 500
+    assert resp.status_code == 502
 
     usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
     assert usage_resp.status_code == 200

--- a/tests/integration/test_rerank_endpoint.py
+++ b/tests/integration/test_rerank_endpoint.py
@@ -120,14 +120,14 @@ def test_rerank_provider_error(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """POST /v1/rerank returns 500 when the provider fails."""
+    """POST /v1/rerank returns 502 when the provider fails."""
     with patch(
         "gateway.api.routes.rerank.arerank",
         new_callable=AsyncMock,
         side_effect=RuntimeError("provider down"),
     ):
         resp = client.post("/v1/rerank", json=RERANK_PAYLOAD, headers=api_key_header)
-    assert resp.status_code == 500
+    assert resp.status_code == 502
     assert "provider" in resp.json()["detail"].lower()
 
 
@@ -173,7 +173,7 @@ def test_rerank_logs_error_on_failure(
         side_effect=RuntimeError("provider down"),
     ):
         resp = client.post("/v1/rerank", json=RERANK_PAYLOAD, headers=api_key_header)
-    assert resp.status_code == 500
+    assert resp.status_code == 502
 
     usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
     assert usage_resp.status_code == 200


### PR DESCRIPTION
> _Note: this PR was implemented by Claude working from issue #259, which was drafted via back-and-forth with @njbrake. The design decisions follow the issue; the code and prose are Claude's._

## Description

The five pass-through provider routes (audio transcriptions, audio speech, images, embeddings, moderations, rerank) each repeated the same ~100-line scaffold: user resolution, rate limiting, provider selector resolution, budget reserve/reconcile/refund, success and error `UsageLog` construction, and the trailing rate-limit-header loop. The copies had drifted apart.

This PR extracts a shared `run_passthrough(...)` helper (`src/gateway/api/routes/_passthrough.py`) that owns the scaffold; each route now supplies only its endpoint-specific pieces (budget estimate, provider call, token extraction, cost computation) as small callbacks. The six route files shrink from ~1,050 lines to ~600 including the new helper (net -148 lines overall).

Behavior is unchanged except for three deliberate fixes from the issue:

1. **Provider failures now map to 502 instead of a blanket 500.** Failures are classified with `_classify_upstream_error` (the same classifier the hybrid fallback path uses) for logging, and surface as `502 Bad Gateway` with the existing fixed detail string, matching the chat, messages, and responses routes. A provider outage on `/v1/embeddings` no longer looks like a gateway bug to monitoring. The raw provider message still never leaks into the response.
2. **`files.py` honors `reject_user_mismatch`.** Its `_resolve_user` now threads `reject_mismatch=config.reject_user_mismatch`, so file routes support the lenient mode like every sibling route instead of being always strict. Ownership still binds to the key's own user either way.
3. **The three `input_price_per_million` unit conventions get named helpers.** `input_token_cost` (per-million tokens; embeddings, rerank), `flat_request_cost` (flat per-request rate scaled by 1e6; moderations), and `per_image_cost` (raw USD per image; images) live in `pricing_service.py` with comments, so a new route copies intent rather than an expression that can misbill by a factor of a million. No DB schema change or migration.

`batches.py` is intentionally untouched (#258 tracks it), as are the chat/messages/responses pipelines. The OpenAPI spec is unchanged (`make openapi-check` passes).

Tests: the provider-failure tests for all five routes now assert 502; two new tests cover the `files.py` strict default and lenient `reject_user_mismatch` threading.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #259

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Fable 5 (Claude Code)

**Any additional AI details you'd like to share:** Implemented from issue #259; verified with the unit suite, the full integration suite against PostgreSQL, ruff, mypy strict, and the OpenAPI freshness check.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
