### PR TITLE
feat(usage): record a status code on usage logs so failures can be classified

### DIFF
--- a/alembic/versions/d7b9f1a3c5e8_add_usage_logs_status_code.py
+++ b/alembic/versions/d7b9f1a3c5e8_add_usage_logs_status_code.py
@@ -1,0 +1,30 @@
+"""Add usage_logs status_code column.
+
+Revision ID: d7b9f1a3c5e8
+Revises: c3f7a9d1e5b8
+Create Date: 2026-07-31 10:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d7b9f1a3c5e8"
+down_revision: str | Sequence[str] | None = "c3f7a9d1e5b8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Nullable: historical rows predate the column, a successful request has no
+    # failure to classify, and some failures carry no HTTP status at all.
+    op.add_column("usage_logs", sa.Column("status_code", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("usage_logs", "status_code")

--- a/alembic/versions/d7b9f1a3c5e8_add_usage_logs_status_code.py
+++ b/alembic/versions/d7b9f1a3c5e8_add_usage_logs_status_code.py
@@ -22,6 +22,14 @@ def upgrade() -> None:
     """Upgrade schema."""
     # Nullable: historical rows predate the column, a successful request has no
     # failure to classify, and some failures carry no HTTP status at all.
+    #
+    # Deliberately unindexed. Filtering on a code implies status='error' (see
+    # ``_usage_filters``) and every aggregate over it is range-bounded, so the
+    # existing (status, timestamp) index already narrows to the error rows in the
+    # window before the code is applied. usage_logs is append-heavy on the request
+    # path, so a further (status, status_code) index would tax every write to save
+    # a scan over one window's failures; add it if error volume ever makes that
+    # scan the bottleneck.
     op.add_column("usage_logs", sa.Column("status_code", sa.Integer(), nullable=True))
 
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -245,7 +245,7 @@ into something a text-only local model can read.
 
 | Method | Path | Description | Auth |
 |--------|------|-------------|------|
-| `GET` | `/v1/usage` | List usage logs. Filters: `start_date`, `end_date`, `user_id`, `status`, `status_code`, `model`, `endpoint`, `provider`, `source`, `source_label`, `api_key_id`. `status_code` is the HTTP status classifying a failure (e.g. 429 provider rate limit, 402 missing pricing); only error rows carry one. | Master key |
+| `GET` | `/v1/usage` | List usage logs. Filters: `start_date`, `end_date`, `user_id`, `status`, `status_code`, `model`, `endpoint`, `provider`, `source`, `source_label`, `api_key_id`. `status_code` is the HTTP status classifying a failure (e.g. 429 provider rate limit, 402 missing pricing); only error rows carry one, so filtering by it also restricts to `status=error` unless `status` is passed explicitly. | Master key |
 | `GET` | `/v1/usage/count` | Total rows matching the filters (paginator total). | Master key |
 | `GET` | `/v1/usage/summary` | Aggregated spend/volume: totals, breakdowns by model/user/key/source/session/endpoint/provider, the failure taxonomy in `errors_by_status_code` (failures grouped by `status_code` with a coarse `error_class`), and a time series. `dimensions` narrows which breakdowns are computed (each one is a separate `GROUP BY`, including `status_code` for the taxonomy); `dimensions=none` returns totals and series only. | Master key |
 | `GET` | `/v1/usage/summary.csv` | Every breakdown as a CSV download. | Master key |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -245,9 +245,9 @@ into something a text-only local model can read.
 
 | Method | Path | Description | Auth |
 |--------|------|-------------|------|
-| `GET` | `/v1/usage` | List usage logs. Filters: `start_date`, `end_date`, `user_id`, `status`, `model`, `endpoint`, `provider`, `source`, `source_label`, `api_key_id`. | Master key |
+| `GET` | `/v1/usage` | List usage logs. Filters: `start_date`, `end_date`, `user_id`, `status`, `status_code`, `model`, `endpoint`, `provider`, `source`, `source_label`, `api_key_id`. `status_code` is the HTTP status classifying a failure (e.g. 429 provider rate limit, 402 missing pricing); only error rows carry one. | Master key |
 | `GET` | `/v1/usage/count` | Total rows matching the filters (paginator total). | Master key |
-| `GET` | `/v1/usage/summary` | Aggregated spend/volume: totals, breakdowns by model/user/key/source/session/endpoint/provider, and a time series. `dimensions` narrows which breakdowns are computed (each one is a separate `GROUP BY`); `dimensions=none` returns totals and series only. | Master key |
+| `GET` | `/v1/usage/summary` | Aggregated spend/volume: totals, breakdowns by model/user/key/source/session/endpoint/provider, the failure taxonomy in `errors_by_status_code` (failures grouped by `status_code` with a coarse `error_class`), and a time series. `dimensions` narrows which breakdowns are computed (each one is a separate `GROUP BY`, including `status_code` for the taxonomy); `dimensions=none` returns totals and series only. | Master key |
 | `GET` | `/v1/usage/summary.csv` | Every breakdown as a CSV download. | Master key |
 | `POST` | `/v1/usage/external-events` | Import externally-observed usage (e.g. Claude Code) as source-tagged rows, priced at API rates, never counted toward budget. An API key (must be budget-exempt) attributes to its own user; the master key may name any user. Idempotent by `(source, source_event_id)`. See [Importing external usage](external-usage.md). | API key (budget-exempt) or master key |
 | `POST` | `/v1/traces` | OTLP receiver for GenAI usage **spans** (protobuf or JSON). Maps the OpenTelemetry GenAI conventions (`gen_ai.*`, `otari.*`) onto external usage ingestion. Any instrumented app can ship here. See [Importing external usage](external-usage.md). | API key (budget-exempt); master key refused |

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -5466,6 +5466,17 @@
             "title": "Status",
             "type": "string"
           },
+          "status_code": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Code"
+          },
           "timestamp": {
             "title": "Timestamp",
             "type": "string"
@@ -5512,12 +5523,44 @@
           "cost",
           "status",
           "error_message",
+          "status_code",
           "latency_ms",
           "source",
           "source_label",
           "counts_toward_budget"
         ],
         "title": "UsageEntry",
+        "type": "object"
+      },
+      "UsageErrorCodeRow": {
+        "description": "One error-taxonomy row: the failures in the window sharing a status code.\n\n``status_code`` is None for failures recorded without one (rows written\nbefore the column existed, and failures no HTTP status describes, e.g. a\nstream that finished without usage data under the ``fail`` policy).\n``error_class`` is the coarse display bucket derived from the code, so a UI\ncan group \"provider fault\" against \"my own misconfiguration\" without\nre-deriving a status ladder; the raw code stays alongside it for precision.",
+        "properties": {
+          "error_class": {
+            "title": "Error Class",
+            "type": "string"
+          },
+          "requests": {
+            "title": "Requests",
+            "type": "integer"
+          },
+          "status_code": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Code"
+          }
+        },
+        "required": [
+          "status_code",
+          "error_class",
+          "requests"
+        ],
+        "title": "UsageErrorCodeRow",
         "type": "object"
       },
       "UsageGroupRow": {
@@ -6006,6 +6049,13 @@
             "title": "End Date",
             "type": "string"
           },
+          "errors_by_status_code": {
+            "items": {
+              "$ref": "#/components/schemas/UsageErrorCodeRow"
+            },
+            "title": "Errors By Status Code",
+            "type": "array"
+          },
           "series": {
             "items": {
               "$ref": "#/components/schemas/UsageSeriesPoint"
@@ -6033,6 +6083,7 @@
           "by_source_label",
           "by_endpoint",
           "by_provider",
+          "errors_by_status_code",
           "series"
         ],
         "title": "UsageSummary",
@@ -9891,7 +9942,7 @@
         ]
       },
       "get": {
-        "description": "List usage logs ordered by timestamp (most recent first).\n\nSupports optional filters for time range, user, status, model, endpoint,\nprovider, source, and session (``source_label``).\nPaginated via skip/limit. The return shape is a bare JSON array; external\nbilling/analytics consumers depend on this, so the total row count for a\npaginated UI is served separately by ``GET /v1/usage/count`` rather than\nwrapped in an envelope here. Timestamps accept either ISO 8601 strings or\nUnix epoch seconds (numeric).",
+        "description": "List usage logs ordered by timestamp (most recent first).\n\nSupports optional filters for time range, user, status, failure status code,\nmodel, endpoint, provider, source, and session (``source_label``).\nPaginated via skip/limit. The return shape is a bare JSON array; external\nbilling/analytics consumers depend on this, so the total row count for a\npaginated UI is served separately by ``GET /v1/usage/count`` rather than\nwrapped in an envelope here. Timestamps accept either ISO 8601 strings or\nUnix epoch seconds (numeric).",
         "operationId": "list_usage_v1_usage_get",
         "parameters": [
           {
@@ -9966,6 +10017,24 @@
               ],
               "description": "Filter to a single status (e.g. 'success' or 'error')",
               "title": "Status"
+            }
+          },
+          {
+            "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+            "in": "query",
+            "name": "status_code",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+              "title": "Status Code"
             }
           },
           {
@@ -10256,6 +10325,24 @@
             }
           },
           {
+            "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+            "in": "query",
+            "name": "status_code",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+              "title": "Status Code"
+            }
+          },
+          {
             "description": "Filter to a single model",
             "in": "query",
             "name": "model",
@@ -10538,7 +10625,7 @@
     },
     "/v1/usage/summary": {
       "get": {
-        "description": "Aggregate spend, tokens, and request volume for the dashboard Usage page.\n\nRange-bounded (default last 30 days, hard-capped): unlike the raw ``/v1/usage``\nlist, every aggregate is scoped to a bounded window so it stays served by the\ntimestamp index. Returns grand totals, breakdowns by model / user / API key /\nsource / session (``source_label``) / endpoint / provider (top rows plus a\nreconciling ``other`` fold), and a UTC-bucketed time series.\n\nEach breakdown is its own ``GROUP BY`` pass, so a caller that reads only the\ntotals or the series should narrow ``dimensions`` rather than pay for all seven\n(the dashboard's tiles, timeline context, and model typeahead all do). Omitting\nthe parameter keeps the full set.",
+        "description": "Aggregate spend, tokens, and request volume for the dashboard Usage page.\n\nRange-bounded (default last 30 days, hard-capped): unlike the raw ``/v1/usage``\nlist, every aggregate is scoped to a bounded window so it stays served by the\ntimestamp index. Returns grand totals, breakdowns by model / user / API key /\nsource / session (``source_label``) / endpoint / provider (top rows plus a\nreconciling ``other`` fold), the error taxonomy grouped by failure status code,\nand a UTC-bucketed time series.\n\nEach breakdown is its own ``GROUP BY`` pass, so a caller that reads only the\ntotals or the series should narrow ``dimensions`` rather than pay for all eight\n(the dashboard's tiles, timeline context, and model typeahead all do). Omitting\nthe parameter keeps the full set.",
         "operationId": "usage_summary_v1_usage_summary_get",
         "parameters": [
           {
@@ -10613,6 +10700,24 @@
               ],
               "description": "Filter to a single status (e.g. 'success' or 'error')",
               "title": "Status"
+            }
+          },
+          {
+            "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+            "in": "query",
+            "name": "status_code",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+              "title": "Status Code"
             }
           },
           {
@@ -10776,7 +10881,7 @@
             }
           },
           {
-            "description": "Which breakdowns to compute; repeatable (dimensions=model&dimensions=user). Each value names the 'by_<value>' response field it fills. Omit for every breakdown (the default); pass 'none' for a totals-and-series-only response. Each dimension left out skips one GROUP BY scan, so a caller that reads only the tiles or the time series should say so. Fields that were not requested come back empty.",
+            "description": "Which breakdowns to compute; repeatable (dimensions=model&dimensions=user). Each value names the 'by_<value>' response field it fills, except 'status_code', which fills the failure taxonomy in 'errors_by_status_code'. Omit for every breakdown (the default); pass 'none' for a totals-and-series-only response. Each dimension left out skips one GROUP BY scan, so a caller that reads only the tiles or the time series should say so. Fields that were not requested come back empty.",
             "in": "query",
             "name": "dimensions",
             "required": false,
@@ -10792,6 +10897,7 @@
                       "source_label",
                       "endpoint",
                       "provider",
+                      "status_code",
                       "none"
                     ],
                     "type": "string"
@@ -10802,7 +10908,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Which breakdowns to compute; repeatable (dimensions=model&dimensions=user). Each value names the 'by_<value>' response field it fills. Omit for every breakdown (the default); pass 'none' for a totals-and-series-only response. Each dimension left out skips one GROUP BY scan, so a caller that reads only the tiles or the time series should say so. Fields that were not requested come back empty.",
+              "description": "Which breakdowns to compute; repeatable (dimensions=model&dimensions=user). Each value names the 'by_<value>' response field it fills, except 'status_code', which fills the failure taxonomy in 'errors_by_status_code'. Omit for every breakdown (the default); pass 'none' for a totals-and-series-only response. Each dimension left out skips one GROUP BY scan, so a caller that reads only the tiles or the time series should say so. Fields that were not requested come back empty.",
               "title": "Dimensions"
             }
           }
@@ -10920,6 +11026,24 @@
               ],
               "description": "Filter to a single status (e.g. 'success' or 'error')",
               "title": "Status"
+            }
+          },
+          {
+            "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+            "in": "query",
+            "name": "status_code",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+              "title": "Status Code"
             }
           },
           {

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -5536,6 +5536,14 @@
         "description": "One error-taxonomy row: the failures in the window sharing a status code.\n\n``status_code`` is None for failures recorded without one (rows written\nbefore the column existed, and failures no HTTP status describes, e.g. a\nstream that finished without usage data under the ``fail`` policy).\n``error_class`` is the coarse display bucket derived from the code, so a UI\ncan group \"provider fault\" against \"my own misconfiguration\" without\nre-deriving a status ladder; the raw code stays alongside it for precision.",
         "properties": {
           "error_class": {
+            "enum": [
+              "pricing",
+              "rate_limit",
+              "auth",
+              "provider_error",
+              "client_error",
+              "unknown"
+            ],
             "title": "Error Class",
             "type": "string"
           },

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -10028,7 +10028,7 @@
             }
           },
           {
-            "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+            "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one, so this filter also restricts to status='error' unless 'status' is given explicitly",
             "in": "query",
             "name": "status_code",
             "required": false,
@@ -10041,7 +10041,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+              "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one, so this filter also restricts to status='error' unless 'status' is given explicitly",
               "title": "Status Code"
             }
           },
@@ -10333,7 +10333,7 @@
             }
           },
           {
-            "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+            "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one, so this filter also restricts to status='error' unless 'status' is given explicitly",
             "in": "query",
             "name": "status_code",
             "required": false,
@@ -10346,7 +10346,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+              "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one, so this filter also restricts to status='error' unless 'status' is given explicitly",
               "title": "Status Code"
             }
           },
@@ -10711,7 +10711,7 @@
             }
           },
           {
-            "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+            "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one, so this filter also restricts to status='error' unless 'status' is given explicitly",
             "in": "query",
             "name": "status_code",
             "required": false,
@@ -10724,7 +10724,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+              "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one, so this filter also restricts to status='error' unless 'status' is given explicitly",
               "title": "Status Code"
             }
           },
@@ -11037,7 +11037,7 @@
             }
           },
           {
-            "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+            "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one, so this filter also restricts to status='error' unless 'status' is given explicitly",
             "in": "query",
             "name": "status_code",
             "required": false,
@@ -11050,7 +11050,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+              "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one, so this filter also restricts to status='error' unless 'status' is given explicitly",
               "title": "Status Code"
             }
           },

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -2208,7 +2208,7 @@
         {
           "name": "List Usage",
           "request": {
-            "description": "List usage logs ordered by timestamp (most recent first).\n\nSupports optional filters for time range, user, status, model, endpoint,\nprovider, source, and session (``source_label``).\nPaginated via skip/limit. The return shape is a bare JSON array; external\nbilling/analytics consumers depend on this, so the total row count for a\npaginated UI is served separately by ``GET /v1/usage/count`` rather than\nwrapped in an envelope here. Timestamps accept either ISO 8601 strings or\nUnix epoch seconds (numeric).",
+            "description": "List usage logs ordered by timestamp (most recent first).\n\nSupports optional filters for time range, user, status, failure status code,\nmodel, endpoint, provider, source, and session (``source_label``).\nPaginated via skip/limit. The return shape is a bare JSON array; external\nbilling/analytics consumers depend on this, so the total row count for a\npaginated UI is served separately by ``GET /v1/usage/count`` rather than\nwrapped in an envelope here. Timestamps accept either ISO 8601 strings or\nUnix epoch seconds (numeric).",
             "header": [],
             "method": "GET",
             "url": {
@@ -2242,6 +2242,12 @@
                   "description": "Filter to a single status (e.g. 'success' or 'error')",
                   "disabled": true,
                   "key": "status",
+                  "value": ""
+                },
+                {
+                  "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+                  "disabled": true,
+                  "key": "status_code",
                   "value": ""
                 },
                 {
@@ -2305,7 +2311,7 @@
                   "value": ""
                 }
               ],
-              "raw": "{{baseUrl}}/v1/usage?start_date=&end_date=&user_id=&status=&model=&endpoint=&provider=&source=&source_label=&api_key_id=&priced=&counts_toward_budget=&skip=&limit="
+              "raw": "{{baseUrl}}/v1/usage?start_date=&end_date=&user_id=&status=&status_code=&model=&endpoint=&provider=&source=&source_label=&api_key_id=&priced=&counts_toward_budget=&skip=&limit="
             }
           }
         },
@@ -2368,6 +2374,12 @@
                   "value": ""
                 },
                 {
+                  "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+                  "disabled": true,
+                  "key": "status_code",
+                  "value": ""
+                },
+                {
                   "description": "Filter to a single model",
                   "disabled": true,
                   "key": "model",
@@ -2416,7 +2428,7 @@
                   "value": ""
                 }
               ],
-              "raw": "{{baseUrl}}/v1/usage/count?start_date=&end_date=&user_id=&status=&model=&endpoint=&provider=&source=&source_label=&api_key_id=&priced=&counts_toward_budget="
+              "raw": "{{baseUrl}}/v1/usage/count?start_date=&end_date=&user_id=&status=&status_code=&model=&endpoint=&provider=&source=&source_label=&api_key_id=&priced=&counts_toward_budget="
             }
           }
         },
@@ -2489,7 +2501,7 @@
         {
           "name": "Usage Summary",
           "request": {
-            "description": "Aggregate spend, tokens, and request volume for the dashboard Usage page.\n\nRange-bounded (default last 30 days, hard-capped): unlike the raw ``/v1/usage``\nlist, every aggregate is scoped to a bounded window so it stays served by the\ntimestamp index. Returns grand totals, breakdowns by model / user / API key /\nsource / session (``source_label``) / endpoint / provider (top rows plus a\nreconciling ``other`` fold), and a UTC-bucketed time series.\n\nEach breakdown is its own ``GROUP BY`` pass, so a caller that reads only the\ntotals or the series should narrow ``dimensions`` rather than pay for all seven\n(the dashboard's tiles, timeline context, and model typeahead all do). Omitting\nthe parameter keeps the full set.",
+            "description": "Aggregate spend, tokens, and request volume for the dashboard Usage page.\n\nRange-bounded (default last 30 days, hard-capped): unlike the raw ``/v1/usage``\nlist, every aggregate is scoped to a bounded window so it stays served by the\ntimestamp index. Returns grand totals, breakdowns by model / user / API key /\nsource / session (``source_label``) / endpoint / provider (top rows plus a\nreconciling ``other`` fold), the error taxonomy grouped by failure status code,\nand a UTC-bucketed time series.\n\nEach breakdown is its own ``GROUP BY`` pass, so a caller that reads only the\ntotals or the series should narrow ``dimensions`` rather than pay for all eight\n(the dashboard's tiles, timeline context, and model typeahead all do). Omitting\nthe parameter keeps the full set.",
             "header": [],
             "method": "GET",
             "url": {
@@ -2524,6 +2536,12 @@
                   "description": "Filter to a single status (e.g. 'success' or 'error')",
                   "disabled": true,
                   "key": "status",
+                  "value": ""
+                },
+                {
+                  "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+                  "disabled": true,
+                  "key": "status_code",
                   "value": ""
                 },
                 {
@@ -2581,13 +2599,13 @@
                   "value": ""
                 },
                 {
-                  "description": "Which breakdowns to compute; repeatable (dimensions=model&dimensions=user). Each value names the 'by_<value>' response field it fills. Omit for every breakdown (the default); pass 'none' for a totals-and-series-only response. Each dimension left out skips one GROUP BY scan, so a caller that reads only the tiles or the time series should say so. Fields that were not requested come back empty.",
+                  "description": "Which breakdowns to compute; repeatable (dimensions=model&dimensions=user). Each value names the 'by_<value>' response field it fills, except 'status_code', which fills the failure taxonomy in 'errors_by_status_code'. Omit for every breakdown (the default); pass 'none' for a totals-and-series-only response. Each dimension left out skips one GROUP BY scan, so a caller that reads only the tiles or the time series should say so. Fields that were not requested come back empty.",
                   "disabled": true,
                   "key": "dimensions",
                   "value": ""
                 }
               ],
-              "raw": "{{baseUrl}}/v1/usage/summary?start_date=&end_date=&user_id=&status=&model=&endpoint=&provider=&source=&source_label=&api_key_id=&priced=&counts_toward_budget=&bucket=&dimensions="
+              "raw": "{{baseUrl}}/v1/usage/summary?start_date=&end_date=&user_id=&status=&status_code=&model=&endpoint=&provider=&source=&source_label=&api_key_id=&priced=&counts_toward_budget=&bucket=&dimensions="
             }
           }
         },
@@ -2629,6 +2647,12 @@
                   "description": "Filter to a single status (e.g. 'success' or 'error')",
                   "disabled": true,
                   "key": "status",
+                  "value": ""
+                },
+                {
+                  "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+                  "disabled": true,
+                  "key": "status_code",
                   "value": ""
                 },
                 {
@@ -2680,7 +2704,7 @@
                   "value": ""
                 }
               ],
-              "raw": "{{baseUrl}}/v1/usage/summary.csv?start_date=&end_date=&user_id=&status=&model=&endpoint=&provider=&source=&source_label=&api_key_id=&priced=&counts_toward_budget="
+              "raw": "{{baseUrl}}/v1/usage/summary.csv?start_date=&end_date=&user_id=&status=&status_code=&model=&endpoint=&provider=&source=&source_label=&api_key_id=&priced=&counts_toward_budget="
             }
           }
         }

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -2245,7 +2245,7 @@
                   "value": ""
                 },
                 {
-                  "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+                  "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one, so this filter also restricts to status='error' unless 'status' is given explicitly",
                   "disabled": true,
                   "key": "status_code",
                   "value": ""
@@ -2374,7 +2374,7 @@
                   "value": ""
                 },
                 {
-                  "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+                  "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one, so this filter also restricts to status='error' unless 'status' is given explicitly",
                   "disabled": true,
                   "key": "status_code",
                   "value": ""
@@ -2539,7 +2539,7 @@
                   "value": ""
                 },
                 {
-                  "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+                  "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one, so this filter also restricts to status='error' unless 'status' is given explicitly",
                   "disabled": true,
                   "key": "status_code",
                   "value": ""
@@ -2650,7 +2650,7 @@
                   "value": ""
                 },
                 {
-                  "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one",
+                  "description": "Filter to a single failure status code (e.g. 429 for provider rate limits, 402 for missing-pricing rejections). Only error rows carry one, so this filter also restricts to status='error' unless 'status' is given explicitly",
                   "disabled": true,
                   "key": "status_code",
                   "value": ""

--- a/src/gateway/api/routes/_passthrough.py
+++ b/src/gateway/api/routes/_passthrough.py
@@ -37,6 +37,7 @@ from gateway.api.routes._helpers import resolve_user_id
 from gateway.api.routes._pipeline import (
     _elapsed_ms,
     _raise_for_unresolvable_model,
+    failure_status_code,
     log_gateway_rejection,
     rate_limit_headers,
     throttle_early_rejection,
@@ -212,17 +213,20 @@ async def run_passthrough(
                 provider=None,
                 endpoint=endpoint,
                 detail=str(exc.detail),
+                status_code=exc.status_code,
                 started_at=started_at,
             )
         raise
 
     rate_limit_info = check_rate_limit(raw_request, user_id)
 
-    async def _log_rejection(detail: str, *, row_model: str, row_provider: str | None) -> None:
+    async def _log_rejection(detail: str, *, row_model: str, row_provider: str | None, status_code: int) -> None:
         """Record a gateway-side rejection of this request.
 
         Call after refunding the reservation, if one is held; this only writes a
         row (see :func:`log_gateway_rejection`) and never touches the budget.
