### PR TITLE
fix(providers): honor the optional API key for keyless custom endpoints

### DIFF
--- a/src/gateway/services/model_discovery_service.py
+++ b/src/gateway/services/model_discovery_service.py
@@ -28,7 +28,7 @@ from any_llm.types.model import Model
 
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
-from gateway.services.provider_kwargs import get_provider_kwargs
+from gateway.services.provider_kwargs import get_provider_kwargs, keyless_placeholder_api_key
 
 # Fallback bound for ad-hoc credential tests when a caller does not pass one. The
 # route passes ``model_discovery_timeout_seconds`` so the saved and unsaved paths
@@ -397,6 +397,10 @@ async def test_provider_credentials(
             models=[],
             error=f"'{impl_name}' is not a known provider implementation.",
         )
+    # A keyless custom endpoint (api_base set, no key) would otherwise be rejected
+    # by any-llm before the connection is even attempted; supply the same
+    # placeholder the saved path uses so "Test connection" honors the optional key.
+    api_key = api_key or keyless_placeholder_api_key(provider_enum, api_base, api_key)
     try:
         # Bounded like the stored-provider path so a black-holed endpoint cannot
         # hang the test button for the SDK's ~600s default.

--- a/src/gateway/services/provider_kwargs.py
+++ b/src/gateway/services/provider_kwargs.py
@@ -9,6 +9,7 @@ any-llm provider (the common case, no ``provider_type`` declared), the two
 coincide and behavior is identical to splitting the selector directly.
 """
 
+import os
 from dataclasses import dataclass
 from typing import Any
 
@@ -22,6 +23,44 @@ from gateway.services.alias_service import resolve_effective_alias
 # Keys that describe an instance to otari but are not credentials any-llm
 # understands, so they must be stripped before the provider call.
 _INSTANCE_META_KEYS = ("provider_type", "models")
+
+# any-llm rejects a keyless call to most providers (openai, anthropic, ...) with
+# MissingApiKeyError, but a self-hosted OpenAI-/Anthropic-compatible backend
+# (vLLM, llama.cpp, Ollama) usually needs no auth. When an instance points at a
+# custom api_base and supplies no key anywhere, hand any-llm this harmless
+# placeholder so the keyless endpoint is reachable, making good on the
+# dashboard's "API key (optional)" promise for custom endpoints. A local server
+# ignores the value; a real one that does need a key rejects it, which is the
+# same failure the operator would already get. Mirrors any-llm's own keyless
+# tolerance (mozilla-ai/any-llm#1198).
+_KEYLESS_PLACEHOLDER_API_KEY = "otari-no-key-required"
+
+
+def _provider_env_key_present(provider: LLMProvider) -> bool:
+    """Whether the provider's native API-key env var (e.g. OPENAI_API_KEY) is set.
+
+    Read directly from the environment because these are any-llm's own SDK
+    variables, not otari config: any-llm falls back to them before raising, so
+    the placeholder must not shadow a key the operator supplied that way.
+    """
+    try:
+        env_name = AnyLLM.get_provider_class(provider).ENV_API_KEY_NAME
+    except (ImportError, AttributeError):
+        return False
+    return bool(env_name and os.getenv(env_name))
+
+
+def keyless_placeholder_api_key(provider: LLMProvider, api_base: Any, api_key: Any) -> str | None:
+    """Return a placeholder key for a keyless custom endpoint, else ``None``.
+
+    A custom endpoint is one with an ``api_base`` set; it is keyless when no key
+    is configured for it and the provider's native env var is unset. Only that
+    case (which any-llm would otherwise reject) gets a placeholder, so this never
+    overrides a real key or the documented env-var fallback.
+    """
+    if api_base and not api_key and not _provider_env_key_present(provider):
+        return _KEYLESS_PLACEHOLDER_API_KEY
+    return None
 
 
 def get_provider_kwargs(
@@ -68,6 +107,10 @@ def get_provider_kwargs(
             kwargs = {k: v for k, v in provider_config.items() if k != "client_args"}
             if "client_args" in provider_config:
                 kwargs["client_args"] = provider_config["client_args"]
+
+    placeholder = keyless_placeholder_api_key(provider, kwargs.get("api_base"), kwargs.get("api_key"))
+    if placeholder is not None:
+        kwargs["api_key"] = placeholder
 
     return kwargs
 

--- a/src/gateway/services/provider_kwargs.py
+++ b/src/gateway/services/provider_kwargs.py
@@ -42,12 +42,19 @@ def _provider_env_key_present(provider: LLMProvider) -> bool:
     Read directly from the environment because these are any-llm's own SDK
     variables, not otari config: any-llm falls back to them before raising, so
     the placeholder must not shadow a key the operator supplied that way.
+
+    ``ENV_API_KEY_NAME`` is not always a single variable name: some providers use
+    a ``/``-joined label listing alternatives (e.g. gemini's
+    ``"GEMINI_API_KEY/GOOGLE_API_KEY"``), so treat it as candidates and count the
+    key present when any one of them is set.
     """
     try:
         env_name = AnyLLM.get_provider_class(provider).ENV_API_KEY_NAME
     except (ImportError, AttributeError):
         return False
