### PR TITLE
docs: use gw_ for the platform gateway token prefix

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -70,7 +70,7 @@ No `providers` block, no `database_url`, no `master_key`.
 
 ### 2. Set your otari.ai credentials
 
-You need the gateway token (`gw-...`) for this Otari instance from otari.ai.
+You need the gateway token (`gw_...`) for this Otari instance from otari.ai.
 In otari.ai, go to `Organisation > Gateways`, create or open a gateway, then
 click `Create token`. This is not the per-request user token (`tk_...`) that
 clients send in `Authorization: Bearer ...`.

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -21,10 +21,15 @@ When connected to [otari.ai](https://otari.ai), Otari delegates provider routing
 
 This mode activates automatically when `OTARI_AI_TOKEN` is set.
 
-`OTARI_AI_TOKEN` is the gateway token (`gw-...`) you create in otari.ai for
+`OTARI_AI_TOKEN` is the gateway token (`gw_...`) you create in otari.ai for
 this Otari instance. In otari.ai, go to `Organisation > Gateways`, create or
 open a gateway, then click `Create token`. It is not the per-request user token
 (`tk_...`) that clients send in `Authorization: Bearer ...`.
+
+Note the prefix: the platform gateway token uses an underscore (`gw_...`),
+whereas a locally issued Otari API key (standalone mode) uses a hyphen
+(`gw-...`). They are different credential types that differ by one character,
+so take care not to confuse them.
 
 ### What otari.ai handles
 
@@ -44,7 +49,7 @@ open a gateway, then click `Create token`. It is not the per-request user token
 ### Setup
 
 ```bash
-export OTARI_AI_TOKEN=gw-your-token-here
+export OTARI_AI_TOKEN=gw_your_token_here
 ```
 
 See [Deployment](deployment.md) for the full Docker setup.


### PR DESCRIPTION
> _Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

The platform gateway token was written as `gw-...` (hyphen) in `docs/modes.md`
and `docs/deployment.md`, but the correct spelling is `gw_...` (underscore). The
hyphen form collides with the prefix of locally issued API keys (`gw-`, see
`generate_api_key()` in `src/gateway/auth/models.py`), so the misspelling made
the platform gateway token look like a local API key, one character apart.

This PR standardizes the prose in both docs on `gw_`, and adds a sentence in
`modes.md` distinguishing the two prefixes (`gw_` platform gateway token vs
`gw-` locally issued API key) since the collision is easy to hit. Docs only; no
source or behavior changes.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #270

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). (Docs-only change; no tests needed.)
- [x] I ran the Definition of Done checks locally (`make lint`). (Docs-only; typecheck and tests not applicable.)
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec. (No API change.)

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Fable 5)

**Any additional AI details you'd like to share:** Drafted and implemented via back-and-forth with @njbrake; the reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
