### PR TITLE
refactor(services): collapse the three MCP tool-loop modules onto one engine

### DIFF
--- a/src/gateway/services/_tool_loop.py
+++ b/src/gateway/services/_tool_loop.py
@@ -1,0 +1,318 @@
+"""Format-agnostic engine for the gateway's agentic tool-use loop.
+
+The chat-completions (:mod:`gateway.services.mcp_loop`), Anthropic Messages
+(:mod:`gateway.services.mcp_loop_messages`), and OpenAI Responses
+(:mod:`gateway.services.mcp_loop_responses`) tool loops run the same
+algorithm: call the provider, split the tool calls it produced into
+gateway-owned and caller-supplied (foreign) ones, execute the owned calls,
+append the assistant turn plus tool results to the transcript, and re-call
+the provider until a terminal answer arrives. Only the wire vocabulary
+differs (message shapes, terminal events, usage field names). This module
+owns the algorithm once; each format contributes a small strategy object
+implementing :class:`ToolLoopStrategy` (non-streaming) and
+:class:`StreamToolLoopStrategy` (streaming).
+
+Provider functions are intentionally not called from here: each strategy's
+``call`` / ``open_stream`` resolves ``acompletion`` / ``amessages`` /
+``aresponses`` as a module global of its own format module at call time, so
+tests can keep monkeypatching them there.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable
+from contextlib import AbstractAsyncContextManager, aclosing, nullcontext
+from enum import Enum, auto
+from typing import Any, Generic, Protocol, TypeVar, cast
+
+ResultT = TypeVar("ResultT")
+ChunkT = TypeVar("ChunkT")
+StateT = TypeVar("StateT")
+AccT = TypeVar("AccT")
+
+
+class ToolBackend(Protocol):
+    """Subset of the tool-backend surface the loop drives.
+
+    Structurally implemented by ``MCPClientPool``, ``SandboxBackend``, and
+    ``WebSearchBackend``; each exposes the same members the loop and the route
+    pipeline need to advertise tools, decide ownership, execute a call, and
+    describe each tool's purpose for the system-message hint block. Widening
+    ``pool`` to this Protocol lets the routes pass any of those backends
+    without casts.
+    """
+
+    @property
+    def openai_tools(self) -> list[dict[str, Any]]: ...
+
+    def owns_tool(self, name: str) -> bool: ...
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str: ...
+
+    def purpose_hints(self) -> list[tuple[str, str]]: ...
+
+
+class MaxToolIterationsExceeded(Exception):
+    """Raised when the loop fails to reach a non-tool-call finish in N rounds."""
+
+
+class StreamAction(Enum):
+    """What the engine does with one upstream stream event.
+
+    ``FORWARD`` yields the event downstream, ``DEFER`` swallows it (the
+    strategy stashed it as a pending terminal), and ``BREAK`` additionally
+    stops consuming the current upstream stream.
+    """
+
+    FORWARD = auto()
+    DEFER = auto()
+    BREAK = auto()
+
+
+class ToolLoopStrategy(Protocol, Generic[ResultT, AccT]):
+    """Per-format hooks for :func:`run_tool_loop`.
+
+    ``transcript_key`` names the kwargs entry carrying the conversation
+    (``messages`` for chat/messages, ``input_data`` for responses). The exit
+    hooks preserve each format's historical check ordering: chat inspects the
+    finish_reason before splitting (``exit_before_split``), while messages
+    checks the stop_reason only after the foreign-tool branch
+    (``exit_after_split``); see :func:`run_tool_loop` for the consequences.
+    """
+
+    transcript_key: str
+
+    def coerce_transcript(self, value: Any) -> list[Any]: ...
+
+    def convert_pool_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]: ...
+
+    async def call(self, kwargs: dict[str, Any]) -> ResultT: ...
+
+    def new_usage_accumulator(self) -> AccT: ...
+
+    def accumulate_usage(self, acc: AccT, result: ResultT) -> None: ...
+
+    def fold_usage(self, result: ResultT, acc: AccT) -> None: ...
+
+    def exit_before_split(self, result: ResultT) -> bool: ...
+
+    def split_owned(self, result: ResultT, pool: ToolBackend) -> tuple[list[Any], bool]: ...
+
+    def exit_after_split(self, result: ResultT) -> bool: ...
+
+    async def execute_owned(self, pool: ToolBackend, owned: list[Any]) -> list[dict[str, Any]]: ...
+
+    def filter_owned(self, result: ResultT, owned: list[Any], pool: ToolBackend) -> None: ...
+
+    async def advance_transcript(
+        self,
+        transcript: list[Any],
+        result: ResultT,
+        owned: list[Any],
+        pool: ToolBackend,
+    ) -> None: ...
+
+
+class StreamToolLoopStrategy(Protocol, Generic[ChunkT, StateT, AccT]):
+    """Per-format hooks for :func:`run_tool_loop_stream`.
+
+    ``observe`` performs the format's per-event bookkeeping (tool-call delta
+    accumulation, terminal-event capture) on the per-iteration ``state`` and
+    tells the engine what to do with the event. ``stream_exiting`` makes the
+    loop-or-exit decision after the stream ends and stashes whatever the
+    continuation needs (owned tool specs) on the state.
+    """
+
+    transcript_key: str
+
+    def coerce_transcript(self, value: Any) -> list[Any]: ...
+
+    def convert_pool_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]: ...
+
+    async def open_stream(self, kwargs: dict[str, Any]) -> AsyncIterator[ChunkT]: ...
+
+    def new_stream_state(self) -> StateT: ...
+
+    def new_stream_accumulator(self) -> AccT: ...
+
+    def observe(self, state: StateT, event: ChunkT) -> StreamAction: ...
+
+    def stream_exiting(self, state: StateT, pool: ToolBackend) -> bool: ...
+
+    def terminal_events(self, state: StateT, acc: AccT) -> list[ChunkT]: ...
+
+    def accumulate_stream_usage(self, acc: AccT, state: StateT) -> None: ...
+
+    async def advance_stream_transcript(
+        self,
+        transcript: list[Any],
+        state: StateT,
+        pool: ToolBackend,
+    ) -> None: ...
+
+
+def _prepare(
+    strategy_key: str,
+    coerce: Callable[[Any], list[Any]],
+    convert: Callable[[list[dict[str, Any]]], list[dict[str, Any]]],
+    completion_kwargs: dict[str, Any],
+    pool: ToolBackend,
+    *,
+    drop_stream: bool,
+) -> tuple[list[Any], list[dict[str, Any]], dict[str, Any]]:
+    """Split ``completion_kwargs`` into (transcript, merged tools, base kwargs)."""
+    transcript = coerce(completion_kwargs.get(strategy_key))
+    user_tools = list(completion_kwargs.get("tools") or [])
+    merged_tools = user_tools + convert(pool.openai_tools)
+    excluded = {strategy_key, "tools", "stream"} if drop_stream else {strategy_key, "tools"}
+    base = {k: v for k, v in completion_kwargs.items() if k not in excluded}
+    return transcript, merged_tools, base
+
+
+def _stream_scope(stream: AsyncIterator[Any]) -> AbstractAsyncContextManager[Any]:
+    """Close ``stream`` on scope exit when it supports ``aclose``.
+
+    The streaming loops stop consuming the upstream stream as soon as they see
+    the format's terminal event; without an explicit close, the async
+    generator (and any underlying connection) would be left to garbage
+    collection. The scope also closes the upstream when the downstream
+    consumer closes the tool-loop generator mid-stream.
+    """
+    if hasattr(stream, "aclose"):
+        return aclosing(cast(Any, stream))
+    return nullcontext(stream)
+
+
+async def run_tool_loop(
+    *,
+    strategy: ToolLoopStrategy[ResultT, Any],
+    completion_kwargs: dict[str, Any],
+    pool: ToolBackend,
+    max_iterations: int,
+    on_first_response: Callable[[], None] | None = None,
+) -> ResultT:
+    """Non-streaming tool loop, generic over the wire format.
+
+    Each iteration calls the provider through the strategy, accumulates usage,
+    and then walks the exit ladder:
+
+    1. ``exit_before_split``: format-level terminal check that runs before any
+       tool accounting (chat: no choices, or finish_reason is not
+       ``tool_calls``). When it fires, nothing is executed even if the result
+       carries gateway-owned calls.
+    2. Foreign tools present: mixed batches execute the owned subset for its
+       side effects and filter it from the returned result, so the caller only
+       sees calls it can dispatch itself. Note the ordering divergence kept
+       from the pre-engine modules: messages/responses run this branch before
+       any stop-reason check, so a mixed batch executes owned calls even when
+       the model stopped for another reason, while chat never reaches this
+       branch unless finish_reason was ``tool_calls``.
+    3. Nothing owned, or ``exit_after_split`` (messages: stop_reason is not
+       ``tool_use``): return the result as the final answer.
+    4. Otherwise execute the owned calls, extend the transcript, and iterate.
+
+    ``on_first_response`` is invoked once, right after the first upstream call
+    returns successfully. Callers use it to lock in the chosen provider: once
+    the model has produced any assistant output, the conversation state is
+    provider-specific and subsequent failures must not silently swap
+    providers. See the hybrid-mode attempt loops in the route modules.
+    """
+    transcript, merged_tools, base = _prepare(
+        strategy.transcript_key,
+        strategy.coerce_transcript,
+        strategy.convert_pool_tools,
+        completion_kwargs,
+        pool,
+        drop_stream=True,
+    )
+    acc = strategy.new_usage_accumulator()
+    first_response_signaled = False
+
+    for _ in range(max_iterations):
+        kwargs: dict[str, Any] = {**base, strategy.transcript_key: transcript, "stream": False}
+        if merged_tools:
+            kwargs["tools"] = merged_tools
+
+        result = await strategy.call(kwargs)
+        if not first_response_signaled:
+            first_response_signaled = True
+            if on_first_response is not None:
+                on_first_response()
+        strategy.accumulate_usage(acc, result)
+
+        if strategy.exit_before_split(result):
+            strategy.fold_usage(result, acc)
+            return result
+
+        owned, has_foreign = strategy.split_owned(result, pool)
+        if has_foreign:
+            if owned:
+                await strategy.execute_owned(pool, owned)
+                strategy.filter_owned(result, owned, pool)
+            strategy.fold_usage(result, acc)
+            return result
+        if not owned or strategy.exit_after_split(result):
+            strategy.fold_usage(result, acc)
+            return result
+
+        await strategy.advance_transcript(transcript, result, owned, pool)
+
+    raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")
+
+
+async def run_tool_loop_stream(
+    *,
+    strategy: StreamToolLoopStrategy[ChunkT, Any, Any],
+    completion_kwargs: dict[str, Any],
+    pool: ToolBackend,
+    max_iterations: int,
+) -> AsyncIterator[ChunkT]:
+    """Streaming tool loop, generic over the wire format.
+
+    Every upstream event flows through ``strategy.observe``, which does the
+    format's bookkeeping and decides whether the event is forwarded downstream
+    or deferred as a pending terminal. After each upstream stream ends,
+    ``strategy.stream_exiting`` decides between exiting (the deferred terminal
+    events are forwarded, with cumulative usage folded in where the format
+    supports it) and continuing (the terminal events are dropped, their usage
+    accumulated, the owned calls executed, and the next round dispatched).
+
+    The upstream stream is closed when the loop stops consuming it early;
+    see :func:`_stream_scope`.
+    """
+    transcript, merged_tools, base = _prepare(
+        strategy.transcript_key,
+        strategy.coerce_transcript,
+        strategy.convert_pool_tools,
+        completion_kwargs,
+        pool,
+        drop_stream=False,
+    )
+    base["stream"] = True
+    acc = strategy.new_stream_accumulator()
+
+    for _ in range(max_iterations):
+        kwargs: dict[str, Any] = {**base, strategy.transcript_key: transcript}
+        if merged_tools:
+            kwargs["tools"] = merged_tools
+
+        stream = await strategy.open_stream(kwargs)
+        state = strategy.new_stream_state()
+
+        async with _stream_scope(stream):
+            async for event in stream:
+                action = strategy.observe(state, event)
+                if action is StreamAction.BREAK:
+                    break
+                if action is StreamAction.FORWARD:
+                    yield event
+
+        if strategy.stream_exiting(state, pool):
+            for terminal in strategy.terminal_events(state, acc):
+                yield terminal
+            return
+
+        strategy.accumulate_stream_usage(acc, state)
+        await strategy.advance_stream_transcript(transcript, state, pool)
+
+    raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")

--- a/src/gateway/services/_tool_loop.py
+++ b/src/gateway/services/_tool_loop.py
@@ -20,7 +20,7 @@ tests can keep monkeypatching them there.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
 from contextlib import AbstractAsyncContextManager, aclosing, nullcontext
 from enum import Enum, auto
 from typing import Any, Generic, Protocol, TypeVar, cast
@@ -266,7 +266,7 @@ async def run_tool_loop_stream(
     completion_kwargs: dict[str, Any],
     pool: ToolBackend,
     max_iterations: int,
-) -> AsyncIterator[ChunkT]:
+) -> AsyncGenerator[ChunkT, None]:
     """Streaming tool loop, generic over the wire format.
 
     Every upstream event flows through ``strategy.observe``, which does the

