### PR TITLE
fix: require any-llm 1.22.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ version = "0.0.0"
 description = "otari, an OpenAI-compatible LLM gateway"
 requires-python = ">=3.13"
 dependencies = [
-    "any-llm-sdk[all]>=1.22.0",
+    "any-llm-sdk[all]>=1.22.1",
     "alembic>=1.13.0",
     "aiosqlite>=0.19.0",
     "asyncpg>=0.29.0",

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "any-llm-sdk"
-version = "1.22.0"
+version = "1.22.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
@@ -204,9 +204,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/0d/941daa951dcf0150472c80f5b7c8abe74853f308c574ead928c3940206bd/any_llm_sdk-1.22.0.tar.gz", hash = "sha256:8c81fd377862c4d40f30b8a8470e8c625f9bbe1f52f968da94d22b12173ee97f", size = 164644, upload-time = "2026-07-22T13:17:22.264Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/de/a29738e1c8702a79a514f9521430fe77686fb9f9122980f4899a7baf58b5/any_llm_sdk-1.22.1.tar.gz", hash = "sha256:b07c6fcef6d7fc13e0f0419bc1464f9316b17e663c34382fb7722a906241f635", size = 164931, upload-time = "2026-07-22T15:43:29.12Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/49/d2061284a47e9541fc0f2521e2183f66819f9ae23ab4d001b07e82b48746/any_llm_sdk-1.22.0-py3-none-any.whl", hash = "sha256:61c7f93e2223a83e9aa4c8d1baa1876b371ae0c1a3b2e4687e3841f7cbb84d2f", size = 217044, upload-time = "2026-07-22T13:17:20.915Z" },
+    { url = "https://files.pythonhosted.org/packages/03/5a/85c558cc9fb6fd8a7fd3e7523c9c20545316190d22372026ddbf53cdc0c9/any_llm_sdk-1.22.1-py3-none-any.whl", hash = "sha256:950339b68ca1d99fb123c523d246140e1c947b0ff26e3fb9bc37194a49f3b509", size = 217209, upload-time = "2026-07-22T15:43:27.664Z" },
 ]
 
 [package.optional-dependencies]
@@ -916,7 +916,7 @@ dev = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0" },
     { name = "alembic", specifier = ">=1.13.0" },
-    { name = "any-llm-sdk", extras = ["all"], specifier = ">=1.22.0" },
+    { name = "any-llm-sdk", extras = ["all"], specifier = ">=1.22.1" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "cryptography", specifier = ">=44.0.0" },


### PR DESCRIPTION
## Description

Require `any-llm-sdk[all]>=1.22.1`, and update the lockfile to the released artifact.

`1.22.1` makes the Responses request validator accept replayed input items such as Codex reasoning and assistant-output items. This prevents the Pydantic validation error encountered when Otari forwards Codex Responses requests. Otari's existing Codex metadata preservation remains unchanged.

Release: https://github.com/mozilla-ai/any-llm/releases/tag/1.22.1

## PR Type

- [x] Bug Fix

## Relevant issues

None.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Validation performed:

- `uv sync --dev --frozen`
- `make test` (full unit and integration suite)
- `uv run pytest tests/integration/test_responses_route_dispatch.py -v` (24 passed)
- Focused `ResponsesParams` check using replayed Codex reasoning and assistant items
- `make lint`
- `make typecheck`

## AI Usage

- [x] AI was used for drafting/refactoring.

**AI Model/Tool used:** Codex

**Any additional AI details you'd like to share:** Dependency floor and lockfile artifact update only; validation results are listed above.

- [x] I am an AI Agent filling out this form (check box if true)