### PR TITLE
fix(observability): don't count locked-in tool-loop failures as abandoned

### DIFF
--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -1797,11 +1797,6 @@ async def run_platform_non_stream(
         )
         if outcome != "success":
             pending_error_reports.append((attempt.attempt_id, outcome, usage, error_class))
-            # Non-streaming attempts have no separable build phase, so a failed
-            # attempt is a timeout when the classifier said so, else a generic
-            # upstream error. Both are waste worth counting for fallback tuning.
-            reason = "timeout" if error_class == "timeout" else "upstream_error"
-            record_abandoned_attempt(attempt.provider, attempt.model, reason, attempt.position)
 
     def _on_attempt_success(attempt: ResolvedAttempt) -> None:
         response.headers["X-Correlation-ID"] = attempt.attempt_id

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel
 from gateway.core.config import GatewayConfig
 from gateway.core.usage import cache_read_tokens_of, cache_write_tokens_of
 from gateway.log_config import logger
+from gateway.metrics import record_abandoned_attempt
 from gateway.models.mcp import McpServerConfig
 from gateway.services.mcp_loop import MaxToolIterationsExceeded
 from gateway.services.sandbox_backend import SandboxNotReachableError
@@ -262,6 +263,14 @@ async def run_platform_attempts(
                 locked_in,
             )
             last_exc = exc
+            # Count as abandoned-before-first-chunk only when nothing was
+            # produced yet. A locked-in failure already yielded a first
+            # assistant message, so it is not abandonment waste. Non-streaming
+            # attempts have no separable build phase, so a classified timeout
+            # maps to ``timeout`` and everything else to ``upstream_error``.
+            if not locked_in:
+                reason = "timeout" if error_class == "timeout" else "upstream_error"
+                record_abandoned_attempt(attempt.provider, attempt.model, reason, attempt.position)
             # Locked-in: at least one tool-loop round produced an assistant
             # message on this attempt. Subsequent failures cannot be
             # transparently retried on another provider.

--- a/tests/unit/test_run_platform_attempts.py
+++ b/tests/unit/test_run_platform_attempts.py
@@ -17,8 +17,25 @@ import pytest
 from fastapi import HTTPException
 
 from gateway.api.routes import _platform
-from gateway.api.routes._platform import ResolvedRoute, run_platform_attempts
+from gateway.api.routes._platform import ResolvedAttempt, ResolvedRoute, run_platform_attempts
 from gateway.core.config import GatewayConfig
+from gateway.metrics import REGISTRY
+
+
+def _abandoned_sample(provider: str, model: str, reason: str, position: int) -> float:
+    return (
+        REGISTRY.get_sample_value(
+            "gateway_abandoned_attempts_total",
+            {"provider": provider, "model": model, "reason": reason, "position": str(position)},
+        )
+        or 0.0
+    )
+
+
+def _single_attempt(provider: str, model: str) -> ResolvedAttempt:
+    return ResolvedAttempt(
+        attempt_id="a0", position=0, provider=provider, model=model, api_key="k", managed=False
+    )
 
 
 @pytest.mark.asyncio
@@ -49,6 +66,67 @@ async def test_empty_attempts_raises_500_with_explicit_diagnostic() -> None:
         )
     assert ei.value.status_code == 500
     assert "empty attempts list" in ei.value.detail
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error_class", "expected_reason"),
+    [("conn_err", "upstream_error"), ("timeout", "timeout")],
+)
+async def test_pre_lock_in_failure_counts_as_abandoned(error_class: str, expected_reason: str) -> None:
+    """A non-streaming attempt that fails before any assistant message is
+    abandonment waste: it is counted under ``gateway_abandoned_attempts`` with a
+    reason derived from the error classification."""
+    attempt = _single_attempt("openai", f"gpt-{expected_reason}")
+    route = ResolvedRoute(request_id="r", fallback_enabled=False, attempts=[attempt])
+    before = _abandoned_sample("openai", attempt.model, expected_reason, 0)
+
+    async def _run_attempt(_kwargs: dict[str, Any], _on_first_response: Any) -> Any:
+        raise RuntimeError("boom before any output")
+
+    with pytest.raises(HTTPException):
+        await run_platform_attempts(
+            route=route,
+            attempts=[attempt],
+            base_request_fields={},
+            run_attempt=_run_attempt,
+            extract_usage=lambda _r: None,
+            classify_error=lambda _exc: (False, error_class),
+            report_attempt_outcome=lambda *_a: None,
+            on_success=lambda _a: None,
+            max_tool_iterations=1,
+        )
+
+    assert _abandoned_sample("openai", attempt.model, expected_reason, 0) - before == 1.0
+
+
+@pytest.mark.asyncio
+async def test_locked_in_failure_not_counted_as_abandoned() -> None:
+    """A locked-in attempt already produced a first assistant message, so a
+    later failure is not abandonment-before-first-chunk and must not inflate the
+    counter."""
+    attempt = _single_attempt("anthropic", "claude-locked")
+    route = ResolvedRoute(request_id="r", fallback_enabled=False, attempts=[attempt])
+    before = _abandoned_sample("anthropic", "claude-locked", "upstream_error", 0)
+
+    async def _run_attempt(_kwargs: dict[str, Any], on_first_response: Any) -> Any:
+        on_first_response()  # lock in on the first upstream response
+        raise RuntimeError("failed after the first assistant message")
+
+    with pytest.raises(HTTPException):
+        await run_platform_attempts(
+            route=route,
+            attempts=[attempt],
+            base_request_fields={},
+            run_attempt=_run_attempt,
+            extract_usage=lambda _r: None,
+            classify_error=lambda _exc: (True, "http_500"),
+            report_attempt_outcome=lambda *_a: None,
+            on_success=lambda _a: None,
+            max_tool_iterations=1,
+        )
+
+    assert _abandoned_sample("anthropic", "claude-locked", "upstream_error", 0) == before
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Follow-up correctness fix for the `gateway_abandoned_attempts` counter added in #324. #324 was squash-merged before this fix reached the branch head, so main currently carries the over-counting version.

The non-streaming recording was placed in `_report_attempt_outcome`, which fires for every non-success outcome, including a **locked-in** attempt: one whose tool loop already produced a first assistant message and then failed on a later round. That is not an attempt abandoned before its first chunk, so it inflated the counter.

This moves the non-streaming recording into `run_platform_attempts`, where the per-attempt `locked_in` flag is in scope, and guards it with `if not locked_in:`. The streaming path is unaffected: its `on_attempt_failed` only ever fires before the first chunk. Adds tests for the counted (pre-lock-in, parametrized over `conn_err` -> `upstream_error` and `timeout` -> `timeout`) and not-counted (locked-in) paths.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Follow-up to #324 (Fixes #238).

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary. (No behavior/config surface change; metric name unchanged.)
- [x] If the API contract changed, I regenerated the OpenAPI spec. (No API contract change.)

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:**

Implemented via Claude Code through back-and-forth with @njbrake; the reasoning and decisions are his.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Moved non-streaming abandoned-attempt metric recording to the attempt runner, where it can distinguish failures occurring before the first assistant response.
- Counted pre-response connection and timeout failures while excluding failures after the response has started.
- Added tests covering both counted and excluded failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->