### PR TITLE
test: drop global reruns, add billable-route enforcement coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,8 +87,11 @@ ORM entities are in `src/gateway/models/entities.py` (User, APIKey, Budget, Usag
 ### Test Environment Notes
 - `pytest.ini` sets:
   - `timeout = 120`
-  - `reruns = 5`
-  - `reruns_delay = 10`
+  - There is no global rerun policy. A blanket `reruns` would let a test that
+    passes one time in several count as green, hiding flakiness and ordering
+    bugs suite-wide. Mark a genuinely flaky test with
+    `@pytest.mark.flaky(reruns=...)` (from `pytest-rerunfailures`) and say why,
+    rather than reintroducing a global retry.
 - Integration tests can use:
   - `TEST_DATABASE_URL` (if provided), or
   - Testcontainers PostgreSQL (`postgres:17`) if not provided.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,2 @@
 [pytest]
 timeout = 120
-reruns = 5
-reruns_delay = 10

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -137,6 +137,28 @@ def db_session(test_config: GatewayConfig) -> Generator[Session]:
         engine.dispose()
 
 
+@pytest.fixture
+def db_session_factory(test_config: GatewayConfig) -> Generator[Callable[[], Session]]:
+    """Hand out fresh standalone DB sessions for verifying state outside the client.
+
+    Some tests read DB state at several points around a request, or poll while a
+    background writer commits usage logs; each read needs its own session so it
+    observes the latest committed rows rather than a cached identity map. This
+    owns one engine for the test and centralizes the boilerplate those tests used
+    to hand-roll (create_engine / sessionmaker / dispose) at each call site.
+    """
+    engine = create_engine(test_config.database_url, pool_pre_ping=True)
+    factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    def make_session() -> Session:
+        return factory()
+
+    try:
+        yield make_session
+    finally:
+        engine.dispose()
+
+
 @pytest.fixture(scope="session")
 def test_config(postgres_url: str) -> GatewayConfig:
     """Create a test configuration."""

--- a/tests/integration/test_passthrough_enforcement.py
+++ b/tests/integration/test_passthrough_enforcement.py
@@ -155,17 +155,16 @@ def test_billable_route_rejects_over_budget_user(
     assert "budget" in response.json()["detail"].lower()
 
 
-@pytest.mark.xfail(reason="batches enforcement lands with #258", strict=False)
 def test_batches_rejects_blocked_user(
     client: TestClient,
     master_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
 ) -> None:
-    """``/v1/batches`` should reject a blocked user, but ``create_batch`` does not
-    yet run the budget/blocked gate (issue #258). Batches bills the API key's own
-    virtual user rather than a ``user`` body field, so we block that virtual user
-    and drive the route with the API key. Marked xfail until #258 wires
-    enforcement in; it will xpass (and this marker can be removed) once it does.
+    """``/v1/batches`` rejects a blocked user with 403 before the provider.
+
+    Batches bills the API key's own virtual user when no ``user`` body field is
+    sent, so we block that virtual user and drive the route with the API key.
+    Enforcement landed with issue #258.
     """
     api_key_header = {API_KEY_HEADER: f"Bearer {api_key_obj['key']}"}
     virtual_user_id = f"apikey-{api_key_obj['id']}"

--- a/tests/integration/test_passthrough_enforcement.py
+++ b/tests/integration/test_passthrough_enforcement.py
@@ -1,0 +1,193 @@
+"""Budget / blocked-user enforcement regression tests for billable routes.
+
+Every billable pass-through route (embeddings, moderations, rerank, images,
+audio transcription, audio speech) resolves a billed user and reserves budget
+*before* the provider call. These tests lock that in: a blocked user and an
+over-budget user must be rejected with 403 on every one of those routes, before
+any provider is reached. This is the guard that would have caught the
+``/v1/batches`` enforcement bypass (nothing asserted a given route actually runs
+the budget gate).
+
+The provider entrypoint for each route is patched to raise if it is ever
+called, so no real provider is needed and, more importantly, a route that
+skipped enforcement would reach the (raising) provider and fail the 403
+assertion instead of silently passing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from httpx2 import Response
+
+from gateway.core.config import API_KEY_HEADER
+
+# Sentinel raised if a provider entrypoint is invoked. Enforcement rejects the
+# request before the provider call, so reaching this is itself the failure.
+_PROVIDER_REACHED = AssertionError("provider entrypoint must not be reached when enforcement rejects the request")
+
+
+def _send_embeddings(client: TestClient, headers: dict[str, str], user_id: str) -> Response:
+    return client.post(
+        "/v1/embeddings",
+        json={"model": "openai:text-embedding-3-small", "input": "hello world", "user": user_id},
+        headers=headers,
+    )
+
+
+def _send_moderations(client: TestClient, headers: dict[str, str], user_id: str) -> Response:
+    return client.post(
+        "/v1/moderations",
+        json={"model": "openai:omni-moderation-latest", "input": "hello world", "user": user_id},
+        headers=headers,
+    )
+
+
+def _send_rerank(client: TestClient, headers: dict[str, str], user_id: str) -> Response:
+    return client.post(
+        "/v1/rerank",
+        json={
+            "model": "cohere:rerank-v3.5",
+            "query": "what is the capital of france",
+            "documents": ["paris is the capital of france", "berlin is the capital of germany"],
+            "user": user_id,
+        },
+        headers=headers,
+    )
+
+
+def _send_images(client: TestClient, headers: dict[str, str], user_id: str) -> Response:
+    return client.post(
+        "/v1/images/generations",
+        json={"model": "openai:dall-e-3", "prompt": "a red bicycle", "user": user_id},
+        headers=headers,
+    )
+
+
+def _send_transcription(client: TestClient, headers: dict[str, str], user_id: str) -> Response:
+    return client.post(
+        "/v1/audio/transcriptions",
+        files={"file": ("clip.mp3", b"fake-audio-bytes", "audio/mpeg")},
+        data={"model": "openai:whisper-1", "user": user_id},
+        headers=headers,
+    )
+
+
+def _send_speech(client: TestClient, headers: dict[str, str], user_id: str) -> Response:
+    return client.post(
+        "/v1/audio/speech",
+        json={"model": "openai:tts-1", "input": "hello world", "voice": "alloy", "user": user_id},
+        headers=headers,
+    )
+
+
+# (id, provider entrypoint to patch, request sender). The patch target is the
+# any-llm symbol as imported into the route module.
+_BILLABLE_ROUTES: list[tuple[str, str, Callable[[TestClient, dict[str, str], str], Response]]] = [
+    ("embeddings", "gateway.api.routes.embeddings.aembedding", _send_embeddings),
+    ("moderations", "gateway.api.routes.moderations.amoderation", _send_moderations),
+    ("rerank", "gateway.api.routes.rerank.arerank", _send_rerank),
+    ("images", "gateway.api.routes.images.aimage_generation", _send_images),
+    ("audio_transcription", "gateway.api.routes.audio.atranscription", _send_transcription),
+    ("audio_speech", "gateway.api.routes.audio.aspeech", _send_speech),
+]
+
+_ROUTE_PARAMS = [pytest.param(patch_target, send, id=route_id) for route_id, patch_target, send in _BILLABLE_ROUTES]
+
+
+def _create_blocked_user(client: TestClient, headers: dict[str, str], user_id: str) -> None:
+    resp = client.post("/v1/users", json={"user_id": user_id, "blocked": True}, headers=headers)
+    assert resp.status_code == 200
+
+
+def _create_over_budget_user(client: TestClient, headers: dict[str, str], user_id: str) -> None:
+    """A user pinned to a zero-dollar budget: any billable request is already at
+    the cap, so ``reserve_budget`` rejects with 403 (mirrors the chat-completions
+    over-budget test)."""
+    budget = client.post("/v1/budgets", json={"max_budget": 0.0}, headers=headers)
+    assert budget.status_code == 200
+    budget_id = budget.json()["budget_id"]
+    created = client.post(
+        "/v1/users",
+        json={"user_id": user_id, "budget_id": budget_id},
+        headers=headers,
+    )
+    assert created.status_code == 200
+
+
+@pytest.mark.parametrize(("patch_target", "send"), _ROUTE_PARAMS)
+def test_billable_route_rejects_blocked_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    patch_target: str,
+    send: Callable[[TestClient, dict[str, str], str], Response],
+) -> None:
+    """Each billable route rejects a blocked user with 403 before the provider."""
+    user_id = "enforce-blocked-user"
+    _create_blocked_user(client, master_key_header, user_id)
+
+    with patch(patch_target, side_effect=_PROVIDER_REACHED):
+        response = send(client, master_key_header, user_id)
+
+    assert response.status_code == 403
+    assert "blocked" in response.json()["detail"].lower()
+
+
+@pytest.mark.parametrize(("patch_target", "send"), _ROUTE_PARAMS)
+def test_billable_route_rejects_over_budget_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    patch_target: str,
+    send: Callable[[TestClient, dict[str, str], str], Response],
+) -> None:
+    """Each billable route rejects an over-budget user with 403 before the provider."""
+    user_id = "enforce-over-budget-user"
+    _create_over_budget_user(client, master_key_header, user_id)
+
+    with patch(patch_target, side_effect=_PROVIDER_REACHED):
+        response = send(client, master_key_header, user_id)
+
+    assert response.status_code == 403
+    assert "budget" in response.json()["detail"].lower()
+
+
+@pytest.mark.xfail(reason="batches enforcement lands with #258", strict=False)
+def test_batches_rejects_blocked_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """``/v1/batches`` should reject a blocked user, but ``create_batch`` does not
+    yet run the budget/blocked gate (issue #258). Batches bills the API key's own
+    virtual user rather than a ``user`` body field, so we block that virtual user
+    and drive the route with the API key. Marked xfail until #258 wires
+    enforcement in; it will xpass (and this marker can be removed) once it does.
+    """
+    api_key_header = {API_KEY_HEADER: f"Bearer {api_key_obj['key']}"}
+    virtual_user_id = f"apikey-{api_key_obj['id']}"
+
+    blocked = client.patch(
+        f"/v1/users/{virtual_user_id}",
+        json={"blocked": True},
+        headers=master_key_header,
+    )
+    assert blocked.status_code == 200
+
+    with patch("gateway.api.routes.batches.acreate_batch", side_effect=_PROVIDER_REACHED):
+        response = client.post(
+            "/v1/batches",
+            json={
+                "model": "openai:gpt-4o-mini",
+                "requests": [
+                    {"custom_id": "req-1", "body": {"messages": [{"role": "user", "content": "hi"}]}},
+                ],
+            },
+            headers=api_key_header,
+        )
+
+    assert response.status_code == 403
+    assert "blocked" in response.json()["detail"].lower()

