### PR TITLE
fix(models): list env-credentialed providers in /v1/models

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,7 +77,7 @@ pricing:
 | `reject_user_mismatch` | bool | `true` | When `true`, a non-master key whose request names a `user` other than its own is rejected (HTTP 403). When `false`, the client `user` is still forwarded to the provider but spend is always bound to the key's own user. The master key may always bill an arbitrary user. |
 | `stream_missing_usage_policy` | string | `"estimate"` | How to bill a streamed response that completes with no provider usage data: `"estimate"` (charge the up-front estimate), `"fail"` (charge estimate and mark errored), or `"allow_free"` (don't bill). |
 | `budget_estimate_default_output_tokens` | int | `1024` | Output-token count assumed when reserving budget for a request with no declared max output; reconciled to actual usage on completion. |
-| `model_discovery` | bool | `true` | Auto-discover models from configured providers for `GET /v1/models`. |
+| `model_discovery` | bool | `true` | Auto-discover models for `GET /v1/models`, from configured providers and from any provider made callable by its native credential environment variable alone (so the catalog matches what routing can reach). |
 | `model_cache_ttl_seconds` | int | `300` | TTL for the in-memory model-discovery cache (`0` disables caching). |
 | `model_discovery_timeout_seconds` | float | `10.0` | Per-provider timeout for a live model-discovery (`list_models`) call. Bounds how long an unreachable or slow provider can stall discovery before it is treated as failed. |
 | `model_discovery_negative_ttl_seconds` | float | `30.0` | How long a failed model-discovery result is remembered before the provider is dialed again, so an unreachable provider is not re-tried on every request (`0` disables negative caching). |

--- a/docs/models.md
+++ b/docs/models.md
@@ -95,7 +95,11 @@ Or via environment variable:
 export OPENAI_API_KEY="sk-..."
 ```
 
-Both approaches work. Config file values take precedence over environment variables.
+Both approaches work, for routing and for discovery alike: a provider whose
+native credential environment variable is set (for example `ANTHROPIC_API_KEY`)
+is callable as `provider:model` and its models also appear in `GET /v1/models`,
+even without a `providers` entry. Config file values take precedence over
+environment variables.
 
 In standalone mode, provider config only tells Otari how to reach the backend.
 Otari also requires pricing for the model you call by default, unless

--- a/src/gateway/services/model_discovery_service.py
+++ b/src/gateway/services/model_discovery_service.py
@@ -221,7 +221,7 @@ def _supports_list_models(provider_name: str) -> bool:
         return False
 
 
-def _env_provider_instances(configured: set[str]) -> list[str]:
+def _env_provider_instances(configured_impls: set[str]) -> list[str]:
     """any-llm provider implementations made callable by their credential env var.
 
     Completion routing works for any any-llm provider once its native credential
@@ -234,14 +234,30 @@ def _env_provider_instances(configured: set[str]) -> list[str]:
     resolves.
 
     Only providers that support live model listing are included; one that cannot
-    list models would just error out and be dropped from the catalog. Providers
-    already in ``configured`` are skipped so a named instance is neither shadowed
-    nor duplicated.
+    list models would just error out and be dropped from the catalog. A provider
+    whose implementation already backs a configured instance is skipped
+    (``configured_impls`` holds those implementation names): otherwise a custom
+    instance such as ``my-anthropic`` (``provider_type: anthropic``) alongside
+    ``ANTHROPIC_API_KEY`` would dial the same credential twice and list the same
+    models under two keys.
+
+    A keyless local provider (``ollama``/``llamacpp``/``llamafile``, whose
+    ``env_key`` is absent) has no credential signal to detect and so is not
+    surfaced here; discovering it would mean dialing a fixed localhost endpoint on
+    spec. That narrow callable-but-undiscoverable case is tracked separately.
     """
     detected: list[str] = []
-    for metadata in AnyLLM.get_all_provider_metadata():
+    try:
+        all_metadata = AnyLLM.get_all_provider_metadata()
+    except Exception:
+        # Match the module's defensive posture (see _supports_list_models and the
+        # return_exceptions fanouts): a registry hiccup must not 500 GET /v1/models
+        # or /v1/models/discoverable. Fall back to configured-only discovery.
+        logger.warning("Could not enumerate provider metadata for env-based discovery", exc_info=True)
+        return detected
+    for metadata in all_metadata:
         name = metadata.name
-        if name in configured or not metadata.list_models:
+        if name in configured_impls or not metadata.list_models:
             continue
         env_key = metadata.env_key
         if not env_key:
@@ -264,10 +280,13 @@ def _discoverable_instances(config: GatewayConfig) -> list[str]:
 
     Configured instances first, then any-llm providers made discoverable by an
     env var alone (see ``_env_provider_instances``), so GET /v1/models matches
-    what completion routing can actually reach.
+    what completion routing can actually reach. Env detection is deduplicated
+    against the *implementations* the configured instances resolve to, so a
+    custom-named instance is never shadowed by a bare env-detected duplicate.
     """
     configured = list(config.providers.keys())
-    return configured + _env_provider_instances(set(configured))
+    configured_impls = {config.provider_instance_type(instance) for instance in configured}
+    return configured + _env_provider_instances(configured_impls)
 
 
 def _declared_models(config: GatewayConfig, instance: str) -> list[Model]:

--- a/src/gateway/services/model_discovery_service.py
+++ b/src/gateway/services/model_discovery_service.py
@@ -18,6 +18,7 @@ of upstream calls:
 """
 
 import asyncio
+import os
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
@@ -220,6 +221,53 @@ def _supports_list_models(provider_name: str) -> bool:
         return False
 
 
+def _env_provider_instances(configured: set[str]) -> list[str]:
+    """any-llm provider implementations made callable by their credential env var.
+
+    Completion routing works for any any-llm provider once its native credential
+    env var is set: ``get_provider_kwargs`` returns ``{}`` for a provider absent
+    from ``config.providers``, so any-llm reads the env var directly. Discovery
+    would otherwise only see ``config.providers``, so such a provider is callable
+    yet missing from GET /v1/models. This closes that gap by treating a provider
+    whose credential env var is present as discoverable under its implementation
+    name, which is exactly the request selector ``<impl>:<model>`` that routing
+    resolves.
+
+    Only providers that support live model listing are included; one that cannot
+    list models would just error out and be dropped from the catalog. Providers
+    already in ``configured`` are skipped so a named instance is neither shadowed
+    nor duplicated.
+    """
+    detected: list[str] = []
+    for metadata in AnyLLM.get_all_provider_metadata():
+        name = metadata.name
+        if name in configured or not metadata.list_models:
+            continue
+        env_key = metadata.env_key
+        if not env_key:
+            continue
+        # ENV_API_KEY_NAME may name interchangeable alternatives separated by "/"
+        # (e.g. gemini's "GEMINI_API_KEY/GOOGLE_API_KEY"); any one present is
+        # enough. Compound descriptions ("AWS_ACCESS_KEY_ID and
+        # AWS_SECRET_ACCESS_KEY") and the literal "None" are not real single
+        # variable names and simply never match os.environ.
+        candidates = (part.strip() for part in env_key.split("/"))
+        if any(part and part in os.environ for part in candidates):
+            detected.append(name)
+    return detected
+
+
+def _discoverable_instances(config: GatewayConfig) -> list[str]:
+    """Instance names to run discovery for.
+
+    Configured instances first, then any-llm providers made discoverable by an
+    env var alone (see ``_env_provider_instances``), so GET /v1/models matches
+    what completion routing can actually reach.
+    """
+    configured = list(config.providers.keys())
+    return configured + _env_provider_instances(set(configured))
+
+
 def _declared_models(config: GatewayConfig, instance: str) -> list[Model]:
     """Build Model rows from an instance's declared ``models:`` list.
 
@@ -409,8 +457,10 @@ async def discover_models_with_status(config: GatewayConfig) -> list[ProviderDis
     Deliberately not gated on ``config.model_discovery``: that flag governs what
     GET /v1/models publishes to API callers, and an operator who curates that
     listing still has to be able to see what their own credentials can reach.
+    Includes providers made callable by an env var alone, so this operator view
+    agrees with completion routing and with GET /v1/models.
     """
-    instances = list(config.providers)
+    instances = _discoverable_instances(config)
     # return_exceptions so one provider that somehow escapes _discover_uncached
     # cannot 500 the whole operator listing (this route awaits with no guard);
     # surface it as a per-provider error instead. Real cancellation still bubbles.
@@ -434,7 +484,11 @@ async def discover_all_models(
     config: GatewayConfig,
     provider_filter: str | None = None,
 ) -> list[tuple[str, Model]]:
-    """Discover models from configured providers with caching.
+    """Discover models from discoverable providers with caching.
+
+    Discoverable providers are the configured instances plus any-llm providers
+    made callable by an env var alone (see ``_discoverable_instances``), so the
+    catalog matches what completion routing can actually reach.
 
     Args:
         config: Gateway configuration with provider credentials.
@@ -445,10 +499,11 @@ async def discover_all_models(
         from the configured provider key rather than relying on ``owned_by``.
 
     """
+    discoverable = _discoverable_instances(config)
     if provider_filter:
-        instances = [provider_filter] if provider_filter in config.providers else []
+        instances = [provider_filter] if provider_filter in discoverable else []
     else:
-        instances = list(config.providers.keys())
+        instances = discoverable
 
     # Each instance goes through the shared cache + single-flight path, so a
     # failing provider is dialed at most once per negative-TTL window and the

--- a/src/gateway/services/model_discovery_service.py
+++ b/src/gateway/services/model_discovery_service.py
@@ -266,11 +266,11 @@ def _env_provider_instances(configured_impls: set[str]) -> list[str]:
         # (e.g. gemini's "GEMINI_API_KEY/GOOGLE_API_KEY"); any one set is enough.
         # Compound descriptions ("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY")
         # and the literal "None" are not real single variable names and simply
-        # never match os.environ. A blank value (common from container
-        # templating) is treated as unset, so it does not add a provider that
-        # would only fail to authenticate.
+        # never match os.environ. A blank or whitespace-only value (common from
+        # container templating) is treated as unset, so it does not add a provider
+        # that would only fail to authenticate.
         candidates = (part.strip() for part in env_key.split("/"))
-        if any(part and os.environ.get(part) for part in candidates):
+        if any(part and os.environ.get(part, "").strip() for part in candidates):
             detected.append(name)
     return detected
 

--- a/src/gateway/services/model_discovery_service.py
+++ b/src/gateway/services/model_discovery_service.py
@@ -244,7 +244,7 @@ def _env_provider_instances(configured_impls: set[str]) -> list[str]:
     A keyless local provider (``ollama``/``llamacpp``/``llamafile``, whose
     ``env_key`` is absent) has no credential signal to detect and so is not
     surfaced here; discovering it would mean dialing a fixed localhost endpoint on
-    spec. That narrow callable-but-undiscoverable case is tracked separately.
+    spec. That narrow callable-but-undiscoverable case is tracked in issue #389.
     """
     detected: list[str] = []
     try:

--- a/src/gateway/services/model_discovery_service.py
+++ b/src/gateway/services/model_discovery_service.py
@@ -247,12 +247,14 @@ def _env_provider_instances(configured: set[str]) -> list[str]:
         if not env_key:
             continue
         # ENV_API_KEY_NAME may name interchangeable alternatives separated by "/"
-        # (e.g. gemini's "GEMINI_API_KEY/GOOGLE_API_KEY"); any one present is
-        # enough. Compound descriptions ("AWS_ACCESS_KEY_ID and
-        # AWS_SECRET_ACCESS_KEY") and the literal "None" are not real single
-        # variable names and simply never match os.environ.
+        # (e.g. gemini's "GEMINI_API_KEY/GOOGLE_API_KEY"); any one set is enough.
+        # Compound descriptions ("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY")
+        # and the literal "None" are not real single variable names and simply
+        # never match os.environ. A blank value (common from container
+        # templating) is treated as unset, so it does not add a provider that
+        # would only fail to authenticate.
         candidates = (part.strip() for part in env_key.split("/"))
-        if any(part and part in os.environ for part in candidates):
+        if any(part and os.environ.get(part) for part in candidates):
             detected.append(name)
     return detected
 

--- a/tests/integration/test_config_env_loading.py
+++ b/tests/integration/test_config_env_loading.py
@@ -1,5 +1,6 @@
 import base64
 import os
+from collections.abc import Iterator
 from pathlib import Path
 from unittest import mock
 
@@ -9,6 +10,21 @@ import gateway.core.config as config_module
 from gateway.core.config import load_config
 from gateway.core.env import otari_env
 from gateway.services.url_safety import UnsafeURLError, validate_mcp_url, validate_outbound_fetch_url
+
+
+@pytest.fixture(autouse=True)
+def _restore_environ() -> Iterator[None]:
+    """Restore ``os.environ`` after each test in this module.
+
+    Several tests call ``load_config()``, which loads a ``.env`` via python-dotenv
+    into the process environment. Those writes persist past the test (monkeypatch
+    only reverts a key the test itself touched first), so a provider credential
+    like ``ANTHROPIC_API_KEY`` would otherwise leak into later tests. That now
+    matters because model discovery treats a provider whose credential env var is
+    set as discoverable.
+    """
+    with mock.patch.dict(os.environ, clear=False):
+        yield
 
 
 def test_load_config_loads_provider_env_vars_from_dotenv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/integration/test_model_discovery.py
+++ b/tests/integration/test_model_discovery.py
@@ -138,6 +138,57 @@ def test_list_models_with_discovery(
     assert "openai:gpt-4o-mini" in ids
 
 
+def test_list_models_includes_env_only_provider(
+    postgres_url: str,
+    discovery_master_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provider callable via its env var alone appears in GET /v1/models (issue #221).
+
+    Setting only ANTHROPIC_API_KEY makes ``anthropic:<model>`` callable for
+    completions (get_provider_kwargs returns {} and any-llm reads the env var),
+    so discovery must list it too even though ``anthropic`` is not in
+    ``config.providers``.
+    """
+    from any_llm.types.model import Model
+
+    # anthropic is NOT configured; only its credential env var is present.
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+    config = GatewayConfig(
+        database_url=postgres_url,
+        master_key="test-master-key",
+        host="127.0.0.1",
+        port=8000,
+        auto_migrate=False,
+        model_discovery=True,
+        model_cache_ttl_seconds=300,
+        providers={},
+    )
+
+    async def fake_alist(provider: Any, **kwargs: Any) -> list[Model]:
+        if provider.value == "anthropic":
+            return [Model(**_make_openai_model("claude-3-5-sonnet", owned_by="anthropic"))]
+        return []
+
+    get_model_cache().clear()
+    client_gen = _make_client(config)
+    client = next(client_gen)
+    try:
+        with (
+            patch("gateway.services.model_discovery_service._supports_list_models", return_value=True),
+            patch("gateway.services.model_discovery_service.alist_models", side_effect=fake_alist),
+        ):
+            resp = client.get("/v1/models", headers=discovery_master_header)
+    finally:
+        client_gen.close()
+
+    assert resp.status_code == 200
+    ids = [m["id"] for m in resp.json()["data"]]
+    assert "anthropic:claude-3-5-sonnet" in ids
+
+
 def test_list_models_discovery_disabled(
     no_discovery_client: TestClient,
     discovery_master_header: dict[str, str],

--- a/tests/unit/test_gateway_model_discovery.py
+++ b/tests/unit/test_gateway_model_discovery.py
@@ -21,6 +21,23 @@ from gateway.services.model_discovery_service import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _no_env_providers() -> Any:
+    """Pin these tests to configured-provider discovery only.
+
+    Discovery now also picks up any-llm providers made callable by an env var
+    alone. The runner's ambient environment (e.g. a real ``OPENAI_API_KEY``)
+    would otherwise leak extra instances into these configured-provider
+    assertions. Env-based detection is covered in
+    ``test_model_discovery_env_providers``.
+    """
+    with patch(
+        "gateway.services.model_discovery_service._env_provider_instances",
+        return_value=[],
+    ):
+        yield
+
+
 def _make_model(model_id: str, owned_by: str = "openai", created: int = 1700000000) -> Model:
     """Create a minimal Model instance for testing."""
     return Model(id=model_id, object="model", created=created, owned_by=owned_by)

--- a/tests/unit/test_model_discovery_env_providers.py
+++ b/tests/unit/test_model_discovery_env_providers.py
@@ -36,6 +36,12 @@ class TestEnvProviderInstances:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         assert "anthropic" not in _env_provider_instances(configured=set())
 
+    def test_blank_env_var_is_treated_as_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A blank credential (common from container templating) would only fail to
+        # authenticate, so it must not add the provider.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+        assert "anthropic" not in _env_provider_instances(configured=set())
+
     def test_already_configured_provider_is_not_duplicated(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
         assert "anthropic" not in _env_provider_instances(configured={"anthropic"})

--- a/tests/unit/test_model_discovery_env_providers.py
+++ b/tests/unit/test_model_discovery_env_providers.py
@@ -42,6 +42,12 @@ class TestEnvProviderInstances:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "")
         assert "anthropic" not in _env_provider_instances(configured_impls=set())
 
+    def test_whitespace_only_env_var_is_treated_as_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A whitespace-only value is as unusable as a blank one and must not add
+        # the provider.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "   ")
+        assert "anthropic" not in _env_provider_instances(configured_impls=set())
+
     def test_already_configured_implementation_is_not_duplicated(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
         assert "anthropic" not in _env_provider_instances(configured_impls={"anthropic"})

--- a/tests/unit/test_model_discovery_env_providers.py
+++ b/tests/unit/test_model_discovery_env_providers.py
@@ -30,27 +30,37 @@ def _make_model(model_id: str, owned_by: str, created: int = 1700000000) -> Mode
 class TestEnvProviderInstances:
     def test_detects_provider_with_credential_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
-        assert "anthropic" in _env_provider_instances(configured=set())
+        assert "anthropic" in _env_provider_instances(configured_impls=set())
 
     def test_absent_env_var_is_not_detected(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-        assert "anthropic" not in _env_provider_instances(configured=set())
+        assert "anthropic" not in _env_provider_instances(configured_impls=set())
 
     def test_blank_env_var_is_treated_as_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # A blank credential (common from container templating) would only fail to
         # authenticate, so it must not add the provider.
         monkeypatch.setenv("ANTHROPIC_API_KEY", "")
-        assert "anthropic" not in _env_provider_instances(configured=set())
+        assert "anthropic" not in _env_provider_instances(configured_impls=set())
 
-    def test_already_configured_provider_is_not_duplicated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_already_configured_implementation_is_not_duplicated(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
-        assert "anthropic" not in _env_provider_instances(configured={"anthropic"})
+        assert "anthropic" not in _env_provider_instances(configured_impls={"anthropic"})
 
     def test_accepts_any_of_slash_separated_alternatives(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # gemini's ENV_API_KEY_NAME is "GEMINI_API_KEY/GOOGLE_API_KEY"; either works.
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.setenv("GOOGLE_API_KEY", "goog-test")
-        assert "gemini" in _env_provider_instances(configured=set())
+        assert "gemini" in _env_provider_instances(configured_impls=set())
+
+    def test_registry_failure_falls_back_to_no_env_providers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A metadata-registry hiccup must not raise (it would 500 GET /v1/models);
+        # env detection degrades to configured-only discovery.
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        with patch(
+            "gateway.services.model_discovery_service.AnyLLM.get_all_provider_metadata",
+            side_effect=RuntimeError("registry down"),
+        ):
+            assert _env_provider_instances(configured_impls=set()) == []
 
 
 class TestDiscoverableInstances:
@@ -63,6 +73,21 @@ class TestDiscoverableInstances:
 
         assert instances[0] == "home_lab"
         assert "anthropic" in instances
+
+    def test_custom_instance_of_same_impl_suppresses_env_duplicate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A custom-named anthropic instance plus ANTHROPIC_API_KEY must not also
+        # yield a bare "anthropic": that would dial the same credential twice and
+        # list the same models under two keys.
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        config = GatewayConfig(providers={"my-anthropic": {"provider_type": "anthropic", "api_key": "x"}})
+
+        instances = _discoverable_instances(config)
+
+        assert instances == ["my-anthropic"]
+        assert "anthropic" not in instances
 
     def test_env_detection_can_be_stubbed_out(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")

--- a/tests/unit/test_model_discovery_env_providers.py
+++ b/tests/unit/test_model_discovery_env_providers.py
@@ -1,0 +1,145 @@
+"""Unit tests for env-var-based provider discovery.
+
+Regression coverage for the discovery vs. completion-routing disagreement
+(issue #221): a provider is callable for completions the moment its native
+credential env var is set (``get_provider_kwargs`` returns ``{}`` and any-llm
+reads the env var), but GET /v1/models used to only see ``config.providers``.
+Discovery now also picks up providers made callable by an env var alone.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from any_llm.types.model import Model
+
+from gateway.core.config import GatewayConfig
+from gateway.services.model_discovery_service import (
+    ModelCache,
+    _discoverable_instances,
+    _env_provider_instances,
+    discover_all_models,
+    discover_models_with_status,
+)
+
+
+def _make_model(model_id: str, owned_by: str, created: int = 1700000000) -> Model:
+    return Model(id=model_id, object="model", created=created, owned_by=owned_by)
+
+
+class TestEnvProviderInstances:
+    def test_detects_provider_with_credential_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        assert "anthropic" in _env_provider_instances(configured=set())
+
+    def test_absent_env_var_is_not_detected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert "anthropic" not in _env_provider_instances(configured=set())
+
+    def test_already_configured_provider_is_not_duplicated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        assert "anthropic" not in _env_provider_instances(configured={"anthropic"})
+
+    def test_accepts_any_of_slash_separated_alternatives(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # gemini's ENV_API_KEY_NAME is "GEMINI_API_KEY/GOOGLE_API_KEY"; either works.
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.setenv("GOOGLE_API_KEY", "goog-test")
+        assert "gemini" in _env_provider_instances(configured=set())
+
+
+class TestDiscoverableInstances:
+    def test_configured_come_first_then_env_detected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        config = GatewayConfig(providers={"home_lab": {"provider_type": "openai", "api_key": "x"}})
+
+        instances = _discoverable_instances(config)
+
+        assert instances[0] == "home_lab"
+        assert "anthropic" in instances
+
+    def test_env_detection_can_be_stubbed_out(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        config = GatewayConfig(providers={"openai": {"api_key": "x"}})
+        with patch(
+            "gateway.services.model_discovery_service._env_provider_instances",
+            return_value=[],
+        ):
+            assert _discoverable_instances(config) == ["openai"]
+
+
+class TestEnvProviderDiscovery:
+    """The bug: an env-only provider is callable but missing from the catalog."""
+
+    def _config(self, providers: dict[str, Any] | None = None) -> GatewayConfig:
+        return GatewayConfig(
+            providers=providers or {},
+            model_discovery=True,
+            model_cache_ttl_seconds=300,
+        )
+
+    @pytest.mark.asyncio
+    async def test_env_only_provider_appears_in_discovery(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Only ANTHROPIC_API_KEY is set; anthropic is NOT in config.providers.
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        config = self._config(providers={})
+
+        async def fake_alist(provider: Any, **kwargs: Any) -> list[Model]:
+            if provider.value == "anthropic":
+                return [_make_model("claude-3-5-sonnet", owned_by="anthropic")]
+            return []
+
+        with (
+            patch("gateway.services.model_discovery_service.get_model_cache", return_value=ModelCache()),
+            patch("gateway.services.model_discovery_service._supports_list_models", return_value=True),
+            patch("gateway.services.model_discovery_service.alist_models", side_effect=fake_alist),
+            patch("gateway.services.model_discovery_service.get_provider_kwargs", return_value={}),
+        ):
+            result = await discover_all_models(config)
+
+        assert ("anthropic", result[0][1]) == result[0]
+        assert result[0][1].id == "claude-3-5-sonnet"
+
+    @pytest.mark.asyncio
+    async def test_env_only_provider_honored_by_filter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        config = self._config(providers={})
+
+        with (
+            patch("gateway.services.model_discovery_service.get_model_cache", return_value=ModelCache()),
+            patch("gateway.services.model_discovery_service._supports_list_models", return_value=True),
+            patch(
+                "gateway.services.model_discovery_service.alist_models",
+                new_callable=AsyncMock,
+                return_value=[_make_model("claude-3-5-sonnet", owned_by="anthropic")],
+            ),
+            patch("gateway.services.model_discovery_service.get_provider_kwargs", return_value={}),
+        ):
+            result = await discover_all_models(config, provider_filter="anthropic")
+
+        assert [name for name, _ in result] == ["anthropic"]
+
+    @pytest.mark.asyncio
+    async def test_env_only_provider_appears_in_operator_status(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        config = self._config(providers={})
+
+        with (
+            patch("gateway.services.model_discovery_service.get_model_cache", return_value=ModelCache()),
+            patch("gateway.services.model_discovery_service._supports_list_models", return_value=True),
+            patch(
+                "gateway.services.model_discovery_service.alist_models",
+                new_callable=AsyncMock,
+                return_value=[_make_model("claude-3-5-sonnet", owned_by="anthropic")],
+            ),
+            patch("gateway.services.model_discovery_service.get_provider_kwargs", return_value={}),
+        ):
+            statuses = await discover_models_with_status(config)
+
+        by_provider = {d.provider: d for d in statuses}
+        assert "anthropic" in by_provider
+        assert by_provider["anthropic"].error is None
+        assert [m.id for m in by_provider["anthropic"].models] == ["claude-3-5-sonnet"]


### PR DESCRIPTION
## Description

`/v1/models` discovery and completion routing disagreed on what a "configured provider" is. Completions work for any any-llm provider once its native credential env var is set (`get_provider_kwargs` returns `{}` for a provider absent from `config.providers`, so any-llm reads the env var directly), but model discovery only queried `config.providers`. Setting only `ANTHROPIC_API_KEY` therefore made Anthropic completions work while its models never appeared in `GET /v1/models`, the exact quick path the Railway template recommends.

Discovery now also picks up any-llm providers made callable by an env var alone: a provider whose credential env var is present and that supports live model listing is treated as discoverable under its implementation name (the same `provider:model` selector routing resolves), unless it is already a configured instance. This is wired into both `GET /v1/models` and `GET /v1/models/discoverable` (and the `?provider=` filter), so the two surfaces agree with what completions can reach. Provider-health and the per-instance connection test are untouched; they operate on explicit or configured instances.

Also restores `os.environ` around each test in `test_config_env_loading`, whose python-dotenv loads leaked provider credentials into the process. That was harmless before, but now that discovery is env-aware it polluted an unrelated test; a pre-existing isolation gap the change surfaced.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #221

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (no contract change; `--check` confirms the spec is up to date).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code (Opus 4.8), driven by @njbrake.

**Any additional AI details you'd like to share:**

Implemented and tested end to end by Claude via back-and-forth with @njbrake; the reasoning and decisions are his.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
