### PR TITLE
refactor(deps): move last_used bump off request session and config to app.state

### DIFF
--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -4,18 +4,22 @@ from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import Depends, HTTPException, Request, status
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.auth.models import hash_key
 from gateway.core.config import API_KEY_HEADER, LEGACY_API_KEY_HEADERS, GatewayConfig
-from gateway.core.database import get_db
+from gateway.core.database import create_session, get_db
+from gateway.log_config import logger
 from gateway.metrics import record_auth_failure
 from gateway.models.entities import APIKey
 from gateway.services.file_store import FileStore
 from gateway.services.log_writer import LogWriter
 
+# Legacy module-level fallback. Config now lives on ``app.state.config`` (set in
+# ``create_app``); ``get_config`` reads from the request's app state and only
+# falls back to this shim for callers that set it directly (see ``set_config``).
 _config: GatewayConfig | None = None
 _LAST_USED_UPDATE_INTERVAL_SECONDS = 300
 
@@ -35,21 +39,35 @@ def _as_utc(value: datetime | None) -> datetime | None:
 
 
 def set_config(config: GatewayConfig) -> None:
-    """Set the global config instance."""
+    """Set the legacy module-level config fallback.
+
+    Compatibility shim. Config is stored on ``app.state.config`` by
+    ``create_app``; this only updates the module-level fallback that
+    ``get_config`` consults when no request-scoped app state is available.
+    """
     global _config  # noqa: PLW0603
     _config = config
 
 
-def get_config() -> GatewayConfig:
-    """Get the global config instance."""
-    if _config is None:
+def get_config(request: Request) -> GatewayConfig:
+    """Return the config for the current app from ``request.app.state``.
+
+    Every shared resource (rate limiter, log writer, file store) lives on
+    ``app.state``; config does too, so two apps in one process no longer share
+    a single instance. Falls back to the legacy module-level shim only when the
+    app state has no config attached.
+    """
+    config: GatewayConfig | None = getattr(request.app.state, "config", None)
+    if config is None:
+        config = _config
+    if config is None:
         msg = "Config not initialized"
         raise RuntimeError(msg)
-    return _config
+    return config
 
 
 def reset_config() -> None:
-    """Reset config state. Intended for testing only."""
+    """Reset the legacy module-level config fallback. Intended for testing only."""
     global _config  # noqa: PLW0603
     _config = None
 
@@ -136,13 +154,25 @@ async def _verify_and_update_api_key(db: AsyncSession, token: str) -> APIKey:
     )
 
     if should_update_last_used:
-        api_key.last_used_at = now
-        try:
-            await db.commit()
-        except SQLAlchemyError:
-            await db.rollback()
+        await _bump_last_used_at(api_key.id, now)
 
     return api_key
+
+
+async def _bump_last_used_at(api_key_id: str, now: datetime) -> None:
+    """Record an API key's last use on a short-lived, separate session.
+
+    The bump runs outside the request's transaction so it never commits the
+    caller's session or leaves it in a dirty state, and a failure is logged
+    rather than swallowed. It is best-effort: throttled by
+    ``_LAST_USED_UPDATE_INTERVAL_SECONDS`` and never fails the request.
+    """
+    try:
+        async with create_session() as session:
+            await session.execute(update(APIKey).where(APIKey.id == api_key_id).values(last_used_at=now))
+            await session.commit()
+    except SQLAlchemyError:
+        logger.warning("Failed to update last_used_at for API key %s", api_key_id, exc_info=True)
 
 
 def _is_valid_master_key(token: str, config: GatewayConfig) -> bool:

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -183,6 +183,7 @@ def create_app(config: GatewayConfig) -> FastAPI:
     else:
         app.state.rate_limiter = None
 
+    app.state.config = config
     app.state.gateway_mode = config.effective_mode
 
     register_routers(app, config)

