### PR TITLE
fix(usage): bill vision side-call before top-up and track usage report tasks

### DIFF
--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine
 from contextlib import AsyncExitStack
 from datetime import UTC, datetime
 from enum import Enum, auto
@@ -609,6 +609,21 @@ async def resolve_request_context(
                 post_chars, vision_usage = await normalize_messages(
                     user_id, gate_impl, gate_model, gate_instance
                 )
+                # Bill the vision describe side-call before the reservation
+                # top-up: its cost is already incurred by normalize_messages,
+                # so a 402 from the top-up below must not skip it (the refund
+                # in the except path releases only the main reservation; the
+                # vision spend is committed independently and stays billed).
+                if vision_usage is not None:
+                    await _bill_vision_side_call(
+                        db=db,
+                        log_writer=log_writer,
+                        config=config,
+                        api_key_id=api_key_id,
+                        user_id=user_id,
+                        endpoint=adapter.endpoint,
+                        usage=vision_usage,
+                    )
                 post_estimate = estimate_cost(
                     gate_pricing,
                     prompt_chars=post_chars,
@@ -622,16 +637,6 @@ async def resolve_request_context(
                     model=model,
                     strategy=config.budget_strategy,
                 )
-                if vision_usage is not None:
-                    await _bill_vision_side_call(
-                        db=db,
-                        log_writer=log_writer,
-                        config=config,
-                        api_key_id=api_key_id,
-                        user_id=user_id,
-                        endpoint=adapter.endpoint,
-                        usage=vision_usage,
-                    )
             except HTTPException:
                 await refund_reservation(db, reservation)
                 raise
@@ -1158,6 +1163,36 @@ async def open_stream(
 # Streaming settlement (the single copy of the callback bundle)
 # ---------------------------------------------------------------------------
 
+# Strong references to in-flight fire-and-forget usage-report tasks. Without
+# these, asyncio only holds a weak reference and a scheduled report can be
+# garbage collected before it runs; a done-callback discards each task once
+# it finishes.
+_USAGE_REPORT_TASKS: set[asyncio.Task[None]] = set()
+
+
+def _schedule_usage_report(coro: Coroutine[Any, Any, None], correlation_id: str) -> None:
+    """Run a platform usage report in the background without losing it.
+
+    Keeps the task strongly referenced until it completes and logs a failed
+    report instead of letting the exception vanish with the task object.
+    """
+    task = asyncio.create_task(coro)
+    _USAGE_REPORT_TASKS.add(task)
+
+    def _finalize(finished: asyncio.Task[None]) -> None:
+        _USAGE_REPORT_TASKS.discard(finished)
+        if finished.cancelled():
+            return
+        exc = finished.exception()
+        if exc is not None:
+            logger.warning(
+                "Background platform usage report failed correlation_id=%s: %s",
+                correlation_id,
+                exc,
+            )
+
+    task.add_done_callback(_finalize)
+
 
 def build_streaming_response(
     *,
@@ -1196,14 +1231,15 @@ def build_streaming_response(
     async def _on_complete(usage_data: CompletionUsage) -> None:
         if platform_active:
             assert platform_correlation_id is not None
-            asyncio.create_task(
+            _schedule_usage_report(
                 _report_platform_usage(
                     config=config,
                     correlation_id=platform_correlation_id,
                     outcome="success",
                     usage=usage_data,
                     session_label=session_label,
-                )
+                ),
+                platform_correlation_id,
             )
             return
         if db is None or log_writer is None:
@@ -1257,14 +1293,15 @@ def build_streaming_response(
     async def _on_error(error: str) -> None:
         if platform_active:
             assert platform_correlation_id is not None
-            asyncio.create_task(
+            _schedule_usage_report(
                 _report_platform_usage(
                     config=config,
                     correlation_id=platform_correlation_id,
                     outcome="error",
                     usage=None,
                     session_label=session_label,
-                )
+                ),
+                platform_correlation_id,
             )
             return
         if db is None or log_writer is None:

--- a/tests/unit/test_pipeline_settlement.py
+++ b/tests/unit/test_pipeline_settlement.py
@@ -14,6 +14,7 @@ platform-fallback streaming paths. These tests pin that contract:
 * a pre-stream dispatch failure refunds the reservation for every format.
 """
 
+import asyncio
 from collections.abc import AsyncIterator
 from typing import Any, cast
 
@@ -304,6 +305,102 @@ async def test_client_disconnect_refunds(monkeypatch: pytest.MonkeyPatch) -> Non
 
     assert settlement.refunded == 1
     assert settlement.reconciled == []
+
+
+# ---------------------------------------------------------------------------
+# Platform usage reports scheduled from streaming callbacks are not lost
+# ---------------------------------------------------------------------------
+
+
+def _build_platform(stream: AsyncIterator[ChatCompletionChunk]) -> Any:
+    return build_streaming_response(
+        adapter=chat._ADAPTER,
+        stream=stream,
+        provider=LLMProvider.OPENAI,
+        model="gpt-4",
+        config=GatewayConfig(),
+        db=None,
+        log_writer=None,
+        api_key_id=None,
+        user_id=None,
+        rate_limit_info=None,
+        reservation=None,
+        platform_correlation_id="corr-1",
+        platform_request_id="req-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_platform_usage_report_task_is_tracked_until_done(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The scheduled report task must be strongly referenced while in flight
+    (a bare fire-and-forget task can be garbage collected mid-run) and
+    discarded once it completes.
+    """
+    tracked: set[asyncio.Task[None]] = set()
+    monkeypatch.setattr(pipeline, "_USAGE_REPORT_TASKS", tracked)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_report(**kwargs: Any) -> None:
+        started.set()
+        await release.wait()
+
+    monkeypatch.setattr(pipeline, "_report_platform_usage", slow_report)
+
+    async def stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield _chunk(CompletionUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2))
+
+    await _drain(_build_platform(stream()))
+    await asyncio.wait_for(started.wait(), timeout=2)
+
+    assert len(tracked) == 1
+    task = next(iter(tracked))
+    release.set()
+    await asyncio.wait_for(task, timeout=2)
+    for _ in range(10):
+        if not tracked:
+            break
+        await asyncio.sleep(0)
+    assert not tracked
+
+
+@pytest.mark.asyncio
+async def test_failed_platform_usage_report_logs_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A report that raises must surface in the logs instead of vanishing
+    with the unreferenced task.
+    """
+    monkeypatch.setattr(pipeline, "_USAGE_REPORT_TASKS", set(), raising=False)
+    warnings: list[tuple[str, tuple[Any, ...]]] = []
+
+    class _LoggerRecorder:
+        def warning(self, msg: str, *args: Any) -> None:
+            warnings.append((msg, args))
+
+        def __getattr__(self, name: str) -> Any:
+            return lambda *args, **kwargs: None
+
+    monkeypatch.setattr(pipeline, "logger", _LoggerRecorder())
+
+    async def failing_report(**kwargs: Any) -> None:
+        raise RuntimeError("usage endpoint down")
+
+    monkeypatch.setattr(pipeline, "_report_platform_usage", failing_report)
+
+    async def stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield _chunk(CompletionUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2))
+
+    await _drain(_build_platform(stream()))
+    for _ in range(20):
+        if warnings:
+            break
+        await asyncio.sleep(0)
+
+    assert warnings, "failed usage report was not logged"
+    assert "corr-1" in warnings[0][1]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pipeline_vision_billing.py
+++ b/tests/unit/test_pipeline_vision_billing.py
@@ -1,0 +1,132 @@
+"""Unit tests for the vision side-call billing order in ``resolve_request_context``.
+
+The vision describe call happens inside ``normalize_messages``, so by the time
+the reservation top-up runs its cost is already incurred. These tests pin the
+guarantee documented on ``_bill_vision_side_call``: the side-call is billed
+even when the top-up rejects with 402, while the main reservation is still
+refunded.
+"""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from any_llm import LLMProvider
+from any_llm.types.completion import CompletionUsage
+from fastapi import HTTPException, Request, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import gateway.api.routes._pipeline as pipeline
+from gateway.api.routes import chat
+from gateway.core.config import GatewayConfig
+from gateway.services.budget_service import ReservationHandle
+
+_VISION_USAGE = CompletionUsage(prompt_tokens=200, completion_tokens=50, total_tokens=250)
+
+
+class _Recorder:
+    """Captures the billing and settlement primitives the pipeline invoked."""
+
+    def __init__(self) -> None:
+        self.usage_logged: list[dict[str, Any]] = []
+        self.reconciled: list[float] = []
+        self.refunded = 0
+
+    def install(self, monkeypatch: pytest.MonkeyPatch, *, topup_status: int | None) -> None:
+        async def fake_verify(*args: Any, **kwargs: Any) -> tuple[Any, bool]:
+            return SimpleNamespace(id="key-1", user_id="user-1"), False
+
+        async def fake_find_pricing(*args: Any, **kwargs: Any) -> None:
+            return None
+
+        async def fake_reserve(*args: Any, **kwargs: Any) -> ReservationHandle:
+            return ReservationHandle(user_id="user-1", estimate=0.0, reserved=True, strategy="for_update")
+
+        async def fake_increase(*args: Any, **kwargs: Any) -> None:
+            if topup_status is not None:
+                raise HTTPException(status_code=topup_status, detail="budget exceeded")
+
+        async def fake_log_usage(**kwargs: Any) -> float:
+            self.usage_logged.append(kwargs)
+            return 0.01
+
+        async def fake_reconcile(db: Any, handle: Any, actual_cost: float) -> None:
+            self.reconciled.append(actual_cost)
+
+        async def fake_refund(db: Any, handle: Any) -> None:
+            self.refunded += 1
+
+        monkeypatch.setattr(pipeline, "verify_api_key_or_master_key", fake_verify)
+        monkeypatch.setattr(pipeline, "check_rate_limit", lambda request, user_id: None)
+        monkeypatch.setattr(pipeline, "find_model_pricing", fake_find_pricing)
+        monkeypatch.setattr(pipeline, "reserve_budget", fake_reserve)
+        monkeypatch.setattr(pipeline, "increase_reservation", fake_increase)
+        monkeypatch.setattr(pipeline, "log_usage", fake_log_usage)
+        monkeypatch.setattr(pipeline, "reconcile_reservation", fake_reconcile)
+        monkeypatch.setattr(pipeline, "refund_reservation", fake_refund)
+
+
+async def _normalize_with_vision(
+    user_id: str, provider: LLMProvider | None, model: str, instance: str | None
+) -> tuple[int, CompletionUsage | None]:
+    return 5000, _VISION_USAGE
+
+
+async def _resolve(config: GatewayConfig) -> pipeline.RequestContext:
+    request = Request({"type": "http", "method": "POST", "path": "/v1/chat/completions", "headers": []})
+    return await pipeline.resolve_request_context(
+        adapter=chat._ADAPTER,
+        raw_request=request,
+        response=Response(),
+        db=cast(AsyncSession, object()),
+        config=config,
+        log_writer=cast(Any, object()),
+        model="openai:gpt-4",
+        user_id_from_request=None,
+        estimate_prompt_chars=100,
+        estimate_max_output_tokens=None,
+        master_key_user_required_detail="user required",
+        user_forbidden_detail="forbidden",
+        normalize_messages=_normalize_with_vision,
+    )
+
+
+def _config() -> GatewayConfig:
+    return GatewayConfig(require_pricing=False, vision_describe_model="openai:gpt-4o-mini")
+
+
+@pytest.mark.asyncio
+async def test_vision_side_call_billed_even_when_topup_rejects_402(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The vision cost is already incurred, so a 402 from the reservation
+    top-up must not skip its usage-log row or its committed spend; the main
+    reservation is still refunded.
+    """
+    recorder = _Recorder()
+    recorder.install(monkeypatch, topup_status=402)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _resolve(_config())
+
+    assert exc_info.value.status_code == 402
+    assert len(recorder.usage_logged) == 1
+    logged = recorder.usage_logged[0]
+    assert logged["model"] == "gpt-4o-mini"
+    assert logged["provider"] == "openai"
+    assert logged["usage_override"] is _VISION_USAGE
+    assert recorder.reconciled == [0.01]
+    assert recorder.refunded == 1
+
+
+@pytest.mark.asyncio
+async def test_vision_side_call_billed_on_successful_setup(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder = _Recorder()
+    recorder.install(monkeypatch, topup_status=None)
+
+    ctx = await _resolve(_config())
+
+    assert ctx.user_id == "user-1"
+    assert len(recorder.usage_logged) == 1
+    assert recorder.reconciled == [0.01]
+    assert recorder.refunded == 0


### PR DESCRIPTION
## Description

Fixes two usage-accounting gaps in the shared request pipeline (`src/gateway/api/routes/_pipeline.py`):

1. **Vision side-call billed after the reservation top-up.** The vision describe call has already run inside `normalize_messages` by the time `increase_reservation` executes, so a 402 from the top-up refunded the reservation and skipped `_bill_vision_side_call`, losing spend that the docstring promises is "already incurred, not gated or refundable". The side-call is now billed right after normalization returns and before the top-up. A top-up rejection still refunds the main reservation; the vision spend commits independently and stays billed. The refund-on-setup-failure behavior for everything else is unchanged.

2. **Fire-and-forget platform usage reports.** `_on_complete` and `_on_error` in `build_streaming_response` scheduled `_report_platform_usage` via bare `asyncio.create_task(...)` with no retained reference, so a report task could be garbage collected mid-flight and a failed report raised into nowhere. Scheduled reports are now held in a module-level task set until done, and a failing report logs a warning with its correlation id. The non-streaming inline flush path is unchanged.

Batch spend recording (item 3 in the issue) is tracked separately in #258 and intentionally not touched here.

Tests: a unit test drives `resolve_request_context` with a top-up that rejects 402 and asserts the vision usage-log write and committed spend still happen while the main reservation is refunded; two unit tests assert report tasks are strongly referenced until completion and that a failing report logs instead of disappearing. All three fail without the fix.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #265

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Fable 5)

**Any additional AI details you'd like to share:** Directed by @njbrake against issue #265. Unit suite, lint, typecheck, and OpenAPI check run locally; integration tests were skipped because Docker/testcontainers was unavailable in the sandbox.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