--- a/src/gateway/services/mcp_loop.py
+++ b/src/gateway/services/mcp_loop.py
@@ -1,4 +1,4 @@
-"""Streaming-aware MCP tool-use loop.
+"""Streaming-aware MCP tool-use loop (OpenAI chat-completions format).
 
 Wraps one or more `acompletion` calls so that when the model emits tool_calls
 for tools owned by the MCPClientPool, the loop executes them against the MCP
@@ -9,19 +9,31 @@ re-calls the provider for the next iteration. Tool calls for user-supplied
 Both streaming and non-streaming variants are provided. The streaming variant
 yields `ChatCompletionChunk` objects across the entire loop as a single
 `AsyncIterator`, which can be fed into the existing `streaming_generator`.
+
+The format-agnostic loop skeleton lives in
+:mod:`gateway.services._tool_loop`; this module supplies the chat-completions
+strategy (wire-shape helpers, exit predicates, usage folding) and the public
+wrappers the routes call.
 """
 
 from __future__ import annotations
 
 import json
 from collections.abc import AsyncIterator, Callable
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any
 
 from any_llm import acompletion
 from any_llm.types.completion import PromptTokensDetails
 
 from gateway.core.env import otari_env
 from gateway.log_config import logger
+from gateway.services._tool_loop import (
+    MaxToolIterationsExceeded,
+    StreamAction,
+    ToolBackend,
+    run_tool_loop,
+    run_tool_loop_stream,
+)
 
 if TYPE_CHECKING:
     from any_llm.types.completion import ChatCompletion, ChatCompletionChunk
@@ -30,21 +42,16 @@ MAX_TOOL_ITERATIONS_CAP = 25
 DEFAULT_MAX_TOOL_ITERATIONS = 10
 
 
-class ToolBackend(Protocol):
-    """Subset of the tool-backend surface the loop drives.
-
-    Structurally implemented by ``MCPClientPool``, ``SandboxBackend``, and
-    ``WebSearchBackend`` — each exposes the same three members the loop needs to
-    advertise tools, decide ownership, and execute a call. Widening ``pool`` to
-    this Protocol lets the routes pass any of those backends without casts.
-    """
-
-    @property
-    def openai_tools(self) -> list[dict[str, Any]]: ...
-
-    def owns_tool(self, name: str) -> bool: ...
-
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str: ...
+__all__ = [
+    "DEFAULT_MAX_TOOL_ITERATIONS",
+    "MAX_TOOL_ITERATIONS_CAP",
+    "PURPOSE_HINT_HEADER",
+    "MaxToolIterationsExceeded",
+    "ToolBackend",
+    "inject_purpose_hints",
+    "mcp_tool_loop",
+    "mcp_tool_loop_stream",
+]
 
 
 # Lead-in for the per-source purpose-hint block we prepend to the system message.
@@ -53,10 +60,6 @@ class ToolBackend(Protocol):
 # model families (open-weight models in particular benefit from more directive
 # language).
 PURPOSE_HINT_HEADER = "You have access to the following tools:"
-
-
-class MaxToolIterationsExceeded(Exception):
-    """Raised when the loop fails to reach a non-tool-call finish in N rounds."""
 
 
 def inject_purpose_hints(
@@ -128,12 +131,12 @@ async def _execute_mcp_calls(pool: ToolBackend, mcp_calls: list[dict[str, Any]])
     """Run each MCP tool call and return the resulting tool-role messages.
 
     Tool failures (network errors, server errors, schema mismatches, MCP-specific
-    or httpx-level transport errors) are converted to a ``[tool error] …`` message
-    so the model can recover. Only cancellation/interrupt-class exceptions
-    (``asyncio.CancelledError``, ``KeyboardInterrupt``) escape — they inherit
-    from ``BaseException`` and never reach the ``Exception`` clause. That's the
-    standard idiom for "treat tool failures as recoverable, let cancellation
-    propagate".
+    or httpx-level transport errors) are converted to a ``[tool error] ...``
+    message so the model can recover. Only cancellation/interrupt-class
+    exceptions (``asyncio.CancelledError``, ``KeyboardInterrupt``) escape; they
+    inherit from ``BaseException`` and never reach the ``Exception`` clause.
+    That's the standard idiom for "treat tool failures as recoverable, let
+    cancellation propagate".
     """
     out: list[dict[str, Any]] = []
     for tc in mcp_calls:
@@ -149,190 +152,6 @@ async def _execute_mcp_calls(pool: ToolBackend, mcp_calls: list[dict[str, Any]])
             text = f"[tool error] {exc}"
         out.append({"role": "tool", "tool_call_id": tc["id"] or "", "content": text})
     return out
-
-
-async def mcp_tool_loop_stream(
-    *,
-    completion_kwargs: dict[str, Any],
-    pool: ToolBackend,
-    max_iterations: int,
-) -> AsyncIterator[ChatCompletionChunk]:
-    """Yield chunks across multiple `acompletion(stream=True)` calls, with MCP execution between rounds.
-
-    Tool-call deltas from intermediate iterations are streamed straight through to the
-    caller (so clients that want to render "thinking" still get those bytes), but the
-    *terminal* chunk of each intermediate iteration — the one carrying
-    ``finish_reason="tool_calls"`` — is buffered and dropped if the loop is going to
-    iterate again. Forwarding that chunk would tell an OpenAI-compatible client "this
-    is the final answer", and most SDKs stop reading at that point; subsequent
-    iterations' content would be silently truncated.
-
-    The terminal chunk is forwarded in three cases:
-      * the iteration ended with a non-``tool_calls`` finish_reason (e.g. ``stop``),
-      * the model produced foreign tool_calls (caller needs to dispatch them), or
-      * the model produced no MCP-owned calls at all (loop exits, terminal goes through).
-    """
-    messages = list(completion_kwargs.get("messages") or [])
-    user_tools = list(completion_kwargs.get("tools") or [])
-    merged_tools = user_tools + pool.openai_tools
-
-    base = {k: v for k, v in completion_kwargs.items() if k not in {"messages", "tools"}}
-    base["stream"] = True
-
-    for _ in range(max_iterations):
-        kwargs: dict[str, Any] = {**base, "messages": messages}
-        if merged_tools:
-            kwargs["tools"] = merged_tools
-
-        stream: AsyncIterator[ChatCompletionChunk] = await acompletion(**kwargs)  # type: ignore[assignment]
-        slots: dict[int, dict[str, Any]] = {}
-        finish_reason: str | None = None
-        pending_terminal: ChatCompletionChunk | None = None
-
-        async for chunk in stream:
-            chunk_is_terminal = False
-            if chunk.choices:
-                choice = chunk.choices[0]
-                delta = getattr(choice, "delta", None)
-                if delta is not None and getattr(delta, "tool_calls", None):
-                    _accumulate_tool_call_deltas(slots, delta.tool_calls)
-                if choice.finish_reason:
-                    # Sticky-tool-calls: a trailing ``stop`` chunk from
-                    # Anthropic must not override ``tool_calls`` we've
-                    # already seen on this same iteration.
-                    if not (finish_reason == "tool_calls" and choice.finish_reason != "tool_calls"):
-                        finish_reason = choice.finish_reason
-                    chunk_is_terminal = True
-            if chunk_is_terminal:
-                pending_terminal = chunk
-                continue
-            yield chunk
-
-        if finish_reason != "tool_calls":
-            if pending_terminal is not None:
-                yield pending_terminal
-            return
-
-        tool_calls = _finalize_tool_calls(slots)
-        mcp_calls, has_foreign = _execute_split(tool_calls, pool)
-        if has_foreign or not mcp_calls:
-            # Mixed (has_foreign with mcp_calls) is handled the same as
-            # all-foreign here: the terminal chunk is forwarded so the
-            # client sees the full tool_calls set, and any MCP-owned calls
-            # in a mixed batch are left for a follow-up turn (the
-            # non-streaming variant filters them out; rewriting deltas
-            # mid-stream is too invasive to do here).
-            if pending_terminal is not None:
-                yield pending_terminal
-            return
-
-        # All-MCP: silently drop the terminal so the client doesn't think
-        # this iteration's response was the final answer.
-        messages.append({"role": "assistant", "tool_calls": mcp_calls})
-        messages.extend(await _execute_mcp_calls(pool, mcp_calls))
-
-    raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")
-
-
-async def mcp_tool_loop(
-    *,
-    completion_kwargs: dict[str, Any],
-    pool: ToolBackend,
-    max_iterations: int,
-    on_first_response: Callable[[], None] | None = None,
-) -> ChatCompletion:
-    """Non-streaming variant. Accumulates usage across iterations into the returned completion.
-
-    ``on_first_response`` is invoked exactly once, right after the first
-    upstream ``acompletion`` call returns successfully. Callers use it to lock
-    in the chosen provider — once the model has produced *any* assistant
-    message, the conversation state is provider-specific and subsequent
-    failures must not silently swap providers. See the hybrid-mode attempt
-    loop in :mod:`gateway.api.routes.chat` for the consumer.
-    """
-    messages = list(completion_kwargs.get("messages") or [])
-    user_tools = list(completion_kwargs.get("tools") or [])
-    merged_tools = user_tools + pool.openai_tools
-
-    base = {k: v for k, v in completion_kwargs.items() if k not in {"messages", "tools", "stream"}}
-
-    acc_prompt = 0
-    acc_completion = 0
-    acc_cache_read = 0
-    first_response_signaled = False
-
-    for _ in range(max_iterations):
-        kwargs: dict[str, Any] = {**base, "messages": messages, "stream": False}
-        if merged_tools:
-            kwargs["tools"] = merged_tools
-
-        completion: ChatCompletion = await acompletion(**kwargs)  # type: ignore[assignment]
-        if not first_response_signaled:
-            first_response_signaled = True
-            if on_first_response is not None:
-                on_first_response()
-        if completion.usage:
-            acc_prompt += completion.usage.prompt_tokens or 0
-            acc_completion += completion.usage.completion_tokens or 0
-            details = completion.usage.prompt_tokens_details
-            if details is not None:
-                acc_cache_read += details.cached_tokens or 0
-
-        if not completion.choices:
-            _fold_usage(completion, acc_prompt, acc_completion, acc_cache_read)
-            return completion
-
-        choice = completion.choices[0]
-        if choice.finish_reason != "tool_calls":
-            _fold_usage(completion, acc_prompt, acc_completion, acc_cache_read)
-            return completion
-
-        sdk_calls = choice.message.tool_calls or []
-        # Duck-type the SDK tool-call: any object with a `.function` attribute is a
-        # function tool-call. We avoid `isinstance` here because `acompletion`'s
-        # return type uses the OpenAI SDK's class, while any_llm exposes a
-        # same-named but distinct class alias.
-        tool_calls = [
-            {
-                "id": tc.id,
-                "type": "function",
-                "function": {"name": tc.function.name, "arguments": tc.function.arguments},
-            }
-            for tc in sdk_calls
-            if hasattr(tc, "function")
-        ]
-        mcp_calls, has_foreign = _execute_split(tool_calls, pool)
-        if has_foreign:
-            # Mixed batch: execute the MCP-owned subset internally so its
-            # work isn't wasted, then filter those calls out of the returned
-            # completion so the caller only sees tool_calls it can itself
-            # dispatch. The conversation continues client-side; if the
-            # caller wants to keep using the gateway's MCP tools they'll
-            # send the foreign-tool results back on the next request.
-            if mcp_calls:
-                await _execute_mcp_calls(pool, mcp_calls)
-                foreign_sdk_calls = [
-                    tc for tc in sdk_calls if hasattr(tc, "function") and not pool.owns_tool(tc.function.name)
-                ]
-                try:
-                    choice.message.tool_calls = foreign_sdk_calls or None
-                except (AttributeError, TypeError):
-                    # If the SDK model is frozen, fall back to leaving the
-                    # original list. Cleaner UX requires SDK mutability.
-                    logger.warning(
-                        "MCP-mixed: could not filter tool_calls on response; client will see MCP calls "
-                        "the gateway already executed (no-op on the client side).",
-                    )
-            _fold_usage(completion, acc_prompt, acc_completion, acc_cache_read)
-            return completion
-        if not mcp_calls:
-            _fold_usage(completion, acc_prompt, acc_completion, acc_cache_read)
-            return completion
-
-        messages.append({"role": "assistant", "tool_calls": mcp_calls})
-        messages.extend(await _execute_mcp_calls(pool, mcp_calls))
-
-    raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")
 
 
 def _fold_usage(
@@ -357,3 +176,226 @@ def _fold_usage(
         # The final iteration carried no prompt_tokens_details, but an earlier
         # one did; create the sub-object so the accumulated count is not lost.
         completion.usage.prompt_tokens_details = PromptTokensDetails(cached_tokens=cache_read_total)
+
+
+class _ChatStreamState:
+    """Per-iteration bookkeeping for the chat streaming loop."""
+
+    def __init__(self) -> None:
+        self.slots: dict[int, dict[str, Any]] = {}
+        self.finish_reason: str | None = None
+        self.pending_terminal: ChatCompletionChunk | None = None
+        self.mcp_calls: list[dict[str, Any]] = []
+
+
+class _ChatToolLoopStrategy:
+    """Chat-completions strategy for the generic tool loop.
+
+    ``acompletion`` is resolved as a module global at call time so tests can
+    monkeypatch ``gateway.services.mcp_loop.acompletion``.
+    """
+
+    transcript_key = "messages"
+
+    def coerce_transcript(self, value: Any) -> list[Any]:
+        return list(value or [])
+
+    def convert_pool_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return tools
+
+    # ---- non-streaming hooks ----
+
+    async def call(self, kwargs: dict[str, Any]) -> ChatCompletion:
+        completion: ChatCompletion = await acompletion(**kwargs)  # type: ignore[assignment]
+        return completion
+
+    def new_usage_accumulator(self) -> dict[str, int]:
+        return {"prompt": 0, "completion": 0, "cache_read": 0}
+
+    def accumulate_usage(self, acc: dict[str, int], result: ChatCompletion) -> None:
+        if result.usage:
+            acc["prompt"] += result.usage.prompt_tokens or 0
+            acc["completion"] += result.usage.completion_tokens or 0
+            details = result.usage.prompt_tokens_details
+            if details is not None:
+                acc["cache_read"] += details.cached_tokens or 0
+
+    def fold_usage(self, result: ChatCompletion, acc: dict[str, int]) -> None:
+        _fold_usage(result, acc["prompt"], acc["completion"], acc["cache_read"])
+
+    def exit_before_split(self, result: ChatCompletion) -> bool:
+        return not result.choices or result.choices[0].finish_reason != "tool_calls"
+
+    def split_owned(self, result: ChatCompletion, pool: ToolBackend) -> tuple[list[Any], bool]:
+        sdk_calls = result.choices[0].message.tool_calls or []
+        # Duck-type the SDK tool-call: any object with a `.function` attribute is a
+        # function tool-call. We avoid `isinstance` here because `acompletion`'s
+        # return type uses the OpenAI SDK's class, while any_llm exposes a
+        # same-named but distinct class alias.
+        tool_calls = [
+            {
+                "id": tc.id,
+                "type": "function",
+                "function": {"name": tc.function.name, "arguments": tc.function.arguments},
+            }
+            for tc in sdk_calls
+            if hasattr(tc, "function")
+        ]
+        return _execute_split(tool_calls, pool)
+
+    def exit_after_split(self, result: ChatCompletion) -> bool:
+        return False
+
+    async def execute_owned(self, pool: ToolBackend, owned: list[Any]) -> list[dict[str, Any]]:
+        return await _execute_mcp_calls(pool, owned)
+
+    def filter_owned(self, result: ChatCompletion, owned: list[Any], pool: ToolBackend) -> None:
+        # Mixed batch: the MCP-owned subset was executed internally so its
+        # work isn't wasted; filter those calls out of the returned completion
+        # so the caller only sees tool_calls it can itself dispatch. The
+        # conversation continues client-side; if the caller wants to keep
+        # using the gateway's MCP tools they'll send the foreign-tool results
+        # back on the next request.
+        choice = result.choices[0]
+        sdk_calls = choice.message.tool_calls or []
+        foreign_sdk_calls = [
+            tc for tc in sdk_calls if hasattr(tc, "function") and not pool.owns_tool(tc.function.name)
+        ]
+        try:
+            choice.message.tool_calls = foreign_sdk_calls or None
+        except (AttributeError, TypeError):
+            # If the SDK model is frozen, fall back to leaving the
+            # original list. Cleaner UX requires SDK mutability.
+            logger.warning(
+                "MCP-mixed: could not filter tool_calls on response; client will see MCP calls "
+                "the gateway already executed (no-op on the client side).",
+            )
+
+    async def advance_transcript(
+        self,
+        transcript: list[Any],
+        result: ChatCompletion,
+        owned: list[Any],
+        pool: ToolBackend,
+    ) -> None:
+        transcript.append({"role": "assistant", "tool_calls": owned})
+        transcript.extend(await _execute_mcp_calls(pool, owned))
+
+    # ---- streaming hooks ----
+
+    async def open_stream(self, kwargs: dict[str, Any]) -> AsyncIterator[ChatCompletionChunk]:
+        stream: AsyncIterator[ChatCompletionChunk] = await acompletion(**kwargs)  # type: ignore[assignment]
+        return stream
+
+    def new_stream_state(self) -> _ChatStreamState:
+        return _ChatStreamState()
+
+    def new_stream_accumulator(self) -> None:
+        # Chat streaming does not fold cumulative usage into the terminal
+        # chunk (parity with the pre-engine behavior); streaming usage
+        # accounting happens downstream in `streaming_generator`.
+        return None
+
+    def observe(self, state: _ChatStreamState, event: ChatCompletionChunk) -> StreamAction:
+        chunk_is_terminal = False
+        if event.choices:
+            choice = event.choices[0]
+            delta = getattr(choice, "delta", None)
+            if delta is not None and getattr(delta, "tool_calls", None):
+                _accumulate_tool_call_deltas(state.slots, delta.tool_calls)
+            if choice.finish_reason:
+                # Sticky-tool-calls: a trailing ``stop`` chunk from
+                # Anthropic must not override ``tool_calls`` we've
+                # already seen on this same iteration.
+                if not (state.finish_reason == "tool_calls" and choice.finish_reason != "tool_calls"):
+                    state.finish_reason = choice.finish_reason
+                chunk_is_terminal = True
+        if chunk_is_terminal:
+            state.pending_terminal = event
+            return StreamAction.DEFER
+        return StreamAction.FORWARD
+
+    def stream_exiting(self, state: _ChatStreamState, pool: ToolBackend) -> bool:
+        if state.finish_reason != "tool_calls":
+            return True
+        tool_calls = _finalize_tool_calls(state.slots)
+        state.mcp_calls, has_foreign = _execute_split(tool_calls, pool)
+        # Mixed (has_foreign with mcp_calls) is handled the same as
+        # all-foreign here: the terminal chunk is forwarded so the
+        # client sees the full tool_calls set, and any MCP-owned calls
+        # in a mixed batch are left for a follow-up turn (the
+        # non-streaming variant filters them out; rewriting deltas
+        # mid-stream is too invasive to do here).
+        return has_foreign or not state.mcp_calls
+
+    def terminal_events(self, state: _ChatStreamState, acc: None) -> list[ChatCompletionChunk]:
+        return [state.pending_terminal] if state.pending_terminal is not None else []
+
+    def accumulate_stream_usage(self, acc: None, state: _ChatStreamState) -> None:
+        return None
+
+    async def advance_stream_transcript(
+        self,
+        transcript: list[Any],
+        state: _ChatStreamState,
+        pool: ToolBackend,
+    ) -> None:
+        # All-MCP: the terminal chunk was silently dropped so the client
+        # doesn't think this iteration's response was the final answer.
+        transcript.append({"role": "assistant", "tool_calls": state.mcp_calls})
+        transcript.extend(await _execute_mcp_calls(pool, state.mcp_calls))
+
+
+_CHAT_STRATEGY = _ChatToolLoopStrategy()
+
+
+async def mcp_tool_loop_stream(
+    *,
+    completion_kwargs: dict[str, Any],
+    pool: ToolBackend,
+    max_iterations: int,
+) -> AsyncIterator[ChatCompletionChunk]:
+    """Yield chunks across multiple `acompletion(stream=True)` calls, with MCP execution between rounds.
+
+    Tool-call deltas from intermediate iterations are streamed straight through to the
+    caller (so clients that want to render "thinking" still get those bytes), but the
+    *terminal* chunk of each intermediate iteration, the one carrying
+    ``finish_reason="tool_calls"``, is buffered and dropped if the loop is going to
+    iterate again. Forwarding that chunk would tell an OpenAI-compatible client "this
+    is the final answer", and most SDKs stop reading at that point; subsequent
+    iterations' content would be silently truncated.
+
+    The terminal chunk is forwarded in three cases:
+      * the iteration ended with a non-``tool_calls`` finish_reason (e.g. ``stop``),
+      * the model produced foreign tool_calls (caller needs to dispatch them), or
+      * the model produced no MCP-owned calls at all (loop exits, terminal goes through).
+    """
+    async for chunk in run_tool_loop_stream(
+        strategy=_CHAT_STRATEGY,
+        completion_kwargs=completion_kwargs,
+        pool=pool,
+        max_iterations=max_iterations,
+    ):
+        yield chunk
+
+
+async def mcp_tool_loop(
+    *,
+    completion_kwargs: dict[str, Any],
+    pool: ToolBackend,
+    max_iterations: int,
+    on_first_response: Callable[[], None] | None = None,
+) -> ChatCompletion:
+    """Non-streaming variant. Accumulates usage across iterations into the returned completion.
+
+    ``on_first_response`` follows the provider lock-in contract documented on
+    :func:`gateway.services._tool_loop.run_tool_loop`; the hybrid-mode attempt
+    loop in :mod:`gateway.api.routes.chat` is the consumer.
+    """
+    return await run_tool_loop(
+        strategy=_CHAT_STRATEGY,
+        completion_kwargs=completion_kwargs,
+        pool=pool,
+        max_iterations=max_iterations,
+        on_first_response=on_first_response,
+    )

--- a/src/gateway/services/mcp_loop.py
+++ b/src/gateway/services/mcp_loop.py
@@ -19,7 +19,8 @@ wrappers the routes call.
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
+from contextlib import aclosing
 from typing import TYPE_CHECKING, Any
 
 from any_llm import acompletion
@@ -354,7 +355,7 @@ async def mcp_tool_loop_stream(
     completion_kwargs: dict[str, Any],
     pool: ToolBackend,
     max_iterations: int,
-) -> AsyncIterator[ChatCompletionChunk]:
+) -> AsyncGenerator[ChatCompletionChunk, None]:
     """Yield chunks across multiple `acompletion(stream=True)` calls, with MCP execution between rounds.
 
     Tool-call deltas from intermediate iterations are streamed straight through to the
