### PR TITLE
fix(sandbox): give exec POST its own timeout above the execution budget

### DIFF
--- a/src/gateway/services/sandbox_backend.py
+++ b/src/gateway/services/sandbox_backend.py
@@ -44,6 +44,12 @@ logger = logging.getLogger(__name__)
 
 CODE_EXECUTION_TOOL_NAME = "code_execution"
 _DEFAULT_TIMEOUT_S = 60.0
+# Headroom added on top of the execution budget for the exec POST's own read
+# timeout. The sandbox is granted ``timeout_seconds`` to run the code; the HTTP
+# client must wait longer than that (network + serialization + the sandbox's own
+# teardown) so a legitimate near-max execution returns its result instead of
+# tripping the client read timeout as a spurious ``SandboxNotReachableError``.
+_EXEC_TIMEOUT_BUFFER_S = 10.0
 _DEFAULT_PURPOSE_HINT = (
     "Prefer `code_execution` for any computation, data analysis, date "
     "arithmetic, statistics, or anything that benefits from exact output. "
@@ -165,6 +171,9 @@ class SandboxBackend:
             response = await self._client.post(
                 f"{self._sandbox_url}/sessions/{self._session_id}/exec",
                 json=payload,
+                # Override the client default (which equals the exec budget) so the
+                # sandbox always gets to answer before the client read timeout fires.
+                timeout=self._timeout_s + _EXEC_TIMEOUT_BUFFER_S,
             )
             response.raise_for_status()
             body = response.json()

--- a/tests/unit/test_sandbox_backend.py
+++ b/tests/unit/test_sandbox_backend.py
@@ -5,6 +5,7 @@ Mocks the HTTP layer with `respx` so the suite needs no sandbox container.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import httpx
@@ -110,8 +111,6 @@ async def test_exec_read_timeout_exceeds_execution_budget(monkeypatch: pytest.Mo
     instant the sandbox finishes, surfacing as a spurious ``SandboxNotReachableError``
     instead of a result. The exec request carries its own longer timeout as headroom.
     """
-    import json
-
     result_block = {
         "type": "code_execution_tool_result",
         "tool_use_id": "t1",

--- a/tests/unit/test_sandbox_backend.py
+++ b/tests/unit/test_sandbox_backend.py
@@ -102,6 +102,43 @@ async def test_call_tool_dispatches_code_to_sandbox(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.asyncio
+async def test_exec_read_timeout_exceeds_execution_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The exec POST's read timeout must be larger than the sandbox's exec budget.
+
+    Regression test for #269: the client default equals ``timeout_seconds``, so a
+    legitimate near-max execution would trip the client read timeout at the same
+    instant the sandbox finishes, surfacing as a spurious ``SandboxNotReachableError``
+    instead of a result. The exec request carries its own longer timeout as headroom.
+    """
+    import json
+
+    result_block = {
+        "type": "code_execution_tool_result",
+        "tool_use_id": "t1",
+        "content": {"type": "code_execution_result", "stdout": "ok\n", "stderr": "", "return_code": 0, "content": []},
+    }
+    transport = _patched_async_client(
+        {
+            ("POST", "/sessions"): httpx.Response(200, json={"session_id": "s1"}),
+            ("POST", "/sessions/s1/exec"): httpx.Response(200, json={"result_block": result_block}),
+            ("DELETE", "/sessions/s1"): httpx.Response(204),
+        },
+        monkeypatch,
+    )
+
+    timeout_s = 30.0
+    async with SandboxBackend(sandbox_url="http://sandbox:8080", timeout_s=timeout_s) as backend:
+        await backend.call_tool(CODE_EXECUTION_TOOL_NAME, {"code": "print(1)"})
+
+    exec_request = next(r for r in transport.captured if r.url.path == "/sessions/s1/exec")
+    granted_budget = json.loads(exec_request.read().decode())["timeout_seconds"]
+    read_timeout = exec_request.extensions["timeout"]["read"]
+    assert read_timeout > granted_budget, (
+        f"exec read timeout {read_timeout} must exceed the granted budget {granted_budget}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_call_tool_surfaces_stderr_and_nonzero_return_code(monkeypatch: pytest.MonkeyPatch) -> None:
     result_block = {
         "type": "code_execution_tool_result",


### PR DESCRIPTION
## Description

In `SandboxBackend` the httpx client was built with `timeout=self._timeout_s`
(default 60s) and the exec POST carried no per-call override, so the HTTP read
timeout equaled the execution budget the payload grants the sandbox
(`timeout_seconds=int(self._timeout_s)`). A legitimate near-max execution tripped
the client read timeout at essentially the same instant the sandbox finished,
surfacing as a spurious `SandboxNotReachableError` instead of the result.

This change gives the exec request its own timeout of the execution budget plus a
10s buffer (network, serialization, and the sandbox's own teardown), mirroring how
`WebSearchBackend` sets its client default above its per-call timeouts, so the
sandbox always gets to answer before the client gives up. A unit test asserts the
exec request's read timeout exceeds the `timeout_seconds` granted to the sandbox;
it fails on the pre-fix code and passes after.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #269

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Fable 5)

**Any additional AI details you'd like to share:** Change and test authored via Claude Code, reviewed and approved by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
