### PR TITLE
feat: add agent skills and scoped review instructions

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.github/skills

--- a/.github/instructions/frontend-standards.instructions.md
+++ b/.github/instructions/frontend-standards.instructions.md
@@ -1,0 +1,42 @@
+---
+applyTo: "web/src/**/*.{ts,tsx,css}"
+---
+
+# Frontend Standards (dashboard)
+
+These auto-apply when reviewing or editing the `web/` admin dashboard (React 19, TypeScript
+strict, HeroUI v3, Tailwind v4, TanStack Query, Vitest). The full guidance, with worked
+examples grounded in this dashboard's code, lives in the skill:
+[.github/skills/frontend-standards/SKILL.md](../skills/frontend-standards/SKILL.md).
+
+## Non-negotiables
+
+1. **HeroUI v3 only.** Unified `@heroui/react` import, compound components (`Card.Content`,
+   `Card.Header`), `onChange` (not `onValueChange`), `onPress` (not `onClick`), and a `variant`
+   (not `color`) on `Button`. No v2 patterns: granular `@heroui/*` imports, `HeroUIProvider`,
+   `classNames={{ slot }}` objects. See [components.md](../skills/frontend-standards/components.md).
+
+2. **Props over `className`.** Use a component's prop (`variant`, `size`, `isDisabled`,
+   `isPending`, `fullWidth`, `isInvalid`) before a `className`; reserve `className` for
+   layout/position. Space siblings with `gap-*` on the parent, not `m-*` on children.
+
+3. **Color comes from the `--otari-*` tokens** in `web/src/styles/globals.css`
+   (`text-[var(--otari-muted)]`, `bg-[var(--otari-surface)]`). Add a token there rather than
+   scattering a hex. Raw Tailwind palette classes are only for status surfaces (`ErrorBanner`,
+   `InfoBanner`). See [design-tokens.md](../skills/frontend-standards/design-tokens.md).
+
+4. **Server state goes through TanStack Query + `apiFetch`.** Fetch via the hooks in
+   `web/src/api/hooks.ts`; keep query keys as module constants, set a deliberate `staleTime`,
+   and invalidate only the keys a mutation changes. Don't call `fetch()` directly for
+   authenticated management requests (the one exception is pre-auth `validateMasterKey`), and
+   never mirror server state into `useState`. Bound every "fetch all" loop with a hard page
+   cap. See [data-fetching.md](../skills/frontend-standards/data-fetching.md).
+
+5. **TypeScript + React hygiene.** `undefined` (not `null`) for absent values in your own
+   types; named exports and named imports; correct effect dependency arrays with cleanup;
+   derive from props/query data rather than duplicating into state. See
+   [typescript-and-react.md](../skills/frontend-standards/typescript-and-react.md).
+
+6. **Tests for changed behavior.** Colocated Vitest tests (`Foo.tsx` → `Foo.test.tsx`) that
+   query the way a user would (`getByRole`/`getByLabelText`/`getByText`, not `getByTestId`),
+   render real providers, and mock only the network boundary (`apiFetch`), not the hooks.