@@ -370,13 +371,19 @@ async def mcp_tool_loop_stream(
       * the model produced foreign tool_calls (caller needs to dispatch them), or
       * the model produced no MCP-owned calls at all (loop exits, terminal goes through).
     """
-    async for chunk in run_tool_loop_stream(
-        strategy=_CHAT_STRATEGY,
-        completion_kwargs=completion_kwargs,
-        pool=pool,
-        max_iterations=max_iterations,
-    ):
-        yield chunk
+    # aclosing makes downstream closes (client disconnect) propagate to the
+    # engine generator, and through it to the upstream provider stream,
+    # instead of waiting for event-loop async-generator finalization.
+    async with aclosing(
+        run_tool_loop_stream(
+            strategy=_CHAT_STRATEGY,
+            completion_kwargs=completion_kwargs,
+            pool=pool,
+            max_iterations=max_iterations,
+        )
+    ) as inner:
+        async for chunk in inner:
+            yield chunk
 
 
 async def mcp_tool_loop(

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -15,7 +15,8 @@ The duck-typed pool interface (``owns_tool`` / ``call_tool`` /
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
+from contextlib import aclosing
 from typing import TYPE_CHECKING, Any
 
 from any_llm import amessages
@@ -418,7 +419,7 @@ async def anthropic_tool_loop_stream(
     completion_kwargs: dict[str, Any],
     pool: ToolBackend,
     max_iterations: int,
-) -> AsyncIterator[MessageStreamEvent]:
+) -> AsyncGenerator[MessageStreamEvent, None]:
     """Streaming Anthropic Messages tool-use loop.
 
     Forwards every Anthropic event downstream **except** the terminal
@@ -444,10 +445,16 @@ async def anthropic_tool_loop_stream(
     needed because ``amessages`` produces a fresh stream; the next call's
     natural ``message_start`` arrives downstream as if nothing had happened.
     """
-    async for event in run_tool_loop_stream(
-        strategy=_MESSAGES_STRATEGY,
-        completion_kwargs=completion_kwargs,
-        pool=pool,
-        max_iterations=max_iterations,
-    ):
-        yield event
+    # aclosing makes downstream closes (client disconnect) propagate to the
+    # engine generator, and through it to the upstream provider stream,
+    # instead of waiting for event-loop async-generator finalization.
+    async with aclosing(
+        run_tool_loop_stream(
+            strategy=_MESSAGES_STRATEGY,
+            completion_kwargs=completion_kwargs,
+            pool=pool,
+            max_iterations=max_iterations,
+        )
+    ) as inner:
+        async for event in inner:
+            yield event

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -4,6 +4,9 @@ Mirrors :mod:`gateway.services.mcp_loop` but speaks the Anthropic wire shape:
 ``content`` blocks instead of ``tool_calls``, ``tool_use`` / ``tool_result``
 blocks, ``stop_reason == "tool_use"`` as the round-continuation signal.
 
+The loop skeleton itself lives in :mod:`gateway.services._tool_loop`; this
+module supplies the Anthropic strategy and thin public wrappers.
+
 The duck-typed pool interface (``owns_tool`` / ``call_tool`` /
 ``openai_tools`` / ``purpose_hints``) is reused unchanged; the
 ``openai_tools`` shape is converted at the boundary in :mod:`tool_format`.
@@ -18,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 from any_llm import amessages
 
 from gateway.log_config import logger
+from gateway.services._tool_loop import StreamAction, run_tool_loop, run_tool_loop_stream
 from gateway.services.mcp_loop import (
     DEFAULT_MAX_TOOL_ITERATIONS,
     MAX_TOOL_ITERATIONS_CAP,
@@ -71,9 +75,9 @@ async def _execute_tool_uses(
 ) -> list[dict[str, Any]]:
     """Run each owned tool_use block and return the Anthropic tool_result blocks.
 
-    Tool failures convert to a ``[tool error] …`` string in the result so the
+    Tool failures convert to a ``[tool error] ...`` string in the result so the
     model can recover. Only cancellation-class exceptions
-    (``asyncio.CancelledError``, ``KeyboardInterrupt``) escape — they inherit
+    (``asyncio.CancelledError``, ``KeyboardInterrupt``) escape; they inherit
     from ``BaseException`` and skip the ``Exception`` clause. Same idiom as
     :func:`gateway.services.mcp_loop._execute_mcp_calls`.
     """
@@ -92,7 +96,7 @@ def _content_to_dicts(content: list[Any]) -> list[dict[str, Any]]:
     """Serialize a list of Anthropic content blocks back to wire shape.
 
     The model returned them as pydantic objects (TextBlock, ToolUseBlock,
-    ThinkingBlock, …); when we feed them back as an assistant message on the
+    ThinkingBlock, ...); when we feed them back as an assistant message on the
     next turn, Anthropic expects plain dicts.
     """
     out: list[dict[str, Any]] = []
@@ -108,98 +112,6 @@ def _content_to_dicts(content: list[Any]) -> list[dict[str, Any]]:
     return out
 
 
-async def anthropic_tool_loop(
-    *,
-    completion_kwargs: dict[str, Any],
-    pool: ToolBackend,
-    max_iterations: int,
-    on_first_response: Callable[[], None] | None = None,
-) -> MessageResponse:
-    """Non-streaming Anthropic Messages tool-use loop.
-
-    Each iteration calls ``amessages``, walks the response's content blocks for
-    ``tool_use`` entries, and if any are gateway-owned, executes them and
-    appends the assistant + tool_result messages for the next round.
-
-    Loop terminates when:
-      * the response has no ``tool_use`` blocks (final answer);
-      * ``stop_reason != "tool_use"`` (model decided to stop);
-      * the response contains foreign ``tool_use`` blocks — those are returned
-        to the caller for client-side dispatch. If the batch is mixed
-        (owned + foreign), the owned subset is executed for its side effects
-        but the response is returned with the owned blocks filtered out so
-        the caller only sees what it can dispatch.
-
-    Accumulates usage across iterations into the returned ``MessageResponse``.
-
-    ``on_first_response`` is invoked exactly once, right after the first
-    upstream ``amessages`` call returns successfully. Mirrors the contract on
-    :func:`gateway.services.mcp_loop.mcp_tool_loop` so hybrid-mode callers
-    can lock in to the chosen provider — once the model has produced any
-    assistant content, the conversation state is provider-specific and
-    subsequent failures must not silently swap providers.
-    """
-    messages = list(completion_kwargs.get("messages") or [])
-    user_tools = list(completion_kwargs.get("tools") or [])
-    merged_tools = user_tools + openai_to_anthropic_tools(pool.openai_tools)
-
-    base = {k: v for k, v in completion_kwargs.items() if k not in {"messages", "tools", "stream"}}
-
-    acc_input = 0
-    acc_output = 0
-    first_response_signaled = False
-
-    for _ in range(max_iterations):
-        kwargs: dict[str, Any] = {**base, "messages": messages, "stream": False}
-        if merged_tools:
-            kwargs["tools"] = merged_tools
-
-        result: MessageResponse = await amessages(**kwargs)  # type: ignore[assignment]
-        if not first_response_signaled:
-            first_response_signaled = True
-            if on_first_response is not None:
-                on_first_response()
-        if result.usage:
-            acc_input += result.usage.input_tokens or 0
-            acc_output += result.usage.output_tokens or 0
-
-        content = list(result.content or [])
-        owned, has_foreign = _split_tool_uses(content, pool)
-
-        if has_foreign:
-            # Mixed batch: execute owned subset for its side effects, then
-            # filter from the returned content so the caller only sees blocks
-            # it can dispatch. Mirrors the chat-completions mixed-batch
-            # handling in mcp_loop._mcp_tool_loop.
-            if owned:
-                await _execute_tool_uses(pool, owned)
-                owned_ids = {b.id for b in owned}
-                try:
-                    result.content = [
-                        b
-                        for b in content
-                        if not (getattr(b, "type", None) == "tool_use" and getattr(b, "id", None) in owned_ids)
-                    ]
-                except (AttributeError, TypeError):
-                    logger.warning(
-                        "Anthropic-mixed: could not filter content on response; client will see tool_use "
-                        "blocks the gateway already executed (no-op on the client side).",
-                    )
-            _fold_usage(result, acc_input, acc_output)
-            return result
-
-        if not owned or result.stop_reason != "tool_use":
-            _fold_usage(result, acc_input, acc_output)
-            return result
-
-        # All-owned: continue the loop. Append the assistant turn (so the model
-        # sees its own tool_use blocks) and a user turn carrying tool_result.
-        messages.append({"role": "assistant", "content": _content_to_dicts(content)})
-        messages.append({"role": "user", "content": await _execute_tool_uses(pool, owned)})
-
-    raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")
-
-
 def _fold_usage(result: MessageResponse, input_total: int, output_total: int) -> None:
     """Replace ``result.usage`` token counts with the loop's running totals.
 
@@ -211,181 +123,6 @@ def _fold_usage(result: MessageResponse, input_total: int, output_total: int) ->
         return
     result.usage.input_tokens = input_total
     result.usage.output_tokens = output_total
-
-
-async def anthropic_tool_loop_stream(
-    *,
-    completion_kwargs: dict[str, Any],
-    pool: ToolBackend,
-    max_iterations: int,
-) -> AsyncIterator[MessageStreamEvent]:
-    """Streaming Anthropic Messages tool-use loop.
-
-    Forwards every Anthropic event downstream **except** the terminal
-    ``message_delta`` / ``message_stop`` of an iteration that's about to
-    continue (a new ``message_start`` after the client thought the message
-    ended would confuse most SDK consumers).
-
-    Per iteration:
-      1. Set ``stream=True`` on ``amessages`` and iterate the event stream.
-      2. Track tool_use content blocks by ``index`` from ``content_block_start``
-         (when ``content_block.type == "tool_use"``). Buffer their
-         ``input_json_delta`` chunks until ``content_block_stop``.
-      3. Yield every event as it arrives (including the tool_use events — the
-         client sees the model's tool intent even mid-loop). Defer
-         ``message_delta`` and ``message_stop`` until we know whether the loop
-         will continue.
-      4. On ``message_stop``: if any buffered tool_use blocks exist AND all
-         owned by the pool, execute them, append messages, drop the terminal
-         events, and continue. If foreign blocks exist OR no tool_use blocks
-         were buffered, forward the terminal events and exit.
-
-    Re-emitting a synthetic ``message_start`` for the next iteration is not
-    needed because ``amessages`` produces a fresh stream — the next call's
-    natural ``message_start`` arrives downstream as if nothing had happened.
-    """
-    messages = list(completion_kwargs.get("messages") or [])
-    user_tools = list(completion_kwargs.get("tools") or [])
-    merged_tools = user_tools + openai_to_anthropic_tools(pool.openai_tools)
-
-    base = {k: v for k, v in completion_kwargs.items() if k not in {"messages", "tools"}}
-    base["stream"] = True
-
-    # Accumulator for output_tokens from dropped intermediate ``message_delta``
-    # events. The final iteration's forwarded ``message_delta`` is modified to
-    # carry the cumulative total so streaming usage reporting downstream sees
-    # the full tool-loop output, not just the final round's tokens.
-    acc_output_tokens = 0
-
-    for _ in range(max_iterations):
-        kwargs: dict[str, Any] = {**base, "messages": messages}
-        if merged_tools:
-            kwargs["tools"] = merged_tools
-
-        stream: AsyncIterator[MessageStreamEvent] = await amessages(**kwargs)  # type: ignore[assignment]
-
-        # All blocks (text, tool_use, thinking, redacted_thinking, …) tracked
-        # by their original ``content_block_start.index`` so the assistant
-        # message we feed back into the next round preserves the model's
-        # original ordering and doesn't silently drop non-text / non-tool_use
-        # block types.
-        blocks_by_index: dict[int, dict[str, Any]] = {}
-        # Per-tool_use JSON-arg buffer, keyed by index. Stored separately from
-        # ``blocks_by_index`` so we don't have to strip an internal field
-        # before serializing the assistant message.
-        tool_use_json_bufs: dict[int, str] = {}
-        stop_reason: str | None = None
-        deferred_terminal: list[MessageStreamEvent] = []
-
-        async for event in stream:
-            event_type = getattr(event, "type", None)
-
-            if event_type == "content_block_start":
-                block = event.content_block  # type: ignore[union-attr]
-                idx = event.index  # type: ignore[union-attr]
-                if hasattr(block, "model_dump"):
-                    blocks_by_index[idx] = block.model_dump(exclude_none=True)
-                else:
-                    blocks_by_index[idx] = dict(block) if isinstance(block, dict) else {}
-                if blocks_by_index[idx].get("type") == "tool_use":
-                    tool_use_json_bufs[idx] = ""
-
-            elif event_type == "content_block_delta":
-                idx = event.index  # type: ignore[union-attr]
-                delta = event.delta  # type: ignore[union-attr]
-                dtype = getattr(delta, "type", None)
-                block_dict = blocks_by_index.get(idx)
-                if block_dict is None:
-                    pass  # delta for an unknown index — defensive no-op
-                elif dtype == "input_json_delta" and idx in tool_use_json_bufs:
-                    tool_use_json_bufs[idx] += getattr(delta, "partial_json", "") or ""
-                elif dtype == "text_delta":
-                    block_dict["text"] = (block_dict.get("text") or "") + (getattr(delta, "text", "") or "")
-                elif dtype == "thinking_delta":
-                    block_dict["thinking"] = (block_dict.get("thinking") or "") + (
-                        getattr(delta, "thinking", "") or ""
-                    )
-                elif dtype == "signature_delta":
-                    block_dict["signature"] = (block_dict.get("signature") or "") + (
-                        getattr(delta, "signature", "") or ""
-                    )
-
-            elif event_type == "message_delta":
-                stop_reason = getattr(event.delta, "stop_reason", None) or stop_reason  # type: ignore[union-attr]
-                deferred_terminal.append(event)
-                continue
-
-            elif event_type == "message_stop":
-                deferred_terminal.append(event)
-                # Fall through to the post-stream decision below.
-                break
-
-            yield event
-
-        # Decide whether to loop or exit.
-        owned_specs: list[dict[str, Any]] = []
-        has_foreign = False
-        for idx in sorted(blocks_by_index):
-            block_dict = blocks_by_index[idx]
-            if block_dict.get("type") != "tool_use":
-                continue
-            if pool.owns_tool(block_dict.get("name", "")):
-                owned_specs.append({"index": idx, **block_dict})
-            else:
-                has_foreign = True
-
-        # Loop exits when: no tool_use blocks, stop_reason isn't tool_use,
-        # the batch is mixed/foreign, or nothing owned. In all of those cases
-        # the deferred terminal events get forwarded (and the message_delta
-        # is rewritten to carry cumulative output_tokens from any prior
-        # dropped iterations).
-        exiting = not owned_specs or has_foreign or stop_reason != "tool_use"
-        if exiting:
-            for term in deferred_terminal:
-                yield _maybe_fold_message_delta_usage(term, acc_output_tokens)
-            return
-
-        # All-owned: continue the loop. Accumulate this iteration's
-        # output_tokens (from the dropped terminal) for the next final-fold.
-        for term in deferred_terminal:
-            if getattr(term, "type", None) == "message_delta":
-                usage = getattr(term, "usage", None)
-                if usage is not None:
-                    acc_output_tokens += getattr(usage, "output_tokens", 0) or 0
-
-        # Assistant message for the next round — preserve original block
-        # ordering. tool_use blocks pick up the parsed input from their
-        # JSON buffer.
-        assistant_content: list[dict[str, Any]] = []
-        for idx in sorted(blocks_by_index):
-            block_dict = blocks_by_index[idx]
-            if block_dict.get("type") == "tool_use":
-                try:
-                    parsed_input = json.loads(tool_use_json_bufs.get(idx, "") or "{}")
-                except json.JSONDecodeError:
-                    parsed_input = {}
-                block_dict = {**block_dict, "input": parsed_input}
-            assistant_content.append(block_dict)
-
-        # Execute owned tool_use blocks and build tool_result blocks for the
-        # next user message.
-        tool_results: list[dict[str, Any]] = []
-        for spec in owned_specs:
-            try:
-                parsed_input = json.loads(tool_use_json_bufs.get(spec["index"], "") or "{}")
-            except json.JSONDecodeError:
-                parsed_input = {}
-            try:
-                text = await pool.call_tool(spec["name"], parsed_input)
-            except Exception as exc:  # noqa: BLE001 — same tool-error-as-message idiom as the non-stream loop
-                logger.warning("MCP tool %s execution failed: %s", spec["name"], exc)
-                text = f"[tool error] {exc}"
-            tool_results.append({"type": "tool_result", "tool_use_id": spec["id"], "content": text})
-
-        messages.append({"role": "assistant", "content": assistant_content})
-        messages.append({"role": "user", "content": tool_results})
-
-    raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")
 
 
 def _maybe_fold_message_delta_usage(event: Any, acc_output_tokens: int) -> Any:
@@ -408,3 +145,309 @@ def _maybe_fold_message_delta_usage(event: Any, acc_output_tokens: int) -> Any:
         update={"output_tokens": (getattr(usage, "output_tokens", 0) or 0) + acc_output_tokens}
     )
     return event.model_copy(update={"usage": new_usage})
