### PR TITLE
fix(config): reject invalid OTARI_SECRET_KEY at startup

### DIFF
--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -33,6 +33,7 @@ from gateway.services.provider_store_service import (
     run_provider_refresher,
 )
 from gateway.services.runtime_settings_service import apply_overrides_from_db
+from gateway.services.secret_box import validate_secret_key
 from gateway.version import __version__
 
 _PUBLIC_PREFIXES = ("/health",)
@@ -150,6 +151,9 @@ def create_app(config: GatewayConfig) -> FastAPI:
     """Create and configure FastAPI application."""
 
     _validate_platform_config(config)
+    # A set-but-invalid OTARI_SECRET_KEY must not silently pass startup and then
+    # break provider-credential storage at request time. Fail fast here instead.
+    validate_secret_key()
     set_config(config)
 
     app = FastAPI(

--- a/src/gateway/services/secret_box.py
+++ b/src/gateway/services/secret_box.py
@@ -75,6 +75,20 @@ def get_secret_box() -> MultiFernet:
     return MultiFernet(fernets)
 
 
+def validate_secret_key() -> None:
+    """Fail fast when ``OTARI_SECRET_KEY`` is set but not a valid Fernet key.
+
+    Unset is allowed: the provider store is simply unavailable until a key is
+    configured. A set-but-invalid key would otherwise pass startup and only
+    surface later when a credential is stored or read, so validating it here
+    turns a latent runtime failure into a clear startup error. Raises
+    ``SecretBoxUnavailableError``; the message never carries key material.
+    """
+    if not secret_box_configured():
+        return
+    get_secret_box()
+
+
 def encrypt_secret(plaintext: str) -> str:
     """Encrypt ``plaintext`` with the primary key; return url-safe ciphertext."""
     return get_secret_box().encrypt(plaintext.encode()).decode()

--- a/tests/unit/test_gateway_root_page.py
+++ b/tests/unit/test_gateway_root_page.py
@@ -8,6 +8,7 @@ import gateway.main as gateway_main
 from gateway.core.config import GatewayConfig
 from gateway.dashboard import get_dashboard_dir
 from gateway.main import create_app
+from gateway.services.secret_box import SecretBoxUnavailableError, generate_secret_key
 
 
 def _config(tmp_path: Path, name: str) -> GatewayConfig:
@@ -72,6 +73,23 @@ def test_dashboard_assets_are_mounted_and_cacheable(tmp_path: Path) -> None:
     assert asset_response.status_code == 200
     # Hashed bundles are immutable, so the security middleware must not force no-store.
     assert "no-store" not in asset_response.headers.get("cache-control", "")
+
+
+def test_create_app_rejects_invalid_secret_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTARI_SECRET_KEY", "not-a-valid-fernet-key")
+    with pytest.raises(SecretBoxUnavailableError) as excinfo:
+        create_app(_config(tmp_path, "gateway-bad-secret-test.db"))
+    assert "not-a-valid-fernet-key" not in str(excinfo.value)
+
+
+def test_create_app_accepts_valid_secret_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTARI_SECRET_KEY", generate_secret_key())
+    app = create_app(_config(tmp_path, "gateway-good-secret-test.db"))
+
+    with TestClient(app) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
 
 
 def test_root_falls_back_to_tutorial_without_dashboard(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_secret_box.py
+++ b/tests/unit/test_secret_box.py
@@ -9,6 +9,7 @@ from gateway.services.secret_box import (
     encrypt_secret,
     generate_secret_key,
     secret_box_configured,
+    validate_secret_key,
 )
 
 
@@ -31,6 +32,24 @@ def test_invalid_key_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OTARI_SECRET_KEY", "not-a-valid-fernet-key")
     with pytest.raises(SecretBoxUnavailableError):
         encrypt_secret("x")
+
+
+def test_validate_secret_key_allows_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OTARI_SECRET_KEY", raising=False)
+    monkeypatch.delenv("GATEWAY_SECRET_KEY", raising=False)
+    validate_secret_key()
+
+
+def test_validate_secret_key_allows_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTARI_SECRET_KEY", generate_secret_key())
+    validate_secret_key()
+
+
+def test_validate_secret_key_rejects_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTARI_SECRET_KEY", "not-a-valid-fernet-key")
+    with pytest.raises(SecretBoxUnavailableError) as excinfo:
+        validate_secret_key()
+    assert "not-a-valid-fernet-key" not in str(excinfo.value)
 
 
 def test_wrong_key_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Description

A set-but-invalid `OTARI_SECRET_KEY` previously passed startup fine and only failed later, at request time, when the dashboard tried to store or read a provider credential. That turned a plain misconfiguration (a typo'd or truncated key) into what looks like a runtime bug.

This validates the key while the app is built (`create_app`), before it serves traffic:

- Unset stays allowed: the provider store is simply unavailable until a key is configured.
- A value that is not a valid Fernet key now fails fast with a clear `SecretBoxUnavailableError`. The error never echoes key material.

Validation lives in `create_app`, the single choke point that both the CLI (`serve`) and the tests build the app through, so every launch path is covered. It reuses the existing `get_secret_box()` validation rather than re-implementing Fernet checks.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #321

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). (No API contract change; OpenAPI verified up to date.)

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:**

Claude drafted the change and tests via back-and-forth with @njbrake; the reasoning and decisions are his.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
