### PR TITLE
feat: add API key rotation endpoint

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -4355,6 +4355,54 @@
         ]
       }
     },
+    "/v1/keys/{key_id}/rotate": {
+      "post": {
+        "description": "Rotate an API key's secret in place.\n\nRequires master key authentication.\n\nGenerates a new secret for the same key row (id, user, name, expiry, and\nmetadata are preserved) and returns the new raw key once, using the same\nresponse shape as key creation. The previous secret stops authenticating\nimmediately; there is no grace window.",
+        "operationId": "rotate_key_v1_keys__key_id__rotate_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "title": "Key Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateKeyResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "summary": "Rotate Key",
+        "tags": [
+          "keys"
+        ]
+      }
+    },
     "/v1/messages": {
       "post": {
         "description": "Anthropic Messages API-compatible endpoint.\n\nSupports MCP tool-use loops, sandboxed code execution, and SearXNG\nweb_search in both standalone mode and hybrid mode. Hybrid-mode\nrequests resolve credentials via the platform service and (for\nnon-tool-loop requests) get multi-attempt fallback across the resolved\nroute. Tool-loop requests collapse to a single attempt \u2014 once\n``on_first_response`` lock-in plumbing lands across the codebase, a\nfollow-up will enable pre-lock-in fallback for tool-loop requests too.",

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -898,6 +898,33 @@
               ]
             }
           }
+        },
+        {
+          "name": "Rotate Key",
+          "request": {
+            "description": "Rotate an API key's secret in place.\n\nRequires master key authentication.\n\nGenerates a new secret for the same key row (id, user, name, expiry, and\nmetadata are preserved) and returns the new raw key once, using the same\nresponse shape as key creation. The previous secret stops authenticating\nimmediately; there is no grace window.",
+            "header": [],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "keys",
+                ":key_id",
+                "rotate"
+              ],
+              "raw": "{{baseUrl}}/v1/keys/:key_id/rotate",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "key_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
         }
       ],
       "name": "keys"

