### PR TITLE
feat(web-search): support recency filtering and publish dates in Brave adapter

### DIFF
--- a/scripts/web-search-brave-adapter/README.md
+++ b/scripts/web-search-brave-adapter/README.md
@@ -6,9 +6,20 @@ bundled SearXNG metasearch (whose free engines rate-limit/CAPTCHA automated
 queries by IP).
 
 It exposes `GET /search?q=…&format=json` returning
-`{"results": [{"url", "title", "content"}]}` — the exact shape
-`WebSearchBackend` expects — and translates that to/from Brave's API. The Brave
+`{"results": [{"url", "title", "content", "published_date"?}]}` — the exact
+shape `WebSearchBackend` expects, plus an optional publish/last-updated date
+when Brave supplies one — and translates that to/from Brave's API. The Brave
 key lives in this service, never in the gateway.
+
+## Provider options
+
+The gateway forwards provider-specific knobs (set via `provider_options` on the
+`otari_web_search` tool entry, or as workspace defaults in hybrid mode) as
+extra query params. This adapter recognizes one, mapped onto Brave's
+`freshness` filter; anything else is ignored:
+
+- `time_range` (`day` | `week` | `month` | `year`, or the single-letter forms
+  `d` | `w` | `m` | `y`)
 
 ## Run it via docker-compose
 

--- a/scripts/web-search-brave-adapter/README.md
+++ b/scripts/web-search-brave-adapter/README.md
@@ -6,9 +6,9 @@ bundled SearXNG metasearch (whose free engines rate-limit/CAPTCHA automated
 queries by IP).
 
 It exposes `GET /search?q=…&format=json` returning
-`{"results": [{"url", "title", "content", "published_date"?}]}` — the exact
+`{"results": [{"url", "title", "content", "published_date"?}]}`, the exact
 shape `WebSearchBackend` expects, plus an optional publish/last-updated date
-when Brave supplies one — and translates that to/from Brave's API. The Brave
+when Brave supplies one, and translates that to/from Brave's API. The Brave
 key lives in this service, never in the gateway.
 
 ## Provider options

--- a/scripts/web-search-brave-adapter/app.py
+++ b/scripts/web-search-brave-adapter/app.py
@@ -16,9 +16,10 @@ SearXNG path). Set ``extracted_content`` here instead if you want snippet-only
 behaviour and to skip the gateway's per-URL fetch.
 
 The gateway may forward provider-specific knobs as extra query params
-(``provider_options`` on the ``otari_web_search`` tool entry). This adapter
-only recognizes ``time_range``, mapped onto Brave's ``freshness`` filter;
-anything else is ignored, never forwarded to Brave.
+(``provider_options`` on the ``otari_web_search`` tool entry, set by the
+operator or workspace, never per-query by the model). This adapter only
+recognizes ``time_range``, mapped onto Brave's ``freshness`` filter; anything
+else is ignored, never forwarded to Brave.
 """
 
 from __future__ import annotations
@@ -52,9 +53,12 @@ app = FastAPI(title="otari web-search Brave adapter")
 
 
 @app.get("/health")
-async def health() -> dict[str, str]:
-    # Surfaces a misconfigured deployment (missing key) without a live query.
-    return {"status": "healthy" if BRAVE_API_KEY else "missing BRAVE_API_KEY"}
+async def health() -> JSONResponse:
+    # Fail closed when misconfigured (missing key) so orchestrators don't treat
+    # an unusable adapter as healthy.
+    if not BRAVE_API_KEY:
+        return JSONResponse(status_code=503, content={"status": "missing BRAVE_API_KEY"})
+    return JSONResponse(status_code=200, content={"status": "healthy"})
 
 
 @app.get("/search")
@@ -84,8 +88,21 @@ async def search(
         )
     except httpx.HTTPError as exc:
         return JSONResponse(status_code=502, content={"error": f"brave search failed: {exc}"})
+    except ValueError as exc:
+        # Invalid / non-JSON body from Brave. Translate to a 502 rather than
+        # letting it bubble up as a 500, so the gateway sees a consistent signal.
+        return JSONResponse(status_code=502, content={"error": f"brave search returned invalid JSON: {exc}"})
 
-    hits = (payload.get("web") or {}).get("results") or []
+    if not isinstance(payload, dict):
+        return JSONResponse(status_code=502, content={"error": "brave search returned an unexpected shape"})
+
+    web = payload.get("web")
+    hits = web.get("results") if isinstance(web, dict) else None
+    if not isinstance(hits, list):
+        # A missing/non-list `results` is an upstream contract break, not "no
+        # hits", so surface it as a 502 instead of silently returning empty.
+        return JSONResponse(status_code=502, content={"error": "brave search returned an unexpected shape"})
+
     results: list[dict[str, Any]] = []
     for h in hits:
         if not isinstance(h, dict) or not h.get("url"):
@@ -95,10 +112,11 @@ async def search(
             "title": h.get("title", ""),
             "content": h.get("description", ""),
         }
-        # Brave documents both `page_age` and `age` on a result with no
-        # documented distinction between them; prefer page_age (appears to be
-        # the more specific field) and fall back to age. Passed through as an
-        # opaque string, whatever format Brave sent, not reformatted here.
+        # page_age (ISO 8601 timestamp) and age (human-readable, e.g. "3 days
+        # ago") are different formats, not interchangeable; prefer page_age
+        # for a consistent, parseable format across results and fall back to
+        # age only when Brave didn't supply it. Passed through as an opaque
+        # string either way, not reformatted here.
         published_date = h.get("page_age") or h.get("age")
         if published_date:
             result["published_date"] = published_date

--- a/scripts/web-search-brave-adapter/app.py
+++ b/scripts/web-search-brave-adapter/app.py
@@ -14,6 +14,11 @@ Each result's ``content`` is Brave's snippet; ``extracted_content`` is left
 unset so the gateway still fetches and extracts the full page (matching the
 SearXNG path). Set ``extracted_content`` here instead if you want snippet-only
 behaviour and to skip the gateway's per-URL fetch.
+
+The gateway may forward provider-specific knobs as extra query params
+(``provider_options`` on the ``otari_web_search`` tool entry). This adapter
+only recognizes ``time_range``, mapped onto Brave's ``freshness`` filter;
+anything else is ignored, never forwarded to Brave.
 """
 
 from __future__ import annotations
