### PR TITLE
feat(batches): add a batches table for idempotent accounting, spend folding, and strict ownership

### DIFF
--- a/alembic/versions/f3b6d8a1c4e7_add_batches_table.py
+++ b/alembic/versions/f3b6d8a1c4e7_add_batches_table.py
@@ -24,7 +24,7 @@ def upgrade() -> None:
         "batches",
         sa.Column("id", sa.String(), nullable=False),
         sa.Column("provider", sa.String(), nullable=False),
-        sa.Column("user_id", sa.String(), nullable=True),
+        sa.Column("user_id", sa.String(), nullable=False),
         sa.Column("api_key_id", sa.String(), nullable=True),
         sa.Column("model", sa.String(), nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),

--- a/alembic/versions/f3b6d8a1c4e7_add_batches_table.py
+++ b/alembic/versions/f3b6d8a1c4e7_add_batches_table.py
@@ -1,0 +1,44 @@
+"""Add batches table for idempotent accounting and strict ownership.
+
+Revision ID: f3b6d8a1c4e7
+Revises: e2f5a7c9b1d4
+Create Date: 2026-07-21 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f3b6d8a1c4e7"
+down_revision: str | Sequence[str] | None = "e2f5a7c9b1d4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "batches",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("provider", sa.String(), nullable=False),
+        sa.Column("user_id", sa.String(), nullable=True),
+        sa.Column("api_key_id", sa.String(), nullable=True),
+        sa.Column("model", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("results_accounted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.user_id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["api_key_id"], ["api_keys.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_batches_user_id", "batches", ["user_id"])
+    op.create_index("ix_batches_api_key_id", "batches", ["api_key_id"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_batches_api_key_id", table_name="batches")
+    op.drop_index("ix_batches_user_id", table_name="batches")
+    op.drop_table("batches")

--- a/src/gateway/api/routes/batches.py
+++ b/src/gateway/api/routes/batches.py
@@ -574,11 +574,22 @@ async def retrieve_batch_results(
     # Recorded batches are accounted exactly once: the first completed retrieval
     # claims the accounting slot, logs usage, and folds the cost into the owner's
     # spend; later retrievals (retries, polling clients) return results without
-    # re-billing. Legacy batches with no record keep the prior behavior (log every
-    # retrieval, no spend fold), since they cannot be deduplicated without a record.
-    should_account = True
-    if record is not None:
+    # re-billing. The claim and the spend fold commit together (below), so if the
+    # spend fold fails or the process dies mid-flight the claim rolls back and a
+    # later retrieval re-accounts, rather than marking the batch accounted but
+    # never billing it.
+    #
+    # A retrieval that finds billable tokens but no pricing row (cost is None)
+    # does not claim the slot, so once pricing exists a later retrieval still
+    # folds the spend once. Legacy batches with no record keep the prior behavior
+    # (log every retrieval, no spend fold), since they cannot be deduplicated.
+    pricing_missing = record is not None and bool(total_tokens) and cost is None
+    if pricing_missing:
+        should_account = False
+    elif record is not None:
         should_account = await claim_batch_accounting(db, batch_id)
+    else:
+        should_account = True
 
     if should_account:
         await log_batch_usage(
@@ -593,8 +604,13 @@ async def retrieve_batch_results(
             total_tokens=total_tokens,
             cost=cost,
         )
-        if record is not None and cost and user_id:
-            await record_external_spend(db, user_id, cost)
+        if record is not None:
+            if cost and user_id:
+                # Folds the spend and commits the claim in one transaction.
+                await record_external_spend(db, user_id, cost)
+            else:
+                # Nothing to bill (no cost/owner); still persist the one-time claim.
+                await db.commit()
 
     return {
         "results": [

--- a/src/gateway/api/routes/batches.py
+++ b/src/gateway/api/routes/batches.py
@@ -21,10 +21,17 @@ from gateway.api.routes._pipeline import _raise_for_unresolvable_model
 from gateway.api.routes.chat import rate_limit_headers
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
-from gateway.models.entities import APIKey, UsageLog
+from gateway.models.entities import APIKey, BatchRecord, UsageLog
 from gateway.rate_limit import check_rate_limit
+from gateway.services.batch_service import (
+    claim_batch_accounting,
+    get_batch_record,
+    get_batch_records,
+    record_batch,
+)
 from gateway.services.budget_service import (
     reconcile_reservation,
+    record_external_spend,
     refund_reservation,
     reserve_budget,
 )
@@ -147,16 +154,35 @@ def _owns_batch(batch: Batch, api_key: APIKey | None, is_master_key: bool) -> bo
     return owner == requester
 
 
-def _check_batch_ownership(batch: Batch, api_key: APIKey | None, is_master_key: bool, batch_id: str) -> None:
-    """Raise 404 when the requester does not own ``batch``.
+async def _authorize_batch(
+    db: AsyncSession,
+    batch: Batch,
+    batch_id: str,
+    api_key: APIKey | None,
+    is_master_key: bool,
+) -> BatchRecord | None:
+    """Authorize access to ``batch`` and return its stored record, if any.
 
-    404 rather than 403 so a foreign key cannot probe which batch ids exist.
+    When a local record exists the check is strict: only its owner (or the
+    master key) may access the batch, regardless of whether the provider
+    round-tripped the metadata marker. Legacy batches with no record fall back to
+    the metadata-anchored :func:`_owns_batch` check. Raises 404 (not 403) on
+    denial so a foreign key cannot probe which batch ids exist.
     """
