### PR TITLE
docs: add dashboard user guide and refresh gateway docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ docker run --rm -p 8000:8000 \
 
 With no master key set, Otari generates one and prints it to the logs once on startup (look for `Your master key:`). Open `http://localhost:8000/`, sign in with that key, then open **Providers** and add your OpenAI key. `OTARI_SECRET_KEY` is a Fernet key that encrypts stored provider credentials at rest; back it up, because losing it makes stored keys undecryptable. Full walkthrough, including the two-key model, in the [Admin dashboard guide](docs/dashboard.md).
 
+This `--rm` container is disposable: it uses the in-container SQLite default, so the master key, the providers, keys, and budgets you create here are lost when it stops. For anything you want to keep, use [Run the full stack](#run-the-full-stack) with a Postgres database.
+
 ## Run the full stack
 
 The Quickstart runs the gateway alone on SQLite. To get a durable database plus the built-in tools and guardrails, run the full stack with Docker Compose.

--- a/README.md
+++ b/README.md
@@ -147,22 +147,7 @@ The returned `gw-` key is shown in full only once.
 
 ### Set it up in the browser instead
 
-Prefer not to pre-set anything on the command line? Launch Otari bare and finish in the dashboard.
-
-```bash
-docker run --rm -p 8000:8000 mzdotai/otari:latest otari serve
-```
-
-With no master key set, Otari generates one and prints it to the logs once on startup:
-
-```text
-Otari first-run: no master key was set, so one was generated.
-Save it now (it is shown only once). Sign in to the dashboard at http://localhost:8000/
-Your master key:
-otari-mk-...
-```
-
-Open `http://localhost:8000/`, sign in with that key, then open **Providers** and add your OpenAI key. Storing a provider key requires `OTARI_SECRET_KEY`, a Fernet key that encrypts credentials at rest; generate one with `otari gen-secret-key` and set it before launch:
+Prefer not to pre-set anything on the command line? Launch Otari bare, then finish in the dashboard.
 
 ```bash
 docker run --rm -p 8000:8000 \
@@ -170,7 +155,7 @@ docker run --rm -p 8000:8000 \
   mzdotai/otari:latest otari serve
 ```
 
-Back it up somewhere safe: losing `OTARI_SECRET_KEY` makes every stored provider key undecryptable. Providers you set in `config.yml` keep working and appear in the dashboard marked `config` (read-only there); keys you add in the UI are marked `stored`, and a stored key of the same name takes precedence.
+With no master key set, Otari generates one and prints it to the logs once on startup (look for `Your master key:`). Open `http://localhost:8000/`, sign in with that key, then open **Providers** and add your OpenAI key. `OTARI_SECRET_KEY` is a Fernet key that encrypts stored provider credentials at rest; back it up, because losing it makes stored keys undecryptable. Full walkthrough, including the two-key model, in the [Admin dashboard guide](docs/dashboard.md).
 
 ## Run the full stack
 
@@ -218,18 +203,16 @@ For hot reload against a local `.env`, use `make dev`.
 ### Admin dashboard
 
 In standalone mode the gateway serves a web admin dashboard at the root URL
-(`http://localhost:8000`). Sign in with your master key (`OTARI_MASTER_KEY`, or
-the one printed to the logs on first run) to add provider API keys, browse the
-model catalogue, set model pricing, manage aliases, and toggle runtime settings
-(model discovery and default pricing). Provider keys added in the **Providers**
-page are encrypted at rest (requires `OTARI_SECRET_KEY`; see
-[Set it up in the browser instead](#set-it-up-in-the-browser-instead)) and merge
-over `config.yml` providers, so you can start with an empty config and add
-credentials after launch. The get-started tutorial page moved to `/welcome`. The
-dashboard is a React +
-HeroUI app that lives in `web/`; its built bundle is committed under
-`src/gateway/static/dashboard`, so the published package and Docker image serve
-it with no extra build step. See [`web/README.md`](web/README.md) to work on it.
+(`http://localhost:8000`). Sign in with your master key to add provider keys,
+browse the model catalogue, set pricing, manage aliases and access (users, keys,
+budgets), and toggle runtime settings. See the
+[Admin dashboard guide](docs/dashboard.md) for the two-key model, a first-run
+walkthrough, and a page-by-page reference.
+
+The dashboard is a React + HeroUI app that lives in `web/`; its built bundle is
+committed under `src/gateway/static/dashboard`, so the published package and
+Docker image serve it with no extra build step. See
+[`web/README.md`](web/README.md) to work on it.
 
 To build and run the container from your local code instead of pulling the published image, layer in the build file:
 
@@ -254,9 +237,7 @@ export OTARI_AI_TOKEN=gw_xxx
 
 ## Built-in tools
 
-Otari can run two tools itself so any model, including open-weight ones, gets parity with what frontier APIs expose as managed tools: `otari_code_execution` (a sandboxed Python REPL) and `otari_web_search`. Both are opt-in per request via the `tools` array and run behind docker-compose profiles, so operators who don't use them don't pull the extra images.
-
-The keyword decides who runs it. An `otari_*` type means Otari runs it in its own sandbox. Any other type, including the provider-native keywords (`code_interpreter`, `code_execution_<date>`, `web_search_<date>`), is passed through to the provider's native sandbox. Either way Otari still handles routing, observability, and billing.
+Otari can run two tools itself so any model, including open-weight ones, gets parity with what frontier APIs expose as managed tools: `otari_code_execution` (a sandboxed Python REPL) and `otari_web_search`. Both are opt-in per request via the `tools` array and run behind docker-compose profiles. An `otari_*` type means Otari runs it in its own sandbox; any other type, including the provider-native keywords, is passed through to the provider. Either way Otari still handles routing, observability, and billing.
 
 ```json
 {
@@ -266,17 +247,7 @@ The keyword decides who runs it. An `otari_*` type means Otari runs it in its ow
 }
 ```
 
-Bring up with `docker compose --profile code-exec up`. Runnable walkthrough in `demo/code-exec/`.
-
-```json
-{
-  "model": "anthropic:claude-sonnet-4-6",
-  "messages": [{"role": "user", "content": "What's the latest stable Python release?"}],
-  "tools": [{"type": "otari_web_search"}]
-}
-```
-
-Bring up with `docker compose --profile web-search up`. Runnable walkthrough in `demo/web-search/`. The bundled backend is SearXNG, fine for trying it out but rate-limited for sustained use. For production, point `OTARI_WEB_SEARCH_URL` at a licensed backend; ready-to-run Brave and Tavily adapters ship in `scripts/`.
+Bring up with `docker compose --profile code-exec up` (or `--profile web-search`). See [Built-in tools](docs/tools.md) for backends, adapters, and the passthrough rules; runnable walkthroughs live under `demo/`.
 
 ## Guardrails
 
@@ -290,7 +261,7 @@ A guardrail is a request-level check Otari runs on the input before the provider
 }
 ```
 
-`mode: monitor` (the default) forwards to the provider and surfaces the verdict on the `X-Otari-Guardrails` response header. `mode: block` returns `403` and never calls the provider when the input is flagged. Bring up the default prompt-injection guardrail with `docker compose --profile guardrails up`. Runnable walkthrough in `demo/guardrails/`.
+`mode: monitor` (the default) forwards to the provider and surfaces the verdict on the `X-Otari-Guardrails` response header; `mode: block` returns `403` and never calls the provider when the input is flagged. Bring up the default prompt-injection guardrail with `docker compose --profile guardrails up`. See [Guardrails](docs/guardrails.md) for profiles and modes; runnable walkthrough in `demo/guardrails/`.
 
 ## API surface
 
@@ -336,10 +307,14 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
 ## Documentation
 
+Full docs live in [`docs/`](docs/index.md), grouped by task. Highlights:
+
 - [Quickstart](docs/quickstart.md), get running and make your first request.
 - [Deployment](docs/deployment.md), run Otari with Docker.
 - [Configuration](docs/configuration.md), config file and environment variable reference.
 - [Modes](docs/modes.md), standalone vs connected to otari.ai.
+- [Admin dashboard](docs/dashboard.md), the operator UI.
+- [Access control](docs/access-control.md), users, keys, and budgets.
 - [API reference](docs/api-reference.md), every endpoint.
 - [Models](docs/models.md), supported providers and model format.
 

--- a/deploy/render/render.yaml
+++ b/deploy/render/render.yaml
@@ -21,7 +21,7 @@ projects:
             plan: free
             region: oregon
             image:
-              url: docker.io/mzdotai/otari:0.2.0
+              url: docker.io/mzdotai/otari:0.3.0
             # Readiness verifies both the process and its Postgres connection.
             healthCheckPath: /health/readiness
             envVars:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,11 @@ services:
       # doesn't override.
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      # Fernet key that encrypts provider credentials added through the admin
+      # dashboard. Needed only for the dashboard-first flow (add providers in
+      # the browser); unset is fine when providers live in config.yml. Generate
+      # one with `docker run --rm mzdotai/otari:latest otari gen-secret-key`.
+      - OTARI_SECRET_KEY=${OTARI_SECRET_KEY:-}
       # Local llamafile (open-weight model) endpoint. host.docker.internal
       # routes from Otari container back to a llamafile running on
       # the macOS/Windows host. Override if you run the model elsewhere.

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -2,7 +2,7 @@
 
 Standalone Otari decides three things about every request: who is calling (the **user**), what credential they presented (the **API key**), and whether they have room to spend (the **budget**). This guide is a task-oriented tour of those three, with the management endpoints that drive them. Everything here is standalone-only and authenticated with the master key; hybrid mode delegates identity and spend to otari.ai.
 
-All management endpoints require the master key. Send it as `Otari-Key: <master-key>` or `Authorization: Bearer <master-key>`. The same actions are available in the dashboard's **Access** section; see the [Admin dashboard guide](dashboard.md).
+The user, key, and budget endpoints in this guide all require the master key (some other management endpoints, such as read-only pricing lookups, also accept a regular API key; see the [API reference](api-reference.md)). Send the master key as `Otari-Key: <master-key>` or `Authorization: Bearer <master-key>`. The same actions are available in the dashboard's **Access** section; see the [Admin dashboard guide](dashboard.md).
 
 ## How the pieces fit
 

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -55,7 +55,7 @@ curl -X POST http://localhost:8000/v1/keys \
 ```
 
 - `expires_at` is an optional expiry; omit it for a key that never expires. Expired keys are rejected.
-- `allowed_models` restricts this one key. The resolution is an override, not an intersection: a key's own list wins when set, a key with no list of its own inherits its user's default, and no list anywhere means unrestricted.
+- `allowed_models` restricts this one key. The resolution is an override, not an intersection: a key's own list wins when set, a key with no list of its own inherits its user's default, and no list anywhere means unrestricted. A key can only narrow, never widen: creating or updating a key with a list broader than its user's default is rejected with `400`.
 - The listing endpoints never return the plaintext again; they show only a `key_prefix` fingerprint (the key's leading characters).
 
 Manage keys with `GET /v1/keys`, `GET /v1/keys/{key_id}`, `PATCH /v1/keys/{key_id}` (rename, toggle `is_active`, change expiry or `allowed_models`), and `DELETE /v1/keys/{key_id}`. To replace a key's secret without changing its identity or settings, use `POST /v1/keys/{key_id}/rotate`; it returns a new plaintext once and invalidates the old secret.

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -1,0 +1,93 @@
+# Access control: users, keys, and budgets
+
+Standalone Otari decides three things about every request: who is calling (the **user**), what credential they presented (the **API key**), and whether they have room to spend (the **budget**). This guide is a task-oriented tour of those three, with the management endpoints that drive them. Everything here is standalone-only and authenticated with the master key; hybrid mode delegates identity and spend to otari.ai.
+
+All management endpoints require the master key. Send it as `Otari-Key: <master-key>` or `Authorization: Bearer <master-key>`. The same actions are available in the dashboard's **Access** section; see the [Admin dashboard guide](dashboard.md).
+
+## How the pieces fit
+
+- A **user** is the identity that spend and usage attach to. A user carries an optional default model allow-list and an optional budget.
+- An **API key** is a credential a client sends to Otari. Each key belongs to a user. A key can narrow which models it may call.
+- A **budget** is a spending limit with an optional reset period. It is a per-user cap; assign it to one user or share it across many.
+
+A request is authenticated to a key, the key resolves to its user, the user's budget is checked and reserved before the provider call, and the usage is billed to that user afterward.
+
+## Users
+
+Create a user, optionally with a default model allow-list and a budget:
+
+```bash
+curl -X POST http://localhost:8000/v1/users \
+  -H "Otari-Key: <master-key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_id": "alice",
+    "alias": "Alice (research)",
+    "budget_id": "<budget-id>",
+    "allowed_models": ["openai:gpt-4o-mini", "anthropic:*"]
+  }'
+```
+
+- `user_id` is the stable identifier you choose; it is what spend and usage key on.
+- `allowed_models` is the default access-list the user's keys inherit. `null` (or omitted) means any model, `[]` denies everything, and a list restricts to canonical `instance:model` entries, with `instance:*` and `instance:prefix*` wildcards.
+- `blocked: true` stops the user from making requests without deleting anything; their calls are rejected until you unblock them.
+
+Manage users with `GET /v1/users`, `GET /v1/users/{user_id}`, `PATCH /v1/users/{user_id}` (update alias, budget, `blocked`, or `allowed_models`), and `DELETE /v1/users/{user_id}`. A user's response includes `spend` and `reserved` (in-flight spend held by accepted but not-yet-settled requests); the committed total is `spend + reserved`. `GET /v1/users/{user_id}/usage` returns that user's request log.
+
+### The default user
+
+A key created with no `user_id` is bound to a shared user called `default`, created on first use. All such keys share one identity, so they share budget, usage, and files. Give a key an explicit `user_id` whenever you want to track or cap it separately.
+
+## API keys
+
+Create a key for a user. The plaintext key (a `gw-...` value) is returned once and never again; store it immediately.
+
+```bash
+curl -X POST http://localhost:8000/v1/keys \
+  -H "Otari-Key: <master-key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key_name": "alice-laptop",
+    "user_id": "alice",
+    "expires_at": "2026-12-31T23:59:59Z",
+    "allowed_models": ["openai:gpt-4o-mini"]
+  }'
+```
+
+- `expires_at` is an optional expiry; omit it for a key that never expires. Expired keys are rejected.
+- `allowed_models` restricts this one key. The resolution is an override, not an intersection: a key's own list wins when set, a key with no list of its own inherits its user's default, and no list anywhere means unrestricted.
+- The listing endpoints never return the plaintext again; they show only a `key_prefix` fingerprint (the key's leading characters).
+
+Manage keys with `GET /v1/keys`, `GET /v1/keys/{key_id}`, `PATCH /v1/keys/{key_id}` (rename, toggle `is_active`, change expiry or `allowed_models`), and `DELETE /v1/keys/{key_id}`. To replace a key's secret without changing its identity or settings, use `POST /v1/keys/{key_id}/rotate`; it returns a new plaintext once and invalidates the old secret.
+
+### Requests that name another user
+
+By default a non-master key that names a `user` other than its own in the request body is rejected with `403`. This is the `reject_user_mismatch` setting (default `true`). Set it to `false` when a trusted client (for example Claude Code, which attaches its own `user_id`) must be allowed to pass a different label; spend is still bound to the key's own user. The master key may always bill an arbitrary user.
+
+## Budgets
+
+A budget is a spending cap with an optional reset period. `max_budget` is the limit **per user**, so a budget shared by several users caps each of them at that amount rather than in aggregate.
+
+```bash
+curl -X POST http://localhost:8000/v1/budgets \
+  -H "Otari-Key: <master-key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "daily-10",
+    "max_budget": 10.0,
+    "budget_duration_sec": 86400
+  }'
+```
+
+- `max_budget` is the per-user ceiling in your pricing currency. Otari reserves an estimated cost before each call and reconciles it after, so a request that would exceed the cap is rejected before it runs.
+- `budget_duration_sec` is the reset period in seconds (for example `86400` for daily, `604800` for weekly). Omit it for a cap that never resets. On each period boundary the user's spend rolls back to zero and a reset is recorded.
+
+Assign a budget to a user by setting `budget_id` on the user (at create time or via `PATCH /v1/users/{user_id}`). Manage budgets with `GET /v1/budgets`, `GET /v1/budgets/{budget_id}`, `PATCH /v1/budgets/{budget_id}`, and `DELETE /v1/budgets/{budget_id}`. A budget's response rolls up the users assigned to it: `user_count`, `total_spend`, and `total_reserved`. `GET /v1/budgets/{budget_id}/reset-logs` returns the per-user reset history.
+
+The enforcement strategy is configurable with `OTARI_BUDGET_STRATEGY` (`for_update` row-lock, `cas` compare-and-swap, or `disabled`); see [Configuration](configuration.md).
+
+## See also
+
+- [Admin dashboard](dashboard.md): the same users, keys, and budgets in the browser UI.
+- [Configuration](configuration.md): `reject_user_mismatch`, `budget_strategy`, and related settings.
+- [API reference](api-reference.md): the full endpoint and schema listing.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -139,6 +139,7 @@ into something a text-only local model can read.
 | `GET` | `/v1/keys` | List all API keys. | Master key |
 | `GET` | `/v1/keys/{key_id}` | Get a specific key. | Master key |
 | `PATCH` | `/v1/keys/{key_id}` | Update a key (name, active status, expiration, metadata). | Master key |
+| `POST` | `/v1/keys/{key_id}/rotate` | Replace a key's secret in place (id, user, name, expiry, and metadata preserved); returns the new key once. The previous secret stops working immediately. | Master key |
 | `DELETE` | `/v1/keys/{key_id}` | Revoke a key. | Master key |
 
 ### User management

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -21,6 +21,7 @@ For full request/response schemas, see the [OpenAPI spec](public/openapi.json) o
 
 - Preferred header: `Otari-Key: <token>` (a `Bearer` prefix is also accepted)
 - `Authorization: Bearer <token>` is also accepted
+- `x-api-key: <token>` is also accepted (for Anthropic-native clients)
 
 Regular API endpoints use an API key. Management endpoints use the master key.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,6 +81,8 @@ pricing:
 | `model_cache_ttl_seconds` | int | `300` | TTL for the in-memory model-discovery cache (`0` disables caching). |
 | `model_discovery_timeout_seconds` | float | `10.0` | Per-provider timeout for a live model-discovery (`list_models`) call. Bounds how long an unreachable or slow provider can stall discovery before it is treated as failed. |
 | `model_discovery_negative_ttl_seconds` | float | `30.0` | How long a failed model-discovery result is remembered before the provider is dialed again, so an unreachable provider is not re-tried on every request (`0` disables negative caching). |
+| `models_dev_metadata` | bool | `true` | Enrich the dashboard's model detail with metadata (modalities, capabilities, knowledge cutoff) fetched from the public models.dev catalog. Set `false` to disable the outbound call; the gateway then falls back to the bundled genai-prices data. |
+| `models_dev_cache_ttl_seconds` | int | `86400` | TTL in seconds for the cached models.dev catalog (`0` disables caching). |
 | `files_enabled` | bool | `true` | Enable the `/v1/files` upload/storage endpoints (standalone mode). |
 | `files_backend` | string | `"local"` | Blob backend for uploaded file bytes (`"local"` filesystem for now). |
 | `files_local_dir` | string | `"./otari-files"` | Directory the `local` files backend writes uploaded bytes to. |
@@ -93,6 +95,7 @@ pricing:
 | `model_capabilities` | dict | `{}` | Per-model multimodal capability overrides (`provider/model` to `{supports_image, supports_pdf}`). Authoritative over any-llm's provider-level flags; needed for text-only local models behind OpenAI-compatible servers. |
 | `sandbox_url` | string | none | Base URL of the code-execution sandbox backend for `otari_code_execution` tools. When unset, such requests are rejected with HTTP 400. Also settable via `OTARI_SANDBOX_URL`. |
 | `guardrails_url` | string | none | Default input-guardrails service URL, used when a request does not pass its own guardrail `url`. Also settable via `OTARI_GUARDRAILS_URL`. |
+| `web_search_url` | string | none | Base URL of the web-search backend (SearXNG instance or a search adapter) for `otari_web_search` tools. When unset, such requests are rejected with HTTP 400. docker-compose sets this to the bundled SearXNG container. Also settable via `OTARI_WEB_SEARCH_URL`. |
 | `tools_header` | string | none | Override for the purpose-hint preamble header injected ahead of gateway-managed tool hints. When unset, a built-in default header is used. Also settable via `OTARI_TOOLS_HEADER`. |
 | `sandbox_purpose_hint` | string | none | Default purpose hint forwarded to the sandbox backend when a tool entry supplies none. Also settable via `OTARI_SANDBOX_PURPOSE_HINT`. |
 | `web_search_purpose_hint` | string | none | Default purpose hint for the web-search backend when a tool entry supplies none. Also settable via `OTARI_WEB_SEARCH_PURPOSE_HINT`. |
@@ -220,7 +223,7 @@ These are only relevant when running connected to [otari.ai](https://otari.ai). 
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OTARI_AI_TOKEN` | -- | Otari token from otari.ai (enables platform connection) |
+| `OTARI_AI_TOKEN` | none | Otari token from otari.ai (enables platform connection) |
 | `PLATFORM_RESOLVE_TIMEOUT_MS` | `5000` | Timeout for provider resolution calls |
 | `PLATFORM_USAGE_TIMEOUT_MS` | `5000` | Timeout for usage reporting calls |
 | `PLATFORM_USAGE_MAX_RETRIES` | `3` | Max retries for transient usage reporting failures |
@@ -344,7 +347,7 @@ Limitations when enabled:
   `require_pricing`.
 
 > **Fail-closed by default.** With `require_pricing: true` (the default), a request for a model
-> that has no pricing entry is rejected with HTTP 402 rather than served free and unmetered — an
+> that has no pricing entry is rejected with HTTP 402 rather than served free and unmetered; an
 > unpriced model would otherwise bypass the budget cap. To run genuinely free or self-hosted
 > models, add an explicit `$0` pricing entry, or set `require_pricing: false`. Audio and moderation
 > endpoints are exempt. A startup warning is logged if `require_pricing` is on with no pricing configured.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -167,6 +167,8 @@ gateway.
   expires).
 - **Budgets**: spending limits callers are held to, with per-period resets.
 
+For how users, keys, and budgets fit together and the management endpoints behind these pages, see [Access control](access-control.md).
+
 ### System
 
 - **Tools & Guardrails**: configure the backends for built-in tools (for

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,200 @@
+# Admin dashboard
+
+Otari ships with a web admin dashboard for operators. It browses the model
+catalogue, sets model pricing, manages aliases, adds and edits provider API
+keys, manages users, keys, and budgets, and toggles runtime settings, all
+against the local management API using the master key.
+
+The dashboard is a **standalone-mode** feature. In standalone mode Otari serves
+the dashboard at the gateway root (`/`). In hybrid mode there is no local
+management API, so the root keeps serving the get-started tutorial (`/welcome`)
+instead. Everything below assumes standalone mode.
+
+## The two-key model
+
+The dashboard involves two separate secrets. They do different jobs, and
+confusing them is the most common first-run snag, so it helps to keep them
+straight.
+
+| | Master key | `OTARI_SECRET_KEY` |
+| --- | --- | --- |
+| **Purpose** | Signs in to the dashboard and authorizes every management API call | Encrypts provider API keys stored through the dashboard (encryption at rest) |
+| **Set via** | `OTARI_MASTER_KEY` (or `master_key` in `config.yml`); generated on first run if unset | `OTARI_SECRET_KEY` only; never generated for you |
+| **Format** | Any string you choose, or a generated `otari-mk-…` value | A Fernet key (generate with `otari gen-secret-key`) |
+| **Where it lives** | Only its SHA-256 hash is stored; in the browser it is held in the tab's session storage | Supplied out of band at runtime; never written to the database |
+| **If you lose it** | Rotate or reset it; nothing else is affected | Every provider key stored in the dashboard becomes undecryptable |
+
+A few consequences worth internalizing:
+
+- **The master key is your dashboard password.** It gates every management route
+  exactly like an operator-set key would. Anyone with it can read and change
+  gateway configuration, so treat it like an admin credential.
+- **`OTARI_SECRET_KEY` is deliberately separate from the master key.** The
+  gateway may rotate the master key; the encryption key must not move with it, or
+  encryption at rest would be theatre against a stolen database. Otari never
+  auto-generates it, never stores it next to the ciphertext, and never derives it
+  from the master key.
+- **You only need `OTARI_SECRET_KEY` to store provider keys in the dashboard.**
+  If your providers are configured entirely in `config.yml`, you can run the
+  dashboard without it. The moment you try to save a provider key in the UI, Otari
+  needs it, and returns a clear "set `OTARI_SECRET_KEY` to store credentials"
+  error if it is missing.
+
+See [Configuration](configuration.md) for the full list of environment
+variables and the [Runtime provider management](configuration.md#runtime-provider-management)
+section for the underlying behavior.
+
+## First-run walkthrough
+
+This walks through going from a fresh gateway to a working request driven
+entirely from the browser.
+
+### 1. Start Otari in standalone mode
+
+Launch the gateway however you normally would, for example:
+
+```bash
+uv run otari serve --config config.yml
+```
+
+or through Docker Compose (`docker compose up`). You do not need any providers
+configured in `config.yml` up front; you can add them from the dashboard in a
+later step.
+
+### 2. Find your master key
+
+If you set `OTARI_MASTER_KEY` (or `master_key` in `config.yml`), that is your
+sign-in key and Otari never overrides it.
+
+If you left it unset, Otari generates one on first startup, stores only its
+hash, and prints the plaintext **once** to the logs. Look for the line:
+
+```
+Your master key: otari-mk-…
+```
+
+For a container, `docker logs <container>` surfaces it. The plaintext is never
+logged again, so copy it now. If you miss it, you can rotate to a new generated
+key from the Settings page later (see below), or set `OTARI_MASTER_KEY`
+explicitly and restart.
+
+### 3. Set `OTARI_SECRET_KEY` before storing provider keys
+
+If you plan to add provider API keys from the dashboard, set `OTARI_SECRET_KEY`
+before you save the first one. Generate a Fernet key with:
+
+```bash
+otari gen-secret-key
+```
+
+Set the output as `OTARI_SECRET_KEY` in the gateway's environment and restart.
+Keep it safe and separate from the database: losing it makes every stored
+provider key undecryptable, and a database dump alone cannot decrypt them. You
+can skip this step if all your providers live in `config.yml`.
+
+### 4. Open the dashboard and sign in
+
+Browse to the gateway root, for example `http://localhost:8000/`. You land on a
+sign-in screen. Paste your master key and select **Sign in**. The key is held
+only in this browser tab's session storage and sent directly to this gateway; it
+is never persisted to disk by the browser and is cleared when you sign out. If
+you are on a fresh install and are not sure where your key is, the "First run?
+Where to find your key" hint on the sign-in screen points you back at the logs.
+
+### 5. Add a provider
+
+Open **Providers** from the sidebar and add a provider (for example OpenAI),
+pasting its API key. Stored keys are encrypted at rest with `OTARI_SECRET_KEY`,
+and the API only ever echoes the last four characters back to the UI; the
+plaintext key is write-only. Providers configured in `config.yml` also appear
+here, marked `config` and read-only; keys you add in the UI are marked `stored`
+and can be edited, tested, and deleted.
+
+### 6. Test the connection
+
+On the Providers page, use **Test the connection** for the provider you just
+added. Otari makes a live call to confirm the credential works before you route
+real traffic through it.
+
+### 7. Send your first request
+
+The Providers page includes a "Send your first request" snippet you can copy.
+Point any OpenAI-compatible client at the gateway using an Otari API key or the
+master key, and select a model in `provider:model` form (for example
+`openai:gpt-4o`). See the [Quickstart](quickstart.md) for a full end-to-end
+example.
+
+### 8. (Optional) Set up keys, users, and budgets
+
+For multi-user or multi-app deployments, use the **Access** section of the
+sidebar to hand out scoped API keys, define users, and attach budgets so spend
+is enforced before each call. These are optional: a single-operator setup can
+run on the master key alone.
+
+## Page-by-page reference
+
+The sidebar groups pages by what they do. This section is filled in as pages
+land; the groups below match the current dashboard.
+
+### Overview
+
+The landing page. An at-a-glance view of spend, traffic, and health across the
+gateway.
+
+### Observability
+
+- **Activity**: the per-request log of what the gateway served, with filters.
+  Use it to inspect individual requests, their models, and their outcomes.
+- **Usage**: aggregate usage and analytics, showing spend and volume over time,
+  broken down by model and by user.
+
+### Catalog
+
+- **Providers**: add, edit, test, and delete provider credentials at runtime
+  (standalone only). Stored keys are encrypted with `OTARI_SECRET_KEY`; config
+  providers appear read-only. See the first-run walkthrough above.
+- **Models**: browse the model catalogue and set per-model pricing, with specs
+  and modality metadata where available (from models.dev).
+- **Aliases**: friendly names that resolve to a real provider model. Callers
+  use the alias; the underlying model stays private to the gateway.
+
+### Access
+
+- **Users**: the principals that keys and budgets attach to, including the
+  default model access for a user's keys.
+- **API keys**: issue and revoke gateway API keys, optionally restricting the
+  models a key may call and setting an expiry (leave blank for a key that never
+  expires).
+- **Budgets**: spending limits callers are held to, with per-period resets.
+
+### System
+
+- **Tools & Guardrails**: configure the backends for built-in tools (for
+  example the `otari_web_search` search backend) and request-level guardrails.
+- **Settings**: search and toggle runtime settings, review and apply default
+  pricing updates, and rotate the generated master key. Rotating the master key
+  issues a fresh `otari-mk-…` value and keeps your current session signed in.
+
+## Security notes
+
+- **The master key is an admin credential.** Anyone who has it can read and
+  change gateway configuration through the management API. Rotate it if you
+  suspect it leaked.
+- **Session storage, not local storage.** The dashboard keeps the master key in
+  the browser tab's session storage, so it does not persist across tabs or
+  survive closing the tab, and signing out clears it along with any cached admin
+  data.
+- **Provider keys are write-only over the API.** Once stored, the plaintext is
+  never returned; the UI shows only the last four characters. Losing
+  `OTARI_SECRET_KEY` makes stored keys undecryptable, so back it up separately
+  from the database and rotate it by prepending a new key (see
+  [Configuration](configuration.md#runtime-provider-management)).
+
+## See also
+
+- [Configuration](configuration.md): every environment variable and config
+  field, including `OTARI_MASTER_KEY` and `OTARI_SECRET_KEY`.
+- [Quickstart](quickstart.md): get the gateway running and make your first
+  request.
+- [Modes](modes.md): standalone versus hybrid, and why the dashboard is
+  standalone-only.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -69,7 +69,7 @@ sign-in key and Otari never overrides it.
 If you left it unset, Otari generates one on first startup, stores only its
 hash, and prints the plaintext **once** to the logs. Look for the line:
 
-```
+```text
 Your master key: otari-mk-…
 ```
 
@@ -182,6 +182,11 @@ For how users, keys, and budgets fit together and the management endpoints behin
 - **The master key is an admin credential.** Anyone who has it can read and
   change gateway configuration through the management API. Rotate it if you
   suspect it leaked.
+- **Use HTTPS for anything but local access.** The `http://localhost:8000/`
+  examples here assume you are on the same machine (loopback). The master key
+  authorizes every management request and must never travel over cleartext HTTP,
+  so put the gateway behind HTTPS or a trusted reverse proxy before signing in
+  from another host.
 - **Session storage, not local storage.** The dashboard keeps the master key in
   the browser tab's session storage, so it does not persist across tabs or
   survive closing the tab, and signing out clears it along with any cached admin

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -23,7 +23,7 @@ When turning that setup into a longer-lived deployment:
 
 This repo contains a Render Blueprint ([`render.yaml`](../deploy/render/render.yaml)), an infrastructure-as-code file that defines your stack.
 
-It deploys the published Otari image (`docker.io/mzdotai/otari:0.2.0`) as a free web service alongside a free Render Postgres 16 database.
+It deploys the published Otari image (`docker.io/mzdotai/otari:0.3.0`) as a free web service alongside a free Render Postgres 16 database.
 
 - On Apply, provide whichever provider credentials you use. Render provisions the web service and Postgres, injects the database’s internal connection string as `OTARI_DATABASE_URL`, generates `OTARI_MASTER_KEY`, sets `PORT` and `OTARI_PORT` to `8000`, enables fail-closed bundled pricing (`OTARI_REQUIRE_PRICING` and `OTARI_DEFAULT_PRICING`), and checks `/health/readiness`.
 - On Otari startup, the app runs database migrations and creates the bootstrap API key (printed once in the service logs).
@@ -36,7 +36,7 @@ If you create the Blueprint from the Dashboard (**New → Blueprint**) instead o
 
 The Blueprint, upgrade instructions, and full env table are available at [`deploy/render/`](https://github.com/mozilla-ai/otari/tree/main/deploy/render).
 
-This Blueprint deploys standalone mode with a local Postgres database. Render also has a hybrid-mode Blueprint connected to otari.ai — see [Hybrid mode](https://github.com/mozilla-ai/otari/tree/main/deploy/render#hybrid-mode) in the Render docs, or [Connect to otari.ai](#connect-to-otariai) below for the general Docker instructions.
+This Blueprint deploys standalone mode with a local Postgres database. Render also has a hybrid-mode Blueprint connected to otari.ai; see [Hybrid mode](https://github.com/mozilla-ai/otari/tree/main/deploy/render#hybrid-mode) in the Render docs, or [Connect to otari.ai](#connect-to-otariai) below for the general Docker instructions.
 
 ## Deploy on Railway
 
@@ -92,7 +92,7 @@ docker run --rm \
   otari serve --config /app/config.yml
 ```
 
-No postgres container is needed -- otari.ai handles storage.
+No postgres container is needed; otari.ai handles storage.
 
 ### 4. Verify
 
@@ -165,7 +165,7 @@ docker compose --profile web-search-tavily up -d --build tavily-adapter otari
 ```
 
 `WebSearchBackend` is URL-configured, so any service exposing a
-SearXNG-compatible `/search?format=json` endpoint works — copy the adapter to
+SearXNG-compatible `/search?format=json` endpoint works; copy the adapter to
 front Exa, Serper, etc.
 
 Both code-exec and web-search profiles can be combined:

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -65,7 +65,7 @@ Content-Type: application/json
 }
 ```
 
-### Response — multi-attempt shape (preferred)
+### Response: multi-attempt shape (preferred)
 
 ```json
 {
@@ -103,7 +103,7 @@ back via `X-Correlation-ID` and reports through `/gateway/usage`.
 platform can attribute spend, render trace timelines, and emit fallback events.
 Otari also surfaces it as the `X-Otari-Request-ID` response header.
 
-`fallback_enabled` is informational — set by the platform when its routing
+`fallback_enabled` is informational, set by the platform when its routing
 policy actually allows fallback (i.e. the policy has multiple enabled entries
 and `fallback_enabled = true`). Otari uses `len(attempts) > 1` for its
 own behaviour.
@@ -111,7 +111,7 @@ own behaviour.
 `attempts` MUST contain at least one entry. An empty list is treated as a
 platform bug and surfaced as `502 Bad Gateway`.
 
-### Response — single-attempt shape
+### Response: single-attempt shape
 
 Otari also accepts a flat payload:
 
@@ -127,7 +127,7 @@ Otari also accepts a flat payload:
 ```
 
 Otari maps this onto a single-attempt route (`attempts = [{...}]`,
-`fallback_enabled = false`) and behaves as it always has — no retry loop, errors
+`fallback_enabled = false`) and behaves as it always has: no retry loop, errors
 propagate to the client. New platform implementations should prefer the
 multi-attempt shape.
 
@@ -246,7 +246,7 @@ this field.
 
 ## Usage report
 
-After every attempt — successful or failed — Otari sends:
+After every attempt, successful or failed, Otari sends:
 
 ```http
 POST /gateway/usage
@@ -303,8 +303,8 @@ The platform must accept these additive keys with lenient parsing; a handler tha
 rejects unknown fields would 422 the report (a non-retryable status), silently
 dropping it. See companion issue mozilla-ai/otari-ai#1168.
 
-A multi-attempt request that iterates two attempts produces two usage reports —
-one per attempt — sharing the same `request_id` (recoverable via the original
+A multi-attempt request that iterates two attempts produces two usage reports,
+one per attempt, sharing the same `request_id` (recoverable via the original
 resolve response). The platform is responsible for correlating them.
 
 `error_class` is a short tag describing why the attempt was abandoned:
@@ -317,7 +317,7 @@ resolve response). The platform is responsible for correlating them.
 | `unknown` | Any other exception class |
 
 The field is **omitted entirely** when Otari can't classify the failure
-back to an exception — this happens with mid-stream errors surfaced via the
+back to an exception; this happens with mid-stream errors surfaced via the
 SSE channel, where only an error string is available. Treat a missing
 `error_class` as "uncategorised error" when aggregating.
 
@@ -326,7 +326,7 @@ SSE channel, where only an error string is available. Treat a missing
 The usage endpoint is called as a background task on Otari side. It
 retries on transient failures (timeout, network error, 5xx) up to
 `PLATFORM_USAGE_MAX_RETRIES` times with exponential backoff
-(`0.25s`, `0.5s`, `1s`). It does **not** retry on `401`, `404`, `409`, `422` —
+(`0.25s`, `0.5s`, `1s`). It does **not** retry on `401`, `404`, `409`, `422`;
 those are treated as terminal client errors.
 
 ## Streaming
@@ -340,8 +340,8 @@ propagates to the SSE channel as today.
 The mechanism is a per-attempt **first-chunk gate**. For each attempt:
 
 1. Open the upstream stream (`acompletion(stream=True, ...)`). If this raises
-   — provider returned `401` / `5xx` / network error before the stream even
-   opened — classify the error: retryable failures move to the next attempt;
+   (provider returned `401` / `5xx` / network error before the stream even
+   opened), classify the error: retryable failures move to the next attempt;
    non-retryable failures propagate.
 2. Wait for the first chunk with a bounded timeout. Non-final attempts use the
    per-attempt failover budget (`STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS`,
@@ -354,7 +354,7 @@ The mechanism is a per-attempt **first-chunk gate**. For each attempt:
 3. Once a first chunk is in hand, commit. Stitch it back onto the iterator
    and start flushing SSE chunks to the client.
 
-**Latency contract:** zero added latency in the success case — the first
+**Latency contract:** zero added latency in the success case: the first
 chunk is held only for the microseconds it takes to call the SSE response
 builder. In the failure case, each abandoned non-final attempt costs at most the
 failover budget; the final attempt costs at most budget + grace.
@@ -377,7 +377,7 @@ flag.
 
 | Env var | Default | Notes |
 |---|---|---|
-| `OTARI_AI_TOKEN` | — | Setting this enables hybrid mode. |
+| `OTARI_AI_TOKEN` | none | Setting this enables hybrid mode. |
 | `PLATFORM_RESOLVE_TIMEOUT_MS` | `5000` | Per-resolve timeout. |
 | `PLATFORM_USAGE_TIMEOUT_MS` | `5000` | Per-usage-report timeout. |
 | `PLATFORM_USAGE_MAX_RETRIES` | `3` | Max retries for transient usage-report failures. |

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -316,8 +316,8 @@ resolve response). The platform is responsible for correlating them.
 | `http_<code>` | Provider returned an HTTP status code (e.g. `http_429`, `http_401`) |
 | `unknown` | Any other exception class |
 
-The field is **omitted entirely** when Otari can't classify the failure
-back to an exception; this happens with mid-stream errors surfaced via the
+The field is **omitted entirely** when Otari can't map the failure to an
+exception class; this happens with mid-stream errors surfaced via the
 SSE channel, where only an error string is available. Treat a missing
 `error_class` as "uncategorised error" when aggregating.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,19 +17,37 @@ Start with the [Quickstart](quickstart.md). It gets Otari running locally and wa
 
 ## Browse the docs
 
+The docs are grouped by what you are trying to do.
+
+### Start here
+
 - [Quickstart](quickstart.md): get running and make your first request.
-- [Deployment](deployment.md): hybrid mode, optional services, and deployment-specific configuration.
 - [Modes](modes.md): standalone vs hybrid, and what changes between them.
+
+### For operators
+
+Running and managing a gateway.
+
+- [Deployment](deployment.md): Docker, Render, Railway, hybrid mode, and optional services.
+- [Configuration](configuration.md): the full config file and environment variable reference.
+- [Admin dashboard](dashboard.md): the operator dashboard, covering the two-key model, a first-run walkthrough, and a page-by-page reference.
+- [Access control](access-control.md): users, API keys, and budgets, with the management endpoints that drive them.
+- [Supported models](models.md): providers, model format, and capabilities.
+- [OpenAI provider guide](providers/openai.md): configure OpenAI and route your first request through Otari.
+
+### For integrators
+
+Calling the gateway from your own code.
+
+- [API reference](api-reference.md): every endpoint, with auth and availability per mode.
 - [Built-in tools](tools.md): sandboxed code execution and web search Otari runs itself.
 - [MCP](mcp.md): connect MCP servers to chat, messages, and responses requests.
 - [Files](files.md): file uploads and document understanding for local models.
 - [Guardrails](guardrails.md): request-level checks like prompt-injection detection.
-- [Admin dashboard](dashboard.md): the operator dashboard, covering the two-key model, a first-run walkthrough, and a page-by-page reference.
-- [Configuration](configuration.md): the full config file and environment variable reference.
-- [API reference](api-reference.md): every endpoint, with auth and availability per mode.
 - [Use with Claude Code](use-with-claude-code.md): point the Claude Code CLI at Otari.
 - [Use with opencode](use-with-opencode.md): point the opencode CLI at Otari.
-- [Supported models](models.md): providers, model format, and capabilities.
-- [OpenAI provider guide](providers/openai.md): configure OpenAI and route your first request through Otari.
-- [Hybrid-mode protocol](hybrid-mode-protocol.md): Otari/platform wire contract, for platform builders.
 - [SDK compatibility](sdk-compatibility.md): how the language SDKs are released and which SDK version works with which Otari version.
+
+### For platform builders
+
+- [Hybrid-mode protocol](hybrid-mode-protocol.md): the Otari/platform wire contract, for building a platform that Otari connects to.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,8 @@ Your applications talk to Otari instead of directly to providers. Otari authenti
 
 ## Two ways to run it
 
-- **Standalone** — Otari manages everything locally: its own database, your provider credentials, keys, budgets, and usage. Nothing leaves your environment. This is the default and the place to start.
-- **Connected to otari.ai** — Otari delegates provider routing, authentication, and usage tracking to the platform, adding multi-provider fallback. Enabled by setting one environment variable.
+- **Standalone**: Otari manages everything locally: its own database, your provider credentials, keys, budgets, and usage. Nothing leaves your environment. This is the default and the place to start.
+- **Connected to otari.ai**: Otari delegates provider routing, authentication, and usage tracking to the platform, adding multi-provider fallback. Enabled by setting one environment variable.
 
 See [Modes](modes.md) for the full comparison.
 
@@ -17,18 +17,19 @@ Start with the [Quickstart](quickstart.md). It gets Otari running locally and wa
 
 ## Browse the docs
 
-- [Quickstart](quickstart.md) — get running and make your first request.
-- [Deployment](deployment.md) — hybrid mode, optional services, and deployment-specific configuration.
-- [Modes](modes.md) — standalone vs hybrid, and what changes between them.
-- [Built-in tools](tools.md) — sandboxed code execution and web search Otari runs itself.
-- [MCP](mcp.md) — connect MCP servers to chat, messages, and responses requests.
-- [Files](files.md) — file uploads and document understanding for local models.
-- [Guardrails](guardrails.md) — request-level checks like prompt-injection detection.
-- [Configuration](configuration.md) — the full config file and environment variable reference.
-- [API reference](api-reference.md) — every endpoint, with auth and availability per mode.
-- [Use with Claude Code](use-with-claude-code.md) — point the Claude Code CLI at Otari.
-- [Use with opencode](use-with-opencode.md) — point the opencode CLI at Otari.
-- [Supported models](models.md) — providers, model format, and capabilities.
-- [OpenAI provider guide](providers/openai.md). Configure OpenAI and route your first request through Otari.
-- [Hybrid-mode protocol](hybrid-mode-protocol.md) — Otari/platform wire contract, for platform builders.
-- [SDK compatibility](sdk-compatibility.md) — how the language SDKs are released and which SDK version works with which Otari version.
+- [Quickstart](quickstart.md): get running and make your first request.
+- [Deployment](deployment.md): hybrid mode, optional services, and deployment-specific configuration.
+- [Modes](modes.md): standalone vs hybrid, and what changes between them.
+- [Built-in tools](tools.md): sandboxed code execution and web search Otari runs itself.
+- [MCP](mcp.md): connect MCP servers to chat, messages, and responses requests.
+- [Files](files.md): file uploads and document understanding for local models.
+- [Guardrails](guardrails.md): request-level checks like prompt-injection detection.
+- [Admin dashboard](dashboard.md): the operator dashboard, covering the two-key model, a first-run walkthrough, and a page-by-page reference.
+- [Configuration](configuration.md): the full config file and environment variable reference.
+- [API reference](api-reference.md): every endpoint, with auth and availability per mode.
+- [Use with Claude Code](use-with-claude-code.md): point the Claude Code CLI at Otari.
+- [Use with opencode](use-with-opencode.md): point the opencode CLI at Otari.
+- [Supported models](models.md): providers, model format, and capabilities.
+- [OpenAI provider guide](providers/openai.md): configure OpenAI and route your first request through Otari.
+- [Hybrid-mode protocol](hybrid-mode-protocol.md): Otari/platform wire contract, for platform builders.
+- [SDK compatibility](sdk-compatibility.md): how the language SDKs are released and which SDK version works with which Otari version.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,7 +8,7 @@ This guide runs the local Docker Compose stack (Otari plus Postgres) from a clon
 
 You can give Otari its provider credentials in one of two ways. Both use the same Docker Compose stack and end at the same first request; pick whichever fits how you like to work.
 
-- **Config-first (Option A):** put your provider key in `config.yml` before starting. Best when you already have keys and want everything in one version-controllable file.
+- **Config-first (Option A):** put your provider key in `config.yml` before starting. Best when you already have keys and want them in one local config file.
 - **Dashboard-first (Option B):** start with almost nothing, then add providers from the admin dashboard in your browser. Best for trying Otari out, or when you would rather manage credentials through a UI.
 
 ## Prerequisites
@@ -16,7 +16,7 @@ You can give Otari its provider credentials in one of two ways. Both use the sam
 - Docker and Docker Compose
 - An API key for at least one LLM provider (this guide uses OpenAI)
 
-Clone the repo first; both options need the Compose file and the example config:
+Clone the repo first. Both options need the Compose file; Option A also copies the example config:
 
 ```bash
 git clone https://github.com/mozilla-ai/otari
@@ -50,6 +50,8 @@ pricing:
     input_price_per_million: 0.15
     output_price_per_million: 0.60
 ```
+
+This `config.yml` holds your master key and provider key, so treat it as a secret: it is gitignored so you will not commit it by default, and for shared deployments keep credentials out of the file entirely by using `${ENV_VAR}` interpolation or environment variables (see [Configuration](configuration.md)).
 
 The `pricing` entry matters because `require_pricing` is on by default: Otari rejects requests for any model it can't resolve a price for, so it can enforce budgets. Add a pricing entry for the model you plan to call, or enable `default_pricing: true` to use the bundled fallback pricing for common models.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,20 +2,34 @@
 
 Get Otari running locally and make your first request in about five minutes. This guide uses **standalone mode**: Otari runs entirely on your own machine, manages its own database, and talks to providers using credentials you supply. Nothing leaves your environment, and you don't need an otari.ai account.
 
-This guide assumes you want to run the full local Docker Compose stack from a cloned checkout. If you want the fastest no-clone path, use the Quickstart in the project [README](../README.md).
+This guide runs the local Docker Compose stack (Otari plus Postgres) from a cloned checkout. If you want the fastest no-clone path, use the Quickstart in the project [README](../README.md).
+
+## Two ways to configure Otari
+
+You can give Otari its provider credentials in one of two ways. Both use the same Docker Compose stack and end at the same first request; pick whichever fits how you like to work.
+
+- **Config-first (Option A):** put your provider key in `config.yml` before starting. Best when you already have keys and want everything in one version-controllable file.
+- **Dashboard-first (Option B):** start with almost nothing, then add providers from the admin dashboard in your browser. Best for trying Otari out, or when you would rather manage credentials through a UI.
 
 ## Prerequisites
 
 - Docker and Docker Compose
 - An API key for at least one LLM provider (this guide uses OpenAI)
 
-## 1. Configure
-
-Clone the repo, then copy the example config and open it:
+Clone the repo first; both options need the Compose file and the example config:
 
 ```bash
 git clone https://github.com/mozilla-ai/otari
 cd otari
+```
+
+## Option A: configure with `config.yml`
+
+### 1. Configure
+
+Copy the example config and open it:
+
+```bash
 cp config.example.yml config.yml
 ```
 
@@ -39,7 +53,7 @@ pricing:
 
 The `pricing` entry matters because `require_pricing` is on by default: Otari rejects requests for any model it can't resolve a price for, so it can enforce budgets. Add a pricing entry for the model you plan to call, or enable `default_pricing: true` to use the bundled fallback pricing for common models.
 
-## 2. Start your Otari
+### 2. Start Otari
 
 ```bash
 docker compose pull
@@ -52,24 +66,65 @@ This starts Otari on port 8000 and a Postgres database. Confirm it's healthy:
 curl http://localhost:8000/health
 ```
 
+You should get `{"status": "healthy"}`. Now skip ahead to [Create an API key](#create-an-api-key).
+
+## Option B: configure from the dashboard
+
+Here you start Otari with no providers configured and add them in the browser. To store a provider key from the dashboard, Otari encrypts it at rest with a Fernet key you supply as `OTARI_SECRET_KEY`, so you set that first. See the [Admin dashboard guide](dashboard.md) for the full tour.
+
+### 1. Write a minimal config
+
+Create `config.yml` with a master key (your dashboard sign-in) and no providers:
+
+```yaml
+host: "0.0.0.0"
+port: 8000
+
+master_key: "your-secret-master-key"
+
+# Serve common models using bundled fallback pricing, so a first request works
+# before you set pricing yourself. Set per-model prices later on the Models page.
+default_pricing: true
+```
+
+### 2. Generate an encryption key and start Otari
+
+Generate a Fernet key and export it so Compose passes it into the container:
+
+```bash
+export OTARI_SECRET_KEY="$(docker run --rm mzdotai/otari:latest otari gen-secret-key)"
+docker compose pull
+docker compose up -d
+```
+
+Keep `OTARI_SECRET_KEY` safe and separate from the database: losing it makes every provider key you store in the dashboard undecryptable. Confirm Otari is healthy:
+
+```bash
+curl http://localhost:8000/health
+```
+
 You should get `{"status": "healthy"}`.
 
-## 3. Create an API key
+### 3. Add a provider in the dashboard
+
+Open `http://localhost:8000/` in your browser, sign in with the master key from your config, then open **Providers** and add OpenAI with your `sk-...` key. Use **Test the connection** to confirm the credential works. The key is encrypted at rest with `OTARI_SECRET_KEY`; the UI only ever shows its last four characters.
+
+## Create an API key
 
 Use your master key (the one you set in `config.yml`) to create an API key for making requests:
- 
+
 ```bash
 curl -X POST http://localhost:8000/v1/keys \
   -H "Otari-Key: your-secret-master-key" \
   -H "Content-Type: application/json" \
   -d '{"key_name": "quickstart"}'
 ```
- 
-The response includes your new key. Copy it, this is the only time it's shown in full. You'll use it in the next step.
- 
-> Otari also creates a bootstrap key on first startup and prints it to the logs. Creating a key explicitly, as above, is more reliable for getting started.
 
-## 4. Make your first request
+The response includes your new key. Copy it, this is the only time it's shown in full. You'll use it in the next step.
+
+> Otari also creates a bootstrap key on first startup and prints it to the logs. Creating a key explicitly, as above, is more reliable for getting started. You can also issue keys from the dashboard's **API keys** page.
+
+## Make your first request
 
 Otari is OpenAI-compatible, so any standard client works. With curl:
 
@@ -109,9 +164,10 @@ Your request went to Otari, not directly to OpenAI. Otari authenticated your key
 
 ## Next steps
 
+- [Admin dashboard](dashboard.md) is the operator's tour of the browser UI: the two-key model, a first-run walkthrough, and a page-by-page reference.
 - [Deployment](deployment.md) picks up from here with hybrid mode, optional services, and deployment-specific configuration.
-- [Built-in tools](tools.md) — let any model use a sandboxed code REPL or web search Otari runs itself.
-- [Guardrails](guardrails.md) — request-level checks like prompt-injection detection, enforced before the provider is called.
+- [Built-in tools](tools.md): let any model use a sandboxed code REPL or web search Otari runs itself.
+- [Guardrails](guardrails.md): request-level checks like prompt-injection detection, enforced before the provider is called.
 - [Configuration](configuration.md) is the full reference for budgets, rate limits, pricing, and provider options.
 - [Models](models.md) lists every supported provider and the model format.
 - [API reference](api-reference.md) documents every endpoint.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -53,6 +53,8 @@ pricing:
 
 The `pricing` entry matters because `require_pricing` is on by default: Otari rejects requests for any model it can't resolve a price for, so it can enforce budgets. Add a pricing entry for the model you plan to call, or enable `default_pricing: true` to use the bundled fallback pricing for common models.
 
+> To add more providers through the dashboard later instead of editing `config.yml`, you also need to set `OTARI_SECRET_KEY`, which encrypts stored provider keys at rest. See [Option B](#option-b-configure-from-the-dashboard) below and the [Admin dashboard guide](dashboard.md).
+
 ### 2. Start Otari
 
 ```bash

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -2,8 +2,8 @@
 
 Otari can run two tools itself so any model, including open-weight ones, gets parity with what frontier APIs expose as managed tools:
 
-- **`otari_code_execution`** — a sandboxed Python REPL
-- **`otari_web_search`** — a web search backend
+- **`otari_code_execution`**: a sandboxed Python REPL
+- **`otari_web_search`**: a web search backend
 
 Both are opt-in per request via the `tools` array and require bringing up additional services via Docker Compose profiles. Operators who don't use them don't pull the extra images.
 

--- a/docs/use-with-claude-code.md
+++ b/docs/use-with-claude-code.md
@@ -46,9 +46,10 @@ claude
 Use `ANTHROPIC_AUTH_TOKEN` (not `ANTHROPIC_API_KEY`): it is sent as
 `Authorization: Bearer <token>`, which is the scheme Otari accepts for
 both standalone API keys and connected user tokens. `ANTHROPIC_API_KEY` is sent
-as an `x-api-key` header instead. Otari does read that header, so it also
-authenticates, but `ANTHROPIC_AUTH_TOKEN` is the variable Claude Code intends for
-a third-party endpoint and works uniformly across both modes.
+as an `x-api-key` header instead. In standalone mode Otari reads that header too,
+so it also authenticates; connected mode, though, expects `Authorization: Bearer`
+and does not use local API keys, so `ANTHROPIC_AUTH_TOKEN` is the portable choice
+that works in both modes.
 
 ### settings.json
 

--- a/docs/use-with-claude-code.md
+++ b/docs/use-with-claude-code.md
@@ -45,8 +45,10 @@ claude
 
 Use `ANTHROPIC_AUTH_TOKEN` (not `ANTHROPIC_API_KEY`): it is sent as
 `Authorization: Bearer <token>`, which is the scheme Otari accepts for
-both standalone API keys and connected user tokens. `ANTHROPIC_API_KEY` sends an
-`x-api-key` header instead, which Otari does not read.
+both standalone API keys and connected user tokens. `ANTHROPIC_API_KEY` is sent
+as an `x-api-key` header instead. Otari does read that header, so it also
+authenticates, but `ANTHROPIC_AUTH_TOKEN` is the variable Claude Code intends for
+a third-party endpoint and works uniformly across both modes.
 
 ### settings.json
 

--- a/docs/use-with-opencode.md
+++ b/docs/use-with-opencode.md
@@ -61,5 +61,5 @@ provider and records usage and cost for it the same way as any other client.
 
 ## See also
 
-- [Use with Claude Code](use-with-claude-code.md) — drive the Claude Code CLI
+- [Use with Claude Code](use-with-claude-code.md): drive the Claude Code CLI
   through the same Otari via the Anthropic Messages API.

--- a/tests/unit/test_dashboard_doc.py
+++ b/tests/unit/test_dashboard_doc.py
@@ -1,0 +1,75 @@
+"""Structural checks for the admin dashboard operator guide (docs/dashboard.md).
+
+The guide is hand-written prose, so these tests guard the contract that matters:
+the file exists, is linked from the docs index, covers the pieces issue #313
+asked for (the two-key model, a first-run walkthrough, a page-by-page
+reference), keeps its internal links pointing at real files, and follows the
+project's no-em-dash-in-prose writing convention.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+_DOCS_DIR = Path(__file__).resolve().parents[2] / "docs"
+_DASHBOARD_DOC = _DOCS_DIR / "dashboard.md"
+_INDEX_DOC = _DOCS_DIR / "index.md"
+
+# Markdown links to other docs, e.g. [text](configuration.md#anchor).
+_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+
+@pytest.fixture(scope="module")
+def dashboard_text() -> str:
+    return _DASHBOARD_DOC.read_text(encoding="utf-8")
+
+
+def test_dashboard_doc_exists() -> None:
+    assert _DASHBOARD_DOC.is_file(), "docs/dashboard.md is missing"
+
+
+def test_dashboard_doc_has_single_top_level_heading(dashboard_text: str) -> None:
+    h1s = [line for line in dashboard_text.splitlines() if line.startswith("# ")]
+    assert h1s == ["# Admin dashboard"], f"expected one H1 'Admin dashboard', got {h1s}"
+
+
+def test_dashboard_doc_covers_required_sections(dashboard_text: str) -> None:
+    for heading in (
+        "## The two-key model",
+        "## First-run walkthrough",
+        "## Page-by-page reference",
+    ):
+        assert heading in dashboard_text, f"missing required section: {heading!r}"
+
+
+def test_dashboard_doc_explains_the_two_keys(dashboard_text: str) -> None:
+    # The whole point of the guide: keep the sign-in key and the encryption key
+    # distinct. Both env var names must appear so the guide stays accurate if
+    # either is renamed in code.
+    for token in ("OTARI_MASTER_KEY", "OTARI_SECRET_KEY", "master key", "gen-secret-key"):
+        assert token in dashboard_text, f"two-key model text should mention {token!r}"
+
+
+def test_dashboard_doc_internal_links_resolve(dashboard_text: str) -> None:
+    for target in _LINK_RE.findall(dashboard_text):
+        if target.startswith(("http://", "https://", "#")):
+            continue
+        path_part = target.split("#", 1)[0]
+        if not path_part:
+            continue
+        resolved = (_DASHBOARD_DOC.parent / path_part).resolve()
+        assert resolved.is_file(), f"broken doc link: {target} -> {resolved}"
+
+
+def test_dashboard_doc_is_linked_from_index() -> None:
+    index_text = _INDEX_DOC.read_text(encoding="utf-8")
+    assert "(dashboard.md)" in index_text, "docs/index.md does not link to dashboard.md"
+
+
+def test_dashboard_doc_avoids_em_dash_prose(dashboard_text: str) -> None:
+    # Project writing convention (AGENTS.md): no em dashes or `--` separators in
+    # doc prose. En-dash numeric ranges and code are out of scope, and this doc
+    # has none, so a plain scan is enough.
+    assert "—" not in dashboard_text, "docs/dashboard.md contains an em dash (—); use commas/colons/periods"
+    assert " -- " not in dashboard_text, "docs/dashboard.md uses ' -- ' as a separator; rephrase"

--- a/tests/unit/test_docs_style.py
+++ b/tests/unit/test_docs_style.py
@@ -1,0 +1,33 @@
+"""Enforce the project's doc prose conventions across all of `docs/`.
+
+AGENTS.md's writing-style section bans em dashes as separators in doc prose
+(en-dash numeric ranges and CLI flags are a different matter and are not em
+dashes). The em dash (U+2014) has no legitimate use in these docs, so a plain
+repo-wide scan keeps the convention from silently drifting back in.
+"""
+
+from pathlib import Path
+
+import pytest
+
+_DOCS_DIR = Path(__file__).resolve().parents[2] / "docs"
+
+_EM_DASH = "—"
+
+_MARKDOWN_DOCS = sorted(_DOCS_DIR.rglob("*.md"))
+
+
+@pytest.mark.parametrize("doc", _MARKDOWN_DOCS, ids=lambda p: p.name)
+def test_doc_has_no_em_dash(doc: Path) -> None:
+    text = doc.read_text(encoding="utf-8")
+    offenders = [i + 1 for i, line in enumerate(text.splitlines()) if _EM_DASH in line]
+    assert not offenders, (
+        f"{doc.relative_to(_DOCS_DIR)} uses an em dash (—) on line(s) {offenders}; "
+        "use commas, semicolons, colons, parentheses, or periods instead"
+    )
+
+
+def test_docs_dir_is_discovered() -> None:
+    # Guard against the glob silently matching nothing (e.g. a moved docs dir),
+    # which would make every parametrized case vacuously pass.
+    assert _MARKDOWN_DOCS, "no markdown docs found under docs/"


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Documents the admin dashboard for operators (closes #313), then follows up with a broader scrub and reorganization of the gateway docs that the review surfaced.

**New: dashboard user guide** (`docs/dashboard.md`)
- The two-key model: the master key (dashboard sign-in and management auth) vs. `OTARI_SECRET_KEY` (Fernet encryption at rest for stored provider keys), and why they are deliberately separate.
- A text first-run walkthrough from a fresh gateway to a working request.
- A page-by-page sidebar reference. Screenshots are left for a follow-up, per discussion.

**New: access-control how-to** (`docs/access-control.md`)
- Task-oriented coverage of users, API keys, and budgets, verified against the code: the model allow-list override semantics, key expiry and rotation, the shared default user, `reject_user_mismatch`, and per-user budgets with period resets, each with the management endpoint that drives it.

**Docs scrub and reorganization**
- Fixed a factual error in `use-with-claude-code.md`: Otari does read the `x-api-key` header, so the prior "which Otari does not read" claim was wrong. Added `x-api-key` to the accepted headers in `api-reference.md`.
- Added the missing `web_search_url`, `models_dev_metadata`, and `models_dev_cache_ttl_seconds` fields to the configuration reference table.
- Rewrote the quickstart to offer two setup paths: config-first (provider key in `config.yml`) and dashboard-first (start minimal, add providers in the browser). Forwarded `OTARI_SECRET_KEY` through `docker-compose.yml` so the dashboard-first flow can encrypt stored keys.
- Bumped the pinned image from `0.2.0` to `0.3.0` in `deployment.md` and the Render blueprint (confirmed the `0.3.0` image is published on Docker Hub).
- Grouped the docs index by audience (Start here, For operators, For integrators, For platform builders).
- Trimmed the README to cut duplication with the docs (dashboard, browser setup, built-in tools, guardrails sections now link to the canonical doc instead of a second copy that drifts).
- Removed em dashes and `--` separators from doc prose per the AGENTS.md writing convention.

**Tests**
- `tests/unit/test_dashboard_doc.py`: the guide exists, is well-formed, covers the two-key model, and its links resolve.
- `tests/unit/test_docs_style.py`: a repo-wide guard that no doc uses an em dash.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #313

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint` and `make typecheck` clean; `make test-unit` 899 passed; `make openapi-check` up to date). Integration suite not run: this is a docs-only change with no route or database behavior.
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:**

Claude drafted the docs and tests through back-and-forth with @njbrake; the scope decisions (bundling the scrub, text-first screenshots, the three IA follow-ups) are his.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a new operator guide for the Admin dashboard, including the two-key sign-in/encryption model, a first-run walkthrough, and a page-by-page sidebar reference.
- Added/expanded an access-control guide covering users, API keys, budgets, model allow-lists, key expiry/rotation, `reject_user_mismatch`, and related management endpoints.
- Refreshed quickstart and documentation navigation with clearer “config-first” and “dashboard-first” setup paths, and reorganized the docs index into categories for different audiences.
- Updated configuration and API documentation (including added dashboard-related encryption config, web search settings, API key rotation in the API reference, and clarified authentication/header usage).
- Updated deployment/docs and run instructions: Docker Compose now supports passing `OTARI_SECRET_KEY`, the Render image pin was bumped to `0.3.0`, and the README was streamlined to emphasize safer first-run and dashboard-first flows.
- Tightened documentation consistency and readability across multiple doc pages (including formatting adjustments) and reduced README duplication.
- Added tests to validate the dashboard operator guide content, ensure internal doc links resolve, and enforce a docs style rule (no em dashes).

## Benefits

Operators can sign in, configure, and manage dashboard access more confidently—especially around secure key setup and credential encryption—while the updated quickstart and docs index make the right documentation easier to find. Automated tests help keep the new dashboard documentation accurate, linked, and stylistically consistent.

## Technical notes

- The dashboard guide documents a separate “master key” for sign-in/management and an `OTARI_SECRET_KEY` for encrypting stored provider credentials.
- Standalone API access guidance was corrected/expanded to include `x-api-key`, and the API reference now includes a key rotation endpoint.
- Documentation now explicitly avoids em dashes via a repo test to prevent style regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->