### PR TITLE
docs: explain how to use Otari with a ChatGPT Plus/Pro subscription

### DIFF
--- a/docs/chatgpt-subscription.md
+++ b/docs/chatgpt-subscription.md
@@ -85,8 +85,9 @@ listing.
 ## 2. Register the proxy as a provider in Otari
 
 Add the proxy as a named OpenAI-compatible instance under `providers:` in your
-`config.yml`. Give it a custom instance name and set `provider_type: openai`
-(the aliases `openai-compatible` and `openai_compatible` also work):
+`config.yml`. Give it a custom instance name and set
+`provider_type: openai-compatible` (this and `openai_compatible` are aliases for
+the underlying `openai` implementation, so `provider_type: openai` works too):
 
 ```yaml
 providers:
@@ -108,6 +109,12 @@ providers:
     api_base: "http://localhost:8317/v1"
     # no api_key: the proxy handles auth via its own Codex OAuth session
 ```
+
+> **The keyless path needs a build newer than v0.4.0.** The #423 fix landed after
+> the `v0.4.0` release, so on the `0.4.0` PyPI package or Docker image a keyless
+> instance still raises `MissingApiKeyError`. Until the next release, either run a
+> build from `main` or use the downstream-key form above (set any non-empty
+> `api_key`; a local proxy that ignores it still accepts the call).
 
 Models on this instance are addressed as `chatgpt:<model>`, so the selector
 carries the instance name rather than the raw `openai:` provider. If the proxy
@@ -147,6 +154,13 @@ Pricing is keyed on the instance name, so price `chatgpt:gpt-5`, not
 so the unpriced model is still served and logged with `cost: null`. See
 [Configuration](configuration.md) for both knobs.
 
+> **Counterfactual pricing is not analytics-only.** Configured pricing also
+> drives budget reservations and reconciliation, so a per-key budget depletes
+> against this imaginary cost and will eventually return HTTP 402 even though no
+> money was spent. If you price counterfactually, size budgets to match, or keep
+> `require_pricing: false` when you want the flat-fee reality and no budget
+> enforcement on these calls.
+
 ## 4. Route a request
 
 Use an Otari client key and the `chatgpt:<model>` selector:
@@ -162,8 +176,9 @@ resp = client.chat.completions.create(
 print(resp.choices[0].message.content)
 ```
 
-Budgets, per-key limits, and usage logging all apply exactly as they do for any
-other provider.
+Budgets, per-key limits, and usage logging apply as they do for any other
+provider (see the pricing note above for how counterfactual pricing interacts
+with budgets).
 
 ## Streaming and usage logging
 
@@ -175,16 +190,26 @@ log_writer_strategy: batch
 ```
 
 With the default inline (`single`) strategy, a streaming client can disconnect
-the moment it sees the SSE `[DONE]` marker, before Otari finishes writing the
-usage row, so some records go uncommitted. The background `batch` writer decouples
-the database write from the response stream and records usage reliably. See
-[Configuration](configuration.md) for the field.
+the moment it sees the SSE `[DONE]` marker, mid-write, so the usage row can go
+uncommitted and, because the cancellation lands before reconciliation runs, the
+budget reservation for that call is left unreconciled too. The background `batch`
+writer moves the database write off the response stream, which removes that
+disconnect race for both the usage row and budget reconciliation.
+
+`batch` is not a durability guarantee: it queues rows in memory and flushes on a
+one-second interval or in 100-row batches, so usage can be up to a second late
+and queued rows are still lost on a hard crash. It fixes the client-disconnect
+race, not process death. This behavior is provider-agnostic; see
+[Configuration](configuration.md) for the `log_writer_strategy` field.
 
 ## Caveats
 
 - **Unofficial backend.** This reaches the ChatGPT backend through Codex OAuth
   and a compatibility proxy, not the supported Platform API. The proxy can break
   when the backend changes.
+- **Account risk.** Reaching the subscription through a third-party OAuth proxy
+  may run against OpenAI's terms of service and could put the account itself at
+  risk. Weigh this before pointing anything you care about at it.
 - **Subscription caps apply.** Usage still counts against your ChatGPT
   subscription's limits; Otari's budgets sit on top and do not raise those caps.
 - **An API key is sturdier.** For anything you depend on, an OpenAI Platform API

--- a/docs/chatgpt-subscription.md
+++ b/docs/chatgpt-subscription.md
@@ -1,0 +1,179 @@
+# Use with a ChatGPT subscription
+
+You can route Otari at the models behind a ChatGPT Plus or Pro subscription,
+even though a subscription ships no API key. This page walks through the one
+extra hop that makes it work.
+
+## Why this needs a proxy
+
+A ChatGPT subscription and the OpenAI Platform API are separate products with
+separate billing. The subscription has no standard `sk-...` API key, so Otari
+cannot point at it directly. The subscription is only reachable programmatically
+through **Codex OAuth**, the same login the Codex CLI uses.
+
+The bridge is a small **Codex-OAuth proxy** you run on `localhost`. It logs in
+with your subscription and re-exposes those models as a standard
+OpenAI-compatible endpoint. Otari then treats that endpoint like any other
+self-hosted OpenAI-compatible backend, and budgets, usage logging, and key
+management layer on top unchanged.
+
+```
+your app  ->  Otari  ->  Codex-OAuth proxy  ->  Codex OAuth (ChatGPT subscription)
+```
+
+The whole stack can stay on `localhost`.
+
+> **This rides an unofficial backend.** You are reaching the ChatGPT backend
+> through a compatibility proxy, not the supported Platform API. It stays subject
+> to your subscription's usage caps, and OpenAI can change the backend at any
+> time and break the proxy. If you want a sturdy, supported path, use an OpenAI
+> Platform API key with the [OpenAI provider guide](providers/openai.md)
+> instead. This recipe is for getting extra mileage from a subscription you
+> already pay for.
+
+## Prerequisites
+
+- Otari running locally (see the [Quickstart](quickstart.md)).
+- A ChatGPT Plus or Pro subscription.
+- A Codex-OAuth proxy. Several exist; any that speaks OpenAI-compatible
+  `/v1/chat/completions` works:
+  - [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) (also published
+    as `ai-cli-proxy-api`), confirmed working end to end in
+    [#436](https://github.com/mozilla-ai/otari/issues/436).
+  - Hermes' bundled `codex-proxy`.
+
+## 1. Run the Codex-OAuth proxy
+
+Follow the proxy's own docs to log in with your subscription and start it. The
+two things you need out of that step:
+
+- the local base URL it serves, for example `http://localhost:8317/v1`, and
+- whether it requires a **downstream key** (a token you set on the proxy and
+  then present to it) or serves keyless.
+
+Confirm the proxy answers before wiring Otari to it:
+
+```bash
+curl -sS http://localhost:8317/v1/models \
+  -H "Authorization: Bearer <downstream-key-if-any>"
+```
+
+You should get back a list of models the subscription exposes (Codex serves
+GPT-5 class models; the exact ids come from the proxy).
+
+## 2. Register the proxy as a provider in Otari
+
+Add the proxy as a named OpenAI-compatible instance under `providers:` in your
+`config.yml`. Give it a custom instance name and set `provider_type: openai`
+(the aliases `openai-compatible` and `openai_compatible` also work):
+
+```yaml
+providers:
+  chatgpt:                       # custom instance name; used in the model selector
+    provider_type: openai-compatible
+    api_base: "http://localhost:8317/v1"
+    api_key: ${CHATGPT_PROXY_KEY}   # the proxy's downstream key
+```
+
+If the proxy is keyless, drop `api_key` entirely. The
+[keyless-custom-endpoint fix (#423)](https://github.com/mozilla-ai/otari/pull/423)
+lets Otari call a keyless custom `api_base` without a `MissingApiKeyError`, so a
+local proxy that needs no key just works:
+
+```yaml
+providers:
+  chatgpt:
+    provider_type: openai-compatible
+    api_base: "http://localhost:8317/v1"
+    # no api_key: the proxy handles auth via its own Codex OAuth session
+```
+
+Models on this instance are addressed as `chatgpt:<model>`, so the selector
+carries the instance name rather than the raw `openai:` provider. If the proxy
+does not expose `/v1/models`, declare the served ids so they still show up in
+`GET /v1/models`:
+
+```yaml
+providers:
+  chatgpt:
+    provider_type: openai-compatible
+    api_base: "http://localhost:8317/v1"
+    models:
+      - gpt-5
+      - gpt-5-codex
+```
+
+See [Named provider instances](models.md#named-provider-instances) for the full
+behavior.
+
+## 3. Price the model (optional but recommended)
+
+Because the subscription bills a flat fee, there is no per-token cost to import.
+If you want cost analytics anyway, add a **counterfactual** price: the rate the
+equivalent Platform API model would charge. Otari then reports what the same
+usage would have cost on the API, which is a useful way to see the value you are
+getting from the subscription.
+
+```yaml
+pricing:
+  chatgpt:gpt-5:
+    input_price_per_million: 1.25
+    output_price_per_million: 10.00
+```
+
+Pricing is keyed on the instance name, so price `chatgpt:gpt-5`, not
+`openai:gpt-5`. If you would rather not price it, set `require_pricing: false`
+so the unpriced model is still served and logged with `cost: null`. See
+[Configuration](configuration.md) for both knobs.
+
+## 4. Route a request
+
+Use an Otari client key and the `chatgpt:<model>` selector:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(api_key="gw-...", base_url="http://localhost:8000/v1")
+resp = client.chat.completions.create(
+    model="chatgpt:gpt-5",
+    messages=[{"role": "user", "content": "Say hello in five words."}],
+)
+print(resp.choices[0].message.content)
+```
+
+Budgets, per-key limits, and usage logging all apply exactly as they do for any
+other provider.
+
+## Streaming and usage logging
+
+If you stream responses (for example from an agent runtime like Hermes), set the
+usage log writer to `batch`:
+
+```yaml
+log_writer_strategy: batch
+```
+
+With the default inline (`single`) strategy, a streaming client can disconnect
+the moment it sees the SSE `[DONE]` marker, before Otari finishes writing the
+usage row, so some records go uncommitted. The background `batch` writer decouples
+the database write from the response stream and records usage reliably. See
+[Configuration](configuration.md) for the field.
+
+## Caveats
+
+- **Unofficial backend.** This reaches the ChatGPT backend through Codex OAuth
+  and a compatibility proxy, not the supported Platform API. The proxy can break
+  when the backend changes.
+- **Subscription caps apply.** Usage still counts against your ChatGPT
+  subscription's limits; Otari's budgets sit on top and do not raise those caps.
+- **An API key is sturdier.** For anything you depend on, an OpenAI Platform API
+  key via the [OpenAI provider guide](providers/openai.md) is the supported
+  route.
+- **Keep it local.** The proxy holds your subscription's OAuth session. Run it on
+  `localhost` and do not expose it publicly.
+
+## See also
+
+- [OpenAI provider guide](providers/openai.md) for the supported API-key route
+- [Supported models](models.md) for the provider list and named-instance selectors
+- [Configuration](configuration.md) for `log_writer_strategy`, `require_pricing`, and pricing

--- a/docs/chatgpt-subscription.md
+++ b/docs/chatgpt-subscription.md
@@ -17,7 +17,7 @@ OpenAI-compatible endpoint. Otari then treats that endpoint like any other
 self-hosted OpenAI-compatible backend, and budgets, usage logging, and key
 management layer on top unchanged.
 
-```
+```text
 your app  ->  Otari  ->  Codex-OAuth proxy  ->  Codex OAuth (ChatGPT subscription)
 ```
 
@@ -51,15 +51,36 @@ two things you need out of that step:
 - whether it requires a **downstream key** (a token you set on the proxy and
   then present to it) or serves keyless.
 
-Confirm the proxy answers before wiring Otari to it:
+Confirm the proxy answers before wiring Otari to it. If the proxy uses a
+downstream key, send it; if it is keyless, omit the header entirely rather than
+sending a placeholder:
 
 ```bash
+# keyed proxy
 curl -sS http://localhost:8317/v1/models \
-  -H "Authorization: Bearer <downstream-key-if-any>"
+  -H "Authorization: Bearer $CHATGPT_PROXY_KEY"
+
+# keyless proxy
+curl -sS http://localhost:8317/v1/models
 ```
 
 You should get back a list of models the subscription exposes (Codex serves
 GPT-5 class models; the exact ids come from the proxy).
+
+Not every proxy implements `/v1/models`. If that request 404s, verify with a
+chat-completions call instead (drop the `-H` line when the proxy is keyless):
+
+```bash
+curl -sS http://localhost:8317/v1/chat/completions \
+  -H "Authorization: Bearer $CHATGPT_PROXY_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-5","messages":[{"role":"user","content":"ping"}]}'
+```
+
+A completion (rather than a connection or auth error) confirms the proxy is
+reaching your subscription. If the proxy has no `/v1/models`, declare the served
+model ids in the provider config (see step 2) so they still appear in Otari's
+listing.
 
 ## 2. Register the proxy as a provider in Otari
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,7 +70,7 @@ pricing:
 | `enable_metrics` | bool | `false` | Enable Prometheus `/metrics` endpoint |
 | `enable_docs` | bool | `true` | Enable `/docs`, `/redoc`, `/openapi.json` |
 | `bootstrap_api_key` | bool | `true` | Create a first-use API key on startup when none exist |
-| `log_writer_strategy` | string | `"single"` | Usage log writing: `"single"` (inline) or `"batch"` (background) |
+| `log_writer_strategy` | string | `"single"` | Usage log writing: `"single"` (inline) or `"batch"` (background). Prefer `"batch"` for streaming clients: with `"single"`, a client that disconnects at the SSE `[DONE]` marker can leave the usage row uncommitted and the budget reservation unreconciled. `"batch"` queues in memory and flushes on a 1s interval or 100-row batch, so it removes that race but is not crash-durable. |
 | `budget_strategy` | string | `"for_update"` | Budget validation: `"for_update"`, `"cas"`, or `"disabled"` |
 | `require_pricing` | bool | `true` | Reject requests for models with no configured pricing (HTTP 402, fail-closed). When `false`, unpriced models are served and logged without cost. Audio and moderation endpoints are always exempt. |
 | `default_pricing` | bool | `false` | When a model has no pricing in the database, fall back to community-maintained defaults from the bundled genai-prices dataset. Off by default (opt-in). Database pricing always wins. See [Default pricing](#default-pricing). |

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,6 @@ Running and managing a gateway.
 - [Access control](access-control.md): users, API keys, and budgets, with the management endpoints that drive them.
 - [Supported models](models.md): providers, model format, and capabilities.
 - [OpenAI provider guide](providers/openai.md): configure OpenAI and route your first request through Otari.
-- [Use with a ChatGPT subscription](chatgpt-subscription.md): route Otari at ChatGPT Plus/Pro models through a local Codex-OAuth proxy.
 
 ### For integrators
 
@@ -48,6 +47,7 @@ Calling the gateway from your own code.
 - [Use with Claude Code](use-with-claude-code.md): point the Claude Code CLI at Otari.
 - [Use with Codex](use-with-codex.md): point the Codex CLI at Otari.
 - [Use with opencode](use-with-opencode.md): point the opencode CLI at Otari.
+- [Use with a ChatGPT subscription](chatgpt-subscription.md): route Otari at ChatGPT Plus/Pro models through a local Codex-OAuth proxy.
 - [Importing external usage](external-usage.md): bring subscription-backed usage (Claude Code, Codex, any OTLP app) into your analytics.
 - [SDK compatibility](sdk-compatibility.md): how the language SDKs are released and which SDK version works with which Otari version.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ Running and managing a gateway.
 - [Access control](access-control.md): users, API keys, and budgets, with the management endpoints that drive them.
 - [Supported models](models.md): providers, model format, and capabilities.
 - [OpenAI provider guide](providers/openai.md): configure OpenAI and route your first request through Otari.
+- [Use with a ChatGPT subscription](chatgpt-subscription.md): route Otari at ChatGPT Plus/Pro models through a local Codex-OAuth proxy.
 
 ### For integrators
 


### PR DESCRIPTION
## Description

A ChatGPT Plus/Pro subscription has no OpenAI Platform API key and is only reachable programmatically through Codex OAuth, so users keep asking whether Otari can front it. It can, via a local Codex-OAuth proxy that re-exposes the subscription as an OpenAI-compatible endpoint, but the setup was undocumented.

This adds `docs/chatgpt-subscription.md`, a recipe that walks through:

- Why the extra hop is needed (subscription vs Platform API, no `sk-` key, Codex OAuth only), with an `app -> Otari -> Codex-OAuth proxy -> Codex OAuth` diagram.
- Running a Codex-OAuth proxy (CLIProxyAPI / `ai-cli-proxy-api`, Hermes' `codex-proxy`) and sanity-checking it.
- Registering it as a named `openai-compatible` provider instance with `api_base: http://localhost:PORT/v1`, both with a downstream key and keyless (the #423 keyless-custom-endpoint fix makes the keyless path clean).
- Optional counterfactual pricing so cost analytics show API-equivalent spend.
- The `log_writer_strategy: batch` note for streaming clients (inline logging can drop usage rows when a client disconnects at SSE `[DONE]`), surfaced by @jtyun in the issue.
- Caveats: unofficial backend, subscription caps, an API key is the sturdier route, keep the proxy local.

It also links the new page from the docs index under "For operators".

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #436

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). Docs-only change; no code paths to test.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). N/A for docs-only; no docs-lint CI exists, and all internal doc links resolve.
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). No API change.

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8), drafted via back-and-forth with @njbrake.

**Any additional AI details you'd like to share:** Prose drafted by Claude; the structure, sources, and caveats reflect @njbrake's reasoning and the discussion on #436.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a new documentation page, `docs/chatgpt-subscription.md`, explaining how to route ChatGPT Plus/Pro model traffic through Otari using a local Codex-OAuth compatibility proxy (including provider setup, optional cost analytics, streaming/usage logging guidance, and important caveats/risks).
- Linked the new “Use with a ChatGPT subscription” guide from `docs/index.md` under “For integrators.”
- Updated `docs/configuration.md` to clarify `log_writer_strategy` behavior—especially the tradeoffs for streaming usage logging (`single` vs `batch`).

This helps users integrate Otari with an existing ChatGPT subscription while still using Otari’s usage logging and budgeting features (with clear warnings about the unofficial backend and subscription limits).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->