### PR TITLE
fix(api): unify error handling and hybrid streaming fallback across completion routes

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -4357,7 +4357,7 @@
     },
     "/v1/messages": {
       "post": {
-        "description": "Anthropic Messages API-compatible endpoint.\n\nSupports MCP tool-use loops, sandboxed code execution, and SearXNG\nweb_search in both standalone mode and hybrid mode. Hybrid-mode\nrequests resolve credentials via the platform service and (for\nnon-tool-loop requests) get multi-attempt fallback across the resolved\nroute. Tool-loop requests collapse to a single attempt \u2014 once\n``on_first_response`` lock-in plumbing lands across the codebase, a\nfollow-up will enable pre-lock-in fallback for tool-loop requests too.",
+        "description": "Anthropic Messages API-compatible endpoint.\n\nSupports MCP tool-use loops, sandboxed code execution, and SearXNG\nweb_search in both standalone mode and hybrid mode. Hybrid-mode requests\nresolve credentials via the platform service and get multi-attempt\nfallback across the resolved route, tool-loop requests included (fallback\napplies up to the pre-lock-in point, same as chat).",
         "operationId": "create_message_v1_messages_post",
         "requestBody": {
           "content": {
@@ -4946,7 +4946,7 @@
     },
     "/v1/responses": {
       "post": {
-        "description": "OpenAI-compatible Responses endpoint.\n\nSupports MCP tool-use loops, sandboxed code execution, and SearXNG\nweb_search in both standalone mode and hybrid mode. Hybrid-mode\nrequests resolve credentials via the platform service and (for\nnon-tool-loop requests) get multi-attempt fallback across the resolved\nroute. Tool-loop requests collapse to a single attempt \u2014 once\n``on_first_response`` lock-in plumbing lands across the codebase, a\nfollow-up will enable pre-lock-in fallback for tool-loop requests too.",
+        "description": "OpenAI-compatible Responses endpoint.\n\nSupports MCP tool-use loops, sandboxed code execution, and SearXNG\nweb_search in both standalone mode and hybrid mode. Hybrid-mode requests\nresolve credentials via the platform service and get multi-attempt\nfallback across the resolved route, tool-loop requests included (fallback\napplies up to the pre-lock-in point, same as chat).",
         "operationId": "create_response_v1_responses_post",
         "requestBody": {
           "content": {

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -916,7 +916,7 @@
               },
               "raw": "{\n  \"model\": \"anthropic:claude-haiku-4-5\",\n  \"max_tokens\": 1024,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Hello from Otari!\"\n    }\n  ]\n}"
             },
-            "description": "Anthropic Messages API-compatible endpoint.\n\nSupports MCP tool-use loops, sandboxed code execution, and SearXNG\nweb_search in both standalone mode and hybrid mode. Hybrid-mode\nrequests resolve credentials via the platform service and (for\nnon-tool-loop requests) get multi-attempt fallback across the resolved\nroute. Tool-loop requests collapse to a single attempt \u2014 once\n``on_first_response`` lock-in plumbing lands across the codebase, a\nfollow-up will enable pre-lock-in fallback for tool-loop requests too.",
+            "description": "Anthropic Messages API-compatible endpoint.\n\nSupports MCP tool-use loops, sandboxed code execution, and SearXNG\nweb_search in both standalone mode and hybrid mode. Hybrid-mode requests\nresolve credentials via the platform service and get multi-attempt\nfallback across the resolved route, tool-loop requests included (fallback\napplies up to the pre-lock-in point, same as chat).",
             "header": [
               {
                 "key": "Content-Type",
@@ -1289,7 +1289,7 @@
               },
               "raw": "{\n  \"model\": \"openai:gpt-4o-mini\",\n  \"input\": \"Hello from Otari!\"\n}"
             },
-            "description": "OpenAI-compatible Responses endpoint.\n\nSupports MCP tool-use loops, sandboxed code execution, and SearXNG\nweb_search in both standalone mode and hybrid mode. Hybrid-mode\nrequests resolve credentials via the platform service and (for\nnon-tool-loop requests) get multi-attempt fallback across the resolved\nroute. Tool-loop requests collapse to a single attempt \u2014 once\n``on_first_response`` lock-in plumbing lands across the codebase, a\nfollow-up will enable pre-lock-in fallback for tool-loop requests too.",
+            "description": "OpenAI-compatible Responses endpoint.\n\nSupports MCP tool-use loops, sandboxed code execution, and SearXNG\nweb_search in both standalone mode and hybrid mode. Hybrid-mode requests\nresolve credentials via the platform service and get multi-attempt\nfallback across the resolved route, tool-loop requests included (fallback\napplies up to the pre-lock-in point, same as chat).",
             "header": [
               {
                 "key": "Content-Type",

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -35,7 +35,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import AsyncExitStack
 from datetime import UTC, datetime
 from enum import Enum, auto
-from typing import Any, Generic, NamedTuple, Protocol, TypeVar
+from typing import Any, Generic, NamedTuple, NoReturn, Protocol, TypeVar
 from urllib.parse import ParseResult, urlparse
 
 import httpx
@@ -69,6 +69,9 @@ from gateway.api.routes._platform import (
     _resolve_platform_mcp_servers,
     _resolve_platform_web_search,
     run_platform_attempts,
+)
+from gateway.api.routes._platform import (
+    default_attempt_kwargs as default_attempt_kwargs,  # explicit re-export for the route modules
 )
 from gateway.api.routes._tools import (
     _build_web_search_backend,
@@ -348,22 +351,6 @@ class FormatAdapter(Protocol, Generic[ResultT, ChunkT]):
         """Adjust the ``run_platform_attempts``-shaped kwargs for the format's
         provider call (the responses format re-splits ``provider:model``)."""
         ...
-
-
-def default_attempt_kwargs(
-    attempt: ResolvedAttempt,
-    base_request_fields: dict[str, Any],
-) -> dict[str, Any]:
-    """Standard platform-attempt kwargs: credentials + ``provider:model`` selector."""
-    attempt_provider = LLMProvider(attempt.provider)
-    kwargs: dict[str, Any] = {"api_key": attempt.api_key}
-    if attempt.api_base:
-        kwargs["api_base"] = attempt.api_base
-    return {
-        **kwargs,
-        **base_request_fields,
-        "model": f"{attempt_provider.value}:{attempt.model}",
-    }
 
 
 # ---------------------------------------------------------------------------
@@ -1647,6 +1634,38 @@ async def _stream_with_stack_cleanup(
         await backend_stack.aclose()
 
 
+def raise_all_streaming_attempts_failed(
+    adapter: FormatAdapter[Any, Any],
+    exc: Exception,
+    route: ResolvedRoute,
+) -> NoReturn:
+    """Map a terminal :func:`run_streaming_with_fallback` failure (no attempt
+    yielded a first chunk) onto the format's wire error.
+
+    Gateway-side backend failures (sandbox / web_search eager-open) get a 502
+    with a backend-specific detail so operators don't chase a fake provider
+    outage. Provider failures are classified when there is a single attempt,
+    or when the failure is a non-retryable invalid request (400/422): that
+    short-circuits the fallback and is definitive regardless of attempt count,
+    matching the non-streaming path. Otherwise the multi-attempt aggregate
+    surfaces (504 when the last failure was a timeout, else 502).
+    """
+    if isinstance(exc, SandboxNotReachableError):
+        logger.error("Sandbox unreachable request_id=%s: %s", route.request_id, exc)
+        raise adapter.error(502, SANDBOX_UNREACHABLE_DETAIL, ErrorKind.API) from exc
+    if isinstance(exc, WebSearchNotReachableError):
+        logger.error("Web search backend unreachable request_id=%s: %s", route.request_id, exc)
+        raise adapter.error(502, WEB_SEARCH_UNREACHABLE_DETAIL, ErrorKind.API) from exc
+    logger.error("All streaming attempts failed request_id=%s: %s", route.request_id, exc)
+    mapping = classify_provider_error(exc)
+    invalid_request = mapping is not None and mapping.status_code == status.HTTP_400_BAD_REQUEST
+    if invalid_request or len(route.attempts) <= 1:
+        raise adapter.provider_error(exc) from exc
+    if isinstance(exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
+        raise adapter.error(504, ALL_PROVIDERS_TIMED_OUT_DETAIL, ErrorKind.API) from exc
+    raise adapter.error(502, ALL_PROVIDERS_FAILED_DETAIL, ErrorKind.API) from exc
+
+
 async def run_platform_non_stream(
     *,
     adapter: FormatAdapter[ResultT, Any],
@@ -1724,6 +1743,20 @@ async def run_platform_non_stream(
             on_success=_on_attempt_success,
             max_tool_iterations=tool_ctx.max_tool_iterations,
         )
+    except SandboxNotReachableError as exc:
+        # The sandbox is part of the gateway's own infra, not the LLM
+        # provider; a distinct status stops operators chasing a "provider
+        # outage" that is actually the sandbox container being down. 502
+        # keeps "upstream dependency failed" semantics. Runs through the
+        # inline flush below because the error response drops the queued
+        # BackgroundTasks for any earlier attempts' reports.
+        logger.error("Sandbox unreachable request_id=%s: %s", route.request_id, exc)
+        await _flush_pending_usage_reports(config, pending_error_reports, route.request_id, session_label)
+        raise adapter.error(502, SANDBOX_UNREACHABLE_DETAIL, ErrorKind.API) from exc
+    except WebSearchNotReachableError as exc:
+        logger.error("Web search backend unreachable request_id=%s: %s", route.request_id, exc)
+        await _flush_pending_usage_reports(config, pending_error_reports, route.request_id, session_label)
+        raise adapter.error(502, WEB_SEARCH_UNREACHABLE_DETAIL, ErrorKind.API) from exc
     except HTTPException:
         # An error response drops the queued BackgroundTasks, so send the
         # per-attempt error reports inline before propagating. The background
@@ -1741,15 +1774,17 @@ async def run_standalone_non_stream(
     ctx: RequestContext,
     tool_ctx: ToolContext,
     call_kwargs: dict[str, Any],
+    response: Response,
     provider: Any,
     model: str,
     display_model: str | None = None,
 ) -> ResultT:
     """Standalone-mode non-streaming dispatch with reservation settlement.
 
-    Success writes the usage log (per the adapter's no-usage policy) and
-    reconciles the reservation against actual cost; every failure path refunds
-    the reservation before mapping the error to the format's wire envelope.
+    Success applies the rate-limit headers to ``response``, writes the usage
+    log (per the adapter's no-usage policy), and reconciles the reservation
+    against actual cost; every failure path refunds the reservation before
+    mapping the error to the format's wire envelope.
 
     ``display_model`` (a configured alias) relabels the result's ``model`` field
     before returning, so the underlying provider/model stays hidden; billing and
@@ -1757,6 +1792,9 @@ async def run_standalone_non_stream(
     """
     try:
         result = await dispatch_non_stream(adapter=adapter, tool_ctx=tool_ctx, call_kwargs=call_kwargs)
+        if ctx.rate_limit_info:
+            for key, value in rate_limit_headers(ctx.rate_limit_info).items():
+                response.headers[key] = value
         if ctx.db is not None:
             usage_data = adapter.extract_usage(result)
             actual_cost: float | None = None

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -27,6 +27,8 @@ from gateway.core.usage import cache_read_tokens_of, cache_write_tokens_of
 from gateway.log_config import logger
 from gateway.models.mcp import McpServerConfig
 from gateway.services.mcp_loop import MaxToolIterationsExceeded
+from gateway.services.sandbox_backend import SandboxNotReachableError
+from gateway.services.web_search_backend import WebSearchNotReachableError
 
 T = TypeVar("T")
 
@@ -104,6 +106,22 @@ class _AttemptFailure(NamedTuple):
     provider: str
     model: str
     error_class: str
+
+
+def default_attempt_kwargs(
+    attempt: ResolvedAttempt,
+    base_request_fields: dict[str, Any],
+) -> dict[str, Any]:
+    """Standard platform-attempt kwargs: credentials + ``provider:model`` selector."""
+    attempt_provider = LLMProvider(attempt.provider)
+    kwargs: dict[str, Any] = {"api_key": attempt.api_key}
+    if attempt.api_base:
+        kwargs["api_base"] = attempt.api_base
+    return {
+        **kwargs,
+        **base_request_fields,
+        "model": f"{attempt_provider.value}:{attempt.model}",
+    }
 
 
 def _provider_failure_http_exc(exc: BaseException, *, fallback_detail: str) -> HTTPException:
@@ -188,16 +206,7 @@ async def run_platform_attempts(
     last_exc: BaseException | None = None
 
     for attempt in attempts:
-        attempt_provider = LLMProvider(attempt.provider)
-        attempt_kwargs: dict[str, Any] = {"api_key": attempt.api_key}
-        if attempt.api_base:
-            attempt_kwargs["api_base"] = attempt.api_base
-
-        completion_kwargs = {
-            **attempt_kwargs,
-            **base_request_fields,
-            "model": f"{attempt_provider.value}:{attempt.model}",
-        }
+        completion_kwargs = default_attempt_kwargs(attempt, base_request_fields)
 
         # Per-attempt lock-in flag. Flipped the moment the upstream returns
         # its first assistant message via the ``_mark_locked_in`` callback
@@ -231,6 +240,13 @@ async def run_platform_attempts(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail=str(exc),
             ) from exc
+        except (SandboxNotReachableError, WebSearchNotReachableError):
+            # Gateway-side backend failure, not an upstream provider error:
+            # the same backend serves every attempt, so falling through cannot
+            # help, and reporting it as a provider attempt error would be
+            # wrong. Propagate raw so ``run_platform_non_stream`` maps it to a
+            # 502 with the backend-specific detail.
+            raise
         except BaseException as exc:
             retryable, error_class = classify_error(exc)
             report_attempt_outcome(attempt, "error", None, error_class)
@@ -349,13 +365,23 @@ async def _post_platform(
         return await client.post(url, headers=headers, json=body)
 
 
-async def _resolve_platform_credentials(
+async def _post_resolve(
     config: GatewayConfig,
+    *,
     user_token: str,
-    model_selector: str,
-) -> ResolvedRoute:
-    """Call the platform's ``/gateway/provider-keys/resolve`` to get the
-    routing plan (one or more ``ResolvedAttempt`` entries).
+    path: str,
+    body: dict[str, Any],
+    client_error_detail: str,
+) -> Any:
+    """POST ``body`` to a platform resolve endpoint and return the parsed JSON.
+
+    Owns the pieces every resolve helper shares: the base_url guard, the
+    gateway/user token headers, the bounded POST, and the status-code ladder.
+    A 200 returns the parsed payload; client errors (401/402/403/404/429) are
+    forwarded with the platform's detail when it is a safe string (falling back
+    to ``client_error_detail``), keeping Retry-After on a 429; timeouts,
+    network errors, the platform's server-side failures, and any unexpected
+    status collapse to a 502.
     """
     platform_base_url = config.platform.get("base_url")
     if not platform_base_url:
@@ -364,22 +390,18 @@ async def _resolve_platform_credentials(
             detail="Hybrid mode is misconfigured",
         )
 
-    provider, model_name = _split_model_selector(model_selector)
     timeout_ms = int(config.platform.get("resolve_timeout_ms", 5000))
-    resolve_url = _platform_url(platform_base_url, "/gateway/provider-keys/resolve")
-    resolve_headers = {
+    resolve_url = _platform_url(platform_base_url, path)
+    headers = {
         "X-Gateway-Token": config.platform_token or "",
         "X-User-Token": user_token,
     }
-    resolve_body: dict[str, Any] = {"model": model_name}
-    if provider:
-        resolve_body["provider"] = provider
 
     try:
         response = await _post_platform(
             url=resolve_url,
-            headers=resolve_headers,
-            body=resolve_body,
+            headers=headers,
+            body=body,
             timeout_seconds=timeout_ms / 1000,
         )
     except (httpx.TimeoutException, httpx.NetworkError):
@@ -389,26 +411,42 @@ async def _resolve_platform_credentials(
         ) from None
 
     if response.status_code == 200:
-        payload = response.json()
-        return _parse_resolve_payload(payload)
+        return response.json()
 
     if response.status_code in {401, 402, 403, 404, 429}:
-        detail = _safe_detail_from_platform(response, "Authorization request rejected")
-        headers: dict[str, str] | None = None
+        detail = _safe_detail_from_platform(response, client_error_detail)
+        response_headers: dict[str, str] | None = None
         if response.status_code == 429 and response.headers.get("Retry-After"):
-            headers = {"Retry-After": response.headers["Retry-After"]}
-        raise HTTPException(status_code=response.status_code, detail=detail, headers=headers)
-
-    if response.status_code == 422 or response.status_code >= 500:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Authorization service unavailable",
-        )
+            response_headers = {"Retry-After": response.headers["Retry-After"]}
+        raise HTTPException(status_code=response.status_code, detail=detail, headers=response_headers)
 
     raise HTTPException(
         status_code=status.HTTP_502_BAD_GATEWAY,
         detail="Authorization service unavailable",
     )
+
+
+async def _resolve_platform_credentials(
+    config: GatewayConfig,
+    user_token: str,
+    model_selector: str,
+) -> ResolvedRoute:
+    """Call the platform's ``/gateway/provider-keys/resolve`` to get the
+    routing plan (one or more ``ResolvedAttempt`` entries).
+    """
+    provider, model_name = _split_model_selector(model_selector)
+    resolve_body: dict[str, Any] = {"model": model_name}
+    if provider:
+        resolve_body["provider"] = provider
+
+    payload = await _post_resolve(
+        config,
+        user_token=user_token,
+        path="/gateway/provider-keys/resolve",
+        body=resolve_body,
+        client_error_detail="Authorization request rejected",
+    )
+    return _parse_resolve_payload(payload)
 
 
 def _parse_resolve_payload(payload: dict[str, Any]) -> ResolvedRoute:
@@ -493,63 +531,23 @@ async def _resolve_platform_mcp_servers(
     mcp_server_ids: list[uuid.UUID],
 ) -> list[McpServerConfig]:
     """Swap workspace-scoped MCP server ids for inline configs by calling the platform."""
-    platform_base_url = config.platform.get("base_url")
-    if not platform_base_url:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Hybrid mode is misconfigured",
-        )
-
-    timeout_ms = int(config.platform.get("resolve_timeout_ms", 5000))
-    resolve_url = _platform_url(platform_base_url, "/gateway/mcp-servers/resolve")
-    headers = {
-        "X-Gateway-Token": config.platform_token or "",
-        "X-User-Token": user_token,
-    }
-    body: dict[str, Any] = {"mcp_server_ids": [str(uid) for uid in mcp_server_ids]}
-
-    try:
-        response = await _post_platform(url=resolve_url, headers=headers, body=body, timeout_seconds=timeout_ms / 1000)
-    except (httpx.TimeoutException, httpx.NetworkError):
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Authorization service unavailable",
-        ) from None
-
-    if response.status_code == 200:
-        payload = response.json()
-        return [
-            McpServerConfig(
-                name=s["name"],
-                url=s["url"],
-                authorization_token=s.get("authorization_token"),
-                purpose_hint=s.get("purpose_hint"),
-                allowed_tools=s.get("allowed_tools"),
-            )
-            for s in payload.get("servers", [])
-        ]
-
-    # Mirror the status-code semantics of `_resolve_platform_credentials`:
-    # client errors (auth/quota/not-found/rate-limit) are forwarded so the
-    # caller sees the real status (and can honour Retry-After on 429), while
-    # the platform's server-side or unexpected responses collapse to 502.
-    if response.status_code in {401, 402, 403, 404, 429}:
-        detail = _safe_detail_from_platform(response, "MCP server resolution failed")
-        response_headers: dict[str, str] | None = None
-        if response.status_code == 429 and response.headers.get("Retry-After"):
-            response_headers = {"Retry-After": response.headers["Retry-After"]}
-        raise HTTPException(status_code=response.status_code, detail=detail, headers=response_headers)
-
-    if response.status_code == 422 or response.status_code >= 500:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Authorization service unavailable",
-        )
-
-    raise HTTPException(
-        status_code=status.HTTP_502_BAD_GATEWAY,
-        detail="Authorization service unavailable",
+    payload = await _post_resolve(
+        config,
+        user_token=user_token,
+        path="/gateway/mcp-servers/resolve",
+        body={"mcp_server_ids": [str(uid) for uid in mcp_server_ids]},
+        client_error_detail="MCP server resolution failed",
     )
+    return [
+        McpServerConfig(
+            name=s["name"],
+            url=s["url"],
+            authorization_token=s.get("authorization_token"),
+            purpose_hint=s.get("purpose_hint"),
+            allowed_tools=s.get("allowed_tools"),
+        )
+        for s in payload.get("servers", [])
+    ]
 
 
 async def _resolve_platform_web_search(
@@ -558,62 +556,19 @@ async def _resolve_platform_web_search(
 ) -> dict[str, Any]:
     """Resolve the workspace's web-search policy via the platform.
 
-    Mirrors `_resolve_platform_mcp_servers`: same base_url guard, timeout,
-    headers, `_post_platform` call, and status-code handling. POSTs an empty
-    body to `/gateway/web-search/resolve` and returns the parsed JSON dict on
-    200 (``{enabled, provider, max_results, purpose_hint, allowed_domains,
-    blocked_domains, provider_options}``). Client errors (auth/quota/not-found/
-    rate-limit) forward verbatim; the platform's server-side or unexpected
-    responses collapse to 502.
+    POSTs an empty body to `/gateway/web-search/resolve` (via `_post_resolve`,
+    which owns the shared guard/headers/status-code ladder) and returns the
+    parsed JSON dict on 200 (``{enabled, provider, max_results, purpose_hint,
+    allowed_domains, blocked_domains, provider_options}``).
     """
-    platform_base_url = config.platform.get("base_url")
-    if not platform_base_url:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Hybrid mode is misconfigured",
-        )
-
-    timeout_ms = int(config.platform.get("resolve_timeout_ms", 5000))
-    resolve_url = _platform_url(platform_base_url, "/gateway/web-search/resolve")
-    headers = {
-        "X-Gateway-Token": config.platform_token or "",
-        "X-User-Token": user_token,
-    }
-    body: dict[str, Any] = {}
-
-    try:
-        response = await _post_platform(url=resolve_url, headers=headers, body=body, timeout_seconds=timeout_ms / 1000)
-    except (httpx.TimeoutException, httpx.NetworkError):
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Authorization service unavailable",
-        ) from None
-
-    if response.status_code == 200:
-        payload = response.json()
-        return payload if isinstance(payload, dict) else {}
-
-    # Mirror the status-code semantics of `_resolve_platform_mcp_servers`:
-    # client errors (auth/quota/not-found/rate-limit) are forwarded so the
-    # caller sees the real status (and can honour Retry-After on 429), while
-    # the platform's server-side or unexpected responses collapse to 502.
-    if response.status_code in {401, 402, 403, 404, 429}:
-        detail = _safe_detail_from_platform(response, "Web search resolution failed")
-        response_headers: dict[str, str] | None = None
-        if response.status_code == 429 and response.headers.get("Retry-After"):
-            response_headers = {"Retry-After": response.headers["Retry-After"]}
-        raise HTTPException(status_code=response.status_code, detail=detail, headers=response_headers)
-
-    if response.status_code == 422 or response.status_code >= 500:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Authorization service unavailable",
-        )
-
-    raise HTTPException(
-        status_code=status.HTTP_502_BAD_GATEWAY,
-        detail="Authorization service unavailable",
+    payload = await _post_resolve(
+        config,
+        user_token=user_token,
+        path="/gateway/web-search/resolve",
+        body={},
+        client_error_detail="Web search resolution failed",
     )
+    return payload if isinstance(payload, dict) else {}
 
 
 async def _resolve_platform_code_execution(
@@ -622,57 +577,20 @@ async def _resolve_platform_code_execution(
 ) -> dict[str, Any]:
     """Resolve the workspace's code-execution policy via the platform.
 
-    Mirrors `_resolve_platform_web_search`: same base_url guard, timeout, headers,
-    `_post_platform` call, and status-code handling. POSTs an empty body to
-    `/gateway/code-execution/resolve` and returns the parsed JSON dict on 200
-    (``{enabled, tools, default_purpose_hint, max_iterations, exec_timeout_s}``,
-    soft limits already clamped to operator ceilings platform-side). Client errors
-    forward verbatim; server-side/unexpected responses collapse to 502.
+    POSTs an empty body to `/gateway/code-execution/resolve` (via
+    `_post_resolve`, which owns the shared guard/headers/status-code ladder)
+    and returns the parsed JSON dict on 200 (``{enabled, tools,
+    default_purpose_hint, max_iterations, exec_timeout_s}``, soft limits
+    already clamped to operator ceilings platform-side).
     """
-    platform_base_url = config.platform.get("base_url")
-    if not platform_base_url:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Platform mode is misconfigured",
-        )
-
-    timeout_ms = int(config.platform.get("resolve_timeout_ms", 5000))
-    resolve_url = _platform_url(platform_base_url, "/gateway/code-execution/resolve")
-    headers = {
-        "X-Gateway-Token": config.platform_token or "",
-        "X-User-Token": user_token,
-    }
-    body: dict[str, Any] = {}
-
-    try:
-        response = await _post_platform(url=resolve_url, headers=headers, body=body, timeout_seconds=timeout_ms / 1000)
-    except (httpx.TimeoutException, httpx.NetworkError):
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Authorization service unavailable",
-        ) from None
-
-    if response.status_code == 200:
-        payload = response.json()
-        return payload if isinstance(payload, dict) else {}
-
-    if response.status_code in {401, 402, 403, 404, 429}:
-        detail = _safe_detail_from_platform(response, "Code execution resolution failed")
-        response_headers: dict[str, str] | None = None
-        if response.status_code == 429 and response.headers.get("Retry-After"):
-            response_headers = {"Retry-After": response.headers["Retry-After"]}
-        raise HTTPException(status_code=response.status_code, detail=detail, headers=response_headers)
-
-    if response.status_code == 422 or response.status_code >= 500:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Authorization service unavailable",
-        )
-
-    raise HTTPException(
-        status_code=status.HTTP_502_BAD_GATEWAY,
-        detail="Authorization service unavailable",
+    payload = await _post_resolve(
+        config,
+        user_token=user_token,
+        path="/gateway/code-execution/resolve",
+        body={},
+        client_error_detail="Code execution resolution failed",
     )
+    return payload if isinstance(payload, dict) else {}
 
 
 async def _report_platform_usage(

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -1,9 +1,7 @@
-import asyncio
 import uuid
 from collections.abc import AsyncIterator, Callable
 from typing import Annotated, Any
 
-import httpx
 from any_llm import LLMProvider, acompletion
 from any_llm.types.completion import (
     ChatCompletion,
@@ -20,17 +18,14 @@ from gateway.api.deps import get_config, get_db_if_needed, get_log_writer
 from gateway.api.routes._helpers import latest_user_text
 from gateway.api.routes._normalize import normalize_request_messages
 from gateway.api.routes._pipeline import (
-    ALL_PROVIDERS_FAILED_DETAIL,
-    ALL_PROVIDERS_TIMED_OUT_DETAIL,
     NO_RESOLVABLE_PROVIDER_DETAIL,
     PROVIDER_ERROR_DETAIL,
-    SANDBOX_UNREACHABLE_DETAIL,
-    WEB_SEARCH_UNREACHABLE_DETAIL,
     ErrorKind,
     classify_provider_error,
     default_attempt_kwargs,
     log_usage,
     prepare_gateway_tools,
+    raise_all_streaming_attempts_failed,
     rate_limit_headers,
     resolve_dispatch_provider,
     resolve_request_context,
@@ -56,8 +51,6 @@ from gateway.services.mcp_loop import (
     mcp_tool_loop_stream,
 )
 from gateway.services.provider_kwargs import get_provider_kwargs as get_provider_kwargs  # noqa: F401
-from gateway.services.sandbox_backend import SandboxNotReachableError
-from gateway.services.web_search_backend import WebSearchNotReachableError
 from gateway.streaming import OPENAI_STREAM_FORMAT, StreamFormat
 
 router = APIRouter(prefix="/v1/chat", tags=["chat"])
@@ -349,43 +342,9 @@ async def chat_completions(
                 )
             except HTTPException:
                 raise
-            except SandboxNotReachableError as exc:
-                logger.error("Sandbox unreachable request_id=%s: %s", route.request_id, exc)
-                raise HTTPException(
-                    status_code=status.HTTP_502_BAD_GATEWAY,
-                    detail=SANDBOX_UNREACHABLE_DETAIL,
-                ) from exc
-            except WebSearchNotReachableError as exc:
-                logger.error("Web search backend unreachable request_id=%s: %s", route.request_id, exc)
-                raise HTTPException(
-                    status_code=status.HTTP_502_BAD_GATEWAY,
-                    detail=WEB_SEARCH_UNREACHABLE_DETAIL,
-                ) from exc
             except Exception as exc:
                 # Every attempt failed before any bytes were flushed.
-                logger.error(
-                    "All streaming attempts failed request_id=%s: %s",
-                    route.request_id,
-                    exc,
-                )
-                # Classify when there is a single attempt, or when the failure is
-                # a non-retryable invalid request (400/422): that short-circuits
-                # the fallback and is definitive regardless of attempt count, so
-                # it matches the non-streaming path. Otherwise surface the
-                # multi-attempt aggregate.
-                mapping = classify_provider_error(exc)
-                invalid_request = mapping is not None and mapping.status_code == status.HTTP_400_BAD_REQUEST
-                if invalid_request or len(route.attempts) <= 1:
-                    raise _ADAPTER.provider_error(exc) from exc
-                if isinstance(exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
-                    raise HTTPException(
-                        status_code=status.HTTP_504_GATEWAY_TIMEOUT,
-                        detail=ALL_PROVIDERS_TIMED_OUT_DETAIL,
-                    ) from exc
-                raise HTTPException(
-                    status_code=status.HTTP_502_BAD_GATEWAY,
-                    detail=ALL_PROVIDERS_FAILED_DETAIL,
-                ) from exc
+                raise_all_streaming_attempts_failed(_ADAPTER, exc, route)
 
         # Standalone path: single attempt, no fallback (no `route.attempts`).
         # Resolve the instance to its implementation; dispatch any-llm against
@@ -429,18 +388,13 @@ async def chat_completions(
 
     resolved = resolve_dispatch_provider(ctx, config, request.model)
     call_kwargs = {**resolved.kwargs, **request_fields, "model": resolved.dispatch_model}
-    completion = await run_standalone_non_stream(
+    return await run_standalone_non_stream(
         adapter=_ADAPTER,
         ctx=ctx,
         tool_ctx=tool_ctx,
         call_kwargs=call_kwargs,
+        response=response,
         provider=resolved.instance,
         model=resolved.model,
         display_model=resolved.alias,
     )
-
-    if ctx.rate_limit_info:
-        for key, value in rate_limit_headers(ctx.rate_limit_info).items():
-            response.headers[key] = value
-
-    return completion

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -1,10 +1,8 @@
-import asyncio
 import math
 import uuid
 from collections.abc import AsyncIterator, Callable
 from typing import Annotated, Any
 
-import httpx
 from any_llm import LLMProvider, amessages
 from any_llm.types.completion import CompletionUsage
 from any_llm.types.messages import (
@@ -23,17 +21,13 @@ from gateway.api.deps import get_config, get_db_if_needed, get_log_writer, verif
 from gateway.api.routes._helpers import latest_user_text
 from gateway.api.routes._normalize import normalize_request_messages
 from gateway.api.routes._pipeline import (
-    ALL_PROVIDERS_FAILED_DETAIL,
-    ALL_PROVIDERS_TIMED_OUT_DETAIL,
     DB_UNAVAILABLE_DETAIL,
     NO_RESOLVABLE_PROVIDER_DETAIL,
-    SANDBOX_UNREACHABLE_DETAIL,
-    WEB_SEARCH_UNREACHABLE_DETAIL,
     ErrorKind,
     classify_provider_error,
     default_attempt_kwargs,
     prepare_gateway_tools,
-    rate_limit_headers,
+    raise_all_streaming_attempts_failed,
     resolve_dispatch_provider,
     resolve_request_context,
     run_platform_non_stream,
@@ -60,9 +54,7 @@ from gateway.services.mcp_loop_messages import (
     anthropic_tool_loop,
     anthropic_tool_loop_stream,
 )
-from gateway.services.sandbox_backend import SandboxNotReachableError
 from gateway.services.tool_format import inject_purpose_hints_anthropic, openai_to_anthropic_tools
-from gateway.services.web_search_backend import WebSearchNotReachableError
 from gateway.streaming import ANTHROPIC_STREAM_FORMAT, StreamFormat
 
 router = APIRouter(prefix="/v1", tags=["messages"])
@@ -326,12 +318,10 @@ async def create_message(
     """Anthropic Messages API-compatible endpoint.
 
     Supports MCP tool-use loops, sandboxed code execution, and SearXNG
-    web_search in both standalone mode and hybrid mode. Hybrid-mode
-    requests resolve credentials via the platform service and (for
-    non-tool-loop requests) get multi-attempt fallback across the resolved
-    route. Tool-loop requests collapse to a single attempt — once
-    ``on_first_response`` lock-in plumbing lands across the codebase, a
-    follow-up will enable pre-lock-in fallback for tool-loop requests too.
+    web_search in both standalone mode and hybrid mode. Hybrid-mode requests
+    resolve credentials via the platform service and get multi-attempt
+    fallback across the resolved route, tool-loop requests included (fallback
+    applies up to the pre-lock-in point, same as chat).
     """
     user_from_metadata = request.metadata.get("user_id") if request.metadata else None
 
@@ -403,10 +393,7 @@ async def create_message(
     # Streaming path
     # ------------------------------------------------------------------
     if request.stream:
-        # Tool-loop streaming collapses to a single attempt for this format
-        # (chat already runs tool loops through the multi-attempt fallback;
-        # wiring the same here is a planned follow-up).
-        if ctx.hybrid_mode and not tool_ctx.use_tool_loop:
+        if ctx.hybrid_mode:
             route = ctx.route
             assert route is not None  # guaranteed by the hybrid-mode preamble
             if not route.attempts:
@@ -436,68 +423,20 @@ async def create_message(
                     raise
                 raise converted from exc
             except Exception as exc:
-                logger.error("All streaming attempts failed request_id=%s: %s", route.request_id, exc)
-                # Classify when there is a single attempt, or when the failure is
-                # a non-retryable invalid request (400/422): that short-circuits
-                # the fallback and is definitive regardless of attempt count, so
-                # it matches the non-streaming path. Otherwise surface the
-                # multi-attempt aggregate.
-                mapping = classify_provider_error(exc)
-                invalid_request = mapping is not None and mapping.status_code == status.HTTP_400_BAD_REQUEST
-                if invalid_request or len(route.attempts) <= 1:
-                    raise _ADAPTER.provider_error(exc) from exc
-                if isinstance(exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
-                    raise _anthropic_error(
-                        _ERR_API,
-                        ALL_PROVIDERS_TIMED_OUT_DETAIL,
-                        status.HTTP_504_GATEWAY_TIMEOUT,
-                    ) from exc
-                raise _anthropic_error(
-                    _ERR_API,
-                    ALL_PROVIDERS_FAILED_DETAIL,
-                    status.HTTP_502_BAD_GATEWAY,
-                ) from exc
+                raise_all_streaming_attempts_failed(_ADAPTER, exc, route)
 
-        # Standalone (or hybrid + tool-loop): single attempt streaming.
-        platform_correlation_id: str | None = None
-        platform_request_id: str | None = None
-        if ctx.hybrid_mode:
-            # Tool-loop hybrid path: build call_kwargs from the primary
-            # attempt and keep the platform contract (X-Correlation-ID,
-            # X-Otari-Request-ID, usage reported via _report_platform_usage).
-            route = ctx.route
-            assert route is not None  # guaranteed by the hybrid-mode preamble
-            if not route.attempts:
-                raise _anthropic_error(
-                    _ERR_API,
-                    NO_RESOLVABLE_PROVIDER_DETAIL,
-                    status.HTTP_502_BAD_GATEWAY,
-                )
-            attempt = route.attempts[0]
-            model = attempt.model
-            call_kwargs = default_attempt_kwargs(attempt, request_fields)
-            platform_correlation_id = attempt.attempt_id
-            platform_request_id = route.request_id
-            billing_provider: Any = LLMProvider(attempt.provider)
-            display_model: str | None = None
-        else:
-            resolved = resolve_dispatch_provider(ctx, config, request.model)
-            model = resolved.model
-            call_kwargs = {**resolved.kwargs, **request_fields, "model": resolved.dispatch_model}
-            billing_provider = resolved.instance
-            display_model = resolved.alias
-
+        # Standalone: single attempt streaming.
+        resolved = resolve_dispatch_provider(ctx, config, request.model)
+        call_kwargs = {**resolved.kwargs, **request_fields, "model": resolved.dispatch_model}
         return await run_single_attempt_stream(
             adapter=_ADAPTER,
             ctx=ctx,
             tool_ctx=tool_ctx,
             call_kwargs=call_kwargs,
-            provider=billing_provider,
-            model=model,
-            platform_correlation_id=platform_correlation_id,
-            platform_request_id=platform_request_id,
+            provider=resolved.instance,
+            model=resolved.model,
             session_label=request.session_label,
-            display_model=display_model,
+            display_model=resolved.alias,
         )
 
     # ------------------------------------------------------------------
@@ -521,25 +460,12 @@ async def create_message(
         except HTTPException as exc:
             # Hybrid terminal failures arrive as format-agnostic plain-string
             # HTTPExceptions; ensure the Anthropic envelope (dict details pass
-            # through unchanged).
+            # through unchanged, including the sandbox / web_search 502s that
+            # run_platform_non_stream raises via the adapter).
             converted = _ensure_anthropic_error(exc)
             if converted is exc:
                 raise
             raise converted from exc
-        except SandboxNotReachableError as e:
-            logger.error("Sandbox unreachable: %s", e)
-            raise _anthropic_error(
-                _ERR_API,
-                SANDBOX_UNREACHABLE_DETAIL,
-                status.HTTP_502_BAD_GATEWAY,
-            ) from e
-        except WebSearchNotReachableError as e:
-            logger.error("Web search backend unreachable: %s", e)
-            raise _anthropic_error(
-                _ERR_API,
-                WEB_SEARCH_UNREACHABLE_DETAIL,
-                status.HTTP_502_BAD_GATEWAY,
-            ) from e
         return result.model_dump(exclude_none=True)
 
     # Standalone non-stream path
@@ -550,14 +476,11 @@ async def create_message(
         ctx=ctx,
         tool_ctx=tool_ctx,
         call_kwargs=call_kwargs,
+        response=response,
         provider=resolved.instance,
         model=resolved.model,
         display_model=resolved.alias,
     )
-
-    if ctx.rate_limit_info:
-        for key, value in rate_limit_headers(ctx.rate_limit_info).items():
-            response.headers[key] = value
 
     return result.model_dump(exclude_none=True)
 

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -1,9 +1,7 @@
-import asyncio
 import uuid
 from collections.abc import AsyncIterator, Callable
 from typing import Annotated, Any
 
-import httpx
 from any_llm import AnyLLM, LLMProvider, aresponses
 from any_llm.types.completion import CompletionUsage
 from any_llm.types.responses import Response as ResponsesResponse
@@ -20,16 +18,12 @@ from gateway.api.deps import get_config, get_db_if_needed, get_log_writer
 from gateway.api.routes._helpers import latest_user_text, text_from_content
 from gateway.api.routes._normalize import normalize_request_messages
 from gateway.api.routes._pipeline import (
-    ALL_PROVIDERS_FAILED_DETAIL,
-    ALL_PROVIDERS_TIMED_OUT_DETAIL,
     NO_RESOLVABLE_PROVIDER_DETAIL,
     PROVIDER_ERROR_DETAIL,
-    SANDBOX_UNREACHABLE_DETAIL,
-    WEB_SEARCH_UNREACHABLE_DETAIL,
     ErrorKind,
     classify_provider_error,
     prepare_gateway_tools,
-    rate_limit_headers,
+    raise_all_streaming_attempts_failed,
     release_reservation,
     resolve_dispatch_provider,
     resolve_request_context,
@@ -43,7 +37,6 @@ from gateway.api.routes._schema_derive import SESSION_LABEL_DESC, SESSION_LABEL_
 from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
 from gateway.core.usage import GatewayUsage
-from gateway.log_config import logger
 from gateway.models.guardrails import GuardrailConfig
 from gateway.models.mcp import McpServerConfig
 from gateway.services.log_writer import LogWriter
@@ -53,9 +46,7 @@ from gateway.services.mcp_loop_responses import (
     responses_tool_loop,
     responses_tool_loop_stream,
 )
-from gateway.services.sandbox_backend import SandboxNotReachableError
 from gateway.services.tool_format import inject_purpose_hints_responses, openai_to_responses_tools
-from gateway.services.web_search_backend import WebSearchNotReachableError
 from gateway.streaming import RESPONSES_STREAM_FORMAT, StreamFormat
 
 router = APIRouter(prefix="/v1", tags=["responses"])
@@ -266,12 +257,10 @@ async def create_response(
     """OpenAI-compatible Responses endpoint.
 
     Supports MCP tool-use loops, sandboxed code execution, and SearXNG
-    web_search in both standalone mode and hybrid mode. Hybrid-mode
-    requests resolve credentials via the platform service and (for
-    non-tool-loop requests) get multi-attempt fallback across the resolved
-    route. Tool-loop requests collapse to a single attempt — once
-    ``on_first_response`` lock-in plumbing lands across the codebase, a
-    follow-up will enable pre-lock-in fallback for tool-loop requests too.
+    web_search in both standalone mode and hybrid mode. Hybrid-mode requests
+    resolve credentials via the platform service and get multi-attempt
+    fallback across the resolved route, tool-loop requests included (fallback
+    applies up to the pre-lock-in point, same as chat).
     """
     # max_output_tokens comes from an extra="allow" body, so it may be absent,
     # non-int, or negative — only trust a non-negative int for the estimate.
@@ -385,7 +374,7 @@ async def create_response(
     # Streaming path
     # ------------------------------------------------------------------
     if stream:
-        if ctx.hybrid_mode and not tool_ctx.use_tool_loop:
+        if ctx.hybrid_mode:
             route = ctx.route
             assert route is not None  # guaranteed by the hybrid-mode preamble
             if not route.attempts:
@@ -407,61 +396,19 @@ async def create_response(
             except HTTPException:
                 raise
             except Exception as exc:
-                logger.error("All streaming attempts failed request_id=%s: %s", route.request_id, exc)
-                # Classify when there is a single attempt, or when the failure is
-                # a non-retryable invalid request (400/422): that short-circuits
-                # the fallback and is definitive regardless of attempt count, so
-                # it matches the non-streaming path. Otherwise surface the
-                # multi-attempt aggregate.
-                mapping = classify_provider_error(exc)
-                invalid_request = mapping is not None and mapping.status_code == status.HTTP_400_BAD_REQUEST
-                if invalid_request or len(route.attempts) <= 1:
-                    raise _ADAPTER.provider_error(exc) from exc
-                if isinstance(exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
-                    raise HTTPException(
-                        status_code=status.HTTP_504_GATEWAY_TIMEOUT,
-                        detail=ALL_PROVIDERS_TIMED_OUT_DETAIL,
-                    ) from exc
-                raise HTTPException(
-                    status_code=status.HTTP_502_BAD_GATEWAY,
-                    detail=ALL_PROVIDERS_FAILED_DETAIL,
-                ) from exc
+                raise_all_streaming_attempts_failed(_ADAPTER, exc, route)
 
-        # Single-attempt streaming (standalone, or hybrid + tool-loop).
-        platform_correlation_id: str | None = None
-        platform_request_id: str | None = None
-        if ctx.hybrid_mode:
-            route = ctx.route
-            assert route is not None  # guaranteed by the hybrid-mode preamble
-            if not route.attempts:
-                raise HTTPException(
-                    status_code=status.HTTP_502_BAD_GATEWAY,
-                    detail=NO_RESOLVABLE_PROVIDER_DETAIL,
-                )
-            attempt = route.attempts[0]
-            provider = LLMProvider(attempt.provider)
-            model = attempt.model
-            call_kwargs = _ADAPTER.attempt_kwargs(attempt, base_request_fields)
-            platform_correlation_id = attempt.attempt_id
-            platform_request_id = route.request_id
-            stream_billing: Any = provider
-            display_model: str | None = None
-        else:
-            call_kwargs = {**provider_kwargs, **base_request_fields, "model": model}
-            stream_billing = billing_instance
-            display_model = resolved.alias
-
+        # Standalone: single attempt streaming.
+        call_kwargs = {**provider_kwargs, **base_request_fields, "model": model}
         return await run_single_attempt_stream(
             adapter=_ADAPTER,
             ctx=ctx,
             tool_ctx=tool_ctx,
             call_kwargs=call_kwargs,
-            provider=stream_billing,
+            provider=billing_instance,
             model=model,
-            platform_correlation_id=platform_correlation_id,
-            platform_request_id=platform_request_id,
             session_label=request_body.session_label,
-            display_model=display_model,
+            display_model=resolved.alias,
         )
 
     # ------------------------------------------------------------------
@@ -470,32 +417,17 @@ async def create_response(
     if ctx.hybrid_mode:
         route = ctx.route
         assert route is not None  # guaranteed by the hybrid-mode preamble
-        try:
-            result = await run_platform_non_stream(
-                adapter=_ADAPTER,
-                route=route,
-                base_request_fields=base_request_fields,
-                tool_ctx=tool_ctx,
-                response=response,
-                background_tasks=background_tasks,
-                config=config,
-                rate_limit_info=ctx.rate_limit_info,
-                session_label=request_body.session_label,
-            )
-        except HTTPException:
-            raise
-        except SandboxNotReachableError as e:
-            logger.error("Sandbox unreachable: %s", e)
-            raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
-                detail=SANDBOX_UNREACHABLE_DETAIL,
-            ) from e
-        except WebSearchNotReachableError as e:
-            logger.error("Web search backend unreachable: %s", e)
-            raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
-                detail=WEB_SEARCH_UNREACHABLE_DETAIL,
-            ) from e
+        result = await run_platform_non_stream(
+            adapter=_ADAPTER,
+            route=route,
+            base_request_fields=base_request_fields,
+            tool_ctx=tool_ctx,
+            response=response,
+            background_tasks=background_tasks,
+            config=config,
+            rate_limit_info=ctx.rate_limit_info,
+            session_label=request_body.session_label,
+        )
         return result.model_dump(exclude_none=True)
 
     # Standalone non-stream path
@@ -505,13 +437,10 @@ async def create_response(
         ctx=ctx,
         tool_ctx=tool_ctx,
         call_kwargs=call_kwargs,
+        response=response,
         provider=billing_instance,
         model=model,
         display_model=resolved.alias,
     )
-
-    if ctx.rate_limit_info:
-        for key, value in rate_limit_headers(ctx.rate_limit_info).items():
-            response.headers[key] = value
 
     return result.model_dump(exclude_none=True)

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -1622,3 +1622,100 @@ def test_platform_mode_sandbox_applies_workspace_max_iterations_cap(
 
     assert response.status_code == 200
     assert captured["max_iterations"] == 2
+
+
+def test_platform_mode_sandbox_unreachable_returns_502(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hybrid non-streaming chat with the sandbox backend down surfaces the
+    backend-specific 502, not a generic provider error or a 500. Regression
+    for the drift where only messages/responses translated this failure: the
+    translation now lives in run_platform_non_stream, so /v1/chat/completions
+    inherits it."""
+    monkeypatch.setenv("OTARI_SANDBOX_URL", "http://sandbox:8080")
+
+    from gateway.api.routes._pipeline import SANDBOX_UNREACHABLE_DETAIL
+    from gateway.services.sandbox_backend import SandboxNotReachableError
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _single_attempt_resolve_response(request_id="sbx-down")
+        if url.endswith("/gateway/code-execution/resolve"):
+            return httpx.Response(200, json={"enabled": True})
+        return httpx.Response(204)
+
+    class _DownSandboxBackend:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "_DownSandboxBackend":
+            raise SandboxNotReachableError("failed to create sandbox session at http://sandbox:8080")
+
+        async def __aexit__(self, *exc: object) -> None:
+            return None
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes._pipeline.SandboxBackend", _DownSandboxBackend)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "otari_code_execution"}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 502
+    assert response.json() == {"detail": SANDBOX_UNREACHABLE_DETAIL}
+
+
+def test_platform_mode_web_search_unreachable_returns_502(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hybrid non-streaming chat with the web-search backend down surfaces the
+    backend-specific 502 (same regression as the sandbox variant)."""
+    monkeypatch.setenv("OTARI_WEB_SEARCH_URL", "http://search:8080")
+
+    from gateway.api.routes._pipeline import WEB_SEARCH_UNREACHABLE_DETAIL
+    from gateway.services.web_search_backend import WebSearchNotReachableError
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _single_attempt_resolve_response(request_id="ws-down")
+        if url.endswith("/gateway/web-search/resolve"):
+            return httpx.Response(200, json={"enabled": True})
+        return httpx.Response(204)
+
+    class _DownWebSearchBackend:
+        async def __aenter__(self) -> "_DownWebSearchBackend":
+            raise WebSearchNotReachableError("web_search failed against http://search:8080")
+
+        async def __aexit__(self, *exc: object) -> None:
+            return None
+
+    def fake_build_web_search_backend(**kwargs: Any) -> _DownWebSearchBackend:
+        return _DownWebSearchBackend()
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes._pipeline._build_web_search_backend", fake_build_web_search_backend)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "otari_web_search"}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 502
+    assert response.json() == {"detail": WEB_SEARCH_UNREACHABLE_DETAIL}

--- a/tests/integration/test_hybrid_mode_messages.py
+++ b/tests/integration/test_hybrid_mode_messages.py
@@ -723,9 +723,9 @@ def test_hybrid_mode_tool_loop_streaming_sets_correlation_id_and_reports_usage(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Single-attempt tool-loop streaming in hybrid mode must still honor
-    the platform contract: X-Correlation-ID + X-Otari-Request-ID headers,
-    and usage reported back via _report_platform_usage on stream complete.
+    """Tool-loop streaming in hybrid mode must honor the platform contract:
+    X-Correlation-ID + X-Otari-Request-ID headers, and usage reported back
+    via _report_platform_usage on stream complete.
 
     Regression test for the issue where ``_stream_messages`` was the
     standalone helper and silently dropped the platform metadata when
@@ -806,9 +806,8 @@ def test_hybrid_mode_tool_loop_streaming_forwards_session_label(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The streaming success closure (``build_streaming_response._on_complete``)
-    on the ``run_single_attempt_stream`` hybrid path (used by messages/responses
-    for tool-loop streaming, which chat does not take) must carry the caller's
-    session_label onto the usage report."""
+    on the hybrid tool-loop streaming path (now ``run_streaming_with_fallback``,
+    same as chat) must carry the caller's session_label onto the usage report."""
     usage_reports: list[dict[str, Any]] = []
 
     async def fake_post_platform(

--- a/tests/integration/test_hybrid_mode_messages.py
+++ b/tests/integration/test_hybrid_mode_messages.py
@@ -1047,3 +1047,72 @@ def test_hybrid_mode_preamble_rejection_uses_anthropic_envelope_and_keeps_retry_
     detail = response.json()["detail"]
     assert detail["type"] == "error"
     assert detail["error"]["type"] == "rate_limit_error"
+
+def test_hybrid_mode_tool_loop_streaming_falls_through_pre_lock_in(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Streaming MCP request on /v1/messages: the first attempt errors before
+    yielding any event, so the gateway falls through to the second attempt and
+    streams its response (same pre-lock-in semantics as chat, which this
+    format previously collapsed to a single attempt)."""
+    from any_llm.types.messages import MessageDelta, MessageDeltaEvent, MessageDeltaUsage
+
+    usage_reports: list[dict[str, Any]] = []
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _two_attempt_resolve_response_anthropic_first(request_id="tool-stream-req-1")
+        usage_reports.append(body)
+        return httpx.Response(204)
+
+    calls: list[str] = []
+
+    class _FakeAuthError(Exception):
+        status_code = 401
+
+    async def fake_loop_stream(**kwargs: Any) -> Any:
+        api_key = str(kwargs["completion_kwargs"].get("api_key"))
+        calls.append(api_key)
+        if api_key == "sk-ant-broken":
+            raise _FakeAuthError("simulated upstream 401 on primary")
+        yield MessageDeltaEvent(
+            type="message_delta",
+            delta=MessageDelta(stop_reason=cast(Any, "end_turn"), stop_sequence=None),
+            usage=MessageDeltaUsage(
+                input_tokens=3,
+                output_tokens=5,
+                cache_creation_input_tokens=None,
+                cache_read_input_tokens=None,
+                server_tool_use=None,
+            ),
+        )
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes._pipeline.MCPClientPool", _FakeMcpPool)
+    monkeypatch.setattr("gateway.api.routes.messages.anthropic_tool_loop_stream", fake_loop_stream)
+
+    response = platform_client.post(
+        "/v1/messages",
+        json={
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+            "stream": True,
+            "mcp_servers": [{"name": "test", "url": "http://127.0.0.1:18080/mcp"}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.headers["X-Correlation-ID"] == "tool-att-fallback"
+    assert response.headers["X-Otari-Request-ID"] == "tool-stream-req-1"
+    assert "message_delta" in response.text
+    # Both attempts were tried in order: the tool-loop gate is gone.
+    assert calls == ["sk-ant-broken", "sk-ant-real"]
+    # The first attempt's failure was reported to the platform.
+    error_reports = [r for r in usage_reports if r.get("status") == "error"]
+    assert len(error_reports) == 1
+    assert error_reports[0]["correlation_id"] == "tool-att-primary"

--- a/tests/integration/test_hybrid_mode_responses.py
+++ b/tests/integration/test_hybrid_mode_responses.py
@@ -608,3 +608,65 @@ def test_hybrid_mode_streaming_single_attempt_classifies_provider_error(
 
     assert response.status_code == 404
     assert response.json() == {"detail": "The requested model was not found on the provider"}
+
+def test_hybrid_mode_tool_loop_streaming_falls_through_pre_lock_in(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Streaming MCP request on /v1/responses: the first attempt errors before
+    yielding any event, so the gateway falls through to the second attempt and
+    streams its response (same pre-lock-in semantics as chat, which this
+    format previously collapsed to a single attempt)."""
+    from openai.types.responses import ResponseCompletedEvent
+
+    usage_reports: list[dict[str, Any]] = []
+
+    async def fake_post_platform(
+        url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return _two_attempt_resolve_response_openai_first(request_id="tool-stream-req-1")
+        usage_reports.append(body)
+        return httpx.Response(204)
+
+    calls: list[str] = []
+
+    class _FakeAuthError(Exception):
+        status_code = 401
+
+    async def fake_loop_stream(**kwargs: Any) -> Any:
+        api_key = str(kwargs["completion_kwargs"].get("api_key"))
+        calls.append(api_key)
+        if api_key == "sk-openai-broken":
+            raise _FakeAuthError("simulated upstream 401 on primary")
+        yield ResponseCompletedEvent(
+            type="response.completed",
+            response=_response_object(),
+            sequence_number=0,
+        )
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes._pipeline.MCPClientPool", _FakeMcpPool)
+    monkeypatch.setattr("gateway.api.routes.responses.responses_tool_loop_stream", fake_loop_stream)
+
+    response = platform_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-4o-mini",
+            "input": "hi",
+            "stream": True,
+            "mcp_servers": [{"name": "test", "url": "http://127.0.0.1:18080/mcp"}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.headers["X-Correlation-ID"] == "tool-att-fallback"
+    assert response.headers["X-Otari-Request-ID"] == "tool-stream-req-1"
+    assert "response.completed" in response.text
+    # Both attempts were tried in order: the tool-loop gate is gone.
+    assert calls == ["sk-openai-broken", "sk-openai-real"]
+    # The first attempt's failure was reported to the platform.
+    error_reports = [r for r in usage_reports if r.get("status") == "error"]
+    assert len(error_reports) == 1
+    assert error_reports[0]["correlation_id"] == "tool-att-primary"

--- a/tests/integration/test_hybrid_mode_responses.py
+++ b/tests/integration/test_hybrid_mode_responses.py
@@ -468,11 +468,11 @@ def test_hybrid_mode_tool_loop_streaming_sets_correlation_id_and_reports_usage(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Single-attempt tool-loop streaming in hybrid mode must honor the
-    platform contract: X-Correlation-ID + X-Otari-Request-ID headers + usage
-    report via _report_platform_usage on complete. Regression test for the
-    issue where ``_stream_responses`` was the standalone helper and silently
-    dropped the platform metadata when invoked for platform + tool_loop.
+    """Tool-loop streaming in hybrid mode must honor the platform contract:
+    X-Correlation-ID + X-Otari-Request-ID headers + usage report via
+    _report_platform_usage on complete. Regression test for the issue where
+    ``_stream_responses`` was the standalone helper and silently dropped the
+    platform metadata when invoked for platform + tool_loop.
     """
     usage_reports: list[dict[str, Any]] = []
 


### PR DESCRIPTION
> _Note: this PR was implemented by Claude (Claude Code) working from issue #260. The direction and approvals are @njbrake's; the code and prose are Claude's._

## Description

The chat, messages, and responses routes share the request pipeline in `_pipeline.py` but had drifted in behavior and carried copy-pasted blocks (#260):

1. **Backend-down errors were swallowed on the hybrid non-streaming path.** A down sandbox or web-search backend was caught by `run_platform_attempts` and surfaced as a generic 502 "LLM provider error" on every route; the per-route translation handlers in `messages.py`/`responses.py` were dead code on that path. `run_platform_attempts` now propagates `SandboxNotReachableError`/`WebSearchNotReachableError` raw (they are gateway-side infra failures, not provider attempt errors, and the same backend serves every attempt so falling through cannot help), and `run_platform_non_stream` maps them to a 502 with the backend-specific detail, so all three routes inherit the translation.
2. **Hybrid tool-loop streaming fallback unified on the chat approach.** `/v1/messages` and `/v1/responses` gated `run_streaming_with_fallback` on `not tool_ctx.use_tool_loop`, collapsing tool-loop streams to a single attempt. The gates and the single-attempt blocks they guarded are gone; all hybrid streaming gets pre-lock-in multi-attempt fallback, with the platform contract (X-Correlation-ID, X-Otari-Request-ID, usage report, session_label) preserved.
3. **Shared `raise_all_streaming_attempts_failed(adapter, exc, route)`** in `_pipeline.py` replaces the three copy-pasted "all streaming attempts failed" classification blocks and also owns the sandbox/web-search 502 translation for the streaming path.
4. **Single `_post_resolve(...)` helper in `_platform.py`** owns the base_url guard, token headers, bounded POST, and status-code ladder shared by the four `_resolve_platform_*` functions. This also unifies the code-execution resolver's misconfiguration detail ("Platform mode is misconfigured" becomes "Hybrid mode is misconfigured", matching the other three).
5. **Smaller duplications:** `run_standalone_non_stream` applies the rate-limit headers itself (per-route tails removed), and `run_platform_attempts` builds attempt kwargs via `default_attempt_kwargs` (moved to `_platform.py`, re-exported from `_pipeline.py`) instead of rebuilding the shape inline.

Regression tests: hybrid chat non-streaming with the sandbox or web-search backend down now returns 502 with the backend-specific detail (verified to fail before the fix with the generic provider-error detail). Existing hybrid tool-loop streaming tests for messages/responses pass unmodified on the fallback path.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #260

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Fable 5 via Claude Code

**Any additional AI details you'd like to share:**

Implemented from issue #260's five sub-items; all five landed. Full unit suite (593 passed), full integration suite on Postgres (522 passed, 9 skipped), lint, typecheck, and openapi-check are green.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