-    return bool(env_name and os.getenv(env_name))
+    if not env_name:
+        return False
+    return any(os.getenv(candidate.strip()) for candidate in env_name.split("/") if candidate.strip())
 
 
 def keyless_placeholder_api_key(provider: LLMProvider, api_base: Any, api_key: Any) -> str | None:

--- a/tests/unit/test_gateway_model_discovery.py
+++ b/tests/unit/test_gateway_model_discovery.py
@@ -19,6 +19,10 @@ from gateway.services.model_discovery_service import (
     discover_models_with_status,
     discover_provider_models,
 )
+from gateway.services.model_discovery_service import (
+    test_provider_credentials as run_credentials_test,  # aliased so pytest does not collect it
+)
+from gateway.services.provider_kwargs import _KEYLESS_PLACEHOLDER_API_KEY
 
 
 def _make_model(model_id: str, owned_by: str = "openai", created: int = 1700000000) -> Model:
@@ -668,3 +672,40 @@ class TestDiscoveryStallGuards:
         by_provider = {d.provider: d for d in statuses}
         assert by_provider["good"].error is None
         assert by_provider["bad"].error is not None  # surfaced as an error, not raised
+
+
+class TestKeylessProviderConnectionTest:
+    """test_provider_credentials must honor the optional key for custom endpoints (otari#421)."""
+
+    @pytest.mark.asyncio
+    async def test_keyless_custom_endpoint_supplies_placeholder(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A keyless "Test connection" for a custom endpoint would otherwise be
+        # rejected by any-llm with MissingApiKeyError; the ad-hoc test path injects
+        # the same placeholder the saved path uses so the endpoint is dialed.
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        mock_alist = AsyncMock(return_value=[_make_model("local-model")])
+        with (
+            patch("gateway.services.model_discovery_service._supports_list_models", return_value=True),
+            patch("gateway.services.model_discovery_service.alist_models", mock_alist),
+        ):
+            result = await run_credentials_test("openai", api_key=None, api_base="http://localhost:8000/v1")
+
+        assert result.error is None
+        assert [m.id for m in result.models] == ["local-model"]
+        assert mock_alist.await_args is not None
+        assert mock_alist.await_args.kwargs["api_key"] == _KEYLESS_PLACEHOLDER_API_KEY
+
+    @pytest.mark.asyncio
+    async def test_explicit_key_is_used_verbatim(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        mock_alist = AsyncMock(return_value=[])
+        with (
+            patch("gateway.services.model_discovery_service._supports_list_models", return_value=True),
+            patch("gateway.services.model_discovery_service.alist_models", mock_alist),
+        ):
+            await run_credentials_test("openai", api_key="sk-real", api_base="http://localhost:8000/v1")
+
+        assert mock_alist.await_args is not None
+        assert mock_alist.await_args.kwargs["api_key"] == "sk-real"

--- a/tests/unit/test_gateway_model_discovery.py
+++ b/tests/unit/test_gateway_model_discovery.py
@@ -674,7 +674,7 @@ class TestDiscoveryStallGuards:
         assert by_provider["bad"].error is not None  # surfaced as an error, not raised
 
 
-class TestKeylessProviderConnectionTest:
+class TestKeylessProviderConnection:
     """test_provider_credentials must honor the optional key for custom endpoints (otari#421)."""
 
     @pytest.mark.asyncio

--- a/tests/unit/test_provider_instances.py
+++ b/tests/unit/test_provider_instances.py
@@ -10,7 +10,9 @@ from gateway.api.routes.pricing import _candidate_model_keys
 from gateway.core.config import GatewayConfig, ModelCapabilityConfig
 from gateway.services.model_capabilities import resolve_capabilities
 from gateway.services.provider_kwargs import (
+    _KEYLESS_PLACEHOLDER_API_KEY,
     get_provider_kwargs,
+    keyless_placeholder_api_key,
     normalize_pricing_key,
     resolve_provider_selector,
     split_selector,
@@ -187,6 +189,57 @@ def test_get_provider_kwargs_strips_provider_type_and_models() -> None:
     assert "provider_type" not in kwargs
     assert "models" not in kwargs
     assert kwargs == {"api_base": "http://x/v1", "api_key": "k"}
+
+
+# ---------------------------------------------------------------------------
+# get_provider_kwargs: keyless custom-endpoint placeholder (mozilla-ai/otari#421)
+# ---------------------------------------------------------------------------
+
+
+def test_keyless_custom_endpoint_gets_placeholder_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A custom OpenAI-compatible endpoint with no key would otherwise be rejected
+    # by any-llm before it is even dialed; the placeholder makes the key optional.
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    config = GatewayConfig(providers={"home_lab": {"provider_type": "openai", "api_base": "http://x/v1"}})
+    kwargs = get_provider_kwargs(config, LLMProvider.OPENAI, instance="home_lab")
+    assert kwargs == {"api_base": "http://x/v1", "api_key": _KEYLESS_PLACEHOLDER_API_KEY}
+
+
+def test_explicit_key_is_not_overridden_by_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    config = GatewayConfig(
+        providers={"home_lab": {"provider_type": "openai", "api_base": "http://x/v1", "api_key": "sk-real"}}
+    )
+    kwargs = get_provider_kwargs(config, LLMProvider.OPENAI, instance="home_lab")
+    assert kwargs["api_key"] == "sk-real"
+
+
+def test_no_placeholder_without_api_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A default hosted endpoint (no custom api_base) still relies on the provider's
+    # native env var; injecting a placeholder there would shadow it.
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    config = GatewayConfig(providers={"openai": {}})
+    kwargs = get_provider_kwargs(config, LLMProvider.OPENAI, instance="openai")
+    assert "api_key" not in kwargs
+
+
+def test_env_var_fallback_preserved_over_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
+    # any-llm falls back to OPENAI_API_KEY before raising, so the placeholder must
+    # not shadow a key the operator supplied that way.
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+    config = GatewayConfig(providers={"home_lab": {"provider_type": "openai", "api_base": "http://x/v1"}})
+    kwargs = get_provider_kwargs(config, LLMProvider.OPENAI, instance="home_lab")
+    assert "api_key" not in kwargs
+
+
+def test_keyless_placeholder_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    # Keyless custom endpoint: placeholder.
+    assert keyless_placeholder_api_key(LLMProvider.ANTHROPIC, "http://x/v1", None) == _KEYLESS_PLACEHOLDER_API_KEY
+    # No api_base (hosted default): no placeholder.
+    assert keyless_placeholder_api_key(LLMProvider.ANTHROPIC, None, None) is None
+    # Key already present: no placeholder.
+    assert keyless_placeholder_api_key(LLMProvider.ANTHROPIC, "http://x/v1", "sk-real") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_provider_instances.py
+++ b/tests/unit/test_provider_instances.py
@@ -242,6 +242,19 @@ def test_keyless_placeholder_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     assert keyless_placeholder_api_key(LLMProvider.ANTHROPIC, "http://x/v1", "sk-real") is None
 
 
+def test_env_var_fallback_honors_compound_key_label(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Some providers expose ``ENV_API_KEY_NAME`` as a ``/``-joined list of
+    # alternatives rather than one variable (gemini: "GEMINI_API_KEY/GOOGLE_API_KEY").
+    # A key set under any alternative must still suppress the placeholder, or it
+    # would shadow the operator's real env-var credential.
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setenv("GOOGLE_API_KEY", "goog-from-env")
+    assert keyless_placeholder_api_key(LLMProvider.GEMINI, "http://x/v1", None) is None
+    # With neither alternative set, a keyless custom endpoint still gets the placeholder.
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    assert keyless_placeholder_api_key(LLMProvider.GEMINI, "http://x/v1", None) == _KEYLESS_PLACEHOLDER_API_KEY
+
+
 # ---------------------------------------------------------------------------
 # normalize_pricing_key
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

The dashboard's "Custom endpoint" form labels the API key optional, but any-llm's `_verify_and_set_api_key` raises `MissingApiKeyError` for the `openai` and `anthropic` implementations when no key and no native env var are present. A keyless local backend (vLLM, llama.cpp, Ollama) added through the form therefore could neither be tested nor served, contradicting the "optional" label.

This supplies a harmless placeholder key (`otari-no-key-required`) when an instance points at a custom `api_base` and has no key anywhere: no configured key and the provider's native env var (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, ...) both empty. The change is purely additive: it only affects the case any-llm would already reject, and it never overrides a real key or the documented env-var fallback. A local server ignores the placeholder; a real one that needs a key rejects it, which is the same failure the operator would already get.

The placeholder is injected in two places so they agree:

- `get_provider_kwargs` (`services/provider_kwargs.py`), the dispatch and stored-provider test path.
- `test_provider_credentials` (`services/model_discovery_service.py`), the pre-save "Test connection" path.

This mirrors any-llm's own keyless tolerance in mozilla-ai/any-llm#1198. When that first-class custom-endpoint path lands and is pinned, this workaround should be removed; tracked in #422.

No frontend change: the form already treats the key as optional, so the "API key (optional)" label is now honest.

## PR Type

- [x] Bug Fix

## Relevant issues

Fixes #421. Follow-up cleanup tracked in #422.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [x] AI was used for drafting/refactoring.

**AI Model/Tool used:** Claude Opus 4.8, via Claude Code.

**Any additional AI details you'd like to share:**

Implemented by Claude via back-and-forth with @njbrake, who directed the approach (placeholder for keyless custom endpoints, gated so it never shadows a real key or the env-var fallback) and pointed at the upstream any-llm path as the eventual replacement. Verified locally: ruff, mypy strict, and the full unit suite pass; the keyless flow was reproduced with `OPENAI_API_KEY` unset and confirmed fixed. Integration tests need Docker, which was not available locally, so they run in CI.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Improved custom endpoint support so dashboards can test and serve keyless local backends when the optional API key field is left empty.
- Injects a harmless placeholder API key only when a custom API base is configured but no real API key (and no provider environment-variable key) is available.
- Applies the same credential behavior to both the saved-provider dispatch path and the pre-save “test connection” flow.
- Added unit tests to verify placeholder injection, correct precedence over explicit keys/env vars, and provider-specific environment-variable suppression rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->