### PR TITLE
feat(files): add S3-compatible object storage backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,18 @@ ocr = [
     "rapidocr-onnxruntime>=1.3.0",
     "numpy>=1.26.0",
 ]
+# S3-compatible (AWS S3 or MinIO/any S3-compatible endpoint) files backend.
+# boto3 is already present transitively via any-llm-sdk[all] (Bedrock), but
+# this extra is what build_file_store checks for and documents, so the S3
+# backend stays decoupled from that implementation detail.
+s3 = [
+    "boto3>=1.42.0",
+]
 
 [dependency-groups]
 dev = [
+    "boto3-stubs[s3]",
+    "moto[s3]>=5.0.0",
     "mypy",
     "pytest>=9.0.3,<10",
     "pytest-asyncio>=0.26.0",

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -357,11 +357,30 @@ class GatewayConfig(BaseSettings):
     )
     files_backend: str = Field(
         default="local",
-        description="Blob backend for uploaded file bytes: 'local' (filesystem). Future: 's3', 'gcs'.",
+        description="Blob backend for uploaded file bytes: 'local' (filesystem) or 's3'. Future: 'gcs'.",
     )
     files_local_dir: str = Field(
         default="./otari-files",
         description="Directory for the 'local' files backend to store uploaded bytes.",
+    )
+    files_s3_bucket: str | None = Field(
+        default=None,
+        description="Bucket name for the 's3' files backend. Required when files_backend is 's3'.",
+    )
+    files_s3_endpoint_url: str | None = Field(
+        default=None,
+        description=(
+            "S3-compatible endpoint URL for the 's3' files backend, e.g. a self-hosted MinIO "
+            "instance. None uses AWS S3's default endpoint resolution (region-based)."
+        ),
+    )
+    files_s3_region: str | None = Field(
+        default=None,
+        description=(
+            "AWS region for the 's3' files backend. Most self-hosted S3-compatible stores "
+            "(e.g. MinIO) ignore this; it still must resolve to some value, so it defaults to "
+            "'us-east-1' when unset."
+        ),
     )
     files_max_bytes: int = Field(
         default=512 * 1024 * 1024,

--- a/src/gateway/services/file_store.py
+++ b/src/gateway/services/file_store.py
@@ -19,8 +19,8 @@ from __future__ import annotations
 
 import asyncio
 import tempfile
-from collections.abc import AsyncGenerator, AsyncIterator
-from contextlib import asynccontextmanager
+from collections.abc import AsyncGenerator, AsyncIterator, Iterator
+from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Protocol, runtime_checkable
 
@@ -210,6 +210,35 @@ class LocalDirFileStore:
         await asyncio.to_thread(_unlink)
 
 
+@contextmanager
+def _translate_s3_errors(storage_ref: str) -> Iterator[None]:
+    """Re-raise boto3/botocore failures as the ``OSError`` family callers expect.
+
+    The local backend surfaces storage failures as ``OSError`` (a missing blob
+    is ``FileNotFoundError``), and the route/service callers catch ``OSError``
+    accordingly: the download route maps it to a clean 500 and the delete
+    route's best-effort cleanup swallows it so a committed soft-delete never
+    becomes a 500. Those callers live in the default local-only install and
+    cannot import ``botocore`` (it ships behind the optional ``otari[s3]``
+    extra), so translating here keeps them backend-agnostic. A missing object
+    maps to ``FileNotFoundError`` to mirror the local backend; every other S3
+    failure maps to ``OSError``.
+    """
+    from botocore.exceptions import BotoCoreError, ClientError
+
+    try:
+        yield
+    except ClientError as exc:
+        code = str(exc.response.get("Error", {}).get("Code", ""))
+        if code in {"NoSuchKey", "NoSuchBucket", "404", "NotFound"}:
+            raise FileNotFoundError(storage_ref) from exc
+        msg = f"S3 operation failed for {storage_ref!r}: {exc}"
+        raise OSError(msg) from exc
+    except BotoCoreError as exc:
+        msg = f"S3 operation failed for {storage_ref!r}: {exc}"
+        raise OSError(msg) from exc
+
+
 class S3FileStore:
     """S3-compatible object-storage :class:`FileStore` (AWS S3, MinIO, or any
     S3 API-compatible endpoint via ``endpoint_url``).
@@ -258,7 +287,8 @@ class S3FileStore:
             finally:
                 body.close()
 
-        return await asyncio.to_thread(_get)
+        with _translate_s3_errors(storage_ref):
+            return await asyncio.to_thread(_get)
 
     async def put_stream(self, file_id: str, chunks: AsyncIterator[bytes]) -> tuple[str, int]:
         key = _shard_key(file_id)
@@ -320,7 +350,8 @@ class S3FileStore:
         return key, total
 
     async def get_stream(self, storage_ref: str) -> AsyncGenerator[bytes, None]:
-        response = await asyncio.to_thread(self._client.get_object, Bucket=self._bucket, Key=storage_ref)
+        with _translate_s3_errors(storage_ref):
+            response = await asyncio.to_thread(self._client.get_object, Bucket=self._bucket, Key=storage_ref)
         body = response["Body"]
         try:
             while chunk := await asyncio.to_thread(body.read, _STREAM_CHUNK_BYTES):
@@ -332,7 +363,8 @@ class S3FileStore:
                 logger.warning("get_stream: failed to close S3 response body for %s: %s", storage_ref, close_exc)
 
     async def delete(self, storage_ref: str) -> None:
-        await asyncio.to_thread(self._client.delete_object, Bucket=self._bucket, Key=storage_ref)
+        with _translate_s3_errors(storage_ref):
+            await asyncio.to_thread(self._client.delete_object, Bucket=self._bucket, Key=storage_ref)
 
 
 def build_file_store(config: GatewayConfig) -> FileStore:

--- a/src/gateway/services/file_store.py
+++ b/src/gateway/services/file_store.py
@@ -34,7 +34,9 @@ _STREAM_CHUNK_BYTES = 1024 * 1024
 # Incoming upload chunks spool here before handing the whole thing to boto3's
 # upload_fileobj (sync boto3 has no streaming-from-async-iterator primitive).
 # Small uploads never touch disk; past this threshold SpooledTemporaryFile
-# transparently rolls over to a real temp file, so memory stays bounded.
+# transparently rolls over to a real temp file, so memory stays bounded. This
+# is a per-upload budget, not a global one: N concurrent put_stream calls can
+# hold up to N * this many bytes in memory before any of them spill to disk.
 _SPOOL_MAX_MEMORY_BYTES = 10 * 1024 * 1024
 
 
@@ -218,6 +220,11 @@ class S3FileStore:
     (see #156). Credentials resolve through boto3's standard chain
     (environment variables, ``~/.aws/credentials``, IAM role); this class
     never handles them directly.
+
+    Objects are written with no ``ServerSideEncryption`` set, so they inherit
+    whatever default encryption (or lack of it) the bucket itself is
+    configured with; enabling encryption at rest is the bucket operator's
+    responsibility, not something this class enforces.
     """
 
     def __init__(self, bucket: str, endpoint_url: str | None, region: str | None) -> None:
@@ -231,11 +238,18 @@ class S3FileStore:
         self._client: S3Client = boto3.client("s3", endpoint_url=endpoint_url, region_name=region or "us-east-1")
 
     async def put(self, file_id: str, data: bytes) -> str:
+        # Intentionally mirrors LocalDirFileStore.put: the caller already has
+        # the full blob in memory here, same as the local backend's put, so
+        # this isn't a new memory regression (put_stream is the streaming
+        # path for both). Not a priority to stream, since files_max_bytes
+        # already bounds the worst case the same way it does for local.
         key = _shard_key(file_id)
         await asyncio.to_thread(self._client.put_object, Bucket=self._bucket, Key=key, Body=data)
         return key
 
     async def get(self, storage_ref: str) -> bytes:
+        # Same intentional symmetry with LocalDirFileStore.get: full-buffer by
+        # design (get_stream is the streaming download path).
         def _get() -> bytes:
             response = self._client.get_object(Bucket=self._bucket, Key=storage_ref)
             body = response["Body"]
@@ -264,7 +278,7 @@ class S3FileStore:
                 # Task lets us find out what actually happened even after
                 # being cancelled, instead of assuming "cancelled" means
                 # "nothing was uploaded".
-                upload_task = asyncio.ensure_future(
+                upload_task = asyncio.create_task(
                     asyncio.to_thread(self._client.upload_fileobj, spool, self._bucket, key)
                 )
                 # upload_fileobj manages multipart upload internally,

--- a/src/gateway/services/file_store.py
+++ b/src/gateway/services/file_store.py
@@ -238,7 +238,11 @@ class S3FileStore:
     async def get(self, storage_ref: str) -> bytes:
         def _get() -> bytes:
             response = self._client.get_object(Bucket=self._bucket, Key=storage_ref)
-            return response["Body"].read()
+            body = response["Body"]
+            try:
+                return body.read()
+            finally:
+                body.close()
 
         return await asyncio.to_thread(_get)
 
@@ -246,15 +250,51 @@ class S3FileStore:
         key = _shard_key(file_id)
         total = 0
         spool: IO[bytes] = tempfile.SpooledTemporaryFile(max_size=_SPOOL_MAX_MEMORY_BYTES)
+        upload_task: asyncio.Task[None] | None = None
         try:
-            async for chunk in chunks:
-                total += len(chunk)
-                await asyncio.to_thread(spool.write, chunk)
-            await asyncio.to_thread(spool.seek, 0)
-            # upload_fileobj manages multipart upload internally, including
-            # aborting an incomplete multipart upload if it fails partway, so
-            # no manual abort_multipart_upload is needed here.
-            await asyncio.to_thread(self._client.upload_fileobj, spool, self._bucket, key)
+            try:
+                async for chunk in chunks:
+                    total += len(chunk)
+                    await asyncio.to_thread(spool.write, chunk)
+                await asyncio.to_thread(spool.seek, 0)
+                # upload_fileobj runs in a worker thread and, once started,
+                # keeps running there even if *we* get cancelled while
+                # awaiting it: to_thread's cancellation only detaches us from
+                # waiting, it does not stop the thread. Wrapping it in a real
+                # Task lets us find out what actually happened even after
+                # being cancelled, instead of assuming "cancelled" means
+                # "nothing was uploaded".
+                upload_task = asyncio.ensure_future(
+                    asyncio.to_thread(self._client.upload_fileobj, spool, self._bucket, key)
+                )
+                # upload_fileobj manages multipart upload internally,
+                # including aborting an incomplete multipart upload if it
+                # fails partway, so no manual abort_multipart_upload is
+                # needed here.
+                await asyncio.shield(upload_task)
+            except BaseException:
+                if upload_task is not None:
+                    try:
+                        # Our await above may have been cancelled while the
+                        # upload was still running in its thread; shield
+                        # keeps upload_task itself uncancelled, so wait for
+                        # it to actually settle and see how it really
+                        # turned out.
+                        await asyncio.shield(upload_task)
+                    except Exception:
+                        pass  # the upload itself failed; s3transfer already aborts multipart on its own failure
+                    else:
+                        # It finished successfully despite the cancellation:
+                        # the object really landed in S3 with nothing that
+                        # will ever reference or clean it up, so remove it
+                        # ourselves.
+                        try:
+                            await asyncio.shield(
+                                asyncio.to_thread(self._client.delete_object, Bucket=self._bucket, Key=key)
+                            )
+                        except Exception as cleanup_exc:
+                            logger.warning("put_stream: failed to remove orphaned upload %s: %s", key, cleanup_exc)
+                raise
         finally:
             # Shielded like _open_handle: this runs during unwind on a
             # cancelled upload too, and an unshielded await here could be cut

--- a/src/gateway/services/file_store.py
+++ b/src/gateway/services/file_store.py
@@ -18,15 +18,37 @@ can implement the same :class:`FileStore` protocol without touching callers.
 from __future__ import annotations
 
 import asyncio
+import tempfile
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import IO, Protocol, runtime_checkable
+from typing import IO, TYPE_CHECKING, Protocol, runtime_checkable
 
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+
 _STREAM_CHUNK_BYTES = 1024 * 1024
+# Incoming upload chunks spool here before handing the whole thing to boto3's
+# upload_fileobj (sync boto3 has no streaming-from-async-iterator primitive).
+# Small uploads never touch disk; past this threshold SpooledTemporaryFile
+# transparently rolls over to a real temp file, so memory stays bounded.
+_SPOOL_MAX_MEMORY_BYTES = 10 * 1024 * 1024
+
+
+def _shard_key(file_id: str) -> str:
+    """Shard ``file_id`` into 256 buckets by the first two hex characters.
+
+    Shared by every backend that benefits from not dumping every object into
+    one flat namespace (local avoids pathologically large directories; S3
+    avoids a hot-prefix pattern under high request rates).
+    """
+    # file ids look like ``file-<hex>``; shard on the first two hex chars.
+    token = file_id.split("-", 1)[-1] or file_id
+    prefix = (token[:2] or "00").lower()
+    return f"{prefix}/{file_id}"
 
 
 @asynccontextmanager
@@ -96,12 +118,6 @@ class LocalDirFileStore:
     def __init__(self, root: str) -> None:
         self._root = Path(root)
 
-    def _shard(self, file_id: str) -> str:
-        # file ids look like ``file-<hex>``; shard on the first two hex chars.
-        token = file_id.split("-", 1)[-1] or file_id
-        prefix = (token[:2] or "00").lower()
-        return f"{prefix}/{file_id}"
-
     def _resolve(self, storage_ref: str) -> Path:
         """Resolve ``storage_ref`` under the root, rejecting any escape.
 
@@ -117,7 +133,7 @@ class LocalDirFileStore:
         return path
 
     async def put(self, file_id: str, data: bytes) -> str:
-        ref = self._shard(file_id)
+        ref = _shard_key(file_id)
         path = self._resolve(ref)
 
         def _write() -> None:
@@ -132,7 +148,7 @@ class LocalDirFileStore:
         return await asyncio.to_thread(path.read_bytes)
 
     async def put_stream(self, file_id: str, chunks: AsyncIterator[bytes]) -> tuple[str, int]:
-        ref = self._shard(file_id)
+        ref = _shard_key(file_id)
         path = self._resolve(ref)
 
         def _mkparent() -> None:
@@ -192,10 +208,88 @@ class LocalDirFileStore:
         await asyncio.to_thread(_unlink)
 
 
+class S3FileStore:
+    """S3-compatible object-storage :class:`FileStore` (AWS S3, MinIO, or any
+    S3 API-compatible endpoint via ``endpoint_url``).
+
+    Uses the synchronous ``boto3`` client via :func:`asyncio.to_thread` rather
+    than ``aioboto3``: the latter pins an older ``botocore`` range that
+    conflicts with the version already required elsewhere for Bedrock support
+    (see #156). Credentials resolve through boto3's standard chain
+    (environment variables, ``~/.aws/credentials``, IAM role); this class
+    never handles them directly.
+    """
+
+    def __init__(self, bucket: str, endpoint_url: str | None, region: str | None) -> None:
+        try:
+            import boto3
+        except ImportError as exc:
+            msg = "S3FileStore requires boto3. Install it with: pip install otari[s3]"
+            raise ImportError(msg) from exc
+
+        self._bucket = bucket
+        self._client: S3Client = boto3.client("s3", endpoint_url=endpoint_url, region_name=region or "us-east-1")
+
+    async def put(self, file_id: str, data: bytes) -> str:
+        key = _shard_key(file_id)
+        await asyncio.to_thread(self._client.put_object, Bucket=self._bucket, Key=key, Body=data)
+        return key
+
+    async def get(self, storage_ref: str) -> bytes:
+        def _get() -> bytes:
+            response = self._client.get_object(Bucket=self._bucket, Key=storage_ref)
+            return response["Body"].read()
+
+        return await asyncio.to_thread(_get)
+
+    async def put_stream(self, file_id: str, chunks: AsyncIterator[bytes]) -> tuple[str, int]:
+        key = _shard_key(file_id)
+        total = 0
+        spool: IO[bytes] = tempfile.SpooledTemporaryFile(max_size=_SPOOL_MAX_MEMORY_BYTES)
+        try:
+            async for chunk in chunks:
+                total += len(chunk)
+                await asyncio.to_thread(spool.write, chunk)
+            await asyncio.to_thread(spool.seek, 0)
+            # upload_fileobj manages multipart upload internally, including
+            # aborting an incomplete multipart upload if it fails partway, so
+            # no manual abort_multipart_upload is needed here.
+            await asyncio.to_thread(self._client.upload_fileobj, spool, self._bucket, key)
+        finally:
+            # Shielded like _open_handle: this runs during unwind on a
+            # cancelled upload too, and an unshielded await here could be cut
+            # off by a repeated cancel() before the spool file actually closes.
+            try:
+                await asyncio.shield(asyncio.to_thread(spool.close))
+            except Exception as cleanup_exc:
+                logger.warning("put_stream: failed to close spool file for %s: %s", key, cleanup_exc)
+        return key, total
+
+    async def get_stream(self, storage_ref: str) -> AsyncGenerator[bytes, None]:
+        response = await asyncio.to_thread(self._client.get_object, Bucket=self._bucket, Key=storage_ref)
+        body = response["Body"]
+        try:
+            while chunk := await asyncio.to_thread(body.read, _STREAM_CHUNK_BYTES):
+                yield chunk
+        finally:
+            try:
+                await asyncio.shield(asyncio.to_thread(body.close))
+            except Exception as close_exc:
+                logger.warning("get_stream: failed to close S3 response body for %s: %s", storage_ref, close_exc)
+
+    async def delete(self, storage_ref: str) -> None:
+        await asyncio.to_thread(self._client.delete_object, Bucket=self._bucket, Key=storage_ref)
+
+
 def build_file_store(config: GatewayConfig) -> FileStore:
     """Construct the configured :class:`FileStore` backend."""
     backend = config.files_backend.strip().lower()
     if backend == "local":
         return LocalDirFileStore(config.files_local_dir)
-    msg = f"Unsupported files_backend: {config.files_backend!r} (supported: 'local')"
+    if backend == "s3":
+        if not config.files_s3_bucket:
+            msg = "files_s3_bucket is required when files_backend is 's3'"
+            raise ValueError(msg)
+        return S3FileStore(config.files_s3_bucket, config.files_s3_endpoint_url, config.files_s3_region)
+    msg = f"Unsupported files_backend: {config.files_backend!r} (supported: 'local', 's3')"
     raise ValueError(msg)

--- a/tests/unit/test_file_store.py
+++ b/tests/unit/test_file_store.py
@@ -185,3 +185,16 @@ def test_build_file_store_rejects_unknown_backend() -> None:
     config = GatewayConfig(files_backend="ceph")
     with pytest.raises(ValueError, match="Unsupported files_backend"):
         build_file_store(config)
+
+
+def test_build_file_store_s3_requires_bucket() -> None:
+    config = GatewayConfig(files_backend="s3", files_s3_bucket=None)
+    with pytest.raises(ValueError, match="files_s3_bucket is required"):
+        build_file_store(config)
+
+
+def test_build_file_store_s3() -> None:
+    from gateway.services.file_store import S3FileStore
+
+    config = GatewayConfig(files_backend="s3", files_s3_bucket="my-bucket")
+    assert isinstance(build_file_store(config), S3FileStore)

--- a/tests/unit/test_s3_file_store.py
+++ b/tests/unit/test_s3_file_store.py
@@ -1,13 +1,11 @@
-"""Unit tests for the S3-compatible file store, mocked with moto (no Docker/MinIO needed).
-
-Real MinIO-via-testcontainers integration coverage is a separate concern (see
-tests/integration/), same split as LocalDirFileStore's unit vs integration tests.
-"""
+"""Unit tests for the S3-compatible file store, mocked with moto."""
 
 from __future__ import annotations
 
 import asyncio
+import threading
 from collections.abc import AsyncIterator, Generator
+from typing import IO
 
 import boto3
 import pytest
@@ -137,3 +135,42 @@ async def test_put_stream_aborts_multipart_upload_on_mid_upload_failure(
 
     lingering = await asyncio.to_thread(client.list_multipart_uploads, Bucket=_BUCKET)
     assert lingering.get("Uploads", []) == []
+
+
+@pytest.mark.asyncio
+async def test_put_stream_removes_orphaned_upload_when_cancelled_after_success(
+    s3_store: S3FileStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """upload_fileobj runs in a worker thread that to_thread cannot interrupt:
+    if *our* await gets cancelled while that thread is still working, the
+    upload can still complete successfully afterward. Confirms put_stream
+    notices that and deletes the now-orphaned object instead of silently
+    leaving it in the bucket with nothing that will ever reference it.
+
+    Uses threading.Event gates instead of sleep-based timing so the sequence
+    (upload thread actually started -> cancel -> release it to finish) is
+    deterministic rather than a timing guess.
+    """
+    client = s3_store._client  # noqa: SLF001 - need the raw client to patch upload_fileobj
+    original_upload_fileobj = client.upload_fileobj
+
+    upload_started = threading.Event()
+    release_upload = threading.Event()
+
+    def _gated_upload_fileobj(fileobj: IO[bytes], bucket: str, key: str) -> None:
+        upload_started.set()
+        release_upload.wait(timeout=5)
+        original_upload_fileobj(fileobj, bucket, key)
+
+    monkeypatch.setattr(client, "upload_fileobj", _gated_upload_fileobj)
+
+    task = asyncio.ensure_future(s3_store.put_stream("file-orphancheck01", _iter([b"data"])))
+    await asyncio.to_thread(upload_started.wait, 5)  # don't cancel until the upload thread is truly running
+    task.cancel()
+    release_upload.set()  # let the (already-committed-to) background upload finish
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    listing = await asyncio.to_thread(client.list_objects_v2, Bucket=_BUCKET, Prefix="or/")
+    assert listing.get("KeyCount", 0) == 0

--- a/tests/unit/test_s3_file_store.py
+++ b/tests/unit/test_s3_file_store.py
@@ -68,13 +68,37 @@ async def test_get_stream_yields_all_bytes(s3_store: S3FileStore) -> None:
 
 @pytest.mark.asyncio
 async def test_delete_removes_object(s3_store: S3FileStore) -> None:
-    from botocore.exceptions import ClientError
-
     ref = await s3_store.put("file-deadbeef", b"data")
     await s3_store.delete(ref)
-    with pytest.raises(ClientError) as exc_info:
+    # S3FileStore translates a missing object into FileNotFoundError, mirroring
+    # the local backend so route callers can keep catching OSError.
+    with pytest.raises(FileNotFoundError):
         await s3_store.get(ref)
-    assert exc_info.value.response.get("Error", {}).get("Code") in {"NoSuchKey", "404", "NotFound"}
+
+
+@pytest.mark.asyncio
+async def test_get_stream_missing_key_raises_file_not_found(s3_store: S3FileStore) -> None:
+    # get_stream is primed by the download route before the OSError handler;
+    # a missing object must surface as FileNotFoundError (an OSError), not a
+    # raw botocore ClientError that would escape that handler.
+    with pytest.raises(FileNotFoundError):
+        async for _ in s3_store.get_stream("no/such-key"):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_delete_failure_raises_oserror(s3_store: S3FileStore, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A non-404 backend failure during delete must map to OSError so the delete
+    # route's best-effort `except OSError` catches it and a committed
+    # soft-delete never turns into a 500.
+    from botocore.exceptions import ClientError
+
+    def _boom(**kwargs: object) -> object:
+        raise ClientError({"Error": {"Code": "AccessDenied", "Message": "nope"}}, "DeleteObject")
+
+    monkeypatch.setattr(s3_store._client, "delete_object", _boom)  # noqa: SLF001 - inject a backend failure
+    with pytest.raises(OSError):  # noqa: PT011 - translated botocore error, message not asserted
+        await s3_store.delete("ab/file-whatever")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_s3_file_store.py
+++ b/tests/unit/test_s3_file_store.py
@@ -1,0 +1,139 @@
+"""Unit tests for the S3-compatible file store, mocked with moto (no Docker/MinIO needed).
+
+Real MinIO-via-testcontainers integration coverage is a separate concern (see
+tests/integration/), same split as LocalDirFileStore's unit vs integration tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Generator
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from gateway.services.file_store import S3FileStore
+
+_BUCKET = "otari-test-bucket"
+
+
+async def _iter(chunks: list[bytes]) -> AsyncIterator[bytes]:
+    for chunk in chunks:
+        yield chunk
+
+
+@pytest.fixture
+def s3_store() -> Generator[S3FileStore, None, None]:
+    with mock_aws():
+        client = boto3.client("s3", region_name="us-east-1")
+        client.create_bucket(Bucket=_BUCKET)
+        yield S3FileStore(bucket=_BUCKET, endpoint_url=None, region="us-east-1")
+
+
+@pytest.mark.asyncio
+async def test_put_get_roundtrip(s3_store: S3FileStore) -> None:
+    ref = await s3_store.put("file-abcdef0123", b"hello bytes")
+    assert await s3_store.get(ref) == b"hello bytes"
+
+
+@pytest.mark.asyncio
+async def test_put_shards_by_prefix(s3_store: S3FileStore) -> None:
+    ref = await s3_store.put("file-ab12cd34", b"x")
+    assert ref == "ab/file-ab12cd34"
+
+
+@pytest.mark.asyncio
+async def test_put_stream_get_roundtrip(s3_store: S3FileStore) -> None:
+    ref, size = await s3_store.put_stream("file-streamtest01", _iter([b"hello ", b"stream", b"ed bytes"]))
+    assert size == len(b"hello streamed bytes")
+    assert await s3_store.get(ref) == b"hello streamed bytes"
+
+
+@pytest.mark.asyncio
+async def test_put_stream_handles_empty_chunks(s3_store: S3FileStore) -> None:
+    ref, size = await s3_store.put_stream("file-emptystream1", _iter([]))
+    assert size == 0
+    assert await s3_store.get(ref) == b""
+
+
+@pytest.mark.asyncio
+async def test_get_stream_yields_all_bytes(s3_store: S3FileStore) -> None:
+    payload = b"x" * (3 * 1024 * 1024 + 17)  # spans multiple 1 MiB read chunks
+    ref = await s3_store.put("file-bigstream0001", payload)
+
+    collected = bytearray()
+    async for chunk in s3_store.get_stream(ref):
+        collected.extend(chunk)
+    assert bytes(collected) == payload
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_object(s3_store: S3FileStore) -> None:
+    ref = await s3_store.put("file-deadbeef", b"data")
+    await s3_store.delete(ref)
+    with pytest.raises(Exception, match="Not Found|NoSuchKey|404"):
+        await s3_store.get(ref)
+
+
+@pytest.mark.asyncio
+async def test_delete_is_idempotent(s3_store: S3FileStore) -> None:
+    ref = await s3_store.put("file-deadbeef", b"data")
+    await s3_store.delete(ref)
+    # S3 DeleteObject is idempotent by design: deleting an absent key is not an error.
+    await s3_store.delete(ref)
+
+
+@pytest.mark.asyncio
+async def test_put_stream_does_not_upload_on_failure_before_upload_starts(s3_store: S3FileStore) -> None:
+    """If the chunk source fails while we're still spooling, nothing has been
+    sent to S3 yet (upload_fileobj hasn't been called), so there's nothing to
+    abort, just the local spool file to close (covered by the shielded finally).
+    """
+
+    async def _failing_chunks() -> AsyncIterator[bytes]:
+        yield b"partial data that should not survive"
+        msg = "simulated upstream failure mid-stream"
+        raise RuntimeError(msg)
+
+    with pytest.raises(RuntimeError, match="simulated upstream failure"):
+        await s3_store.put_stream("file-failmidstream", _failing_chunks())
+
+    client = s3_store._client  # noqa: SLF001 - inspecting internal state to assert nothing was uploaded
+    listing = await asyncio.to_thread(client.list_objects_v2, Bucket=_BUCKET, Prefix="fa/")
+    assert listing.get("KeyCount", 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_put_stream_aborts_multipart_upload_on_mid_upload_failure(
+    s3_store: S3FileStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verifies the claim made in the #156 design comment: upload_fileobj's
+    multipart handling aborts an incomplete multipart upload on failure, so
+    S3FileStore doesn't need to call abort_multipart_upload itself.
+
+    Forces multipart (default threshold is 8 MiB) and injects a failure on the
+    second part upload to simulate a network error partway through.
+    """
+    client = s3_store._client  # noqa: SLF001 - need the raw client to patch upload_part
+    original_upload_part = client.upload_part
+
+    call_count = {"value": 0}
+
+    def _flaky_upload_part(**kwargs: object) -> object:
+        call_count["value"] += 1
+        if call_count["value"] == 2:
+            msg = "simulated network failure on part 2"
+            raise RuntimeError(msg)
+        return original_upload_part(**kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(client, "upload_part", _flaky_upload_part)
+
+    payload = b"y" * (9 * 1024 * 1024)  # > 8 MiB default multipart_threshold
+    with pytest.raises(RuntimeError, match="simulated network failure"):
+        await s3_store.put_stream("file-multipartfail1", _iter([payload]))
+
+    assert call_count["value"] >= 2  # confirms multipart (and our failure point) actually engaged
+
+    lingering = await asyncio.to_thread(client.list_multipart_uploads, Bucket=_BUCKET)
+    assert lingering.get("Uploads", []) == []

--- a/tests/unit/test_s3_file_store.py
+++ b/tests/unit/test_s3_file_store.py
@@ -68,10 +68,13 @@ async def test_get_stream_yields_all_bytes(s3_store: S3FileStore) -> None:
 
 @pytest.mark.asyncio
 async def test_delete_removes_object(s3_store: S3FileStore) -> None:
+    from botocore.exceptions import ClientError
+
     ref = await s3_store.put("file-deadbeef", b"data")
     await s3_store.delete(ref)
-    with pytest.raises(Exception, match="Not Found|NoSuchKey|404"):
+    with pytest.raises(ClientError) as exc_info:
         await s3_store.get(ref)
+    assert exc_info.value.response.get("Error", {}).get("Code") in {"NoSuchKey", "404", "NotFound"}
 
 
 @pytest.mark.asyncio
@@ -165,7 +168,10 @@ async def test_put_stream_removes_orphaned_upload_when_cancelled_after_success(
     monkeypatch.setattr(client, "upload_fileobj", _gated_upload_fileobj)
 
     task = asyncio.ensure_future(s3_store.put_stream("file-orphancheck01", _iter([b"data"])))
-    await asyncio.to_thread(upload_started.wait, 5)  # don't cancel until the upload thread is truly running
+    # Don't cancel until the upload thread is truly running: an ignored
+    # timeout here would let the test proceed anyway, cancelling before the
+    # race it's meant to reproduce even started, silently.
+    assert await asyncio.to_thread(upload_started.wait, 5), "upload thread never started"
     task.cancel()
     release_upload.set()  # let the (already-committed-to) background upload finish
 

--- a/uv.lock
+++ b/uv.lock
@@ -344,6 +344,24 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3-stubs"
+version = "1.43.55"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore-stubs" },
+    { name = "types-s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/cb/687986860a838ab80e80c3bd5fe772eedb551a52cc54d792a12accafc2f0/boto3_stubs-1.43.55.tar.gz", hash = "sha256:a37249dcd19341e42c873025cf33fa82d3f1bac5f708a5a43f01bea064162df7", size = 103222, upload-time = "2026-07-23T19:58:49.637Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/86/723a9c08c8b4217960cbf4c46189cc148415cd5838ec472a514006fdf9ce/boto3_stubs-1.43.55-py3-none-any.whl", hash = "sha256:5ed616c65231a56866cd6a0355c8d9135be0b10cf3f924845ecebac6f5768a9d", size = 70961, upload-time = "2026-07-23T19:58:46.307Z" },
+]
+
+[package.optional-dependencies]
+s3 = [
+    { name = "mypy-boto3-s3" },
+]
+
+[[package]]
 name = "botocore"
 version = "1.42.81"
 source = { registry = "https://pypi.org/simple" }
@@ -355,6 +373,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fa/5f/b0bb9a8768398fb131e1fe722c9cc5b18f74d21ca1970efe8576912b2c6e/botocore-1.42.81.tar.gz", hash = "sha256:48e6f6f52de1cc107a34810309b8ca998ea9bb719a3fe4c06f903a604b3138cb", size = 15129980, upload-time = "2026-04-01T19:35:23.439Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/33/c7a01649a6cb7219b233d2ed071ab925e52cdb64e15ce935024c0007376f/botocore-1.42.81-py3-none-any.whl", hash = "sha256:bcef8c93c20ebeba95e4f8b9edfbffbc78a0e11235425a92ee32e48fd8e03c37", size = 14807198, upload-time = "2026-04-01T19:35:20.437Z" },
+]
+
+[[package]]
+name = "botocore-stubs"
+version = "1.43.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-awscrt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/81/79693e833291c00dc89ee610e5e915381b6f08233912e28df50106840780/botocore_stubs-1.43.14.tar.gz", hash = "sha256:9e3bc1fdd51da7473f0df726c82747a1b0ae913449d629659765c247fecc2039", size = 42738, upload-time = "2026-05-25T06:06:37.484Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/ca/f017727b11895908c5dedc829cf2ec35e0c4b2a26ba875db325fef2cefdf/botocore_stubs-1.43.14-py3-none-any.whl", hash = "sha256:fb98f1475c92fd718644e786b5c543a20f1b1f610e89e0a7191c3f1f429c75aa", size = 67093, upload-time = "2026-05-25T06:06:34.532Z" },
 ]
 
 [[package]]
@@ -899,9 +929,14 @@ ocr = [
     { name = "numpy" },
     { name = "rapidocr-onnxruntime" },
 ]
+s3 = [
+    { name = "boto3" },
+]
 
 [package.dev-dependencies]
 dev = [
+    { name = "boto3-stubs", extra = ["s3"] },
+    { name = "moto", extra = ["s3"] },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -919,6 +954,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "any-llm-sdk", extras = ["all"], specifier = ">=1.22.1" },
     { name = "asyncpg", specifier = ">=0.29.0" },
+    { name = "boto3", marker = "extra == 's3'", specifier = ">=1.42.0" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "cryptography", specifier = ">=44.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
@@ -941,10 +977,12 @@ requires-dist = [
     { name = "trafilatura", specifier = ">=2.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },
 ]
-provides-extras = ["ocr"]
+provides-extras = ["ocr", "s3"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "boto3-stubs", extras = ["s3"] },
+    { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
     { name = "mypy" },
     { name = "pytest", specifier = ">=9.0.3,<10" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
@@ -1978,6 +2016,30 @@ wheels = [
 ]
 
 [[package]]
+name = "moto"
+version = "5.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "cryptography" },
+    { name = "requests" },
+    { name = "responses" },
+    { name = "werkzeug" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/63/d944f387582cc53f53febbff2b3fa36a6d2ed7c1feef8990bf646cfa9cba/moto-5.2.2.tar.gz", hash = "sha256:aac8023a429e125e91c91f8f4730a67b54f518cda587352f7e67252fe3168f75", size = 8678761, upload-time = "2026-06-06T18:57:54.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/45/13cff46f4f617a6e97e1d497d75abd913e250bb4c823a4985668c6e593e4/moto-5.2.2-py3-none-any.whl", hash = "sha256:3817f1e39721ca833579b921e53e3b68547ace6a34d848c9486fbb5905808de9", size = 6698689, upload-time = "2026-06-06T18:57:51.435Z" },
+]
+
+[package.optional-dependencies]
+s3 = [
+    { name = "py-partiql-parser" },
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "msgspec"
 version = "0.21.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2100,6 +2162,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/37/a946bb416e37a57fa752b3100fd5ede0e28df94f92366d1716555d47c454/mypy-1.20.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:555493c44a4f5a1b58d611a43333e71a9981c6dbe26270377b6f8174126a0526", size = 15858565, upload-time = "2026-03-31T16:53:36.997Z" },
     { url = "https://files.pythonhosted.org/packages/2f/99/7690b5b5b552db1bd4ff362e4c0eb3107b98d680835e65823fbe888c8b78/mypy-1.20.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2721f0ce49cb74a38f00c50da67cb7d36317b5eda38877a49614dc018e91c787", size = 16087874, upload-time = "2026-03-31T16:52:48.313Z" },
     { url = "https://files.pythonhosted.org/packages/21/66/4d734961ce167f0fd8380769b3b7c06dbdd6ff54c2190f3f2ecd22528158/mypy-1.20.0-py3-none-any.whl", hash = "sha256:a6e0641147cbfa7e4e94efdb95c2dab1aff8cfc159ded13e07f308ddccc8c48e", size = 2636365, upload-time = "2026-03-31T16:51:44.911Z" },
+]
+
+[[package]]
+name = "mypy-boto3-s3"
+version = "1.43.50"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/e6/83141bd1cb8e060ecfd98ba23cfc295eae0123194add7d02e16d6d7e211e/mypy_boto3_s3-1.43.50.tar.gz", hash = "sha256:206817d22e80795da35daf704225f2e2a2b561fa4bf8c609f2150b04800ae811", size = 78807, upload-time = "2026-07-16T19:56:32.496Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/f4/39480da24fe26490234d081bc36b967a6ed1b592507d459a94338558bc35/mypy_boto3_s3-1.43.50-py3-none-any.whl", hash = "sha256:778aa2a48314ea47aeccca48ae151fe208b48d568d02578494b7201621ff2d6a", size = 86184, upload-time = "2026-07-16T19:56:30.283Z" },
 ]
 
 [[package]]
@@ -2632,6 +2703,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-partiql-parser"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456, upload-time = "2025-10-18T13:56:13.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752, upload-time = "2025-10-18T13:56:12.256Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3110,6 +3190,20 @@ wheels = [
 ]
 
 [[package]]
+name = "responses"
+version = "0.26.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/1a/4af3e6d659394b809838490b144e4ab8d7ed3b9fecc7ca78f5d2f79b1a3d/responses-0.26.2.tar.gz", hash = "sha256:9c9259b46a8349197edebf43cfa68a87e1a2802ef503ff8b2fecbabc0b45afd8", size = 84030, upload-time = "2026-07-03T16:44:50.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/28/693e1d9ebf72baa062ded80d837a035b86ce75eda5a269379e9e2b1008a8/responses-0.26.2-py3-none-any.whl", hash = "sha256:6fdfeabd58e5ec473b98dfe02e6d46d3173bd8dd573eff2ccccf1a05a5135364", size = 35609, upload-time = "2026-07-03T16:44:49.1Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3488,6 +3582,15 @@ wheels = [
 ]
 
 [[package]]
+name = "types-awscrt"
+version = "0.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/59/44409a8fc06b444ab1a6f71dcb29d49a6e17e02424345eb51b051bebb345/types_awscrt-0.34.1.tar.gz", hash = "sha256:559aa04250f6a419a617dfb788f3e10903aaf74700ef23e521b64a411b83b803", size = 19062, upload-time = "2026-06-05T04:40:10.689Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/b1/214b12162b452ed6acd230065e6c587cde6b96871e3ce6d653f40888f8df/types_awscrt-0.34.1-py3-none-any.whl", hash = "sha256:20c752b6031544d8f694803c35174aee129f1be5ddf886ae46d22f7ffd9b7d75", size = 45688, upload-time = "2026-06-05T04:40:09.198Z" },
+]
+
+[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20250915"
 source = { registry = "https://pypi.org/simple" }
@@ -3506,6 +3609,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c1/7b/a06527d20af1441d813360b8e0ce152a75b7d8e4aab7c7d0a156f405d7ec/types_requests-2.33.0.20260402.tar.gz", hash = "sha256:1bdd3ada9b869741c5c4b887d2c8b4e38284a1449751823b5ebbccba3eefd9da", size = 23851, upload-time = "2026-04-02T04:19:55.942Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/65/3853bb6bac5ae789dc7e28781154705c27859eccc8e46282c3f36780f5f5/types_requests-2.33.0.20260402-py3-none-any.whl", hash = "sha256:c98372d7124dd5d10af815ee25c013897592ff92af27b27e22c98984102c3254", size = 20739, upload-time = "2026-04-02T04:19:54.955Z" },
+]
+
+[[package]]
+name = "types-s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/64/42689150509eb3e6e82b33ee3d89045de1592488842ddf23c56957786d05/types_s3transfer-0.16.0.tar.gz", hash = "sha256:b4636472024c5e2b62278c5b759661efeb52a81851cde5f092f24100b1ecb443", size = 13557, upload-time = "2025-12-08T08:13:09.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/27/e88220fe6274eccd3bdf95d9382918716d312f6f6cef6a46332d1ee2feff/types_s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:1c0cd111ecf6e21437cb410f5cddb631bfb2263b77ad973e79b9c6d0cb24e0ef", size = 19247, upload-time = "2025-12-08T08:13:08.426Z" },
 ]
 
 [[package]]
@@ -3748,6 +3860,18 @@ wheels = [
 ]
 
 [[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
 name = "wrapt"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3826,6 +3950,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940, upload-time = "2025-09-16T00:16:21.63Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315, upload-time = "2025-09-16T00:16:20.108Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Adds `S3FileStore`, an implementation of the `FileStore` protocol for AWS S3 or any S3-compatible endpoint (MinIO, self-hosted), completing the second half of #156's streaming work.

Uses sync `boto3` via `asyncio.to_thread` rather than `aioboto3`, which pins an `aiobotocore`/`botocore` range incompatible with the version already required for Bedrock support (confirmed earlier on #156). Streaming uploads spool to a `SpooledTemporaryFile` (bounded in-memory threshold, spills to disk past it) before handing off to `upload_fileobj`, which manages multipart upload internally and aborts an incomplete multipart upload on failure; confirmed with a test that injects a mid-upload failure and checks no multipart upload lingers afterward.

Credentials resolve through boto3's standard chain (env vars, `~/.aws/credentials`, IAM role), not app config, matching how `master_key` is already treated as a secret. New config: `files_s3_bucket`, `files_s3_endpoint_url`, `files_s3_region`. S3 support sits behind an optional `otari[s3]` extra with a lazy import inside `S3FileStore`, so local-only installs aren't forced into it.

## PR Type
- [x] New Feature

## Relevant issues
Part of #156

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`) — note: ran via a manual pip venv, not `uv`, since Windows is excluded from your lockfile's supported platforms; integration tests (`tests/integration`) couldn't run locally without Docker, but the modified files pass lint/typecheck/unit tests.
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec — not applicable this time, no routes changed.

## AI Usage
- [x] AI was used for drafting/refactoring.

**AI Model/Tool used:** Claude Code (Sonnet 5)

**Any additional AI details you'd like to share:** Design discussed and confirmed on #156 before implementation (credential handling, config fields, streaming/multipart strategy); code written by Claude Code under my direction and review, including verifying the multipart-abort behavior with a test rather than assuming it.

- [ ] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a new S3-backed file storage backend (`S3FileStore`) for AWS S3 and S3-compatible services (e.g., MinIO).
- Extended configuration to allow selecting the new `"s3"` backend and supplying S3 bucket/endpoint/region settings.
- Updated storage reference/key generation to use shared helper logic for consistent formatting across file-store implementations.
- Added an optional dependency group for S3 support (`otari[s3]`) and expanded dev dependencies to include S3 typing/mocking tooling.
- Added unit tests for S3 operations, including streaming uploads/downloads, deterministic reference formatting, delete idempotency, and cleanup behavior for failed or cancelled multipart uploads.

## Technical notes

- Wraps synchronous `boto3` S3 calls with `asyncio.to_thread` so the async API remains responsive.
- Streaming uploads buffer data in a bounded `SpooledTemporaryFile` before using S3 multipart upload via `upload_fileobj`, with tests ensuring no orphaned multipart uploads remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->