### PR TITLE
fix(otlp): price imported cache creation at the 5m rate, not 1h

### DIFF
--- a/docs/external-usage.md
+++ b/docs/external-usage.md
@@ -202,6 +202,16 @@ see the dedicated guides:
 - [Use with Claude Code](use-with-claude-code.md)
 - [Use with Codex](use-with-codex.md)
 
+No OTLP shape reports the 5-minute/1-hour split of cache creation, so every imported
+cache write is priced at the 5-minute rate. Claude Code does use both TTLs, and its
+`api_request` event reports only a combined `cache_creation_tokens`, so whichever rate
+Otari assumes is wrong for the other share: the 5-minute assumption undercharges the
+1-hour writes (the larger share on measured Claude Code workloads), and assuming
+1 hour would overcharge the 5-minute ones. A 1-hour write costs 2x base input against
+1.25x for a 5-minute one, so Otari books the cheaper bucket and an imported cost never
+reads above true cost. To bill the true split, send `cache_write_1h_tokens` yourself
+via `POST /v1/usage/external-events`.
+
 ## Other sources
 
 `POST /v1/usage/external-events` (above) is the explicit path for any source that is

--- a/src/gateway/api/routes/otlp.py
+++ b/src/gateway/api/routes/otlp.py
@@ -232,11 +232,18 @@ def _build_event(
     """
     provider: Any
     duration: Any
+    # No OTLP shape carries the 5m/1h cache-write split, so every cache write stays in
+    # the base (5m) bucket. Claude Code writes with both TTLs (measured on real session
+    # transcripts, roughly a quarter to a third of creation tokens are 5m and the rest
+    # 1h), so either default is wrong for the other share: 5m undercharges the 1h
+    # tokens, 1h overcharges the 5m ones. Anthropic prices a 1h write at 2x base input
+    # against 1.25x for a 5m one, so booking the base bucket keeps an imported estimate
+    # from ever reading above true cost. Callers holding the real split use
+    # POST /v1/usage/external-events, which takes cache_write_1h_tokens directly.
     cache_write_1h = 0
     event_name = attrs.get("event.name")
     if event_name == "api_request":
-        # Claude Code: cache reads/writes are additive (outside input_tokens), and
-        # it uses 1h caching with no split, so cache creation is booked as 1h.
+        # Claude Code: cache reads/writes are additive (outside input_tokens).
         source = "claude_code"
         provider = "anthropic"
         model = attrs.get("model")
@@ -245,7 +252,6 @@ def _build_event(
         output_tokens = _int(attrs.get("output_tokens"))
         cache_read = _int(attrs.get("cache_read_tokens"))
         cache_write = _int(attrs.get("cache_creation_tokens"))
-        cache_write_1h = cache_write
         session = attrs.get("session.id")
         duration = attrs.get("duration_ms", duration_ms)
         cache_tokens_in_prompt = False

--- a/src/gateway/api/routes/otlp.py
+++ b/src/gateway/api/routes/otlp.py
@@ -240,6 +240,8 @@ def _build_event(
     # against 1.25x for a 5m one, so booking the base bucket keeps an imported estimate
     # from ever reading above true cost. Callers holding the real split use
     # POST /v1/usage/external-events, which takes cache_write_1h_tokens directly.
+    # No branch below reassigns this today: it stays a variable rather than a literal at
+    # the construction site as the seam for an emitter that does report the split.
     cache_write_1h = 0
     event_name = attrs.get("event.name")
     if event_name == "api_request":

--- a/tests/integration/test_otlp.py
+++ b/tests/integration/test_otlp.py
@@ -66,7 +66,7 @@ def _exempt_key(client: TestClient, master_key_header: dict[str, str], user_id: 
 
 
 def _seed_pricing(client: TestClient, master_key_header: dict[str, str]) -> None:
-    client.post(
+    resp = client.post(
         "/v1/pricing",
         json={
             "model_key": "anthropic:claude-opus-4-8",
@@ -74,10 +74,15 @@ def _seed_pricing(client: TestClient, master_key_header: dict[str, str]) -> None
             "output_price_per_million": 75.0,
             "cache_read_price_per_million": 1.5,
             "cache_write_price_per_million": 18.75,
+            "cache_write_1h_price_per_million": 30.0,
             "effective_at": "2020-01-01T00:00:00Z",
         },
         headers=master_key_header,
     )
+    assert resp.status_code == 200, resp.text
+    # The 1h rate must land distinct from the 5m one: if it fell back to the 5m rate,
+    # a cache write booked in the wrong bucket would cost the same and go unnoticed.
+    assert resp.json()["cache_write_1h_price_per_million"] == 30.0
 
 
 def test_otlp_api_request_is_ingested_and_priced(
@@ -96,11 +101,16 @@ def test_otlp_api_request_is_ingested_and_priced(
     assert row.counts_toward_budget is False
     assert row.model == "claude-opus-4-8"
     assert row.prompt_tokens == 1200 and row.completion_tokens == 450 and row.cache_read_tokens == 8000
-    # Claude Code uses 1h caching, and the event has no split, so cache creation is
-    # booked entirely as 1h (priced at the 1h rate, not the 5m base).
-    assert row.cache_write_tokens == 1024 and row.cache_write_1h_tokens == 1024
-    # Otari prices at its own configured rate (Claude Code's cost_usd is ignored).
-    assert row.cost is not None and row.cost > 0
+    # The api_request event carries no 5m/1h split, so cache creation stays in the base
+    # bucket and is priced at the 5m rate rather than the dearer 1h one.
+    assert row.cache_write_tokens == 1024 and row.cache_write_1h_tokens == 0
+    assert row.billing_meters is not None
+    assert row.billing_meters["cache_write_tokens"] == 1024
+    assert row.billing_meters["cache_write_1h_tokens"] == 0
+    # Otari prices at its own configured rates (Claude Code's cost_usd is ignored):
+    # 1200 fresh input + 450 output + 8000 cache read + 1024 cache writes at the 5m rate.
+    expected = (1200 * 15.0 + 450 * 75.0 + 8000 * 1.5 + 1024 * 18.75) / 1_000_000
+    assert row.cost == pytest.approx(expected)
     # The email attribute present in the OTLP record must never be persisted.
     assert "example.com" not in (row.source_label or "")
 


### PR DESCRIPTION
## Description

The Claude Code branch of the OTLP logs receiver booked every `cache_creation_tokens` as a 1h cache write. Because `cache_write_1h_tokens` is a subset of `cache_write_tokens` (`cache_write_base_tokens = cache_write_tokens - cache_write_1h_tokens`), setting the two equal drove the base bucket to zero, so nothing imported on this path could ever be priced at the 5m rate. That structural dead end is the bug.

The premise behind it was also wrong. Claude Code writes with both TTLs; it is the `api_request` event that collapses them into one combined counter, and `cache_creation_5m_tokens` / `cache_creation_1h_tokens` appear nowhere in the client. With the split unrecoverable from the logs signal, the only decision left is which TTL to assume, and either choice is wrong for the other share.

**On which default is chosen, and why.** The measured split in #424 is 30.1% 5m / 69.9% 1h, so 1h is the *larger* bucket. (Issue #424's option-1 text says 5m is the majority, which contradicts the table directly above it; the table and the title are right. An earlier revision of this PR repeated that error.) So this change is not the more-often-right default: it is chosen on direction of error. Anthropic prices a 1h write at 2x base input against 1.25x for a 5m one, so booking the base bucket keeps an imported estimate from ever reading above true cost. Imported usage is budget-exempt cost observability, so erring low beats showing a user spend they did not incur.

For the record, the tradeoff in magnitude on the cache-creation slice, against a true blended rate of 1.77x base input: the old all-1h behavior overcharged about 13%, this all-5m behavior undercharges about 30%. If minimizing absolute error matters more than never overbilling, the alternatives are option 2 from the issue (a configurable assumed TTL) or a blended default, and this PR is the wrong shape. Flagging it explicitly since the issue's own framing understated it.

Cache writes now stay in the base (5m) bucket. `POST /v1/usage/external-events` is unchanged, so importers that do have the real split (anything reading Claude Code transcripts, where `ephemeral_5m_input_tokens` / `ephemeral_1h_input_tokens` are both present) keep sending `cache_write_1h_tokens` directly.

Scope notes, both from the options listed in the issue:

* Option 2 (a configurable assumed TTL per source) is deliberately not implemented. It adds config surface for a guess, and an operator who knows their workload well enough to configure it can send true numbers through `/v1/usage/external-events` instead.
* Option 3 (an upstream request that Claude Code emit the split on `api_request`) is worth filing but is not part of this PR.

On already-ingested rows: `POST /v1/usage/set-price` builds its transient pricing with `cache_write_1h_price_per_million=None`, so the 1h rate falls back to the 5m rate and repricing corrects the cost of existing rows. Their stored `cache_write_1h_tokens` values stay misclassified; nothing here backfills them. (The issue calls this endpoint `/v1/usage/reprice`; the actual route is `/v1/usage/set-price`.)

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #424

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Verification detail:

* `tests/integration/test_otlp.py::test_otlp_api_request_is_ingested_and_priced` fails without the fix (`assert 1024 == 0`) and passes with it. `_seed_pricing` now sets a distinct `cache_write_1h_price_per_million` (30.0 against 18.75) and asserts it landed, so a write booked in the wrong bucket moves the cost instead of silently falling back to the same rate. The test pins `cache_write_1h_tokens`, the `billing_meters` the pricing layer actually charged, and the exact cost.
* All 19 OTLP integration tests pass. `ruff` and `mypy` are clean; `make openapi-check` and `make postman-check` both report up to date (no API contract change, so neither artifact moved).
* Full suite: 1853 passed, 2 failed. Both failures (`test_error_detail_leakage.py::test_provider_error_does_not_leak_details` and `test_streaming_error_event.py::test_streaming_creation_error_returns_http_error`) reproduce identically on a clean baseline worktree at the same `HEAD`, are provider-error-mapping tests untouched by this diff, and are environmental in this sandbox.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code (Claude Opus 5)

**Any additional AI details you'd like to share:**

Implemented by Claude Code via back-and-forth with @njbrake: the fix, the test, and the prose are Claude's; the decision to take option 1 from the issue and to leave options 2 and 3 out of scope is his. A second Claude Code agent reviewed the diff cold and caught the inverted majority-bucket claim described above, which has been corrected here, in the commit message, in the code comment, and in the docs.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- OTLP Claude Code cache writes now use the base 5-minute cache bucket when the TTL split is unavailable.
- Documentation explains this pricing behavior and identifies the external-events API for accurate 1-hour pricing.
- Integration tests verify token allocation, billing meters, and cost calculations.

## Benefits

- Prevents unsplit cache writes from being incorrectly classified as 1-hour writes.
- Improves billing accuracy for OTLP-imported Claude Code usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->