-    if not _owns_batch(batch, api_key, is_master_key):
+    record = await get_batch_record(db, batch_id)
+    if is_master_key:
+        return record
+    if record is not None:
+        requester = str(api_key.user_id) if api_key and api_key.user_id else None
+        authorized = record.user_id == requester
+    else:
+        authorized = _owns_batch(batch, api_key, is_master_key)
+    if not authorized:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Batch '{batch_id}' not found",
         )
+    return record
 
 
 async def _retrieve_batch_or_502(
@@ -330,6 +356,19 @@ async def create_batch(
     )
     await reconcile_reservation(db, reservation, 0.0)
 
+    # Persist the ownership record so results accounting can be made idempotent,
+    # spend can be folded once, and ownership enforced without depending on the
+    # provider round-tripping the metadata marker. Best-effort: the batch already
+    # exists upstream, so a persistence failure must not fail the request.
+    await record_batch(
+        db,
+        batch_id=batch.id,
+        provider=resolved.instance,
+        user_id=user_id,
+        api_key_id=api_key_id,
+        model=model,
+    )
+
     if rate_limit_info:
         for key, value in rate_limit_headers(rate_limit_info).items():
             response.headers[key] = value
@@ -345,6 +384,7 @@ async def retrieve_batch(
     provider: str,
     raw_request: Request,
     auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> dict[str, Any]:
     """Retrieve the status of a batch."""
@@ -352,7 +392,7 @@ async def retrieve_batch(
     provider_enum, provider_kwargs = _resolve_batch_provider(config, provider)
 
     batch = await _retrieve_batch_or_502(provider_enum, batch_id, provider, provider_kwargs)
-    _check_batch_ownership(batch, api_key, is_master_key, batch_id)
+    await _authorize_batch(db, batch, batch_id, api_key, is_master_key)
 
     response_data = batch.model_dump()
     response_data["provider"] = provider
@@ -365,6 +405,7 @@ async def cancel_batch(
     provider: str,
     raw_request: Request,
     auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> dict[str, Any]:
     """Cancel a batch."""
@@ -372,7 +413,7 @@ async def cancel_batch(
     provider_enum, provider_kwargs = _resolve_batch_provider(config, provider)
 
     existing = await _retrieve_batch_or_502(provider_enum, batch_id, provider, provider_kwargs)
-    _check_batch_ownership(existing, api_key, is_master_key, batch_id)
+    await _authorize_batch(db, existing, batch_id, api_key, is_master_key)
 
     try:
         batch: Batch = await acancel_batch(
@@ -399,6 +440,7 @@ async def list_batches(
     provider: str,
     raw_request: Request,
     auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
     after: str | None = None,
     limit: int | None = None,
@@ -432,13 +474,20 @@ async def list_batches(
             detail="LLM provider error",
         ) from e
 
-    return {
-        "data": [
-            {**batch.model_dump(), "provider": provider}
-            for batch in batches
-            if _owns_batch(batch, api_key, is_master_key)
-        ]
-    }
+    # Prefer the local records (strict) and fall back to the metadata marker for
+    # legacy batches. One bulk lookup avoids a per-batch query.
+    records = {} if is_master_key else await get_batch_records(db, [batch.id for batch in batches])
+    requester = str(api_key.user_id) if api_key and api_key.user_id else None
+
+    def _visible(batch: Batch) -> bool:
+        if is_master_key:
+            return True
+        record = records.get(batch.id)
+        if record is not None:
+            return record.user_id == requester
+        return _owns_batch(batch, api_key, is_master_key)
+
+    return {"data": [{**batch.model_dump(), "provider": provider} for batch in batches if _visible(batch)]}
 
 
 @router.get(
@@ -465,13 +514,13 @@ async def retrieve_batch_results(
     provider_enum, provider_kwargs = _resolve_batch_provider(config, provider)
 
     batch = await _retrieve_batch_or_502(provider_enum, batch_id, provider, provider_kwargs)
-    _check_batch_ownership(batch, api_key, is_master_key, batch_id)
+    record = await _authorize_batch(db, batch, batch_id, api_key, is_master_key)
 
-    # Attribute usage to the batch owner stamped at creation time (so a
-    # master-key retrieval bills the owner, not user_id=None), falling back to
-    # the key's user for legacy batches without the marker.
-    owner = (batch.metadata or {}).get(_OWNER_METADATA_KEY)
-    user_id = owner or (api_key.user_id if api_key else None)
+    # Attribute usage to the batch owner: the stored record when present (strict,
+    # so a master-key retrieval bills the true owner), else the metadata marker
+    # stamped at creation, else the key's own user for legacy batches with neither.
+    metadata_owner = (batch.metadata or {}).get(_OWNER_METADATA_KEY)
+    user_id = (record.user_id if record else None) or metadata_owner or (api_key.user_id if api_key else None)
 
     try:
         result = await aretrieve_batch_results(
@@ -522,18 +571,30 @@ async def retrieve_batch_results(
                 completion_tokens / 1_000_000
             ) * pricing.output_price_per_million
 
-    await log_batch_usage(
-        log_writer=log_writer,
-        api_key_id=api_key_id,
-        model=batch_model,
-        provider=provider,
-        endpoint="/v1/batches/results",
-        user_id=user_id,
-        prompt_tokens=prompt_tokens,
-        completion_tokens=completion_tokens,
-        total_tokens=total_tokens,
-        cost=cost,
-    )
+    # Recorded batches are accounted exactly once: the first completed retrieval
+    # claims the accounting slot, logs usage, and folds the cost into the owner's
+    # spend; later retrievals (retries, polling clients) return results without
+    # re-billing. Legacy batches with no record keep the prior behavior (log every
+    # retrieval, no spend fold), since they cannot be deduplicated without a record.
+    should_account = True
+    if record is not None:
+        should_account = await claim_batch_accounting(db, batch_id)
+
+    if should_account:
+        await log_batch_usage(
+            log_writer=log_writer,
+            api_key_id=api_key_id,
+            model=batch_model,
+            provider=provider,
+            endpoint="/v1/batches/results",
+            user_id=user_id,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            cost=cost,
+        )
+        if record is not None and cost and user_id:
+            await record_external_spend(db, user_id, cost)
 
     return {
         "results": [

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -375,6 +375,37 @@ class FileObject(Base):
         }
 
 
+class BatchRecord(Base):
+    """Ownership and accounting record for an asynchronous batch job.
+
+    Written at creation time so results accounting can be made idempotent (bill
+    and log once, on the first completed retrieval), the batch cost can be folded
+    into ``users.spend``, and ownership can be enforced without depending on the
+    provider round-tripping the ``otari_user_id`` metadata marker. Batches created
+    before this table existed carry no record and fall back to the
+    metadata-anchored ownership path in ``api/routes/batches.py``.
+    """
+
+    __tablename__ = "batches"
+
+    # Provider-assigned batch id (globally unique per provider), used as the
+    # lookup key on retrieve/cancel/results.
+    id: Mapped[str] = mapped_column(primary_key=True)
+    # Instance/provider name the batch was created against (echoed to clients).
+    provider: Mapped[str] = mapped_column()
+    # Billed owner, stamped from the authenticated principal at creation. CASCADE:
+    # deleting the user drops the ownership record (the user's keys are gone too,
+    # and usage_logs remain the billing history).
+    user_id: Mapped[str | None] = mapped_column(ForeignKey("users.user_id", ondelete="CASCADE"), index=True)
+    # SET NULL: a key may be revoked while its batch is still in flight.
+    api_key_id: Mapped[str | None] = mapped_column(ForeignKey("api_keys.id", ondelete="SET NULL"), index=True)
+    model: Mapped[str] = mapped_column()
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    # NULL until the first completed results retrieval accounts the batch; the
+    # atomic NULL -> now transition is the idempotency gate for billing/logging.
+    results_accounted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
 class BudgetResetLog(Base):
     """Budget reset log model for tracking budget resets."""
 

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -393,10 +393,13 @@ class BatchRecord(Base):
     id: Mapped[str] = mapped_column(primary_key=True)
     # Instance/provider name the batch was created against (echoed to clients).
     provider: Mapped[str] = mapped_column()
-    # Billed owner, stamped from the authenticated principal at creation. CASCADE:
-    # deleting the user drops the ownership record (the user's keys are gone too,
-    # and usage_logs remain the billing history).
-    user_id: Mapped[str | None] = mapped_column(ForeignKey("users.user_id", ondelete="CASCADE"), index=True)
+    # Billed owner, stamped from the authenticated principal at creation. Non-null:
+    # this record is the strict ownership anchor, so it must always name an owner.
+    # CASCADE: deleting the user drops the ownership record (the user's keys are
+    # gone too, and usage_logs remain the billing history).
+    user_id: Mapped[str] = mapped_column(
+        ForeignKey("users.user_id", ondelete="CASCADE"), nullable=False, index=True
+    )
     # SET NULL: a key may be revoked while its batch is still in flight.
     api_key_id: Mapped[str | None] = mapped_column(ForeignKey("api_keys.id", ondelete="SET NULL"), index=True)
     model: Mapped[str] = mapped_column()

--- a/src/gateway/services/batch_service.py
+++ b/src/gateway/services/batch_service.py
@@ -76,6 +76,13 @@ async def claim_batch_accounting(db: AsyncSession, batch_id: str) -> bool:
     clients). Only the winning caller logs usage and folds the batch cost into
     the user's spend, so repeated retrievals of the same completed batch do not
     double-count.
+
+    This does not commit: the caller commits the claim in the same transaction
+    as the spend fold, so the two are atomic. If the spend fold fails (or the
+    process dies) before that commit, the claim rolls back and a later retrieval
+    re-accounts, rather than leaving the batch marked-accounted-but-unbilled. The
+    UPDATE still takes the row lock immediately, so a concurrent claim on the same
+    batch blocks and then sees ``results_accounted_at`` set, returning False.
     """
     result = await db.execute(
         update(BatchRecord)
@@ -83,5 +90,6 @@ async def claim_batch_accounting(db: AsyncSession, batch_id: str) -> bool:
         .values(results_accounted_at=datetime.now(UTC))
         .execution_options(synchronize_session=False)
     )
-    await db.commit()
+    # getattr with a default: mypy sees .execute() as Result (no rowcount);
+    # rowcount lives on CursorResult. Matches reserve_budget/_cas_reset_user_budget.
     return bool(getattr(result, "rowcount", 0))

--- a/src/gateway/services/batch_service.py
+++ b/src/gateway/services/batch_service.py
@@ -1,0 +1,87 @@
+"""Persistence for batch jobs: ownership records and idempotent accounting.
+
+The gateway stores one row per created batch (:class:`BatchRecord`). That record
+is the durable anchor the route uses to enforce strict ownership and to bill and
+log a completed batch's usage exactly once. Batches created before this table
+existed carry no record; the route keeps the metadata-anchored fallback for them.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select, update
+from sqlalchemy.exc import SQLAlchemyError
+
+from gateway.log_config import logger
+from gateway.models.entities import BatchRecord
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def record_batch(
+    db: AsyncSession,
+    *,
+    batch_id: str,
+    provider: str,
+    user_id: str,
+    api_key_id: str | None,
+    model: str,
+) -> None:
+    """Persist an ownership record for a newly created batch.
+
+    Best-effort: the provider has already accepted the batch, so a failure to
+    persist the record must not fail the request. Ownership then degrades to the
+    metadata-anchored fallback (the ``otari_user_id`` marker) for that batch.
+    """
+    db.add(
+        BatchRecord(
+            id=batch_id,
+            provider=provider,
+            user_id=user_id,
+            api_key_id=api_key_id,
+            model=model,
+        )
+    )
+    try:
+        await db.commit()
+    except SQLAlchemyError as e:
+        await db.rollback()
+        logger.warning("Failed to persist batch record for '%s': %s", batch_id, e)
+
+
+async def get_batch_record(db: AsyncSession, batch_id: str) -> BatchRecord | None:
+    """Return the stored record for ``batch_id`` (or None for legacy batches)."""
+    return (await db.execute(select(BatchRecord).where(BatchRecord.id == batch_id))).scalar_one_or_none()
+
+
+async def get_batch_records(db: AsyncSession, batch_ids: Iterable[str]) -> dict[str, BatchRecord]:
+    """Return stored records for ``batch_ids`` keyed by id, for list filtering."""
+    ids = list(batch_ids)
+    if not ids:
+        return {}
+    rows = (await db.execute(select(BatchRecord).where(BatchRecord.id.in_(ids)))).scalars().all()
+    return {row.id: row for row in rows}
+
+
+async def claim_batch_accounting(db: AsyncSession, batch_id: str) -> bool:
+    """Atomically claim the one-time results accounting for a batch.
+
+    Returns True to the single caller that transitions ``results_accounted_at``
+    from NULL to now, and False for every later retrieval (retries, polling
+    clients). Only the winning caller logs usage and folds the batch cost into
+    the user's spend, so repeated retrievals of the same completed batch do not
+    double-count.
+    """
+    result = await db.execute(
+        update(BatchRecord)
+        .where(BatchRecord.id == batch_id, BatchRecord.results_accounted_at.is_(None))
+        .values(results_accounted_at=datetime.now(UTC))
+        .execution_options(synchronize_session=False)
+    )
+    await db.commit()
+    return bool(getattr(result, "rowcount", 0))

--- a/src/gateway/services/budget_service.py
+++ b/src/gateway/services/budget_service.py
@@ -301,6 +301,20 @@ async def reconcile_reservation(db: AsyncSession, handle: ReservationHandle, act
     await db.commit()
 
 
+async def record_external_spend(db: AsyncSession, user_id: str, cost: float) -> None:
+    """Fold already-incurred cost into ``users.spend`` outside the reservation flow.
+
+    Used by asynchronous billable paths (batch results) where the create-time
+    reservation has already been reconciled and no live hold exists at the point
+    the cost becomes known. This deliberately does not enforce the budget: the
+    spend has already happened upstream at the provider, so it is recorded, not
+    gated. Writing goes through :func:`reconcile_reservation` (with an empty
+    handle) so ``users.spend`` still has a single writer.
+    """
+    handle = ReservationHandle(user_id=user_id, estimate=0.0, reserved=False, strategy="disabled")
+    await reconcile_reservation(db, handle, cost)
+
+
 async def refund_reservation(db: AsyncSession, handle: ReservationHandle) -> None:
     """Release a reservation without recording spend (e.g. provider failure)."""
     if not handle.reserved:

--- a/tests/integration/test_batches_endpoint.py
+++ b/tests/integration/test_batches_endpoint.py
@@ -823,6 +823,177 @@ def test_retrieve_batch_results_records_tokens_and_cost(
 
 
 # ---------------------------------------------------------------------------
+# Batches table — idempotent accounting, spend folding, strict ownership (#290)
+# ---------------------------------------------------------------------------
+
+
+def _completed_results_patches(tokens: CompletionUsage | None = None) -> tuple[Any, Any]:
+    """Patches returning a completed batch plus a single successful result."""
+    mock_completion = MagicMock()
+    mock_completion.model = "gpt-4o-mini"
+    mock_completion.usage = tokens
+    mock_completion.model_dump.return_value = {"id": "chatcmpl-1", "choices": []}
+    mock_result = BatchResult(results=[BatchResultItem(custom_id="req-1", result=mock_completion, error=None)])
+    return (
+        patch(
+            "gateway.api.routes.batches.aretrieve_batch",
+            new_callable=AsyncMock,
+            return_value=_mock_batch(status="completed"),
+        ),
+        patch("gateway.api.routes.batches.aretrieve_batch_results", new_callable=AsyncMock, return_value=mock_result),
+    )
+
+
+def _create_recorded_batch(
+    client: TestClient,
+    headers: dict[str, str],
+    *,
+    batch_id: str = "batch_abc123",
+    **body_overrides: Any,
+) -> str:
+    """Create a batch through the endpoint so a batches-table record exists."""
+    with (
+        patch(
+            "gateway.api.routes.batches.acreate_batch",
+            new_callable=AsyncMock,
+            return_value=_mock_batch(id=batch_id),
+        ),
+        patch("gateway.api.routes.batches.AnyLLM.get_provider_class", return_value=_SupportsBatch),
+    ):
+        resp = client.post("/v1/batches", json=_create_batch_body(**body_overrides), headers=headers)
+    assert resp.status_code == 200
+    created_id: str = resp.json()["id"]
+    return created_id
+
+
+def test_recorded_batch_results_accounted_once(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """A recorded batch logs usage and folds spend exactly once across retries."""
+    user_id = api_key_obj["user_id"]
+    pricing_resp = client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "openai:gpt-4o-mini",
+            "input_price_per_million": 1.0,
+            "output_price_per_million": 2.0,
+        },
+        headers=master_key_header,
+    )
+    assert pricing_resp.status_code == 200
+
+    batch_id = _create_recorded_batch(client, api_key_header)
+
+    retrieve_patch, results_patch = _completed_results_patches(
+        CompletionUsage(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+    )
+    with retrieve_patch, results_patch:
+        first = client.get(f"/v1/batches/{batch_id}/results?provider=openai", headers=api_key_header)
+        second = client.get(f"/v1/batches/{batch_id}/results?provider=openai", headers=api_key_header)
+
+    # Both retrievals return the results; only the first bills.
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+    usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
+    results_logs = [log for log in usage_resp.json() if log["endpoint"] == "/v1/batches/results"]
+    assert len(results_logs) == 1
+
+    expected_cost = 100 / 1_000_000 * 1.0 + 50 / 1_000_000 * 2.0
+    assert results_logs[0]["cost"] == pytest.approx(expected_cost)
+
+    user_resp = client.get(f"/v1/users/{user_id}", headers=master_key_header)
+    assert user_resp.status_code == 200
+    assert user_resp.json()["spend"] == pytest.approx(expected_cost)
+
+
+def test_unrecorded_batch_results_logs_every_retrieval(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """Legacy batches with no record keep the prior log-every-retrieval behavior."""
+    user_id = api_key_obj["user_id"]
+
+    # No create call -> no batches-table record; falls to the metadata fallback.
+    retrieve_patch, results_patch = _completed_results_patches(
+        CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    )
+    with retrieve_patch, results_patch:
+        first = client.get("/v1/batches/legacy_batch/results?provider=openai", headers=api_key_header)
+        second = client.get("/v1/batches/legacy_batch/results?provider=openai", headers=api_key_header)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+    usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
+    results_logs = [log for log in usage_resp.json() if log["endpoint"] == "/v1/batches/results"]
+    assert len(results_logs) == 2
+
+
+def test_recorded_batch_strict_ownership_ignores_missing_metadata(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """A recorded batch is owner-only even when the provider drops the metadata marker."""
+    batch_id = _create_recorded_batch(client, api_key_header)
+
+    other_key_resp = client.post(
+        "/v1/keys",
+        json={"key_name": "other", "user_id": "batch-other-user"},
+        headers=master_key_header,
+    )
+    assert other_key_resp.status_code == 200
+    other_header = {API_KEY_HEADER: f"Bearer {other_key_resp.json()['key']}"}
+
+    # Provider returns the batch without the ownership marker: the record alone
+    # must keep a foreign key out (the metadata fallback would fail open).
+    no_marker = _mock_batch(id=batch_id, status="completed", metadata=None)
+    with patch("gateway.api.routes.batches.aretrieve_batch", new_callable=AsyncMock, return_value=no_marker):
+        foreign = client.get(f"/v1/batches/{batch_id}?provider=openai", headers=other_header)
+        owner = client.get(f"/v1/batches/{batch_id}?provider=openai", headers=api_key_header)
+
+    assert foreign.status_code == 404
+    assert owner.status_code == 200
+
+
+def test_recorded_batch_list_hides_foreign_without_metadata(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """List filtering uses the records table, so an unmarked foreign batch is hidden."""
+    other_key_resp = client.post(
+        "/v1/keys",
+        json={"key_name": "other-list", "user_id": "batch-list-other"},
+        headers=master_key_header,
+    )
+    assert other_key_resp.status_code == 200
+    other_header = {API_KEY_HEADER: f"Bearer {other_key_resp.json()['key']}"}
+
+    own_id = _create_recorded_batch(client, api_key_header, batch_id="batch_own")
+    foreign_id = _create_recorded_batch(client, other_header, batch_id="batch_foreign")
+
+    # Both batches come back from the provider without the metadata marker.
+    listed = [
+        _mock_batch(id=own_id, metadata=None),
+        _mock_batch(id=foreign_id, metadata=None),
+    ]
+    with patch("gateway.api.routes.batches.alist_batches", new_callable=AsyncMock, return_value=listed):
+        resp = client.get("/v1/batches?provider=openai", headers=api_key_header)
+
+    assert resp.status_code == 200
+    ids = [item["id"] for item in resp.json()["data"]]
+    assert own_id in ids
+    assert foreign_id not in ids
+
+
+# ---------------------------------------------------------------------------
 # Hybrid mode — batch endpoints not registered
 # ---------------------------------------------------------------------------
 

--- a/tests/integration/test_batches_endpoint.py
+++ b/tests/integration/test_batches_endpoint.py
@@ -910,6 +910,64 @@ def test_recorded_batch_results_accounted_once(
     assert user_resp.json()["spend"] == pytest.approx(expected_cost)
 
 
+def test_recorded_batch_results_defers_accounting_until_pricing_exists(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """A retrieval before pricing exists must not burn the one-time slot.
+
+    With billable tokens but no ModelPricing row, cost is None; the batch stays
+    unaccounted so a later retrieval, once pricing is added, still logs usage and
+    folds spend exactly once.
+    """
+    user_id = api_key_obj["user_id"]
+    batch_id = _create_recorded_batch(client, api_key_header)
+
+    tokens = CompletionUsage(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+
+    # First retrieval with no pricing configured: cost is None, so nothing is
+    # billed and the accounting slot is left unclaimed.
+    retrieve_patch, results_patch = _completed_results_patches(tokens)
+    with retrieve_patch, results_patch:
+        before_pricing = client.get(f"/v1/batches/{batch_id}/results?provider=openai", headers=api_key_header)
+    assert before_pricing.status_code == 200
+
+    usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
+    assert [log for log in usage_resp.json() if log["endpoint"] == "/v1/batches/results"] == []
+    user_resp = client.get(f"/v1/users/{user_id}", headers=master_key_header)
+    assert user_resp.json()["spend"] == pytest.approx(0.0)
+
+    # Add pricing, then retrieve again (and once more): now it accounts exactly once.
+    pricing_resp = client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "openai:gpt-4o-mini",
+            "input_price_per_million": 1.0,
+            "output_price_per_million": 2.0,
+        },
+        headers=master_key_header,
+    )
+    assert pricing_resp.status_code == 200
+
+    retrieve_patch, results_patch = _completed_results_patches(tokens)
+    with retrieve_patch, results_patch:
+        first = client.get(f"/v1/batches/{batch_id}/results?provider=openai", headers=api_key_header)
+        second = client.get(f"/v1/batches/{batch_id}/results?provider=openai", headers=api_key_header)
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+    usage_resp = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header)
+    results_logs = [log for log in usage_resp.json() if log["endpoint"] == "/v1/batches/results"]
+    assert len(results_logs) == 1
+
+    expected_cost = 100 / 1_000_000 * 1.0 + 50 / 1_000_000 * 2.0
+    assert results_logs[0]["cost"] == pytest.approx(expected_cost)
+    user_resp = client.get(f"/v1/users/{user_id}", headers=master_key_header)
+    assert user_resp.json()["spend"] == pytest.approx(expected_cost)
+
+
 def test_unrecorded_batch_results_logs_every_retrieval(
     client: TestClient,
     master_key_header: dict[str, str],


### PR DESCRIPTION
## Description

PR #273 anchored `/v1/batches` ownership and accounting solely on provider-side batch metadata, which left three gaps (all called out in #290):

1. Results accounting was not idempotent: every `GET /v1/batches/{id}/results` wrote a fresh `UsageLog`, so retries and polling clients overstated usage for the same spend.
2. Batch cost was never folded into `users.spend`, so batch spend was visible in usage logs but never consumed budget.
3. Unmarked batches (created before the marker, or via providers that do not round-trip metadata) stayed accessible to any authenticated key.

This PR adds a `batches` table written at creation time, and uses it to close all three:

- **Idempotent accounting**: the first completed results retrieval atomically claims `results_accounted_at` (NULL to now via a conditional UPDATE guarded on rowcount); later retrievals return the results without re-logging or re-billing.
- **Spend folding**: on that same first retrieval the batch cost is folded into `users.spend` once, through a new `budget_service.record_external_spend` that writes spend outside the reservation flow (via `reconcile_reservation` with an empty handle, keeping `users.spend` single-writer). It is deliberately not budget-gated, since the spend already happened upstream at the provider.
- **Strict ownership**: retrieve, cancel, results, and list now consult the local record first. Only its owner (or the master key) gets access, regardless of whether the provider round-tripped the `otari_user_id` marker. List does one bulk record lookup instead of a per-batch provider call.

Batches created before this table shipped carry no record and keep the existing metadata-anchored fallback (log every retrieval, no spend fold), as specified in the issue.

Includes a matching Alembic migration (`f3b6d8a1c4e7`, chained to the current head, reversible). The FK columns follow house conventions: `user_id` to `users` with `ondelete=CASCADE` (indexed), `api_key_id` to `api_keys` with `ondelete=SET NULL` (indexed).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #290

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [ ] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). No contract change; `make openapi-check` is clean.

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code (Claude Opus 4.8), driven by @njbrake.

**Any additional AI details you'd like to share:**

Implementation and tests were drafted by Claude via back-and-forth with @njbrake; the design decisions and review are his. Integration tests were run against a local PostgreSQL 18 instance (Docker/testcontainers was unavailable in the sandbox): 36 batch tests, 734 unit tests, and the budget/user/usage integration suites all pass.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added persistent batch records to track ownership, provider details, models, and one-time accounting status.
- Enforced ownership for batch retrieval, cancellation, results, and listing, while preserving legacy metadata-based behavior.
- Ensured completed batch results are logged and charged only once.
- Added external spend tracking to include batch costs in user spending without budget checks.
- Added migration, supporting services, and integration tests covering accounting, pricing deferral, ownership, and legacy behavior.

## Technical notes

- Accounting claims and spend updates occur atomically.
- Master keys bypass ownership checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->