### PR TITLE
feat(observability): count upstream attempts abandoned before first chunk

### DIFF
--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -83,7 +83,7 @@ from gateway.core.config import GatewayConfig
 from gateway.core.env import otari_env
 from gateway.core.usage import cache_read_tokens_of, cache_write_tokens_of
 from gateway.log_config import logger
-from gateway.metrics import record_cost, record_tokens
+from gateway.metrics import record_abandoned_attempt, record_cost, record_tokens
 from gateway.model_labeling import relabel_model
 from gateway.models.entities import UsageLog
 from gateway.models.guardrails import GuardrailConfig
@@ -1630,6 +1630,7 @@ async def run_streaming_with_fallback(
             session_label,
         )
         pending_error_reports.append((attempt.attempt_id, "error", None, failure.error_class))
+        record_abandoned_attempt(attempt.provider, attempt.model, failure.reason, attempt.position)
         logger.warning(
             "Streaming attempt failed request_id=%s position=%d provider=%s model=%s error=%s",
             route.request_id,
@@ -1796,6 +1797,11 @@ async def run_platform_non_stream(
         )
         if outcome != "success":
             pending_error_reports.append((attempt.attempt_id, outcome, usage, error_class))
+            # Non-streaming attempts have no separable build phase, so a failed
+            # attempt is a timeout when the classifier said so, else a generic
+            # upstream error. Both are waste worth counting for fallback tuning.
+            reason = "timeout" if error_class == "timeout" else "upstream_error"
+            record_abandoned_attempt(attempt.provider, attempt.model, reason, attempt.position)
 
     def _on_attempt_success(attempt: ResolvedAttempt) -> None:
         response.headers["X-Correlation-ID"] = attempt.attempt_id

--- a/src/gateway/metrics.py
+++ b/src/gateway/metrics.py
@@ -54,6 +54,13 @@ REQUEST_COST_DOLLARS = Histogram(
     registry=REGISTRY,
 )
 
+ABANDONED_ATTEMPTS = Counter(
+    "gateway_abandoned_attempts",
+    "Total upstream attempts abandoned before their first chunk (provider fallback / timeout waste)",
+    ["provider", "model", "reason", "position"],
+    registry=REGISTRY,
+)
+
 RATE_LIMIT_HITS = Counter(
     "gateway_rate_limit_hits",
     "Total number of rate limit hits",
@@ -177,6 +184,18 @@ def record_tokens(provider: str, model: str, prompt_tokens: int, completion_toke
 def record_cost(provider: str, model: str, cost: float) -> None:
     """Record request cost."""
     REQUEST_COST_DOLLARS.labels(provider=provider, model=model).observe(cost)
+
+
+def record_abandoned_attempt(provider: str, model: str, reason: str, position: int) -> None:
+    """Record an upstream attempt abandoned before it produced its first chunk.
+
+    ``reason`` is one of ``timeout`` (the first-chunk wait elapsed),
+    ``build_error`` (opening the upstream stream failed), or ``upstream_error``
+    (the upstream raised before yielding a chunk). ``position`` is the attempt's
+    index in the resolved routing plan; label cardinality stays bounded by the
+    plan length.
+    """
+    ABANDONED_ATTEMPTS.labels(provider=provider, model=model, reason=reason, position=str(position)).inc()
 
 
 def record_rate_limit_hit() -> None:

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -22,10 +22,18 @@ DEFAULT_FIRST_CHUNK_TIMEOUT_SECONDS = 2.0
 
 @dataclass(frozen=True)
 class StreamingAttemptFailure:
-    """The reason an attempt was abandoned before any bytes were flushed."""
+    """The reason an attempt was abandoned before any bytes were flushed.
+
+    ``error_class`` is the fine-grained classifier label used for logging and
+    upstream reporting (``timeout``, ``conn_err``, ``http_503``, ...). ``reason``
+    is the coarse phase bucket for metrics: ``build_error`` when opening the
+    stream failed, ``timeout`` when the first-chunk wait elapsed, or
+    ``upstream_error`` when the upstream raised before yielding a chunk.
+    """
 
     error_class: str
     exception: BaseException
+    reason: str
 
 
 @dataclass(frozen=True)
@@ -215,7 +223,7 @@ async def iterate_streaming_attempts(
             stream = await build_stream(attempt)
         except BaseException as exc:
             retryable, error_class = classify_error(exc)
-            await on_attempt_failed(attempt, StreamingAttemptFailure(error_class, exc))
+            await on_attempt_failed(attempt, StreamingAttemptFailure(error_class, exc, reason="build_error"))
             last_exception = exc
             if not retryable:
                 raise
@@ -242,14 +250,14 @@ async def iterate_streaming_attempts(
         except asyncio.TimeoutError as exc:
             await on_attempt_failed(
                 attempt,
-                StreamingAttemptFailure("timeout", exc),
+                StreamingAttemptFailure("timeout", exc, reason="timeout"),
             )
             await _close_stream_quietly(stream)
             last_exception = exc
             continue
         except BaseException as exc:
             retryable, error_class = classify_error(exc)
-            await on_attempt_failed(attempt, StreamingAttemptFailure(error_class, exc))
+            await on_attempt_failed(attempt, StreamingAttemptFailure(error_class, exc, reason="upstream_error"))
             await _close_stream_quietly(stream)
             last_exception = exc
             if not retryable:

--- a/tests/unit/test_gateway_metrics.py
+++ b/tests/unit/test_gateway_metrics.py
@@ -9,6 +9,7 @@ from gateway.metrics import (
     REGISTRY,
     MetricsMiddleware,
     metrics_endpoint,
+    record_abandoned_attempt,
     record_auth_failure,
     record_budget_exceeded,
     record_cost,
@@ -79,6 +80,30 @@ def test_record_auth_failure_increments_counter() -> None:
     record_auth_failure("unit-test-reason")
 
     assert _sample("gateway_auth_failures_total", labels) - before == 1.0
+
+
+def test_record_abandoned_attempt_increments_counter() -> None:
+    labels = {"provider": "ab-prov", "model": "ab-model", "reason": "timeout", "position": "0"}
+    before = _sample("gateway_abandoned_attempts_total", labels)
+
+    record_abandoned_attempt("ab-prov", "ab-model", "timeout", 0)
+
+    assert _sample("gateway_abandoned_attempts_total", labels) - before == 1.0
+
+
+def test_record_abandoned_attempt_labels_by_reason_and_position() -> None:
+    """Each (reason, position) pair is its own series so operators can spot which
+    plan entry and failure phase dominates the fallback waste."""
+    build_labels = {"provider": "ab-prov2", "model": "ab-model2", "reason": "build_error", "position": "1"}
+    upstream_labels = {"provider": "ab-prov2", "model": "ab-model2", "reason": "upstream_error", "position": "2"}
+    before_build = _sample("gateway_abandoned_attempts_total", build_labels)
+    before_upstream = _sample("gateway_abandoned_attempts_total", upstream_labels)
+
+    record_abandoned_attempt("ab-prov2", "ab-model2", "build_error", 1)
+    record_abandoned_attempt("ab-prov2", "ab-model2", "upstream_error", 2)
+
+    assert _sample("gateway_abandoned_attempts_total", build_labels) - before_build == 1.0
+    assert _sample("gateway_abandoned_attempts_total", upstream_labels) - before_upstream == 1.0
 
 
 def test_config_enable_metrics_defaults_to_false() -> None:

--- a/tests/unit/test_streaming_attempts.py
+++ b/tests/unit/test_streaming_attempts.py
@@ -160,6 +160,66 @@ async def test_final_attempt_of_chain_gets_the_grace() -> None:
     assert failures == [("primary", "_RetryableError")]
 
 
+async def _raising_stream(exc: Exception) -> AsyncIterator[str]:
+    """Async stream that raises on its first ``__anext__`` (upstream error before
+    the first chunk), rather than timing out or failing at build time."""
+    raise exc
+    yield  # unreachable; makes this a generator
+
+
+@pytest.mark.asyncio
+async def test_failure_reason_buckets_by_abandonment_phase() -> None:
+    """Each abandonment site tags the failure with its coarse ``reason`` bucket:
+    ``build_error`` when opening the stream fails, ``timeout`` when the first-chunk
+    wait elapses, and ``upstream_error`` when the stream raises before yielding."""
+    reasons: list[str] = []
+
+    def classify_error(exc: BaseException) -> tuple[bool, str]:
+        return True, type(exc).__name__
+
+    async def on_attempt_failed(attempt: SimpleNamespace, failure: StreamingAttemptFailure) -> None:
+        reasons.append(failure.reason)
+
+    async def build_stream_ok_but_raises(_attempt: SimpleNamespace) -> AsyncIterator[str]:
+        return _raising_stream(_RetryableError("upstream blew up before first chunk"))
+
+    async def build_stream_that_fails(_attempt: SimpleNamespace) -> AsyncIterator[str]:
+        raise _RetryableError("could not open stream")
+
+    # build_error: build_stream raises before any stream exists.
+    with pytest.raises(_RetryableError):
+        await iterate_streaming_attempts(
+            attempts=[_attempt("only")],
+            build_stream=build_stream_that_fails,
+            classify_error=classify_error,
+            on_attempt_failed=on_attempt_failed,
+            first_chunk_timeout_seconds=_BUDGET_SECONDS,
+        )
+
+    # timeout: the stream opens but the first chunk never arrives in time.
+    build_stream, _classify, _on_failed, _failures = _harness()
+    with pytest.raises(TimeoutError):
+        await iterate_streaming_attempts(
+            attempts=[_attempt("only", delay=_BEYOND_GRACE_DELAY)],
+            build_stream=build_stream,
+            classify_error=classify_error,
+            on_attempt_failed=on_attempt_failed,
+            first_chunk_timeout_seconds=_BUDGET_SECONDS,
+        )
+
+    # upstream_error: the stream opens but raises before yielding a first chunk.
+    with pytest.raises(_RetryableError):
+        await iterate_streaming_attempts(
+            attempts=[_attempt("only")],
+            build_stream=build_stream_ok_but_raises,
+            classify_error=classify_error,
+            on_attempt_failed=on_attempt_failed,
+            first_chunk_timeout_seconds=_BUDGET_SECONDS,
+        )
+
+    assert reasons == ["build_error", "timeout", "upstream_error"]
+
+
 @pytest.mark.asyncio
 async def test_default_extra_is_zero_preserves_uniform_cap() -> None:
     """With no grace passed, every attempt (including the sole one) is capped at


### PR DESCRIPTION
## Description

When a hybrid-mode attempt fails before its first chunk, the runner fails over to the next entry in the routing plan and only emits a WARNING log (`Streaming attempt failed ...`, `All upstream attempts failed`). There was no metric, so operators could not spot pathological failover/timeout waste: a too-tight first-chunk timeout, a flaky primary provider, or a spike in abandoned attempts that still incurred upstream cost.

This adds a Prometheus counter `gateway_abandoned_attempts`, labelled by `provider`, `model`, `reason` (`timeout` | `build_error` | `upstream_error`), and `position`, incremented in both hybrid-mode fallback paths:

- **Streaming** (`iterate_streaming_attempts` / `run_streaming_with_fallback`): a new `reason` field on `StreamingAttemptFailure` tags the coarse phase bucket at each of its three abandonment sites (`build_error` when opening the stream fails, `timeout` when the first-chunk wait elapses, `upstream_error` when the upstream raises before yielding). The streaming `on_attempt_failed` callback records the counter.
- **Non-streaming** (`run_platform_attempts` / `run_platform_non_stream`): the attempt-outcome callback maps a classified `timeout` to `timeout` and everything else to `upstream_error` (this path has no separable build phase).

`position` is the attempt's index in the resolved plan, so counter cardinality stays bounded by the plan length.

Scope note: the issue's *optional* per-attempt input-token and cost estimates are deferred as a follow-up; this lands the core counter (the primary proposal bullet). Only the upstream provider's own billing is ground truth; this signal is a relative/trend indicator to catch pathological waste, not exact accounting.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #238

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary. (No metric names are enumerated in docs; `/metrics` is already documented.)
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). (No API contract change; spec verified up to date.)

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:**

Implemented via Claude Code through back-and-forth with @njbrake; the reasoning and decisions are his.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
