### PR TITLE
test(integration): pin cross-SDK control-plane error contract

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,48 @@
+# Gateway integration tests
+
+Integration tests spin up the FastAPI app against a real database (Postgres via
+testcontainers, or `TEST_DATABASE_URL`) and exercise routes end to end. See the
+root `AGENTS.md` for how to run them (`make test-integration`).
+
+Most files here test the gateway in isolation. A small number encode a
+**cross-SDK contract**: a behavior the gateway guarantees that the four language
+SDKs (Python, TS, Rust, Go) depend on, and that each SDK re-asserts in its own
+integration suite so the hand-mirrored shells cannot silently diverge. This file
+documents those shared contracts.
+
+## Cross-SDK control-plane conformance
+
+Each SDK wraps the generated `_client` core (see
+[`scripts/sdk_codegen/README.md`](../../scripts/sdk_codegen/README.md)) with a
+thin, hand-written shell. The shell, not the generated core, is where typed
+error mapping lives, and it is hand-mirrored in four repos with no shared
+compiler enforcing that they stay aligned. The control-plane surface (keys,
+users, budgets, pricing, usage) must honor the same contracts as the inference
+surface.
+
+### Error-mapping assertion (issue #226)
+
+> A control-plane call made with an invalid master key surfaces the SDK's typed
+> authentication error (the same type the inference path raises on a 401), not
+> the raw generated or transport error type.
+
+Optionally broaden to a couple more statuses (for example 404 and 429) to assert
+the control-plane and inference paths share one error contract end to end. With
+this in each SDK's CI, any SDK whose control-plane stops mapping errors fails the
+contract, so the four shells cannot silently drift apart again.
+
+This assertion has two halves:
+
+- **SDK side (one per SDK repo):** the shell maps the control-plane HTTP error to
+  the SDK's typed error hierarchy, exactly as the inference path already does.
+  Tracked and fixed per SDK in `otari-sdk-python`, `otari-sdk-ts`,
+  `otari-sdk-rust`, and `otari-sdk-go`.
+- **Gateway side (this repo):** the server must actually return one uniform error
+  contract across both surfaces, otherwise no shell could map them the same way.
+  [`test_control_plane_error_contract.py`](test_control_plane_error_contract.py)
+  pins it: an invalid credential yields a 401 with a JSON `{"detail": <str>}`
+  body on both the inference path and every control-plane router, so the two
+  paths are mappable to a single typed authentication error.
+
+The gateway anchor and the per-SDK tests are the same assertion viewed from the
+two ends of the wire; keep them phrased the same way when either changes.

