### PR TITLE
docs: add guides for community contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-provider-guide.md
+++ b/.github/ISSUE_TEMPLATE/add-provider-guide.md
@@ -1,0 +1,47 @@
+---
+name: "Docs: add a provider guide"
+about: "Write a setup guide for one LLM provider, following the OpenAI exemplar"
+title: "docs: add provider guide for <Provider>"
+labels: "good first issue, documentation"
+---
+
+## What
+
+Add a short setup guide for **&lt;Provider&gt;** at `docs/providers/<provider-key>.md`, matching the existing exemplar at `docs/providers/openai.md`.
+
+The provider is already in the reference table at `docs/models.md`. This issue adds the deeper "how to set it up, and the gotchas" page for it.
+
+## Why
+
+Each provider has its own auth, base URL, and model-naming quirks. A per-provider page saves the next user from rediscovering them, and it's a small, well-scoped way for a new contributor to help.
+
+## Steps
+
+1. Copy `docs/providers/openai.md` to `docs/providers/<provider-key>.md`. Use the config key from `docs/models.md` (for example `anthropic`, `mistral`, `groq`).
+2. Fill in each section for this provider:
+   - [ ] **Prerequisites** — where to get an API key (link the provider's console)
+   - [ ] **Configure** — the `providers:` block; note if this provider needs `api_base` or extra fields (check `config.example.yml` and `docs/configuration.md`)
+   - [ ] **Choose a model** — 2 to 3 real `provider:model` examples
+   - [ ] **Verify** — point readers to the Quickstart for starting Otari and creating a client key, then keep a provider-specific request example and swap the model name
+   - [ ] **Troubleshooting** — at least one provider-specific gotcha
+   - [ ] **Pricing** — optional, only if you have real numbers
+3. Test it end to end against a running Otari.
+4. Link the new page from the docs navigation (`docs/index.md`) and any provider index (`docs/providers/README.md` or `docs/models.md`) if one exists.
+
+## Acceptance criteria
+
+- [ ] New file at `docs/providers/<provider-key>.md`
+- [ ] Same section order as `docs/providers/openai.md`
+- [ ] Config snippet matches the schema in `config.example.yml`
+- [ ] At least one provider-specific troubleshooting row
+- [ ] Linked from `docs/index.md` and any provider index that exists
+
+## Good picks to start
+
+Anthropic, Mistral, Groq, or OpenRouter are good starter picks. Leave Vertex AI and Bedrock for later; they need service accounts or AWS credentials. Ollama also works well, but it is a local-server setup rather than a hosted `api_key` flow.
+
+## Resources
+
+- Exemplar: `docs/providers/openai.md`
+- Config schema: `config.example.yml`
+- Provider list and model format: `docs/models.md`

--- a/.github/ISSUE_TEMPLATE/add-provider-guide.md
+++ b/.github/ISSUE_TEMPLATE/add-provider-guide.md
@@ -2,7 +2,7 @@
 name: "Docs: add a provider guide"
 about: "Write a setup guide for one LLM provider, following the OpenAI exemplar"
 title: "docs: add provider guide for <Provider>"
-labels: "good first issue, documentation"
+labels: ["good first issue", "documentation"]
 ---
 
 ## What
@@ -19,12 +19,12 @@ Each provider has its own auth, base URL, and model-naming quirks. A per-provide
 
 1. Copy `docs/providers/openai.md` to `docs/providers/<provider-key>.md`. Use the config key from `docs/models.md` (for example `anthropic`, `mistral`, `groq`).
 2. Fill in each section for this provider:
-   - [ ] **Prerequisites** — where to get an API key (link the provider's console)
-   - [ ] **Configure** — the `providers:` block; note if this provider needs `api_base` or extra fields (check `config.example.yml` and `docs/configuration.md`)
-   - [ ] **Choose a model** — 2 to 3 real `provider:model` examples
-   - [ ] **Verify** — point readers to the Quickstart for starting Otari and creating a client key, then keep a provider-specific request example and swap the model name
-   - [ ] **Troubleshooting** — at least one provider-specific gotcha
-   - [ ] **Pricing** — optional, only if you have real numbers
+   - [ ] **Prerequisites**: where to get an API key (link the provider's console)
+   - [ ] **Configure**: the `providers:` block; note if this provider needs `api_base` or extra fields (check `config.example.yml` and `docs/configuration.md`)
+   - [ ] **Choose a model**: 2 to 3 real `provider:model` examples
+   - [ ] **Verify**: point readers to the Quickstart for starting Otari and creating a client key, then keep a provider-specific request example and swap the model name
+   - [ ] **Troubleshooting**: at least one provider-specific gotcha
+   - [ ] **Pricing**: optional, only if you have real numbers
 3. Test it end to end against a running Otari.
 4. Link the new page from the docs navigation (`docs/index.md`) and any provider index (`docs/providers/README.md` or `docs/models.md`) if one exists.
 

--- a/.github/ISSUE_TEMPLATE/add-use-with-guide.md
+++ b/.github/ISSUE_TEMPLATE/add-use-with-guide.md
@@ -2,7 +2,7 @@
 name: "Docs: add a use-with guide"
 about: "Write an integration guide for a coding tool or client, following the Claude Code and opencode guides"
 title: "docs: add use-with guide for <Tool>"
-labels: "good first issue, documentation"
+labels: ["good first issue", "documentation"]
 ---
 
 ## What
@@ -20,12 +20,12 @@ Coding tools are the most common reason people reach for a gateway. Each one set
 
 1. Copy the matching exemplar (`docs/use-with-claude-code.md` for Anthropic/Messages clients, or `docs/use-with-opencode.md` for OpenAI-compatible clients) to `docs/use-with-<tool>.md`.
 2. Fill in each section for this tool:
-   - [ ] **Intro** — which API surface the tool speaks (OpenAI `/v1/chat/completions`, Anthropic `/v1/messages`, etc.) and which Otari endpoints it hits
-   - [ ] **Quick start** — cover both **Connected to otari.ai** and **Standalone**, either as separate subsections or clearly labeled examples, with the exact env vars or config file the tool uses (base URL, auth token, model)
-   - [ ] **Choosing a model** — document the selector format this tool passes to Otari (for example `provider:model`, `provider/model`, or tool-prefixed forms like `otari/openai:gpt-4o`), with an example or two the tool supports
-   - [ ] **Gotchas** — anything tool-specific (header names, base URL with or without `/v1`, user-id handling), like the `ANTHROPIC_AUTH_TOKEN` vs `ANTHROPIC_API_KEY` note in the Claude Code guide
-   - [ ] **See also** — link back to the Quickstart and the provider setup
-3. Don't re-explain provider setup — link to it. This guide assumes a provider is already configured.
+   - [ ] **Intro**: which API surface the tool speaks (OpenAI `/v1/chat/completions`, Anthropic `/v1/messages`, etc.) and which Otari endpoints it hits
+   - [ ] **Quick start**: cover both **Connected to otari.ai** and **Standalone**, either as separate subsections or clearly labeled examples, with the exact env vars or config file the tool uses (base URL, auth token, model)
+   - [ ] **Choosing a model**: document the selector format this tool passes to Otari (for example `provider:model`, `provider/model`, or tool-prefixed forms like `otari/openai:gpt-4o`), with an example or two the tool supports
+   - [ ] **Gotchas**: anything tool-specific (header names, base URL with or without `/v1`, user-id handling), like the `ANTHROPIC_AUTH_TOKEN` vs `ANTHROPIC_API_KEY` note in the Claude Code guide
+   - [ ] **See also**: link back to the Quickstart and the provider setup
+3. Don't re-explain provider setup. Link to it. This guide assumes a provider is already configured.
 4. Test it end to end against a running Otari.
 5. Link the new page from the docs navigation (`docs/index.md`) and any nearby cross-references that should mention it.
 
@@ -40,7 +40,7 @@ Coding tools are the most common reason people reach for a gateway. Each one set
 
 ## Good picks to start
 
-Cursor, Continue, Aider, Zed, Cline, Windsurf, Codex CLI, Gemini CLI — all support a custom OpenAI- or Anthropic-compatible base URL.
+Cursor, Continue, Aider, Zed, Cline, Windsurf, Codex CLI, and Gemini CLI all support a custom OpenAI- or Anthropic-compatible base URL.
 
 ## Resources
 

--- a/.github/ISSUE_TEMPLATE/add-use-with-guide.md
+++ b/.github/ISSUE_TEMPLATE/add-use-with-guide.md
@@ -1,0 +1,49 @@
+---
+name: "Docs: add a use-with guide"
+about: "Write an integration guide for a coding tool or client, following the Claude Code and opencode guides"
+title: "docs: add use-with guide for <Tool>"
+labels: "good first issue, documentation"
+---
+
+## What
+
+Add a guide at `docs/use-with-<tool>.md` showing how to point **&lt;Tool&gt;** at Otari, following the matching exemplar for its API surface:
+
+- `docs/use-with-claude-code.md` for tools that speak the Anthropic Messages API
+- `docs/use-with-opencode.md` for tools that speak an OpenAI-compatible API
+
+## Why
+
+Coding tools are the most common reason people reach for a gateway. Each one sets its base URL, auth token, and model differently, so a per-tool guide is what turns "does it work with X" into "yes, here's how."
+
+## Steps
+
+1. Copy the matching exemplar (`docs/use-with-claude-code.md` for Anthropic/Messages clients, or `docs/use-with-opencode.md` for OpenAI-compatible clients) to `docs/use-with-<tool>.md`.
+2. Fill in each section for this tool:
+   - [ ] **Intro** — which API surface the tool speaks (OpenAI `/v1/chat/completions`, Anthropic `/v1/messages`, etc.) and which Otari endpoints it hits
+   - [ ] **Quick start** — cover both **Connected to otari.ai** and **Standalone**, either as separate subsections or clearly labeled examples, with the exact env vars or config file the tool uses (base URL, auth token, model)
+   - [ ] **Choosing a model** — document the selector format this tool passes to Otari (for example `provider:model`, `provider/model`, or tool-prefixed forms like `otari/openai:gpt-4o`), with an example or two the tool supports
+   - [ ] **Gotchas** — anything tool-specific (header names, base URL with or without `/v1`, user-id handling), like the `ANTHROPIC_AUTH_TOKEN` vs `ANTHROPIC_API_KEY` note in the Claude Code guide
+   - [ ] **See also** — link back to the Quickstart and the provider setup
+3. Don't re-explain provider setup — link to it. This guide assumes a provider is already configured.
+4. Test it end to end against a running Otari.
+5. Link the new page from the docs navigation (`docs/index.md`) and any nearby cross-references that should mention it.
+
+## Acceptance criteria
+
+- [ ] New file at `docs/use-with-<tool>.md`
+- [ ] Follows the matching exemplar for the tool's API surface
+- [ ] Both "Connected to otari.ai" and "Standalone" variants covered, either as separate subsections or clearly labeled examples
+- [ ] The tool's selector format for Otari is explained with concrete examples
+- [ ] At least one tool-specific gotcha called out
+- [ ] Linked from `docs/index.md`
+
+## Good picks to start
+
+Cursor, Continue, Aider, Zed, Cline, Windsurf, Codex CLI, Gemini CLI — all support a custom OpenAI- or Anthropic-compatible base URL.
+
+## Resources
+
+- Exemplars: `docs/use-with-claude-code.md`, `docs/use-with-opencode.md`
+- Model format and providers: `docs/models.md`
+- Base config: `docs/quickstart.md`

--- a/README.md
+++ b/README.md
@@ -163,19 +163,13 @@ This starts Otari on port 8000 backed by a Postgres container, so keys, budgets,
 
 ### Render
 
-Deploy Otari with fully managed Postgres on Render for free. Just add your provider credentials; Render provisions and connects your services automatically.
-
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/mozilla-ai/otari&path=deploy/render/render.yaml)
-
-Read [`the docs`](deploy/render/README.md) for more details, including a hybrid-mode Blueprint connected to otari.ai.
 
 ### Railway
 
-Want a hosted gateway with no local setup? Deploy Otari plus a managed Postgres on [Railway](https://railway.com) in one click. Bring a provider key (OpenAI, Anthropic, Mistral, or Gemini) and you get a running gateway with virtual keys, budgets, and usage tracking.
-
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/otari-railway-template-demo)
 
-The two-service template, its environment inputs, and how to publish it are documented in [`deploy/railway/`](deploy/railway/README.md).
+See [Deployment](docs/deployment.md) for setup details on both platforms, including hybrid mode connected to otari.ai.
 
 ### From source (development)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,5 +29,6 @@ Start with the [Quickstart](quickstart.md). It gets Otari running locally and wa
 - [Use with Claude Code](use-with-claude-code.md) — point the Claude Code CLI at Otari.
 - [Use with opencode](use-with-opencode.md) — point the opencode CLI at Otari.
 - [Supported models](models.md) — providers, model format, and capabilities.
+- [OpenAI provider guide](providers/openai.md). Configure OpenAI and route your first request through Otari.
 - [Hybrid-mode protocol](hybrid-mode-protocol.md) — Otari/platform wire contract, for platform builders.
 - [SDK compatibility](sdk-compatibility.md) — how the language SDKs are released and which SDK version works with which Otari version.

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -1,0 +1,111 @@
+# OpenAI
+
+Route requests to OpenAI models (GPT-4o, GPT-4.1, the o-series, and others) through Otari. For the full provider list and the model-name format, see [Models](../models.md).
+
+## What you'll set up
+
+An OpenAI provider entry in your `config.yml` (or a single environment variable), then a first request that Otari routes to OpenAI.
+
+## Prerequisites
+
+- Otari running locally — see the [Quickstart](../quickstart.md)
+- An OpenAI account and an API key from <https://platform.openai.com/api-keys>
+
+## Configure
+
+Add OpenAI under `providers:` in your `config.yml`:
+
+```yaml
+providers:
+  openai:
+    api_key: "sk-..."                        # your OpenAI API key
+    # api_base: "https://api.openai.com/v1"  # optional; override for a proxy or compatible endpoint
+```
+
+To keep your provider key out of the file with environment interpolation:
+
+```yaml
+providers:
+  openai:
+    api_key: ${OPENAI_API_KEY}
+```
+
+...then export it before starting Otari:
+
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+> Otari routes through [any-llm](https://pypi.org/project/any-llm-sdk/), so a standard `OPENAI_API_KEY` in the environment is picked up automatically even if you don't list the provider explicitly.
+
+### Optional settings
+
+`client_args` are passed through to the underlying `any-llm` provider client, for options such as custom headers or timeouts:
+
+```yaml
+providers:
+  openai:
+    api_key: ${OPENAI_API_KEY}
+    client_args:
+      timeout: 60
+      custom_headers:
+        OpenAI-Organization: "org-..."
+```
+
+## Choose a model
+
+Models are addressed as `openai:<model>`:
+
+```
+openai:gpt-4o
+openai:gpt-4o-mini
+openai:o4-mini
+```
+
+Everything after the colon is passed straight to OpenAI, so any model your key can access works.
+
+## Verify
+
+If you have not already started Otari and created a client key, follow the [Quickstart](../quickstart.md) through step 3 first.
+
+Then make a request with any OpenAI client, using an `openai:<model>` selector:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(api_key="gw-...", base_url="http://localhost:8000/v1")
+resp = client.chat.completions.create(
+    model="openai:gpt-4o-mini",
+    messages=[{"role": "user", "content": "Say hello in five words."}],
+)
+print(resp.choices[0].message.content)
+```
+
+Expected (sample) output:
+
+```
+Hello, nice to meet you!
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| HTTP 502 `The provider rejected the gateway's credentials` | The `api_key` Otari sent to OpenAI is missing, invalid, or lacks access. Check the `api_key` (or `OPENAI_API_KEY`) configured on the gateway. |
+| HTTP 404 `The requested model was not found on the provider` | The name after `openai:` is not a model your key can access, or the model name is misspelled. |
+| HTTP 502 `LLM provider error` | Generic fallback: Otari reached the provider but the upstream call failed in a way it could not classify (for example a provider-side 5xx or a connection error). |
+| HTTP 402 `No pricing configured for model ...` | Otari could not resolve pricing for that model and `require_pricing` rejected the request. Add a `pricing:` entry, enable `default_pricing: true` for bundled fallback pricing, or use a model that already has pricing coverage. |
+| HTTP 401 `Invalid master key` on `/v1/keys` | You passed a client (`gw-...`) key, or the wrong master key, instead of the configured master key. |
+
+## Pricing (optional)
+
+To track cost for a model, add a `pricing:` entry in `config.yml`:
+
+```yaml
+pricing:
+  openai:gpt-4o-mini:
+    input_price_per_million: 0.15
+    output_price_per_million: 0.60
+```
+
+See [Configuration](../configuration.md) for all options.

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -8,7 +8,7 @@ An OpenAI provider entry in your `config.yml` (or a single environment variable)
 
 ## Prerequisites
 
-- Otari running locally — see the [Quickstart](../quickstart.md)
+- Otari running locally (see the [Quickstart](../quickstart.md))
 - An OpenAI account and an API key from <https://platform.openai.com/api-keys>
 
 ## Configure
@@ -91,9 +91,9 @@ Hello, nice to meet you!
 
 | Symptom | Likely cause |
 |---------|--------------|
-| HTTP 502 `The provider rejected the gateway's credentials` | The `api_key` Otari sent to OpenAI is missing, invalid, or lacks access. Check the `api_key` (or `OPENAI_API_KEY`) configured on the gateway. |
+| HTTP 502 `The provider rejected the gateway's credentials` | The `api_key` Otari sent to OpenAI is invalid or lacks access. Check the `api_key` (or `OPENAI_API_KEY`) configured on the gateway. |
 | HTTP 404 `The requested model was not found on the provider` | The name after `openai:` is not a model your key can access, or the model name is misspelled. |
-| HTTP 502 `LLM provider error` | Generic fallback: Otari reached the provider but the upstream call failed in a way it could not classify (for example a provider-side 5xx or a connection error). |
+| HTTP 502 `LLM provider error` | Generic fallback: Otari reached the provider but the upstream call failed in a way it could not classify (for example a missing provider key, a provider-side 5xx, or a connection error). |
 | HTTP 402 `No pricing configured for model ...` | Otari could not resolve pricing for that model and `require_pricing` rejected the request. Add a `pricing:` entry, enable `default_pricing: true` for bundled fallback pricing, or use a model that already has pricing coverage. |
 | HTTP 401 `Invalid master key` on `/v1/keys` | You passed a client (`gw-...`) key, or the wrong master key, instead of the configured master key. |
 


### PR DESCRIPTION
## Description
This PR adds contributor-facing docs scaffolding to make community guide contributions easier and more consistent.

It introduces:

- a new provider guide example at `docs/providers/openai.md`
- a `Docs: add a provider guide` issue template
- a `Docs: add a use-with guide` issue template
- a small README cleanup that points deployment readers to the main deployment docs instead of repeating platform-specific details

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [X] Documentation
- [ ] Infrastructure / CI


## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [X] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [X] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [X] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**


**Any additional AI details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a new OpenAI provider setup guide at `docs/providers/openai.md` covering configuration, model examples, verification, troubleshooting, and optional pricing.
- Added GitHub issue templates to standardize documentation contributions for provider guides and “use-with” guides.
- Updated `docs/index.md` to include the OpenAI provider guide in the docs browsing list.
- Simplified the “Other ways to run” deployment section in `README.md` to point readers to the central Deployment documentation instead of repeating details.

These updates help contributors follow consistent documentation patterns and keep deployment guidance centralized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->