--- a/src/gateway/api/routes/keys.py
+++ b/src/gateway/api/routes/keys.py
@@ -216,6 +216,50 @@ async def update_key(
     return KeyInfo.from_model(key)
 
 
+@router.post("/{key_id}/rotate", dependencies=[Depends(verify_master_key)])
+async def rotate_key(
+    key_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> CreateKeyResponse:
+    """Rotate an API key's secret in place.
+
+    Requires master key authentication.
+
+    Generates a new secret for the same key row (id, user, name, expiry, and
+    metadata are preserved) and returns the new raw key once, using the same
+    response shape as key creation. The previous secret stops authenticating
+    immediately; there is no grace window.
+    """
+    result = await db.execute(select(APIKey).where(APIKey.id == key_id))
+    key = result.scalar_one_or_none()
+
+    if not key:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"API key with id '{key_id}' not found",
+        )
+
+    new_api_key = generate_api_key()
+    key.key_hash = hash_key(new_api_key)
+    key.last_used_at = None
+
+    try:
+        await db.commit()
+    except SQLAlchemyError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database error",
+        ) from None
+    await db.refresh(key)
+
+    key_info = KeyInfo.from_model(key)
+    return CreateKeyResponse(
+        **key_info.model_dump(exclude={"last_used_at"}),
+        key=new_api_key,
+    )
+
+
 @router.delete("/{key_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(verify_master_key)])
 async def delete_key(
     key_id: str,

--- a/tests/integration/test_key_management.py
+++ b/tests/integration/test_key_management.py
@@ -172,6 +172,112 @@ def test_delete_nonexistent_api_key(client: TestClient, master_key_header: dict[
     assert response.status_code == 404
 
 
+def test_rotate_api_key_returns_new_working_key_same_id(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
+    """Rotating a key returns a new secret for the same id, and the new key authenticates."""
+    create_response = client.post(
+        "/v1/keys",
+        json={"key_name": "rotate-me", "metadata": {"team": "eng"}},
+        headers=master_key_header,
+    )
+    assert create_response.status_code == 200
+    original = create_response.json()
+
+    rotate_response = client.post(
+        f"/v1/keys/{original['id']}/rotate",
+        headers=master_key_header,
+    )
+    assert rotate_response.status_code == 200
+    rotated = rotate_response.json()
+
+    assert rotated["id"] == original["id"]
+    assert rotated["key"].startswith("gw-")
+    assert rotated["key"] != original["key"]
+    assert rotated["key_name"] == original["key_name"]
+    assert rotated["user_id"] == original["user_id"]
+    assert rotated["metadata"] == {"team": "eng"}
+    assert rotated["is_active"] is True
+
+    # The new secret authenticates.
+    response = client.get(
+        "/v1/models",
+        headers={API_KEY_HEADER: f"Bearer {rotated['key']}"},
+    )
+    assert response.status_code == 200
+
+
+def test_rotate_api_key_old_secret_stops_working(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
+    """After rotation the previous secret no longer authenticates."""
+    create_response = client.post(
+        "/v1/keys",
+        json={"key_name": "rotate-invalidate"},
+        headers=master_key_header,
+    )
+    assert create_response.status_code == 200
+    original = create_response.json()
+
+    # Old secret works before rotation.
+    before = client.get(
+        "/v1/models",
+        headers={API_KEY_HEADER: f"Bearer {original['key']}"},
+    )
+    assert before.status_code == 200
+
+    rotate_response = client.post(
+        f"/v1/keys/{original['id']}/rotate",
+        headers=master_key_header,
+    )
+    assert rotate_response.status_code == 200
+
+    # Old secret is rejected immediately, with no grace window.
+    after = client.get(
+        "/v1/models",
+        headers={API_KEY_HEADER: f"Bearer {original['key']}"},
+    )
+    assert after.status_code == 401
+
+
+def test_rotate_api_key_resets_last_used_at(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
+    """Rotation clears last_used_at since the new secret has never been used."""
+    create_response = client.post(
+        "/v1/keys",
+        json={"key_name": "rotate-last-used"},
+        headers=master_key_header,
+    )
+    api_key = create_response.json()
+
+    # Exercise the key so last_used_at is populated.
+    client.get("/v1/models", headers={API_KEY_HEADER: f"Bearer {api_key['key']}"})
+    used_state = client.get(f"/v1/keys/{api_key['id']}", headers=master_key_header)
+    assert used_state.json()["last_used_at"] is not None
+
+    client.post(f"/v1/keys/{api_key['id']}/rotate", headers=master_key_header)
+
+    rotated_state = client.get(f"/v1/keys/{api_key['id']}", headers=master_key_header)
+    assert rotated_state.json()["last_used_at"] is None
+
+
+def test_rotate_nonexistent_api_key(client: TestClient, master_key_header: dict[str, str]) -> None:
+    """Rotating a non-existent key returns 404."""
+    response = client.post("/v1/keys/nonexistent-id/rotate", headers=master_key_header)
+
+    assert response.status_code == 404
+
+
+def test_rotate_api_key_without_master_key_fails(
+    client: TestClient, api_key_obj: dict[str, Any]
+) -> None:
+    """Rotation without master key authentication is rejected."""
+    response = client.post(f"/v1/keys/{api_key_obj['id']}/rotate")
+
+    assert response.status_code in [401, 422]
+
+
 def test_api_key_last_used_tracking(
     client: TestClient, master_key_header: dict[str, str], test_config: GatewayConfig
 ) -> None:


### PR DESCRIPTION
## Description
Adds `POST /v1/keys/{key_id}/rotate` so a leaked or aging key can be re-secreted in place. Today the only way to change a key's secret is delete plus recreate, which mints a new key id and breaks usage-history attribution and anything referencing the old id (external references, budgets tied to workflows). Rotation preserves the id, user, name, expiry, and metadata while issuing a fresh secret.

Behavior:
- Master-key auth, same as the other key management routes.
- Regenerates the secret for the same row, updates the stored SHA-256 hash, clears `last_used_at` (the new secret has never been used), and returns the new raw key once using the same response shape as key creation.
- The previous secret stops authenticating immediately; there is no grace window. A configurable overlap window for zero-downtime rollover is noted in the issue as a possible follow-up.
- Unknown or already-deleted keys return 404.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
Fixes #271

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). Note: `make lint`, `make typecheck`, and the full unit suite ran locally; the integration tests need Docker for Testcontainers PostgreSQL, which was unavailable, so the endpoint was validated end-to-end against SQLite via the real app and the integration suite runs in CI.
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code

**Any additional AI details you'd like to share:**
Integration tests could not run in the authoring environment (no Docker for Testcontainers PostgreSQL); the endpoint was validated end-to-end against SQLite via the real app, and CI runs the integration suite. Lint, typecheck, unit tests, and the OpenAPI freshness check all pass locally.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
