### PR TITLE
chore: remove dead code (superseded budget fns, phantom route, unused globals)

### DIFF
--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -50,7 +50,6 @@ from gateway.services.mcp_loop import (
     mcp_tool_loop,
     mcp_tool_loop_stream,
 )
-from gateway.services.provider_kwargs import get_provider_kwargs as get_provider_kwargs  # noqa: F401
 from gateway.streaming import OPENAI_STREAM_FORMAT, StreamFormat
 
 router = APIRouter(prefix="/v1/chat", tags=["chat"])
@@ -58,7 +57,6 @@ router = APIRouter(prefix="/v1/chat", tags=["chat"])
 __all__ = [
     "ChatCompletionRequest",
     "chat_completions",
-    "get_provider_kwargs",
     "log_usage",
     "rate_limit_headers",
     "router",

--- a/src/gateway/api/routes/hybrid_mode.py
+++ b/src/gateway/api/routes/hybrid_mode.py
@@ -27,7 +27,7 @@ async def budgets_disabled() -> None:
     _raise_disabled()
 
 
-@router.api_route("/v1/spend/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
-@router.api_route("/v1/spend", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
-async def spend_disabled() -> None:
+@router.api_route("/v1/usage/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+@router.api_route("/v1/usage", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+async def usage_disabled() -> None:
     _raise_disabled()

--- a/src/gateway/core/database.py
+++ b/src/gateway/core/database.py
@@ -19,7 +19,6 @@ from gateway.core.config import GatewayConfig
 
 _engine: AsyncEngine | None = None
 _SessionLocal: async_sessionmaker[AsyncSession] | None = None
-_SYNC_DATABASE_URL: str | None = None
 
 # How long a SQLite connection waits for a held lock before raising
 # "database is locked", in milliseconds.
@@ -85,7 +84,7 @@ def _configure_sqlite_pragmas(engine: AsyncEngine) -> None:
 def init_db(config: GatewayConfig) -> None:
     """Initialize async database engine and optionally run migrations."""
 
-    global _engine, _SessionLocal, _SYNC_DATABASE_URL  # noqa: PLW0603
+    global _engine, _SessionLocal  # noqa: PLW0603
 
     database_url = config.database_url
     async_url, connect_args = _to_async_url(database_url)
@@ -104,7 +103,6 @@ def init_db(config: GatewayConfig) -> None:
 
     _engine = create_async_engine(async_url, **engine_kwargs)
     _SessionLocal = async_sessionmaker(_engine, expire_on_commit=False)
-    _SYNC_DATABASE_URL = database_url
 
     if is_sqlite:
         _configure_sqlite_pragmas(_engine)
@@ -139,12 +137,11 @@ async def create_session() -> AsyncIterator[AsyncSession]:
 def reset_db() -> None:
     """Dispose the active engine so it can be re-initialized (testing helper)."""
 
-    global _engine, _SessionLocal, _SYNC_DATABASE_URL  # noqa: PLW0603
+    global _engine, _SessionLocal  # noqa: PLW0603
 
     engine = _engine
     _engine = None
     _SessionLocal = None
-    _SYNC_DATABASE_URL = None
 
     if engine is None:
         return

--- a/src/gateway/services/budget_service.py
+++ b/src/gateway/services/budget_service.py
@@ -31,38 +31,6 @@ def calculate_next_reset(start: datetime, duration_sec: int) -> datetime:
     return start + timedelta(seconds=duration_sec)
 
 
-async def reset_user_budget(db: AsyncSession, user: User, budget: Budget, now: datetime) -> None:
-    """Reset user's budget spend and schedule next reset."""
-
-    previous_spend = float(user.spend)
-    user_id_str = user.user_id
-
-    user.spend = 0.0
-    user.budget_started_at = now
-
-    if budget.budget_duration_sec:
-        user.next_budget_reset_at = calculate_next_reset(now, budget.budget_duration_sec)
-    else:
-        user.next_budget_reset_at = None
-
-    reset_log = BudgetResetLog(
-        user_id=user.user_id,
-        budget_id=budget.budget_id,
-        previous_spend=previous_spend,
-        reset_at=now,
-        next_reset_at=user.next_budget_reset_at,
-    )
-    db.add(reset_log)
-
-    try:
-        await db.commit()
-        await db.refresh(user)
-    except SQLAlchemyError as e:
-        await db.rollback()
-        logger.error("Failed to commit budget reset for user '%s': %s", user_id_str, e)
-        raise
-
-
 async def _cas_reset_user_budget(db: AsyncSession, user: User, budget: Budget, now: datetime) -> User:
     next_reset_at = calculate_next_reset(now, budget.budget_duration_sec) if budget.budget_duration_sec else None
 
@@ -108,73 +76,6 @@ async def _cas_reset_user_budget(db: AsyncSession, user: User, budget: Budget, n
 async def _get_budget(db: AsyncSession, budget_id: str) -> Budget | None:
     result = await db.execute(select(Budget).where(Budget.budget_id == budget_id))
     return result.scalar_one_or_none()
-
-
-async def validate_user_budget(
-    db: AsyncSession,
-    user_id: str,
-    model: str | None = None,
-    *,
-    strategy: str = "for_update",
-) -> User:
-    """Validate user exists, is not blocked, and has available budget.
-
-    Args:
-        db: Database session
-        user_id: User identifier
-        model: Optional model identifier (e.g., "provider/model") to check if it's a free model
-
-    Returns:
-        User object if validation passes
-
-    Raises:
-        HTTPException: If user is blocked, doesn't exist, or exceeded budget
-
-    """
-    normalized_strategy = strategy or "for_update"
-    normalized_strategy = normalized_strategy.strip().lower()
-    if normalized_strategy not in {"for_update", "cas", "disabled"}:
-        normalized_strategy = "for_update"
-
-    lock_for_update = normalized_strategy == "for_update"
-    user = await get_active_user(db, user_id, for_update=lock_for_update)
-
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"User '{user_id}' not found",
-        )
-
-    if user.blocked:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"User '{user_id}' is blocked",
-        )
-
-    if normalized_strategy == "disabled" or not user.budget_id:
-        return user
-
-    budget = await _get_budget(db, user.budget_id)
-    if not budget:
-        return user
-
-    now = datetime.now(UTC)
-    if user.next_budget_reset_at and now >= user.next_budget_reset_at:
-        if normalized_strategy == "cas":
-            user = await _cas_reset_user_budget(db, user, budget, now)
-        else:
-            await reset_user_budget(db, user, budget, now)
-
-    if budget.max_budget is not None and user.spend >= budget.max_budget:
-        if model and await _is_model_free(db, model):
-            return user
-        record_budget_exceeded()
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"User '{user_id}' has exceeded budget limit",
-        )
-
-    return user
 
 
 async def _is_model_free(db: AsyncSession, model: str) -> bool:
@@ -303,9 +204,9 @@ async def reserve_budget(
     now = datetime.now(UTC)
     if user.next_budget_reset_at and now >= user.next_budget_reset_at:
         # Always reset via the atomic CAS path: reserve_budget never holds a
-        # row lock (see for_update=False above), so the read-modify-write
-        # reset_user_budget would let concurrent requests at the reset boundary
-        # double-reset (duplicate reset logs, clobbered spend).
+        # row lock (see for_update=False above), so a non-atomic
+        # read-modify-write reset would let concurrent requests at the reset
+        # boundary double-reset (duplicate reset logs, clobbered spend).
         user = await _cas_reset_user_budget(db, user, budget, now)
 
     # Free models do not consume budget; nothing to reserve. Reconciliation will

--- a/src/gateway/services/budget_service.py
+++ b/src/gateway/services/budget_service.py
@@ -52,8 +52,12 @@ async def _cas_reset_user_budget(db: AsyncSession, user: User, budget: Budget, n
 
     rowcount = getattr(result, "rowcount", 0)
     if rowcount and rowcount > 0:
+        # Captured before commit: rollback() expires ORM instances, so reading
+        # user.user_id in the error path would attempt sync IO in the async
+        # session (MissingGreenlet), masking the original commit error.
+        user_id_str = user.user_id
         reset_log = BudgetResetLog(
-            user_id=user.user_id,
+            user_id=user_id_str,
             budget_id=budget.budget_id,
             previous_spend=float(user.spend),
             reset_at=now,
@@ -64,9 +68,9 @@ async def _cas_reset_user_budget(db: AsyncSession, user: User, budget: Budget, n
             await db.commit()
         except SQLAlchemyError as e:
             await db.rollback()
-            logger.error("Failed to commit CAS budget reset for user '%s': %s", user.user_id, e)
+            logger.error("Failed to commit CAS budget reset for user '%s': %s", user_id_str, e)
             raise
-        refreshed = await get_active_user(db, user.user_id)
+        refreshed = await get_active_user(db, user_id_str)
         return refreshed or user
 
     await db.rollback()

--- a/src/gateway/services/model_discovery_service.py
+++ b/src/gateway/services/model_discovery_service.py
@@ -47,24 +47,6 @@ class ModelCache:
         """Store a provider's model list with the current timestamp."""
         self._store[provider] = _CacheEntry(models=list(models), cached_at=time.monotonic())
 
-    def get_all_cached(self, ttl: int | None = None) -> dict[str, list[Model]]:
-        """Return stored entries, optionally filtering by TTL.
-
-        Returns shallow copies so callers cannot mutate the internal cache.
-
-        Args:
-            ttl: If set, only return entries that are still valid. If None, return all.
-        """
-        result: dict[str, list[Model]] = {}
-        now = time.monotonic()
-        for provider, entry in list(self._store.items()):
-            if ttl is not None:
-                elapsed = now - entry.cached_at
-                if ttl <= 0 or elapsed >= ttl:
-                    continue
-            result[provider] = list(entry.models)
-        return result
-
     def clear(self, provider: str | None = None) -> None:
         """Invalidate one or all providers."""
         if provider is None:

--- a/tests/integration/test_budget_race_condition.py
+++ b/tests/integration/test_budget_race_condition.py
@@ -14,15 +14,14 @@ from gateway.services.budget_service import (
     reconcile_reservation,
     refund_reservation,
     reserve_budget,
-    validate_user_budget,
 )
 
 
 @pytest.mark.asyncio
-async def test_validate_user_budget_reads_user_without_locking(
+async def test_reserve_budget_reads_user_without_locking(
     async_db: Any,
 ) -> None:
-    """validate_user_budget should allow under-limit users without lock contention."""
+    """reserve_budget should read the user without a row lock (no for_update)."""
     budget = Budget(
         budget_id="race-budget",
         max_budget=10.0,
@@ -31,7 +30,7 @@ async def test_validate_user_budget_reads_user_without_locking(
 
     user = User(
         user_id="race-user",
-        spend=9.99,
+        spend=9.0,
         budget_id="race-budget",
     )
     async_db.add(user)
@@ -41,19 +40,17 @@ async def test_validate_user_budget_reads_user_without_locking(
         "gateway.services.budget_service.get_active_user",
         wraps=get_active_user,
     ) as mock_get_active_user:
-        result = await validate_user_budget(async_db, "race-user", strategy="cas")
+        handle = await reserve_budget(async_db, "race-user", 0.5, strategy="cas")
 
-    assert result.user_id == "race-user"
+    assert handle.reserved
     assert mock_get_active_user.call_args.kwargs.get("for_update", False) is False
 
 
 @pytest.mark.asyncio
-async def test_budget_check_rejects_at_limit(
+async def test_reserve_budget_rejects_at_limit(
     async_db: Any,
 ) -> None:
-    """Test that a user at or over budget limit is rejected."""
-    from fastapi import HTTPException
-
+    """A user already at the budget limit is rejected, even for a zero-cost request."""
     budget = Budget(
         budget_id="full-budget",
         max_budget=10.0,
@@ -69,7 +66,7 @@ async def test_budget_check_rejects_at_limit(
     await async_db.commit()
 
     with pytest.raises(HTTPException) as exc_info:
-        await validate_user_budget(async_db, "full-user")
+        await reserve_budget(async_db, "full-user", 0.0)
     assert exc_info.value.status_code == 403
 
 

--- a/tests/integration/test_hybrid_mode_surface.py
+++ b/tests/integration/test_hybrid_mode_surface.py
@@ -43,7 +43,7 @@ def test_hybrid_mode_disables_local_management_endpoints(monkeypatch: pytest.Mon
         users_response = client.post("/v1/users", json={"user_id": "u1"})
         keys_response = client.get("/v1/keys")
         budgets_response = client.get("/v1/budgets")
-        spend_response = client.get("/v1/spend")
+        usage_response = client.get("/v1/usage")
 
     expected = {"detail": "This endpoint is not available in hybrid mode. Manage this resource via the platform UI."}
     assert users_response.status_code == 404
@@ -52,8 +52,8 @@ def test_hybrid_mode_disables_local_management_endpoints(monkeypatch: pytest.Mon
     assert keys_response.json() == expected
     assert budgets_response.status_code == 404
     assert budgets_response.json() == expected
-    assert spend_response.status_code == 404
-    assert spend_response.json() == expected
+    assert usage_response.status_code == 404
+    assert usage_response.json() == expected
 
     reset_config()
     reset_db()

--- a/tests/integration/test_provider_kwargs_override.py
+++ b/tests/integration/test_provider_kwargs_override.py
@@ -9,10 +9,10 @@ from any_llm import LLMProvider
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, text
 
-from gateway.api.routes.chat import get_provider_kwargs
 from gateway.core.config import API_KEY_HEADER, GatewayConfig
 from gateway.db import Base, get_db
 from gateway.main import create_app
+from gateway.services.provider_kwargs import get_provider_kwargs
 
 from .conftest import _run_alembic_migrations, build_async_session_override
 

--- a/tests/integration/test_transaction_safety.py
+++ b/tests/integration/test_transaction_safety.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.core.config import API_KEY_HEADER
 from gateway.models.entities import Budget, User
-from gateway.services.budget_service import _is_model_free, reset_user_budget
+from gateway.services.budget_service import _cas_reset_user_budget, _is_model_free
 
 
 def test_create_user_rollback_on_commit_failure(
@@ -104,23 +104,23 @@ def test_set_pricing_rollback_on_commit_failure(
 
 
 @pytest.mark.asyncio
-async def test_reset_user_budget_rollback_on_commit_failure(async_db: AsyncSession) -> None:
-    """reset_user_budget rolls back and re-raises when commit fails."""
-    from datetime import UTC, datetime
+async def test_cas_reset_user_budget_rollback_on_commit_failure(async_db: AsyncSession) -> None:
+    """_cas_reset_user_budget rolls back and re-raises when commit fails."""
+    from datetime import UTC, datetime, timedelta
 
-    user = User(user_id="reset-fail-user", spend=50.0)
+    now = datetime.now(UTC)
+    # A past reset time makes the CAS UPDATE match the row so the code reaches commit.
+    user = User(user_id="reset-fail-user", spend=50.0, next_budget_reset_at=now - timedelta(seconds=1))
     budget = Budget(max_budget=100.0, budget_duration_sec=3600)
     async_db.add_all([user, budget])
     await async_db.commit()
-
-    now = datetime.now(UTC)
 
     with (
         patch.object(async_db, "commit", side_effect=OperationalError("db", {}, Exception("disk full"))),
         patch.object(async_db, "rollback", wraps=async_db.rollback) as mock_rollback,
     ):
         with pytest.raises(OperationalError):
-            await reset_user_budget(async_db, user, budget, now)
+            await _cas_reset_user_budget(async_db, user, budget, now)
 
         mock_rollback.assert_called_once()
 

--- a/tests/unit/test_gateway_model_discovery.py
+++ b/tests/unit/test_gateway_model_discovery.py
@@ -81,41 +81,6 @@ class TestModelCache:
         assert cache.get("openai", ttl=300) is None
         assert cache.get("anthropic", ttl=300) is None
 
-    def test_get_all_cached(self) -> None:
-        cache = ModelCache()
-        cache.set("openai", [_make_model("gpt-4o")])
-        cache.set("anthropic", [_make_model("claude-3-opus")])
-
-        all_cached = cache.get_all_cached()
-        assert "openai" in all_cached
-        assert "anthropic" in all_cached
-        assert len(all_cached["openai"]) == 1
-        assert len(all_cached["anthropic"]) == 1
-
-    def test_get_all_cached_respects_ttl(self) -> None:
-        """get_all_cached with ttl filters out expired entries."""
-        cache = ModelCache()
-        cache.set("openai", [_make_model("gpt-4o")])
-        cache.set("anthropic", [_make_model("claude-3-opus")])
-
-        # Backdate the openai entry so it appears expired.
-        cache._store["openai"].cached_at = time.monotonic() - 400
-
-        all_cached = cache.get_all_cached(ttl=300)
-        assert "openai" not in all_cached
-        assert "anthropic" in all_cached
-
-    def test_get_all_cached_returns_shallow_copy(self) -> None:
-        """Mutating the returned list should not affect the cache."""
-        cache = ModelCache()
-        cache.set("openai", [_make_model("gpt-4o")])
-
-        returned = cache.get_all_cached()
-        returned["openai"].append(_make_model("gpt-3.5"))
-
-        # Internal cache should still have only 1 model.
-        assert len(cache._store["openai"].models) == 1
-
     def test_get_returns_shallow_copy(self) -> None:
         """Mutating the returned list should not affect the cache."""
         cache = ModelCache()


### PR DESCRIPTION
## Description

Removes several pieces of dead or vestigial code, each verified to have zero production callers:

- **budget_service:** drops `validate_user_budget` and `reset_user_budget`. Both are superseded by the reservation model (`reserve_budget` / `reconcile_reservation` / `refund_reservation`) and were only reachable through tests. `reset_user_budget` is the non-atomic read-modify-write reset that could get re-wired by accident; the live path uses the atomic CAS reset. Integration coverage is retargeted onto the live path (non-locking read and at-limit rejection now exercise `reserve_budget`; the reset rollback-on-commit-failure test now exercises `_cas_reset_user_budget`). No race-condition coverage is dropped.
- **hybrid_mode:** the friendly 404 guarded `/v1/spend`, a path that does not exist. Retargeted it to the real bulk usage route `/v1/usage` so hybrid-mode callers get the consistent "manage via the platform UI" message instead of a bare 404.
- **model_discovery_service:** deletes `ModelCache.get_all_cached` (test-only) and its unit tests.
- **core/database:** deletes the `_SYNC_DATABASE_URL` global (assigned and cleared, never read) and the `global` statements referencing it.
- **routes/chat:** removes the `get_provider_kwargs` re-export shim and its `__all__` entry; the one importer now imports from the real module `gateway.services.provider_kwargs`.

The unused `batches.py` parameters (`background_tasks`, `raw_request`) are intentionally left in place: issue #258 is concurrently reworking `batches.py` enforcement, and removing those parameters from five handlers would risk a merge collision.

## PR Type

- [x] Refactor

## Relevant issues

Fixes #266

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). Note: DB-backed integration tests require Docker, which was unavailable locally; unit suites, lint, typecheck, and openapi-check all pass, and the touched integration files collect cleanly.
- [x] Documentation was updated where necessary. (No docs affected.)
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). (`make openapi-check` reports the spec is up to date.)

## AI Usage

- [x] AI was used for drafting/refactoring.

**AI Model/Tool used:** Claude Code (Fable 5)

**Any additional AI details you'd like to share:** Each dead-code claim was re-verified by grepping for all callers before deletion; the retargeted budget tests preserve the race-condition coverage on the live reservation path.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
