### PR TITLE
fix(hybrid): recognize SDK-wrapped timeout/connection errors for fallback

### DIFF
--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -311,10 +311,21 @@ resolve response). The platform is responsible for correlating them.
 
 | Tag | Cause |
 |---|---|
-| `timeout` | `httpx.TimeoutException`, `asyncio.TimeoutError`, `TimeoutError` |
-| `conn_err` | `httpx.NetworkError` |
+| `timeout` | `httpx.TimeoutException`, `asyncio.TimeoutError`, `TimeoutError`, or the OpenAI/Anthropic SDKs' own `APITimeoutError` |
+| `conn_err` | `httpx.NetworkError`, or the OpenAI/Anthropic SDKs' own `APIConnectionError` |
 | `http_<code>` | Provider returned an HTTP status code (e.g. `http_429`, `http_401`) |
 | `unknown` | Any other exception class |
+
+Otari calls the OpenAI/Anthropic SDKs directly rather than httpx, and both SDKs
+catch `httpx.TimeoutException`/network errors internally and re-raise as their
+own `APITimeoutError`/`APIConnectionError`; neither is an instance of any
+`httpx` exception, and neither carries `status_code`/`response`. Otari
+recognizes these wrapped types explicitly (covering the majority of providers,
+which reuse the OpenAI/Anthropic base provider classes), plus a conservative
+class-name-based fallback (`*TimeoutError` / `*ConnectionError`, only when no
+status code is present) for the other any-llm provider SDKs, so a real
+"provider unreachable" or provider-side timeout still falls through to the
+next attempt instead of being misclassified as `unknown`.
 
 The field is **omitted entirely** when Otari can't map the failure to an
 exception class; this happens with mid-stream errors surfaced via the

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -325,7 +325,13 @@ which reuse the OpenAI/Anthropic base provider classes), plus a conservative
 class-name-based fallback (`*TimeoutError` / `*ConnectionError`, only when no
 status code is present) for the other any-llm provider SDKs, so a real
 "provider unreachable" or provider-side timeout still falls through to the
-next attempt instead of being misclassified as `unknown`.
+next attempt instead of being misclassified as `unknown`. If any-llm's unified
+exceptions (`ANY_LLM_UNIFIED_EXCEPTIONS=1`) are enabled in the future, the same
+detection still applies through `original_exception`: any-llm re-wraps a raw
+SDK timeout/connection error into a generic `any_llm.exceptions.ProviderError`
+that carries neither a recognizable class name nor a status code, but keeps
+the original SDK exception on `.original_exception`, which Otari unwraps and
+re-classifies.
 
 The field is **omitted entirely** when Otari can't map the failure to an
 exception class; this happens with mid-stream errors surfaced via the

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -38,7 +38,6 @@ from enum import Enum, auto
 from typing import Any, Generic, Literal, NamedTuple, NoReturn, Protocol, TypeVar
 from urllib.parse import ParseResult, urlparse
 
