### PR TITLE
fix(compose): bind quickstart postgres to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,11 +71,15 @@ services:
   postgres:
     image: postgres:16-alpine
     ports:
-      # Host port 5433 (container still :5432) — avoids clashing with another
-      # local postgres on the default port. Gateway connects via the Docker
-      # network at postgres:5432, so the host mapping is only for external
-      # tools (psql / TablePlus / etc.). Override with $OTARI_POSTGRES_PORT.
-      - "${OTARI_POSTGRES_PORT:-5433}:5432"
+      # Bound to localhost only. The database holds API key hashes, users,
+      # budgets, usage, and dashboard sessions, so an open port on the host
+      # network would expose all of it (default creds otari/otari) to anyone
+      # on the LAN. The Otari container reaches it via the Docker network at
+      # postgres:5432; this host mapping is only for external tools (psql /
+      # TablePlus / etc.) on the operator's own machine.
+      # Host port 5433 (container still :5432) avoids clashing with another
+      # local postgres on the default port. Override with $OTARI_POSTGRES_PORT.
+      - "127.0.0.1:${OTARI_POSTGRES_PORT:-5433}:5432"
     environment:
       - POSTGRES_USER=otari
       - POSTGRES_PASSWORD=otari


### PR DESCRIPTION
> _Note: @njbrake restored the required template sections (via Claude) so the `check-template` gate passes. The contributor's original description is preserved below. The Checklist and AI Usage boxes are left unchecked, as those are the contributor's own attestations to make._

## Description

Bind the quickstart `postgres` service to `127.0.0.1` instead of all host interfaces.

The postgres port used Docker's two-part short syntax (`"${OTARI_POSTGRES_PORT:-5433}:5432"`), which binds to `0.0.0.0`. With the static default credentials `otari/otari`, any peer that can reach the host on port 5433 (a LAN machine, or a cloud VM without a firewall) could read and write the whole gateway database: API key hashes, users, budgets, usage, and dashboard sessions.

Every other service in the file (`sandbox`, `searxng`, `brave-adapter`, `tavily-adapter`, `anyguardrails`, `encoderfile`) is already bound to `127.0.0.1` with a security comment. The database was the only exception, and the comment on the block already notes the host mapping is only for external tools, so the gateway itself does not need it (it uses the Docker network at `postgres:5432`).

**Change:** `docker-compose.yml` adds the `127.0.0.1:` prefix to the postgres port mapping and expands the comment to explain the localhost bind, consistent with the other services. No behavior change for the gateway (it never used the host mapping). Operators who connect external tools from the host itself are unaffected; anyone who connected from another machine should use an SSH tunnel or set `OTARI_POSTGRES_PORT` and bind explicitly.

**Test:**
- `docker compose config` still parses cleanly.
- Verified the gateway continues to reach postgres over the internal Docker network (`postgres:5432`), which the change does not touch.

*Contribution as part of [KIberblick.de](https://kiberblick.de).*

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

Closes #412.

## Checklist

- [ ] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**


**Any additional AI details you'd like to share:**