--- a/tests/unit/test_deps_db_error.py
+++ b/tests/unit/test_deps_db_error.py
@@ -8,15 +8,17 @@ never a bare 500, so callers can distinguish "key not found" (401) from
 "could not check the key right now" (503).
 """
 
+from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException, status
 from sqlalchemy.exc import OperationalError
 
+from gateway.api import deps
 from gateway.api.deps import _verify_and_update_api_key
-from gateway.auth.models import generate_api_key
+from gateway.auth.models import generate_api_key, hash_key
 
 
 @pytest.mark.asyncio
@@ -31,3 +33,52 @@ async def test_lookup_db_error_raises_503_not_500() -> None:
     assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     assert isinstance(exc_info.value.detail, str)
     assert exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_failed_last_used_bump_logs_warning_and_does_not_poison_request_session() -> None:
+    """A failed ``last_used_at`` bump must be logged and must not fail the request.
+
+    The bump runs on a separate short-lived session, so the request session is
+    never committed or rolled back by auth, and a ``SQLAlchemyError`` from the
+    bump is swallowed after a warning rather than surfaced to the caller.
+    """
+    token = generate_api_key()
+    api_key: Any = SimpleNamespace(
+        id="key-abc123",
+        key_hash=hash_key(token),
+        is_active=True,
+        expires_at=None,
+        last_used_at=None,
+    )
+
+    db: Any = AsyncMock()
+    lookup_result = MagicMock()
+    lookup_result.scalar_one_or_none.return_value = api_key
+    db.execute.return_value = lookup_result
+
+    class _FailingSession:
+        async def execute(self, *args: Any, **kwargs: Any) -> None:
+            raise OperationalError("UPDATE", {}, Exception("database is locked"))
+
+        async def commit(self) -> None:  # pragma: no cover - not reached
+            raise AssertionError("commit should not be reached")
+
+    class _FailingSessionCM:
+        async def __aenter__(self) -> "_FailingSession":
+            return _FailingSession()
+
+        async def __aexit__(self, *args: Any) -> bool:
+            return False
+
+    with (
+        patch.object(deps, "create_session", lambda: _FailingSessionCM()),
+        patch("gateway.api.deps.logger.warning") as mock_warning,
+    ):
+        result = await _verify_and_update_api_key(db, token)
+
+    assert result is api_key
+    mock_warning.assert_called_once()
+    assert "key-abc123" in mock_warning.call_args.args
+    db.commit.assert_not_called()
+    db.rollback.assert_not_called()

--- a/tests/unit/test_global_state_reset.py
+++ b/tests/unit/test_global_state_reset.py
@@ -1,10 +1,24 @@
 """Unit tests for module-level state reset helpers."""
 
+from types import SimpleNamespace
+from typing import cast
+
 import pytest
+from fastapi import Request
 
 from gateway.api.deps import get_config, reset_config, set_config
 from gateway.core.config import GatewayConfig
 from gateway.core.database import reset_db
+
+
+def _request_without_app_config() -> Request:
+    """Build a minimal request whose app state has no config attached.
+
+    Forces ``get_config`` down its legacy module-level fallback path so the
+    compatibility shim (``set_config`` / ``reset_config``) can be exercised in
+    isolation from ``app.state``.
+    """
+    return cast(Request, SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace())))
 
 
 def test_reset_config_clears_state() -> None:
@@ -12,13 +26,34 @@ def test_reset_config_clears_state() -> None:
         database_url="postgresql://localhost/test",
         master_key="test",
     )
+    request = _request_without_app_config()
+
     set_config(config)
-    assert get_config() is config
+    assert get_config(request) is config
 
     reset_config()
 
     with pytest.raises(RuntimeError, match="Config not initialized"):
-        get_config()
+        get_config(request)
+
+
+def test_two_apps_hold_independent_configs() -> None:
+    """Two apps in one process must not share a single config instance."""
+    from gateway.main import create_app
+
+    config_a = GatewayConfig(database_url="sqlite:///./a.db", master_key="key-a", auto_migrate=False)
+    config_b = GatewayConfig(database_url="sqlite:///./b.db", master_key="key-b", auto_migrate=False)
+
+    app_a = create_app(config_a)
+    app_b = create_app(config_b)
+
+    assert app_a.state.config is config_a
+    assert app_b.state.config is config_b
+    assert app_a.state.config is not app_b.state.config
+    assert app_a.state.config.master_key == "key-a"
+    assert app_b.state.config.master_key == "key-b"
+
+    reset_config()
 
 
 def test_reset_db_allows_reinit() -> None:


### PR DESCRIPTION
> _Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Two design smells in the auth/dependency layer (issue #272).

1. The auth dependency committed the request session mid-request to bump
   `last_used_at`, coupling auth to the route's transaction boundary and
   silently swallowing `SQLAlchemyError`. The bump now runs on a separate
   short-lived session via `create_session()`, keeps the 300s throttle, and
   logs a warning on failure instead of hiding it. Auth no longer commits or
   rolls back the request session, so a failed bump cannot poison it.

2. Config flowed through a module-level mutable singleton that two apps in one
   process would share and clobber. `create_app` now stores it on
   `app.state.config`, matching the pattern already used for the rate limiter,
   log writer, and file store, and `get_config` is a dependency reading
   `request.app.state`. `set_config` / `reset_config` remain as thin
   compatibility shims over a module-level fallback for tests that set config
   directly.

The ambiguous `(APIKey | None, bool)` tuple / `Principal` cleanup mentioned in
the issue is intentionally left out to keep this change focused.

## PR Type

- [x] Refactor

## Relevant issues

Fixes #272

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). Note: unit tests, lint, typecheck, and `make openapi-check` all pass locally; the Postgres integration run (including the key-management `last_used_at` throttle test) needs Docker, which is unavailable in the dev environment, so it is validated by CI.
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (no API contract change; `make openapi-check` is clean).

## AI Usage

- [x] AI was used for drafting/refactoring.

**AI Model/Tool used:** Claude Code

**Any additional AI details you'd like to share:**
Change was implemented and validated (unit tests, lint, typecheck, OpenAPI check)
with Claude Code under human direction. Integration tests require Docker/Postgres
and are validated by CI.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