+        ``status_code`` is the status this rejection is about to return, which the
+        row keeps so the failure taxonomy can tell a refusal from a provider fault.
         """
         await log_gateway_rejection(
             db=db,
@@ -233,6 +237,7 @@ async def run_passthrough(
             provider=row_provider,
             endpoint=endpoint,
             detail=detail,
+            status_code=status_code,
             started_at=started_at,
         )
 
@@ -255,7 +260,12 @@ async def run_passthrough(
             )
         except HTTPException as exc:
             if exc.status_code != status.HTTP_404_NOT_FOUND:
-                await _log_rejection(str(exc.detail), row_model=row_model, row_provider=row_provider)
+                await _log_rejection(
+                    str(exc.detail),
+                    row_model=row_model,
+                    row_provider=row_provider,
+                    status_code=exc.status_code,
+                )
             raise
 
     pricing: ModelPricing | None = None
@@ -273,14 +283,24 @@ async def run_passthrough(
             resolved = resolve_provider_selector(config, model, user_id)
         except (ValueError, AnyLLMError) as exc:
             await refund_reservation(db, reservation)
-            await _log_rejection(unresolvable_model_detail(model), row_model=model, row_provider=None)
+            await _log_rejection(
+                unresolvable_model_detail(model),
+                row_model=model,
+                row_provider=None,
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
             _raise_for_unresolvable_model(model, exc)
     else:
         try:
             resolved = resolve_provider_selector(config, model, user_id)
         except (ValueError, AnyLLMError) as exc:
             # Nothing is reserved yet on this branch, so there is no refund to do.
-            await _log_rejection(unresolvable_model_detail(model), row_model=model, row_provider=None)
+            await _log_rejection(
+                unresolvable_model_detail(model),
+                row_model=model,
+                row_provider=None,
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
             _raise_for_unresolvable_model(model, exc)
         if lookup_pricing:
             pricing = await find_model_pricing(db, resolved.instance, resolved.model)
@@ -307,6 +327,7 @@ async def run_passthrough(
                 no_pricing_detail,
                 row_model=resolved.model,
                 row_provider=resolved.instance,
+                status_code=status.HTTP_402_PAYMENT_REQUIRED,
             )
             raise HTTPException(
                 status_code=status.HTTP_402_PAYMENT_REQUIRED,
@@ -322,7 +343,12 @@ async def run_passthrough(
     ):
         await refund_reservation(db, reservation)
         not_allowed_detail = model_not_allowed_detail(model)
-        await _log_rejection(not_allowed_detail, row_model=resolved.model, row_provider=resolved.instance)
+        await _log_rejection(
+            not_allowed_detail,
+            row_model=resolved.model,
+            row_provider=resolved.instance,
+            status_code=status.HTTP_403_FORBIDDEN,
+        )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=not_allowed_detail,
@@ -371,7 +397,7 @@ async def run_passthrough(
         await refund_reservation(db, reservation)
         raise
     except Exception as e:
-        await log_writer.put(_usage_row("error", error_message=str(e)))
+        await log_writer.put(_usage_row("error", error_message=str(e), status_code=failure_status_code(e)))
         await refund_reservation(db, reservation)
 
         mapped = map_provider_error(e) if map_provider_error else None

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -2335,7 +2335,7 @@ async def run_standalone_non_stream(
         # Gateway-owned cap, not an upstream provider failure. 422 lets
         # callers distinguish a runaway tool loop from a real outage.
         logger.warning("Tool loop iteration cap hit (standalone): cap=%d", tool_ctx.max_tool_iterations)
-        await _log_failure_and_refund(ctx, adapter, provider, model, str(e), 422)
+        await _log_failure_and_refund(ctx, adapter, provider, model, str(e), status.HTTP_422_UNPROCESSABLE_CONTENT)
         raise adapter.error(422, str(e), ErrorKind.INVALID_REQUEST) from e
     except SandboxNotReachableError as e:
         # Sandbox is gateway-side infra, not an LLM provider. Clearer detail

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -297,6 +297,25 @@ def classify_provider_error(exc: BaseException) -> ProviderErrorMapping | None:
     return None
 
 
+def failure_status_code(exc: BaseException) -> int:
+    """The HTTP status to record on the usage log for an upstream failure.
+
+    Prefers the status the provider actually returned, which is deliberately not
+    always the status the caller saw: an upstream 401/403 surfaces to the caller
+    as a generic 502 (a provider rejecting the gateway's credentials is a
+    gateway-config fault, and the response must not say so), but the log keeps
+    the 401 so "how much of my error rate is my own misconfiguration" stays
+    answerable. When the provider returned no status at all (timeout,
+    unreachable), records the gateway's own classification instead, so an error
+    row still carries a code to group on.
+    """
+    _kind, status_code = upstream_exception_shape(exc)
+    if status_code is not None:
+        return status_code
+    mapping = classify_provider_error(exc)
+    return mapping.status_code if mapping is not None else status.HTTP_502_BAD_GATEWAY
+
+
 _DEFAULT_PORTS = {"http": 80, "https": 443}
 
 
@@ -543,6 +562,7 @@ async def resolve_dispatch_provider(
             provider=None,
             endpoint=adapter.endpoint,
             detail=unresolvable_model_detail(model_selector),
+            status_code=status.HTTP_400_BAD_REQUEST,
             started_at=ctx.started_at,
         )
         _raise_for_unresolvable_model(model_selector, exc)
@@ -723,6 +743,7 @@ async def resolve_request_context(
                     provider=None,
                     endpoint=adapter.endpoint,
                     detail=user_forbidden_detail,
+                    status_code=exc.status_code,
                     started_at=started_at,
                 )
             raise
@@ -765,6 +786,7 @@ async def resolve_request_context(
                 provider=gate_instance,
                 endpoint=adapter.endpoint,
                 detail=not_allowed_detail,
+                status_code=status.HTTP_403_FORBIDDEN,
                 started_at=started_at,
             )
             raise adapter.error(403, not_allowed_detail, ErrorKind.PERMISSION)
@@ -811,6 +833,7 @@ async def resolve_request_context(
                     provider=gate_instance,
                     endpoint=adapter.endpoint,
                     detail=str(exc.detail),
+                    status_code=exc.status_code,
                     started_at=started_at,
                 )
             raise
@@ -832,6 +855,7 @@ async def resolve_request_context(
                 provider=gate_instance,
                 endpoint=adapter.endpoint,
                 detail=no_pricing_detail,
+                status_code=status.HTTP_402_PAYMENT_REQUIRED,
                 started_at=started_at,
             )
             raise adapter.error(
@@ -1199,6 +1223,7 @@ async def log_usage(
     response: ChatCompletion | AsyncIterator[ChatCompletionChunk] | None = None,
     usage_override: CompletionUsage | None = None,
     error: str | None = None,
+    status_code: int | None = None,
     cost_override: float | None = None,
     latency_ms: int | None = None,
     counts_toward_budget: bool = True,
@@ -1220,6 +1245,8 @@ async def log_usage(
         response: Response object (if successful)
         usage_override: Usage data for streaming requests
         error: Error message (if failed)
+        status_code: HTTP status classifying the failure (see
+            ``UsageLog.status_code``), or None when nothing was rejected over HTTP
         cost_override: Fixed amount to record when billing without provider usage
         latency_ms: Total server-side request duration in milliseconds, or None
             when the caller has no meaningful duration to record
@@ -1238,6 +1265,7 @@ async def log_usage(
         endpoint=endpoint,
         status="success" if error is None else "error",
         error_message=error,
+        status_code=status_code,
         latency_ms=latency_ms,
         counts_toward_budget=counts_toward_budget,
     )
@@ -1338,6 +1366,7 @@ async def log_gateway_rejection(
     provider: str | None,
     endpoint: str,
     detail: str,
+    status_code: int,
     started_at: float | None,
 ) -> None:
     """Record a request the gateway itself refused before any provider was called.