+
+
+class _MessagesStreamState:
+    """Per-iteration bookkeeping for the Anthropic streaming loop.
+
+    All blocks (text, tool_use, thinking, redacted_thinking, ...) are tracked
+    by their original ``content_block_start.index`` so the assistant message
+    fed back into the next round preserves the model's original ordering and
+    doesn't silently drop non-text / non-tool_use block types. The per-tool_use
+    JSON-arg buffer is stored separately so no internal field has to be
+    stripped before serializing the assistant message.
+    """
+
+    def __init__(self) -> None:
+        self.blocks_by_index: dict[int, dict[str, Any]] = {}
+        self.tool_use_json_bufs: dict[int, str] = {}
+        self.stop_reason: str | None = None
+        self.deferred_terminal: list[MessageStreamEvent] = []
+        self.owned_specs: list[dict[str, Any]] = []
+
+
+class _MessagesToolLoopStrategy:
+    """Anthropic Messages strategy for the generic tool loop.
+
+    ``amessages`` is resolved as a module global at call time so tests can
+    monkeypatch ``gateway.services.mcp_loop_messages.amessages``.
+    """
+
+    transcript_key = "messages"
+
+    def coerce_transcript(self, value: Any) -> list[Any]:
+        return list(value or [])
+
+    def convert_pool_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return openai_to_anthropic_tools(tools)
+
+    # ---- non-streaming hooks ----
+
+    async def call(self, kwargs: dict[str, Any]) -> MessageResponse:
+        result: MessageResponse = await amessages(**kwargs)  # type: ignore[assignment]
+        return result
+
+    def new_usage_accumulator(self) -> dict[str, int]:
+        return {"input": 0, "output": 0}
+
+    def accumulate_usage(self, acc: dict[str, int], result: MessageResponse) -> None:
+        if result.usage:
+            acc["input"] += result.usage.input_tokens or 0
+            acc["output"] += result.usage.output_tokens or 0
+
+    def fold_usage(self, result: MessageResponse, acc: dict[str, int]) -> None:
+        _fold_usage(result, acc["input"], acc["output"])
+
+    def exit_before_split(self, result: MessageResponse) -> bool:
+        return False
+
+    def split_owned(self, result: MessageResponse, pool: ToolBackend) -> tuple[list[Any], bool]:
+        return _split_tool_uses(list(result.content or []), pool)
+
+    def exit_after_split(self, result: MessageResponse) -> bool:
+        # The model emitted tool_use blocks but stopped for another reason
+        # (e.g. ``end_turn`` because ``max_tokens`` was hit mid-tool-call):
+        # exit rather than try to execute them.
+        return result.stop_reason != "tool_use"
+
+    async def execute_owned(self, pool: ToolBackend, owned: list[Any]) -> list[dict[str, Any]]:
+        return await _execute_tool_uses(pool, owned)
+
+    def filter_owned(self, result: MessageResponse, owned: list[Any], pool: ToolBackend) -> None:
+        # Mixed batch: the owned subset was executed for its side effects;
+        # filter it from the returned content so the caller only sees blocks
+        # it can dispatch. Mirrors the chat-completions mixed-batch handling.
+        owned_ids = {b.id for b in owned}
+        content = list(result.content or [])
+        try:
+            result.content = [
+                b
+                for b in content
+                if not (getattr(b, "type", None) == "tool_use" and getattr(b, "id", None) in owned_ids)
+            ]
+        except (AttributeError, TypeError):
+            logger.warning(
+                "Anthropic-mixed: could not filter content on response; client will see tool_use "
+                "blocks the gateway already executed (no-op on the client side).",
+            )
+
+    async def advance_transcript(
+        self,
+        transcript: list[Any],
+        result: MessageResponse,
+        owned: list[Any],
+        pool: ToolBackend,
+    ) -> None:
+        # All-owned: continue the loop. Append the assistant turn (so the model
+        # sees its own tool_use blocks) and a user turn carrying tool_result.
+        content = list(result.content or [])
+        transcript.append({"role": "assistant", "content": _content_to_dicts(content)})
+        transcript.append({"role": "user", "content": await _execute_tool_uses(pool, owned)})
+
+    # ---- streaming hooks ----
+
+    async def open_stream(self, kwargs: dict[str, Any]) -> AsyncIterator[MessageStreamEvent]:
+        stream: AsyncIterator[MessageStreamEvent] = await amessages(**kwargs)  # type: ignore[assignment]
+        return stream
+
+    def new_stream_state(self) -> _MessagesStreamState:
+        return _MessagesStreamState()
+
+    def new_stream_accumulator(self) -> dict[str, int]:
+        # output_tokens from dropped intermediate ``message_delta`` events.
+        # The final iteration's forwarded ``message_delta`` is modified to
+        # carry the cumulative total so streaming usage reporting downstream
+        # sees the full tool-loop output, not just the final round's tokens.
+        return {"output_tokens": 0}
+
+    def observe(self, state: _MessagesStreamState, event: MessageStreamEvent) -> StreamAction:
+        event_type = getattr(event, "type", None)
+
+        if event_type == "content_block_start":
+            block = event.content_block  # type: ignore[union-attr]
+            idx = event.index  # type: ignore[union-attr]
+            if hasattr(block, "model_dump"):
+                state.blocks_by_index[idx] = block.model_dump(exclude_none=True)
+            else:
+                state.blocks_by_index[idx] = dict(block) if isinstance(block, dict) else {}
+            if state.blocks_by_index[idx].get("type") == "tool_use":
+                state.tool_use_json_bufs[idx] = ""
+
+        elif event_type == "content_block_delta":
+            idx = event.index  # type: ignore[union-attr]
+            delta = event.delta  # type: ignore[union-attr]
+            dtype = getattr(delta, "type", None)
+            block_dict = state.blocks_by_index.get(idx)
+            if block_dict is None:
+                pass  # delta for an unknown index; defensive no-op
+            elif dtype == "input_json_delta" and idx in state.tool_use_json_bufs:
+                state.tool_use_json_bufs[idx] += getattr(delta, "partial_json", "") or ""
+            elif dtype == "text_delta":
+                block_dict["text"] = (block_dict.get("text") or "") + (getattr(delta, "text", "") or "")
+            elif dtype == "thinking_delta":
+                block_dict["thinking"] = (block_dict.get("thinking") or "") + (
+                    getattr(delta, "thinking", "") or ""
+                )
+            elif dtype == "signature_delta":
+                block_dict["signature"] = (block_dict.get("signature") or "") + (
+                    getattr(delta, "signature", "") or ""
+                )
+
+        elif event_type == "message_delta":
+            state.stop_reason = getattr(event.delta, "stop_reason", None) or state.stop_reason  # type: ignore[union-attr]
+            state.deferred_terminal.append(event)
+            return StreamAction.DEFER
+
+        elif event_type == "message_stop":
+            state.deferred_terminal.append(event)
+            return StreamAction.BREAK
+
+        return StreamAction.FORWARD
+
+    def stream_exiting(self, state: _MessagesStreamState, pool: ToolBackend) -> bool:
+        owned_specs: list[dict[str, Any]] = []
+        has_foreign = False
+        for idx in sorted(state.blocks_by_index):
+            block_dict = state.blocks_by_index[idx]
+            if block_dict.get("type") != "tool_use":
+                continue
+            if pool.owns_tool(block_dict.get("name", "")):
+                owned_specs.append({"index": idx, **block_dict})
+            else:
+                has_foreign = True
+        state.owned_specs = owned_specs
+        # Loop exits when: no tool_use blocks, stop_reason isn't tool_use,
+        # the batch is mixed/foreign, or nothing owned. In all of those cases
+        # the deferred terminal events get forwarded (and the message_delta
+        # is rewritten to carry cumulative output_tokens from any prior
+        # dropped iterations).
+        return not owned_specs or has_foreign or state.stop_reason != "tool_use"
+
+    def terminal_events(self, state: _MessagesStreamState, acc: dict[str, int]) -> list[MessageStreamEvent]:
+        return [_maybe_fold_message_delta_usage(term, acc["output_tokens"]) for term in state.deferred_terminal]
+
+    def accumulate_stream_usage(self, acc: dict[str, int], state: _MessagesStreamState) -> None:
+        # All-owned continuation: fold this iteration's output_tokens (from
+        # the dropped terminal) into the running total for the final fold.
+        for term in state.deferred_terminal:
+            if getattr(term, "type", None) == "message_delta":
+                usage = getattr(term, "usage", None)
+                if usage is not None:
+                    acc["output_tokens"] += getattr(usage, "output_tokens", 0) or 0
+
+    async def advance_stream_transcript(
+        self,
+        transcript: list[Any],
+        state: _MessagesStreamState,
+        pool: ToolBackend,
+    ) -> None:
+        # Assistant message for the next round; preserve original block
+        # ordering. tool_use blocks pick up the parsed input from their
+        # JSON buffer.
+        assistant_content: list[dict[str, Any]] = []
+        for idx in sorted(state.blocks_by_index):
+            block_dict = state.blocks_by_index[idx]
+            if block_dict.get("type") == "tool_use":
+                try:
+                    parsed_input = json.loads(state.tool_use_json_bufs.get(idx, "") or "{}")
+                except json.JSONDecodeError:
+                    parsed_input = {}
+                block_dict = {**block_dict, "input": parsed_input}
+            assistant_content.append(block_dict)
+
+        # Execute owned tool_use blocks and build tool_result blocks for the
+        # next user message.
+        tool_results: list[dict[str, Any]] = []
+        for spec in state.owned_specs:
+            try:
+                parsed_input = json.loads(state.tool_use_json_bufs.get(spec["index"], "") or "{}")
+            except json.JSONDecodeError:
+                parsed_input = {}
+            try:
+                text = await pool.call_tool(spec["name"], parsed_input)
+            except Exception as exc:  # noqa: BLE001 — same tool-error-as-message idiom as the non-stream loop
+                logger.warning("MCP tool %s execution failed: %s", spec["name"], exc)
+                text = f"[tool error] {exc}"
+            tool_results.append({"type": "tool_result", "tool_use_id": spec["id"], "content": text})
+
+        transcript.append({"role": "assistant", "content": assistant_content})
+        transcript.append({"role": "user", "content": tool_results})
+
+
+_MESSAGES_STRATEGY = _MessagesToolLoopStrategy()
+
+
+async def anthropic_tool_loop(
+    *,
+    completion_kwargs: dict[str, Any],
+    pool: ToolBackend,
+    max_iterations: int,
+    on_first_response: Callable[[], None] | None = None,
+) -> MessageResponse:
+    """Non-streaming Anthropic Messages tool-use loop.
+
+    Each iteration calls ``amessages``, walks the response's content blocks for
+    ``tool_use`` entries, and if any are gateway-owned, executes them and
+    appends the assistant + tool_result messages for the next round.
+
+    Loop terminates when:
+      * the response has no ``tool_use`` blocks (final answer);
+      * ``stop_reason != "tool_use"`` (model decided to stop);
+      * the response contains foreign ``tool_use`` blocks, which are returned
+        to the caller for client-side dispatch. If the batch is mixed
+        (owned + foreign), the owned subset is executed for its side effects
+        but the response is returned with the owned blocks filtered out so
+        the caller only sees what it can dispatch.
+
+    Accumulates usage across iterations into the returned ``MessageResponse``.
+
+    ``on_first_response`` follows the provider lock-in contract documented on
+    :func:`gateway.services._tool_loop.run_tool_loop`.
+    """
+    return await run_tool_loop(
+        strategy=_MESSAGES_STRATEGY,
+        completion_kwargs=completion_kwargs,
+        pool=pool,
+        max_iterations=max_iterations,
+        on_first_response=on_first_response,
+    )
+
+
+async def anthropic_tool_loop_stream(
+    *,
+    completion_kwargs: dict[str, Any],
+    pool: ToolBackend,
+    max_iterations: int,
+) -> AsyncIterator[MessageStreamEvent]:
+    """Streaming Anthropic Messages tool-use loop.
+
+    Forwards every Anthropic event downstream **except** the terminal
+    ``message_delta`` / ``message_stop`` of an iteration that's about to
+    continue (a new ``message_start`` after the client thought the message
+    ended would confuse most SDK consumers).
+
+    Per iteration:
+      1. Set ``stream=True`` on ``amessages`` and iterate the event stream.
+      2. Track tool_use content blocks by ``index`` from ``content_block_start``
+         (when ``content_block.type == "tool_use"``). Buffer their
+         ``input_json_delta`` chunks until ``content_block_stop``.
+      3. Yield every event as it arrives (including the tool_use events, so the
+         client sees the model's tool intent even mid-loop). Defer
+         ``message_delta`` and ``message_stop`` until we know whether the loop
+         will continue.
+      4. On ``message_stop``: if any buffered tool_use blocks exist AND all
+         owned by the pool, execute them, append messages, drop the terminal
+         events, and continue. If foreign blocks exist OR no tool_use blocks
+         were buffered, forward the terminal events and exit.
+
+    Re-emitting a synthetic ``message_start`` for the next iteration is not
+    needed because ``amessages`` produces a fresh stream; the next call's
+    natural ``message_start`` arrives downstream as if nothing had happened.
+    """
+    async for event in run_tool_loop_stream(
+        strategy=_MESSAGES_STRATEGY,
+        completion_kwargs=completion_kwargs,
+        pool=pool,
+        max_iterations=max_iterations,
+    ):
+        yield event

