### PR TITLE
feat(auth): rate-limit dashboard sign-in against brute-force attempts

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -6334,7 +6334,7 @@
         ]
       },
       "post": {
-        "description": "Verify the master key and set the HttpOnly session cookie.",
+        "description": "Verify the master key and set the HttpOnly session cookie.\n\nThe rate-limit check deliberately runs only after a failed verification,\nnot before it: a pre-verification gate can't know whether *this* attempt\nwould have succeeded, so once an IP has used up its failure quota it\nwould end up blocking that IP's legitimate owner too, not just further\nattackers. The issue this implements explicitly rules that out. The\nDB/hash lookup this exposes to repeated attempts only runs when no fixed\nmaster_key is configured (the auto-generated bootstrap-key path); with a\nconfigured master_key, verification is a constant-time string compare,\nnot a DB round trip.",
         "operationId": "create_session_v1_auth_session_post",
         "requestBody": {
           "content": {

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -225,7 +225,7 @@
               },
               "raw": "{\n  \"master_key\": \"string\"\n}"
             },
-            "description": "Verify the master key and set the HttpOnly session cookie.",
+            "description": "Verify the master key and set the HttpOnly session cookie.\n\nThe rate-limit check deliberately runs only after a failed verification,\nnot before it: a pre-verification gate can't know whether *this* attempt\nwould have succeeded, so once an IP has used up its failure quota it\nwould end up blocking that IP's legitimate owner too, not just further\nattackers. The issue this implements explicitly rules that out. The\nDB/hash lookup this exposes to repeated attempts only runs when no fixed\nmaster_key is configured (the auto-generated bootstrap-key path); with a\nconfigured master_key, verification is a constant-time string compare,\nnot a DB round trip.",
             "header": [
               {
                 "key": "Content-Type",

--- a/src/gateway/api/routes/auth_session.py
+++ b/src/gateway/api/routes/auth_session.py
@@ -48,7 +48,11 @@ def _check_login_rate_limit(request: Request) -> None:
     """Throttle repeated failed sign-in attempts per client IP.
 
     Only called on a *failed* verification, so a correct master key is never
-    throttled. Separate limiter from the general per-user ``rate_limit_rpm``
+    throttled, even from an IP that has already used up its failure quota:
+    the issue this implements explicitly requires that a legitimate operator
+    is never locked out. That requirement is why this can't run *before*
+    verification (see the note on create_session for why that was tried and
+    reverted). Separate limiter from the general per-user ``rate_limit_rpm``
     (that one is keyed to authenticated users and never sees this pre-auth
     path). Raises 429 with Retry-After via RateLimiter.check when the calling
     IP is already over the configured limit.
@@ -82,7 +86,18 @@ async def create_session(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> SessionResponse:
-    """Verify the master key and set the HttpOnly session cookie."""
+    """Verify the master key and set the HttpOnly session cookie.
+
+    The rate-limit check deliberately runs only after a failed verification,
+    not before it: a pre-verification gate can't know whether *this* attempt
+    would have succeeded, so once an IP has used up its failure quota it
+    would end up blocking that IP's legitimate owner too, not just further
+    attackers. The issue this implements explicitly rules that out. The
+    DB/hash lookup this exposes to repeated attempts only runs when no fixed
+    master_key is configured (the auto-generated bootstrap-key path); with a
+    configured master_key, verification is a constant-time string compare,
+    not a DB round trip.
+    """
     if not await is_valid_master_key(body.master_key, config, db):
         record_auth_failure("invalid_key")
         _check_login_rate_limit(request)

--- a/src/gateway/api/routes/auth_session.py
+++ b/src/gateway/api/routes/auth_session.py
@@ -19,6 +19,7 @@ from gateway.api.deps import get_config, get_db, is_valid_master_key
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.metrics import record_auth_failure
+from gateway.rate_limit import RateLimiter
 from gateway.services.dashboard_session_service import (
     SESSION_COOKIE_NAME,
     apply_session_cookie,
@@ -43,6 +44,36 @@ class SessionResponse(BaseModel):
     expires_at: datetime = Field(description="When the session cookie stops being accepted.")
 
 
+def _check_login_rate_limit(request: Request) -> None:
+    """Throttle repeated failed sign-in attempts per client IP.
+
+    Only called on a *failed* verification, so a correct master key is never
+    throttled. Separate limiter from the general per-user ``rate_limit_rpm``
+    (that one is keyed to authenticated users and never sees this pre-auth
+    path). Raises 429 with Retry-After via RateLimiter.check when the calling
+    IP is already over the configured limit.
+
+    Client IP comes from ``request.client.host``, not a hand-parsed
+    X-Forwarded-For: uvicorn's ProxyHeadersMiddleware already rewrites it from
+    that header, but only when the immediate peer is in ``forwarded_allow_ips``
+    (loopback by default, the same trust boundary ``request_is_https`` relies
+    on for X-Forwarded-Proto). Parsing the header directly here, instead of
+    through that trust boundary, would let anyone bypass the throttle by
+    sending their own X-Forwarded-For.
+    """
+    login_rate_limiter: RateLimiter | None = getattr(request.app.state, "login_rate_limiter", None)
+    if login_rate_limiter is None:
+        return
+    client_ip = request.client.host if request.client else None
+    if client_ip is None:
+        return
+    try:
+        login_rate_limiter.check(client_ip)
+    except HTTPException:
+        logger.warning("Dashboard sign-in rate limit exceeded for %s", client_ip)
+        raise
+
+
 @router.post("")
 async def create_session(
     body: CreateSessionRequest,
@@ -54,6 +85,7 @@ async def create_session(
     """Verify the master key and set the HttpOnly session cookie."""
     if not await is_valid_master_key(body.master_key, config, db):
         record_auth_failure("invalid_key")
+        _check_login_rate_limit(request)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid master key")
     try:
         token, expires_at = await create_dashboard_session(db, config.dashboard_session_ttl_hours)

--- a/src/gateway/api/routes/settings.py
+++ b/src/gateway/api/routes/settings.py
@@ -96,7 +96,7 @@ _CONFIG_VIEW: tuple[tuple[str, tuple[str, ...]], ...] = (
     ),
     (
         "Rate limiting & CORS",
-        ("rate_limit_rpm", "cors_allow_origins"),
+        ("rate_limit_rpm", "dashboard_login_rate_limit_per_minute", "cors_allow_origins"),
     ),
     (
         "Files",

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -215,6 +215,16 @@ class GatewayConfig(BaseSettings):
     rate_limit_rpm: int | None = Field(
         default=None, ge=1, description="Maximum requests per minute per user (None disables rate limiting)"
     )
+    dashboard_login_rate_limit_per_minute: int | None = Field(
+        default=10,
+        ge=1,
+        description=(
+            "Maximum failed POST /v1/auth/session attempts per client IP per minute "
+            "(None disables this limit). Only failed attempts count, so a correct "
+            "master key is never throttled. Separate from rate_limit_rpm, which is "
+            "keyed to authenticated users and does not cover this pre-auth path."
+        ),
+    )
     cors_allow_origins: list[str] = Field(
         default_factory=list, description="Allowed CORS origins (empty list disables CORS)"
     )

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -313,6 +313,11 @@ def create_app(config: GatewayConfig) -> FastAPI:
     else:
         app.state.rate_limiter = None
 
+    if config.dashboard_login_rate_limit_per_minute is not None:
+        app.state.login_rate_limiter = RateLimiter(config.dashboard_login_rate_limit_per_minute)
+    else:
+        app.state.login_rate_limiter = None
+
     app.state.config = config
     app.state.gateway_mode = config.effective_mode
 

--- a/tests/unit/test_dashboard_session.py
+++ b/tests/unit/test_dashboard_session.py
@@ -266,6 +266,29 @@ def test_successful_sign_in_is_never_throttled(tmp_path: Path) -> None:
         assert client.post("/v1/auth/session", json={"master_key": MASTER_KEY}).status_code == 200
 
 
+def test_rate_limit_buckets_are_isolated_per_client_ip(tmp_path: Path) -> None:
+    """A regression to a single global bucket (instead of per-IP) would let one
+    noisy/attacked IP lock out every other client; prove two IPs get separate
+    quotas, not just that throttling happens at all.
+    """
+    app = create_app(_rate_limited_config(tmp_path, limit=2))
+    with TestClient(app, client=("10.0.0.1", 12345)) as client_a:
+        # A second TestClient on the same app reuses its already-started
+        # lifespan (DB, rate limiter, etc.); only the wrapper differs, with
+        # its own fixed client IP for this test.
+        client_b = TestClient(app, client=("10.0.0.2", 12345))
+
+        for _ in range(2):
+            assert client_a.post("/v1/auth/session", json={"master_key": "wrong"}).status_code == 401
+        assert client_a.post("/v1/auth/session", json={"master_key": "wrong"}).status_code == 429
+
+        # A different IP is unaffected by A's usage: still real 401s, not
+        # inheriting A's throttled state from a shared/global bucket.
+        for _ in range(2):
+            assert client_b.post("/v1/auth/session", json={"master_key": "wrong"}).status_code == 401
+        assert client_b.post("/v1/auth/session", json={"master_key": "wrong"}).status_code == 429
+
+
 def test_login_rate_limit_disabled_by_config(tmp_path: Path) -> None:
     with TestClient(create_app(_rate_limited_config(tmp_path, limit=None))) as client:
         # Many failures in a row, none throttled: the limiter is off entirely.

--- a/tests/unit/test_dashboard_session.py
+++ b/tests/unit/test_dashboard_session.py
@@ -233,3 +233,41 @@ def test_rotation_revokes_other_sessions_and_reminting_keeps_the_caller_signed_i
         for stale in (other_tab_session, rotating_session):
             client.cookies.set(SESSION_COOKIE_NAME, stale)
             assert client.get("/v1/settings").status_code == 401
+
+
+def _rate_limited_config(tmp_path: Path, *, limit: int | None) -> GatewayConfig:
+    return GatewayConfig(
+        database_url=f"sqlite:///{tmp_path / 'session-rate-limit-test.db'}",
+        master_key=MASTER_KEY,
+        require_pricing=False,
+        dashboard_login_rate_limit_per_minute=limit,
+    )
+
+
+def test_repeated_failed_sign_ins_get_throttled(tmp_path: Path) -> None:
+    with TestClient(create_app(_rate_limited_config(tmp_path, limit=2))) as client:
+        # First two failures are real 401s (attempt count is still under the cap).
+        for _ in range(2):
+            response = client.post("/v1/auth/session", json={"master_key": "wrong"})
+            assert response.status_code == 401
+
+        # The third failed attempt within the window is throttled, not a 401.
+        throttled = client.post("/v1/auth/session", json={"master_key": "wrong"})
+        assert throttled.status_code == 429
+        assert "Retry-After" in throttled.headers
+
+
+def test_successful_sign_in_is_never_throttled(tmp_path: Path) -> None:
+    with TestClient(create_app(_rate_limited_config(tmp_path, limit=2))) as client:
+        # Exhaust the limit with failures...
+        for _ in range(2):
+            assert client.post("/v1/auth/session", json={"master_key": "wrong"}).status_code == 401
+        # ...then the real key still gets in: only failures count against the cap.
+        assert client.post("/v1/auth/session", json={"master_key": MASTER_KEY}).status_code == 200
+
+
+def test_login_rate_limit_disabled_by_config(tmp_path: Path) -> None:
+    with TestClient(create_app(_rate_limited_config(tmp_path, limit=None))) as client:
+        # Many failures in a row, none throttled: the limiter is off entirely.
+        for _ in range(5):
+            assert client.post("/v1/auth/session", json={"master_key": "wrong"}).status_code == 401


### PR DESCRIPTION
## Description
Adds a per-IP throttle to `POST /v1/auth/session`, which had no rate limiting despite being a purpose-built credential-checking endpoint (each attempt touches the DB for a hash lookup). Not a new exposure, header auth on every management endpoint was already unthrottled, but this endpoint deserves its own purpose-built limiter.

Reuses the existing `RateLimiter` (sliding window, 429 + `Retry-After`) keyed by client IP instead of user_id, as a separate instance from the general `rate_limit_rpm` (which is keyed to authenticated users and never sees this pre-auth path). Only counts failed attempts, so a correct master key is never throttled.

Client IP comes from `request.client.host`, not a hand-parsed `X-Forwarded-For`: uvicorn's `ProxyHeadersMiddleware` already rewrites it from that header, but only when the immediate peer is trusted (loopback by default), the same trust boundary `request_is_https` already relies on for `X-Forwarded-Proto`. Parsing the header directly in application code would let anyone bypass the throttle by sending their own `X-Forwarded-For`.

New config: `dashboard_login_rate_limit_per_minute` (default 10, `None` disables). Surfaced read-only in the settings dashboard alongside `rate_limit_rpm`, not hot-settable, matching that field's own precedent.

## PR Type
- [x] New Feature

## Relevant issues
Fixes #390

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`) — note: ran via a manual pip venv, not `uv`, since Windows is excluded from your lockfile's supported platforms; integration tests (`tests/integration`) couldn't run locally without Docker, but this change is fully covered by `tests/unit/test_dashboard_session.py` (TestClient + SQLite), which passes.
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec — not applicable, no route signature changed.

## AI Usage
- [x] AI was used for drafting/refactoring.

**AI Model/Tool used:** Claude Code (Sonnet 5)

**Any additional AI details you'd like to share:** Approach followed the plan you laid out in the issue; code written by Claude Code under my direction and review.

- [ ] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Added an optional, per-IP “failed login” rate limit for `POST /v1/auth/session` to help slow down brute-force attempts against the dashboard sign-in flow.

- Introduced `dashboard_login_rate_limit_per_minute` (default **10**; set to **None** to disable).
- The limit applies **only after a failed master-key verification**; successful sign-ins are never throttled.
- Once exceeded, the endpoint returns **`429`** with a **`Retry-After`** header and logs the throttled source IP.
- The limiter is separate from the existing authenticated-user `rate_limit_rpm`.
- Wired into app startup and exposed as a read-only setting in the settings dashboard.
- Added unit tests for throttling on repeated failures, no throttling on success, disabling via config, and isolating rate-limit counters between different client IPs.
- Updated Postman/OpenAPI documentation for the session endpoint’s master-key verification and the point at which throttling occurs.

## Technical notes

- Uses `request.client.host` (from trusted proxy handling) as the per-IP key.
- The dashboard login limiter is stored on app state as `login_rate_limiter`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->