@@ -30,6 +35,19 @@ BRAVE_ENDPOINT = "https://api.search.brave.com/res/v1/web/search"
 # Brave caps `count` at 20; the gateway slices to its own max_results anyway.
 DEFAULT_COUNT = 10
 
+# Same time_range vocabulary as the Tavily adapter (single vs. plural forms
+# both accepted), mapped onto Brave's `freshness` filter values.
+_FRESHNESS_BY_TIME_RANGE = {
+    "d": "pd",
+    "day": "pd",
+    "w": "pw",
+    "week": "pw",
+    "m": "pm",
+    "month": "pm",
+    "y": "py",
+    "year": "py",
+}
+
 app = FastAPI(title="otari web-search Brave adapter")
 
 
@@ -40,13 +58,18 @@ async def health() -> dict[str, str]:
 
 
 @app.get("/search")
-async def search(q: str = Query(..., min_length=1)) -> JSONResponse:
+async def search(
+    q: str = Query(..., min_length=1),
+    time_range: str | None = Query(default=None, pattern="^(day|week|month|year|d|w|m|y)$"),
+) -> JSONResponse:
     """Translate a SearXNG-style query into a Brave Search API call."""
     if not BRAVE_API_KEY:
         return JSONResponse(status_code=503, content={"error": "BRAVE_API_KEY is not set"})
 
     headers = {"X-Subscription-Token": BRAVE_API_KEY, "Accept": "application/json"}
     params: dict[str, str | int] = {"q": q, "count": DEFAULT_COUNT}
+    if time_range is not None:
+        params["freshness"] = _FRESHNESS_BY_TIME_RANGE[time_range]
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.get(BRAVE_ENDPOINT, params=params, headers=headers)
@@ -63,13 +86,21 @@ async def search(q: str = Query(..., min_length=1)) -> JSONResponse:
         return JSONResponse(status_code=502, content={"error": f"brave search failed: {exc}"})
 
     hits = (payload.get("web") or {}).get("results") or []