--- a/src/gateway/services/mcp_loop_responses.py
+++ b/src/gateway/services/mcp_loop_responses.py
@@ -7,13 +7,16 @@ shape: ``Response.output`` items (``function_call`` entries) instead of
 ``response.output_item.*`` / ``response.function_call_arguments.*`` /
 ``response.completed`` stream events.
 
+The loop skeleton itself lives in :mod:`gateway.services._tool_loop`; this
+module supplies the Responses strategy and thin public wrappers.
+
 The duck-typed pool interface (``owns_tool`` / ``call_tool`` /
 ``openai_tools`` / ``purpose_hints``) is reused unchanged; the
 ``openai_tools`` shape is converted at the boundary in :mod:`tool_format`.
 
 Native server-managed tools that the Responses API can run upstream
 (``web_search_call``, ``code_interpreter_call``, ``mcp_call``, etc.) are not
-intercepted here — those output items belong to the provider's own tool
+intercepted here; those output items belong to the provider's own tool
 execution path and the gateway has nothing to dispatch against.
 """
 
@@ -26,6 +29,7 @@ from typing import TYPE_CHECKING, Any
 from any_llm import aresponses
 
 from gateway.log_config import logger
+from gateway.services._tool_loop import StreamAction, run_tool_loop, run_tool_loop_stream
 from gateway.services.mcp_loop import (
     DEFAULT_MAX_TOOL_ITERATIONS,
     MAX_TOOL_ITERATIONS_CAP,
@@ -55,7 +59,7 @@ def _split_function_calls(
 
     Walks ``output`` for items with ``type == "function_call"`` and partitions
     by ``pool.owns_tool(item.name)``. Non-function-call items (text messages,
-    web_search_call, code_interpreter_call, mcp_call, …) are ignored — they're
+    web_search_call, code_interpreter_call, mcp_call, ...) are ignored; they're
     not gateway-managed tool dispatch.
     """
     owned: list[Any] = []