@@ -1351,6 +1380,13 @@ async def log_gateway_rejection(
 
     Callers own the reservation: refund it before calling this, exactly as the
     pre-existing rejection sites do. Nothing here touches the budget.
+
+    ``status_code`` is the status the caller is about to return, and it is
+    required rather than optional: a rejection row without one classifies as
+    ``unknown`` in the failure taxonomy (``errors_by_status_code``), which is
+    indistinguishable from a pre-column historical row. It is always statically
+    known here, since these are the gateway's own refusals rather than upstream
+    faults, so there is nothing to infer from an exception.
 
     ``counts_toward_budget`` is always True. The dashboard classifies
     ``counts_toward_budget=False`` rows as imported usage and offers them for
@@ -1398,6 +1434,7 @@ async def log_gateway_rejection(
             endpoint=endpoint,
             user_id=user_id,
             error=detail,
+            status_code=status_code,
             latency_ms=_elapsed_ms(started_at),
             counts_toward_budget=True,
         )
@@ -1416,6 +1453,7 @@ async def _log_failure_and_refund(
     provider: Any,
     model: str,
     error: str,
+    status_code: int | None = None,
 ) -> None:
     if ctx.db is None:
         return
@@ -1428,6 +1466,7 @@ async def _log_failure_and_refund(
         endpoint=adapter.endpoint,
         user_id=ctx.user_id,
         error=error,
+        status_code=status_code,
         latency_ms=_elapsed_ms(ctx.started_at),
         counts_toward_budget=_handle_counts_toward_budget(ctx.reservation),
     )
@@ -1678,7 +1717,9 @@ def build_streaming_response(
             await refund_reservation(db, reservation)
             return
         # 'estimate' and 'fail' both charge the up-front estimate; 'fail' also
-        # records the request as errored.
+        # records the request as errored. status_code stays NULL: the stream
+        # itself completed (the caller got a 200), so no HTTP status classifies
+        # this, and stamping one would fake a rejection that never happened.
         await log_usage(
             db=db,
             log_writer=log_writer,
@@ -1694,7 +1735,7 @@ def build_streaming_response(
         )
         await reconcile_reservation(db, reservation, reservation.estimate)
 
-    async def _on_error(error: str) -> None:
+    async def _on_error(exc: BaseException) -> None:
         if platform_active:
             assert platform_correlation_id is not None
             _schedule_usage_report(
@@ -1718,7 +1759,8 @@ def build_streaming_response(
             provider=provider,
             endpoint=adapter.endpoint,
             user_id=user_id,
-            error=error,
+            error=str(exc),
+            status_code=failure_status_code(exc),
             latency_ms=_elapsed_ms(started_at),
             counts_toward_budget=_handle_counts_toward_budget(reservation),
         )
@@ -1848,7 +1890,7 @@ async def run_single_attempt_stream(
         await release_reservation(ctx)
         raise adapter.error(502, WEB_SEARCH_UNREACHABLE_DETAIL, ErrorKind.API) from exc
     except Exception as exc:
-        await _log_failure_and_refund(ctx, adapter, provider, model, str(exc))
+        await _log_failure_and_refund(ctx, adapter, provider, model, str(exc), failure_status_code(exc))
         logger.error("Stream creation failed for %s:%s: %s", provider, model, exc)
         raise adapter.provider_error(exc) from exc
 
@@ -2283,7 +2325,7 @@ async def run_standalone_non_stream(
         # Gateway-owned cap, not an upstream provider failure. 422 lets
         # callers distinguish a runaway tool loop from a real outage.
         logger.warning("Tool loop iteration cap hit (standalone): cap=%d", tool_ctx.max_tool_iterations)
-        await _log_failure_and_refund(ctx, adapter, provider, model, str(e))
+        await _log_failure_and_refund(ctx, adapter, provider, model, str(e), 422)
         raise adapter.error(422, str(e), ErrorKind.INVALID_REQUEST) from e
     except SandboxNotReachableError as e:
         # Sandbox is gateway-side infra, not an LLM provider. Clearer detail
@@ -2297,6 +2339,6 @@ async def run_standalone_non_stream(
         await release_reservation(ctx)
         raise adapter.error(502, WEB_SEARCH_UNREACHABLE_DETAIL, ErrorKind.API) from e
     except Exception as e:
-        await _log_failure_and_refund(ctx, adapter, provider, model, str(e))
+        await _log_failure_and_refund(ctx, adapter, provider, model, str(e), failure_status_code(e))
         logger.error("Provider call failed for %s:%s: %s", provider, model, e)
         raise adapter.provider_error(e) from e

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -308,7 +308,17 @@ def failure_status_code(exc: BaseException) -> int:
     answerable. When the provider returned no status at all (timeout,
     unreachable), records the gateway's own classification instead, so an error
     row still carries a code to group on.
+
+    The tool-loop cap is checked first because it is the gateway's own limit, not
+    an upstream failure: it carries no HTTP status of its own, so it would
+    otherwise fall through to the generic 502 and read in the taxonomy as a
+    provider outage. It reaches here from the streaming path, where the cap is
+    raised while the SSE body is already streaming (see ``run_tool_loop_stream``)
+    and settles through ``on_error``; the non-streaming path records the same 422
+    at its own ``except MaxToolIterationsExceeded``.
     """
+    if isinstance(exc, MaxToolIterationsExceeded):
+        return status.HTTP_422_UNPROCESSABLE_CONTENT
     _kind, status_code = upstream_exception_shape(exc)
     if status_code is not None:
         return status_code

--- a/src/gateway/api/routes/batches.py
+++ b/src/gateway/api/routes/batches.py
@@ -17,7 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
 from gateway.api.routes._helpers import resolve_user_id
-from gateway.api.routes._pipeline import _raise_for_unresolvable_model
+from gateway.api.routes._pipeline import _raise_for_unresolvable_model, failure_status_code
 from gateway.api.routes.chat import rate_limit_headers
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
@@ -79,6 +79,7 @@ async def log_batch_usage(
     endpoint: str,
     user_id: str | None = None,
     error: str | None = None,
+    status_code: int | None = None,
     prompt_tokens: int | None = None,
     completion_tokens: int | None = None,
     total_tokens: int | None = None,
@@ -103,6 +104,7 @@ async def log_batch_usage(
         cost=cost,
         status="success" if error is None else "error",
         error_message=error,
+        status_code=status_code,
         counts_toward_budget=counts_toward_budget,
     )
     await log_writer.put(usage_log)
@@ -343,6 +345,7 @@ async def create_batch(
             endpoint="/v1/batches",
             user_id=user_id,
             error=str(e),
+            status_code=failure_status_code(e),
             counts_toward_budget=not budget_exempt,
         )
         await refund_reservation(db, reservation)

--- a/src/gateway/api/routes/search.py
+++ b/src/gateway/api/routes/search.py
@@ -52,7 +52,12 @@ from gateway.api.routes._passthrough import (
     PASSTHROUGH_PROVIDER_ERROR_DETAIL,
     resolve_passthrough_user_id,
 )
-from gateway.api.routes._pipeline import _elapsed_ms, log_gateway_rejection, rate_limit_headers
+from gateway.api.routes._pipeline import (
+    _elapsed_ms,
+    failure_status_code,
+    log_gateway_rejection,
+    rate_limit_headers,
+)
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import APIKey, UsageLog
@@ -233,12 +238,14 @@ async def _dispatch_search(
     user_id = resolve_passthrough_user_id(auth_result, request.user, reject_mismatch=config.reject_user_mismatch)
     rate_limit_info = check_rate_limit(raw_request, user_id)
 
-    async def log_rejection(detail: str, *, row_model: str, row_provider: str | None) -> None:
+    async def log_rejection(detail: str, *, row_model: str, row_provider: str | None, status_code: int) -> None:
         """Record a search the gateway itself refused.
 
         The shared writer owns the row shape (``status="error"``, no cost,
         ``counts_toward_budget`` pinned True) and swallows a writer failure, so a
         sick log writer cannot turn this route's 400 or 403 into a 500.
+        ``status_code`` is the status this refusal returns, which the row keeps so
+        the failure taxonomy can tell a refusal from a provider fault.
         """
         await log_gateway_rejection(
             db=db,
@@ -249,6 +256,7 @@ async def _dispatch_search(
             provider=row_provider,
             endpoint=SEARCH_ENDPOINT,
             detail=detail,
+            status_code=status_code,
             started_at=started_at,
         )
 
@@ -263,7 +271,12 @@ async def _dispatch_search(
         # No tool was resolved, so there is no provider to attribute the row to
         # and the name is whatever the caller asked for, matching how the
         # pass-through routes log a selector that did not resolve.
-        await log_rejection(tool_error_detail, row_model=tool_name or _UNRESOLVED_TOOL, row_provider=None)
+        await log_rejection(
+            tool_error_detail,
+            row_model=tool_name or _UNRESOLVED_TOOL,
+            row_provider=None,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=tool_error_detail) from exc
 
     pricing_key = f"{tool.provider}:{tool.name}"
@@ -275,7 +288,12 @@ async def _dispatch_search(
     key_allowlist = await resolve_request_allowlist(db, api_key)
     if key_allowlist is not None and not is_model_allowed(key_allowlist, pricing_key):
         not_allowed_detail = model_not_allowed_detail(pricing_key)
-        await log_rejection(not_allowed_detail, row_model=tool.name, row_provider=tool.provider)
+        await log_rejection(
+            not_allowed_detail,
+            row_model=tool.name,
+            row_provider=tool.provider,
+            status_code=status.HTTP_403_FORBIDDEN,
+        )
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=not_allowed_detail)
 
     # A search tool is not a model, so the community default-pricing dataset can
@@ -336,7 +354,7 @@ async def _dispatch_search(
         await refund_reservation(db, reservation)
         raise
     except Exception as exc:
-        await log_writer.put(usage_row(status="error", error_message=str(exc)))
+        await log_writer.put(usage_row(status="error", error_message=str(exc), status_code=failure_status_code(exc)))
         await refund_reservation(db, reservation)
         # The raw provider message is kept on the usage log and the gateway log,
         # never in the response: it can carry upstream internals, and the

--- a/src/gateway/api/routes/usage.py
+++ b/src/gateway/api/routes/usage.py
@@ -66,9 +66,19 @@ _SUMMARY_DIMENSIONS: dict[str, tuple[Any, int]] = {
     "provider": (UsageLog.provider, _BREAKDOWN_TOP_N),
 }
 
+# The failure taxonomy (``errors_by_status_code``) is a GROUP BY pass like the
+# breakdowns above, but it groups failures by status code rather than spend by a
+# dimension, so it is selectable by name without living in _SUMMARY_DIMENSIONS.
+# It is the one dimension whose response field is not ``by_<name>``.
+_ERROR_TAXONOMY_DIMENSION = "status_code"
+
 # Keep in step with _SUMMARY_DIMENSIONS; the extra ``none`` is the explicit empty
 # selection (a repeated query param cannot express an empty list on the wire).
-SummaryDimension = Literal["model", "user", "api_key", "source", "source_label", "endpoint", "provider", "none"]
+SummaryDimension = Literal[
+    "model", "user", "api_key", "source", "source_label", "endpoint", "provider", "status_code", "none"
+]
+
+_ALL_SUMMARY_DIMENSIONS: set[str] = set(_SUMMARY_DIMENSIONS) | {_ERROR_TAXONOMY_DIMENSION}
 
 
 def _utc_iso(value: datetime) -> str:
@@ -105,6 +115,7 @@ class UsageEntry(BaseModel):
     cost: float | None
     status: str
     error_message: str | None
+    status_code: int | None
     latency_ms: int | None
     source: str
     source_label: str | None
@@ -134,6 +145,7 @@ class UsageEntry(BaseModel):
             cost=log.cost,
             status=log.status,
             error_message=log.error_message,
+            status_code=log.status_code,
             latency_ms=log.latency_ms,
         )
 
@@ -149,6 +161,10 @@ _START_DESC = "Return logs with timestamp >= start_date (ISO 8601 or Unix epoch 
 _END_DESC = "Return logs with timestamp < end_date (ISO 8601 or Unix epoch seconds)"
 _USER_DESC = "Filter to a single user"
 _STATUS_DESC = "Filter to a single status (e.g. 'success' or 'error')"
+_STATUS_CODE_DESC = (
+    "Filter to a single failure status code (e.g. 429 for provider rate limits, "
+    "402 for missing-pricing rejections). Only error rows carry one"
+)
 _MODEL_DESC = "Filter to a single model"
 _ENDPOINT_DESC = "Filter to a single endpoint (e.g. '/v1/chat/completions')"
 _PROVIDER_DESC = "Filter to a single provider (e.g. 'openai')"
@@ -162,7 +178,8 @@ _COUNTS_DESC = (
 )
 _DIMENSIONS_DESC = (
     "Which breakdowns to compute; repeatable (dimensions=model&dimensions=user). Each value names the "
-    "'by_<value>' response field it fills. Omit for every breakdown (the default); pass 'none' for a "
+    "'by_<value>' response field it fills, except 'status_code', which fills the failure taxonomy in "
+    "'errors_by_status_code'. Omit for every breakdown (the default); pass 'none' for a "
     "totals-and-series-only response. Each dimension left out skips one GROUP BY scan, so a caller that "
     "reads only the tiles or the time series should say so. Fields that were not requested come back empty."
 )
@@ -182,6 +199,7 @@ def _usage_filters(
     api_key_id: str | None = None,
     priced: bool | None = None,
     counts_toward_budget: bool | None = None,
+    status_code: int | None = None,
 ) -> list[ColumnElement[bool]]:
     """Build the shared WHERE conditions for the list and count endpoints.
 
@@ -197,6 +215,8 @@ def _usage_filters(
         conditions.append(UsageLog.user_id == user_id)
     if status is not None:
         conditions.append(UsageLog.status == status)
+    if status_code is not None:
+        conditions.append(UsageLog.status_code == status_code)
     if model is not None:
         conditions.append(UsageLog.model == model)
     if endpoint is not None:
@@ -225,6 +245,7 @@ async def list_usage(
     end_date: datetime | None = Query(default=None, description=_END_DESC),
     user_id: str | None = Query(default=None, description=_USER_DESC),
     status: str | None = Query(default=None, description=_STATUS_DESC),
+    status_code: int | None = Query(default=None, description=_STATUS_CODE_DESC),
     model: str | None = Query(default=None, description=_MODEL_DESC),
     endpoint: str | None = Query(default=None, description=_ENDPOINT_DESC),
     provider: str | None = Query(default=None, description=_PROVIDER_DESC),
@@ -238,8 +259,8 @@ async def list_usage(
 ) -> list[UsageEntry]:
     """List usage logs ordered by timestamp (most recent first).
 
-    Supports optional filters for time range, user, status, model, endpoint,
-    provider, source, and session (``source_label``).
+    Supports optional filters for time range, user, status, failure status code,
+    model, endpoint, provider, source, and session (``source_label``).
     Paginated via skip/limit. The return shape is a bare JSON array; external
     billing/analytics consumers depend on this, so the total row count for a
     paginated UI is served separately by ``GET /v1/usage/count`` rather than
@@ -251,6 +272,7 @@ async def list_usage(
         end_date=end_date,
         user_id=user_id,
         status=status,
+        status_code=status_code,
         model=model,
         endpoint=endpoint,
         provider=provider,
@@ -308,6 +330,7 @@ async def count_usage(
     end_date: datetime | None = Query(default=None, description=_END_DESC),
     user_id: str | None = Query(default=None, description=_USER_DESC),
     status: str | None = Query(default=None, description=_STATUS_DESC),
+    status_code: int | None = Query(default=None, description=_STATUS_CODE_DESC),
     model: str | None = Query(default=None, description=_MODEL_DESC),
     endpoint: str | None = Query(default=None, description=_ENDPOINT_DESC),
     provider: str | None = Query(default=None, description=_PROVIDER_DESC),
@@ -330,6 +353,7 @@ async def count_usage(
         end_date=end_date,
         user_id=user_id,
         status=status,
+        status_code=status_code,
         model=model,
         endpoint=endpoint,
         provider=provider,
@@ -421,6 +445,22 @@ class UsageGroupRow(BaseModel):
     is_other: bool = False
 
 
+class UsageErrorCodeRow(BaseModel):
+    """One error-taxonomy row: the failures in the window sharing a status code.
+
+    ``status_code`` is None for failures recorded without one (rows written
+    before the column existed, and failures no HTTP status describes, e.g. a
+    stream that finished without usage data under the ``fail`` policy).
+    ``error_class`` is the coarse display bucket derived from the code, so a UI
+    can group "provider fault" against "my own misconfiguration" without
+    re-deriving a status ladder; the raw code stays alongside it for precision.
+    """
+
+    status_code: int | None
+    error_class: str
+    requests: int
+
+
 class UsageSeriesPoint(BaseModel):
     """One time bucket. ``bucket_start`` is canonical ISO-8601 UTC (``...Z``),
     identical across SQLite and PostgreSQL for the same underlying instant."""
@@ -457,6 +497,9 @@ class UsageSummary(BaseModel):
     # other endpoint reports.
     by_endpoint: list[UsageGroupRow]
     by_provider: list[UsageGroupRow]
+    # Failures only, so the taxonomy is not swamped by the successes that carry
+    # no status code. Counts reconcile with ``totals.error_count``.
+    errors_by_status_code: list[UsageErrorCodeRow]
     series: list[UsageSeriesPoint]
 
 
@@ -605,6 +648,60 @@ async def _breakdown(
     return result
 
 
+def error_class_for(status_code: int | None) -> str:
+    """Coarse display bucket for a failure's HTTP status code.
+
+    401 and 403 read as ``auth`` rather than as a budget denial because the codes
+    that actually reach this column come from upstream: a provider rejecting the
+    gateway's credentials. Budget and blocked-user rejections are refused before
+    anything is logged, so they have no row here to classify (see #317).
+    """
+    if status_code is None:
+        return "unknown"
+    if status_code == 402:
+        return "pricing"
+    if status_code == 429:
+        return "rate_limit"
+    if status_code in (401, 403, 407):
+        return "auth"
+    if 500 <= status_code <= 599:
+        return "provider_error"
+    if 400 <= status_code <= 499:
+        return "client_error"
+    return "unknown"
+
+
+async def _errors_by_status_code(
+    db: AsyncSession,
+    conditions: list[ColumnElement[bool]],
+) -> list[UsageErrorCodeRow]:
+    """Failures in the window grouped by status code, most frequent first.
+
+    The whole point of the column: this is a GROUP BY rather than substring
+    matching over provider-specific error prose. Capped at ``_BREAKDOWN_TOP_N``
+    distinct codes, which no real window reaches (HTTP has far fewer), so unlike
+    the cost breakdowns there is no synthesized fold row.
+    """
+    request_count = func.count()
+    rows = (
+        await db.execute(
+            select(UsageLog.status_code, request_count)
+            .where(*conditions, UsageLog.status == "error")
+            .group_by(UsageLog.status_code)
+            .order_by(request_count.desc())
+            .limit(_BREAKDOWN_TOP_N)
+        )
+    ).all()
+    return [
+        UsageErrorCodeRow(
+            status_code=row[0],
+            error_class=error_class_for(row[0]),
+            requests=int(row[1]),
+        )
+        for row in rows
+    ]
+
+
 async def _summary_context(
     db: AsyncSession,
     *,
@@ -620,6 +717,7 @@ async def _summary_context(
     api_key_id: str | None = None,
     priced: bool | None = None,
     counts_toward_budget: bool | None = None,
+    status_code: int | None = None,
 ) -> tuple[datetime, datetime, list[ColumnElement[bool]], UsageTotals]:
     """Resolve the bounded window, the shared WHERE conditions, and the grand
     totals: the common preamble both summary endpoints run, kept in one place so a
@@ -631,6 +729,7 @@ async def _summary_context(
         end_date=end,
         user_id=user_id,
         status=status,
+        status_code=status_code,
         model=model,
         endpoint=endpoint,
         provider=provider,
@@ -693,6 +792,7 @@ async def usage_summary(
     end_date: datetime | None = Query(default=None, description=_END_DESC),
     user_id: str | None = Query(default=None, description=_USER_DESC),
     status: str | None = Query(default=None, description=_STATUS_DESC),
+    status_code: int | None = Query(default=None, description=_STATUS_CODE_DESC),
     model: str | None = Query(default=None, description=_MODEL_DESC),
     endpoint: str | None = Query(default=None, description=_ENDPOINT_DESC),
     provider: str | None = Query(default=None, description=_PROVIDER_DESC),
@@ -710,10 +810,11 @@ async def usage_summary(
     list, every aggregate is scoped to a bounded window so it stays served by the
     timestamp index. Returns grand totals, breakdowns by model / user / API key /
     source / session (``source_label``) / endpoint / provider (top rows plus a
-    reconciling ``other`` fold), and a UTC-bucketed time series.
+    reconciling ``other`` fold), the error taxonomy grouped by failure status code,
+    and a UTC-bucketed time series.
 
     Each breakdown is its own ``GROUP BY`` pass, so a caller that reads only the
-    totals or the series should narrow ``dimensions`` rather than pay for all seven
+    totals or the series should narrow ``dimensions`` rather than pay for all eight
     (the dashboard's tiles, timeline context, and model typeahead all do). Omitting
     the parameter keeps the full set.
     """
@@ -723,6 +824,7 @@ async def usage_summary(
         end_date=end_date,
         user_id=user_id,
         status=status,
+        status_code=status_code,
         model=model,
         endpoint=endpoint,
         provider=provider,
@@ -734,12 +836,18 @@ async def usage_summary(
     )
     # ``none`` is dropped rather than rejected: it exists only so a caller can send
     # an empty selection, and it never contributes a dimension of its own.
-    requested: set[str] = set(_SUMMARY_DIMENSIONS) if dimensions is None else {d for d in dimensions if d != "none"}
+    requested: set[str] = _ALL_SUMMARY_DIMENSIONS if dimensions is None else {d for d in dimensions if d != "none"}
     breakdowns = {
         name: await _breakdown(db, column, conditions, totals, limit=cap)
         for name, (column, cap) in _SUMMARY_DIMENSIONS.items()
         if name in requested
     }
+    # The failure taxonomy is a GROUP BY pass like the others, so it answers to the
+    # same selector rather than being charged to every caller: the tiles and the
+    # timeline ask for no dimensions at all.
+    errors_by_status_code = (
+        await _errors_by_status_code(db, conditions) if _ERROR_TAXONOMY_DIMENSION in requested else []
+    )
 
     expr = _bucket_expr(_dialect_name(db), bucket)
     series_rows = (
@@ -770,6 +878,7 @@ async def usage_summary(
         by_source_label=breakdowns.get("source_label", []),
         by_endpoint=breakdowns.get("endpoint", []),
         by_provider=breakdowns.get("provider", []),
+        errors_by_status_code=errors_by_status_code,
         series=series,
     )
 
@@ -797,6 +906,7 @@ async def usage_summary_csv(
     end_date: datetime | None = Query(default=None, description=_END_DESC),
     user_id: str | None = Query(default=None, description=_USER_DESC),
     status: str | None = Query(default=None, description=_STATUS_DESC),
+    status_code: int | None = Query(default=None, description=_STATUS_CODE_DESC),
     model: str | None = Query(default=None, description=_MODEL_DESC),
     endpoint: str | None = Query(default=None, description=_ENDPOINT_DESC),
     provider: str | None = Query(default=None, description=_PROVIDER_DESC),
@@ -821,6 +931,7 @@ async def usage_summary_csv(
         end_date=end_date,
         user_id=user_id,
         status=status,
+        status_code=status_code,
         model=model,
         endpoint=endpoint,
         provider=provider,

--- a/src/gateway/api/routes/usage.py
+++ b/src/gateway/api/routes/usage.py
@@ -53,6 +53,11 @@ _SESSION_BREAKDOWN_TOP_N = 250
 
 Bucket = Literal["hour", "day"]
 
+# Coarse display buckets for a failure's status code. A closed Literal rather than
+# a bare str so the set lands in the OpenAPI schema as an enum and a consumer can
+# switch on it exhaustively instead of string-matching whatever the server sent.
+ErrorClass = Literal["pricing", "rate_limit", "auth", "provider_error", "client_error", "unknown"]
+
 # Every breakdown ``/summary`` can compute, mapped to the column it groups by and
 # its top-N cap. A dimension name is the ``by_<name>`` response field it fills, so
 # a caller reads the selector and the payload with one vocabulary.
@@ -457,7 +462,7 @@ class UsageErrorCodeRow(BaseModel):
     """
 
     status_code: int | None
-    error_class: str
+    error_class: ErrorClass
     requests: int
 
 
@@ -498,7 +503,10 @@ class UsageSummary(BaseModel):
     by_endpoint: list[UsageGroupRow]
     by_provider: list[UsageGroupRow]
     # Failures only, so the taxonomy is not swamped by the successes that carry
-    # no status code. Counts reconcile with ``totals.error_count``.
+    # no status code. Counts sum to ``totals.error_count``, unless a window
+    # somehow held more than ``_BREAKDOWN_TOP_N`` distinct codes, in which case
+    # the tail is omitted rather than folded (there is no synthesized "other"
+    # row: a null key would collide with the real "no code recorded" group).
     errors_by_status_code: list[UsageErrorCodeRow]
     series: list[UsageSeriesPoint]
 
@@ -648,7 +656,7 @@ async def _breakdown(
     return result
 
 
-def error_class_for(status_code: int | None) -> str:
+def error_class_for(status_code: int | None) -> ErrorClass:
     """Coarse display bucket for a failure's HTTP status code.
 
     401 and 403 read as ``auth`` rather than as a budget denial because the codes

--- a/src/gateway/api/routes/usage.py
+++ b/src/gateway/api/routes/usage.py
@@ -669,15 +669,20 @@ async def _breakdown(
 def error_class_for(status_code: int | None) -> ErrorClass:
     """Coarse display bucket for a failure's HTTP status code.
 
-    401 and 403 read as ``auth`` rather than as a budget denial because the codes
-    that reach this column today come from upstream: a provider rejecting the
-    gateway's credentials. Budget and blocked-user rejections are refused before
-    the provider call and currently write no row at all (see #317), so they have
-    nothing here to classify. Once #465 starts recording them they arrive with no
-    status code and land in ``unknown``; whichever change stamps a code on those
-    rows owns the decision of what they should read as, because a blocked or
-    over-budget user is refused with 403 and would otherwise be filed under
-    ``auth`` alongside a genuine credential fault.
+    Two kinds of code reach this column: the status a provider returned, and the
+    status the gateway itself refused with, since #465 records those rejections
+    too and each row carries the code it returned (403 for a blocked or
+    over-budget user, a user/key mismatch, or a model outside a key's allow-list,
+    402 for missing pricing, 400 for a selector that no longer resolves).
+
+    So ``auth`` currently covers both a provider rejecting the gateway's
+    credentials and the gateway rejecting the caller, and a **budget denial files
+    as ``auth``**, because ``reserve_budget`` refuses with 403 and the code is all
+    this function sees. Splitting budget and permission refusals into their own
+    class needs a discriminator the row does not reliably carry (``provider`` is
+    NULL only on the gates that refuse before the selector resolves, not on the
+    budget gate), and these names are dashboard-visible, so that stays a
+    deliberate follow-up rather than something guessed at here.
     """
     if status_code is None:
         return "unknown"

--- a/src/gateway/api/routes/usage.py
+++ b/src/gateway/api/routes/usage.py
@@ -168,7 +168,8 @@ _USER_DESC = "Filter to a single user"
 _STATUS_DESC = "Filter to a single status (e.g. 'success' or 'error')"
 _STATUS_CODE_DESC = (
     "Filter to a single failure status code (e.g. 429 for provider rate limits, "
-    "402 for missing-pricing rejections). Only error rows carry one"
+    "402 for missing-pricing rejections). Only error rows carry one, so this "
+    "filter also restricts to status='error' unless 'status' is given explicitly"
 )
 _MODEL_DESC = "Filter to a single model"
 _ENDPOINT_DESC = "Filter to a single endpoint (e.g. '/v1/chat/completions')"
@@ -222,6 +223,15 @@ def _usage_filters(
         conditions.append(UsageLog.status == status)
     if status_code is not None:
         conditions.append(UsageLog.status_code == status_code)
+        if status is None:
+            # Only a failure carries a status code (see ``UsageLog.status_code``),
+            # so a bare code filter means "these failures" rather than "whatever
+            # rows happen to hold this code": it stays error-scoped even if a
+            # future write path starts stamping a code on a non-error row, and it
+            # is served by the (status, timestamp) index instead of scanning the
+            # window. An explicit ``status`` wins, so the combination stays a
+            # literal query rather than a silently contradictory one.
+            conditions.append(UsageLog.status == "error")
     if model is not None:
         conditions.append(UsageLog.model == model)
     if endpoint is not None:
@@ -660,9 +670,14 @@ def error_class_for(status_code: int | None) -> ErrorClass:
     """Coarse display bucket for a failure's HTTP status code.
 
     401 and 403 read as ``auth`` rather than as a budget denial because the codes
-    that actually reach this column come from upstream: a provider rejecting the
+    that reach this column today come from upstream: a provider rejecting the
     gateway's credentials. Budget and blocked-user rejections are refused before
-    anything is logged, so they have no row here to classify (see #317).
+    the provider call and currently write no row at all (see #317), so they have
+    nothing here to classify. Once #465 starts recording them they arrive with no
+    status code and land in ``unknown``; whichever change stamps a code on those
+    rows owns the decision of what they should read as, because a blocked or
+    over-budget user is refused with 403 and would otherwise be filed under
+    ``auth`` alongside a genuine credential fault.
     """
     if status_code is None:
         return "unknown"

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -408,6 +408,17 @@ class UsageLog(Base):
     status: Mapped[str] = mapped_column()
     error_message: Mapped[str | None] = mapped_column()
 
+    # HTTP status that classifies a failure, so failures can be grouped with a
+    # GROUP BY instead of substring-matching provider-specific error prose. It is
+    # the status the provider returned when it sent one (an upstream 401 stays
+    # visible as a credential fault even though the caller sees the generic 502
+    # that keeps gateway config out of the response), otherwise the gateway's own
+    # rejection or classification code (402 missing pricing, 422 tool-loop cap,
+    # 504 timeout, 502 unreachable). Nullable: historical rows predate the column,
+    # a successful request has no failure to classify, and some failures carry no
+    # HTTP status at all (e.g. a stream that ended without usage data).
+    status_code: Mapped[int | None] = mapped_column()
+
     # Total server-side wall-clock for the request, in milliseconds. Nullable:
     # historical rows predate the column, and some write paths (batch jobs,
     # provider-never-reached rejections) have no meaningful request duration.
@@ -439,6 +450,7 @@ class UsageLog(Base):
             "cost": self.cost,
             "status": self.status,
             "error_message": self.error_message,
+            "status_code": self.status_code,
             "latency_ms": self.latency_ms,
         }
 

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -97,7 +97,7 @@ async def streaming_generator(
     extract_usage: Callable[[Any], CompletionUsage | None],
     fmt: StreamFormat,
     on_complete: Callable[[CompletionUsage], Awaitable[None]],
-    on_error: Callable[[str], Awaitable[None]],
+    on_error: Callable[[BaseException], Awaitable[None]],
     label: str,
     on_no_usage: Callable[[], Awaitable[None]] | None = None,
     on_incomplete: Callable[[], Awaitable[None]] | None = None,
@@ -115,7 +115,9 @@ async def streaming_generator(
             underlying provider/model never appears on the wire.
         on_complete: Called with aggregated usage after successful streaming that
             included usage data
-        on_error: Called with error message on failure
+        on_error: Called with the raised exception on failure. The exception
+            itself, not a message, so the caller can classify it (e.g. record the
+            upstream HTTP status on the usage log) as well as render it.
         label: Identifier for error log messages (e.g., "openai:gpt-4")
         on_no_usage: Called when streaming completes successfully but the provider
             sent no usage data. Lets the caller bill per ``stream_missing_usage_policy``
@@ -167,7 +169,7 @@ async def streaming_generator(
             yield fmt.done_marker
         settled = True
         try:
-            await on_error(str(e))
+            await on_error(e)
         except Exception as log_err:
             logger.error("Failed to log streaming error usage: %s", log_err)
         logger.error("Streaming error for %s: %s", label, e)

--- a/tests/integration/test_require_pricing.py
+++ b/tests/integration/test_require_pricing.py
@@ -112,6 +112,9 @@ def test_missing_pricing_rejection_is_recorded_in_the_usage_log(strict_pricing_c
     assert rows[0]["status"] == "error"
     assert rows[0]["cost"] is None
     assert "pricing" in rows[0]["error_message"].lower()
+    # The gateway's own rejection code, so this shows up as "pricing" in the error
+    # taxonomy instead of being indistinguishable from a provider fault (#433).
+    assert rows[0]["status_code"] == 402
     # Always an enforced row, never an imported-looking one: the dashboard treats
     # counts_toward_budget=False as imported and offers those to bulk delete and
     # set-price, which must never reach a row the gateway wrote itself.
@@ -145,6 +148,7 @@ def test_passthrough_missing_pricing_rejection_is_recorded_too(strict_pricing_cl
     assert rows[0]["endpoint"] == "/v1/embeddings"
     assert rows[0]["cost"] is None
     assert rows[0]["counts_toward_budget"] is True
+    assert rows[0]["status_code"] == 402
     # Bare model with the instance in `provider`, the one form both scaffolds now
     # use for every row they write (see the chat assertion above).
     assert rows[0]["model"] == "text-embedding-3-small"

--- a/tests/integration/test_search_endpoint.py
+++ b/tests/integration/test_search_endpoint.py
@@ -262,6 +262,9 @@ def test_search_logs_an_unknown_tool_refusal(
     # and set-price, which must not reach a row the gateway wrote itself.
     assert entry["counts_toward_budget"] is True
     assert "Unknown search tool" in entry["error_message"]
+    # The status this refusal returned, so it groups as a client error in the
+    # failure taxonomy instead of as an unclassified row (#433).
+    assert entry["status_code"] == 400
 
 
 def test_search_logs_an_allowlist_refusal(
@@ -292,6 +295,7 @@ def test_search_logs_an_allowlist_refusal(
     assert entry["provider"] == "exa"
     assert entry["cost"] is None
     assert entry["counts_toward_budget"] is True
+    assert entry["status_code"] == 403
 
 
 def test_a_budget_exempt_keys_search_refusal_still_counts_toward_budget(

--- a/tests/integration/test_usage_endpoint.py
+++ b/tests/integration/test_usage_endpoint.py
@@ -34,6 +34,7 @@ def _make_log(
     cost: float | None = 0.01,
     status: str = "success",
     error_message: str | None = None,
+    status_code: int | None = None,
     latency_ms: int | None = None,
     log_id: str | None = None,
 ) -> UsageLog:
@@ -52,6 +53,7 @@ def _make_log(
         cost=cost,
         status=status,
         error_message=error_message,
+        status_code=status_code,
         latency_ms=latency_ms,
     )
     db.add(log)
@@ -243,6 +245,7 @@ def test_list_usage_response_shape(
         cost=1.23,
         status="error",
         error_message="capacity",
+        status_code=503,
         latency_ms=842,
         log_id="shape-log-id",
     )
@@ -271,6 +274,7 @@ def test_list_usage_response_shape(
         "cost": 1.23,
         "status": "error",
         "error_message": "capacity",
+        "status_code": 503,
         "latency_ms": 842,
         "source": "gateway",
         "source_label": None,

--- a/tests/integration/test_usage_status_code.py
+++ b/tests/integration/test_usage_status_code.py
@@ -1,0 +1,236 @@
+"""End-to-end tests for ``usage_logs.status_code`` (the error taxonomy).
+
+Regression for #433: a usage log recorded ``status`` (success/error) and free-text
+``error_message``, so failures could be counted but not classified. Breaking them
+down meant substring-matching provider-specific error prose, which differs per
+provider and changes without notice. These tests pin the column that makes the
+breakdown a GROUP BY: what each failure path records, that it survives the
+gateway's deliberate coarsening of the client-facing status, and that it is
+filterable and groupable over the API.
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from any_llm.types.completion import ChatCompletion, ChatCompletionMessage, Choice, CompletionUsage
+from fastapi.testclient import TestClient
+
+_MESSAGES = [{"role": "user", "content": "Hi"}]
+_MODEL = "openai:gpt-4o"
+
+
+class _StatusError(Exception):
+    """Upstream failure carrying an HTTP status, as the provider SDKs raise."""
+
+    def __init__(self, status_code: int) -> None:
+        super().__init__("raw upstream message SECRET-9f3a")
+        self.status_code = status_code
+
+
+@contextmanager
+def _upstream_fails(exc: BaseException) -> Iterator[None]:
+    """Fail the provider call, for both streaming and non-streaming requests
+    (the chat adapter opens streams through the same ``acompletion``)."""
+    with patch("gateway.api.routes.chat.acompletion", new_callable=AsyncMock, side_effect=exc):
+        yield
+
+
+@contextmanager
+def _upstream_succeeds() -> Iterator[None]:
+    response = ChatCompletion(
+        id="chatcmpl-status-code",
+        object="chat.completion",
+        created=0,
+        model=_MODEL,
+        choices=[
+            Choice(index=0, message=ChatCompletionMessage(role="assistant", content="hi"), finish_reason="stop")
+        ],
+        usage=CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+    )
+    with patch("gateway.api.routes.chat.acompletion", new_callable=AsyncMock, return_value=response):
+        yield
+
+
+def _chat(client: TestClient, headers: dict[str, str], *, stream: bool = False) -> int:
+    body: dict[str, Any] = {"model": _MODEL, "messages": _MESSAGES}
+    if stream:
+        body["stream"] = True
+    return int(client.post("/v1/chat/completions", json=body, headers=headers).status_code)
+
+
+def _error_rows(client: TestClient, master_key_header: dict[str, str], **params: Any) -> list[dict[str, Any]]:
+    query: dict[str, Any] = {"status": "error", **params}
+    response = client.get("/v1/usage", params=query, headers=master_key_header)
+    assert response.status_code == 200
+    rows: list[dict[str, Any]] = response.json()
+    return rows
+
+
+@pytest.mark.parametrize("upstream", [400, 404, 429, 500])
+def test_upstream_status_is_recorded_on_the_error_row(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+    upstream: int,
+) -> None:
+    """The provider's own status lands on the row, per code, not a boolean."""
+    with _upstream_fails(_StatusError(upstream)):
+        _chat(client, api_key_header)
+
+    rows = _error_rows(client, master_key_header)
+    assert len(rows) == 1
+    assert rows[0]["status_code"] == upstream
+
+
+def test_upstream_credential_fault_is_classifiable_despite_the_generic_502(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """An upstream 401 is recorded as 401 even though the caller sees 502.
+
+    This is the case that makes the column load-bearing rather than cosmetic. A
+    provider rejecting the gateway's credentials is a gateway-config fault, so
+    the response deliberately says only "502 / provider error" and the raw
+    provider message never reaches the caller. That leaves the operator with no
+    way to tell "my key is wrong" from "the provider is down": the client-facing
+    status is 502 for both, ``status`` is "error" for both, and matching the
+    error prose is the brittle heuristic this issue exists to remove.
+    """
+    with _upstream_fails(_StatusError(401)):
+        response = client.post(
+            "/v1/chat/completions", json={"model": _MODEL, "messages": _MESSAGES}, headers=api_key_header
+        )
+    # What the caller is told: a generic 502, with no trace of the upstream 401.
+    assert response.status_code == 502
+    assert "401" not in response.text
+    assert "SECRET" not in response.text
+
+    # What the operator can now see, on the master-key-only usage surface.
+    rows = _error_rows(client, master_key_header)
+    assert len(rows) == 1
+    assert rows[0]["status_code"] == 401
+
+
+def test_timeout_records_the_gateways_own_classification(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """A provider that never answered carries no status, so the row records the
+    gateway's classification (504) rather than staying unclassifiable."""
+    with _upstream_fails(TimeoutError("no response")):
+        assert _chat(client, api_key_header) == 504
+
+    rows = _error_rows(client, master_key_header)
+    assert len(rows) == 1
+    assert rows[0]["status_code"] == 504
+
+
+def test_streaming_failure_records_the_upstream_status(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """A stream that fails before its first chunk is classified too.
+
+    Streaming settles through its own callbacks, so without this the whole
+    streaming half of the traffic would log NULL and the taxonomy would silently
+    under-report whichever failures happen to arrive on streaming requests.
+    """
+    with _upstream_fails(_StatusError(429)):
+        _chat(client, api_key_header, stream=True)
+
+    rows = _error_rows(client, master_key_header)
+    assert len(rows) == 1
+    assert rows[0]["status_code"] == 429
+
+
+def test_successful_request_records_no_status_code(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """A success has no failure to classify, so the column stays NULL rather than
+    a constant 200 that would dilute every GROUP BY over it."""
+    with _upstream_succeeds():
+        assert _chat(client, api_key_header) == 200
+
+    rows = client.get("/v1/usage", params={"status": "success"}, headers=master_key_header).json()
+    assert len(rows) == 1
+    assert rows[0]["status_code"] is None
+
+
+def test_status_code_filters_the_list_and_the_count(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """``status_code`` narrows both /v1/usage and /v1/usage/count, so a paginated
+    "show me the 429s" view agrees with its own total."""
+    for upstream in (429, 429, 500):
+        with _upstream_fails(_StatusError(upstream)):
+            _chat(client, api_key_header)
+
+    rows = _error_rows(client, master_key_header, status_code=429)
+    assert len(rows) == 2
+    assert {row["status_code"] for row in rows} == {429}
+
+    count = client.get(
+        "/v1/usage/count", params={"status_code": 429}, headers=master_key_header
+    ).json()
+    assert count["total"] == 2
+
+
+def test_summary_groups_failures_by_status_code(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """The summary answers "which failures, and how many of each" as an aggregate.
+
+    Two 429s and one 401 must come back as two rows carrying their coarse display
+    class, and the counts must reconcile with ``totals.error_count`` so the
+    taxonomy cannot disagree with the tile above it.
+    """
+    for upstream in (429, 429, 401):
+        with _upstream_fails(_StatusError(upstream)):
+            _chat(client, api_key_header)
+
+    summary = client.get("/v1/usage/summary", headers=master_key_header).json()
+    taxonomy = summary["errors_by_status_code"]
+    assert taxonomy == [
+        {"status_code": 429, "error_class": "rate_limit", "requests": 2},
+        {"status_code": 401, "error_class": "auth", "requests": 1},
+    ]
+    assert sum(row["requests"] for row in taxonomy) == summary["totals"]["error_count"]
+
+
+def test_summary_taxonomy_excludes_successful_requests(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """Only failures are grouped, so a mostly-healthy window does not bury the
+    error taxonomy under one giant NULL bucket of successes."""
+    with _upstream_succeeds():
+        assert _chat(client, api_key_header) == 200
+    with _upstream_fails(_StatusError(429)):
+        _chat(client, api_key_header)
+
+    summary = client.get("/v1/usage/summary", headers=master_key_header).json()
+    assert summary["totals"]["request_count"] == 2
+    assert summary["errors_by_status_code"] == [
+        {"status_code": 429, "error_class": "rate_limit", "requests": 1}
+    ]

--- a/tests/integration/test_usage_status_code.py
+++ b/tests/integration/test_usage_status_code.py
@@ -234,3 +234,107 @@ def test_summary_taxonomy_excludes_successful_requests(
     assert summary["errors_by_status_code"] == [
         {"status_code": 429, "error_class": "rate_limit", "requests": 1}
     ]
+
+
+def test_bare_status_code_filter_returns_only_failures(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """``status_code`` alone is an error-scoped filter, so a code can never pull a
+    success row in: the column belongs to failures, and the query says so instead
+    of trusting every caller to add ``status=error`` (and every future write path
+    to leave the column NULL on success)."""
+    with _upstream_succeeds():
+        assert _chat(client, api_key_header) == 200
+    with _upstream_fails(_StatusError(429)):
+        _chat(client, api_key_header)
+
+    rows = client.get("/v1/usage", params={"status_code": 429}, headers=master_key_header).json()
+    assert [(row["status"], row["status_code"]) for row in rows] == [("error", 429)]
+
+    count = client.get("/v1/usage/count", params={"status_code": 429}, headers=master_key_header).json()
+    assert count["total"] == 1
+
+    # An explicit status still wins, so the filter stays literal rather than
+    # quietly overriding what the caller asked for.
+    contradictory = client.get(
+        "/v1/usage", params={"status": "success", "status_code": 429}, headers=master_key_header
+    ).json()
+    assert contradictory == []
+
+
+def test_passthrough_provider_failure_records_the_upstream_status(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """The pass-through scaffold (embeddings, images, rerank, audio) classifies its
+    provider failures too.
+
+    These routes settle through their own error row in ``_passthrough.py`` rather
+    than through the chat pipeline, so without this the whole non-chat half of
+    billable traffic could stop recording a code and every other test would still
+    pass.
+    """
+    with patch(
+        "gateway.api.routes.embeddings.aembedding",
+        new_callable=AsyncMock,
+        side_effect=_StatusError(429),
+    ):
+        response = client.post(
+            "/v1/embeddings",
+            json={"model": "openai:text-embedding-3-small", "input": "hi"},
+            headers=api_key_header,
+        )
+    # The caller sees the deliberately generic provider error, not the upstream 429.
+    assert response.status_code == 502
+    assert "SECRET" not in response.text
+
+    rows = _error_rows(client, master_key_header, endpoint="/v1/embeddings")
+    assert len(rows) == 1
+    assert rows[0]["status_code"] == 429
+
+
+def test_batch_create_failure_records_the_upstream_status(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """``POST /v1/batches`` classifies its provider failure on its own error row.
+
+    Batches write usage through ``log_batch_usage`` instead of the chat pipeline's
+    writer, so this is the second independent stamp that a refactor could drop
+    silently.
+    """
+
+    class _SupportsBatch:
+        SUPPORTS_BATCH = True
+
+    body = {
+        "model": "openai:gpt-4o-mini",
+        "requests": [{"custom_id": "req-1", "body": {"messages": _MESSAGES, "max_tokens": 16}}],
+    }
+    with (
+        patch(
+            "gateway.api.routes.batches.acreate_batch",
+            new_callable=AsyncMock,
+            side_effect=_StatusError(503),
+        ),
+        patch("gateway.api.routes.batches.AnyLLM.get_provider_class", return_value=_SupportsBatch),
+    ):
+        response = client.post("/v1/batches", json=body, headers=api_key_header)
+    assert response.status_code == 502
+    assert "SECRET" not in response.text
+
+    rows = _error_rows(client, master_key_header, endpoint="/v1/batches")
+    assert len(rows) == 1
+    assert rows[0]["status_code"] == 503
+    # And it reaches the taxonomy as a provider fault rather than as "unknown".
+    summary = client.get("/v1/usage/summary", headers=master_key_header).json()
+    assert summary["errors_by_status_code"] == [
+        {"status_code": 503, "error_class": "provider_error", "requests": 1}
+    ]

--- a/tests/integration/test_usage_status_code.py
+++ b/tests/integration/test_usage_status_code.py
@@ -18,6 +18,10 @@ import pytest
 from any_llm.types.completion import ChatCompletion, ChatCompletionMessage, Choice, CompletionUsage
 from fastapi.testclient import TestClient
 
+# The gateway-rejection gates are set up exactly as the tests that own them do,
+# so a gate whose fixture shape changes cannot drift between the two files.
+from .test_gateway_rejection_logging import _make_key, _make_user, _zero_budget
+
 _MESSAGES = [{"role": "user", "content": "Hi"}]
 _MODEL = "openai:gpt-4o"
 
@@ -54,8 +58,8 @@ def _upstream_succeeds() -> Iterator[None]:
         yield
 
 
-def _chat(client: TestClient, headers: dict[str, str], *, stream: bool = False) -> int:
-    body: dict[str, Any] = {"model": _MODEL, "messages": _MESSAGES}
+def _chat(client: TestClient, headers: dict[str, str], *, stream: bool = False, **overrides: Any) -> int:
+    body: dict[str, Any] = {"model": _MODEL, "messages": _MESSAGES, **overrides}
     if stream:
         body["stream"] = True
     return int(client.post("/v1/chat/completions", json=body, headers=headers).status_code)
@@ -338,3 +342,140 @@ def test_batch_create_failure_records_the_upstream_status(
     assert summary["errors_by_status_code"] == [
         {"status_code": 503, "error_class": "provider_error", "requests": 1}
     ]
+
+
+def _one_error_row(client: TestClient, master_key_header: dict[str, str]) -> dict[str, Any]:
+    rows = _error_rows(client, master_key_header)
+    assert len(rows) == 1, rows
+    return rows[0]
+
+
+def _embeddings(client: TestClient, headers: dict[str, str], model: str, **body: Any) -> int:
+    response = client.post("/v1/embeddings", json={"model": model, "input": "hi", **body}, headers=headers)
+    return int(response.status_code)
+
+
+# ---------------------------------------------------------------------------
+# Gateway-side rejections (#465): the gateway refused the request itself, so the
+# row carries the status it returned rather than an upstream one. Without a code
+# these rows classify as "unknown", which is indistinguishable from a row written
+# before the column existed, so every gate that writes one is pinned here.
+# ---------------------------------------------------------------------------
+
+
+def test_over_budget_rejection_records_its_403(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """The refusal raised inside ``reserve_budget`` records the 403 it returns.
+
+    A budget denial reads as ``auth`` in the taxonomy, which is deliberate for now
+    and documented on ``error_class_for``: the code alone cannot separate the
+    gateway refusing the caller from a provider refusing the gateway.
+    """
+    _make_user(client, master_key_header, "broke-user", budget_id=_zero_budget(client, master_key_header))
+
+    assert _chat(client, master_key_header, user="broke-user") == 403
+
+    assert _one_error_row(client, master_key_header)["status_code"] == 403
+    summary = client.get("/v1/usage/summary", headers=master_key_header).json()
+    assert summary["errors_by_status_code"] == [{"status_code": 403, "error_class": "auth", "requests": 1}]
+
+
+def test_user_key_mismatch_rejection_records_its_403(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """The mismatch gate fires before anything is resolved and still records 403."""
+    _make_user(client, master_key_header, "owner")
+    _make_user(client, master_key_header, "someone-else")
+    key = _make_key(client, master_key_header, "owned", user_id="owner")
+
+    assert _chat(client, key, user="someone-else") == 403
+
+    row = _one_error_row(client, master_key_header)
+    assert row["user_id"] == "owner"
+    assert row["status_code"] == 403
+
+
+def test_allow_list_rejection_records_its_403(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """A key's allow-list refusal records 403, so a mis-scoped key is not filed as
+    a provider outage."""
+    _make_user(client, master_key_header, "scoped-user")
+    key = _make_key(client, master_key_header, "scoped", user_id="scoped-user", allowed_models=["anthropic:*"])
+
+    assert _chat(client, key) == 403
+
+    assert _one_error_row(client, master_key_header)["status_code"] == 403
+
+
+def test_unresolvable_selector_rejection_records_its_400(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """A selector that no longer resolves records the 400 the caller sees, which
+    reads as ``client_error`` rather than as a provider fault."""
+    _make_user(client, master_key_header, "curious-user")
+
+    assert _chat(client, master_key_header, model="nosuchprovider:some-model", user="curious-user") == 400
+
+    assert _one_error_row(client, master_key_header)["status_code"] == 400
+    summary = client.get("/v1/usage/summary", headers=master_key_header).json()
+    assert summary["errors_by_status_code"] == [{"status_code": 400, "error_class": "client_error", "requests": 1}]
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [("openai:text-embedding-3-small", 403), ("nosuchprovider:embed", 400)],
+)
+def test_passthrough_gateway_rejections_record_the_status_they_return(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    model: str,
+    expected: int,
+) -> None:
+    """The pass-through scaffold stamps its own rejections too: a blocked user
+    refused after the selector resolved (403) and a selector that never resolved
+    (400). These settle through the scaffold's own helper, so the chat coverage
+    above says nothing about them."""
+    _make_user(client, master_key_header, "blocked-embedder", blocked=True)
+
+    assert _embeddings(client, master_key_header, model, user="blocked-embedder") == expected
+
+    row = _one_error_row(client, master_key_header)
+    assert row["endpoint"] == "/v1/embeddings"
+    assert row["status_code"] == expected
+
+
+def test_passthrough_allow_list_rejection_records_its_403(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """The pass-through allow-list gate refunds and then records its 403."""
+    _make_user(client, master_key_header, "scoped-embedder")
+    key = _make_key(
+        client, master_key_header, "scoped-embed", user_id="scoped-embedder", allowed_models=["cohere:*"]
+    )
+
+    assert _embeddings(client, key, "openai:text-embedding-3-small") == 403
+
+    assert _one_error_row(client, master_key_header)["status_code"] == 403
+
+
+def test_passthrough_user_key_mismatch_records_its_403(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """The pass-through mismatch gate records 403, like its pipeline counterpart."""
+    _make_user(client, master_key_header, "embed-owner")
+    _make_user(client, master_key_header, "embed-stranger")
+    key = _make_key(client, master_key_header, "embed-owned", user_id="embed-owner")
+
+    assert _embeddings(client, key, "openai:text-embedding-3-small", user="embed-stranger") == 403
+
+    row = _one_error_row(client, master_key_header)
+    assert row["user_id"] == "embed-owner"
+    assert row["status_code"] == 403

--- a/tests/integration/test_usage_status_code.py
+++ b/tests/integration/test_usage_status_code.py
@@ -220,6 +220,37 @@ def test_summary_groups_failures_by_status_code(
     assert sum(row["requests"] for row in taxonomy) == summary["totals"]["error_count"]
 
 
+@pytest.mark.parametrize(
+    ("params", "expected_rows"),
+    [
+        ({}, 1),
+        ({"dimensions": "status_code"}, 1),
+        ({"dimensions": "none"}, 0),
+        ({"dimensions": "model"}, 0),
+    ],
+)
+def test_summary_taxonomy_answers_to_the_dimension_selector(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+    params: dict[str, str],
+    expected_rows: int,
+) -> None:
+    """The taxonomy is one more GROUP BY pass, so it obeys ``dimensions`` like the
+    spend breakdowns do (#469): present by default and when asked for by name,
+    skipped for a caller that only wants totals and the series, which is what the
+    dashboard's tiles and timelines request.
+    """
+    with _upstream_fails(_StatusError(429)):
+        _chat(client, api_key_header)
+
+    summary = client.get("/v1/usage/summary", params=params, headers=master_key_header).json()
+    assert len(summary["errors_by_status_code"]) == expected_rows
+    # Either way the totals still count the failure: only the extra pass is skipped.
+    assert summary["totals"]["error_count"] == 1
+
+
 def test_summary_taxonomy_excludes_successful_requests(
     client: TestClient,
     api_key_header: dict[str, str],

--- a/tests/unit/test_gateway_rejection_logging_best_effort.py
+++ b/tests/unit/test_gateway_rejection_logging_best_effort.py
@@ -56,6 +56,9 @@ def _kwargs(log_writer: Any) -> dict[str, Any]:
         "provider": "openai",
         "endpoint": "/v1/chat/completions",
         "detail": "User 'user-1' has exceeded budget limit",
+        # The status this rejection returns, recorded so the failure taxonomy can
+        # tell a refusal from a provider fault (see UsageLog.status_code).
+        "status_code": 403,
         "started_at": None,
     }
 
@@ -78,3 +81,6 @@ async def test_healthy_writer_still_records_the_rejection() -> None:
     assert row.cost is None
     assert row.counts_toward_budget is True
     assert row.user_id == "user-1"
+    # Without this the row classifies as "unknown" in errors_by_status_code,
+    # indistinguishable from a row written before the column existed.
+    assert row.status_code == 403

--- a/tests/unit/test_provider_error_classification.py
+++ b/tests/unit/test_provider_error_classification.py
@@ -20,6 +20,7 @@ from gateway.api.routes._pipeline import (
     PROVIDER_REASONING_TOOLS_UNSUPPORTED_DETAIL,
     PROVIDER_TIMEOUT_DETAIL,
     classify_provider_error,
+    failure_status_code,
 )
 from gateway.api.routes._platform import _provider_failure_http_exc
 
@@ -149,6 +150,52 @@ def test_platform_terminal_exc_falls_back_to_generic() -> None:
     assert exc.status_code == 502
     assert exc.detail == "LLM provider error"
     assert "SECRET" not in str(exc.detail)
+
+
+# ---------------------------------------------------------------------------
+# failure_status_code: what lands on usage_logs.status_code
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status_code", [400, 401, 403, 404, 422, 429, 500, 503, 529])
+def test_failure_status_code_keeps_the_upstream_status(status_code: int) -> None:
+    """The upstream status is recorded verbatim, including the codes the caller
+    never sees: an upstream 401/403 surfaces as a generic 502 (a provider
+    rejecting the gateway's credentials must not be echoed as a client error),
+    but the log has to keep the 401 or the misconfiguration is unattributable.
+    """
+    assert failure_status_code(_StatusError(status_code)) == status_code
+
+
+def test_failure_status_code_reads_an_attached_response() -> None:
+    assert failure_status_code(_ResponseStatusError(429)) == 429
+
+
+def test_failure_status_code_records_504_for_a_timeout() -> None:
+    """A timeout carries no upstream status, so the gateway's own classification
+    is recorded rather than leaving the row unclassifiable."""
+    request = httpx.Request("POST", "http://upstream")
+    for exc in (asyncio.TimeoutError(), httpx.TimeoutException("slow"), OpenAIAPITimeoutError(request=request)):
+        assert failure_status_code(exc) == 504
+
+
+@pytest.mark.parametrize("exc", [Exception(_RAW), ValueError(_RAW), httpx.ConnectError("refused")])
+def test_failure_status_code_falls_back_to_502(exc: BaseException) -> None:
+    """An unreachable or otherwise unclassifiable provider still gets a code, so
+    every error row is groupable."""
+    assert failure_status_code(exc) == 502
+
+
+def test_failure_status_code_unwraps_original_exception() -> None:
+    """An any-llm-wrapped error surfaces the inner status, matching how
+    ``classify_provider_error`` reads the same chain."""
+
+    class _WrappedByAnyLLM(Exception):
+        def __init__(self, original_exception: BaseException) -> None:
+            super().__init__(str(original_exception))
+            self.original_exception = original_exception
+
+    assert failure_status_code(_WrappedByAnyLLM(_StatusError(429))) == 429
 
 
 @pytest.mark.parametrize("status_code", [400, 422])

--- a/tests/unit/test_provider_error_classification.py
+++ b/tests/unit/test_provider_error_classification.py
@@ -23,6 +23,7 @@ from gateway.api.routes._pipeline import (
     failure_status_code,
 )
 from gateway.api.routes._platform import _provider_failure_http_exc
+from gateway.services.mcp_loop import MaxToolIterationsExceeded
 
 _RAW = "raw provider detail SECRET token=abc123"
 
@@ -196,6 +197,20 @@ def test_failure_status_code_unwraps_original_exception() -> None:
             self.original_exception = original_exception
 
     assert failure_status_code(_WrappedByAnyLLM(_StatusError(429))) == 429
+
+
+def test_failure_status_code_records_422_for_the_tool_loop_cap() -> None:
+    """The gateway's own tool-loop cap records 422, not the generic 502.
+
+    The non-streaming path stamps 422 at its own ``except`` clause, but a
+    streaming request raises the cap while the SSE body is already in flight, so
+    it settles through ``on_error`` and lands here instead. Without this branch
+    the cap carries no status, falls through to 502, and shows up in the error
+    taxonomy as a provider outage: precisely the confusion the 422 exists to
+    prevent, and only on streaming traffic, so the two halves of the same failure
+    would classify differently.
+    """
+    assert failure_status_code(MaxToolIterationsExceeded("Exceeded max_tool_iterations=8")) == 422
 
 
 @pytest.mark.parametrize("status_code", [400, 422])

--- a/tests/unit/test_streaming_generator.py
+++ b/tests/unit/test_streaming_generator.py
@@ -15,6 +15,14 @@ _PROVIDER_CRASHED = "provider crashed"
 _LOGGING_FAILED = "logging failed too"
 
 
+class _StatusCodeError(Exception):
+    """Upstream failure carrying an HTTP status, as the provider SDKs raise."""
+
+    def __init__(self, status_code: int) -> None:
+        super().__init__(_PROVIDER_CRASHED)
+        self.status_code = status_code
+
+
 def _format_chunk(chunk: str) -> str:
     return f"data: {chunk}\n\n"
 
@@ -37,7 +45,7 @@ async def test_streaming_generator_success_with_usage() -> None:
     async def on_complete(usage: CompletionUsage) -> None:
         completed_usage.append(usage)
 
-    async def on_error(error: str) -> None:
+    async def on_error(exc: BaseException) -> None:
         pytest.fail("on_error should not be called")
 
     events = [
@@ -67,7 +75,7 @@ async def test_streaming_generator_no_usage_skips_on_complete() -> None:
         nonlocal completed
         completed = True
 
-    async def on_error(error: str) -> None:
+    async def on_error(exc: BaseException) -> None:
         pytest.fail("on_error should not be called")
 
     events = [
@@ -97,7 +105,7 @@ async def test_streaming_generator_no_usage_invokes_on_no_usage() -> None:
         nonlocal completed
         completed = True
 
-    async def on_error(error: str) -> None:
+    async def on_error(exc: BaseException) -> None:
         pytest.fail("on_error should not be called")
 
     async def on_no_usage() -> None:
@@ -131,7 +139,7 @@ async def test_streaming_generator_on_incomplete_on_client_disconnect() -> None:
     async def on_complete(usage: CompletionUsage) -> None:
         settled.append("complete")
 
-    async def on_error(error: str) -> None:
+    async def on_error(exc: BaseException) -> None:
         settled.append("error")
 
     async def on_no_usage() -> None:
@@ -172,8 +180,8 @@ async def test_streaming_generator_error_openai_format() -> None:
     async def on_complete(usage: CompletionUsage) -> None:
         pytest.fail("on_complete should not be called on error")
 
-    async def on_error(error: str) -> None:
-        error_logged.append(error)
+    async def on_error(exc: BaseException) -> None:
+        error_logged.append(str(exc))
 
     async def _failing_stream() -> AsyncIterator[str]:
         yield "hello"
@@ -199,14 +207,52 @@ async def test_streaming_generator_error_openai_format() -> None:
 
 
 @pytest.mark.asyncio
+async def test_streaming_generator_hands_the_exception_to_on_error() -> None:
+    """on_error receives the raised exception itself, not a rendered message.
+
+    The settlement callback classifies it (recording the upstream HTTP status on
+    the usage log, see ``failure_status_code``), which a string cannot support:
+    provider error prose carries no reliable status. Pinned separately from the
+    format tests above, which only compare ``str(exc)`` and so would pass either
+    way.
+    """
+    raised = _StatusCodeError(429)
+    received: list[BaseException] = []
+
+    async def on_complete(usage: CompletionUsage) -> None:
+        pytest.fail("on_complete should not be called on error")
+
+    async def on_error(exc: BaseException) -> None:
+        received.append(exc)
+
+    async def _failing_stream() -> AsyncIterator[str]:
+        raise raised
+        yield  # pragma: no cover
+
+    async for _ in streaming_generator(
+        stream=_failing_stream(),
+        format_chunk=_format_chunk,
+        extract_usage=lambda _: None,
+        fmt=OPENAI_STREAM_FORMAT,
+        on_complete=on_complete,
+        on_error=on_error,
+        label="test:model",
+    ):
+        pass
+
+    assert received == [raised]
+    assert getattr(received[0], "status_code", None) == 429
+
+
+@pytest.mark.asyncio
 async def test_streaming_generator_error_anthropic_format() -> None:
     error_logged: list[str] = []
 
     async def on_complete(usage: CompletionUsage) -> None:
         pytest.fail("on_complete should not be called on error")
 
-    async def on_error(error: str) -> None:
-        error_logged.append(error)
+    async def on_error(exc: BaseException) -> None:
+        error_logged.append(str(exc))
 
     async def _failing_stream() -> AsyncIterator[str]:
         raise RuntimeError(_PROVIDER_CRASHED)
@@ -236,7 +282,7 @@ async def test_streaming_generator_error_logging_failure_is_swallowed() -> None:
     async def on_complete(usage: CompletionUsage) -> None:
         pytest.fail("on_complete should not be called on error")
 
-    async def on_error(error: str) -> None:
+    async def on_error(exc: BaseException) -> None:
         raise RuntimeError(_LOGGING_FAILED)
 
     async def _failing_stream() -> AsyncIterator[str]:

--- a/tests/unit/test_usage_error_class.py
+++ b/tests/unit/test_usage_error_class.py
@@ -1,0 +1,42 @@
+"""Unit tests for the coarse error-class mapping in the usage summary."""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.api.routes.usage import error_class_for
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected"),
+    [
+        (402, "pricing"),
+        (429, "rate_limit"),
+        (401, "auth"),
+        (403, "auth"),
+        (407, "auth"),
+        (400, "client_error"),
+        (404, "client_error"),
+        (422, "client_error"),
+        (500, "provider_error"),
+        (502, "provider_error"),
+        (504, "provider_error"),
+        (529, "provider_error"),
+    ],
+)
+def test_status_codes_map_to_their_display_class(status_code: int, expected: str) -> None:
+    assert error_class_for(status_code) == expected
+
+
+def test_missing_code_is_unknown() -> None:
+    # Rows written before the column existed, plus failures no HTTP status
+    # describes, must land in a bucket rather than crash the breakdown.
+    assert error_class_for(None) == "unknown"
+
+
+@pytest.mark.parametrize("status_code", [0, 200, 302, 600, 999])
+def test_out_of_range_codes_are_unknown(status_code: int) -> None:
+    # status_code comes from provider exceptions, so it is not guaranteed to be a
+    # sane 4xx/5xx. A garbage value must classify as unknown, never as a fault
+    # class an operator would act on.
+    assert error_class_for(status_code) == "unknown"


### PR DESCRIPTION
## Description

`UsageLog` carried `status` (success/error) and a free-text `error_message`, so failures could be counted but not broken down. Any breakdown had to be built on substring matching over provider-specific error prose, which differs per provider and changes without notice.

This adds a nullable `usage_logs.status_code` and populates it on every path that already writes an error row: the pipeline's non-streaming and streaming provider failures, the tool-loop cap (422), the missing-pricing rejections (402) in both the pipeline and the pass-through gate, the pass-through provider failure, and batch creation.

**The recorded code prefers the status the provider returned, which is deliberately not always the status the caller saw.** An upstream 401/403 is a provider rejecting the gateway's credentials, so the response stays a generic 502 and never says so; the log keeps the 401, which is what makes "how much of my error rate is my own misconfiguration" answerable. A provider that never answered carries no status, so the row records the gateway's own classification (504 timeout, 502 unreachable) rather than staying unclassifiable. Success rows stay NULL: there is no failure to classify, and a constant 200 would dilute every `GROUP BY` over the column.

New read surface:

- `status_code` filter on all four `/v1/usage` read endpoints (list, count, summary, summary.csv).
- `errors_by_status_code` on `/v1/usage/summary`, scoped to failures and carrying a coarse `error_class` (`pricing` / `rate_limit` / `auth` / `provider_error` / `client_error`) alongside the raw code. Counts reconcile with `totals.error_count`.

One shared-utility change: mid-stream failures settle through `streaming_generator`'s `on_error`, which received a rendered message. It now receives the exception itself so the callback can classify it; a string cannot carry a status. Without this, the streaming half of the traffic would log NULL.

### Two parts of the issue deliberately left out

- **403 budget / blocked-user and 401 auth rejections.** These write no usage-log row at all today, so there is nothing to stamp. The issue presumes those rows exist; adding them is #317's scope (which is what added the 402 row) and would put a log write on a hot rejection path. 401 is additionally out of reach: it happens before a model or user is resolved, and `usage_logs.model` is non-nullable.
- **The OTLP import path.** It hardcodes `status="success"` and drops events with no token counts, so populating a status code there would change *what gets imported*, not just classify it. The issue framed this as a "could", not part of the proposal.

No dashboard changes, so the committed bundle is not stale. The Activity-log and alerting consumers of this data are follow-ups (#317, #410).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #433

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

### Test notes

New `tests/integration/test_usage_status_code.py` covers: the upstream status landing per code; the 401-recorded-behind-a-502 case (the one that makes the column load-bearing); timeouts recording 504; a streaming failure recording its upstream status; success recording NULL; the filter agreeing between list and count; and the summary grouping with its coarse classes. `tests/unit/test_usage_error_class.py` pins the class mapping including garbage codes. `failure_status_code` unit tests live alongside the existing `classify_provider_error` ones.

Migration `d7b9f1a3c5e8` applies and reverses cleanly against PostgreSQL, and `alembic check` reports no drift for `usage_logs`.

Full unit suite passes (1068). Integration: 830 passed, 2 failed, both pre-existing and environmental in my sandbox (`test_streaming_error_event` and `test_error_detail_leakage::test_provider_error_does_not_leak_details` make a real provider call and get a 404 where they expect the generic 502). I confirmed both fail identically on clean `origin/main` in a separate worktree, so they are not a regression from this change; worth a sanity check that they pass in CI.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 5)

**Any additional AI details you'd like to share:**

Implemented by Claude Code via back-and-forth with @njbrake. The design decisions (recording the upstream status rather than the client-facing one, keeping success rows NULL, scoping out the 401/403 and OTLP paths) were reviewed by him; the prose is Claude's.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