--- a/.github/instructions/performance-review.instructions.md
+++ b/.github/instructions/performance-review.instructions.md
@@ -1,0 +1,184 @@
+---
+applyTo: "src/gateway/**/*.py,web/src/**/*.{ts,tsx}"
+---
+
+# Performance Review Instructions
+
+Apply this checklist when reviewing performance-sensitive gateway code (database access on the
+request path, list endpoints, budget/usage services) and dashboard code (`web/`). The gateway
+is async SQLAlchemy 2.0 throughout; examples use its real entities (`User`, `APIKey`, `Budget`,
+`UsageLog`, `ModelPricing`, `ModelAlias`).
+
+## Database performance
+
+### N+1 queries: CWE-driven, but mostly a latency bug
+
+```python
+# BAD: a query per row inside a loop
+for model_key in model_keys:
+    row = (await db.execute(
+        select(ModelPricing).where(ModelPricing.model_key == model_key)
+    )).scalar_one_or_none()
+
+# GOOD: one batched query
+rows = (await db.execute(
+    select(ModelPricing).where(ModelPricing.model_key.in_(model_keys))
+)).scalars().all()
+```
+
+**Checklist:**
+- ✅ No `await db.execute(select(...))` inside a `for` loop, batch with `.in_()`, or eager-load
+  a relationship with `selectinload`/`joinedload` instead of touching it lazily per row.
+- ✅ No one-by-one deletes in a loop, use a bulk `delete().where(... .in_(...))` or a cascade.
+- ✅ Endpoints returning nested/derived data are checked (log SQL or `echo=True`) to confirm
+  they don't fan out into N+1.
+- **Severity:** High on the request/billing path.
+
+### Missing indexes
+
+Foreign keys and hot filter/sort columns must be indexed. otari already does this (e.g.
+`APIKey.user_id` is `ForeignKey(..., ondelete="CASCADE"), index=True`; `User.deleted_at` is
+`index=True`), keep it up when you add columns.
+
+```python
+# BAD: FK with no index: slow joins and slow CASCADE deletes
+user_id: Mapped[str | None] = mapped_column(ForeignKey("users.user_id", ondelete="CASCADE"))
+
+# GOOD
+user_id: Mapped[str | None] = mapped_column(
+    ForeignKey("users.user_id", ondelete="CASCADE"), index=True,
+)
+```
+
+**Checklist:**
+- ✅ Every `ForeignKey` column has `index=True`.
+- ✅ Columns used in `WHERE`, `ORDER BY`, or join conditions are indexed; frequently
+  co-filtered columns get a composite `Index`.
+- ✅ The Alembic migration creates the index alongside the column.
+- **Severity:** Medium to High.
+
+### Query optimization
+
+**Push work into SQL; don't fetch rows to process in Python.**
+
+```python
+# BAD: load everything, filter/count in Python
+logs = (await db.execute(select(UsageLog))).scalars().all()
+recent = [l for l in logs if l.created_at > cutoff]
+n = len(recent)
+
+# GOOD: filter and count in SQL
+recent = (await db.execute(
+    select(UsageLog).where(UsageLog.created_at > cutoff)
+)).scalars().all()
+n = (await db.execute(
+    select(func.count()).select_from(UsageLog).where(UsageLog.created_at > cutoff)
+)).scalar_one()
+```
+
+**Every list endpoint has a hard upper bound.** Growing tables (`UsageLog`, `ModelPricing`)
+must never be selected without a `limit`. The dashboard's pricing read already pages with a
+server-side `limit` cap of 1000 and a client-side page cap, mirror that on both ends.
+
+**Checklist:**
+- ✅ `func.count()` for counts, not `len(all())`; an existence check selects one row / uses
+  `.limit(1)`, not a full count.
+- ✅ Pagination (`limit`/`skip`) with a sane default and maximum on every list endpoint,
+  including admin/master-key ones.
+- ✅ No `select(Model)` without `WHERE` or `LIMIT` on a table that grows over time.
+- ✅ Filter, sort, count, and aggregate in SQL, not in Python.
+- **Severity:** Medium.
+
+### Transaction atomicity & batch writes
+
+```python
+# BAD: a commit per iteration
+for user_id in user_ids:
+    user = (await db.execute(select(User).where(User.user_id == user_id))).scalar_one()
+    user.blocked = True
+    await db.commit()
+
+# GOOD: one bulk update, one commit
+await db.execute(update(User).where(User.user_id.in_(user_ids)).values(blocked=True))
+await db.commit()
+```
+
+**Checklist:**
+- ✅ Related writes are grouped in one transaction; commit once, not inside a loop.
+- ✅ Multi-step writes that must succeed or fail together share a transaction.
+- ✅ Budget/spend updates follow the atomic reservation pattern (a single conditional
+  `UPDATE`), never read-modify-write across a provider call, see the security instructions
+  (§0.2/§0.3).
+- **Severity:** High on hot paths.
+
+## Async efficiency
+
+```python
+# BAD: sequential awaits on independent work
+pricing = await load_pricing()
+providers = await load_providers()
+
+# GOOD: run independent awaits together
+pricing, providers = await asyncio.gather(load_pricing(), load_providers())
+```
+
+- ✅ Independent awaits use `asyncio.gather`; sequential `await` only when one result feeds the
+  next.
+- ✅ No blocking/sync I/O on the event loop in a request handler; sessions and file handles are
+  closed via context managers / FastAPI dependencies.
+- ✅ No unbounded in-memory accumulation of a growing table.
+- **Severity:** Medium to High.
+
+## Algorithm efficiency
+
+```python
+# BAD: O(n*m) membership scan          # GOOD: O(n) set lookup
+for a in list_a:                        seen = set(list_b)
+    if a in list_b:                     for a in list_a:
+        ...                                 if a in seen:
+                                                ...
+```
+
+- ✅ Watch for O(n²) nested loops / repeated linear scans; use `set`/`dict` for membership.
+- ✅ Sort once and reuse; prefer generators for large sequences.
+
+## Frontend (`web/`)
+
+The dashboard is small, but the same principles apply:
+
+- ✅ **Server does the shaping.** No client-side filtering/sorting/pagination of large server
+  datasets when the endpoint can do it. Don't assemble a view from several requests and join in
+  the browser, prefer one endpoint that returns what the page needs.
+- ✅ **TanStack Query owns server-state caching**, never duplicate it in `useState`. Pick
+  `staleTime` per how fast the data moves; invalidate only the keys a mutation actually changes
+  (see the frontend `data-fetching` guide).
+- ✅ **Bounded "fetch all" loops** (`fetchAllPricing` caps pages) so a misbehaving backend can't
+  spin an unbounded request loop.
+- ✅ **Effect cleanup**: remove listeners/intervals/subscriptions on unmount; correct
+  dependency arrays.
+- ✅ Memoize (`useMemo`/`useCallback`) only when a re-render is a measured problem, not by
+  reflex.
+
+## Severity guidelines
+
+- **Critical**: request-path query that overloads the DB; unbounded memory growth on a hot
+  path.
+- **High**: endpoint >1s; N+1 on a frequently used route; unbounded list fetch on a growing
+  table; per-iteration commits on a billing path.
+- **Medium**: missing index on a moderately used query; suboptimal algorithm on small data;
+  avoidable re-renders.
+- **Low**: marginal caching wins; readability-only tweaks.
+
+## Finding format
+
+```markdown
+## [Severity]: Performance: [brief description]
+**File:** `src/gateway/.../file.py:line`
+**Issue:** what is slow and why.
+**Impact:** affected route(s), how it degrades as data grows.
+**Recommendation:** the fix, ideally with a snippet.
+```
+
+## References
+- [SQLAlchemy performance](https://docs.sqlalchemy.org/en/20/faq/performance.html) ·
+  [React performance](https://react.dev/learn/render-and-commit#optimizing-performance)

--- a/.github/instructions/security-review.instructions.md
+++ b/.github/instructions/security-review.instructions.md
@@ -1,3 +1,7 @@
+---
+applyTo: "src/gateway/api/**/*.py,src/gateway/auth/**/*.py,src/gateway/services/**/*.py,src/gateway/core/config.py,src/gateway/models/entities.py,src/gateway/streaming.py,alembic/versions/**/*.py"
+---
+
 # Security Review Instructions
 
 How to review otari for security regressions. otari is a self-hosted, OpenAI-compatible

--- a/.github/skills/backend-standards/SKILL.md
+++ b/.github/skills/backend-standards/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: backend-standards
+description: Backend conventions for the otari gateway (`src/gateway/`), async SQLAlchemy 2.0, FastAPI, budget/reservation lifecycle, Alembic migrations, config layering. Use when writing or reviewing gateway request handling, services, models, or migrations.
+---
+
+# Backend Standards: otari gateway (`src/gateway/`)
+
+The gateway is an async FastAPI service: request handlers in `api/routes/`, business logic in
+`services/`, ORM in `models/entities.py`, migrations in `alembic/versions/`. This guide is the
+backend counterpart to the frontend skill and to the path-scoped review instructions in
+`.github/instructions/` (performance and security). `AGENTS.md` is the source of truth for
+build/test/lint commands and the two-mode architecture; read it first. This file captures the
+conventions that keep new backend code correct and consistent.
+
+## Async SQLAlchemy 2.0: the house style
+
+Everything is async. Match the shapes already in `services/`:
+
+```python
+from sqlalchemy import select, func
+
+# scalar list
+rows = (await db.execute(select(ModelAlias))).scalars().all()
+
+# single row (or None)
+existing = (await db.execute(select(APIKey.id).limit(1))).scalar_one_or_none()
+
+# count without loading rows
+count = (await db.execute(select(func.count()).select_from(ModelPricing))).scalar_one()
+```
+
+- Use `await db.execute(select(...))` + `.scalars()` / `.scalar_one_or_none()` /
+  `.scalar_one()`. Don't fetch rows to count them (`len(all())`), use `func.count()`.
+- ORM columns are typed with `Mapped[...]` + `mapped_column(...)`. Follow the existing style:
+  modern generics (`str | None`, `list[str]`), timezone-aware `DateTime(timezone=True)`.
+- Sessions come from the `get_db` dependency in routes; non-request code uses
+  `create_session()` (`core/database.py`). Don't open ad-hoc engines.
+
+## Layering
+
+- **Routes** (`api/routes/`) stay thin: parse the request, resolve identity, call a service,
+  shape the response. Keep request/response Pydantic models near the handler; return typed
+  models, not raw dicts; use `fastapi.status` constants.
+- **Services** (`services/`, one concern per `*_service.py`) hold the business logic and own
+  the DB work.
+- Service-specific exceptions live beside their service (e.g. `UnsafeURLError`,
+  `GuardrailsNotReachableError`). Raise `HTTPException` with a clear `detail` in the API layer;
+  prefer specific exceptions (`ValueError`, `SQLAlchemyError`) over broad `except Exception`.
+
+## The budget / reservation lifecycle is load-bearing
+
+Billable routes hold money-adjacent state. The invariant (detailed in
+[../../instructions/security-review.instructions.md](../../instructions/security-review.instructions.md#0-budget-billing--tenant-isolation-otari-specific--read-first))
+is: **reserve before the provider call, then reconcile on success or refund on every error
+path**, including provider errors, tool-iteration caps, unreachable sandbox/web-search,
+generic `except`, and `except HTTPException`, plus streaming completion and client disconnect.
+A reservation that never settles leaks and permanently shrinks the user's budget.
+
+- Bind spend to the **authenticated principal** via `resolve_user_id`, never to the
+  client-supplied `user` field.
+- Enforce budgets atomically (the reservation is a single conditional `UPDATE`), not
+  check-then-act. Use `is None` for "absent" vs a legitimate `0` (falsy-zero traps).
+- New billable logic must be correct in **both** standalone and hybrid mode, verify which
+  branch (`db is not None`) it belongs in.
+
+## Migrations (Alembic)
+
+- A change to `models/entities.py` ships with a matching migration in `alembic/versions/`,
+  chained to the current head, in the same PR.
+- New non-nullable columns need a `server_default` for existing rows (e.g. `users.reserved`
+  defaults to `"0"`).
+- Every foreign key needs an explicit `ondelete` policy; index it (`index=True`), see the
+  performance instructions. Account deletion must leave no orphaned billable rows.
+- Provide a real, reversible `downgrade()`.
+
+## Config & env
+
+`GatewayConfig` (`core/config.py`) loads `config.yml` then layers env vars, with the
+user-facing `OTARI_` prefix winning over the legacy `GATEWAY_` prefix. New security-relevant
+flags **fail closed by default** and are validated at load (reject unknown values), like the
+`stream_missing_usage_policy` validator. Don't read `os.getenv` directly on a hot path; route
+through the config / `otari_env()`.
+
+## Logging
+
+- Use the module logger from `gateway.log_config` with `%s` placeholders.
+- **Never log secrets or user payloads**: no API keys, no `messages`/`input`/completion text,
+  no full request bodies. Log opaque ids, token counts, model/provider names, status. (The
+  one sanctioned exception is the intentional one-time bootstrap key print.)
+
+## Before you finish
+
+- Add happy-path **and** error-path tests next to the changed behavior (unit for pure logic,
+  integration for route/DB behavior; integration spins up Postgres via testcontainers).
+- If you touched request/response models, run `uv run python scripts/generate_openapi.py
+  --check`.
+- Run `make lint` and `make typecheck` (ruff + mypy strict over `src`, `tests`, `scripts`).
+
+## Related instructions
+
+- [performance-review.instructions.md](../../instructions/performance-review.instructions.md): N+1, indexes, pagination limits, transaction atomicity, async efficiency.
+- [security-review.instructions.md](../../instructions/security-review.instructions.md): budget/tenant isolation, auth, SSRF, prompt injection, migration safety.

--- a/.github/skills/frontend-standards/SKILL.md
+++ b/.github/skills/frontend-standards/SKILL.md
@@ -50,7 +50,8 @@ Build and check from the repo root:
 - New HeroUI **v2** patterns: granular imports (`@heroui/button`), `HeroUIProvider`,
   `classNames={{ slot }}` objects, `onValueChange` on inputs, or `color` on `Button`. This is
   v3: unified `@heroui/react` import, compound components (`Card.Content`, `Card.Header`),
-  `onChange`, `onPress`, `variant="primary"|"secondary"|"ghost"|"outline"|"danger"|"danger-soft"`.
+  `onChange`, `onPress`, and a `variant` (the dashboard uses `primary`, `ghost`, `outline`,
+  `danger`, `danger-soft`) instead of `color` on `Button`.
 - Inline `style={{}}` or `<style>` tags. Use Tailwind utilities or a token.
 - Manual polling with bare `setInterval`/`setTimeout`. Use TanStack Query's `refetchInterval`
   (see `useDashboardBuild`).

--- a/.github/skills/frontend-standards/SKILL.md
+++ b/.github/skills/frontend-standards/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: frontend-standards
+description: Guidelines for the otari admin dashboard (`web/`), React 19 + TypeScript (strict) + HeroUI v3 + Tailwind v4 + TanStack Query. Use when writing or reviewing dashboard components, styling, data fetching, or tests.
+---
+
+# Frontend Standards: otari dashboard (`web/`)
+
+`web/` is the standalone admin dashboard: a small React SPA that talks to the gateway's
+management API (`/v1/models`, `/v1/pricing`, `/v1/aliases`, `/v1/settings`) with the master
+key. It is a focused operator tool, not a general-purpose app; keep its footprint small and
+its conventions consistent with what is already there.
+
+Stack: React 19, TypeScript (`strict`), HeroUI v3 (`@heroui/react`), Tailwind CSS v4,
+TanStack Query, Vite, Vitest + Testing Library. Package manager is **npm**. Layout is flat
+(`web/src/{components,pages,api,lib,auth}`), there is no `features/`/`shared/` architecture,
+no router, no Playwright/screenshot suite, and no analytics. Do not introduce those to match
+some other repo; match what `web/` does.
+
+Build and check from the repo root:
+
+- `npm --prefix web ci && npm --prefix web run build` (output is committed to
+  `src/gateway/static/dashboard/`; rebuild and commit after any change under `web/src`).
+- `npm --prefix web run typecheck`
+- `npm --prefix web test`
+
+## Critical rules
+
+**Always:**
+
+- Reach for a HeroUI component prop (`variant`, `size`, `isDisabled`, `isPending`,
+  `fullWidth`, `isInvalid`) before a `className`. `className` is for layout/position, not for
+  restyling a component HeroUI already styles. See [components.md](./components.md).
+- Use the `--otari-*` CSS variables for brand/surface/text color
+  (`text-[var(--otari-muted)]`, `bg-[var(--otari-brand-tint)]`), defined once in
+  `web/src/styles/globals.css`. If you need a new brand/surface color, add a token there
+  rather than scattering a hex. See [design-tokens.md](./design-tokens.md).
+- Fetch server state through TanStack Query hooks in `web/src/api/hooks.ts`. Keep query keys
+  as module constants, set a deliberate `staleTime`, and invalidate the affected keys in a
+  mutation's `onSuccess`. See [data-fetching.md](./data-fetching.md).
+- Bound every paginated read. `fetchAllPricing` walks pages behind a hard `PRICING_MAX_PAGES`
+  cap so a backend that ignores `skip` can't spin an unbounded loop, copy that shape for any
+  new "fetch everything" hook.
+- Prefer `undefined` over `null` for absent values in your own types (the API layer may return
+  `null`; convert at the boundary).
+- Add a Vitest test for any component or helper whose behavior you change (`Foo.tsx` →
+  `Foo.test.tsx`, colocated). See [typescript-and-react.md](./typescript-and-react.md#testing).
+
+**Never:**
+
+- New HeroUI **v2** patterns: granular imports (`@heroui/button`), `HeroUIProvider`,
+  `classNames={{ slot }}` objects, `onValueChange` on inputs, or `color` on `Button`. This is
+  v3: unified `@heroui/react` import, compound components (`Card.Content`, `Card.Header`),
+  `onChange`, `onPress`, `variant="primary"|"secondary"|"ghost"|"danger"|"danger-soft"`.
+- Inline `style={{}}` or `<style>` tags. Use Tailwind utilities or a token.
+- Manual polling with bare `setInterval`/`setTimeout`. Use TanStack Query's `refetchInterval`
+  (see `useDashboardBuild`).
+- A raw `fetch()` for the management API. Go through `apiFetch` in `web/src/api/client.ts`, so
+  the Bearer key, error extraction, and 401/403 sign-out handling stay in one place.
+- Client-side filtering/sorting/pagination of large server datasets when the endpoint can do
+  it. (Small, already-loaded lists rendered in a `Table` are fine.)
+- `getByTestId` when a semantic query (`getByRole`, `getByLabelText`, `getByText`) works.
+
+## A note on status colors
+
+`web/` uses raw Tailwind palette classes for one narrow case: semantic status surfaces
+(`ErrorBanner` uses `border-red-200 bg-red-50 text-red-700`; `InfoBanner` uses `amber`). That
+is the existing convention, so match it for new alert/status elements rather than reformatting
+them into `--otari-*` tokens. Everything else (brand, surface, text, borders) uses the
+`--otari-*` variables. Don't reach for `bg-white`/`text-gray-900` for general chrome.
+
+## Topic guides
+
+- [design-tokens.md](./design-tokens.md): the `--otari-*` variables, where they live, when to add one.
+- [components.md](./components.md): HeroUI v3 patterns, props over `className`, the shared UI primitives in `components/ui.tsx`.
+- [data-fetching.md](./data-fetching.md): TanStack Query conventions: query keys, `staleTime`, invalidation, bounded pagination.
+- [typescript-and-react.md](./typescript-and-react.md): strict TS, `undefined` over `null`, hook/effect hygiene, and Vitest testing.

--- a/.github/skills/frontend-standards/SKILL.md
+++ b/.github/skills/frontend-standards/SKILL.md
@@ -50,7 +50,7 @@ Build and check from the repo root:
 - New HeroUI **v2** patterns: granular imports (`@heroui/button`), `HeroUIProvider`,
   `classNames={{ slot }}` objects, `onValueChange` on inputs, or `color` on `Button`. This is
   v3: unified `@heroui/react` import, compound components (`Card.Content`, `Card.Header`),
-  `onChange`, `onPress`, `variant="primary"|"secondary"|"ghost"|"danger"|"danger-soft"`.
+  `onChange`, `onPress`, `variant="primary"|"secondary"|"ghost"|"outline"|"danger"|"danger-soft"`.
 - Inline `style={{}}` or `<style>` tags. Use Tailwind utilities or a token.
 - Manual polling with bare `setInterval`/`setTimeout`. Use TanStack Query's `refetchInterval`
   (see `useDashboardBuild`).

--- a/.github/skills/frontend-standards/SKILL.md
+++ b/.github/skills/frontend-standards/SKILL.md
@@ -54,8 +54,10 @@ Build and check from the repo root:
 - Inline `style={{}}` or `<style>` tags. Use Tailwind utilities or a token.
 - Manual polling with bare `setInterval`/`setTimeout`. Use TanStack Query's `refetchInterval`
   (see `useDashboardBuild`).
-- A raw `fetch()` for the management API. Go through `apiFetch` in `web/src/api/client.ts`, so
-  the Bearer key, error extraction, and 401/403 sign-out handling stay in one place.
+- A raw `fetch()` for **authenticated** management requests. Go through `apiFetch` in
+  `web/src/api/client.ts`, so the Bearer key, error extraction, and 401/403 sign-out handling
+  stay in one place. (The sanctioned exception is `validateMasterKey`, which raw-`fetch`es a
+  master-key-gated endpoint to check a candidate key *before* it becomes the stored `masterKey`.)
 - Client-side filtering/sorting/pagination of large server datasets when the endpoint can do
   it. (Small, already-loaded lists rendered in a `Table` are fine.)
 - `getByTestId` when a semantic query (`getByRole`, `getByLabelText`, `getByText`) works.

--- a/.github/skills/frontend-standards/components.md
+++ b/.github/skills/frontend-standards/components.md
@@ -62,4 +62,6 @@ use it rather than reaching into `error.message` yourself.
 - Space siblings with `gap-*` on the flex/grid parent, not `m-*` on each child.
 - Responsive via Tailwind breakpoints (`sm:`, `md:`, `lg:`) and flex/grid; avoid fixed pixel
   widths for anything that should reflow (`min-w-[180px]` on a wrapping stat card is fine).
-- One component per file, colocated with its test.
+- One component per file for pages and standalone components, colocated with its test. Small
+  shared primitives are the exception: closely related ones live together in
+  `components/ui.tsx` (the primitives listed above), rather than a file each.

--- a/.github/skills/frontend-standards/components.md
+++ b/.github/skills/frontend-standards/components.md
@@ -30,8 +30,8 @@ import { Button, Card } from "@heroui/react";
 </Button>
 ```
 
-`variant` values in use: `primary`, `secondary`, `ghost`, `danger`, `danger-soft`. Stick to
-these unless you're deliberately adding a new one.
+`variant` values the dashboard uses: `primary`, `secondary`, `ghost`, `outline`, `danger`,
+`danger-soft`. Stick to these unless you're deliberately adding a new one.
 
 ## Props over `className`
 

--- a/.github/skills/frontend-standards/components.md
+++ b/.github/skills/frontend-standards/components.md
@@ -1,0 +1,65 @@
+# Components: HeroUI v3 + the shared UI primitives
+
+The dashboard uses HeroUI **v3** (`@heroui/react`). v3 is a ground-up rewrite; v2 habits are
+wrong here.
+
+## v2 → v3
+
+| Concern | v2 (wrong here) | v3 (correct) |
+|---|---|---|
+| Import | `@heroui/button`, `@heroui/card` | unified `@heroui/react` |
+| Provider | `HeroUIProvider` | none needed for these components |
+| Structure | flat `Card`, `Modal` | compound: `Card.Header` / `Card.Content` / `Card.Footer` |
+| Styling override | `classNames={{ slot: "…" }}` | `className` on the subcomponent directly |
+| Change handler | `onValueChange` | `onChange` (v3 ignores `onValueChange` silently) |
+| Click handler | `onClick` | `onPress` |
+| Button intent | `color="danger"` | `variant="danger"` |
+| Disabled | `isLoading` for disabled | `isDisabled` / `isPending` |
+
+Real example from `components/ui.tsx`:
+
+```tsx
+import { Button, Card } from "@heroui/react";
+
+<Card className="flex-1 min-w-[180px]">
+  <Card.Content className="flex flex-col gap-1 p-5">…</Card.Content>
+</Card>
+
+<Button size="sm" variant="danger" isDisabled={isPending} onPress={onConfirm}>
+  {confirmLabel}
+</Button>
+```
+
+`variant` values in use: `primary`, `secondary`, `ghost`, `danger`, `danger-soft`. Stick to
+these unless you're deliberately adding a new one.
+
+## Props over `className`
+
+If a component exposes a prop for what you want (`variant`, `size`, `isDisabled`, `isPending`,
+`fullWidth`, `isInvalid`), use the prop. Reserve `className` for layout and positioning
+(`flex`, `gap-*`, `min-w-[…]`, responsive prefixes), not for re-skinning something HeroUI
+already styles.
+
+## Check `components/ui.tsx` before hand-rolling
+
+Small shared primitives already exist. Reuse or extend them instead of duplicating markup:
+
+| Need | Use |
+|---|---|
+| Labeled metric tile | `StatCard` |
+| Error alert from an unknown thrown value | `ErrorBanner` (pairs with `errorMessage(error)`) |
+| Info/warning callout | `InfoBanner` (`tone="info" \| "warning"`) |
+| Page title + description + action | `PageHeader` |
+| Destructive action without a modal | `ConfirmButton` (two-click arm/confirm) |
+| Form field wrapper | `Field` (`components/Field.tsx`) |
+| Tabular data | `Table` (`components/Table.tsx`) |
+
+`errorMessage(error)` centralizes turning an `ApiError`/`Error`/unknown into a display string;
+use it rather than reaching into `error.message` yourself.
+
+## Layout and spacing
+
+- Space siblings with `gap-*` on the flex/grid parent, not `m-*` on each child.
+- Responsive via Tailwind breakpoints (`sm:`, `md:`, `lg:`) and flex/grid; avoid fixed pixel
+  widths for anything that should reflow (`min-w-[180px]` on a wrapping stat card is fine).
+- One component per file, colocated with its test.

--- a/.github/skills/frontend-standards/components.md
+++ b/.github/skills/frontend-standards/components.md
@@ -30,8 +30,9 @@ import { Button, Card } from "@heroui/react";
 </Button>
 ```
 
-`variant` values the dashboard uses: `primary`, `secondary`, `ghost`, `outline`, `danger`,
-`danger-soft`. Stick to these unless you're deliberately adding a new one.
+`variant` values the dashboard uses: `primary`, `ghost`, `outline`, `danger`, `danger-soft`.
+`secondary` and the other HeroUI v3 variants are available if a new need arises; stick to the
+in-use set unless you're deliberately adding one.
 
 ## Props over `className`
 

--- a/.github/skills/frontend-standards/data-fetching.md
+++ b/.github/skills/frontend-standards/data-fetching.md
@@ -1,0 +1,91 @@
+# Data fetching: TanStack Query
+
+All server state flows through TanStack Query hooks in `web/src/api/hooks.ts`, which call
+`apiFetch` from `web/src/api/client.ts`. Never call `fetch()` for the management API directly
+and never mirror server state into `useState`.
+
+## The API boundary
+
+`apiFetch<T>(path, init)` is the single door to the gateway's management API. It:
+
+- attaches the master key as `Authorization: Bearer …`,
+- sets JSON headers, extracts `detail` from error bodies into an `ApiError`,
+- treats **401 and 403** as "this session can't use the management API", it calls the
+  registered unauthorized handler (drops the key, bounces to sign-in) and throws.
+
+Because 401/403 are handled centrally, hooks don't need to. The query client
+(`web/src/provider.tsx`) also **never retries** an `ApiError` with status 401/403 (they won't
+fix themselves) and retries other failures twice.
+
+## Query conventions
+
+- **Query keys are module constants**, not inline literals:
+
+  ```ts
+  const MODELS = "models";
+  const PRICING = "pricing";
+  // ...
+  export function useModels() {
+    return useQuery({ queryKey: [MODELS], queryFn: () => apiFetch<ModelListResponse>("/v1/models"), staleTime: 60_000 });
+  }
+  ```
+
+- **Set `staleTime` deliberately**, sized to how fast the data actually moves: seconds for
+  mutable lists (`aliases`, `settings`, `models`), several minutes for near-static gateway
+  metadata (`providers`, discovery, model metadata). Add a one-line comment when the choice is
+  non-obvious, as the existing hooks do.
+
+- **Keep independent keys independent.** `discoverable` is deliberately *not* nested under
+  `models` because a pricing change can't alter which models a provider serves, sharing the
+  key would fire a live provider call on every save. Think about invalidation blast radius when
+  you pick a key.
+
+## Mutations invalidate what they change
+
+Every mutation invalidates exactly the keys its write affects, no more, no less:
+
+```ts
+export function useCreateAlias() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateAliasRequest) =>
+      apiFetch<AliasResponse>("/v1/aliases", { method: "POST", body: JSON.stringify(body) }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: [ALIASES] });
+      void queryClient.invalidateQueries({ queryKey: [MODELS] }); // an alias shows up as a model
+    },
+  });
+}
+```
+
+- Invalidate the primary key **and** any derived view the write touches (creating an alias
+  changes the model catalog too).
+- Use `setQueryData` when the mutation already returns the fresh object (`useUpdateSettings`
+  seeds `[SETTINGS]` from the response, then invalidates the derived model lists).
+- Prefix fire-and-forget invalidations with `void` so the floating-promise lint stays happy.
+
+## Bounded pagination
+
+When a hook fetches "everything," cap the walk so a backend or proxy that ignores `skip`
+can't turn it into an unbounded request loop. Copy the `fetchAllPricing` shape:
+
+```ts
+const PRICING_PAGE_SIZE = 1000;   // matches the server-side cap
+const PRICING_MAX_PAGES = 100;    // hard stop: 100k rows, far beyond any real history
+
+async function fetchAllPricing(): Promise<PricingResponse[]> {
+  const all: PricingResponse[] = [];
+  for (let page = 0; page < PRICING_MAX_PAGES; page += 1) {
+    const rows = await apiFetch<PricingResponse[]>(`/v1/pricing?skip=${page * PRICING_PAGE_SIZE}&limit=${PRICING_PAGE_SIZE}`);
+    all.push(...rows);
+    if (rows.length < PRICING_PAGE_SIZE) break;
+  }
+  return all;
+}
+```
+
+## Polling
+
+Use `refetchInterval` for anything that must stay live, not a hand-rolled `setInterval`.
+`useDashboardBuild` polls a small build hash every 60s (and on window focus, with `retry:
+false`) so an open tab notices a redeploy, model that when you need liveness.

--- a/.github/skills/frontend-standards/data-fetching.md
+++ b/.github/skills/frontend-standards/data-fetching.md
@@ -1,8 +1,9 @@
 # Data fetching: TanStack Query
 
-All server state flows through TanStack Query hooks in `web/src/api/hooks.ts`, which call
-`apiFetch` from `web/src/api/client.ts`. Never call `fetch()` for the management API directly
-and never mirror server state into `useState`.
+All *authenticated* server state flows through TanStack Query hooks in `web/src/api/hooks.ts`,
+which call `apiFetch` from `web/src/api/client.ts`. Don't call `fetch()` directly for
+authenticated management requests, and never mirror server state into `useState`. (The one
+exception is pre-auth candidate-key validation, described under "The API boundary" below.)
 
 ## The API boundary
 
@@ -16,6 +17,11 @@ and never mirror server state into `useState`.
 Because 401/403 are handled centrally, hooks don't need to. The query client
 (`web/src/provider.tsx`) also **never retries** an `ApiError` with status 401/403 (they won't
 fix themselves) and retries other failures twice.
+
+The one deliberate raw-`fetch` exception is **pre-auth**: `validateMasterKey` (`client.ts`)
+hits a master-key-gated endpoint to check a *candidate* key before it becomes the stored
+`masterKey`, so it can't use `apiFetch` (which would attach the not-yet-accepted key). Every
+request after sign-in goes through `apiFetch`.
 
 ## Query conventions
 

--- a/.github/skills/frontend-standards/design-tokens.md
+++ b/.github/skills/frontend-standards/design-tokens.md
@@ -1,0 +1,48 @@
+# Design tokens: `web/`
+
+The dashboard's palette is a small set of CSS custom properties defined once, at the top of
+`web/src/styles/globals.css`:
+
+```css
+:root {
+  --otari-brand: #4e8295;
+  --otari-brand-dark: #3c6678;
+  --otari-brand-tint: #eaf1f3;
+  --otari-ink: #14242c;      /* primary text */
+  --otari-muted: #5b6b73;    /* secondary text */
+  --otari-line: #dbe5e8;     /* borders/dividers */
+  --otari-surface: #ffffff;  /* cards/panels */
+  --otari-bg: #f6f9fa;       /* page background */
+}
+```
+
+Consume them through Tailwind arbitrary values:
+
+```tsx
+<span className="text-[var(--otari-muted)]">…</span>
+<div className="border border-[var(--otari-line)] bg-[var(--otari-surface)]">…</div>
+<h1 className="text-[var(--otari-ink)]">…</h1>
+```
+
+## Rules
+
+- **Add a token, don't scatter a hex.** If you need a new brand or surface color, add a
+  `--otari-*` variable in `globals.css` and reference it. A one-off hex in a component is a
+  review smell: the next person can't retheme the app from one place.
+- **Name by role, not appearance.** `--otari-muted`, `--otari-line`, `--otari-surface` describe
+  what the color is for. Don't add `--otari-teal-500` or `--otari-gray`; if you're tempted, the
+  role is missing, not the shade.
+- **Status surfaces are the documented exception.** Alert/banner components
+  (`ErrorBanner`, `InfoBanner` in `components/ui.tsx`) use raw Tailwind palette classes
+  (`red`, `amber`) for their semantic meaning. Match that for new status elements; don't
+  convert them to `--otari-*` and don't invent brand tokens for them.
+- **No general-purpose palette classes for chrome.** `bg-white`, `text-gray-900`, `bg-zinc-800`
+  for ordinary surfaces/text should be a `--otari-*` variable instead.
+
+## HeroUI theming
+
+HeroUI v3 ships its own styles (`@import "@heroui/styles"` in `globals.css`) and its `dark`
+variant is wired via `@custom-variant dark (&:is(.dark *))`. Let HeroUI components carry their
+own theming through `variant`/`size` props rather than overriding their internals with
+`className`. If a HeroUI surface needs to match an `--otari-*` color, prefer a prop or a small
+wrapper over reaching into the component's classes.

--- a/.github/skills/frontend-standards/typescript-and-react.md
+++ b/.github/skills/frontend-standards/typescript-and-react.md
@@ -1,0 +1,49 @@
+# TypeScript & React conventions: `web/`
+
+TypeScript runs in `strict` mode; `npm --prefix web run typecheck` must pass. React 19.
+
+## TypeScript
+
+- **`undefined`, not `null`, for absent values** in your own types and props. The API layer may
+  hand back `null` (it mirrors the server JSON), convert at the boundary rather than letting
+  `null` spread through the component tree. (`ApiError`-style third-party shapes that
+  explicitly use `null` are the exception.)
+- **Named exports**, not default exports, for components/hooks/helpers, consistent names
+  across imports, better tooling and tree-shaking. (`web/` already does this throughout.)
+- **Named imports**, not namespace imports (`import * as …`).
+- Type the API surface in `web/src/api/types.ts` and thread those types through
+  `apiFetch<T>(…)`; don't fetch into `any`.
+- Let inference work for locals; annotate function signatures and exported values.
+
+## React
+
+- **`onPress`, not `onClick`**, for HeroUI interactive components (see
+  [components.md](./components.md)).
+- **Correct dependency arrays** on `useEffect`/`useMemo`/`useCallback`. Clean up subscriptions,
+  intervals, and event listeners in the effect's return.
+- **Derive, don't duplicate.** Compute values from props/query data during render instead of
+  copying them into `useState` and syncing with effects. Server state lives in TanStack Query,
+  not in component state (see [data-fetching.md](./data-fetching.md)).
+- **Stable `key`s** for lists, a stable id, not the array index.
+- Reach for memoization only when a re-render is measurably a problem, not by reflex.
+- Keep a component per file, colocated with its test.
+
+## Testing
+
+Vitest + Testing Library (`@testing-library/react`, `@testing-library/user-event`,
+`@testing-library/jest-dom` via `web/src/test/setup.ts`). Run `npm --prefix web test`.
+
+- **Colocate**: `Foo.tsx` → `Foo.test.tsx`, `format.ts` → `format.test.ts`.
+- **Query the way a user would**: `getByRole`, `getByLabelText`, `getByText`. Avoid
+  `getByTestId` and CSS/class selectors, they break the moment markup or tokens change.
+- **Render real providers, mock the network boundary.** Wrap the component in a real
+  `QueryClientProvider` (see the existing page tests) so the real hooks and formatters run;
+  set the master key with `setMasterKey(…)` and stub `apiFetch`'s endpoints, not the hooks
+  themselves. Mocking `useModels`/`usePricing` directly hides query-key, loading, and error
+  regressions.
+- **Drive interactions with `userEvent`** and assert on the user-visible result; don't poke
+  component internals.
+- **Wait on the thing, not the clock.** Use `findBy*`/`waitFor` for async UI; never
+  `setTimeout`-sleep a test.
+- Keep test data explicit and deterministic (fixed ids, absolute dates like the existing
+  `ModelsPage.test.tsx` fixtures), not `Date.now()`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,16 @@ Scope: entire repo.
 - Database: SQLite by default (async via `aiosqlite`), PostgreSQL in integration tests (async via `asyncpg`).
 - Provider calls go through the `any-llm` SDK (`any_llm`), not hand-rolled HTTP clients.
 
+## Skills & Scoped Instructions
+Detailed, task-scoped guidance lives outside this file so it loads only when relevant
+(progressive disclosure). Read the applicable one before editing:
+
+- **Backend (`src/gateway/`)** → [.github/skills/backend-standards/SKILL.md](.github/skills/backend-standards/SKILL.md): async SQLAlchemy house style, layering, the budget/reservation lifecycle, migrations, config/logging conventions.
+- **Dashboard (`web/`)** → [.github/skills/frontend-standards/SKILL.md](.github/skills/frontend-standards/SKILL.md): HeroUI v3, the `--otari-*` design tokens, TanStack Query patterns, and Vitest testing for the admin dashboard.
+- **Reviewing a change** → the path-scoped files in [.github/instructions/](.github/instructions/) auto-apply during Copilot reviews (they carry `applyTo` globs): [security-review](.github/instructions/security-review.instructions.md) (budget/tenant isolation, auth, SSRF, prompt injection) and [performance-review](.github/instructions/performance-review.instructions.md) (N+1, indexes, pagination limits, transaction atomicity).
+
+The `.claude/skills` directory symlinks to `.github/skills`, so the same skills are available to Claude and to GitHub Copilot from one source.
+
 ## Architecture (Big Picture)
 Read these together before changing request behavior, the flow spans several files.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Detailed, task-scoped guidance lives outside this file so it loads only when rel
 
 - **Backend (`src/gateway/`)** → [.github/skills/backend-standards/SKILL.md](.github/skills/backend-standards/SKILL.md): async SQLAlchemy house style, layering, the budget/reservation lifecycle, migrations, config/logging conventions.
 - **Dashboard (`web/`)** → [.github/skills/frontend-standards/SKILL.md](.github/skills/frontend-standards/SKILL.md): HeroUI v3, the `--otari-*` design tokens, TanStack Query patterns, and Vitest testing for the admin dashboard.
-- **Reviewing a change** → the path-scoped files in [.github/instructions/](.github/instructions/) auto-apply during Copilot reviews (they carry `applyTo` globs): [security-review](.github/instructions/security-review.instructions.md) (budget/tenant isolation, auth, SSRF, prompt injection) and [performance-review](.github/instructions/performance-review.instructions.md) (N+1, indexes, pagination limits, transaction atomicity).
+- **Reviewing a change** → the path-scoped files in [.github/instructions/](.github/instructions/) auto-apply during Copilot reviews (they carry `applyTo` globs): [security-review](.github/instructions/security-review.instructions.md) (budget/tenant isolation, auth, SSRF, prompt injection) and [performance-review](.github/instructions/performance-review.instructions.md) (N+1, indexes, pagination limits, transaction atomicity) for `src/gateway/`, and [frontend-standards](.github/instructions/frontend-standards.instructions.md) (HeroUI v3, design tokens, TanStack Query) for `web/`.
 
 The `.claude/skills` directory symlinks to `.github/skills`, so the same skills are available to Claude and to GitHub Copilot from one source.
 


### PR DESCRIPTION
## Description

Adds progressive-disclosure agent guidance so coding tools and Copilot reviews have task-scoped standards to follow, instead of everything living in one long `AGENTS.md`.

What is included:

- **`.github/skills/frontend-standards/`** (`SKILL.md` plus `design-tokens`, `components`, `data-fetching`, `typescript-and-react`): conventions for the `web/` admin dashboard, grounded in what it already does. Covers HeroUI v3 (compound components, props over `className`), the `--otari-*` CSS design tokens, the `apiFetch` and TanStack Query patterns from `web/src/api/hooks.ts`, and Vitest testing.
- **`.github/skills/backend-standards/SKILL.md`**: the gateway backend conventions the issue asked for, all pointed at real code: async SQLAlchemy 2.0 house style, route/service layering, the budget reservation and reconcile/refund lifecycle, Alembic migration safety, and config/logging rules. It links to the two review instruction files rather than duplicating them.
- **`.github/instructions/performance-review.instructions.md`** (new): a path-scoped performance checklist (N+1, foreign-key indexes, pagination caps, transaction atomicity, async efficiency), with `applyTo` scoped to `src/gateway/**/*.py` and `web/src/**/*.{ts,tsx}`. Examples use this repo's real entities.
- **`.github/instructions/security-review.instructions.md`**: added an `applyTo` glob so the existing gateway security checklist auto-applies during Copilot reviews like the others. The body is unchanged.
- **Wiring**: a new "Skills & Scoped Instructions" section in `AGENTS.md` links each skill and instruction file, and `.claude/skills` is a symlink to `.github/skills` so one source serves both Claude and Copilot.

Every example is written against this repository's own code (`src/gateway/`, `web/src/`); nothing here is generic boilerplate. No product or application code changed.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [x] Infrastructure / CI

## Relevant issues

Fixes #295

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). (N/A: no application code changed; this PR only adds agent guidance docs and a symlink.)
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). (N/A: no Python or web source changed, so lint/typecheck/tests have nothing to cover here. Markdown links and frontmatter were validated.)
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec. (N/A: no API change.)

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:** Drafted by Claude Code via back-and-forth with @njbrake; the scope decisions and the review of what to include are his. Content was written from this repo's own code.

- [x] I am an AI Agent filling out this form (check box if true)

---

**Update:** Addressed review feedback (CodeRabbit + @khaledosman). Scoped the raw-fetch and one-component-per-file rules to match `web/`, corrected the in-use HeroUI variant list, and added `.github/instructions/frontend-standards.instructions.md` (scoped to `web/src/**`) so Copilot reviews of the dashboard auto-load the frontend rules alongside the security and performance checklists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added shared “skills” and standards to guide both the backend gateway and the `web/` dashboard (UI/component usage, design tokens, data-fetching patterns, and TypeScript/React + testing conventions).
- Added new path-scoped review instructions for performance and security so Copilot reviews focus on the right parts of the repo.
- Added a frontend standards instruction file scoped to `web/src/**` to ensure reviews load the correct dashboard guidance.
- Linked `AGENTS.md` and a `.claude/skills` symlink to the same skill sources in `.github/skills` to keep guidance consistent across coding tools.
- Minor adjustment to the HeroUI v3 guidance by removing a `secondary` variant that isn’t used in `web/`.

## Technical notes

- `.claude/skills` is now a symlink to `../.github/skills`.
- The security review instructions include an `applyTo` path-glob directive controlling where they apply.
- The performance review instructions include concrete backend and frontend checklists (e.g., query efficiency and transaction safety for the backend; bounded fetching and cache/invalidation expectations for the frontend).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->