@@ -76,8 +80,8 @@ async def _execute_function_calls(
 ) -> list[dict[str, Any]]:
     """Run each owned function_call and return the Responses function_call_output items.
 
-    Tool failures convert to a ``[tool error] …`` string in the output so the
-    model can recover. Only cancellation-class exceptions escape — same idiom
+    Tool failures convert to a ``[tool error] ...`` string in the output so the
+    model can recover. Only cancellation-class exceptions escape; same idiom
     as :func:`gateway.services.mcp_loop._execute_mcp_calls`.
     """
     out: list[dict[str, Any]] = []
@@ -124,101 +128,6 @@ def _coerce_input_to_list(input_data: Any) -> list[Any]:
     return [input_data]
 
 
-async def responses_tool_loop(
-    *,
-    completion_kwargs: dict[str, Any],
-    pool: ToolBackend,
-    max_iterations: int,
-    on_first_response: Callable[[], None] | None = None,
-) -> Response:
-    """Non-streaming OpenAI Responses tool-use loop.
-
-    Each iteration calls ``aresponses``, walks ``result.output`` for owned
-    ``function_call`` items, executes them, and appends the originals plus
-    matching ``function_call_output`` items to ``input_data`` for the next
-    round. Loop terminates when:
-
-    - the response has no owned ``function_call`` items (final answer);
-    - the response includes foreign ``function_call`` items — those are
-      returned to the caller for client-side dispatch. Mixed batches execute
-      the owned subset for its side effects and filter those out of the
-      returned ``output`` so the caller only sees the foreign ones.
-
-    Accumulates ``input_tokens`` / ``output_tokens`` / ``total_tokens`` across
-    iterations into the returned ``Response``.
-
-    ``on_first_response`` is invoked exactly once, right after the first
-    upstream ``aresponses`` call returns successfully. Mirrors the contract
-    on :func:`gateway.services.mcp_loop.mcp_tool_loop` so hybrid-mode
-    callers can lock in to the chosen provider once an assistant turn has
-    materialized — subsequent failures terminate the request instead of
-    silently swapping providers (a Responses transcript carries
-    provider-specific call_ids and reasoning items that can't be replayed).
-    """
-    input_items = _coerce_input_to_list(completion_kwargs.get("input_data"))
-    user_tools = list(completion_kwargs.get("tools") or [])
-    merged_tools = user_tools + openai_to_responses_tools(pool.openai_tools)
-
-    base = {k: v for k, v in completion_kwargs.items() if k not in {"input_data", "tools", "stream"}}
-
-    acc_input = 0
-    acc_output = 0
-    acc_total = 0
-    first_response_signaled = False
-
-    for _ in range(max_iterations):
-        kwargs: dict[str, Any] = {**base, "input_data": input_items, "stream": False}
-        if merged_tools:
-            kwargs["tools"] = merged_tools
-
-        result: Response = await aresponses(**kwargs)  # type: ignore[assignment]
-        if not first_response_signaled:
-            first_response_signaled = True
-            if on_first_response is not None:
-                on_first_response()
-        if result.usage:
-            acc_input += result.usage.input_tokens or 0
-            acc_output += result.usage.output_tokens or 0
-            acc_total += result.usage.total_tokens or 0
-
-        output = list(result.output or [])
-        owned, has_foreign = _split_function_calls(output, pool)
-
-        if has_foreign:
-            # Mixed batch: execute owned for side effects, filter from output.
-            if owned:
-                await _execute_function_calls(pool, owned)
-                owned_call_ids = {item.call_id for item in owned}
-                try:
-                    result.output = [
-                        item
-                        for item in output
-                        if not (
-                            getattr(item, "type", None) == "function_call"
-                            and getattr(item, "call_id", None) in owned_call_ids
-                        )
-                    ]
-                except (AttributeError, TypeError):
-                    logger.warning(
-                        "Responses-mixed: could not filter output on response; client will see function_call "
-                        "items the gateway already executed (no-op on the client side).",
-                    )
-            _fold_usage(result, acc_input, acc_output, acc_total)
-            return result
-
-        if not owned:
-            _fold_usage(result, acc_input, acc_output, acc_total)
-            return result
-
-        # All-owned: continue. Append the assistant's function_call items AND
-        # the matching function_call_output items so the next call's input has
-        # the full transcript.
-        input_items.extend(_items_to_dicts(owned))
-        input_items.extend(await _execute_function_calls(pool, owned))
-
-    raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")
-
-
 def _fold_usage(result: Response, input_total: int, output_total: int, total_total: int) -> None:
     """Replace ``result.usage`` token counts with the loop's running totals."""
     if result.usage is None:
