### PR TITLE
fix(cli): honor --log-level names and reject unsupported --workers

### DIFF
--- a/src/gateway/cli.py
+++ b/src/gateway/cli.py
@@ -13,6 +13,30 @@ from gateway.core.config import load_config
 from gateway.log_config import setup_logger
 from gateway.main import create_app
 
+_LOG_LEVEL_NAMES: dict[str, int] = {
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARNING": logging.WARNING,
+    "ERROR": logging.ERROR,
+    "CRITICAL": logging.CRITICAL,
+}
+
+
+def _parse_log_level(ctx: click.Context, param: click.Parameter, value: str | None) -> int:
+    """Map a symbolic (DEBUG/INFO/...) or numeric log level to its numeric value."""
+    if value is None:
+        return logging.INFO
+    normalized = value.strip().upper()
+    if normalized in _LOG_LEVEL_NAMES:
+        return _LOG_LEVEL_NAMES[normalized]
+    if normalized.isdigit():
+        return int(normalized)
+    choices = ", ".join(_LOG_LEVEL_NAMES)
+    raise click.BadParameter(
+        f"{value!r} is not a valid log level. Choose one of {choices} (case-insensitive) "
+        "or a numeric level such as 20."
+    )
+
 
 @click.group()
 def cli() -> None:
@@ -40,12 +64,17 @@ def cli() -> None:
     default=None,
     help="Automatically run database migrations on startup",
 )
