### PR TITLE
feat(config): surface hidden otari_env settings on GatewayConfig and fix config docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,6 @@ GEMINI_API_KEY=
 # /search?format=json service. The bundled `web-search-tavily` /
 # `web-search-brave` compose profiles front a licensed API; the key lives in
 # the adapter container, not the gateway.
-# GATEWAY_WEB_SEARCH_URL=http://tavily-adapter:8080
+# OTARI_WEB_SEARCH_URL=http://tavily-adapter:8080
 # TAVILY_API_KEY=
 # BRAVE_API_KEY=

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -79,7 +79,7 @@ For a full client setup example, see [Use with Claude Code](use-with-claude-code
 
 | Method | Path | Description | Auth |
 |--------|------|-------------|------|
-| `GET` | `/v1/models` | List available models from pricing entries. | API key or master key |
+| `GET` | `/v1/models` | List available models: auto-discovered from configured providers (when `model_discovery` is on, the default), plus configured pricing entries and aliases. | API key or master key |
 | `GET` | `/v1/models/{model_id}` | Get a specific model. | API key or master key |
 
 ### Moderations

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,6 +65,7 @@ pricing:
 | `rate_limit_rpm` | int | none | Max requests per minute per user (none = disabled) |
 | `cors_allow_origins` | list | `[]` | Allowed CORS origins (empty = disabled) |
 | `providers` | dict | `{}` | Provider credentials (see below) |
+| `aliases` | dict | `{}` | Model name aliases (display name to target selector `instance:model` or `provider:model`). The alias is what users see in `GET /v1/models` and in response `model` fields; pricing, budgets, and usage key on the resolved target. Standalone mode only. |
 | `pricing` | dict | `{}` | Model pricing entries |
 | `enable_metrics` | bool | `false` | Enable Prometheus `/metrics` endpoint |
 | `enable_docs` | bool | `true` | Enable `/docs`, `/redoc`, `/openapi.json` |
@@ -76,6 +77,29 @@ pricing:
 | `reject_user_mismatch` | bool | `true` | When `true`, a non-master key whose request names a `user` other than its own is rejected (HTTP 403). When `false`, the client `user` is still forwarded to the provider but spend is always bound to the key's own user. The master key may always bill an arbitrary user. |
 | `stream_missing_usage_policy` | string | `"estimate"` | How to bill a streamed response that completes with no provider usage data: `"estimate"` (charge the up-front estimate), `"fail"` (charge estimate and mark errored), or `"allow_free"` (don't bill). |
 | `budget_estimate_default_output_tokens` | int | `1024` | Output-token count assumed when reserving budget for a request with no declared max output; reconciled to actual usage on completion. |
+| `model_discovery` | bool | `true` | Auto-discover models from configured providers for `GET /v1/models`. |
+| `model_cache_ttl_seconds` | int | `300` | TTL for the in-memory model-discovery cache (`0` disables caching). |
+| `files_enabled` | bool | `true` | Enable the `/v1/files` upload/storage endpoints (standalone mode). |
+| `files_backend` | string | `"local"` | Blob backend for uploaded file bytes (`"local"` filesystem for now). |
+| `files_local_dir` | string | `"./otari-files"` | Directory the `local` files backend writes uploaded bytes to. |
+| `files_max_bytes` | int | `536870912` | Maximum size in bytes for a single uploaded file (512 MiB default). |
+| `files_retention_hours` | int | none | Stop serving files older than N hours (they return 404); none keeps files indefinitely. Stored bytes are not auto-reclaimed. |
+| `file_understanding_enabled` | bool | `true` | Normalize file/image content blocks before the provider call (pass through for capable models, extract to text otherwise). When `false`, blocks are forwarded unchanged. |
+| `vision_strategy` | string | `"describe"` | How image blocks are handled for text-only models: `"describe"` (vision side-call), `"ocr"` (extract text only), or `"off"` (drop with a log line). |
+| `vision_describe_model` | string | none | `provider/model` used to caption images for text-only targets when `vision_strategy="describe"`. When unset, `describe` falls back to a logged drop. |
+| `vision_describe_max_tokens` | int | `1024` | Cap on the describe model's output tokens per image; bounds cost and latency of the vision side-call. |
+| `model_capabilities` | dict | `{}` | Per-model multimodal capability overrides (`provider/model` to `{supports_image, supports_pdf}`). Authoritative over any-llm's provider-level flags; needed for text-only local models behind OpenAI-compatible servers. |
+| `sandbox_url` | string | none | Base URL of the code-execution sandbox backend for `otari_code_execution` tools. When unset, such requests are rejected with HTTP 400. Also settable via `OTARI_SANDBOX_URL`. |
+| `guardrails_url` | string | none | Default input-guardrails service URL, used when a request does not pass its own guardrail `url`. Also settable via `OTARI_GUARDRAILS_URL`. |
+| `tools_header` | string | none | Override for the purpose-hint preamble header injected ahead of gateway-managed tool hints. When unset, a built-in default header is used. Also settable via `OTARI_TOOLS_HEADER`. |
+| `sandbox_purpose_hint` | string | none | Default purpose hint forwarded to the sandbox backend when a tool entry supplies none. Also settable via `OTARI_SANDBOX_PURPOSE_HINT`. |
+| `web_search_purpose_hint` | string | none | Default purpose hint for the web-search backend when a tool entry supplies none. Also settable via `OTARI_WEB_SEARCH_PURPOSE_HINT`. |
+| `web_search_engines` | string | none | Comma-separated SearXNG engine list for the web-search backend. Also settable via `OTARI_WEB_SEARCH_ENGINES`. |
+| `web_search_max_results` | int | none | Default cap on web-search hits (a per-tool `max_results` still overrides it). Also settable via `OTARI_WEB_SEARCH_MAX_RESULTS`. |
+| `web_search_extract` | bool | none | Whether the web-search backend extracts page content in-process (`true`) or returns snippet-only results (`false`). When unset, extraction is on. Also settable via `OTARI_WEB_SEARCH_EXTRACT`. |
+| `web_search_allow_private_hosts` | bool | `false` | SSRF gate: allow the web-search backend to fetch private/loopback/reserved hosts. Also settable via `OTARI_WEB_SEARCH_ALLOW_PRIVATE_HOSTS`. |
+| `mcp_allow_loopback` | bool | `true` | SSRF gate: allow MCP server URLs that resolve to loopback (same-host sidecars). Also settable via `OTARI_MCP_ALLOW_LOOPBACK`. |
+| `mcp_allow_private_hosts` | bool | `false` | SSRF gate: allow MCP server URLs that resolve to private/reserved hosts (and accept hostnames that fail to resolve at validation time). Also settable via `OTARI_MCP_ALLOW_PRIVATE_HOSTS`. |
 | `mode` | string | `"standalone"` | Configured mode (`"standalone"` or `"hybrid"`; the legacy value `"platform"` is still accepted). Effective behavior is driven by presence of `OTARI_AI_TOKEN`. |
 | `platform` | dict | `{}` | otari.ai integration settings (`base_url`, timeouts, retries) |
 
@@ -128,6 +152,25 @@ Note the `require_pricing` interaction: it defaults to `true` (fail-closed), so 
 | `OTARI_PORT` | Server bind port |
 | `OTARI_AUTO_MIGRATE` | Auto-run migrations on startup |
 | `OTARI_BOOTSTRAP_API_KEY` | Create first-use API key |
+
+### Built-in tools and guardrails variables
+
+These operator-facing settings configure the gateway-managed tools (`otari_code_execution`, `otari_web_search`), the MCP tool loop, and input guardrails. Each is validated at startup and, where it maps to a scalar `GatewayConfig` field, can also be set in the config file (see the config reference above). Every variable also accepts its legacy `GATEWAY_` prefix; `OTARI_` wins when both are set.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OTARI_SANDBOX_URL` | none | Base URL of the code-execution sandbox backend for `otari_code_execution` tools. Required to use that tool. |
+| `OTARI_WEB_SEARCH_URL` | none | Base URL of the web-search backend for `otari_web_search` tools. Required to use that tool. |
+| `OTARI_GUARDRAILS_URL` | none | Default input-guardrails service URL, used when a request does not pass its own guardrail `url`. |
+| `OTARI_TOOLS_HEADER` | built-in | Override for the purpose-hint preamble header injected ahead of gateway-managed tool hints. |
+| `OTARI_SANDBOX_PURPOSE_HINT` | none | Default purpose hint forwarded to the sandbox backend when a tool entry supplies none. |
+| `OTARI_WEB_SEARCH_PURPOSE_HINT` | none | Default purpose hint for the web-search backend when a tool entry supplies none. |
+| `OTARI_WEB_SEARCH_ENGINES` | backend default | Comma-separated SearXNG engine list (e.g. `google,bing`). |
+| `OTARI_WEB_SEARCH_MAX_RESULTS` | backend default | Default cap on returned hits (a per-tool `max_results` still overrides it). Must be `>= 1`. |
+| `OTARI_WEB_SEARCH_EXTRACT` | `true` | `0`/`false` disables in-process content extraction (snippet-only mode). |
+| `OTARI_WEB_SEARCH_ALLOW_PRIVATE_HOSTS` | `false` | SSRF gate: allow the web-search backend to fetch private/loopback/reserved hosts. |
+| `OTARI_MCP_ALLOW_LOOPBACK` | `true` | SSRF gate: allow MCP server URLs that resolve to loopback (same-host sidecars). |
+| `OTARI_MCP_ALLOW_PRIVATE_HOSTS` | `false` | SSRF gate: allow MCP server URLs that resolve to private/reserved hosts, and accept hostnames that fail to resolve at validation time. |
 
 ### Provider credentials
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,7 +100,7 @@ pricing:
 | `web_search_allow_private_hosts` | bool | `false` | SSRF gate: allow the web-search backend to fetch private/loopback/reserved hosts. Also settable via `OTARI_WEB_SEARCH_ALLOW_PRIVATE_HOSTS`. |
 | `mcp_allow_loopback` | bool | `true` | SSRF gate: allow MCP server URLs that resolve to loopback (same-host sidecars). Also settable via `OTARI_MCP_ALLOW_LOOPBACK`. |
 | `mcp_allow_private_hosts` | bool | `false` | SSRF gate: allow MCP server URLs that resolve to private/reserved hosts (and accept hostnames that fail to resolve at validation time). Also settable via `OTARI_MCP_ALLOW_PRIVATE_HOSTS`. |
-| `mode` | string | `"standalone"` | Configured mode (`"standalone"` or `"hybrid"`; the legacy value `"platform"` is still accepted). Effective behavior is driven by presence of `OTARI_AI_TOKEN`. |
+| `mode` | string | none | Operating mode (`"standalone"` or `"hybrid"`; the legacy value `"platform"` means hybrid): when unset, the mode is derived from the presence of `OTARI_AI_TOKEN`; when set explicitly it is enforced at startup, so `"hybrid"` without a token and `"standalone"` with a token both fail as conflicting configuration. |
 | `platform` | dict | `{}` | otari.ai integration settings (`base_url`, timeouts, retries) |
 
 ## Environment variables

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -46,7 +46,7 @@ so take care not to confuse them.
 
 - No local database is used for keys, users, budgets, or usage logs.
 - The `providers` block in `config.yml` must be empty (or absent).
-- Only these routes are exposed: `/health`, `/health/liveness`, `/health/readiness`, `/v1/chat/completions`, `/v1/messages`, and `/v1/responses`.
+- Only these routes are exposed: `/health`, `/health/liveness`, `/health/readiness`, `/v1/chat/completions`, `/v1/messages`, `/v1/messages/count_tokens`, and `/v1/responses`.
 - Chat requests use `Authorization: Bearer <otari-user-token>`.
 - The `/health` endpoint includes platform reachability status.
 

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -39,6 +39,25 @@ OTARI_ENV_PREFIX = "OTARI_"
 # scalar fields reachable via OTARI_<FIELD>. Raw YAML wins when both are set.
 OTARI_CONFIG_YAML_ENV = "OTARI_CONFIG_YAML"
 OTARI_CONFIG_B64_ENV = "OTARI_CONFIG_B64"
+# GatewayConfig fields promoted from ad hoc otari_env() reads in route/service
+# code. The read sites still consult otari_env() (they have no config object in
+# scope), so load_config bridges values set in the YAML config into the process
+# environment for these fields; without the bridge a YAML-set value would
+# validate at startup and then be silently ignored at request time. Each field
+# name maps onto its OTARI_<FIELD> environment variable.
+ENV_BRIDGED_FIELDS = (
+    "sandbox_url",
+    "guardrails_url",
+    "tools_header",
+    "sandbox_purpose_hint",
+    "web_search_purpose_hint",
+    "web_search_engines",
+    "web_search_max_results",
+    "web_search_extract",
+    "web_search_allow_private_hosts",
+    "mcp_allow_loopback",
+    "mcp_allow_private_hosts",
+)
 
 
 class _NonScalarField(Exception):
@@ -684,6 +703,12 @@ def load_config(config_path: str | None = None) -> GatewayConfig:
     if structured_env_config:
         config_dict.update(structured_env_config)
 
+    # Snapshot which bridged fields the YAML config set, before the env
+    # overrides below inject OTARI_ values into the same dict: only YAML-set
+    # values need bridging into the environment (env-set values are already
+    # visible to the otari_env() read sites, with unchanged semantics).
+    yaml_bridged_fields = {name for name in ENV_BRIDGED_FIELDS if config_dict.get(name) is not None}
+
     _apply_otari_env_overrides(config_dict)
     _apply_platform_env_overrides(config_dict)
 
@@ -695,6 +720,7 @@ def load_config(config_path: str | None = None) -> GatewayConfig:
     config.validate_mode_selection()
     config.validate_provider_instances()
     config.validate_aliases()
+    _bridge_yaml_fields_to_env(config, yaml_bridged_fields)
     return config
 
 
@@ -728,6 +754,26 @@ def _coerce_scalar_env(value: str, annotation: Any) -> Any:
     if annotation is str:
         return value
     raise _NonScalarField
+
+
+def _bridge_yaml_fields_to_env(config: GatewayConfig, yaml_set_fields: set[str]) -> None:
+    """Bridge YAML-set promoted fields into the process env for otari_env() readers.
+
+    The runtime read sites for ENV_BRIDGED_FIELDS call ``otari_env()``, which
+    only sees environment variables. ``os.environ.setdefault`` keeps env
+    precedence intact: an ``OTARI_<FIELD>`` variable that is already set always
+    wins, and fields not set in YAML are left untouched, so pure-env
+    deployments (including legacy ``GATEWAY_`` names and their exact string
+    spellings) behave byte-for-byte as before. Values are serialized from the
+    validated field, with booleans lowercased to ``true``/``false``, the
+    spellings every otari_env() consumer parses.
+    """
+    for field_name in yaml_set_fields:
+        value = getattr(config, field_name)
+        if value is None:
+            continue
+        serialized = ("true" if value else "false") if isinstance(value, bool) else str(value)
+        os.environ.setdefault(f"{OTARI_ENV_PREFIX}{field_name.upper()}", serialized)
 
 
 def _apply_otari_env_overrides(config: dict[str, Any]) -> None:

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -300,6 +300,91 @@ class GatewayConfig(BaseSettings):
             "local models behind OpenAI-compatible servers."
         ),
     )
+    sandbox_url: str | None = Field(
+        default=None,
+        description=(
+            "Base URL of the code-execution sandbox backend for otari_code_execution tools. "
+            "Legacy env alias: GATEWAY_SANDBOX_URL. When unset, otari_code_execution requests "
+            "are rejected with 400."
+        ),
+    )
+    guardrails_url: str | None = Field(
+        default=None,
+        description=(
+            "Default URL of the input-guardrails service used when a request does not pass its "
+            "own guardrail `url`. Legacy env alias: GATEWAY_GUARDRAILS_URL. docker-compose sets "
+            "this to the bundled guardrails container."
+        ),
+    )
+    tools_header: str | None = Field(
+        default=None,
+        description=(
+            "Per-deployment override for the purpose-hint preamble header injected ahead of "
+            "gateway-managed tool hints. Legacy env alias: GATEWAY_TOOLS_HEADER. When unset, a "
+            "built-in default header is used."
+        ),
+    )
+    sandbox_purpose_hint: str | None = Field(
+        default=None,
+        description=(
+            "Default purpose hint forwarded to the sandbox backend when an otari_code_execution "
+            "tool entry does not supply its own. Legacy env alias: GATEWAY_SANDBOX_PURPOSE_HINT."
+        ),
+    )
+    web_search_purpose_hint: str | None = Field(
+        default=None,
+        description=(
+            "Default purpose hint for the web-search backend when an otari_web_search tool entry "
+            "does not supply its own. Legacy env alias: GATEWAY_WEB_SEARCH_PURPOSE_HINT."
+        ),
+    )
+    web_search_engines: str | None = Field(
+        default=None,
+        description=(
+            "Comma-separated SearXNG engine list for the web-search backend (e.g. 'google,bing'). "
+            "Legacy env alias: GATEWAY_WEB_SEARCH_ENGINES. When unset, the backend default engines "
+            "are used."
+        ),
+    )
+    web_search_max_results: int | None = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Default cap on the number of hits returned by the web-search backend (a per-tool "
+            "max_results still overrides it). Legacy env alias: GATEWAY_WEB_SEARCH_MAX_RESULTS."
+        ),
+    )
+    web_search_extract: bool | None = Field(
+        default=None,
+        description=(
+            "Whether the web-search backend extracts page content in-process (True) or returns "
+            "snippet-only results (False). Legacy env alias: GATEWAY_WEB_SEARCH_EXTRACT. When "
+            "unset, the backend default (extraction on) applies."
+        ),
+    )
+    web_search_allow_private_hosts: bool = Field(
+        default=False,
+        description=(
+            "SSRF gate: allow the web-search backend to fetch private/loopback/reserved hosts. "
+            "Off by default. Legacy env alias: GATEWAY_WEB_SEARCH_ALLOW_PRIVATE_HOSTS. Only enable "
+            "for unusual setups such as a private search index."
+        ),
+    )
+    mcp_allow_loopback: bool = Field(
+        default=True,
+        description=(
+            "SSRF gate: allow MCP server URLs that resolve to loopback (useful for same-host "
+            "sidecars). On by default. Legacy env alias: GATEWAY_MCP_ALLOW_LOOPBACK."
+        ),
+    )
+    mcp_allow_private_hosts: bool = Field(
+        default=False,
+        description=(
+            "SSRF gate: allow MCP server URLs that resolve to private/reserved hosts, and accept "
+            "hostnames that fail to resolve at validation time. Off by default. Legacy env alias: "
+            "GATEWAY_MCP_ALLOW_PRIVATE_HOSTS."
+        ),
+    )
     mode: str | None = Field(
         default=None,
         description=(

--- a/tests/integration/test_config_env_loading.py
+++ b/tests/integration/test_config_env_loading.py
@@ -143,6 +143,69 @@ def test_load_config_honors_legacy_gateway_prefix(tmp_path: Path, monkeypatch: p
     assert config.port == 7100
 
 
+def test_load_config_promotes_service_level_fields_from_otari_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The service-level knobs that used to be read only via otari_env() deep in
+    # route/service code are now typed GatewayConfig fields, validated at startup
+    # and populated by the same OTARI_ override machinery as every scalar field.
+    config_file = tmp_path / "gateway.yml"
+    config_file.write_text("{}\n", encoding="utf-8")
+
+    for legacy in (
+        "GATEWAY_SANDBOX_URL",
+        "GATEWAY_GUARDRAILS_URL",
+        "GATEWAY_WEB_SEARCH_MAX_RESULTS",
+        "GATEWAY_MCP_ALLOW_LOOPBACK",
+    ):
+        monkeypatch.delenv(legacy, raising=False)
+    monkeypatch.setenv("OTARI_SANDBOX_URL", "http://sandbox:9000")
+    monkeypatch.setenv("OTARI_GUARDRAILS_URL", "http://guardrails:8000")
+    monkeypatch.setenv("OTARI_WEB_SEARCH_MAX_RESULTS", "7")
+    monkeypatch.setenv("OTARI_WEB_SEARCH_EXTRACT", "false")
+    monkeypatch.setenv("OTARI_MCP_ALLOW_LOOPBACK", "false")
+
+    config = load_config(str(config_file))
+
+    assert config.sandbox_url == "http://sandbox:9000"
+    assert config.guardrails_url == "http://guardrails:8000"
+    assert config.web_search_max_results == 7
+    assert config.web_search_extract is False
+    assert config.mcp_allow_loopback is False
+
+
+def test_load_config_service_level_fields_honor_legacy_gateway_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Promoting these knobs must not break their legacy GATEWAY_ env names.
+    config_file = tmp_path / "gateway.yml"
+    config_file.write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.delenv("OTARI_SANDBOX_URL", raising=False)
+    monkeypatch.delenv("OTARI_MCP_ALLOW_PRIVATE_HOSTS", raising=False)
+    monkeypatch.setenv("GATEWAY_SANDBOX_URL", "http://legacy-sandbox:9000")
+    monkeypatch.setenv("GATEWAY_MCP_ALLOW_PRIVATE_HOSTS", "true")
+
+    config = load_config(str(config_file))
+
+    assert config.sandbox_url == "http://legacy-sandbox:9000"
+    assert config.mcp_allow_private_hosts is True
+
+
+def test_load_config_rejects_invalid_service_level_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The promotion buys startup validation: a value the old code silently
+    # ignored (a non-int web-search cap) now fails fast at config load.
+    config_file = tmp_path / "gateway.yml"
+    config_file.write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.setenv("OTARI_WEB_SEARCH_MAX_RESULTS", "not-an-int")
+
+    with pytest.raises(ValueError):
+        load_config(str(config_file))
+
+
 def test_load_config_otari_env_overrides_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     config_file = tmp_path / "gateway.yml"
     config_file.write_text("budget_strategy: for_update\n", encoding="utf-8")

--- a/tests/integration/test_config_env_loading.py
+++ b/tests/integration/test_config_env_loading.py
@@ -1,11 +1,14 @@
 import base64
 import os
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
 import gateway.core.config as config_module
 from gateway.core.config import load_config
+from gateway.core.env import otari_env
+from gateway.services.url_safety import UnsafeURLError, validate_mcp_url, validate_outbound_fetch_url
 
 
 def test_load_config_loads_provider_env_vars_from_dotenv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -204,6 +207,105 @@ def test_load_config_rejects_invalid_service_level_field(
 
     with pytest.raises(ValueError):
         load_config(str(config_file))
+
+
+def test_load_config_bridges_yaml_service_fields_into_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The otari_env() read sites only see environment variables, so load_config
+    # bridges YAML-set promoted fields into the process env; without this a
+    # YAML-set sandbox_url would validate at startup and be ignored at request
+    # time.
+    config_file = tmp_path / "gateway.yml"
+    config_file.write_text(
+        "sandbox_url: http://yaml-sandbox:9000\nmcp_allow_loopback: false\nweb_search_max_results: 5\n",
+        encoding="utf-8",
+    )
+    for var in (
+        "OTARI_SANDBOX_URL",
+        "GATEWAY_SANDBOX_URL",
+        "OTARI_MCP_ALLOW_LOOPBACK",
+        "GATEWAY_MCP_ALLOW_LOOPBACK",
+        "OTARI_WEB_SEARCH_MAX_RESULTS",
+        "GATEWAY_WEB_SEARCH_MAX_RESULTS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    with mock.patch.dict(os.environ):
+        config = load_config(str(config_file))
+
+        assert config.sandbox_url == "http://yaml-sandbox:9000"
+        assert otari_env("SANDBOX_URL") == "http://yaml-sandbox:9000"
+        assert otari_env("MCP_ALLOW_LOOPBACK") == "false"
+        assert otari_env("WEB_SEARCH_MAX_RESULTS") == "5"
+
+
+def test_load_config_env_wins_over_yaml_for_bridged_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The bridge uses setdefault: an OTARI_ variable that is already set keeps
+    # its value (and also wins in the field, via the env override machinery).
+    config_file = tmp_path / "gateway.yml"
+    config_file.write_text("sandbox_url: http://yaml-sandbox:9000\n", encoding="utf-8")
+
+    monkeypatch.setenv("OTARI_SANDBOX_URL", "http://env-sandbox:9000")
+
+    config = load_config(str(config_file))
+
+    assert config.sandbox_url == "http://env-sandbox:9000"
+    assert otari_env("SANDBOX_URL") == "http://env-sandbox:9000"
+
+
+def test_load_config_does_not_bridge_fields_absent_from_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A field populated only from the legacy GATEWAY_ env var is not bridged:
+    # the read sites already see that variable, and leaving it alone keeps
+    # env-only deployments byte-for-byte identical (including nonstandard
+    # boolean spellings the strict gate parsers treat differently).
+    config_file = tmp_path / "gateway.yml"
+    config_file.write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.delenv("OTARI_SANDBOX_URL", raising=False)
+    monkeypatch.setenv("GATEWAY_SANDBOX_URL", "http://legacy-sandbox:9000")
+
+    with mock.patch.dict(os.environ):
+        config = load_config(str(config_file))
+
+        assert config.sandbox_url == "http://legacy-sandbox:9000"
+        assert "OTARI_SANDBOX_URL" not in os.environ
+        assert otari_env("SANDBOX_URL") == "http://legacy-sandbox:9000"
+
+
+@pytest.mark.asyncio
+async def test_yaml_ssrf_gates_round_trip_through_env_bridge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A YAML-set SSRF gate boolean must reach the url_safety gate parsers with
+    # the spelling they accept: `true` opens the private-host gates for both
+    # the MCP and web-search fetch paths.
+    config_file = tmp_path / "gateway.yml"
+    config_file.write_text(
+        "mcp_allow_private_hosts: true\nweb_search_allow_private_hosts: true\n",
+        encoding="utf-8",
+    )
+    for var in (
+        "OTARI_MCP_ALLOW_PRIVATE_HOSTS",
+        "GATEWAY_MCP_ALLOW_PRIVATE_HOSTS",
+        "OTARI_WEB_SEARCH_ALLOW_PRIVATE_HOSTS",
+        "GATEWAY_WEB_SEARCH_ALLOW_PRIVATE_HOSTS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    with mock.patch.dict(os.environ):
+        load_config(str(config_file))
+
+        await validate_mcp_url("https://10.0.0.5/mcp", has_authorization_token=False)
+        await validate_outbound_fetch_url("https://10.0.0.5/page")
+
+    # Outside the bridged environment the gates are closed again.
+    with pytest.raises(UnsafeURLError, match="private"):
+        await validate_outbound_fetch_url("https://10.0.0.5/page")
 
 
 def test_load_config_otari_env_overrides_yaml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_url_safety.py
+++ b/tests/unit/test_url_safety.py
@@ -2,7 +2,11 @@
 
 import pytest
 
-from gateway.services.url_safety import UnsafeURLError, validate_mcp_url
+from gateway.services.url_safety import (
+    UnsafeURLError,
+    validate_mcp_url,
+    validate_outbound_fetch_url,
+)
 
 
 @pytest.mark.asyncio
@@ -68,6 +72,29 @@ async def test_no_host_rejected() -> None:
 async def test_private_override_allows_internal(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GATEWAY_MCP_ALLOW_PRIVATE_HOSTS", "true")
     await validate_mcp_url("https://10.0.0.5/mcp", has_authorization_token=False)
+
+
+@pytest.mark.asyncio
+async def test_mcp_private_override_reads_otari_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    # After promoting these gates to GatewayConfig, the SSRF read path still
+    # consults otari_env() directly (the functions have no config in scope), so
+    # the canonical OTARI_ prefix must keep toggling the gate.
+    monkeypatch.delenv("GATEWAY_MCP_ALLOW_PRIVATE_HOSTS", raising=False)
+    monkeypatch.setenv("OTARI_MCP_ALLOW_PRIVATE_HOSTS", "true")
+    await validate_mcp_url("https://10.0.0.5/mcp", has_authorization_token=False)
+
+
+@pytest.mark.asyncio
+async def test_web_search_private_override_reads_otari_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Same gate, web-search fetch path: rejected by default, allowed by the env
+    # override that the promoted web_search_allow_private_hosts field mirrors.
+    monkeypatch.delenv("OTARI_WEB_SEARCH_ALLOW_PRIVATE_HOSTS", raising=False)
+    monkeypatch.delenv("GATEWAY_WEB_SEARCH_ALLOW_PRIVATE_HOSTS", raising=False)
+    with pytest.raises(UnsafeURLError, match="private"):
+        await validate_outbound_fetch_url("https://10.0.0.5/page")
+
+    monkeypatch.setenv("OTARI_WEB_SEARCH_ALLOW_PRIVATE_HOSTS", "true")
+    await validate_outbound_fetch_url("https://10.0.0.5/page")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
> _Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

A set of operator-facing settings (the code-execution sandbox URL, guardrails URL,
tool purpose-hint header, web-search knobs, and three SSRF gates for MCP and
web-search fetches) was read ad hoc via `otari_env()` deep in route and service
code: never surfaced on `GatewayConfig`, never validated at startup, and mostly
undocumented. The SSRF gates in particular are security-relevant toggles that
should not be invisible config.

This PR promotes them to typed `GatewayConfig` fields (`sandbox_url`,
`guardrails_url`, `tools_header`, `sandbox_purpose_hint`, `web_search_purpose_hint`,
`web_search_engines`, `web_search_max_results`, `web_search_extract`,
`web_search_allow_private_hosts`, `mcp_allow_loopback`, `mcp_allow_private_hosts`).
The existing `OTARI_`/`GATEWAY_` override machinery populates them for free (it
already covers every scalar field), so each is now validated at startup and
discoverable in one place.

Compatibility: the read sites keep calling `otari_env()`. Several of them
(`url_safety`, `tool_format`, `mcp_loop`) are pure module-level functions with no
config object in scope, so threading a config through them and every caller would
be a risky refactor. Keeping the reads on `otari_env()` makes request-time and
SSRF-gate behavior identical (field and read derive from the same env var),
while the fields deliver startup validation and discoverability. No env var name
changes; the legacy `GATEWAY_` prefix keeps working. One intended improvement: a
malformed value the old code silently ignored now fails fast at startup.

Docs: added the 13 previously-missing `GatewayConfig` fields to the
`configuration.md` reference table, added a service-level env-var table (including
`OTARI_GUARDRAILS_URL`), fixed `.env.example` to `OTARI_WEB_SEARCH_URL`, corrected
the `/v1/models` description in `api-reference.md`, and added
`/v1/messages/count_tokens` to the hybrid route list in `modes.md`.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #263

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (no API contract change; `--check` confirms the spec is up to date).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code

**Any additional AI details you'd like to share:** Implemented and validated end to end (targeted tests, full unit suite, config integration tests, lint, typecheck, openapi-check) before commit.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Exposed previously hidden sandbox, guardrails, web-search, tool, MCP, and SSRF settings through typed configuration with startup validation.
- Preserved `OTARI_` and legacy `GATEWAY_` environment-variable compatibility and precedence.
- Bridged YAML configuration into runtime environment variables so existing readers use validated values.
- Expanded configuration and API documentation, corrected the `.env.example` variable, and updated hybrid route documentation.
- Added integration and unit tests covering validation, precedence, compatibility, environment bridging, and SSRF protections.

## Benefits

Operators can discover and validate more settings consistently, configure security controls safely, and continue using existing environment variables without behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->