@@ -226,153 +135,6 @@ def _fold_usage(result: Response, input_total: int, output_total: int, total_tot
     result.usage.input_tokens = input_total
     result.usage.output_tokens = output_total
     result.usage.total_tokens = total_total
-
-
-async def responses_tool_loop_stream(
-    *,
-    completion_kwargs: dict[str, Any],
-    pool: ToolBackend,
-    max_iterations: int,
-) -> AsyncIterator[ResponseStreamEvent]:
-    """Streaming OpenAI Responses tool-use loop.
-
-    Forwards every event downstream and tracks ``function_call`` output items
-    by buffering ``response.function_call_arguments.delta`` chunks per
-    ``output_index``. ``response.function_call_arguments.done``, if present,
-    overrides the running buffer with the terminal argument string.
-
-    Loop continuation is decided on ``response.completed``: if any buffered
-    function_call items exist AND all are owned by the pool, execute them,
-    append the originals plus the ``function_call_output`` items to
-    ``input_data``, drop the terminal ``response.completed`` event, and start
-    the next round. If any foreign function_call is present (or none at all),
-    forward ``response.completed`` and exit.
-
-    Mixed batches in streaming mode forward everything as-is (rewriting the
-    output_items mid-stream to remove owned ones would be too invasive); the
-    client sees what it sees and the loop exits. Same trade-off as the
-    Anthropic streaming variant.
-
-    Cumulative usage across iterations: each iteration's
-    ``response.completed`` carries that iteration's usage on ``event.response.usage``.
-    When the loop continues, that event is dropped and its usage would be
-    lost from streaming token reporting. We accumulate the per-iteration
-    ``output_tokens`` and fold the running total into the final forwarded
-    ``response.completed`` so downstream usage logging sees the full
-    tool-loop output count.
-    """
-    input_items = _coerce_input_to_list(completion_kwargs.get("input_data"))
-    user_tools = list(completion_kwargs.get("tools") or [])
-    merged_tools = user_tools + openai_to_responses_tools(pool.openai_tools)
-
-    base = {k: v for k, v in completion_kwargs.items() if k not in {"input_data", "tools"}}
-    base["stream"] = True
-
-    acc_output_tokens = 0  # see usage-accumulation note in the docstring.
-
-    for _ in range(max_iterations):
-        kwargs: dict[str, Any] = {**base, "input_data": input_items}
-        if merged_tools:
-            kwargs["tools"] = merged_tools
-
-        stream: AsyncIterator[ResponseStreamEvent] = await aresponses(**kwargs)  # type: ignore[assignment]
-
-        # Per-iteration state.
-        function_calls: dict[int, dict[str, Any]] = {}  # output_index -> {"call_id", "name", "arguments"}
-        deferred_completed: ResponseStreamEvent | None = None
-
-        async for event in stream:
-            etype = getattr(event, "type", None)
-
-            if etype == "response.output_item.added":
-                item = getattr(event, "item", None)
-                output_index = getattr(event, "output_index", None)
-                if item is not None and output_index is not None and getattr(item, "type", None) == "function_call":
-                    function_calls[output_index] = {
-                        "call_id": getattr(item, "call_id", ""),
-                        "name": getattr(item, "name", ""),
-                        "arguments": getattr(item, "arguments", "") or "",
-                    }
-
-            elif etype == "response.function_call_arguments.delta":
-                idx = getattr(event, "output_index", None)
-                if idx is not None and idx in function_calls:
-                    function_calls[idx]["arguments"] += getattr(event, "delta", "") or ""
-
-            elif etype == "response.function_call_arguments.done":
-                # The terminal arguments value overrides the running buffer —
-                # the SDK uses this event for completeness even when the
-                # deltas already concatenate cleanly.
-                idx = getattr(event, "output_index", None)
-                if idx is not None and idx in function_calls:
-                    final_args = getattr(event, "arguments", None)
-                    if final_args:
-                        function_calls[idx]["arguments"] = final_args
-                    final_name = getattr(event, "name", None)
-                    if final_name:
-                        function_calls[idx]["name"] = final_name
-
-            elif etype == "response.completed":
-                # Defer — we'll decide whether to forward or drop after the
-                # tool-call accounting below. Break out so the `yield event`
-                # below this if/elif chain is skipped.
-                deferred_completed = event
-                break
-
-            yield event
-
-        # Decide whether to loop or exit.
-        if not function_calls:
-            if deferred_completed is not None:
-                yield _maybe_fold_response_completed_usage(deferred_completed, acc_output_tokens)
-            return
-
-        owned_specs: list[dict[str, Any]] = []
-        has_foreign = False
-        for idx in sorted(function_calls):
-            spec = function_calls[idx]
-            if pool.owns_tool(spec["name"]):
-                owned_specs.append(spec)
-            else:
-                has_foreign = True
-
-        if has_foreign or not owned_specs:
-            # Caller dispatches the foreign calls; or there's nothing to do.
-            if deferred_completed is not None:
-                yield _maybe_fold_response_completed_usage(deferred_completed, acc_output_tokens)
-            return
-
-        # All-owned: accumulate this iteration's output_tokens from the
-        # dropped ``response.completed`` event (so the next final-fold sees
-        # the running total), then execute, append to input, and continue.
-        if deferred_completed is not None:
-            iter_response = getattr(deferred_completed, "response", None)
-            iter_usage = getattr(iter_response, "usage", None) if iter_response is not None else None
-            if iter_usage is not None:
-                acc_output_tokens += getattr(iter_usage, "output_tokens", 0) or 0
-        for spec in owned_specs:
-            input_items.append(
-                {
-                    "type": "function_call",
-                    "call_id": spec["call_id"],
-                    "name": spec["name"],
-                    "arguments": spec["arguments"] or "{}",
-                }
-            )
-
-        for spec in owned_specs:
-            try:
-                parsed_args = json.loads(spec["arguments"] or "{}")
-            except json.JSONDecodeError:
-                parsed_args = {}
-            try:
-                text = await pool.call_tool(spec["name"], parsed_args)
-            except Exception as exc:  # noqa: BLE001 — same tool-error-as-message idiom as the non-stream loop
-                logger.warning("MCP tool %s execution failed: %s", spec["name"], exc)
-                text = f"[tool error] {exc}"
-            input_items.append({"type": "function_call_output", "call_id": spec["call_id"], "output": text})
-
-    raise MaxToolIterationsExceeded(f"Exceeded max_tool_iterations={max_iterations}")
 
 
 def _maybe_fold_response_completed_usage(event: Any, acc_output_tokens: int) -> Any:
@@ -397,3 +159,279 @@ def _maybe_fold_response_completed_usage(event: Any, acc_output_tokens: int) -> 
     new_usage = usage.model_copy(update={"output_tokens": new_output, "total_tokens": new_total})
     new_response = response_obj.model_copy(update={"usage": new_usage})
     return event.model_copy(update={"response": new_response})
+
+
+class _ResponsesStreamState:
+    """Per-iteration bookkeeping for the Responses streaming loop."""
+
+    def __init__(self) -> None:
+        # output_index -> {"call_id", "name", "arguments"}
+        self.function_calls: dict[int, dict[str, Any]] = {}
+        self.deferred_completed: ResponseStreamEvent | None = None
+        self.owned_specs: list[dict[str, Any]] = []
+
+
+class _ResponsesToolLoopStrategy:
+    """OpenAI Responses strategy for the generic tool loop.
+
+    ``aresponses`` is resolved as a module global at call time so tests can
+    monkeypatch ``gateway.services.mcp_loop_responses.aresponses``.
+    """
+
+    transcript_key = "input_data"
+
+    def coerce_transcript(self, value: Any) -> list[Any]:
+        return _coerce_input_to_list(value)
+
+    def convert_pool_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return openai_to_responses_tools(tools)
+
+    # ---- non-streaming hooks ----
+
+    async def call(self, kwargs: dict[str, Any]) -> Response:
+        result: Response = await aresponses(**kwargs)  # type: ignore[assignment]
+        return result
+
+    def new_usage_accumulator(self) -> dict[str, int]:
+        return {"input": 0, "output": 0, "total": 0}
+
+    def accumulate_usage(self, acc: dict[str, int], result: Response) -> None:
+        if result.usage:
+            acc["input"] += result.usage.input_tokens or 0
+            acc["output"] += result.usage.output_tokens or 0
+            acc["total"] += result.usage.total_tokens or 0
+
+    def fold_usage(self, result: Response, acc: dict[str, int]) -> None:
+        _fold_usage(result, acc["input"], acc["output"], acc["total"])
+
+    def exit_before_split(self, result: Response) -> bool:
+        return False
+
+    def split_owned(self, result: Response, pool: ToolBackend) -> tuple[list[Any], bool]:
+        return _split_function_calls(list(result.output or []), pool)
+
+    def exit_after_split(self, result: Response) -> bool:
+        return False
+
+    async def execute_owned(self, pool: ToolBackend, owned: list[Any]) -> list[dict[str, Any]]:
+        return await _execute_function_calls(pool, owned)
+
+    def filter_owned(self, result: Response, owned: list[Any], pool: ToolBackend) -> None:
+        # Mixed batch: the owned subset was executed for its side effects;
+        # filter it from the returned output so the caller only sees the
+        # foreign function_call items it can dispatch itself.
+        owned_call_ids = {item.call_id for item in owned}
+        output = list(result.output or [])
+        try:
+            result.output = [
+                item
+                for item in output
+                if not (
+                    getattr(item, "type", None) == "function_call"
+                    and getattr(item, "call_id", None) in owned_call_ids
+                )
+            ]
+        except (AttributeError, TypeError):
+            logger.warning(
+                "Responses-mixed: could not filter output on response; client will see function_call "
+                "items the gateway already executed (no-op on the client side).",
+            )
+
+    async def advance_transcript(
+        self,
+        transcript: list[Any],
+        result: Response,
+        owned: list[Any],
+        pool: ToolBackend,
+    ) -> None:
+        # All-owned: continue. Append the assistant's function_call items AND
+        # the matching function_call_output items so the next call's input has
+        # the full transcript.
+        transcript.extend(_items_to_dicts(owned))
+        transcript.extend(await _execute_function_calls(pool, owned))
+
+    # ---- streaming hooks ----
+
+    async def open_stream(self, kwargs: dict[str, Any]) -> AsyncIterator[ResponseStreamEvent]:
+        stream: AsyncIterator[ResponseStreamEvent] = await aresponses(**kwargs)  # type: ignore[assignment]
+        return stream
+
+    def new_stream_state(self) -> _ResponsesStreamState:
+        return _ResponsesStreamState()
+
+    def new_stream_accumulator(self) -> dict[str, int]:
+        # Each iteration's ``response.completed`` carries that iteration's
+        # usage on ``event.response.usage``. When the loop continues, that
+        # event is dropped and its usage would be lost from streaming token
+        # reporting. Accumulate the per-iteration ``output_tokens`` and fold
+        # the running total into the final forwarded ``response.completed``
+        # so downstream usage logging sees the full tool-loop output count.
+        return {"output_tokens": 0}
+
+    def observe(self, state: _ResponsesStreamState, event: ResponseStreamEvent) -> StreamAction:
+        etype = getattr(event, "type", None)
+
+        if etype == "response.output_item.added":
+            item = getattr(event, "item", None)
+            output_index = getattr(event, "output_index", None)
+            if item is not None and output_index is not None and getattr(item, "type", None) == "function_call":
+                state.function_calls[output_index] = {
+                    "call_id": getattr(item, "call_id", ""),
+                    "name": getattr(item, "name", ""),
+                    "arguments": getattr(item, "arguments", "") or "",
+                }
+
+        elif etype == "response.function_call_arguments.delta":
+            idx = getattr(event, "output_index", None)
+            if idx is not None and idx in state.function_calls:
+                state.function_calls[idx]["arguments"] += getattr(event, "delta", "") or ""
+
+        elif etype == "response.function_call_arguments.done":
+            # The terminal arguments value overrides the running buffer;
+            # the SDK uses this event for completeness even when the
+            # deltas already concatenate cleanly.
+            idx = getattr(event, "output_index", None)
+            if idx is not None and idx in state.function_calls:
+                final_args = getattr(event, "arguments", None)
+                if final_args:
+                    state.function_calls[idx]["arguments"] = final_args
+                final_name = getattr(event, "name", None)
+                if final_name:
+                    state.function_calls[idx]["name"] = final_name
+
+        elif etype == "response.completed":
+            # Defer: whether it is forwarded or dropped depends on the
+            # tool-call accounting in ``stream_exiting``.
+            state.deferred_completed = event
+            return StreamAction.BREAK
+
+        return StreamAction.FORWARD
+
+    def stream_exiting(self, state: _ResponsesStreamState, pool: ToolBackend) -> bool:
+        if not state.function_calls:
+            return True
+        owned_specs: list[dict[str, Any]] = []
+        has_foreign = False
+        for idx in sorted(state.function_calls):
+            spec = state.function_calls[idx]
+            if pool.owns_tool(spec["name"]):
+                owned_specs.append(spec)
+            else:
+                has_foreign = True
+        state.owned_specs = owned_specs
+        # Mixed batches in streaming mode forward everything as-is (rewriting
+        # the output_items mid-stream to remove owned ones would be too
+        # invasive); the client sees what it sees and the loop exits. Same
+        # trade-off as the Anthropic streaming variant.
+        return has_foreign or not owned_specs
+
+    def terminal_events(self, state: _ResponsesStreamState, acc: dict[str, int]) -> list[ResponseStreamEvent]:
+        if state.deferred_completed is None:
+            return []
+        return [_maybe_fold_response_completed_usage(state.deferred_completed, acc["output_tokens"])]
+
+    def accumulate_stream_usage(self, acc: dict[str, int], state: _ResponsesStreamState) -> None:
+        # All-owned continuation: fold this iteration's output_tokens from the
+        # dropped ``response.completed`` event into the running total.
+        if state.deferred_completed is not None:
+            iter_response = getattr(state.deferred_completed, "response", None)
+            iter_usage = getattr(iter_response, "usage", None) if iter_response is not None else None
+            if iter_usage is not None:
+                acc["output_tokens"] += getattr(iter_usage, "output_tokens", 0) or 0
+
+    async def advance_stream_transcript(
+        self,
+        transcript: list[Any],
+        state: _ResponsesStreamState,
+        pool: ToolBackend,
+    ) -> None:
+        transcript.extend(
+            {
+                "type": "function_call",
+                "call_id": spec["call_id"],
+                "name": spec["name"],
+                "arguments": spec["arguments"] or "{}",
+            }
+            for spec in state.owned_specs
+        )
+
+        for spec in state.owned_specs:
+            try:
+                parsed_args = json.loads(spec["arguments"] or "{}")
+            except json.JSONDecodeError:
+                parsed_args = {}
+            try:
+                text = await pool.call_tool(spec["name"], parsed_args)
+            except Exception as exc:  # noqa: BLE001 — same tool-error-as-message idiom as the non-stream loop
+                logger.warning("MCP tool %s execution failed: %s", spec["name"], exc)
+                text = f"[tool error] {exc}"
+            transcript.append({"type": "function_call_output", "call_id": spec["call_id"], "output": text})
+
+
+_RESPONSES_STRATEGY = _ResponsesToolLoopStrategy()
+
+
+async def responses_tool_loop(
+    *,
+    completion_kwargs: dict[str, Any],
+    pool: ToolBackend,
+    max_iterations: int,
+    on_first_response: Callable[[], None] | None = None,
+) -> Response:
+    """Non-streaming OpenAI Responses tool-use loop.
+
+    Each iteration calls ``aresponses``, walks ``result.output`` for owned
+    ``function_call`` items, executes them, and appends the originals plus
+    matching ``function_call_output`` items to ``input_data`` for the next
+    round. Loop terminates when:
+
+    - the response has no owned ``function_call`` items (final answer);
+    - the response includes foreign ``function_call`` items, which are
+      returned to the caller for client-side dispatch. Mixed batches execute
+      the owned subset for its side effects and filter those out of the
+      returned ``output`` so the caller only sees the foreign ones.
+
+    Accumulates ``input_tokens`` / ``output_tokens`` / ``total_tokens`` across
+    iterations into the returned ``Response``.
+
+    ``on_first_response`` follows the provider lock-in contract documented on
+    :func:`gateway.services._tool_loop.run_tool_loop`. Lock-in matters even
+    more here: a Responses transcript carries provider-specific call_ids and
+    reasoning items that can't be replayed against another provider.
+    """
+    return await run_tool_loop(
+        strategy=_RESPONSES_STRATEGY,
+        completion_kwargs=completion_kwargs,
+        pool=pool,
+        max_iterations=max_iterations,
+        on_first_response=on_first_response,
+    )
+
+
+async def responses_tool_loop_stream(
+    *,
+    completion_kwargs: dict[str, Any],
+    pool: ToolBackend,
+    max_iterations: int,
+) -> AsyncIterator[ResponseStreamEvent]:
+    """Streaming OpenAI Responses tool-use loop.
+
+    Forwards every event downstream and tracks ``function_call`` output items
+    by buffering ``response.function_call_arguments.delta`` chunks per
+    ``output_index``. ``response.function_call_arguments.done``, if present,
+    overrides the running buffer with the terminal argument string.
+
+    Loop continuation is decided on ``response.completed``: if any buffered
+    function_call items exist AND all are owned by the pool, execute them,
+    append the originals plus the ``function_call_output`` items to
+    ``input_data``, drop the terminal ``response.completed`` event, and start
+    the next round. If any foreign function_call is present (or none at all),
+    forward ``response.completed`` and exit.
+    """
+    async for event in run_tool_loop_stream(
+        strategy=_RESPONSES_STRATEGY,
+        completion_kwargs=completion_kwargs,
+        pool=pool,
+        max_iterations=max_iterations,
+    ):
+        yield event

--- a/src/gateway/services/mcp_loop_responses.py
+++ b/src/gateway/services/mcp_loop_responses.py
@@ -23,7 +23,8 @@ execution path and the gateway has nothing to dispatch against.
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
+from contextlib import aclosing
 from typing import TYPE_CHECKING, Any
 
 from any_llm import aresponses
@@ -413,7 +414,7 @@ async def responses_tool_loop_stream(
     completion_kwargs: dict[str, Any],
     pool: ToolBackend,
     max_iterations: int,
-) -> AsyncIterator[ResponseStreamEvent]:
+) -> AsyncGenerator[ResponseStreamEvent, None]:
     """Streaming OpenAI Responses tool-use loop.
 
     Forwards every event downstream and tracks ``function_call`` output items
@@ -428,10 +429,16 @@ async def responses_tool_loop_stream(
     the next round. If any foreign function_call is present (or none at all),
     forward ``response.completed`` and exit.
     """