-@click.option("--workers", default=1, type=int, help="Number of worker processes")
+@click.option(
+    "--workers",
+    default=1,
+    type=int,
+    help="Number of worker processes. Only 1 is supported today; values greater than 1 are rejected.",
+)
 @click.option(
     "--log-level",
-    default=logging.INFO,
-    type=click.Choice([logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL]),
-    help="Logging level",
+    default="INFO",
+    callback=_parse_log_level,
+    help="Logging level (case-insensitive): DEBUG, INFO, WARNING, ERROR, CRITICAL. Numeric levels are also accepted.",
 )
 def serve(
     config: str | None,
@@ -58,6 +87,15 @@ def serve(
     log_level: int,
 ) -> None:
     """Start the Otari server."""
+    if workers > 1:
+        raise click.ClickException(
+            "Otari does not support running more than one worker process yet. "
+            "uvicorn only honors workers greater than 1 when it is given an import string, "
+            "but Otari builds the app in-process from your resolved config, and its startup "
+            "hooks (schema init and bootstrap key creation) are not safe to run once per worker. "
+            "To scale out, run several otari processes behind a load balancer or process manager. "
+            "Re-run with --workers 1 (the default)."
+        )
     try:
         gateway_config = load_config(config)
     except ValueError as e:
@@ -109,7 +147,6 @@ def serve(
             app,
             host=gateway_config.host,
             port=gateway_config.port,
-            workers=workers,
         )
     except KeyboardInterrupt:
         logger.info("\nShutting down Otari...")

--- a/tests/unit/test_gateway_cli.py
+++ b/tests/unit/test_gateway_cli.py
@@ -1,9 +1,89 @@
+import logging
 import sys
+from dataclasses import dataclass
 
 import pytest
+import uvicorn
+from click.testing import CliRunner
 
 import gateway.cli as gateway_cli
 from gateway.core.config import GatewayConfig
+
+
+@dataclass
+class ServeCapture:
+    """Records observable side effects of the serve command under test."""
+
+    log_level: int | None = None
+    uvicorn_calls: int = 0
+
+
+@pytest.fixture
+def serve_stubs(monkeypatch: pytest.MonkeyPatch) -> ServeCapture:
+    """Stub out config loading, app creation, and the uvicorn server for serve tests.
+
+    Captures the log level passed to setup_logger and how many times uvicorn.run
+    was invoked, so tests can assert CLI behavior without starting a real server
+    or touching a database.
+    """
+    captured = ServeCapture()
+
+    def fake_load_config(config_path: str | None = None) -> GatewayConfig:
+        return GatewayConfig(master_key="test-master-key")
+
+    def fake_setup_logger(level: int) -> None:
+        captured.log_level = level
+
+    def fake_create_app(config: GatewayConfig) -> object:
+        return object()
+
+    def fake_uvicorn_run(*args: object, **kwargs: object) -> None:
+        captured.uvicorn_calls += 1
+
+    monkeypatch.setattr(gateway_cli, "load_config", fake_load_config)
+    monkeypatch.setattr(gateway_cli, "setup_logger", fake_setup_logger)
+    monkeypatch.setattr(gateway_cli, "create_app", fake_create_app)
+    monkeypatch.setattr(uvicorn, "run", fake_uvicorn_run)
+    return captured
+
+
+def test_serve_log_level_symbolic_name(serve_stubs: ServeCapture) -> None:
+    result = CliRunner().invoke(gateway_cli.serve, ["--log-level", "info"])
+    assert result.exit_code == 0, result.output
+    assert serve_stubs.log_level == logging.INFO
+    assert serve_stubs.uvicorn_calls == 1
+
+
+def test_serve_log_level_symbolic_uppercase(serve_stubs: ServeCapture) -> None:
+    result = CliRunner().invoke(gateway_cli.serve, ["--log-level", "DEBUG"])
+    assert result.exit_code == 0, result.output
+    assert serve_stubs.log_level == logging.DEBUG
+
+
+def test_serve_log_level_numeric_backcompat(serve_stubs: ServeCapture) -> None:
+    result = CliRunner().invoke(gateway_cli.serve, ["--log-level", "20"])
+    assert result.exit_code == 0, result.output
+    assert serve_stubs.log_level == 20
+
+
+def test_serve_log_level_invalid_is_rejected(serve_stubs: ServeCapture) -> None:
+    result = CliRunner().invoke(gateway_cli.serve, ["--log-level", "bogus"])
+    assert result.exit_code != 0
+    assert "not a valid log level" in result.output
+    assert serve_stubs.uvicorn_calls == 0
+
+
+def test_serve_default_workers_starts_server(serve_stubs: ServeCapture) -> None:
+    result = CliRunner().invoke(gateway_cli.serve, [])
+    assert result.exit_code == 0, result.output
+    assert serve_stubs.uvicorn_calls == 1
+
+
+def test_serve_workers_greater_than_one_is_rejected(serve_stubs: ServeCapture) -> None:
+    result = CliRunner().invoke(gateway_cli.serve, ["--workers", "4"])
+    assert result.exit_code != 0
+    assert "does not support running more than one worker" in result.output
+    assert serve_stubs.uvicorn_calls == 0
 
 
 def test_main_invokes_cli(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
> _Note: this PR was drafted by Claude via back-and-forth with @njbrake. The analysis and decisions are his; the prose is Claude's._

## Description

Two `otari serve` options were broken and this fixes both.

`--log-level` used `click.Choice` over the numeric `logging` constants
(10/20/30/40/50), so the natural `--log-level INFO` was rejected and users had
to pass `--log-level 20`. It now accepts the symbolic names DEBUG, INFO,
WARNING, ERROR, CRITICAL (case-insensitive) mapped to their numeric level, and
still accepts numeric strings for backward compatibility.

`--workers` was silently ignored. uvicorn only honors workers greater than 1
when given an import string, but the CLI passes a live app instance, so it
always ran a single worker while appearing to accept `--workers 4`. A factory
path is unsound here: the app is built in-process from a resolved config object,
and its startup hooks (schema init and bootstrap key creation) are not safe to
run once per worker (the bootstrap check-then-insert would race and mint
multiple keys). Instead of pretending, the CLI now fails fast with a clear,
actionable error when workers greater than 1 is requested, and the limitation is
documented in the option help text.

Tests: unit tests cover symbolic log level names (lower and upper case), the
numeric back-compat form, rejection of an invalid level, the default
single-worker start, and rejection of `--workers 4` before the server starts.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #268

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Fable 5)

**Any additional AI details you'd like to share:** Directed by @njbrake against issue #268. The decision to reject multi-worker rather than add an app factory reflects his review. Unit suite, lint, and typecheck run locally; integration tests were not affected (CLI-only change).

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