--- a/tests/integration/test_streaming_precommit_refund.py
+++ b/tests/integration/test_streaming_precommit_refund.py
@@ -12,15 +12,14 @@ guard so all three endpoints stay consistent.
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session
 
-from gateway.core.config import GatewayConfig
 from gateway.models.entities import UsageLog, User
 
 from .conftest import MODEL_NAME
@@ -45,41 +44,33 @@ def _configure_pricing(client: TestClient, headers: dict[str, str], model_key: s
     assert res.status_code == 200
 
 
-def _user_state(test_config: GatewayConfig, user_id: str) -> tuple[float, float]:
-    engine = create_engine(test_config.database_url)
-    session_local = sessionmaker(bind=engine)
-    db = session_local()
+def _user_state(make_session: Callable[[], Session], user_id: str) -> tuple[float, float]:
+    db = make_session()
     try:
         user = db.query(User).filter(User.user_id == user_id).first()
         assert user is not None
         return float(user.spend), float(user.reserved)
     finally:
         db.close()
-        engine.dispose()
 
 
-def _poll_usage_logs(test_config: GatewayConfig, user_id: str, *, timeout: float = 3.0) -> list[str]:
-    engine = create_engine(test_config.database_url)
-    session_local = sessionmaker(bind=engine)
+def _poll_usage_logs(make_session: Callable[[], Session], user_id: str, *, timeout: float = 3.0) -> list[str]:
     deadline = time.time() + timeout
-    try:
-        while True:
-            db = session_local()
-            try:
-                rows = db.query(UsageLog).filter(UsageLog.user_id == user_id).all()
-                if rows or time.time() > deadline:
-                    return [r.status for r in rows]
-            finally:
-                db.close()
-            time.sleep(0.1)
-    finally:
-        engine.dispose()
+    while True:
+        db = make_session()
+        try:
+            rows = db.query(UsageLog).filter(UsageLog.user_id == user_id).all()
+            if rows or time.time() > deadline:
+                return [r.status for r in rows]
+        finally:
+            db.close()
+        time.sleep(0.1)
 
 
 def test_chat_streaming_precommit_error_refunds(
     client: TestClient,
     master_key_header: dict[str, str],
-    test_config: GatewayConfig,
+    db_session_factory: Callable[[], Session],
 ) -> None:
     user_id = "precommit-chat"
     _seed_budgeted_user(client, master_key_header, user_id)
@@ -101,16 +92,16 @@ def test_chat_streaming_precommit_error_refunds(
         )
 
     assert response.status_code == 502
-    spend, reserved = _user_state(test_config, user_id)
+    spend, reserved = _user_state(db_session_factory, user_id)
     assert spend == pytest.approx(0.0)
     assert reserved == pytest.approx(0.0)
-    assert _poll_usage_logs(test_config, user_id) == ["error"]
+    assert _poll_usage_logs(db_session_factory, user_id) == ["error"]
 
 
 def test_messages_streaming_precommit_error_refunds(
     client: TestClient,
     master_key_header: dict[str, str],
-    test_config: GatewayConfig,
+    db_session_factory: Callable[[], Session],
 ) -> None:
     user_id = "precommit-messages"
     _seed_budgeted_user(client, master_key_header, user_id)
@@ -133,16 +124,16 @@ def test_messages_streaming_precommit_error_refunds(
         )
 
     assert response.status_code == 500
-    spend, reserved = _user_state(test_config, user_id)
+    spend, reserved = _user_state(db_session_factory, user_id)
     assert spend == pytest.approx(0.0)
     assert reserved == pytest.approx(0.0)  # hold refunded (was leaked before the fix)
-    assert _poll_usage_logs(test_config, user_id) == ["error"]
+    assert _poll_usage_logs(db_session_factory, user_id) == ["error"]
 
 
 def test_responses_streaming_precommit_error_refunds(
     client: TestClient,
     master_key_header: dict[str, str],
-    test_config: GatewayConfig,
+    db_session_factory: Callable[[], Session],
 ) -> None:
     user_id = "precommit-responses"
     _seed_budgeted_user(client, master_key_header, user_id)
@@ -161,7 +152,7 @@ def test_responses_streaming_precommit_error_refunds(
         )
 
     assert response.status_code == 502
-    spend, reserved = _user_state(test_config, user_id)
+    spend, reserved = _user_state(db_session_factory, user_id)
     assert spend == pytest.approx(0.0)
     assert reserved == pytest.approx(0.0)  # hold refunded (was leaked before the fix)
-    assert _poll_usage_logs(test_config, user_id) == ["error"]
+    assert _poll_usage_logs(db_session_factory, user_id) == ["error"]

--- a/tests/integration/test_usage_tracking.py
+++ b/tests/integration/test_usage_tracking.py
@@ -1,16 +1,15 @@
 import asyncio
 import json
 import os
+from collections.abc import Callable
 from typing import Any
 from unittest.mock import patch
 
 import pytest
 from any_llm.types.completion import ChatCompletion, ChatCompletionMessage, Choice, CompletionUsage
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session
 
-from gateway.core.config import GatewayConfig
 from gateway.models.entities import UsageLog, User
 
 from .conftest import MODEL_NAME
@@ -24,16 +23,13 @@ async def test_completion_accuracy(
     client: TestClient,
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
-    test_config: GatewayConfig,
     test_user: dict[str, Any],
     test_messages: list[dict[str, str]],
     model_pricing: dict[str, Any],
+    db_session_factory: Callable[[], Session],
 ) -> None:
-    engine = create_engine(test_config.database_url)
-    session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
     # Capture initial user spend
-    db = session_local()
+    db = db_session_factory()
     try:
         user = db.query(User).filter(User.user_id == test_user["user_id"]).first()
         initial_spend = float(user.spend) if user else 0.0
@@ -68,7 +64,7 @@ async def test_completion_accuracy(
     output_price = model_pricing["output_price_per_million"]
     expected_cost = (prompt_tokens / 1_000_000) * input_price + (completion_tokens / 1_000_000) * output_price
 
-    db = session_local()
+    db = db_session_factory()
     try:
         # Check usage log
         usage_logs = db.query(UsageLog).filter(UsageLog.api_key_id == api_key_obj["id"]).all()
@@ -121,17 +117,14 @@ async def test_streaming_completion_accuracy(
     client: TestClient,
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
-    test_config: GatewayConfig,
     test_user: dict[str, Any],
     test_messages_with_longer_response: list[dict[str, str]],
     model_pricing: dict[str, Any],
+    db_session_factory: Callable[[], Session],
 ) -> None:
     """Test that streaming requests correctly aggregate usage, calculate costs, and update user spend."""
-    engine = create_engine(test_config.database_url)
-    session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
     # Capture initial user spend
-    db = session_local()
+    db = db_session_factory()
     try:
         user = db.query(User).filter(User.user_id == test_user["user_id"]).first()
         initial_spend = float(user.spend) if user else 0.0
@@ -195,7 +188,7 @@ async def test_streaming_completion_accuracy(
     await asyncio.sleep(1)
 
     # Verify usage log and user spend
-    db = session_local()
+    db = db_session_factory()
     try:
         # Check usage log
         usage_logs = db.query(UsageLog).filter(UsageLog.api_key_id == api_key_obj["id"]).all()
@@ -257,9 +250,9 @@ async def test_failed_request_logs_error(
     client: TestClient,
     api_key_header: dict[str, str],
     api_key_obj: dict[str, Any],
-    test_config: GatewayConfig,
     test_user: dict[str, Any],
     test_messages: list[dict[str, str]],
+    db_session: Session,
 ) -> None:
     """Test that failed requests are logged with error status."""
     response = client.post(
@@ -273,27 +266,20 @@ async def test_failed_request_logs_error(
 
     assert response.status_code == 502
 
-    engine = create_engine(test_config.database_url)
-    session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-    db = session_local()
+    usage_logs = db_session.query(UsageLog).filter(UsageLog.api_key_id == api_key_obj["id"]).all()
 
-    try:
-        usage_logs = db.query(UsageLog).filter(UsageLog.api_key_id == api_key_obj["id"]).all()
+    assert len(usage_logs) > 0
+    log = usage_logs[0]
 
-        assert len(usage_logs) > 0
-        log = usage_logs[0]
-
-        assert log.status == "error"
-        assert log.error_message is not None
-    finally:
-        db.close()
+    assert log.status == "error"
+    assert log.error_message is not None
 
 
 def test_spend_incremented_via_reconciliation(
     client: TestClient,
     master_key_header: dict[str, str],
-    test_config: GatewayConfig,
     test_messages: list[dict[str, str]],
+    db_session: Session,
 ) -> None:
     """End-to-end: a successful billable request reserves then reconciles, so
     users.spend increases by the actual cost (the reconcile path is the sole
@@ -333,13 +319,7 @@ def test_spend_incremented_via_reconciliation(
     assert response.status_code == 200
 
     # Expected cost: 1M/1M * 2.5 + 0.5M/1M * 10 = 2.5 + 5.0 = 7.5
-    engine = create_engine(test_config.database_url)
-    session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-    db = session_local()
-    try:
-        user = db.query(User).filter(User.user_id == "spend-user").first()
-        assert user is not None
-        assert user.spend == pytest.approx(7.5)
-        assert float(user.reserved) == pytest.approx(0.0)  # hold released
-    finally:
-        db.close()
+    user = db_session.query(User).filter(User.user_id == "spend-user").first()
+    assert user is not None
+    assert user.spend == pytest.approx(7.5)
+    assert float(user.reserved) == pytest.approx(0.0)  # hold released


### PR DESCRIPTION
## Description
Addresses three test-hygiene gaps from #267.

1. **Drop the suite-wide retry policy.** `pytest.ini` set `reruns = 5` and
   `reruns_delay = 10` for the whole suite, so a test that passes one time in
   several counted as green, hiding flakiness and ordering bugs and burning
   retry delay on genuine failures. No test relied on it and its addition was
   never documented. No known-flaky tests exist to convert, so none are marked;
   `pytest-rerunfailures` stays a dependency so a real flake can later be pinned
   with `@pytest.mark.flaky(reruns=...)`. The AGENTS.md test note is updated
   accordingly.

2. **Enforcement regression coverage on billable routes.** New
   `tests/integration/test_passthrough_enforcement.py` asserts that every
   billable pass-through route (embeddings, moderations, rerank, images, audio
   transcription, audio speech) rejects a blocked user and an over-budget user
   with 403, before the provider is reached. Each provider entrypoint is patched
   to raise if invoked, so no real provider is needed and a route that skipped
   the budget gate would reach the raising mock and fail. This is the guard that
   would have caught the `/v1/batches` bypass; batches is included as an xfail
   case (its enforcement lands with #258).

3. **Consolidate ad-hoc DB session boilerplate.** `test_usage_tracking.py` and
   `test_streaming_precommit_refund.py` hand-rolled `create_engine` and
   `sessionmaker` at several call sites. Single-read assertions now use the
   existing `db_session` fixture; reads that must observe freshly committed
   state (multi-read tests and the usage-log poll) use a new `db_session_factory`
   fixture that hands out fresh sessions from one managed engine.
   Behavior-preserving.

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues
Fixes #267

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Note on the DoD checklist: `make lint` and `make typecheck` pass locally.
`make test` (Postgres via testcontainers) could not run in the authoring
sandbox (no Docker); the new and refactored tests were validated against a
SQLite database instead, and the full Postgres run is left to CI. No API
contract change, so the OpenAPI spec is unchanged.

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Claude Code

**Any additional AI details you'd like to share:**
Test design and code drafted by Claude via back-and-forth with @njbrake; the
reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