-    async for event in run_tool_loop_stream(
-        strategy=_RESPONSES_STRATEGY,
-        completion_kwargs=completion_kwargs,
-        pool=pool,
-        max_iterations=max_iterations,
-    ):
-        yield event
+    # aclosing makes downstream closes (client disconnect) propagate to the
+    # engine generator, and through it to the upstream provider stream,
+    # instead of waiting for event-loop async-generator finalization.
+    async with aclosing(
+        run_tool_loop_stream(
+            strategy=_RESPONSES_STRATEGY,
+            completion_kwargs=completion_kwargs,
+            pool=pool,
+            max_iterations=max_iterations,
+        )
+    ) as inner:
+        async for event in inner:
+            yield event

--- a/tests/unit/test_tool_loop_stream_close.py
+++ b/tests/unit/test_tool_loop_stream_close.py
@@ -26,10 +26,11 @@ from any_llm.types.messages import (
     MessageDeltaUsage,
     MessageStopEvent,
     MessageStreamEvent,
+    TextBlock,
     ToolUseBlock,
 )
 from any_llm.types.responses import Response
-from openai.types.responses import ResponseCompletedEvent, ResponseUsage
+from openai.types.responses import ResponseCompletedEvent, ResponseTextDeltaEvent, ResponseUsage
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
 from gateway.services import mcp_loop_messages as messages_loop_module
@@ -215,4 +216,66 @@ async def test_responses_stream_closes_upstream_on_terminal_exit(monkeypatch: py
         )
     ]
     assert types == ["response.completed"]
+    assert stream.closed
+
+
+def _text_block_start(index: int) -> MsgContentBlockStartEvent:
+    return MsgContentBlockStartEvent(
+        type="content_block_start",
+        index=index,
+        content_block=cast(Any, TextBlock(type="text", text="", citations=None)),
+    )
+
+
+def _responses_text_delta(delta: str) -> ResponseTextDeltaEvent:
+    return ResponseTextDeltaEvent(
+        type="response.output_text.delta",
+        item_id="msg_1",
+        output_index=0,
+        content_index=0,
+        delta=delta,
+        sequence_number=0,
+        logprobs=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_messages_stream_downstream_close_propagates_to_upstream(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Closing the tool-loop generator mid-stream must close the upstream stream too."""
+    stream = _ClosableStream([_text_block_start(0), _text_block_start(1)])
+
+    async def fake_amessages(**kwargs: Any) -> _ClosableStream:
+        return stream
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    agen = anthropic_tool_loop_stream(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 10},
+        pool=cast(Any, _FakePool(tool_names=[])),
+        max_iterations=3,
+    )
+    first = await anext(agen)
+    assert getattr(first, "type", None) == "content_block_start"
+    await agen.aclose()
+    assert stream.closed
+
+
+@pytest.mark.asyncio
+async def test_responses_stream_downstream_close_propagates_to_upstream(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Closing the tool-loop generator mid-stream must close the upstream stream too."""
+    stream = _ClosableStream([_responses_text_delta("hi"), _responses_text_delta(" there")])
+
+    async def fake_aresponses(**kwargs: Any) -> _ClosableStream:
+        return stream
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    agen = responses_tool_loop_stream(
+        completion_kwargs={"model": "fake", "input_data": "hi"},
+        pool=cast(Any, _FakePool(tool_names=[])),
+        max_iterations=3,
+    )
+    first = await anext(agen)
+    assert getattr(first, "type", None) == "response.output_text.delta"
+    await agen.aclose()
     assert stream.closed

--- a/tests/unit/test_tool_loop_stream_close.py
+++ b/tests/unit/test_tool_loop_stream_close.py
@@ -1,0 +1,218 @@
+"""Regression tests: streaming tool loops close the upstream stream.
+
+The Anthropic messages and OpenAI Responses streaming loops stop consuming
+the upstream event stream at their terminal event (``message_stop`` /
+``response.completed``). Before the shared engine in
+:mod:`gateway.services._tool_loop`, that early exit left the async stream
+(and any underlying connection) to garbage collection; the engine now closes
+it deterministically, both when the loop exits and between iterations.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+from any_llm.types.messages import (
+    ContentBlockDeltaEvent as MsgContentBlockDeltaEvent,
+)
+from any_llm.types.messages import (
+    ContentBlockStartEvent as MsgContentBlockStartEvent,
+)
+from any_llm.types.messages import (
+    InputJSONDelta,
+    MessageDelta,
+    MessageDeltaEvent,
+    MessageDeltaUsage,
+    MessageStopEvent,
+    MessageStreamEvent,
+    ToolUseBlock,
+)
+from any_llm.types.responses import Response
+from openai.types.responses import ResponseCompletedEvent, ResponseUsage
+from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+
+from gateway.services import mcp_loop_messages as messages_loop_module
+from gateway.services import mcp_loop_responses as responses_loop_module
+from gateway.services.mcp_loop_messages import anthropic_tool_loop_stream
+from gateway.services.mcp_loop_responses import responses_tool_loop_stream
+
+
+class _ClosableStream:
+    """Async iterator that records whether ``aclose`` was called."""
+
+    def __init__(self, events: list[Any]) -> None:
+        self._events = iter(events)
+        self.closed = False
+
+    def __aiter__(self) -> "_ClosableStream":
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            return next(self._events)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class _FakePool:
+    def __init__(self, tool_names: list[str], results: dict[str, str] | None = None) -> None:
+        self._tool_names = set(tool_names)
+        self._results = results or {}
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    @property
+    def openai_tools(self) -> list[dict[str, Any]]:
+        return [
+            {"type": "function", "function": {"name": n, "description": "", "parameters": {}}}
+            for n in sorted(self._tool_names)
+        ]
+
+    def owns_tool(self, name: str) -> bool:
+        return name in self._tool_names
+
+    def purpose_hints(self) -> list[tuple[str, str]]:
+        return []
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+        self.calls.append((name, arguments))
+        return self._results.get(name, f"ran {name}")
+
+
+def _msg_delta_event(stop_reason: str) -> MessageDeltaEvent:
+    return MessageDeltaEvent(
+        type="message_delta",
+        delta=MessageDelta(stop_reason=cast(Any, stop_reason), stop_sequence=None),
+        usage=MessageDeltaUsage(
+            input_tokens=None,
+            output_tokens=1,
+            cache_creation_input_tokens=None,
+            cache_read_input_tokens=None,
+            server_tool_use=None,
+        ),
+    )
+
+
+def _tool_use_block_start(index: int, tool_id: str, name: str) -> MsgContentBlockStartEvent:
+    return MsgContentBlockStartEvent(
+        type="content_block_start",
+        index=index,
+        content_block=cast(Any, ToolUseBlock(type="tool_use", id=tool_id, name=name, input={})),
+    )
+
+
+def _input_json_delta(index: int, partial: str) -> MsgContentBlockDeltaEvent:
+    return MsgContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=index,
+        delta=cast(Any, InputJSONDelta(type="input_json_delta", partial_json=partial)),
+    )
+
+
+def _response_completed() -> ResponseCompletedEvent:
+    return ResponseCompletedEvent(
+        type="response.completed",
+        response=Response(
+            id="resp_test",
+            created_at=0.0,
+            model="fake",
+            object="response",
+            status="completed",
+            output=[],
+            parallel_tool_calls=False,
+            tool_choice="auto",
+            tools=[],
+            usage=ResponseUsage(
+                input_tokens=1,
+                input_tokens_details=InputTokensDetails(cached_tokens=0),
+                output_tokens=1,
+                output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+                total_tokens=2,
+            ),
+            error=None,
+            incomplete_details=None,
+            instructions=None,
+            metadata=None,
+            temperature=None,
+            top_p=None,
+        ),
+        sequence_number=0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_messages_stream_closes_upstream_on_terminal_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The loop breaks out of the stream at ``message_stop``; the stream must be closed."""
+    stream = _ClosableStream([_msg_delta_event("end_turn"), MessageStopEvent(type="message_stop")])
+
+    async def fake_amessages(**kwargs: Any) -> _ClosableStream:
+        return stream
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    events: list[MessageStreamEvent] = [
+        event
+        async for event in anthropic_tool_loop_stream(
+            completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 10},
+            pool=cast(Any, _FakePool(tool_names=[])),
+            max_iterations=3,
+        )
+    ]
+    assert [getattr(e, "type", None) for e in events] == ["message_delta", "message_stop"]
+    assert stream.closed
+
+
+@pytest.mark.asyncio
+async def test_messages_stream_closes_upstream_between_iterations(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A mid-loop continuation must also close the iteration's upstream stream."""
+    first = _ClosableStream(
+        [
+            _tool_use_block_start(0, "tu_1", "fetch_url"),
+            _input_json_delta(0, "{}"),
+            _msg_delta_event("tool_use"),
+            MessageStopEvent(type="message_stop"),
+        ]
+    )
+    second = _ClosableStream([_msg_delta_event("end_turn"), MessageStopEvent(type="message_stop")])
+    streams = iter([first, second])
+
+    async def fake_amessages(**kwargs: Any) -> _ClosableStream:
+        return next(streams)
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    pool = _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})
+    async for _event in anthropic_tool_loop_stream(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}], "max_tokens": 10},
+        pool=cast(Any, pool),
+        max_iterations=3,
+    ):
+        pass
+    assert pool.calls == [("fetch_url", {})]
+    assert first.closed
+    assert second.closed
+
+
+@pytest.mark.asyncio
+async def test_responses_stream_closes_upstream_on_terminal_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The loop breaks out of the stream at ``response.completed``; the stream must be closed."""
+    stream = _ClosableStream([_response_completed()])
+
+    async def fake_aresponses(**kwargs: Any) -> _ClosableStream:
+        return stream
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    types = [
+        event.type
+        async for event in responses_tool_loop_stream(
+            completion_kwargs={"model": "fake", "input_data": "hi"},
+            pool=cast(Any, _FakePool(tool_names=[])),
+            max_iterations=3,
+        )
+    ]
+    assert types == ["response.completed"]
+    assert stream.closed


### PR DESCRIPTION
## Description

The chat, Anthropic messages, and OpenAI Responses MCP tool loops implemented the same agentic algorithm three times, and the copies had already drifted (mixed-batch handling, stream cleanup). This hoists the non-streaming and streaming skeletons into `services/_tool_loop.py` as `run_tool_loop` / `run_tool_loop_stream`, parameterized by a per-format strategy object covering the wire-specific edges: transcript coercion, tool-shape conversion, owned/foreign split, result serialization, terminal detection, and usage accumulation/folding. The three modules become strategy definitions plus thin wrappers; every import path, call site, and monkeypatch target (module-global `acompletion` / `amessages` / `aresponses`) keeps working.

Per-format behavior is preserved bit for bit, including the divergences the issue flagged (chat checks finish_reason before splitting; messages/responses run the mixed-batch branch before any stop-reason check; chat streaming folds no cumulative usage into its terminal chunk). Each is kept in its strategy and documented on `run_tool_loop`.

Two deliberate fixes ride along:

- The streaming loops now close the upstream stream when they stop consuming it early. The messages/responses variants used a bare `break`, leaving the async generator and its connection to GC; covered by new regression tests in `tests/unit/test_tool_loop_stream_close.py`.
- `purpose_hints()` joins the `ToolBackend` protocol; the route pipeline already calls it on every backend.

Note on line count: the issue estimated a 450-550 line collapse. The duplicated skeletons did collapse, but strategy-protocol scaffolding and preserved documentation offset that in raw lines (net +441 in `src`). The payoff is that the algorithm now exists once, so the three formats can no longer drift.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #261

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Fable 5 (Claude Code)

**Any additional AI details you'd like to share:** Implemented from issue #261 with the three existing unit test files treated as the behavioral contract; they pass unchanged. Integration tests were not run locally (no Docker in the sandbox); unit tests, lint, typecheck, and the OpenAPI check all pass.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