-    results: list[dict[str, Any]] = [
-        {
+    results: list[dict[str, Any]] = []
+    for h in hits:
+        if not isinstance(h, dict) or not h.get("url"):
+            continue
+        result: dict[str, Any] = {
             "url": h["url"],
             "title": h.get("title", ""),
             "content": h.get("description", ""),
         }
-        for h in hits
-        if isinstance(h, dict) and h.get("url")
-    ]
+        # Brave documents both `page_age` and `age` on a result with no
+        # documented distinction between them; prefer page_age (appears to be
+        # the more specific field) and fall back to age. Passed through as an
+        # opaque string, whatever format Brave sent, not reformatted here.
+        published_date = h.get("page_age") or h.get("age")
+        if published_date:
+            result["published_date"] = published_date
+        results.append(result)
     return JSONResponse(content={"results": results})

--- a/src/gateway/services/web_search_backend.py
+++ b/src/gateway/services/web_search_backend.py
@@ -423,5 +423,11 @@ def _format_results_for_model(query: str, results: list[dict[str, Any]]) -> str:
         body = extracted or snippet
         if len(body) > _CONTENT_TRUNCATE_CHARS:
             body = body[:_CONTENT_TRUNCATE_CHARS].rstrip() + "…"
-        parts.append(f"[{i}] {title}\n{url}\n{body}".rstrip())
+        # Optional: only backends that supply a recency signal (e.g. the
+        # Brave adapter's provider_options time_range support) set this. The
+        # model can't judge how current a result is from the snippet alone,
+        # so surface it when present instead of silently dropping it.
+        published_date = str(r.get("published_date") or "").strip()
+        header = f"[{i}] {title}" + (f" ({published_date})" if published_date else "")
+        parts.append(f"{header}\n{url}\n{body}".rstrip())
     return "\n\n".join(parts)

--- a/src/gateway/services/web_search_backend.py
+++ b/src/gateway/services/web_search_backend.py
@@ -77,6 +77,11 @@ _FETCH_MAX_REDIRECTS = 5
 # /search?format=json shape.
 _DEFAULT_ENGINES = ("duckduckgo", "mojeek", "qwant", "wikipedia")
 _CONTENT_TRUNCATE_CHARS = 1500
+# published_date is backend-controlled, untrusted input (e.g. whatever a
+# search-API-fronting adapter forwards from the provider); bound it before it
+# reaches model context so a malicious/compromised backend can't inject
+# newlines or an oversized string through this field.
+_PUBLISHED_DATE_MAX_CHARS = 128
 
 _DEFAULT_PURPOSE_HINT = (
     "Prefer `web_search` for current information, news, recent events, "
@@ -427,7 +432,10 @@ def _format_results_for_model(query: str, results: list[dict[str, Any]]) -> str:
         # Brave adapter's provider_options time_range support) set this. The
         # model can't judge how current a result is from the snippet alone,
         # so surface it when present instead of silently dropping it.
-        published_date = str(r.get("published_date") or "").strip()
+        # Untrusted backend-controlled input: collapse to one line and cap
+        # the length so a malicious/compromised backend can't use this field
+        # to inject newlines or an oversized string into model context.
+        published_date = " ".join(str(r.get("published_date") or "").split())[:_PUBLISHED_DATE_MAX_CHARS]
         header = f"[{i}] {title}" + (f" ({published_date})" if published_date else "")
         parts.append(f"{header}\n{url}\n{body}".rstrip())
     return "\n\n".join(parts)

--- a/src/gateway/services/web_search_backend.py
+++ b/src/gateway/services/web_search_backend.py
@@ -11,9 +11,10 @@ expected to speak a SearXNG-compatible JSON API:
 The default deployment points this at a bundled SearXNG container (see
 ``docker-compose.yml``, ``web-search`` profile). Any other container
 that exposes the same JSON shape on ``/search`` is a drop-in
-replacement — including commercial-API-fronting adapters whose response
+replacement, including commercial-API-fronting adapters whose response
 sets the optional ``extracted_content`` field to bypass the
-gateway-side trafilatura step.
+gateway-side trafilatura step, or the optional ``published_date`` field
+(e.g. the Brave adapter) to surface a result's recency to the model.
 
 After search, the backend optionally fetches the top results' URLs and
 runs trafilatura in-process to produce LLM-ready Markdown. Fetch +
@@ -77,10 +78,10 @@ _FETCH_MAX_REDIRECTS = 5
 # /search?format=json shape.
 _DEFAULT_ENGINES = ("duckduckgo", "mojeek", "qwant", "wikipedia")
 _CONTENT_TRUNCATE_CHARS = 1500
-# published_date is backend-controlled, untrusted input (e.g. whatever a
-# search-API-fronting adapter forwards from the provider); bound it before it
-# reaches model context so a malicious/compromised backend can't inject
-# newlines or an oversized string through this field.
+# published_date is backend-controlled (whatever a search-API-fronting
+# adapter forwards from the provider); bound it as basic rendering hygiene, a
+# single overlong or multiline value here shouldn't be the thing that makes
+# the result block hard to read.
 _PUBLISHED_DATE_MAX_CHARS = 128
 
 _DEFAULT_PURPOSE_HINT = (
@@ -432,9 +433,11 @@ def _format_results_for_model(query: str, results: list[dict[str, Any]]) -> str:
         # Brave adapter's provider_options time_range support) set this. The
         # model can't judge how current a result is from the snippet alone,
         # so surface it when present instead of silently dropping it.
-        # Untrusted backend-controlled input: collapse to one line and cap
-        # the length so a malicious/compromised backend can't use this field
-        # to inject newlines or an oversized string into model context.
+        # Collapsed to one line and length-capped as rendering hygiene, not a
+        # security boundary: title/content above aren't normalized the same
+        # way, so this alone doesn't stop a compromised backend from
+        # injecting newlines into the block; it just keeps this one new field
+        # from being the messiest part of it.
         published_date = " ".join(str(r.get("published_date") or "").split())[:_PUBLISHED_DATE_MAX_CHARS]
         header = f"[{i}] {title}" + (f" ({published_date})" if published_date else "")
         parts.append(f"{header}\n{url}\n{body}".rstrip())

--- a/tests/unit/_search_adapter_test_support.py
+++ b/tests/unit/_search_adapter_test_support.py
@@ -1,0 +1,62 @@
+"""Shared test helpers for the standalone web-search adapter scripts.
+
+Each adapter (Brave, Tavily, ...) lives under ``scripts/`` outside the
+gateway package, so its tests load it by file path rather than import it
+normally. Not itself a test module (no ``test_`` prefix), pytest won't collect
+it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+
+
+def load_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    adapter_dir: str,
+    module_name: str,
+    env: dict[str, str],
+) -> Any:
+    """Load an adapter's ``app.py`` by path, with ``env`` set via monkeypatch.
+
+    ``module_name`` must be unique per adapter (it's registered in
+    ``sys.modules``) so loading one adapter in a test run doesn't shadow
+    another's.
+    """
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    adapter_path = _SCRIPTS_DIR / adapter_dir / "app.py"
+    spec = importlib.util.spec_from_file_location(module_name, adapter_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def mock_async_client(handler: Any) -> Any:
+    """Return an httpx.AsyncClient subclass whose outbound calls use a mock
+    transport, so an adapter's own outbound call to its upstream API is
+    intercepted."""
+
+    real_async_client = httpx.AsyncClient
+
+    class _MockAsyncClient(real_async_client):  # type: ignore[valid-type, misc]
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            # The test drives the ASGI app through its own AsyncClient with an
+            # explicit transport; leave that one untouched. Only the adapter's
+            # own outbound call (which passes no transport) gets the mock.
+            if "transport" not in kwargs:
+                kwargs["transport"] = httpx.MockTransport(handler)
+            super().__init__(*args, **kwargs)
+
+    return _MockAsyncClient

--- a/tests/unit/test_brave_adapter.py
+++ b/tests/unit/test_brave_adapter.py
@@ -7,25 +7,20 @@ suite needs no network access or live key.
 
 from __future__ import annotations
 
-import importlib.util
-import sys
-from pathlib import Path
 from typing import Any
 
 import httpx
 import pytest
-
-_ADAPTER_PATH = Path(__file__).resolve().parents[2] / "scripts" / "web-search-brave-adapter" / "app.py"
+from _search_adapter_test_support import load_adapter, mock_async_client
 
 
 def _load_adapter(monkeypatch: pytest.MonkeyPatch, *, api_key: str = "brv-test") -> Any:
-    monkeypatch.setenv("BRAVE_API_KEY", api_key)
-    spec = importlib.util.spec_from_file_location("brave_adapter_app", _ADAPTER_PATH)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["brave_adapter_app"] = module
-    spec.loader.exec_module(module)
-    return module
+    return load_adapter(
+        monkeypatch,
+        adapter_dir="web-search-brave-adapter",
+        module_name="brave_adapter_app",
+        env={"BRAVE_API_KEY": api_key},
+    )
 
 
 @pytest.mark.asyncio
@@ -34,6 +29,9 @@ async def test_health_reports_missing_key(monkeypatch: pytest.MonkeyPatch) -> No
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
         resp = await client.get("/health")
+    # Fail closed: an orchestrator health check must not treat a keyless,
+    # unusable adapter as healthy.
+    assert resp.status_code == 503
     assert resp.json() == {"status": "missing BRAVE_API_KEY"}
 
 
@@ -43,6 +41,7 @@ async def test_health_healthy_with_key(monkeypatch: pytest.MonkeyPatch) -> None:
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
         resp = await client.get("/health")
+    assert resp.status_code == 200
     assert resp.json() == {"status": "healthy"}
 
 
@@ -80,7 +79,7 @@ async def test_search_maps_brave_shape(monkeypatch: pytest.MonkeyPatch) -> None:
             },
         )
 
-    monkeypatch.setattr(module.httpx, "AsyncClient", _mock_async_client(handler))
+    monkeypatch.setattr(module.httpx, "AsyncClient", mock_async_client(handler))
 
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
@@ -114,7 +113,7 @@ async def test_search_forwards_time_range_as_freshness(monkeypatch: pytest.Monke
         captured["params"] = dict(request.url.params)
         return httpx.Response(200, json={"web": {"results": []}})
 
-    monkeypatch.setattr(module.httpx, "AsyncClient", _mock_async_client(handler))
+    monkeypatch.setattr(module.httpx, "AsyncClient", mock_async_client(handler))
 
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
@@ -150,7 +149,7 @@ async def test_search_surfaces_brave_status_as_502(monkeypatch: pytest.MonkeyPat
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(401, json={"error": "bad key"})
 
-    monkeypatch.setattr(module.httpx, "AsyncClient", _mock_async_client(handler))
+    monkeypatch.setattr(module.httpx, "AsyncClient", mock_async_client(handler))
 
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
@@ -161,30 +160,77 @@ async def test_search_surfaces_brave_status_as_502(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.asyncio
+async def test_search_invalid_json_returns_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_adapter(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"<html>not json</html>", headers={"content-type": "application/json"})
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", mock_async_client(handler))
+
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get("/search", params={"q": "x"})
+
+    assert resp.status_code == 502
+    assert "invalid JSON" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_search_non_dict_payload_returns_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_adapter(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=["not", "a", "dict"])
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", mock_async_client(handler))
+
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get("/search", params={"q": "x"})
+
+    assert resp.status_code == 502
+    assert "unexpected shape" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_search_non_list_results_returns_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_adapter(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"web": {"results": "not-a-list"}})
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", mock_async_client(handler))
+
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get("/search", params={"q": "x"})
+
+    assert resp.status_code == 502
+    assert "unexpected shape" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_search_missing_web_key_returns_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_adapter(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={})
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", mock_async_client(handler))
+
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get("/search", params={"q": "x"})
+
+    assert resp.status_code == 502
+    assert "unexpected shape" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
 async def test_search_503_when_key_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_adapter(monkeypatch, api_key="")
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
         resp = await client.get("/search", params={"q": "x"})
     assert resp.status_code == 503
-
-
-# ----- helpers -----
-
-
-def _mock_async_client(handler: Any) -> Any:
-    """Return an httpx.AsyncClient subclass whose outbound calls use a mock
-    transport, so the adapter's GET to Brave is intercepted."""
-
-    real_async_client = httpx.AsyncClient
-
-    class _MockAsyncClient(real_async_client):  # type: ignore[valid-type, misc]
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            # The test drives the ASGI app through its own AsyncClient with an
-            # explicit transport; leave that one untouched. Only the adapter's
-            # own outbound call (which passes no transport) gets the mock.
-            if "transport" not in kwargs:
-                kwargs["transport"] = httpx.MockTransport(handler)
-            super().__init__(*args, **kwargs)
-
-    return _MockAsyncClient

--- a/tests/unit/test_brave_adapter.py
+++ b/tests/unit/test_brave_adapter.py
@@ -1,0 +1,190 @@
+"""Unit tests for the Brave web-search adapter (scripts/web-search-brave-adapter).
+
+The adapter is a standalone service outside the gateway package, so we load
+it by path. Outbound Brave calls are mocked via an httpx transport; the test
+suite needs no network access or live key.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+_ADAPTER_PATH = Path(__file__).resolve().parents[2] / "scripts" / "web-search-brave-adapter" / "app.py"
+
+
+def _load_adapter(monkeypatch: pytest.MonkeyPatch, *, api_key: str = "brv-test") -> Any:
+    monkeypatch.setenv("BRAVE_API_KEY", api_key)
+    spec = importlib.util.spec_from_file_location("brave_adapter_app", _ADAPTER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["brave_adapter_app"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_health_reports_missing_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_adapter(monkeypatch, api_key="")
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get("/health")
+    assert resp.json() == {"status": "missing BRAVE_API_KEY"}
+
+
+@pytest.mark.asyncio
+async def test_health_healthy_with_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_adapter(monkeypatch)
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get("/health")
+    assert resp.json() == {"status": "healthy"}
+
+
+@pytest.mark.asyncio
+async def test_search_maps_brave_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_adapter(monkeypatch)
+
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["params"] = dict(request.url.params)
+        captured["token"] = request.headers.get("x-subscription-token")
+        return httpx.Response(
+            200,
+            json={
+                "web": {
+                    "results": [
+                        {
+                            "url": "https://example.com/a",
+                            "title": "Post A",
+                            "description": "snippet a",
+                            "page_age": "2026-07-20T00:00:00.000Z",
+                            "age": "1 week ago",
+                        },
+                        {
+                            "url": "https://example.org/b",
+                            "title": "Post B",
+                            "description": "snippet b",
+                            "age": "3 days ago",
+                        },
+                        {"title": "no url", "description": "x"},
+                    ]
+                }
+            },
+        )
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", _mock_async_client(handler))
+
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get("/search", params={"q": "claude code"})
+
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert len(results) == 2  # the url-less hit is dropped
+    assert results[0] == {
+        "url": "https://example.com/a",
+        "title": "Post A",
+        "content": "snippet a",
+        # page_age wins over age when both are present.
+        "published_date": "2026-07-20T00:00:00.000Z",
+    }
+    # No page_age on this hit: falls back to age.
+    assert results[1]["published_date"] == "3 days ago"
+
+    assert captured["token"] == "brv-test"
+    assert captured["params"]["q"] == "claude code"
+    assert "freshness" not in captured["params"]
+
+
+@pytest.mark.asyncio
+async def test_search_forwards_time_range_as_freshness(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_adapter(monkeypatch)
+
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["params"] = dict(request.url.params)
+        return httpx.Response(200, json={"web": {"results": []}})
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", _mock_async_client(handler))
+
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        for time_range, expected_freshness in (
+            ("day", "pd"),
+            ("d", "pd"),
+            ("week", "pw"),
+            ("w", "pw"),
+            ("month", "pm"),
+            ("m", "pm"),
+            ("year", "py"),
+            ("y", "py"),
+        ):
+            resp = await client.get("/search", params={"q": "x", "time_range": time_range})
+            assert resp.status_code == 200, resp.text
+            assert captured["params"]["freshness"] == expected_freshness
+
+
+@pytest.mark.asyncio
+async def test_search_invalid_time_range_returns_422(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Bad time_range is rejected at the edge (Query pattern) before any Brave call.
+    module = _load_adapter(monkeypatch)
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get("/search", params={"q": "x", "time_range": "bogus"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_search_surfaces_brave_status_as_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_adapter(monkeypatch)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": "bad key"})
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", _mock_async_client(handler))
+
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get("/search", params={"q": "x"})
+
+    assert resp.status_code == 502
+    assert resp.json() == {"error": "brave search returned 401"}
+
+
+@pytest.mark.asyncio
+async def test_search_503_when_key_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_adapter(monkeypatch, api_key="")
+    transport = httpx.ASGITransport(app=module.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
+        resp = await client.get("/search", params={"q": "x"})
+    assert resp.status_code == 503
+
+
+# ----- helpers -----
+
+
+def _mock_async_client(handler: Any) -> Any:
+    """Return an httpx.AsyncClient subclass whose outbound calls use a mock
+    transport — so the adapter's GET to Brave is intercepted."""
+
+    real_async_client = httpx.AsyncClient
+
+    class _MockAsyncClient(real_async_client):  # type: ignore[valid-type, misc]
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            # The test drives the ASGI app through its own AsyncClient with an
+            # explicit transport; leave that one untouched. Only the adapter's
+            # own outbound call (which passes no transport) gets the mock.
+            if "transport" not in kwargs:
+                kwargs["transport"] = httpx.MockTransport(handler)
+            super().__init__(*args, **kwargs)
+
+    return _MockAsyncClient

--- a/tests/unit/test_brave_adapter.py
+++ b/tests/unit/test_brave_adapter.py
@@ -174,7 +174,7 @@ async def test_search_503_when_key_missing(monkeypatch: pytest.MonkeyPatch) -> N
 
 def _mock_async_client(handler: Any) -> Any:
     """Return an httpx.AsyncClient subclass whose outbound calls use a mock
-    transport — so the adapter's GET to Brave is intercepted."""
+    transport, so the adapter's GET to Brave is intercepted."""
 
     real_async_client = httpx.AsyncClient
 

--- a/tests/unit/test_tavily_adapter.py
+++ b/tests/unit/test_tavily_adapter.py
@@ -7,25 +7,20 @@ suite needs no network access or live key.
 
 from __future__ import annotations
 
-import importlib.util
-import sys
-from pathlib import Path
 from typing import Any
 
 import httpx
 import pytest
-
-_ADAPTER_PATH = Path(__file__).resolve().parents[2] / "scripts" / "web-search-tavily-adapter" / "app.py"
+from _search_adapter_test_support import load_adapter, mock_async_client
 
 
 def _load_adapter(monkeypatch: pytest.MonkeyPatch, *, api_key: str = "tvly-test") -> Any:
-    monkeypatch.setenv("TAVILY_API_KEY", api_key)
-    spec = importlib.util.spec_from_file_location("tavily_adapter_app", _ADAPTER_PATH)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["tavily_adapter_app"] = module
-    spec.loader.exec_module(module)
-    return module
+    return load_adapter(
+        monkeypatch,
+        adapter_dir="web-search-tavily-adapter",
+        module_name="tavily_adapter_app",
+        env={"TAVILY_API_KEY": api_key},
+    )
 
 
 @pytest.mark.asyncio
@@ -78,7 +73,7 @@ async def test_search_maps_tavily_shape_and_whitelists(monkeypatch: pytest.Monke
             },
         )
 
-    monkeypatch.setattr(module.httpx, "AsyncClient", _mock_async_client(handler))
+    monkeypatch.setattr(module.httpx, "AsyncClient", mock_async_client(handler))
 
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
@@ -125,7 +120,7 @@ async def test_search_surfaces_tavily_status_as_502(monkeypatch: pytest.MonkeyPa
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(401, json={"error": "bad key"})
 
-    monkeypatch.setattr(module.httpx, "AsyncClient", _mock_async_client(handler))
+    monkeypatch.setattr(module.httpx, "AsyncClient", mock_async_client(handler))
 
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
@@ -142,7 +137,7 @@ async def test_search_invalid_json_returns_502(monkeypatch: pytest.MonkeyPatch) 
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, content=b"<html>not json</html>", headers={"content-type": "application/json"})
 
-    monkeypatch.setattr(module.httpx, "AsyncClient", _mock_async_client(handler))
+    monkeypatch.setattr(module.httpx, "AsyncClient", mock_async_client(handler))
 
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
@@ -159,7 +154,7 @@ async def test_search_non_list_results_returns_502(monkeypatch: pytest.MonkeyPat
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, json={"results": "not-a-list"})
 
-    monkeypatch.setattr(module.httpx, "AsyncClient", _mock_async_client(handler))
+    monkeypatch.setattr(module.httpx, "AsyncClient", mock_async_client(handler))
 
     transport = httpx.ASGITransport(app=module.app)
     async with httpx.AsyncClient(transport=transport, base_url="http://adapter") as client:
@@ -196,21 +191,3 @@ def json_body(request: httpx.Request) -> dict[str, Any]:
 
     body: dict[str, Any] = json.loads(request.content.decode())
     return body
-
-
-def _mock_async_client(handler: Any) -> Any:
-    """Return an httpx.AsyncClient subclass whose outbound calls use a mock
-    transport — so the adapter's POST to Tavily is intercepted."""
-
-    real_async_client = httpx.AsyncClient
-
-    class _MockAsyncClient(real_async_client):  # type: ignore[valid-type, misc]
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            # The test drives the ASGI app through its own AsyncClient with an
-            # explicit transport; leave that one untouched. Only the adapter's
-            # own outbound call (which passes no transport) gets the mock.
-            if "transport" not in kwargs:
-                kwargs["transport"] = httpx.MockTransport(handler)
-            super().__init__(*args, **kwargs)
-
-    return _MockAsyncClient

--- a/tests/unit/test_web_search_backend.py
+++ b/tests/unit/test_web_search_backend.py
@@ -143,6 +143,41 @@ async def test_published_date_is_rendered_when_backend_supplies_it(monkeypatch: 
 
 
 @pytest.mark.asyncio
+async def test_published_date_is_bounded_and_normalized(monkeypatch: pytest.MonkeyPatch) -> None:
+    """published_date is backend-controlled, untrusted input: a malicious or
+    compromised backend must not be able to use it to inject newlines or an
+    oversized string into the model-facing result.
+    """
+    body = {
+        "results": [
+            {
+                "url": "https://example.com/a",
+                "title": "Post A",
+                "content": "snippet a",
+                "published_date": "line one\nline two\r\nline three",
+            },
+            {
+                "url": "https://example.org/b",
+                "title": "Post B",
+                "content": "snippet b",
+                "published_date": "x" * 500,
+            },
+        ]
+    }
+    _patched_async_client({("searxng", "/search"): httpx.Response(200, json=body)}, monkeypatch)
+
+    async with WebSearchBackend(base_url="http://searxng:8080", extract_content=False) as backend:
+        result = await backend.call_tool(WEB_SEARCH_TOOL_NAME, {"query": "claude code"})
+
+    # Multiline input collapses to one line, no injected newlines survive it.
+    assert "line one line two line three" in result
+    assert "line one\nline two" not in result
+    # Oversized input is capped, not reproduced in full.
+    assert "x" * 500 not in result
+    assert "x" * 128 in result
+
+
+@pytest.mark.asyncio
 async def test_call_tool_extracts_content_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     _patched_async_client(
         {

--- a/tests/unit/test_web_search_backend.py
+++ b/tests/unit/test_web_search_backend.py
@@ -112,6 +112,37 @@ async def test_call_tool_returns_formatted_results_without_extraction(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_published_date_is_rendered_when_backend_supplies_it(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A recency-aware adapter (e.g. Brave with time_range) may set
+    # published_date; a plain SearXNG backend never does. Both must render
+    # correctly: present inline next to the title, absent means no residue.
+    body = {
+        "results": [
+            {
+                "url": "https://example.com/post-a",
+                "title": "Post A",
+                "content": "snippet about A",
+                "published_date": "2026-07-20T00:00:00.000Z",
+            },
+            {
+                "url": "https://example.org/post-b",
+                "title": "Post B",
+                "content": "snippet about B",
+            },
+        ]
+    }
+    _patched_async_client({("searxng", "/search"): httpx.Response(200, json=body)}, monkeypatch)
+
+    async with WebSearchBackend(base_url="http://searxng:8080", extract_content=False) as backend:
+        result = await backend.call_tool(WEB_SEARCH_TOOL_NAME, {"query": "claude code"})
+
+    assert "[1] Post A (2026-07-20T00:00:00.000Z)" in result
+    # No published_date supplied for B: no stray parens/empty date rendered.
+    assert "[2] Post B" in result
+    assert "[2] Post B (" not in result
+
+
+@pytest.mark.asyncio
 async def test_call_tool_extracts_content_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     _patched_async_client(
         {

--- a/tests/unit/test_web_search_backend.py
+++ b/tests/unit/test_web_search_backend.py
@@ -144,9 +144,8 @@ async def test_published_date_is_rendered_when_backend_supplies_it(monkeypatch: 
 
 @pytest.mark.asyncio
 async def test_published_date_is_bounded_and_normalized(monkeypatch: pytest.MonkeyPatch) -> None:
-    """published_date is backend-controlled, untrusted input: a malicious or
-    compromised backend must not be able to use it to inject newlines or an
-    oversized string into the model-facing result.
+    """A multiline or oversized published_date shouldn't make the rendered
+    result block hard to read; collapse to one line and cap the length.
     """
     body = {
         "results": [
@@ -173,8 +172,8 @@ async def test_published_date_is_bounded_and_normalized(monkeypatch: pytest.Monk
     assert "line one line two line three" in result
     assert "line one\nline two" not in result
     # Oversized input is capped, not reproduced in full.
-    assert "x" * 500 not in result
-    assert "x" * 128 in result
+    assert f"[2] Post B ({'x' * 128})" in result
+    assert f"[2] Post B ({'x' * 129})" not in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description
The Brave adapter ignored `time_range` entirely and dropped Brave's per-result publish date, so a time-sensitive query returned relevance-ranked evergreen pages with no way to judge how current any result was.

Adds `time_range` support to the Brave adapter, mapped onto Brave's `freshness` filter (`day`/`d` -> `pd`, `week`/`w` -> `pw`, `month`/`m` -> `pm`, `year`/`y` -> `py`), matching the vocabulary the Tavily adapter already uses. Each result's `page_age` (preferred) or `age` field is passed through as `published_date`, whichever Brave supplied, unmodified.

Also updates `web_search_backend.py`'s result rendering to surface `published_date` next to the title when a backend supplies it (Brave now does; plain SearXNG never will), otherwise the model has no way to judge recency from a snippet alone, which is the actual point of requesting a `time_range` filter in the first place.

## PR Type
- [x] New Feature

## Relevant issues
Fixes #402

## Checklist
- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`) — note: ran via a manual pip venv, not `uv`, since Windows is excluded from your lockfile's supported platforms.
- [x] Documentation was updated where necessary (adapter README's Provider options section).
- [x] If the API contract changed, I regenerated the OpenAPI spec — not applicable, no gateway routes changed.

## AI Usage
- [x] AI was used for drafting/refactoring.

**AI Model/Tool used:** Claude Code (Sonnet 5)

**Any additional AI details you'd like to share:** Followed the existing Tavily adapter's pattern for time_range handling and test structure; code written by Claude Code under my direction and review.

- [ ] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added Brave recency support to the web-search adapter by translating a requested `time_range` (day/week/month/year) into Brave’s `freshness` filter so callers can get recent results.
- Extended results to carry a per-hit `published_date` from Brave (using Brave’s `page_age` when available, otherwise `age`) and display it alongside each result title when present.
- Tightened Brave integration robustness: added provider/date parameter validation, safer response parsing/shape checks, and clearer upstream error handling.
- Updated the adapter README and the result contract documentation to describe `published_date` and how provider `time_range` is forwarded.
- Improved safety when rendering `published_date` in the backend by normalizing whitespace and bounding the displayed length.
- Added/expanded unit tests for Brave recency, `published_date` mapping/rendering, input validation, error handling, and missing API-key behavior; also refactored shared test helpers used by adapter test suites.

These changes help consumers retrieve and assess time-sensitive search results rather than only relevance-ranked evergreen pages.

## Technical notes

- `time_range` is mapped to Brave freshness codes: `day|d→pd`, `week|w→pw`, `month|m→pm`, `year|y→py`.
- `published_date` is sourced from Brave’s `page_age` (preferred) or `age`, then rendered in the backend after whitespace normalization and max-length bounding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->