### PR TITLE
docs: remove GitHub repository browse link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,6 @@ A few names you'll run into, and how they fit together:
 | **Otari CLI** | Command-line tool for accessing and managing Otari, a thin wrapper over the Python SDK. | [mozilla-ai/otari-cli](https://github.com/mozilla-ai/otari-cli) (`pip install otari-cli`) |
 
 
-> Browse every Otari repository on GitHub with [this filter](https://github.com/orgs/mozilla-ai/repositories?q=otari).
-
-
 ## Quickstart
 
 Get a metered gateway running and make a request in about a minute. No clone, no config file, no database. This is **standalone mode**: Otari runs on your machine and talks to providers with credentials you supply, and you don't need an otari.ai account.


### PR DESCRIPTION
Removed link to browse Otari repositories on GitHub.

## Description
<!-- What does this PR do and why? -->


## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
<!-- e.g. "Fixes #123" -->

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [ ] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**


**Any additional AI details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)