-import httpx
 from any_llm import LLMProvider
 from any_llm.exceptions import AnyLLMError
 from any_llm.types.completion import (
@@ -69,6 +68,7 @@ from gateway.api.routes._platform import (
     _resolve_platform_mcp_servers,
     _resolve_platform_web_search,
     run_platform_attempts,
+    upstream_exception_shape,
 )
 from gateway.api.routes._platform import (
     default_attempt_kwargs as default_attempt_kwargs,  # explicit re-export for the route modules
@@ -192,20 +192,6 @@ class ProviderErrorMapping(NamedTuple):
     detail: str
 
 
-def _upstream_status_code(exc: BaseException) -> int | None:
-    """Pull an HTTP status off an upstream exception, if it carries one.
-
-    any-llm surfaces provider HTTP errors either as ``exc.status_code`` or via an
-    attached ``exc.response.status_code``; everything else has neither.
-    """
-    status_code = getattr(exc, "status_code", None)
-    if status_code is None:
-        response = getattr(exc, "response", None)
-        if response is not None:
-            status_code = getattr(response, "status_code", None)
-    return status_code if isinstance(status_code, int) else None
-
-
 def _upstream_error_param(exc: BaseException) -> str | None:
     """Pull the offending request field off an upstream exception, if it names one.
 
@@ -271,12 +257,17 @@ def classify_provider_error(exc: BaseException) -> ProviderErrorMapping | None:
     detail returned here is a fixed string: the raw provider message is never
     included, preserving the no-leak guarantee. The mapping is intentionally
     conservative, classifying only the cases a caller can act on and leaving
-    everything else (including provider 5xx) to the generic 502.
-    """
-    if isinstance(exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
-        return ProviderErrorMapping(status.HTTP_504_GATEWAY_TIMEOUT, PROVIDER_TIMEOUT_DETAIL)
+    everything else (including provider 5xx and connection errors) to the
+    generic 502.
 
-    status_code = _upstream_status_code(exc)
+    Timeout detection (including the OpenAI/Anthropic SDKs' own
+    ``APITimeoutError``, and a duck-typed fallback for other provider SDKs) is
+    shared with the hybrid-mode fallback classifier via
+    :func:`upstream_exception_shape`, so both stay in sync.
+    """
+    kind, status_code = upstream_exception_shape(exc)
+    if kind == "timeout":
+        return ProviderErrorMapping(status.HTTP_504_GATEWAY_TIMEOUT, PROVIDER_TIMEOUT_DETAIL)
     if status_code is None:
         return None
     if status_code in (400, 422):
@@ -1899,7 +1890,8 @@ def raise_all_streaming_attempts_failed(
     invalid_request = mapping is not None and mapping.status_code == status.HTTP_400_BAD_REQUEST
     if invalid_request or len(route.attempts) <= 1:
         raise adapter.provider_error(exc) from exc
-    if isinstance(exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
+    kind, _ = upstream_exception_shape(exc)
+    if kind == "timeout":
         raise adapter.error(504, ALL_PROVIDERS_TIMED_OUT_DETAIL, ErrorKind.API) from exc
     raise adapter.error(502, ALL_PROVIDERS_FAILED_DETAIL, ErrorKind.API) from exc
 

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import uuid
 from collections.abc import Awaitable, Callable
-from typing import Any, NamedTuple, TypeVar
+from typing import Any, Literal, NamedTuple, TypeVar
 
 import httpx
 from anthropic import APIConnectionError as _AnthropicAPIConnectionError
@@ -510,17 +510,24 @@ def _parse_resolve_payload(payload: dict[str, Any]) -> ResolvedRoute:
     )
 
 
-def upstream_exception_shape(exc: BaseException) -> tuple[str | None, int | None]:
+UpstreamErrorKind = Literal["timeout", "conn_err"]
+
+
+def upstream_exception_shape(exc: BaseException) -> tuple[UpstreamErrorKind | None, int | None]:
     """Classify the *shape* of an upstream exception, independent of retry policy.
 
     Returns ``(kind, status_code)`` where ``kind`` is ``"timeout"``,
     ``"conn_err"``, or ``None``, and ``status_code`` is the HTTP status the
-    exception carries, or ``None``. At most one of the two is set. Shared by
-    :func:`_classify_upstream_error` (drives the hybrid-mode fallback decision)
-    and :func:`gateway.api.routes._pipeline.classify_provider_error` (drives the
+    exception carries, or ``None``. At most one of the two is set. ``kind`` is
+    a ``Literal``, not a bare ``str``, so a typo at a ``kind == "..."``
+    comparison site (e.g. in :func:`_classify_upstream_error`) is a mypy error
+    instead of a silent no-op. Shared by :func:`_classify_upstream_error`
+    (drives the hybrid-mode fallback decision) and
+    :func:`gateway.api.routes._pipeline.classify_provider_error` (drives the
     final client-facing status/detail), so the two stay in sync.
 
-    Recognizes, in order:
+    Recognizes, in order, walking ``.original_exception`` when the current
+    exception carries no signal of its own:
 
     1. Stdlib/httpx timeout and network exceptions directly.
     2. The OpenAI and Anthropic SDKs' own ``APITimeoutError`` /
@@ -543,34 +550,51 @@ def upstream_exception_shape(exc: BaseException) -> tuple[str | None, int | None
        heuristic ``any_llm.utils.exception_handler.convert_exception`` already
        uses internally. Only applies when the exception carries no status code
        at all, so it never shadows a real HTTP-status classification.
+    5. If none of the above match, ``.original_exception`` (set by any-llm's
+       ``AnyLLMError`` family, e.g. via ``convert_exception``) is unwrapped and
+       reclassified from step 1. This keeps detection working once
+       ``ANY_LLM_UNIFIED_EXCEPTIONS=1`` becomes the default: any-llm's
+       ``convert_exception`` re-wraps a raw SDK timeout/connection error into
+       a generic ``any_llm.exceptions.ProviderError`` (class name matches
+       neither ``*TimeoutError`` nor ``*ConnectionError``, no ``status_code``),
+       but always preserves the original SDK exception on
+       ``original_exception``. Bounded by an ``id()``-based seen-set so a
+       (pathological, self-referential) cycle terminates instead of looping.
     """
-    if isinstance(
-        exc,
-        (
-            asyncio.TimeoutError,
-            TimeoutError,
-            httpx.TimeoutException,
-            _OpenAIAPITimeoutError,
-            _AnthropicAPITimeoutError,
-        ),
-    ):
-        return "timeout", None
-    if isinstance(exc, (httpx.NetworkError, _OpenAIAPIConnectionError, _AnthropicAPIConnectionError)):
-        return "conn_err", None
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
 
-    status_code = getattr(exc, "status_code", None)
-    if status_code is None:
-        resp = getattr(exc, "response", None)
-        if resp is not None:
-            status_code = getattr(resp, "status_code", None)
-    if isinstance(status_code, int):
-        return None, status_code
+        if isinstance(
+            current,
+            (
+                asyncio.TimeoutError,
+                TimeoutError,
+                httpx.TimeoutException,
+                _OpenAIAPITimeoutError,
+                _AnthropicAPITimeoutError,
+            ),
+        ):
+            return "timeout", None
+        if isinstance(current, (httpx.NetworkError, _OpenAIAPIConnectionError, _AnthropicAPIConnectionError)):
+            return "conn_err", None
 
-    class_name = type(exc).__name__
-    if class_name.endswith("TimeoutError"):
-        return "timeout", None
-    if class_name.endswith("ConnectionError"):
-        return "conn_err", None
+        status_code = getattr(current, "status_code", None)
+        if status_code is None:
+            resp = getattr(current, "response", None)
+            if resp is not None:
+                status_code = getattr(resp, "status_code", None)
+        if isinstance(status_code, int):
+            return None, status_code
+
+        class_name = type(current).__name__
+        if class_name.endswith("TimeoutError"):
+            return "timeout", None
+        if class_name.endswith("ConnectionError"):
+            return "conn_err", None
+
+        current = getattr(current, "original_exception", None)
 
     return None, None
 

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -17,9 +17,13 @@ from collections.abc import Awaitable, Callable
 from typing import Any, NamedTuple, TypeVar
 
 import httpx
+from anthropic import APIConnectionError as _AnthropicAPIConnectionError
+from anthropic import APITimeoutError as _AnthropicAPITimeoutError
 from any_llm import LLMProvider
 from any_llm.types.completion import CompletionUsage
 from fastapi import HTTPException, Request, status
+from openai import APIConnectionError as _OpenAIAPIConnectionError
+from openai import APITimeoutError as _OpenAIAPITimeoutError
 from pydantic import BaseModel
 
 from gateway.core.config import GatewayConfig
@@ -293,7 +297,7 @@ async def run_platform_attempts(
         failures,
     )
     is_single_attempt = len(attempts) <= 1
-    if last_exc is not None and isinstance(last_exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
+    if last_exc is not None and upstream_exception_shape(last_exc)[0] == "timeout":
         detail = "LLM provider timeout" if is_single_attempt else "All upstream providers timed out"
         raise HTTPException(
             status_code=status.HTTP_504_GATEWAY_TIMEOUT,
@@ -506,6 +510,71 @@ def _parse_resolve_payload(payload: dict[str, Any]) -> ResolvedRoute:
     )
 
 
+def upstream_exception_shape(exc: BaseException) -> tuple[str | None, int | None]:
+    """Classify the *shape* of an upstream exception, independent of retry policy.
+
+    Returns ``(kind, status_code)`` where ``kind`` is ``"timeout"``,
+    ``"conn_err"``, or ``None``, and ``status_code`` is the HTTP status the
+    exception carries, or ``None``. At most one of the two is set. Shared by
+    :func:`_classify_upstream_error` (drives the hybrid-mode fallback decision)
+    and :func:`gateway.api.routes._pipeline.classify_provider_error` (drives the
+    final client-facing status/detail), so the two stay in sync.
+
+    Recognizes, in order:
+
+    1. Stdlib/httpx timeout and network exceptions directly.
+    2. The OpenAI and Anthropic SDKs' own ``APITimeoutError`` /
+       ``APIConnectionError``. any-llm calls these SDKs directly (it does not
+       wrap httpx itself unless ``ANY_LLM_UNIFIED_EXCEPTIONS=1``), and both
+       SDKs catch ``httpx.TimeoutException`` / network errors internally and
+       re-raise as their own types. Those wrapped types are not instances of
+       any httpx exception and carry no ``status_code``/``response``, so a
+       real provider timeout or "provider unreachable" would otherwise be
+       unclassifiable. ``APITimeoutError`` subclasses ``APIConnectionError``
+       in both SDKs, so the timeout check must run first. This covers the
+       majority of any-llm providers, which reuse ``BaseOpenAIProvider`` or
+       ``BaseAnthropicProvider``.
+    3. An HTTP status code carried directly on the exception or on its
+       attached ``.response``.
+    4. A conservative duck-typed fallback, by exception class name, for the
+       remaining any-llm provider SDKs that don't reuse the OpenAI/Anthropic
+       base classes (e.g. cohere, mistral, groq, bedrock) and whose own
+       timeout/connection exception types aren't imported here. Mirrors the
+       heuristic ``any_llm.utils.exception_handler.convert_exception`` already
+       uses internally. Only applies when the exception carries no status code
+       at all, so it never shadows a real HTTP-status classification.
+    """
+    if isinstance(
+        exc,
+        (
+            asyncio.TimeoutError,
+            TimeoutError,
+            httpx.TimeoutException,
+            _OpenAIAPITimeoutError,
+            _AnthropicAPITimeoutError,
+        ),
+    ):
+        return "timeout", None
+    if isinstance(exc, (httpx.NetworkError, _OpenAIAPIConnectionError, _AnthropicAPIConnectionError)):
+        return "conn_err", None
+
+    status_code = getattr(exc, "status_code", None)
+    if status_code is None:
+        resp = getattr(exc, "response", None)
+        if resp is not None:
+            status_code = getattr(resp, "status_code", None)
+    if isinstance(status_code, int):
+        return None, status_code
+
+    class_name = type(exc).__name__
+    if class_name.endswith("TimeoutError"):
+        return "timeout", None
+    if class_name.endswith("ConnectionError"):
+        return "conn_err", None
+
+    return None, None
+
+
 def _classify_upstream_error(exc: BaseException) -> tuple[bool, str]:
     """Classify an upstream provider error.
 
@@ -513,16 +582,9 @@ def _classify_upstream_error(exc: BaseException) -> tuple[bool, str]:
     for logging and reporting back to the platform. Streaming-only failures still
     pass through this classifier; the caller decides whether to actually retry.
     """
-    if isinstance(exc, (asyncio.TimeoutError, TimeoutError, httpx.TimeoutException)):
-        return True, "timeout"
-    if isinstance(exc, httpx.NetworkError):
-        return True, "conn_err"
-
-    status_code = getattr(exc, "status_code", None)
-    if status_code is None:
-        resp = getattr(exc, "response", None)
-        if resp is not None:
-            status_code = getattr(resp, "status_code", None)
+    kind, status_code = upstream_exception_shape(exc)
+    if kind is not None:
+        return True, kind
 
     if isinstance(status_code, int):
         if status_code in _FALLBACK_NON_RETRYABLE_STATUS_CODES:

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -747,6 +747,74 @@ def test_hybrid_mode_streaming_returns_502_when_all_attempts_fail(
     assert response.json() == {"detail": "All upstream providers failed"}
 
 
+def test_hybrid_mode_streaming_returns_504_when_all_attempts_time_out(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If every attempt fails with the OpenAI SDK's own ``APITimeoutError``
+    (not a raw ``httpx`` exception; see the non-streaming
+    ``test_hybrid_mode_maps_provider_timeout``), the terminal streaming
+    aggregate must still surface 504 with the timeout-specific wording, not
+    the generic 502. Covers ``raise_all_streaming_attempts_failed``'s timeout
+    branch, which none of the other streaming tests exercise."""
+    import openai
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json={
+                    "request_id": "stream-req-timeout",
+                    "fallback_enabled": True,
+                    "attempts": [
+                        {
+                            "attempt_id": "att-a",
+                            "position": 0,
+                            "provider": "anthropic",
+                            "model": "claude-haiku-4-5",
+                            "api_key": "sk-ant-slow",
+                            "api_base": None,
+                            "managed": False,
+                        },
+                        {
+                            "attempt_id": "att-b",
+                            "position": 1,
+                            "provider": "openai",
+                            "model": "gpt-4o-mini",
+                            "api_key": "sk-openai-slow",
+                            "api_base": None,
+                            "managed": False,
+                        },
+                    ],
+                },
+            )
+        return httpx.Response(204)
+
+    async def fake_acompletion(**kwargs: Any) -> Any:
+        raise openai.APITimeoutError(request=httpx.Request("POST", "http://upstream"))
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.acompletion", fake_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "anything",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 504
+    assert response.json() == {"detail": "All upstream providers timed out"}
+
+
 def test_hybrid_mode_streaming_reports_every_attempt_when_all_fail(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -347,6 +347,98 @@ def test_hybrid_mode_maps_provider_timeout(
     assert response.json() == {"detail": "LLM provider timeout"}
 
 
+def test_hybrid_mode_falls_through_on_sdk_wrapped_connection_error(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The first attempt fails with the OpenAI SDK's own ``APIConnectionError``
+    (how a real DNS failure / connection refused / TLS error actually reaches
+    the gateway when any-llm calls the SDK directly, not a raw ``httpx``
+    exception) → falls through to the second attempt instead of failing the
+    whole request. Regression test for the SDK-wrapped exception shape not
+    being recognized as retryable.
+    """
+    import openai
+
+    usage_reports: list[dict[str, Any]] = []
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json={
+                    "request_id": "conn-err-req-1",
+                    "fallback_enabled": True,
+                    "attempts": [
+                        {
+                            "attempt_id": "conn-err-att-broken",
+                            "position": 0,
+                            "provider": "openai",
+                            "model": "gpt-4o-mini",
+                            "api_key": "sk-unreachable",
+                            "api_base": "https://unreachable.example.com/v1",
+                            "managed": False,
+                        },
+                        {
+                            "attempt_id": "conn-err-att-good",
+                            "position": 1,
+                            "provider": "openai",
+                            "model": "gpt-4o-mini",
+                            "api_key": "sk-openai-real",
+                            "api_base": "https://api.openai.com/v1",
+                            "managed": False,
+                        },
+                    ],
+                },
+            )
+        usage_reports.append(body)
+        return httpx.Response(204)
+
+    calls: list[str] = []
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        calls.append(kwargs["api_base"])
+        if kwargs["api_base"] == "https://unreachable.example.com/v1":
+            raise openai.APIConnectionError(request=httpx.Request("POST", kwargs["api_base"]))
+        return ChatCompletion(
+            id="chatcmpl-fallback",
+            object="chat.completion",
+            created=1700000000,
+            model="gpt-4o-mini",
+            choices=[
+                Choice(
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="hello"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=CompletionUsage(prompt_tokens=5, completion_tokens=1, total_tokens=6),
+        )
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.acompletion", fake_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={"model": "anything", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["X-Correlation-ID"] == "conn-err-att-good"
+    assert calls == ["https://unreachable.example.com/v1", "https://api.openai.com/v1"]
+
+    error_reports = [r for r in usage_reports if r.get("status") == "error"]
+    assert len(error_reports) == 1
+    assert error_reports[0]["correlation_id"] == "conn-err-att-broken"
+    assert error_reports[0]["error_class"] == "conn_err"
+
+
 def test_hybrid_mode_propagates_resolve_rate_limit_retry_after(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_classify_upstream_error.py
+++ b/tests/unit/test_classify_upstream_error.py
@@ -113,6 +113,57 @@ def test_duck_typed_fallback_for_unenumerated_sdks(class_name: str, expected_cla
     assert error_class == expected_class
 
 
+class _WrappedByAnyLLM(Exception):
+    """Mimics ``any_llm.exceptions.AnyLLMError`` once ``ANY_LLM_UNIFIED_EXCEPTIONS=1``
+    is enabled: the outer exception carries no ``status_code`` and a class name
+    the duck-typed fallback doesn't recognize (``convert_exception`` maps a raw
+    SDK timeout/connection error to the generic ``ProviderError`` bucket), but
+    preserves the raw SDK exception on ``original_exception``.
+    """
+
+    def __init__(self, original_exception: BaseException) -> None:
+        super().__init__(str(original_exception))
+        self.original_exception = original_exception
+
+
+@pytest.mark.parametrize(
+    "sdk_error, expected_class",
+    [
+        (OpenAIAPITimeoutError, "timeout"),
+        (AnthropicAPITimeoutError, "timeout"),
+        (OpenAIAPIConnectionError, "conn_err"),
+        (AnthropicAPIConnectionError, "conn_err"),
+    ],
+)
+def test_unwraps_original_exception_for_unified_any_llm_errors(sdk_error: type, expected_class: str) -> None:
+    """Once otari enables ``ANY_LLM_UNIFIED_EXCEPTIONS=1``, a raw SDK
+    timeout/connection error arrives wrapped in a generic ``AnyLLMError``
+    subclass rather than the SDK type directly. The classifier must still
+    recognize it by unwrapping ``original_exception``, or this regresses back
+    to the exact "unknown"/non-retryable bug this module fixes.
+    """
+    request = httpx.Request("POST", "http://upstream")
+    wrapped = _WrappedByAnyLLM(sdk_error(request=request))
+
+    retryable, error_class = _classify_upstream_error(wrapped)
+    assert retryable is True
+    assert error_class == expected_class
+
+
+def test_unwrap_terminates_on_self_referential_original_exception() -> None:
+    """Defensive: a (pathological, shouldn't-happen-in-practice) exception
+    whose ``original_exception`` points back to itself must not loop forever;
+    it should fall through to the same terminal ``unknown`` classification as
+    any other unrecognized exception.
+    """
+    exc = _WrappedByAnyLLM(ValueError("placeholder"))
+    exc.original_exception = exc  # self-reference, must not loop
+
+    retryable, error_class = _classify_upstream_error(exc)
+    assert retryable is False
+    assert error_class == "unknown"
+
+
 @pytest.mark.parametrize("sdk_error", [AnthropicAPIStatusError, OpenAIAPIStatusError])
 @pytest.mark.parametrize("status, retryable", [(404, True), (410, True), (400, False), (422, False)])
 def test_classifies_provider_sdk_status_errors(sdk_error: type, status: int, retryable: bool) -> None:

--- a/tests/unit/test_classify_upstream_error.py
+++ b/tests/unit/test_classify_upstream_error.py
@@ -6,8 +6,12 @@ import asyncio
 
 import httpx
 import pytest
+from anthropic import APIConnectionError as AnthropicAPIConnectionError
 from anthropic import APIStatusError as AnthropicAPIStatusError
+from anthropic import APITimeoutError as AnthropicAPITimeoutError
+from openai import APIConnectionError as OpenAIAPIConnectionError
 from openai import APIStatusError as OpenAIAPIStatusError
+from openai import APITimeoutError as OpenAIAPITimeoutError
 
 from gateway.api.routes._platform import _classify_upstream_error
 
@@ -59,6 +63,54 @@ def test_error_without_status_is_unknown_and_terminal() -> None:
     retryable, error_class = _classify_upstream_error(ValueError("no status here"))
     assert retryable is False
     assert error_class == "unknown"
+
+
+@pytest.mark.parametrize(
+    "sdk_error, expected_class",
+    [
+        (OpenAIAPITimeoutError, "timeout"),
+        (AnthropicAPITimeoutError, "timeout"),
+        (OpenAIAPIConnectionError, "conn_err"),
+        (AnthropicAPIConnectionError, "conn_err"),
+    ],
+)
+def test_sdk_wrapped_timeout_and_connection_errors_are_retryable(sdk_error: type, expected_class: str) -> None:
+    """any-llm calls the OpenAI/Anthropic SDKs directly, and both SDKs catch
+    ``httpx.TimeoutException``/network errors internally and re-raise as their
+    own ``APITimeoutError``/``APIConnectionError`` (``APITimeoutError``
+    subclasses ``APIConnectionError`` in both SDKs). Neither wrapped type is an
+    instance of any httpx exception or carries ``status_code``/``response``, so
+    a real provider timeout or "provider unreachable" reaches the classifier in
+    this shape in production, not as a raw httpx exception.
+    """
+    request = httpx.Request("POST", "http://upstream")
+    exc = sdk_error(request=request)
+    assert not hasattr(exc, "status_code")
+
+    retryable, error_class = _classify_upstream_error(exc)
+    assert retryable is True
+    assert error_class == expected_class
+
+
+@pytest.mark.parametrize(
+    "class_name, expected_class",
+    [
+        ("SomeProviderAPITimeoutError", "timeout"),
+        ("SomeProviderConnectionError", "conn_err"),
+    ],
+)
+def test_duck_typed_fallback_for_unenumerated_sdks(class_name: str, expected_class: str) -> None:
+    """Provider SDKs any-llm supports beyond OpenAI/Anthropic (cohere, mistral,
+    groq, bedrock, ...) may raise their own timeout/connection exception types
+    that this module doesn't import. A conservative class-name fallback still
+    classifies them as retryable rather than falling into ``unknown``, as long
+    as they carry no status code (so a real HTTP-status classification is
+    never shadowed).
+    """
+    exc_type = type(class_name, (Exception,), {})
+    retryable, error_class = _classify_upstream_error(exc_type("boom"))
+    assert retryable is True
+    assert error_class == expected_class
 
 
 @pytest.mark.parametrize("sdk_error", [AnthropicAPIStatusError, OpenAIAPIStatusError])

--- a/tests/unit/test_provider_error_classification.py
+++ b/tests/unit/test_provider_error_classification.py
@@ -86,6 +86,24 @@ def test_sdk_wrapped_timeout_maps_to_504() -> None:
         assert classify_provider_error(exc) == (504, PROVIDER_TIMEOUT_DETAIL)
 
 
+def test_unified_any_llm_wrapped_timeout_maps_to_504() -> None:
+    """Once otari enables ``ANY_LLM_UNIFIED_EXCEPTIONS=1``, a raw SDK timeout
+    error arrives wrapped in a generic ``AnyLLMError`` subclass (no
+    ``status_code``, a class name the duck-typed fallback won't recognize)
+    rather than the SDK type directly. ``classify_provider_error`` must still
+    resolve it to 504 via the shared ``original_exception`` unwrap, not fall
+    back to the generic 502."""
+
+    class _WrappedByAnyLLM(Exception):
+        def __init__(self, original_exception: BaseException) -> None:
+            super().__init__(str(original_exception))
+            self.original_exception = original_exception
+
+    request = httpx.Request("POST", "http://upstream")
+    wrapped = _WrappedByAnyLLM(OpenAIAPITimeoutError(request=request))
+    assert classify_provider_error(wrapped) == (504, PROVIDER_TIMEOUT_DETAIL)
+
+
 @pytest.mark.parametrize(
     ("status_code", "expected"),
     [

--- a/tests/unit/test_provider_error_classification.py
+++ b/tests/unit/test_provider_error_classification.py
@@ -9,6 +9,8 @@ import asyncio
 
 import httpx
 import pytest
+from anthropic import APITimeoutError as AnthropicAPITimeoutError
+from openai import APITimeoutError as OpenAIAPITimeoutError
 
 from gateway.api.routes._pipeline import (
     PROVIDER_BAD_REQUEST_DETAIL,
@@ -72,6 +74,16 @@ def test_timeout_maps_to_504() -> None:
     for exc in (asyncio.TimeoutError(), TimeoutError(), httpx.TimeoutException("slow")):
         mapping = classify_provider_error(exc)
         assert mapping == (504, PROVIDER_TIMEOUT_DETAIL)
+
+
+def test_sdk_wrapped_timeout_maps_to_504() -> None:
+    """The OpenAI/Anthropic SDKs wrap httpx timeouts into their own
+    ``APITimeoutError`` (no ``status_code``, not an httpx exception instance).
+    any-llm surfaces that wrapped type directly, so it must still classify
+    as a 504, not fall through to the generic 502."""
+    request = httpx.Request("POST", "http://upstream")
+    for exc in (OpenAIAPITimeoutError(request=request), AnthropicAPITimeoutError(request=request)):
+        assert classify_provider_error(exc) == (504, PROVIDER_TIMEOUT_DETAIL)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Hybrid mode's multi-attempt fallback (and the single-attempt terminal error
mapping) misclassified real provider timeouts and connection failures as
`unknown`/non-retryable, so a request would fail outright instead of falling
through to the next attempt in the routing policy.

`_classify_upstream_error` (`_platform.py`) and `classify_provider_error`
(`_pipeline.py`) only recognized raw `httpx.TimeoutException`/
`httpx.NetworkError` and exceptions carrying a `status_code`. In production,
any-llm calls the OpenAI/Anthropic SDKs directly rather than httpx. Both SDKs
catch `httpx.TimeoutException`/network errors internally and re-raise as their
own `APITimeoutError`/`APIConnectionError`, neither of which is an instance of
any httpx exception, and neither carries `status_code`/`response`. So a real
"provider timeout" or "provider unreachable" (DNS failure, connection refused,
TLS error) surfacing through OpenAI/Anthropic-backed providers (the majority
of any-llm's ~50 providers reuse `BaseOpenAIProvider`/`BaseAnthropicProvider`)
was misclassified as an unrecognized error and treated as terminal,
contradicting the documented fallback semantics
(`docs/hybrid-mode-protocol.md`).

Verified empirically:
```python
>>> isinstance(openai.APIConnectionError(request=req), httpx.NetworkError)
False
>>> hasattr(openai.APIConnectionError(request=req), "status_code")
False
```

Changes:
- `src/gateway/api/routes/_platform.py`: new `upstream_exception_shape()`
  helper recognizes `openai`/`anthropic` `APITimeoutError`/`APIConnectionError`
  explicitly (timeout checked before connection, since `APITimeoutError`
  subclasses `APIConnectionError` in both SDKs), plus a conservative
  duck-typed fallback (by exception class name, only when no status code is
  present) for the other any-llm provider SDKs (cohere, mistral, groq,
  bedrock, ...), mirroring the heuristic
  `any_llm.utils.exception_handler.convert_exception` already uses
  internally.
- `src/gateway/api/routes/_pipeline.py`: `classify_provider_error` and
  `raise_all_streaming_attempts_failed` now use the same shared helper, so a
  single-attempt/all-exhausted timeout gets the correct 504 instead of a
  generic 502. Removed the now-redundant `_upstream_status_code`.
- Consolidated the previously-duplicated status/timeout/connection detection
  into one shared helper so the non-streaming and streaming paths (and the
  terminal error mapping) can't drift again — this duplication is how the gap
  went unnoticed.
- `docs/hybrid-mode-protocol.md`: updated the `error_class` table to describe
  the broadened detection.
- Tests: added regression cases raising the real
  `openai.APIConnectionError`/`APITimeoutError` and Anthropic equivalents
  (unit, in both classifiers), a duck-typed-fallback case, and an integration
  test driving `run_platform_attempts` end-to-end with an
  `openai.APIConnectionError` on attempt 1 falling through to a successful
  attempt 2.

Out of scope: bespoke-SDK provider exceptions (e.g. `botocore`/Bedrock's
`EndpointConnectionError`) aren't enumerated explicitly, only covered by the
duck-typed class-name fallback. Standalone mode has no cross-provider
fallback by design (unaffected either way).

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
<!-- e.g. "Fixes #123" -->

None.

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). (No contract change; verified with `--check`.)

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** OpenCode (Claude Sonnet 4.5)

**Any additional AI details you'd like to share:**

Root cause found by tracing the OpenAI/Anthropic SDK's `_base_client.py`
exception-wrapping behavior and empirically confirming the wrapped exceptions
don't satisfy the classifier's `isinstance`/`status_code` checks.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed hybrid-mode fallback so the gateway correctly recognizes provider timeouts and connection failures even when they’re wrapped by SDK-specific exception types.
- Centralized the upstream error “shape” detection and reused it consistently for both streaming and non-streaming retry paths, ensuring fallback behavior matches the right failure class.
- Improved response mapping so terminal timeouts now return HTTP 504 (instead of a generic failure code), including for the streaming “all attempts timed out” case.
- Updated documentation and added regression tests to cover SDK-wrapped connection errors, streaming timeout behavior, unified any-llm-style exception wrapping, and safe unwrapping.

## Technical notes

- Introduced a shared helper (`upstream_exception_shape`) that classifies upstream exceptions into timeout/connection categories using SDK types, conservative name-based heuristics, and bounded `original_exception` unwrapping with cycle protection.
- Updated pipeline/route logic to rely on this shared classification for retryability and for the final “all attempts” streaming decision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->