--- a/tests/integration/test_control_plane_error_contract.py
+++ b/tests/integration/test_control_plane_error_contract.py
@@ -1,0 +1,93 @@
+"""Cross-SDK control-plane error-mapping conformance anchor (issue #226).
+
+All four language SDKs (Python, TS, Rust, Go) wrap a generated ``_client`` core
+with a hand-written shell that maps HTTP errors to the SDK's typed error
+hierarchy. On the inference path the shell maps a 401 to the SDK's typed
+authentication error; on the control-plane path (keys, users, budgets, pricing,
+usage) it historically did not, so management calls leaked the raw
+generated/transport error type. The per-SDK fixes are tracked in the SDK repos;
+the cross-SDK conformance assertion that keeps them aligned is documented in
+``tests/integration/README.md``.
+
+This test pins the **server-side half** of that contract: the gateway must
+return one uniform error contract on the control-plane path that is identical to
+the inference path for the same auth failure, a 401 with a JSON
+``{"detail": <str>}`` body. If the control-plane path ever diverged (a different
+status, or a non-JSON / differently shaped body), the SDK shells could not map
+both paths to the same typed error and the documented conformance assertion
+would be unsatisfiable no matter what the shells did.
+"""
+
+from fastapi.testclient import TestClient
+
+from gateway.core.config import API_KEY_HEADER
+
+# A well-formed but unknown key: it passes ``validate_api_key_format`` so it
+# reaches the hash lookup and misses, the closest inference-path analog to an
+# invalid master key (both are recognized-shape-but-wrong credentials).
+INVALID_API_KEY = "gw-" + "a" * 60
+
+# The inference path guards on ``verify_api_key``; an unknown key yields 401.
+INFERENCE_ENDPOINT = ("POST", "/v1/chat/completions")
+INFERENCE_BODY = {"model": "openai:gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}
+
+# One read endpoint on every standalone control-plane router, each guarded by
+# ``verify_master_key``. Pricing's GET also accepts an API key, so its
+# master-key-only POST stands in for the pricing surface.
+CONTROL_PLANE_ENDPOINTS = [
+    ("GET", "/v1/keys", None),
+    ("GET", "/v1/users", None),
+    ("GET", "/v1/budgets", None),
+    ("GET", "/v1/usage", None),
+    ("POST", "/v1/pricing", {"model_key": "openai:gpt-4o-mini", "input_cost_per_token": 0.0}),
+]
+
+
+def _invalid_auth_header() -> dict[str, str]:
+    return {API_KEY_HEADER: f"Bearer {INVALID_API_KEY}"}
+
+
+def _assert_typed_auth_error_shape(response_json: object) -> None:
+    """The body must be a JSON object carrying a string ``detail``.
+
+    This is the shape an SDK shell maps onto its typed authentication error; a
+    missing/empty or non-JSON body is what forces the shell to surface the raw
+    transport error instead.
+    """
+    assert isinstance(response_json, dict), f"expected a JSON object, got {type(response_json).__name__}"
+    assert isinstance(response_json.get("detail"), str) and response_json["detail"]
+
+
+def test_inference_invalid_credential_is_typed_auth_error(client: TestClient) -> None:
+    """Baseline: the inference path returns 401 with a mappable JSON body."""
+    method, path = INFERENCE_ENDPOINT
+    response = client.request(method, path, json=INFERENCE_BODY, headers=_invalid_auth_header())
+
+    assert response.status_code == 401
+    assert response.headers["content-type"].startswith("application/json")
+    _assert_typed_auth_error_shape(response.json())
+
+
+def test_control_plane_shares_the_inference_auth_error_contract(client: TestClient) -> None:
+    """Conformance: every control-plane endpoint mirrors the inference path.
+
+    An invalid master key on any control-plane call surfaces the *same* status
+    and body shape the inference path raises on an invalid key, so an SDK shell
+    can map both to one typed authentication error rather than leaking the raw
+    generated/transport error on management calls.
+    """
+    inference_method, inference_path = INFERENCE_ENDPOINT
+    baseline = client.request(inference_method, inference_path, json=INFERENCE_BODY, headers=_invalid_auth_header())
+    assert baseline.status_code == 401
+
+    for method, path, body in CONTROL_PLANE_ENDPOINTS:
+        response = client.request(method, path, json=body, headers=_invalid_auth_header())
+
+        assert response.status_code == baseline.status_code, (
+            f"{method} {path} returned {response.status_code}, "
+            f"but the inference path returns {baseline.status_code} for the same auth failure"
+        )
+        assert response.headers["content-type"].startswith("application/json"), (
+            f"{method} {path} returned a non-JSON error body: {response.headers.get('content-type')!r}"
+        )
+        _assert_typed_auth_error_shape(response.json())


### PR DESCRIPTION
## Description

All four language SDKs (Python, TS, Rust, Go) wrap the generated `_client` core with a hand-written shell that maps HTTP errors to the SDK's typed error hierarchy. On the inference path the shell maps a 401 to the typed authentication error; on the control-plane path (keys, users, budgets, pricing, usage) it historically did not, so management calls leaked the raw generated/transport error type. The same drift lives in four repos with no shared enforcement, which is what issue #226 is about preventing.

Codegen cannot fix this: it regenerates only the typed `_client` core, not the hand-written shell where error mapping lives. Enforcement has to live in the cross-SDK test contract. The per-SDK shell fixes are tracked in the SDK repos; this PR adds the gateway side of the conformance contract that keeps them aligned.

This PR adds two new files and modifies nothing existing:

- **`tests/integration/README.md`** documents the cross-SDK control-plane conformance assertion (the shape each SDK's integration suite implements), so the four shells have one shared source of truth.
- **`tests/integration/test_control_plane_error_contract.py`** pins the server-side half: an invalid credential yields a `401` with a JSON `{"detail": <str>}` body on both the inference path and every standalone control-plane router. That uniform contract is what lets each SDK shell map both paths to a single typed authentication error. If the control-plane path ever diverged (a different status, or a non-JSON / differently shaped body), no shell could map it the same way and the documented assertion would be unsatisfiable; this test catches that on the server.

Note on scope: issue #226 references `tests/integration/README.md` as already defining the cross-SDK shape, but no such file existed, so this PR creates it. The bug itself lives in the SDK shells (separate repos); what this repo can enforce in its own CI is the server contract those shells map against.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

<!-- Primarily a test + contract-doc addition. -->

## Relevant issues

Fixes #226

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

<!-- Lint and typecheck pass. The new conformance test passes and was verified to fail when a control-plane path is pointed at a divergent route (proving it catches drift). No API contract changed. -->

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:**

Implemented via the fix-github-issue workflow: read the issue and the backend-standards skill, mapped the cross-repo assertion to the gateway-side contract it depends on, added the anchor test plus the shared contract doc, and verified the test fails when the contract is broken.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added integration documentation for the shared cross-SDK authentication error contract.
- Added tests covering invalid credentials on inference and control-plane routes.
- Ensured these routes consistently return HTTP 401 responses with a structured error message, helping SDKs expose the same typed authentication error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->