### PR TITLE
feat(search): add a billed POST /v1/search pass-through

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -105,6 +105,20 @@ providers:
     # input_price_per_million: 0.25
     # output_price_per_million: 1.00
 
+# Search tools (optional): what POST /v1/search can run against, keyed by the
+# name callers pass as `search_tool_name` (or in the /v1/search/{tool} path).
+# `provider` defaults to the tool name and must be one of: exa. `options` holds
+# provider-native request defaults for knobs the request body has no field for;
+# the caller's query always wins. Standalone-mode only.
+# search_tools:
+#   exa-search:
+#     provider: exa
+#     api_key: ${EXA_API_KEY}
+#     # api_base: "https://api.exa.ai"   # optional
+#     # timeout: 30                      # optional, seconds
+#     options:
+#       type: fast
+
 # Model aliases (optional): expose a friendly display name that maps to a real
 # selector, hiding the underlying provider/model. Format: name -> target
 # ("provider:model" or a named "instance:model"). The alias is what users see in

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -29,7 +29,7 @@ curl -X POST http://localhost:8000/v1/users \
 ```
 
 - `user_id` is the stable identifier you choose; it is what spend and usage key on.
-- `allowed_models` is the default access-list the user's keys inherit. `null` (or omitted) means any model, `[]` denies everything, and a list restricts to canonical `instance:model` entries, with `instance:*` and `instance:prefix*` wildcards.
+- `allowed_models` is the default access-list the user's keys inherit. `null` (or omitted) means any model, `[]` denies everything, and a list restricts to canonical `instance:model` entries, with `instance:*` and `instance:prefix*` wildcards. The list also gates the non-model spend surfaces that key on the same `instance:model` form, so a restricted key that should be able to call [`POST /v1/search`](api-reference.md#search) needs its search tool named too, as `<provider>:<tool>` (for example `exa:exa-search`).
 - `blocked: true` stops the user from making requests without deleting anything; their calls are rejected until you unblock them.
 
 Manage users with `GET /v1/users`, `GET /v1/users/{user_id}`, `PATCH /v1/users/{user_id}` (update alias, budget, `blocked`, or `allowed_models`), and `DELETE /v1/users/{user_id}`. A user's response includes `spend` and `reserved` (in-flight spend held by accepted but not-yet-settled requests); the committed total is `spend + reserved`. `GET /v1/users/{user_id}/usage` returns that user's request log.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -94,6 +94,57 @@ For a full client setup example, see [Use with Claude Code](use-with-claude-code
 |--------|------|-------------|------|
 | `POST` | `/v1/rerank` | Reorder documents by relevance to a query. | API key or master key |
 
+### Search
+
+| Method | Path | Description | Auth |
+|--------|------|-------------|------|
+| `POST` | `/v1/search` | Run a search against a configured search tool, named in `search_tool_name`. | API key or master key |
+| `POST` | `/v1/search/{search_tool_name}` | Same, with the tool named in the path. | API key or master key |
+
+Search tools are declared under [`search_tools`](configuration.md#search-tools)
+in `config.yml`. This is the direct counterpart to the `otari_web_search` tool:
+the tool answers a model's search call mid-completion, while this endpoint takes
+a query from the caller and returns results. Both forms log
+`endpoint="/v1/search"`, so one Activity filter covers every search.
+
+The request and response follow LiteLLM's `/v1/search` (itself shaped after
+Perplexity's Search API), so a client moving off the LiteLLM proxy needs no
+changes:
+
+```bash
+curl http://localhost:8000/v1/search/exa-search \
+  -H "Otari-Key: Bearer $OTARI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "post-training quantization for small models",
+    "max_results": 5,
+    "search_domain_filter": ["arxiv.org"]
+  }'
+```
+
+```json
+{
+  "object": "search",
+  "search_tool": "exa-search",
+  "results": [
+    {
+      "title": "…",
+      "url": "https://arxiv.org/abs/…",
+      "snippet": "…",
+      "date": "2026-01-02T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+Prefix a domain with `-` in `search_domain_filter` to exclude it instead of
+restricting to it. Search bills per request rather than per token, so a usage
+row carries zero tokens and a cost taken from the provider's own reported charge
+when it reports one (Exa does); otherwise it uses the flat per-request rate
+configured for `<provider>:<tool>`, under the same convention as
+[moderations](#moderations). Like moderations, search is exempt from
+`require_pricing`.
+
 ### Images
 
 | Method | Path | Description | Auth |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -153,7 +153,14 @@ row carries zero tokens and a cost taken from the provider's own reported charge
 when it reports one (Exa does); otherwise it uses the flat per-request rate
 configured for `<provider>:<tool>`, under the same convention as
 [moderations](#moderations). Like moderations, search is exempt from
-`require_pricing`.
+`require_pricing`. Configuring the flat rate is still
+[recommended](configuration.md#search-tools): it is what gets reserved against
+the caller's budget before the search runs.
+
+A search the gateway itself refuses, an unknown or ambiguous `search_tool_name`
+(400) or a tool the key's allowed-models list does not name (403), is written to
+the usage log too, with a null cost, so refused searches are visible in Activity
+and counted as failures rather than only in the caller's own logs.
 
 ### Images
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -108,8 +108,8 @@ a query from the caller and returns results. Both forms log
 `endpoint="/v1/search"`, so one Activity filter covers every search.
 
 The request and response follow LiteLLM's `/v1/search` (itself shaped after
-Perplexity's Search API), so a client moving off the LiteLLM proxy needs no
-changes:
+Perplexity's Search API), so a client moving off the LiteLLM proxy keeps its
+request shape:
 
 ```bash
 curl http://localhost:8000/v1/search/exa-search \
@@ -137,8 +137,18 @@ curl http://localhost:8000/v1/search/exa-search \
 }
 ```
 
-Prefix a domain with `-` in `search_domain_filter` to exclude it instead of
-restricting to it. Search bills per request rather than per token, so a usage
+The accepted request fields are `query`, `search_tool_name`, `max_results`
+(1 to 20), `search_domain_filter` (up to 20 entries; prefix a domain with `-` to
+exclude it rather than restrict to it), `country`, `max_tokens_per_page`, and
+`user`. Two differences from Perplexity are worth knowing before you migrate:
+`query` must be a single string, so the multi-query array form is rejected with
+a 422; and the filters Otari does not model (`search_recency_filter`,
+`search_context_size`, the published-date filters) are ignored rather than
+rejected, so check that your client does not depend on one. Provider-native
+knobs with no request field, such as Exa's `type` or `category`, belong in the
+tool's `options`.
+
+Search bills per request rather than per token, so a usage
 row carries zero tokens and a cost taken from the provider's own reported charge
 when it reports one (Exa does); otherwise it uses the flat per-request rate
 configured for `<provider>:<tool>`, under the same convention as

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,7 @@ pricing:
 | `providers` | dict | `{}` | Provider credentials (see below) |
 | `aliases` | dict | `{}` | Model name aliases (display name to target selector `instance:model` or `provider:model`). The alias is what users see in `GET /v1/models` and in response `model` fields; pricing, budgets, and usage key on the resolved target. Standalone mode only. |
 | `pricing` | dict | `{}` | Model pricing entries |
+| `search_tools` | dict | `{}` | Search tools served by `POST /v1/search` (see below). Standalone mode only. |
 | `enable_metrics` | bool | `false` | Enable Prometheus `/metrics` endpoint |
 | `enable_docs` | bool | `true` | Enable `/docs`, `/redoc`, `/openapi.json` |
 | `bootstrap_api_key` | bool | `true` | Create a first-use API key on startup when none exist |
@@ -255,6 +256,46 @@ providers:
 ```
 
 The `credentials` field points to a Google Cloud service account JSON file.
+
+## Search tools
+
+`search_tools` declares what [`POST /v1/search`](api-reference.md#search) can
+run against, keyed by the name callers pass as `search_tool_name` (or in the
+`/v1/search/{tool}` path):
+
+```yaml
+search_tools:
+  exa-search:
+    provider: exa
+    api_key: ${EXA_API_KEY}
+    # api_base: "https://api.exa.ai"   # optional; override to route via a proxy
+    # timeout: 30                      # optional; seconds
+    options:                           # optional provider-native defaults
+      type: fast
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `provider` | string | the tool name | Search provider to dispatch to. Supported: `exa`. |
+| `api_key` | string | required | Credential for the provider. |
+| `api_base` | string | provider default | Override the provider's base URL. |
+| `timeout` | number | `30` | Request timeout in seconds. |
+| `options` | dict | `{}` | Provider-native request fields used as defaults. |
+
+`options` is the escape hatch for knobs the LiteLLM-shaped request has no field
+for, such as Exa's `type`, `category`, or `moderation`. Fields derived from the
+request win over it, and `query` always comes from the caller.
+
+Every entry is validated at startup, so an unsupported provider or a missing
+`api_key` fails before the first request. Search tools are standalone mode only:
+in hybrid mode, search is the platform's to configure.
+
+To price search, add a flat per-request rate under the model key
+`<provider>:<tool>` (for example `exa:exa-search`), following the same
+convention as moderations: the stored `input_price_per_million` is USD per
+million requests, so `5000.0` charges $0.005 per search. This is only a
+fallback; when the provider reports its own charge (Exa returns `costDollars`),
+that is what gets billed.
 
 ## Pricing
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -279,12 +279,30 @@ search_tools:
 | `provider` | string | the tool name | Search provider to dispatch to. Supported: `exa`. |
 | `api_key` | string | required | Credential for the provider. |
 | `api_base` | string | provider default | Override the provider's base URL. |
-| `timeout` | number | `30` | Request timeout in seconds. |
+| `timeout` | number | `30` | Request timeout in seconds; must be greater than 0. |
 | `options` | dict | `{}` | Provider-native request fields used as defaults. |
 
 `options` is the escape hatch for knobs the LiteLLM-shaped request has no field
 for, such as Exa's `type`, `category`, or `moderation`. Fields derived from the
 request win over it, and `query` always comes from the caller.
+
+Page content is requested by default, because the `snippet` on each result is
+that text. Providers charge per page for it, so a deployment that only wants
+ranked URLs (or highlights) can opt out by pinning `contents.text` to null:
+
+```yaml
+search_tools:
+  exa-urls-only:
+    provider: exa
+    api_key: ${EXA_API_KEY}
+    options:
+      contents:
+        text: null        # no page content, so no per-page content charge
+        highlights: true  # keep the cheaper highlight sentences as the snippet
+```
+
+The opt-out is the operator's, so it holds even for a request that carries
+`max_tokens_per_page`.
 
 Every entry is validated at startup, so an unsupported provider or a missing
 `api_key` fails before the first request. Search tools are standalone mode only:
@@ -293,9 +311,20 @@ in hybrid mode, search is the platform's to configure.
 To price search, add a flat per-request rate under the model key
 `<provider>:<tool>` (for example `exa:exa-search`), following the same
 convention as moderations: the stored `input_price_per_million` is USD per
-million requests, so `5000.0` charges $0.005 per search. This is only a
-fallback; when the provider reports its own charge (Exa returns `costDollars`),
-that is what gets billed.
+million requests, so `5000.0` charges $0.005 per search. For what a search is
+billed at, this is only a fallback; when the provider reports its own charge
+(Exa returns `costDollars`), that is what gets billed.
+
+Configuring the rate anyway is strongly recommended, because it is also what
+the gateway reserves against the caller's budget *before* the search runs. With
+no rate configured, that reservation is $0: a user already over their cap is
+still refused, but one just under it can overshoot by a search's cost, and
+concurrent searches cannot see each other's holds. Spend stays truthful either
+way (the provider's charge is reconciled onto the usage row afterwards), so this
+is about how tightly the cap holds, not about billing accuracy. Set the rate to
+a typical search cost for the tool and the pre-flight hold does its job. Otari
+logs a warning at startup for any configured search tool with no rate; an
+explicit `0` counts as configured, for a tool you mean to be free.
 
 ## Pricing
 

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -3993,6 +3993,8 @@
           "country": {
             "anyOf": [
               {
+                "maxLength": 2,
+                "minLength": 2,
                 "type": "string"
               },
               {

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -9455,7 +9455,7 @@
     },
     "/v1/search": {
       "post": {
-        "description": "Run a search against a configured search tool.\n\nThe tool is taken from ``search_tool_name``, which may be omitted when\nexactly one tool is configured.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use the shared \"default\" user",
+        "description": "Run a search against a configured search tool.\n\nThe tool is taken from ``search_tool_name``, which may be omitted when\nexactly one tool is configured.\n\nAuthentication modes:\n- Master key: the ``user`` field is required and may name any existing user.\n- API key: usage and spend always bind to the key's own user. A ``user``\n  field naming a different user is rejected with 403 (or ignored, when\n  ``reject_user_mismatch`` is disabled); it is never billed to that user.",
         "operationId": "create_search_v1_search_post",
         "requestBody": {
           "content": {
@@ -9505,7 +9505,7 @@
     },
     "/v1/search/{search_tool_name}": {
       "post": {
-        "description": "Run a search against the search tool named in the path.\n\nIdentical to ``POST /v1/search`` except that the path names the tool, which\nis the form LiteLLM clients use. Any ``search_tool_name`` in the body is\nignored.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use the shared \"default\" user",
+        "description": "Run a search against the search tool named in the path.\n\nIdentical to ``POST /v1/search`` except that the path names the tool, which\nis the form LiteLLM clients use. Any ``search_tool_name`` in the body is\nignored.\n\nAuthentication modes:\n- Master key: the ``user`` field is required and may name any existing user.\n- API key: usage and spend always bind to the key's own user. A ``user``\n  field naming a different user is rejected with 403 (or ignored, when\n  ``reject_user_mismatch`` is disabled); it is never billed to that user.",
         "operationId": "create_search_for_tool_v1_search__search_tool_name__post",
         "parameters": [
           {

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -3983,6 +3983,181 @@
         "title": "RotateMasterKeyResponse",
         "type": "object"
       },
+      "SearchRequest": {
+        "description": "A search request, following LiteLLM's ``/v1/search`` body.",
+        "example": {
+          "max_results": 5,
+          "query": "otari llm gateway"
+        },
+        "properties": {
+          "country": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Two-letter ISO country code to localize results to",
+            "title": "Country"
+          },
+          "max_results": {
+            "anyOf": [
+              {
+                "maximum": 20.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Maximum number of results to return",
+            "title": "Max Results"
+          },
+          "max_tokens_per_page": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Approximate cap on the page content returned per result",
+            "title": "Max Tokens Per Page"
+          },
+          "query": {
+            "description": "The search query",
+            "minLength": 1,
+            "title": "Query",
+            "type": "string"
+          },
+          "search_domain_filter": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 20,
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Restrict results to these domains; prefix a domain with '-' to exclude it instead",
+            "title": "Search Domain Filter"
+          },
+          "search_tool_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Configured search tool to run against. Optional when exactly one tool is configured, and ignored on POST /v1/search/{search_tool_name}.",
+            "title": "Search Tool Name"
+          },
+          "user": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "User ID for usage attribution",
+            "title": "User"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "title": "SearchRequest",
+        "type": "object"
+      },
+      "SearchResponse": {
+        "description": "A completed search.",
+        "properties": {
+          "object": {
+            "const": "search",
+            "default": "search",
+            "title": "Object",
+            "type": "string"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/SearchResultItem"
+            },
+            "title": "Results",
+            "type": "array"
+          },
+          "search_tool": {
+            "description": "The configured search tool that served the request",
+            "title": "Search Tool",
+            "type": "string"
+          }
+        },
+        "required": [
+          "search_tool",
+          "results"
+        ],
+        "title": "SearchResponse",
+        "type": "object"
+      },
+      "SearchResultItem": {
+        "description": "One search result.",
+        "properties": {
+          "date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "snippet": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Snippet"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "url": {
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "title": "SearchResultItem",
+        "type": "object"
+      },
       "SessionResponse": {
         "description": "A freshly minted dashboard session (the token travels only in the cookie).",
         "properties": {
@@ -9273,6 +9448,119 @@
         "summary": "Create Response",
         "tags": [
           "responses"
+        ]
+      }
+    },
+    "/v1/search": {
+      "post": {
+        "description": "Run a search against a configured search tool.\n\nThe tool is taken from ``search_tool_name``, which may be omitted when\nexactly one tool is configured.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use the shared \"default\" user",
+        "operationId": "create_search_v1_search_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Create Search",
+        "tags": [
+          "search"
+        ]
+      }
+    },
+    "/v1/search/{search_tool_name}": {
+      "post": {
+        "description": "Run a search against the search tool named in the path.\n\nIdentical to ``POST /v1/search`` except that the path names the tool, which\nis the form LiteLLM clients use. Any ``search_tool_name`` in the body is\nignored.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use the shared \"default\" user",
+        "operationId": "create_search_for_tool_v1_search__search_tool_name__post",
+        "parameters": [
+          {
+            "description": "Configured search tool to run against",
+            "in": "path",
+            "name": "search_tool_name",
+            "required": true,
+            "schema": {
+              "description": "Configured search tool to run against",
+              "title": "Search Tool Name",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Create Search For Tool",
+        "tags": [
+          "search"
         ]
       }
     },

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -1969,7 +1969,7 @@
               },
               "raw": "{\n  \"max_results\": 5,\n  \"query\": \"otari llm gateway\"\n}"
             },
-            "description": "Run a search against a configured search tool.\n\nThe tool is taken from ``search_tool_name``, which may be omitted when\nexactly one tool is configured.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use the shared \"default\" user",
+            "description": "Run a search against a configured search tool.\n\nThe tool is taken from ``search_tool_name``, which may be omitted when\nexactly one tool is configured.\n\nAuthentication modes:\n- Master key: the ``user`` field is required and may name any existing user.\n- API key: usage and spend always bind to the key's own user. A ``user``\n  field naming a different user is rejected with 403 (or ignored, when\n  ``reject_user_mismatch`` is disabled); it is never billed to that user.",
             "header": [
               {
                 "key": "Content-Type",
@@ -2001,7 +2001,7 @@
               },
               "raw": "{\n  \"max_results\": 5,\n  \"query\": \"otari llm gateway\"\n}"
             },
-            "description": "Run a search against the search tool named in the path.\n\nIdentical to ``POST /v1/search`` except that the path names the tool, which\nis the form LiteLLM clients use. Any ``search_tool_name`` in the body is\nignored.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use the shared \"default\" user",
+            "description": "Run a search against the search tool named in the path.\n\nIdentical to ``POST /v1/search`` except that the path names the tool, which\nis the form LiteLLM clients use. Any ``search_tool_name`` in the body is\nignored.\n\nAuthentication modes:\n- Master key: the ``user`` field is required and may name any existing user.\n- API key: usage and spend always bind to the key's own user. A ``user``\n  field naming a different user is rejected with 403 (or ignored, when\n  ``reject_user_mismatch`` is disabled); it is never billed to that user.",
             "header": [
               {
                 "key": "Content-Type",

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -1958,6 +1958,83 @@
     {
       "item": [
         {
+          "name": "Create Search",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"max_results\": 5,\n  \"query\": \"otari llm gateway\"\n}"
+            },
+            "description": "Run a search against a configured search tool.\n\nThe tool is taken from ``search_tool_name``, which may be omitted when\nexactly one tool is configured.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use the shared \"default\" user",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "search"
+              ],
+              "raw": "{{baseUrl}}/v1/search"
+            }
+          }
+        },
+        {
+          "name": "Create Search For Tool",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"max_results\": 5,\n  \"query\": \"otari llm gateway\"\n}"
+            },
+            "description": "Run a search against the search tool named in the path.\n\nIdentical to ``POST /v1/search`` except that the path names the tool, which\nis the form LiteLLM clients use. Any ``search_tool_name`` in the body is\nignored.\n\nAuthentication modes:\n- Master key + user field: Use specified user (must exist)\n- API key + user field: Use specified user (must exist)\n- API key without user field: Use the shared \"default\" user",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "search",
+                ":search_tool_name"
+              ],
+              "raw": "{{baseUrl}}/v1/search/:search_tool_name",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "search_tool_name",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "name": "search"
+    },
+    {
+      "item": [
+        {
           "name": "Get Settings",
           "request": {
             "description": "Return non-secret runtime settings for the admin dashboard.",

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -56,3 +56,9 @@ Use in a request:
 The bundled SearXNG backend is suitable for trying things out but rate-limited for sustained use. For production, point `OTARI_WEB_SEARCH_URL` at a licensed backend. Ready-to-run Brave and Tavily adapters ship in `scripts/` and are available as separate Compose profiles (`web-search-brave`, `web-search-tavily`).
 
 A runnable walkthrough is in `demo/web-search/`.
+
+To search directly rather than as part of a completion, use
+[`POST /v1/search`](api-reference.md#search). It is billed and usage-logged the
+same way, but the caller supplies the query instead of the model, and it is
+configured separately under
+[`search_tools`](configuration.md#search-tools).

--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -21,6 +21,7 @@ from gateway.api.routes import (
     providers,
     rerank,
     responses,
+    search,
     settings,
     tool_settings,
     usage,
@@ -47,6 +48,7 @@ def register_routers(app: FastAPI, config: GatewayConfig) -> None:
     app.include_router(audio.router)
     app.include_router(files.router)
     app.include_router(rerank.router)
+    app.include_router(search.router)
     app.include_router(batches.router)
     app.include_router(moderations.router)
     app.include_router(models.router)

--- a/src/gateway/api/routes/search.py
+++ b/src/gateway/api/routes/search.py
@@ -8,9 +8,13 @@ so a client that proxies a search API can keep one gateway on the billing path
 instead of holding a second provider key of its own.
 
 The request and response follow LiteLLM's ``/v1/search`` (itself shaped after
-Perplexity's Search API), so a caller moving off the LiteLLM proxy needs no
-changes; :mod:`gateway.services.search_backend` translates to and from the
-provider's native shape and owns the per-provider adapters.
+Perplexity's Search API), so a caller moving off the LiteLLM proxy keeps its
+request shape; :mod:`gateway.services.search_backend` translates to and from the
+provider's native shape and owns the per-provider adapters. Two Perplexity
+features are deliberately not modeled: ``query`` is a single string rather than
+the multi-query array, and the filters with no field below (recency, context
+size, published-date) are ignored rather than rejected. Both are called out in
+``docs/api-reference.md`` so a migrating caller can check for them.
 
 Both the body-selected (``POST /v1/search``) and path-selected
 (``POST /v1/search/{search_tool_name}``) forms log ``endpoint="/v1/search"``,
@@ -48,6 +52,7 @@ from gateway.models.entities import APIKey, UsageLog
 from gateway.rate_limit import check_rate_limit
 from gateway.services.budget_service import reconcile_reservation, refund_reservation, reserve_budget
 from gateway.services.log_writer import LogWriter
+from gateway.services.model_access import is_model_allowed, model_not_allowed_detail, resolve_request_allowlist
 from gateway.services.pricing_service import find_model_pricing, flat_request_cost
 from gateway.services.search_backend import (
     MAX_RESULTS_CAP,
@@ -91,7 +96,12 @@ class SearchRequest(BaseModel):
         max_length=_MAX_DOMAIN_FILTERS,
         description="Restrict results to these domains; prefix a domain with '-' to exclude it instead",
     )
-    country: str | None = Field(default=None, description="Two-letter ISO country code to localize results to")
+    country: str | None = Field(
+        default=None,
+        min_length=2,
+        max_length=2,
+        description="Two-letter ISO country code to localize results to",
+    )
     max_tokens_per_page: int | None = Field(
         default=None, ge=1, description="Approximate cap on the page content returned per result"
     )
@@ -217,6 +227,18 @@ async def _dispatch_search(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
     pricing_key = f"{tool.provider}:{tool.name}"
+
+    # Model access control (per-key), keyed on the same <provider>:<tool> string
+    # pricing uses. A key with no list of its own inherits its user's default, so
+    # an unrestricted key is unaffected; a restricted one must name the search
+    # tool, which is the fail-closed side to be on for a brand-new spend surface.
+    key_allowlist = await resolve_request_allowlist(db, api_key)
+    if key_allowlist is not None and not is_model_allowed(key_allowlist, pricing_key):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=model_not_allowed_detail(pricing_key),
+        )
+
     # A search tool is not a model, so the community default-pricing dataset can
     # only produce a false match on the tool's name.
     pricing = await find_model_pricing(db, tool.provider, tool.name, use_defaults=False)
@@ -224,7 +246,13 @@ async def _dispatch_search(
         db,
         user_id,
         flat_request_cost(pricing),
-        model=pricing_key,
+        # Deliberately not the pricing key: ``model`` exists only to drive
+        # reserve_budget's free-model shortcut, which splits the string through
+        # any-llm. A search tool is not an any-llm model, so passing it logs a
+        # warning on every request, and for a tool whose name did happen to be an
+        # any-llm provider the shortcut would run an unguarded default-pricing
+        # lookup on the tool name and could skip the reservation outright.
+        model=None,
         strategy=config.budget_strategy,
         counts_toward_budget=not budget_exempt,
     )

--- a/src/gateway/api/routes/search.py
+++ b/src/gateway/api/routes/search.py
@@ -21,6 +21,11 @@ Both the body-selected (``POST /v1/search``) and path-selected
 so one Activity filter covers every search regardless of how the tool was
 named.
 
+A request the gateway itself turns away (an unknown or ambiguous tool name, a
+tool the caller's key may not use) writes a usage row too, with a null cost:
+refused traffic is dropped traffic, and it should be visible in Activity and
+countable as a failure rather than invisible outside the caller's own logs.
+
 Billing: search is priced per request, not per token, so a usage row carries
 zero tokens and a cost taken from the provider's own reported charge when it
 reports one. Otherwise the cost is the flat per-request rate configured for
@@ -71,6 +76,11 @@ SEARCH_ENDPOINT = "/v1/search"
 # Perplexity's documented ceiling on search_domain_filter, mirrored so an
 # oversized list is rejected here rather than by the upstream provider.
 _MAX_DOMAIN_FILTERS = 20
+
+# Stands in for the usage row's model when the request named no tool that could
+# be resolved (unknown name, or none given with several configured). The column
+# is not nullable, and "unknown" reads better in Activity than an empty string.
+_UNRESOLVED_TOOL = "unknown"
 
 
 class SearchRequest(BaseModel):
@@ -141,9 +151,10 @@ async def create_search(
     exactly one tool is configured.
 
     Authentication modes:
-    - Master key + user field: Use specified user (must exist)
-    - API key + user field: Use specified user (must exist)
-    - API key without user field: Use the shared "default" user
+    - Master key: the ``user`` field is required and may name any existing user.
+    - API key: usage and spend always bind to the key's own user. A ``user``
+      field naming a different user is rejected with 403 (or ignored, when
+      ``reject_user_mismatch`` is disabled); it is never billed to that user.
     """
     return await _dispatch_search(
         raw_request=raw_request,
@@ -175,9 +186,10 @@ async def create_search_for_tool(
     ignored.
 
     Authentication modes:
-    - Master key + user field: Use specified user (must exist)
-    - API key + user field: Use specified user (must exist)
-    - API key without user field: Use the shared "default" user
+    - Master key: the ``user`` field is required and may name any existing user.
+    - API key: usage and spend always bind to the key's own user. A ``user``
+      field naming a different user is rejected with 403 (or ignored, when
+      ``reject_user_mismatch`` is disabled); it is never billed to that user.
     """
     return await _dispatch_search(
         raw_request=raw_request,
@@ -219,12 +231,40 @@ async def _dispatch_search(
     user_id = resolve_passthrough_user_id(auth_result, request.user, reject_mismatch=config.reject_user_mismatch)
     rate_limit_info = check_rate_limit(raw_request, user_id)
 
+    def usage_row(*, model: str, provider: str | None, **overrides: Any) -> UsageLog:
+        return UsageLog(
+            id=str(uuid.uuid4()),
+            api_key_id=api_key_id,
+            user_id=user_id,
+            timestamp=datetime.now(UTC),
+            model=model,
+            provider=provider,
+            endpoint=SEARCH_ENDPOINT,
+            latency_ms=_elapsed_ms(started_at),
+            counts_toward_budget=not budget_exempt,
+            **overrides,
+        )
+
     # Resolved before any reservation is taken, so an unknown tool costs the
-    # caller nothing to be told about.
+    # caller nothing to be told about. The refusal is still logged: a request
+    # the gateway turned away is dropped traffic, and it belongs in Activity and
+    # in the failure count rather than reaching the operator as a complaint.
+    # cost stays null on every refusal row, since nothing was spent.
     try:
         tool = resolve_search_tool(config, tool_name)
     except SearchToolError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+        tool_error_detail = str(exc)
+        await log_writer.put(
+            usage_row(
+                # No tool was resolved, so there is no provider to attribute the
+                # row to and the name is whatever the caller asked for.
+                model=tool_name or _UNRESOLVED_TOOL,
+                provider=None,
+                status="error",
+                error_message=tool_error_detail,
+            )
+        )
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=tool_error_detail) from exc
 
     pricing_key = f"{tool.provider}:{tool.name}"
 
@@ -234,10 +274,16 @@ async def _dispatch_search(
     # tool, which is the fail-closed side to be on for a brand-new spend surface.
     key_allowlist = await resolve_request_allowlist(db, api_key)
     if key_allowlist is not None and not is_model_allowed(key_allowlist, pricing_key):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=model_not_allowed_detail(pricing_key),
+        not_allowed_detail = model_not_allowed_detail(pricing_key)
+        await log_writer.put(
+            usage_row(
+                model=tool.name,
+                provider=tool.provider,
+                status="error",
+                error_message=not_allowed_detail,
+            )
         )
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=not_allowed_detail)
 
     # A search tool is not a model, so the community default-pricing dataset can
     # only produce a false match on the tool's name.
@@ -257,20 +303,6 @@ async def _dispatch_search(
         counts_toward_budget=not budget_exempt,
     )
 
-    def usage_row(**overrides: Any) -> UsageLog:
-        return UsageLog(
-            id=str(uuid.uuid4()),
-            api_key_id=api_key_id,
-            user_id=user_id,
-            timestamp=datetime.now(UTC),
-            model=tool.name,
-            provider=tool.provider,
-            endpoint=SEARCH_ENDPOINT,
-            latency_ms=_elapsed_ms(started_at),
-            counts_toward_budget=not budget_exempt,
-            **overrides,
-        )
-
     try:
         outcome = await run_search(tool, _search_query(request))
         # The provider's own charge is the true cost; the configured flat rate is
@@ -278,6 +310,8 @@ async def _dispatch_search(
         cost = outcome.cost_usd if outcome.cost_usd is not None else flat_request_cost(pricing)
         await log_writer.put(
             usage_row(
+                model=tool.name,
+                provider=tool.provider,
                 status="success",
                 # Search bills per request; there are no tokens to report, and a
                 # zero is truthful where a null would read as "unknown".
@@ -292,7 +326,9 @@ async def _dispatch_search(
         await refund_reservation(db, reservation)
         raise
     except Exception as exc:
-        await log_writer.put(usage_row(status="error", error_message=str(exc)))
+        await log_writer.put(
+            usage_row(model=tool.name, provider=tool.provider, status="error", error_message=str(exc))
+        )
         await refund_reservation(db, reservation)
         # The raw provider message is kept on the usage log and the gateway log,
         # never in the response: it can carry upstream internals, and the

--- a/src/gateway/api/routes/search.py
+++ b/src/gateway/api/routes/search.py
@@ -1,0 +1,299 @@
+"""Search pass-through endpoint: a direct, billed search request.
+
+``otari_web_search`` answers a model's tool call mid-completion. This endpoint
+is the standalone counterpart: the caller asks, the gateway asks the search
+provider, and the result comes straight back, having gone through the same
+auth, rate limit, budget reservation, and usage log as a completion. It exists
+so a client that proxies a search API can keep one gateway on the billing path
+instead of holding a second provider key of its own.
+
+The request and response follow LiteLLM's ``/v1/search`` (itself shaped after
+Perplexity's Search API), so a caller moving off the LiteLLM proxy needs no
+changes; :mod:`gateway.services.search_backend` translates to and from the
+provider's native shape and owns the per-provider adapters.
+
+Both the body-selected (``POST /v1/search``) and path-selected
+(``POST /v1/search/{search_tool_name}``) forms log ``endpoint="/v1/search"``,
+so one Activity filter covers every search regardless of how the tool was
+named.
+
+Billing: search is priced per request, not per token, so a usage row carries
+zero tokens and a cost taken from the provider's own reported charge when it
+reports one. Otherwise the cost is the flat per-request rate configured for
+``<provider>:<tool>`` under the same convention moderations uses
+(:func:`flat_request_cost`). Like moderations and audio, search is exempt from
+``require_pricing``: a provider that reports its own cost is metered whether or
+not a rate is configured, so failing closed would reject calls the gateway can
+bill precisely.
+"""
+
+import time
+import uuid
+from datetime import UTC, datetime
+from typing import Annotated, Any, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response, status
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
+from gateway.api.routes._passthrough import (
+    PASSTHROUGH_PROVIDER_ERROR_DETAIL,
+    resolve_passthrough_user_id,
+)
+from gateway.api.routes._pipeline import _elapsed_ms, rate_limit_headers
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger
+from gateway.models.entities import APIKey, UsageLog
+from gateway.rate_limit import check_rate_limit
+from gateway.services.budget_service import reconcile_reservation, refund_reservation, reserve_budget
+from gateway.services.log_writer import LogWriter
+from gateway.services.pricing_service import find_model_pricing, flat_request_cost
+from gateway.services.search_backend import (
+    MAX_RESULTS_CAP,
+    SearchHit,
+    SearchQuery,
+    SearchTool,
+    SearchToolError,
+    resolve_search_tool,
+    run_search,
+)
+
+router = APIRouter(prefix="/v1", tags=["search"])
+
+SEARCH_ENDPOINT = "/v1/search"
+
+# Perplexity's documented ceiling on search_domain_filter, mirrored so an
+# oversized list is rejected here rather than by the upstream provider.
+_MAX_DOMAIN_FILTERS = 20
+
+
+class SearchRequest(BaseModel):
+    """A search request, following LiteLLM's ``/v1/search`` body."""
+
+    model_config = ConfigDict(
+        json_schema_extra={"example": {"query": "otari llm gateway", "max_results": 5}},
+    )
+
+    query: str = Field(min_length=1, description="The search query")
+    search_tool_name: str | None = Field(
+        default=None,
+        description=(
+            "Configured search tool to run against. Optional when exactly one tool is "
+            "configured, and ignored on POST /v1/search/{search_tool_name}."
+        ),
+    )
+    max_results: int | None = Field(
+        default=None, ge=1, le=MAX_RESULTS_CAP, description="Maximum number of results to return"
+    )
+    search_domain_filter: list[str] | None = Field(
+        default=None,
+        max_length=_MAX_DOMAIN_FILTERS,
+        description="Restrict results to these domains; prefix a domain with '-' to exclude it instead",
+    )
+    country: str | None = Field(default=None, description="Two-letter ISO country code to localize results to")
+    max_tokens_per_page: int | None = Field(
+        default=None, ge=1, description="Approximate cap on the page content returned per result"
+    )
+    user: str | None = Field(default=None, description="User ID for usage attribution")
+
+
+class SearchResultItem(BaseModel):
+    """One search result."""
+
+    title: str | None = None
+    url: str
+    snippet: str | None = None
+    date: str | None = None
+
+
+class SearchResponse(BaseModel):
+    """A completed search."""
+
+    object: Literal["search"] = "search"
+    search_tool: str = Field(description="The configured search tool that served the request")
+    results: list[SearchResultItem]
+
+
+@router.post("/search")
+async def create_search(
+    raw_request: Request,
+    response: Response,
+    request: SearchRequest,
+    auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    log_writer: Annotated[LogWriter, Depends(get_log_writer)],
+) -> SearchResponse:
+    """Run a search against a configured search tool.
+
+    The tool is taken from ``search_tool_name``, which may be omitted when
+    exactly one tool is configured.
+
+    Authentication modes:
+    - Master key + user field: Use specified user (must exist)
+    - API key + user field: Use specified user (must exist)
+    - API key without user field: Use the shared "default" user
+    """
+    return await _dispatch_search(
+        raw_request=raw_request,
+        response=response,
+        request=request,
+        tool_name=request.search_tool_name,
+        auth_result=auth_result,
+        db=db,
+        config=config,
+        log_writer=log_writer,
+    )
+
+
+@router.post("/search/{search_tool_name}")
+async def create_search_for_tool(
+    raw_request: Request,
+    response: Response,
+    request: SearchRequest,
+    search_tool_name: Annotated[str, Path(description="Configured search tool to run against")],
+    auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    log_writer: Annotated[LogWriter, Depends(get_log_writer)],
+) -> SearchResponse:
+    """Run a search against the search tool named in the path.
+
+    Identical to ``POST /v1/search`` except that the path names the tool, which
+    is the form LiteLLM clients use. Any ``search_tool_name`` in the body is
+    ignored.
+
+    Authentication modes:
+    - Master key + user field: Use specified user (must exist)
+    - API key + user field: Use specified user (must exist)
+    - API key without user field: Use the shared "default" user
+    """
+    return await _dispatch_search(
+        raw_request=raw_request,
+        response=response,
+        request=request,
+        tool_name=search_tool_name,
+        auth_result=auth_result,
+        db=db,
+        config=config,
+        log_writer=log_writer,
+    )
+
+
+async def _dispatch_search(
+    *,
+    raw_request: Request,
+    response: Response,
+    request: SearchRequest,
+    tool_name: str | None,
+    auth_result: tuple[APIKey | None, bool],
+    db: AsyncSession,
+    config: GatewayConfig,
+    log_writer: LogWriter,
+) -> SearchResponse:
+    """Run the search request scaffold: reserve, call, log, settle.
+
+    The shape mirrors :func:`gateway.api.routes._passthrough.run_passthrough`,
+    which cannot be reused directly: it resolves the request's model against
+    the any-llm provider instances, and a search tool is neither a model nor an
+    any-llm provider.
+    """
+    started_at = time.monotonic()
+    api_key, _ = auth_result
+    api_key_id = api_key.id if api_key else None
+    # A key flagged exclude_from_budget logs cost but is never reserved or folded
+    # into users.spend, matching every other billed endpoint.
+    budget_exempt = api_key is not None and api_key.exclude_from_budget
+
+    user_id = resolve_passthrough_user_id(auth_result, request.user, reject_mismatch=config.reject_user_mismatch)
+    rate_limit_info = check_rate_limit(raw_request, user_id)
+
+    # Resolved before any reservation is taken, so an unknown tool costs the
+    # caller nothing to be told about.
+    try:
+        tool = resolve_search_tool(config, tool_name)
+    except SearchToolError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    pricing_key = f"{tool.provider}:{tool.name}"
+    # A search tool is not a model, so the community default-pricing dataset can
+    # only produce a false match on the tool's name.
+    pricing = await find_model_pricing(db, tool.provider, tool.name, use_defaults=False)
+    reservation = await reserve_budget(
+        db,
+        user_id,
+        flat_request_cost(pricing),
+        model=pricing_key,
+        strategy=config.budget_strategy,
+        counts_toward_budget=not budget_exempt,
+    )
+
+    def usage_row(**overrides: Any) -> UsageLog:
+        return UsageLog(
+            id=str(uuid.uuid4()),
+            api_key_id=api_key_id,
+            user_id=user_id,
+            timestamp=datetime.now(UTC),
+            model=tool.name,
+            provider=tool.provider,
+            endpoint=SEARCH_ENDPOINT,
+            latency_ms=_elapsed_ms(started_at),
+            counts_toward_budget=not budget_exempt,
+            **overrides,
+        )
+
+    try:
+        outcome = await run_search(tool, _search_query(request))
+        # The provider's own charge is the true cost; the configured flat rate is
+        # the fallback for a provider that reports none.
+        cost = outcome.cost_usd if outcome.cost_usd is not None else flat_request_cost(pricing)
+        await log_writer.put(
+            usage_row(
+                status="success",
+                # Search bills per request; there are no tokens to report, and a
+                # zero is truthful where a null would read as "unknown".
+                prompt_tokens=0,
+                completion_tokens=0,
+                total_tokens=0,
+                cost=cost,
+            )
+        )
+        await reconcile_reservation(db, reservation, cost)
+    except HTTPException:
+        await refund_reservation(db, reservation)
+        raise
+    except Exception as exc:
+        await log_writer.put(usage_row(status="error", error_message=str(exc)))
+        await refund_reservation(db, reservation)
+        # The raw provider message is kept on the usage log and the gateway log,
+        # never in the response: it can carry upstream internals, and the
+        # pass-through routes hold the same line.
+        logger.error("Search failed for tool '%s' (%s): %s", tool.name, tool.provider, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=PASSTHROUGH_PROVIDER_ERROR_DETAIL,
+        ) from exc
+
+    if rate_limit_info:
+        for header, value in rate_limit_headers(rate_limit_info).items():
+            response.headers[header] = value
+
+    return _to_response(tool, outcome.results)
+
+
+def _search_query(request: SearchRequest) -> SearchQuery:
+    return SearchQuery(
+        query=request.query,
+        max_results=request.max_results,
+        domain_filter=tuple(request.search_domain_filter or ()),
+        country=request.country,
+        max_tokens_per_page=request.max_tokens_per_page,
+    )
+
+
+def _to_response(tool: SearchTool, hits: list[SearchHit]) -> SearchResponse:
+    return SearchResponse(
+        search_tool=tool.name,
+        results=[SearchResultItem(title=hit.title, url=hit.url, snippet=hit.snippet, date=hit.date) for hit in hits],
+    )

--- a/src/gateway/api/routes/search.py
+++ b/src/gateway/api/routes/search.py
@@ -22,9 +22,11 @@ so one Activity filter covers every search regardless of how the tool was
 named.
 
 A request the gateway itself turns away (an unknown or ambiguous tool name, a
-tool the caller's key may not use) writes a usage row too, with a null cost:
-refused traffic is dropped traffic, and it should be visible in Activity and
-countable as a failure rather than invisible outside the caller's own logs.
+tool the caller's key may not use) writes a usage row too, through the shared
+:func:`gateway.api.routes._pipeline.log_gateway_rejection` the pass-through
+routes use: refused traffic is dropped traffic, and it should be visible in
+Activity and countable as a failure rather than invisible outside the caller's
+own logs.
 
 Billing: search is priced per request, not per token, so a usage row carries
 zero tokens and a cost taken from the provider's own reported charge when it
@@ -50,7 +52,7 @@ from gateway.api.routes._passthrough import (
     PASSTHROUGH_PROVIDER_ERROR_DETAIL,
     resolve_passthrough_user_id,
 )
-from gateway.api.routes._pipeline import _elapsed_ms, rate_limit_headers
+from gateway.api.routes._pipeline import _elapsed_ms, log_gateway_rejection, rate_limit_headers
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import APIKey, UsageLog
@@ -231,39 +233,37 @@ async def _dispatch_search(
     user_id = resolve_passthrough_user_id(auth_result, request.user, reject_mismatch=config.reject_user_mismatch)
     rate_limit_info = check_rate_limit(raw_request, user_id)
 
-    def usage_row(*, model: str, provider: str | None, **overrides: Any) -> UsageLog:
-        return UsageLog(
-            id=str(uuid.uuid4()),
+    async def log_rejection(detail: str, *, row_model: str, row_provider: str | None) -> None:
+        """Record a search the gateway itself refused.
+
+        The shared writer owns the row shape (``status="error"``, no cost,
+        ``counts_toward_budget`` pinned True) and swallows a writer failure, so a
+        sick log writer cannot turn this route's 400 or 403 into a 500.
+        """
+        await log_gateway_rejection(
+            db=db,
+            log_writer=log_writer,
             api_key_id=api_key_id,
             user_id=user_id,
-            timestamp=datetime.now(UTC),
-            model=model,
-            provider=provider,
+            model=row_model,
+            provider=row_provider,
             endpoint=SEARCH_ENDPOINT,
-            latency_ms=_elapsed_ms(started_at),
-            counts_toward_budget=not budget_exempt,
-            **overrides,
+            detail=detail,
+            started_at=started_at,
         )
 
     # Resolved before any reservation is taken, so an unknown tool costs the
     # caller nothing to be told about. The refusal is still logged: a request
     # the gateway turned away is dropped traffic, and it belongs in Activity and
     # in the failure count rather than reaching the operator as a complaint.
-    # cost stays null on every refusal row, since nothing was spent.
     try:
         tool = resolve_search_tool(config, tool_name)
     except SearchToolError as exc:
         tool_error_detail = str(exc)
-        await log_writer.put(
-            usage_row(
-                # No tool was resolved, so there is no provider to attribute the
-                # row to and the name is whatever the caller asked for.
-                model=tool_name or _UNRESOLVED_TOOL,
-                provider=None,
-                status="error",
-                error_message=tool_error_detail,
-            )
-        )
+        # No tool was resolved, so there is no provider to attribute the row to
+        # and the name is whatever the caller asked for, matching how the
+        # pass-through routes log a selector that did not resolve.
+        await log_rejection(tool_error_detail, row_model=tool_name or _UNRESOLVED_TOOL, row_provider=None)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=tool_error_detail) from exc
 
     pricing_key = f"{tool.provider}:{tool.name}"
@@ -275,14 +275,7 @@ async def _dispatch_search(
     key_allowlist = await resolve_request_allowlist(db, api_key)
     if key_allowlist is not None and not is_model_allowed(key_allowlist, pricing_key):
         not_allowed_detail = model_not_allowed_detail(pricing_key)
-        await log_writer.put(
-            usage_row(
-                model=tool.name,
-                provider=tool.provider,
-                status="error",
-                error_message=not_allowed_detail,
-            )
-        )
+        await log_rejection(not_allowed_detail, row_model=tool.name, row_provider=tool.provider)
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=not_allowed_detail)
 
     # A search tool is not a model, so the community default-pricing dataset can
@@ -303,6 +296,25 @@ async def _dispatch_search(
         counts_toward_budget=not budget_exempt,
     )
 
+    def usage_row(**overrides: Any) -> UsageLog:
+        """Build the row for a search that reached the provider.
+
+        Unlike a refusal row, this one carries a cost and so honors the key's
+        ``exclude_from_budget`` flag.
+        """
+        return UsageLog(
+            id=str(uuid.uuid4()),
+            api_key_id=api_key_id,
+            user_id=user_id,
+            timestamp=datetime.now(UTC),
+            model=tool.name,
+            provider=tool.provider,
+            endpoint=SEARCH_ENDPOINT,
+            latency_ms=_elapsed_ms(started_at),
+            counts_toward_budget=not budget_exempt,
+            **overrides,
+        )
+
     try:
         outcome = await run_search(tool, _search_query(request))
         # The provider's own charge is the true cost; the configured flat rate is
@@ -310,8 +322,6 @@ async def _dispatch_search(
         cost = outcome.cost_usd if outcome.cost_usd is not None else flat_request_cost(pricing)
         await log_writer.put(
             usage_row(
-                model=tool.name,
-                provider=tool.provider,
                 status="success",
                 # Search bills per request; there are no tokens to report, and a
                 # zero is truthful where a null would read as "unknown".
@@ -326,9 +336,7 @@ async def _dispatch_search(
         await refund_reservation(db, reservation)
         raise
     except Exception as exc:
-        await log_writer.put(
-            usage_row(model=tool.name, provider=tool.provider, status="error", error_message=str(exc))
-        )
+        await log_writer.put(usage_row(status="error", error_message=str(exc)))
         await refund_reservation(db, reservation)
         # The raw provider message is kept on the usage log and the gateway log,
         # never in the response: it can carry upstream internals, and the

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -882,9 +882,16 @@ class GatewayConfig(BaseSettings):
                 msg = f"search_tools.{name}.api_key is required."
                 raise ValueError(msg)
             timeout = entry.get("timeout")
-            if timeout is not None and (isinstance(timeout, bool) or not isinstance(timeout, (int, float))):
-                msg = f"search_tools.{name}.timeout must be a number of seconds."
-                raise ValueError(msg)
+            if timeout is not None:
+                if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
+                    msg = f"search_tools.{name}.timeout must be a number of seconds."
+                    raise ValueError(msg)
+                # A negative timeout would reach httpx and fail at request time,
+                # and a zero is silently swapped for the default when the tool is
+                # resolved. Both are misconfigurations worth failing on here.
+                if timeout <= 0:
+                    msg = f"search_tools.{name}.timeout must be greater than 0 seconds, got {timeout}."
+                    raise ValueError(msg)
             options = entry.get("options")
             if options is not None and not isinstance(options, dict):
                 msg = f"search_tools.{name}.options must be a mapping."

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -69,6 +69,12 @@ ENV_BRIDGED_FIELDS = (
 STREAM_MISSING_USAGE_POLICIES = ("estimate", "fail", "allow_free")
 VISION_STRATEGIES = ("describe", "ocr", "off")
 
+# Search providers the standalone POST /v1/search endpoint can dispatch to.
+# Declared here rather than in the adapter module so startup validation can
+# reject an unknown ``search_tools.<name>.provider`` without the config layer
+# importing the service layer.
+SEARCH_PROVIDERS = ("exa",)
+
 
 class _NonScalarField(Exception):
     """Raised when a config field is not a simple scalar settable from a plain env string."""
@@ -283,6 +289,16 @@ class GatewayConfig(BaseSettings):
         default_factory=dict,
         description=(
             "Pre-configured model USD pricing (model_key -> {input_price_per_million, output_price_per_million})"
+        ),
+    )
+    search_tools: dict[str, dict[str, Any]] = Field(
+        default_factory=dict,
+        description=(
+            "Search tools served by POST /v1/search, keyed by the name callers pass as "
+            "'search_tool_name' (or in the /v1/search/{tool} path). Each entry needs an "
+            "'api_key' and may declare a 'provider' (one of: exa; defaults to the tool "
+            "name), an 'api_base', a 'timeout' in seconds, and an 'options' mapping of "
+            "provider-native defaults. Standalone-mode only."
         ),
     )
     enable_metrics: bool = Field(
@@ -828,6 +844,43 @@ class GatewayConfig(BaseSettings):
             return providers
         return {instance: ({} if entry is None else entry) for instance, entry in providers.items()}
 
+    def validate_search_tools(self) -> None:
+        """Validate the ``search_tools`` map at startup so misconfig fails fast.
+
+        Every supported provider authenticates with an API key, so a tool
+        without one is rejected here rather than at request time as an opaque
+        upstream 401. The tool name doubles as a ``/v1/search/{tool}`` path
+        segment, so it must not contain a slash.
+        """
+        for name, entry in self.search_tools.items():
+            if not name:
+                msg = "search tool name must not be empty."
+                raise ValueError(msg)
+            if "/" in name:
+                msg = f"search tool name '{name}' must not contain '/' (it is used as a URL path segment)."
+                raise ValueError(msg)
+            if not isinstance(entry, dict):
+                msg = f"search_tools.{name} must be a mapping."
+                raise ValueError(msg)
+            provider = entry.get("provider") or name
+            if provider not in SEARCH_PROVIDERS:
+                msg = (
+                    f"search_tools.{name}.provider '{provider}' is not a supported search provider "
+                    f"(one of: {', '.join(SEARCH_PROVIDERS)})."
+                )
+                raise ValueError(msg)
+            if not entry.get("api_key"):
+                msg = f"search_tools.{name}.api_key is required."
+                raise ValueError(msg)
+            timeout = entry.get("timeout")
+            if timeout is not None and (isinstance(timeout, bool) or not isinstance(timeout, (int, float))):
+                msg = f"search_tools.{name}.timeout must be a number of seconds."
+                raise ValueError(msg)
+            options = entry.get("options")
+            if options is not None and not isinstance(options, dict):
+                msg = f"search_tools.{name}.options must be a mapping."
+                raise ValueError(msg)
+
     @field_validator("stream_missing_usage_policy")
     @classmethod
     def _validate_stream_missing_usage_policy(cls, value: str) -> str:
@@ -979,6 +1032,7 @@ def load_config(config_path: str | None = None) -> GatewayConfig:
     config.validate_mode_selection()
     config.validate_provider_instances()
     config.validate_aliases()
+    config.validate_search_tools()
     _bridge_yaml_fields_to_env(config, yaml_bridged_fields)
     return config
 

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -844,6 +844,15 @@ class GatewayConfig(BaseSettings):
             return providers
         return {instance: ({} if entry is None else entry) for instance, entry in providers.items()}
 
+    def search_tool_providers(self) -> set[str]:
+        """The distinct providers backing the configured search tools.
+
+        These are prefixes of the ``<provider>:<tool>`` keys that search pricing,
+        usage, and per-key access lists are written against, so the allow-list
+        writer has to accept them alongside real provider instances.
+        """
+        return {str(entry.get("provider") or name) for name, entry in self.search_tools.items()}
+
     def validate_search_tools(self) -> None:
         """Validate the ``search_tools`` map at startup so misconfig fails fast.
 

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -26,6 +26,7 @@ from gateway.services.master_key_service import ensure_master_key
 from gateway.services.pricing_init_service import (
     initialize_pricing_from_config,
     warn_if_require_pricing_without_pricing,
+    warn_if_search_tools_lack_flat_pricing,
 )
 from gateway.services.pricing_refresh_service import (
     load_persisted_price_snapshot,
@@ -38,6 +39,7 @@ from gateway.services.provider_store_service import (
     run_provider_refresher,
 )
 from gateway.services.runtime_settings_service import apply_overrides_from_db
+from gateway.services.search_backend import close_search_client
 from gateway.services.secret_box import validate_secret_key
 from gateway.services.tool_settings_service import apply_overrides_from_db as apply_tool_overrides_from_db
 from gateway.version import __version__
@@ -138,6 +140,7 @@ def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
                 await bootstrap_first_api_key(config, session)
                 await initialize_pricing_from_config(config, session)
                 await warn_if_require_pricing_without_pricing(config, session)
+                await warn_if_search_tools_lack_flat_pricing(config, session)
                 await load_aliases_at_startup(session)
             log_writer = create_log_writer(config.log_writer_strategy)
             app.state.file_store = build_file_store(config)
@@ -181,6 +184,9 @@ def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
             # nothing to stop, but the refreshers above still needed cancelling.
             if log_writer_started:
                 await log_writer.stop()
+            # POST /v1/search dispatches on one pooled client for the process, so
+            # shutdown owns closing it. A no-op when no search was ever served.
+            await close_search_client()
 
     return lifespan
 

--- a/src/gateway/services/model_access.py
+++ b/src/gateway/services/model_access.py
@@ -128,8 +128,17 @@ def is_model_allowed(allowlist: list[str] | None, canonical_key: str) -> bool:
 
 
 def _known_prefix(config: GatewayConfig, prefix: str) -> bool:
-    """Whether a prefix names a configured instance or a known any-llm provider."""
+    """Whether a prefix names something an allow-list entry can legitimately gate.
+
+    A configured provider instance or a known any-llm provider, plus the
+    providers behind the configured search tools: ``/v1/search`` checks the same
+    allow-list against its ``<provider>:<tool>`` key, so refusing to store that
+    prefix would leave a restricted key permanently denied search with no way for
+    an operator to grant it.
+    """
     if prefix in config.providers:
+        return True
+    if prefix in config.search_tool_providers():
         return True
     try:
         LLMProvider(prefix)

--- a/src/gateway/services/pricing_init_service.py
+++ b/src/gateway/services/pricing_init_service.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import ModelPricing
-from gateway.services.pricing_service import normalize_effective_at
+from gateway.services.pricing_service import find_model_pricing, normalize_effective_at
 from gateway.services.provider_kwargs import normalize_pricing_key
 
 
@@ -39,6 +39,35 @@ async def warn_if_require_pricing_without_pricing(config: GatewayConfig, db: Asy
             "require_pricing is enabled with no configured pricing; relying on default_pricing "
             "(genai-prices) for billing. Models outside its coverage are still rejected with HTTP 402."
         )
+
+
+async def warn_if_search_tools_lack_flat_pricing(config: GatewayConfig, db: AsyncSession) -> None:
+    """Warn at startup for a search tool with no flat per-request rate.
+
+    ``POST /v1/search`` reserves the rate configured for ``<provider>:<tool>``
+    before calling the provider, so an unpriced tool reserves nothing: a user
+    already over their cap is still refused, but one just under it can overshoot
+    by a search, and concurrent searches cannot see each other's holds. The
+    provider's own reported charge is still billed afterwards, so spend stays
+    truthful; it is the pre-flight hold that is missing. An explicit rate of 0 is
+    a deliberate "this tool is free" and is left alone.
+    """
+    unpriced: list[str] = []
+    for name, entry in config.search_tools.items():
+        provider = str(entry.get("provider") or name) if isinstance(entry, dict) else name
+        # use_defaults=False for the same reason the route sets it: a search tool
+        # is not a model, so the community dataset can only produce a false match.
+        if await find_model_pricing(db, provider, name, use_defaults=False) is None:
+            unpriced.append(f"{provider}:{name}")
+    if not unpriced:
+        return
+    logger.warning(
+        "No flat per-request rate is configured for search tool(s): %s. Nothing is reserved against a "
+        "caller's budget before the search runs, so a user just under their cap can overshoot by one "
+        "search. Add a rate for the model key (config `pricing` section or POST /v1/pricing); the "
+        "convention is USD per million requests, so 5000.0 charges $0.005 per search.",
+        ", ".join(sorted(unpriced)),
+    )
 
 
 async def initialize_pricing_from_config(config: GatewayConfig, db: AsyncSession) -> None:

--- a/src/gateway/services/pricing_service.py
+++ b/src/gateway/services/pricing_service.py
@@ -268,6 +268,7 @@ async def find_model_pricing(
     model: str,
     *,
     as_of: datetime | None = None,
+    use_defaults: bool = True,
 ) -> ModelPricing | None:
     """Look up model pricing as of a timestamp.
 
@@ -276,6 +277,12 @@ async def find_model_pricing(
     maintained default pricing from genai-prices. Explicit pricing stored in the
     database always takes precedence over defaults. The default fallback is gated
     by ``GatewayConfig.default_pricing`` via :func:`configure_default_pricing`.
+
+    ``use_defaults=False`` skips that fallback for keys that are not models at
+    all. The genai-prices lookup falls back to a provider-agnostic match on the
+    bare name, so a search tool an operator happened to name after a real model
+    would otherwise pick up that model's per-million-token rate and be billed
+    under a per-request convention.
     """
 
     lookup_time = normalize_effective_at(as_of)
@@ -285,7 +292,7 @@ async def find_model_pricing(
     if pricing is None and provider:
         pricing = await _find_by_model_key(db, f"{provider}/{model}", lookup_time)
 
-    if pricing is None and default_pricing_enabled():
+    if pricing is None and use_defaults and default_pricing_enabled():
         pricing = default_model_pricing(provider, model, lookup_time)
 
     return pricing

--- a/src/gateway/services/search_backend.py
+++ b/src/gateway/services/search_backend.py
@@ -1,0 +1,295 @@
+"""Standalone search dispatch for ``POST /v1/search``.
+
+Otari's other web-search surface (:mod:`gateway.services.web_search_backend`)
+is an in-loop tool: the model emits ``web_search(query=…)`` and the gateway
+answers it mid-completion. This module is the direct one. A caller posts a
+query and gets ranked results back, on the same auth, budget, and usage-logging
+path as a completion, which is what a sidecar proxying a search API through the
+gateway needs.
+
+Tools are declared in ``config.yml``, keyed by the name callers pass as
+``search_tool_name`` (or in the ``/v1/search/{tool}`` path)::
+
+    search_tools:
+      exa-search:
+        provider: exa
+        api_key: ${EXA_API_KEY}
+        options:
+          type: fast
+
+``options`` is a mapping of provider-native request fields used as defaults;
+fields derived from the request win over it, and ``query`` always comes from
+the caller. Every entry is validated at startup by
+``GatewayConfig.validate_search_tools``, so an unsupported provider or a
+missing API key fails before the first request.
+
+The wire contract of the route follows LiteLLM's ``/v1/search`` (itself shaped
+after Perplexity's Search API) so a caller migrating off the LiteLLM proxy
+needs no request changes. Translating that contract to and from each provider's
+native shape happens here: the route never sees a provider payload.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from gateway.core.config import SEARCH_PROVIDERS, GatewayConfig
+
+EXA_PROVIDER = "exa"
+
+_DEFAULT_API_BASE = {EXA_PROVIDER: "https://api.exa.ai"}
+_DEFAULT_TIMEOUT_S = 30.0
+
+# Result-count defaults and the ceiling the route also enforces on the request
+# field. Applied again here because a tool's ``options`` can carry its own
+# ``numResults``, which must not escape the cap either.
+DEFAULT_MAX_RESULTS = 10
+MAX_RESULTS_CAP = 20
+
+# Perplexity meters per-page content in tokens and Exa in characters, so the
+# request's ``max_tokens_per_page`` is converted at the usual rough ratio and
+# clamped to the range Exa documents for ``contents.text.maxCharacters``.
+DEFAULT_MAX_TOKENS_PER_PAGE = 1024
+_CHARS_PER_TOKEN = 4
+_EXA_MAX_CHARACTERS = 10_000
+
+# How much of an upstream error body is kept for the usage log's error_message.
+# The full body can be large and is never returned to the caller.
+_ERROR_BODY_CHARS = 500
+
+
+class SearchToolError(ValueError):
+    """The requested search tool is unknown, ambiguous, or not configured."""
+
+
+class SearchProviderError(RuntimeError):
+    """The search provider could not be reached or returned malformed data."""
+
+
+@dataclass(frozen=True)
+class SearchTool:
+    """A resolved ``search_tools`` entry, ready to dispatch against."""
+
+    name: str
+    provider: str
+    api_key: str
+    api_base: str
+    timeout_s: float
+    options: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SearchQuery:
+    """One search request in the gateway's provider-neutral terms."""
+
+    query: str
+    max_results: int | None = None
+    domain_filter: tuple[str, ...] = ()
+    country: str | None = None
+    max_tokens_per_page: int | None = None
+
+
+@dataclass(frozen=True)
+class SearchHit:
+    """One normalized result."""
+
+    url: str
+    title: str | None = None
+    snippet: str | None = None
+    date: str | None = None
+
+
+@dataclass(frozen=True)
+class SearchOutcome:
+    """A completed provider search.
+
+    ``cost_usd`` is the provider's own reported charge when it reports one (Exa
+    returns ``costDollars.total``), which the route bills in preference to a
+    configured flat rate. ``None`` means the provider said nothing about cost.
+    """
+
+    results: list[SearchHit]
+    cost_usd: float | None = None
+
+
+def resolve_search_tool(config: GatewayConfig, name: str | None) -> SearchTool:
+    """Resolve a request's tool name against ``config.search_tools``.
+
+    The name may be omitted when exactly one tool is configured, which is the
+    common single-provider deployment. Raises :class:`SearchToolError` when no
+    tool is configured, when the name is unknown, and when it is omitted with
+    several configured; the route maps all three to a 400, since each is
+    something the caller can act on.
+    """
+    configured = config.search_tools
+    if not configured:
+        msg = "No search tools are configured. Declare one under 'search_tools' in config.yml."
+        raise SearchToolError(msg)
+
+    if name is None:
+        if len(configured) > 1:
+            msg = (
+                "Several search tools are configured; name one in 'search_tool_name' or use "
+                f"POST /v1/search/{{tool}}. Available: {', '.join(sorted(configured))}."
+            )
+            raise SearchToolError(msg)
+        name = next(iter(configured))
+
+    entry = configured.get(name)
+    if entry is None:
+        msg = f"Unknown search tool '{name}'. Available: {', '.join(sorted(configured))}."
+        raise SearchToolError(msg)
+
+    provider = str(entry.get("provider") or name)
+    api_key = entry.get("api_key")
+    # Defense in depth: startup validation already guarantees both, so this only
+    # fires for a config built in-process. Refusing here beats calling an unknown
+    # provider or calling a known one unauthenticated.
+    if provider not in SEARCH_PROVIDERS or not api_key:
+        msg = f"Search tool '{name}' is not configured correctly."
+        raise SearchToolError(msg)
+
+    api_base = str(entry.get("api_base") or _DEFAULT_API_BASE[provider]).rstrip("/")
+    options = entry.get("options")
+    return SearchTool(
+        name=name,
+        provider=provider,
+        api_key=str(api_key),
+        api_base=api_base,
+        timeout_s=float(entry.get("timeout") or _DEFAULT_TIMEOUT_S),
+        options=dict(options) if isinstance(options, dict) else {},
+    )
+
+
+async def run_search(tool: SearchTool, query: SearchQuery) -> SearchOutcome:
+    """Dispatch one search against the tool's provider."""
+    if tool.provider == EXA_PROVIDER:
+        return await _search_exa(tool, query)
+    # Unreachable via config: startup validation rejects unknown providers.
+    msg = f"Unsupported search provider '{tool.provider}'."
+    raise SearchProviderError(msg)
+
+
+# --------------------------------------------------------------------------- #
+# Exa
+# --------------------------------------------------------------------------- #
+
+
+def build_exa_payload(tool: SearchTool, query: SearchQuery) -> dict[str, Any]:
+    """Build Exa's ``POST /search`` body from the neutral request.
+
+    The tool's ``options`` are the base, so an operator can pin Exa-native knobs
+    (``type``, ``category``, ``moderation``) that the LiteLLM-shaped request has
+    no field for. Request-derived fields are layered on top, and ``query`` is
+    written last so no configured option can displace the caller's query.
+    """
+    payload: dict[str, Any] = dict(tool.options)
+
+    requested = query.max_results or payload.get("numResults") or DEFAULT_MAX_RESULTS
+    payload["numResults"] = max(1, min(int(requested), MAX_RESULTS_CAP))
+
+    # Perplexity's convention: a leading '-' excludes a domain instead of
+    # restricting to it. Mapped to Exa's two separate lists so a '-example.com'
+    # entry excludes rather than being sent as a domain that matches nothing.
+    include = [d for d in query.domain_filter if not d.startswith("-")]
+    exclude = [d[1:] for d in query.domain_filter if d.startswith("-") and len(d) > 1]
+    if include:
+        payload["includeDomains"] = include
+    if exclude:
+        payload["excludeDomains"] = exclude
+
+    if query.country:
+        payload["userLocation"] = query.country
+
+    # Exa returns page text only when asked for it, and the response's
+    # ``snippet`` is that text, so contents are always requested. A tool that
+    # pins its own ``contents.text`` keeps it unless the caller asked for a
+    # specific per-page size.
+    contents = dict(payload.get("contents") or {})
+    if query.max_tokens_per_page is not None or "text" not in contents:
+        max_tokens = query.max_tokens_per_page or DEFAULT_MAX_TOKENS_PER_PAGE
+        max_chars = max(1, min(max_tokens * _CHARS_PER_TOKEN, _EXA_MAX_CHARACTERS))
+        contents["text"] = {"maxCharacters": max_chars}
+    payload["contents"] = contents
+
+    payload["query"] = query.query
+    return payload
+
+
+async def _search_exa(tool: SearchTool, query: SearchQuery) -> SearchOutcome:
+    payload = build_exa_payload(tool, query)
+    try:
+        async with httpx.AsyncClient(timeout=tool.timeout_s) as client:
+            response = await client.post(
+                f"{tool.api_base}/search",
+                json=payload,
+                headers={"x-api-key": tool.api_key},
+            )
+    except httpx.HTTPError as exc:
+        msg = f"exa search request failed: {exc}"
+        raise SearchProviderError(msg) from exc
+
+    if response.status_code >= 400:
+        msg = f"exa search returned HTTP {response.status_code}: {response.text[:_ERROR_BODY_CHARS]}"
+        raise SearchProviderError(msg)
+
+    try:
+        body = response.json()
+    except ValueError as exc:
+        msg = "exa search returned a body that is not JSON"
+        raise SearchProviderError(msg) from exc
+    if not isinstance(body, dict):
+        msg = f"exa search returned a {type(body).__name__} body, expected an object"
+        raise SearchProviderError(msg)
+
+    return SearchOutcome(results=_exa_hits(body), cost_usd=_exa_cost(body))
+
+
+def _exa_hits(body: dict[str, Any]) -> list[SearchHit]:
+    raw = body.get("results")
+    if not isinstance(raw, list):
+        msg = "exa search response has no 'results' list"
+        raise SearchProviderError(msg)
+
+    hits: list[SearchHit] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        url = item.get("url")
+        if not isinstance(url, str) or not url:
+            continue
+        hits.append(
+            SearchHit(
+                url=url,
+                title=_text_or_none(item.get("title")),
+                # Full text when it was returned, else the highlight sentences,
+                # which is what a snippet-only search mode yields.
+                snippet=_text_or_none(item.get("text")) or _highlights(item.get("highlights")),
+                date=_text_or_none(item.get("publishedDate")),
+            )
+        )
+    return hits
+
+
+def _exa_cost(body: dict[str, Any]) -> float | None:
+    costs = body.get("costDollars")
+    if not isinstance(costs, dict):
+        return None
+    total = costs.get("total")
+    if isinstance(total, bool) or not isinstance(total, (int, float)):
+        return None
+    return max(float(total), 0.0)
+
+
+def _text_or_none(value: Any) -> str | None:
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _highlights(value: Any) -> str | None:
+    if not isinstance(value, list):
+        return None
+    joined = " ".join(part.strip() for part in value if isinstance(part, str) and part.strip())
+    return joined or None

--- a/src/gateway/services/search_backend.py
+++ b/src/gateway/services/search_backend.py
@@ -23,6 +23,11 @@ the caller. Every entry is validated at startup by
 ``GatewayConfig.validate_search_tools``, so an unsupported provider or a
 missing API key fails before the first request.
 
+Provider calls go through one pooled ``httpx.AsyncClient`` for the process
+(:func:`get_search_client`), closed on shutdown by :func:`close_search_client`.
+A search is a single request, so a client per call would pay a fresh TCP and TLS
+handshake every time and pool nothing.
+
 The wire contract of the route follows LiteLLM's ``/v1/search`` (itself shaped
 after Perplexity's Search API) so a caller migrating off the LiteLLM proxy
 needs no request changes. Translating that contract to and from each provider's
@@ -59,6 +64,32 @@ _EXA_MAX_CHARACTERS = 10_000
 # How much of an upstream error body is kept for the usage log's error_message.
 # The full body can be large and is never returned to the caller.
 _ERROR_BODY_CHARS = 500
+
+# Pooled client, shared by every search in the process so connections survive
+# between requests. Created lazily and replaced when closed; no lock is needed
+# because there is no await between the check and the assignment, so two
+# coroutines cannot interleave and build two clients.
+_client: httpx.AsyncClient | None = None
+
+
+def get_search_client() -> httpx.AsyncClient:
+    """The process-wide pooled client search requests are dispatched on.
+
+    Timeouts are per tool, so they are passed on each request rather than baked
+    into the client.
+    """
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient()
+    return _client
+
+
+async def close_search_client() -> None:
+    """Close the pooled client. A no-op when no search was ever dispatched."""
+    global _client
+    client, _client = _client, None
+    if client is not None and not client.is_closed:
+        await client.aclose()
 
 
 class SearchToolError(ValueError):
@@ -205,21 +236,32 @@ def build_exa_payload(tool: SearchTool, query: SearchQuery) -> dict[str, Any]:
         payload["userLocation"] = query.country
 
     # Exa returns page text only when asked for it, and the response's
-    # ``snippet`` is that text, so contents are always requested. A tool that
+    # ``snippet`` is that text, so contents are requested by default. A tool that
     # pins its own ``contents.text`` keeps it unless the caller asked for a
-    # specific per-page size.
+    # specific per-page size. Pinning ``text: null`` (or ``false``) opts out
+    # entirely: page content is what Exa charges per page for, and a caller that
+    # wants only ranked URLs, or highlights, should not have to pay for it. The
+    # opt-out is the operator's, so it holds even when the request carries a
+    # ``max_tokens_per_page``.
     contents = dict(payload.get("contents") or {})
-    if query.max_tokens_per_page is not None or "text" not in contents:
+    pinned = contents.get("text")
+    if "text" in contents and (pinned is None or pinned is False):
+        del contents["text"]
+    elif query.max_tokens_per_page is not None or "text" not in contents:
         max_tokens = query.max_tokens_per_page or DEFAULT_MAX_TOKENS_PER_PAGE
         max_chars = max(1, min(max_tokens * _CHARS_PER_TOKEN, _EXA_MAX_CHARACTERS))
         # Merge rather than replace: ``text`` has siblings (``verbosity``,
         # ``includeHtmlTags``) that a tool may have pinned, and only the size is
         # the caller's to set.
-        pinned = contents.get("text")
         text_options = dict(pinned) if isinstance(pinned, dict) else {}
         text_options["maxCharacters"] = max_chars
         contents["text"] = text_options
-    payload["contents"] = contents
+    # An opted-out tool with nothing else pinned wants no ``contents`` block at
+    # all, rather than an empty one Exa would have to interpret.
+    if contents:
+        payload["contents"] = contents
+    else:
+        payload.pop("contents", None)
 
     payload["query"] = query.query
     return payload
@@ -227,13 +269,14 @@ def build_exa_payload(tool: SearchTool, query: SearchQuery) -> dict[str, Any]:
 
 async def _search_exa(tool: SearchTool, query: SearchQuery) -> SearchOutcome:
     payload = build_exa_payload(tool, query)
+    client = get_search_client()
     try:
-        async with httpx.AsyncClient(timeout=tool.timeout_s) as client:
-            response = await client.post(
-                f"{tool.api_base}/search",
-                json=payload,
-                headers={"x-api-key": tool.api_key},
-            )
+        response = await client.post(
+            f"{tool.api_base}/search",
+            json=payload,
+            headers={"x-api-key": tool.api_key},
+            timeout=tool.timeout_s,
+        )
     except httpx.HTTPError as exc:
         msg = f"exa search request failed: {exc}"
         raise SearchProviderError(msg) from exc

--- a/src/gateway/services/search_backend.py
+++ b/src/gateway/services/search_backend.py
@@ -212,7 +212,13 @@ def build_exa_payload(tool: SearchTool, query: SearchQuery) -> dict[str, Any]:
     if query.max_tokens_per_page is not None or "text" not in contents:
         max_tokens = query.max_tokens_per_page or DEFAULT_MAX_TOKENS_PER_PAGE
         max_chars = max(1, min(max_tokens * _CHARS_PER_TOKEN, _EXA_MAX_CHARACTERS))
-        contents["text"] = {"maxCharacters": max_chars}
+        # Merge rather than replace: ``text`` has siblings (``verbosity``,
+        # ``includeHtmlTags``) that a tool may have pinned, and only the size is
+        # the caller's to set.
+        pinned = contents.get("text")
+        text_options = dict(pinned) if isinstance(pinned, dict) else {}
+        text_options["maxCharacters"] = max_chars
+        contents["text"] = text_options
     payload["contents"] = contents
 
     payload["query"] = query.query

--- a/tests/integration/test_find_model_pricing.py
+++ b/tests/integration/test_find_model_pricing.py
@@ -194,6 +194,18 @@ async def test_find_pricing_falls_back_to_genai_defaults(async_db: AsyncSession)
 
 
 @pytest.mark.asyncio
+async def test_find_pricing_skips_genai_defaults_when_asked(async_db: AsyncSession) -> None:
+    """use_defaults=False suppresses the fallback for keys that are not models.
+
+    The genai-prices lookup also tries a provider-agnostic match on the bare
+    name, so a non-model key (a search tool named after a real model) would
+    otherwise inherit that model's per-million-token rate.
+    """
+    configure_default_pricing(True)
+    assert await find_model_pricing(async_db, "exa", "gpt-4o", use_defaults=False) is None
+
+
+@pytest.mark.asyncio
 async def test_find_pricing_db_overrides_genai_defaults(async_db: AsyncSession) -> None:
     """An explicit DB price for a known model wins over the genai-prices default."""
     configure_default_pricing(True)

--- a/tests/integration/test_pricing_startup_warning.py
+++ b/tests/integration/test_pricing_startup_warning.py
@@ -1,13 +1,18 @@
-"""Startup warning for require_pricing interacts with default pricing."""
+"""Startup pricing warnings: require_pricing, and unpriced search tools."""
 
 import logging
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger as gateway_logger
-from gateway.services.pricing_init_service import warn_if_require_pricing_without_pricing
+from gateway.models.entities import ModelPricing
+from gateway.services.pricing_init_service import (
+    warn_if_require_pricing_without_pricing,
+    warn_if_search_tools_lack_flat_pricing,
+)
 
 _WARNING_MARKER = "ALL billable requests"
 
@@ -49,3 +54,51 @@ async def test_warning_when_default_pricing_disabled_and_no_rows(
         gateway_logger.removeHandler(caplog.handler)
 
     assert _WARNING_MARKER in caplog.text
+
+
+_SEARCH_WARNING_MARKER = "No flat per-request rate is configured for search tool(s)"
+
+
+def _search_config() -> GatewayConfig:
+    return GatewayConfig(
+        master_key="k",
+        require_pricing=False,
+        search_tools={"exa-search": {"provider": "exa", "api_key": "k"}},
+    )
+
+
+async def _warn_for_search_tools(db: AsyncSession, caplog: pytest.LogCaptureFixture) -> None:
+    _capture_gateway_logs(caplog)
+    try:
+        await warn_if_search_tools_lack_flat_pricing(_search_config(), db)
+    finally:
+        gateway_logger.removeHandler(caplog.handler)
+
+
+@pytest.mark.asyncio
+async def test_warning_for_a_search_tool_with_no_flat_rate(
+    async_db: AsyncSession, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An unpriced tool reserves nothing, so the operator hears about it at startup."""
+    await _warn_for_search_tools(async_db, caplog)
+    assert _SEARCH_WARNING_MARKER in caplog.text
+    assert "exa:exa-search" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_no_warning_once_a_flat_rate_exists(
+    async_db: AsyncSession, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An explicit rate silences it, including a deliberate 0 for a free tool."""
+    async_db.add(
+        ModelPricing(
+            model_key="exa:exa-search",
+            effective_at=datetime(2020, 1, 1, tzinfo=UTC),
+            input_price_per_million=0.0,
+            output_price_per_million=0.0,
+        )
+    )
+    await async_db.commit()
+
+    await _warn_for_search_tools(async_db, caplog)
+    assert _SEARCH_WARNING_MARKER not in caplog.text

--- a/tests/integration/test_search_endpoint.py
+++ b/tests/integration/test_search_endpoint.py
@@ -5,6 +5,7 @@ own job: auth, tool selection, budget reservation and settlement, and the usage
 row that makes a search visible in the Activity and Usage views.
 """
 
+import logging
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -183,6 +184,61 @@ def test_search_max_results_above_cap_is_422(client: TestClient, api_key_header:
     payload = {**SEARCH_PAYLOAD, "max_results": 50}
     resp = client.post("/v1/search/exa-search", json=payload, headers=api_key_header)
     assert resp.status_code == 422
+
+
+def test_search_rejects_a_country_that_is_not_a_two_letter_code(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    payload = {**SEARCH_PAYLOAD, "country": "United States"}
+    resp = client.post("/v1/search/exa-search", json=payload, headers=api_key_header)
+    assert resp.status_code == 422
+
+
+def test_search_honors_the_keys_model_allowlist(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """A key restricted to models it may call cannot spend on an unlisted search tool."""
+    client.post("/v1/users", json={"user_id": "narrow-user"}, headers=master_key_header)
+    key = client.post(
+        "/v1/keys",
+        json={"key_name": "narrow-key", "user_id": "narrow-user", "allowed_models": ["openai:gpt-4o"]},
+        headers=master_key_header,
+    ).json()
+    headers = {API_KEY_HEADER: f"Bearer {key['key']}"}
+
+    with _mock_search():
+        denied = client.post("/v1/search/exa-search", json=SEARCH_PAYLOAD, headers=headers)
+    assert denied.status_code == 403
+
+    # Naming the tool as <provider>:<tool> is what grants it.
+    client.patch(
+        f"/v1/keys/{key['id']}",
+        json={"allowed_models": ["openai:gpt-4o", "exa:exa-search"]},
+        headers=master_key_header,
+    )
+    with _mock_search():
+        allowed = client.post("/v1/search/exa-search", json=SEARCH_PAYLOAD, headers=headers)
+    assert allowed.status_code == 200
+
+
+def test_search_does_not_warn_about_provider_pricing(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The tool key must not reach reserve_budget's any-llm model split.
+
+    It is not an any-llm selector, so the split fails and is swallowed into a
+    warning on every request. Worse, the shortcut behind it runs a
+    default-pricing lookup that the route's own use_defaults=False guard is
+    there to prevent, and can skip the reservation outright.
+    """
+    with caplog.at_level(logging.WARNING), _mock_search():
+        resp = client.post("/v1/search/exa-search", json=SEARCH_PAYLOAD, headers=api_key_header)
+    assert resp.status_code == 200
+    assert "Failed to determine provider pricing" not in caplog.text
 
 
 def test_search_logs_usage_with_provider_reported_cost(

--- a/tests/integration/test_search_endpoint.py
+++ b/tests/integration/test_search_endpoint.py
@@ -1,0 +1,309 @@
+"""Integration tests for the POST /v1/search endpoint.
+
+The provider adapter is stubbed at ``run_search`` so these exercise the route's
+own job: auth, tool selection, budget reservation and settlement, and the usage
+row that makes a search visible in the Activity and Usage views.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway.api.deps import reset_config
+from gateway.core.config import API_KEY_HEADER, GatewayConfig
+from gateway.core.database import reset_db
+from gateway.main import create_app
+from gateway.services.search_backend import SearchHit, SearchOutcome, SearchProviderError
+
+SEARCH_PAYLOAD: dict[str, Any] = {"query": "what is otari"}
+
+_HITS = [
+    SearchHit(
+        url="https://example.com/otari",
+        title="Otari",
+        snippet="An OpenAI-compatible LLM gateway.",
+        date="2026-01-02T00:00:00.000Z",
+    )
+]
+
+
+@pytest.fixture
+def test_config(postgres_url: str) -> GatewayConfig:
+    """Override the shared config with two configured search tools."""
+    return GatewayConfig(
+        database_url=postgres_url,
+        master_key="test-master-key",
+        host="127.0.0.1",
+        port=8000,
+        auto_migrate=False,
+        require_pricing=False,
+        search_tools={
+            "exa-search": {"provider": "exa", "api_key": "exa-secret"},
+            "exa-fast": {"provider": "exa", "api_key": "exa-secret", "options": {"type": "fast"}},
+        },
+    )
+
+
+def _mock_search(outcome: SearchOutcome | None = None, *, side_effect: Exception | None = None) -> Any:
+    """Stub the provider adapter with a fixed outcome or a failure."""
+    mock = AsyncMock(
+        return_value=outcome if outcome is not None else SearchOutcome(results=_HITS, cost_usd=0.007),
+        side_effect=side_effect,
+    )
+    return patch("gateway.api.routes.search.run_search", mock)
+
+
+def test_search_requires_auth(client: TestClient) -> None:
+    """POST /v1/search requires authentication."""
+    resp = client.post("/v1/search", json={**SEARCH_PAYLOAD, "search_tool_name": "exa-search"})
+    assert resp.status_code == 401
+
+
+def test_search_with_api_key(client: TestClient, api_key_header: dict[str, str]) -> None:
+    """POST /v1/search returns normalized results for an authenticated key."""
+    with _mock_search():
+        resp = client.post(
+            "/v1/search",
+            json={**SEARCH_PAYLOAD, "search_tool_name": "exa-search"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["object"] == "search"
+    assert data["search_tool"] == "exa-search"
+    assert data["results"] == [
+        {
+            "title": "Otari",
+            "url": "https://example.com/otari",
+            "snippet": "An OpenAI-compatible LLM gateway.",
+            "date": "2026-01-02T00:00:00.000Z",
+        }
+    ]
+
+
+def test_search_by_path_selects_the_tool(client: TestClient, api_key_header: dict[str, str]) -> None:
+    """POST /v1/search/{tool} runs against the tool named in the path."""
+    mock = AsyncMock(return_value=SearchOutcome(results=_HITS))
+    with patch("gateway.api.routes.search.run_search", mock):
+        resp = client.post("/v1/search/exa-fast", json=SEARCH_PAYLOAD, headers=api_key_header)
+    assert resp.status_code == 200
+    assert resp.json()["search_tool"] == "exa-fast"
+    assert mock.call_args.args[0].name == "exa-fast"
+
+
+def test_search_path_tool_wins_over_the_body(client: TestClient, api_key_header: dict[str, str]) -> None:
+    """A search_tool_name in the body does not override the path segment."""
+    mock = AsyncMock(return_value=SearchOutcome(results=_HITS))
+    with patch("gateway.api.routes.search.run_search", mock):
+        resp = client.post(
+            "/v1/search/exa-fast",
+            json={**SEARCH_PAYLOAD, "search_tool_name": "exa-search"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+    assert resp.json()["search_tool"] == "exa-fast"
+
+
+def test_search_forwards_request_fields(client: TestClient, api_key_header: dict[str, str]) -> None:
+    """Request knobs reach the backend as a neutral SearchQuery."""
+    mock = AsyncMock(return_value=SearchOutcome(results=_HITS))
+    with patch("gateway.api.routes.search.run_search", mock):
+        resp = client.post(
+            "/v1/search/exa-search",
+            json={
+                **SEARCH_PAYLOAD,
+                "max_results": 3,
+                "search_domain_filter": ["arxiv.org"],
+                "country": "US",
+                "max_tokens_per_page": 256,
+            },
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+    query = mock.call_args.args[1]
+    assert query.query == "what is otari"
+    assert query.max_results == 3
+    assert query.domain_filter == ("arxiv.org",)
+    assert query.country == "US"
+    assert query.max_tokens_per_page == 256
+
+
+def test_search_ambiguous_tool_is_400(client: TestClient, api_key_header: dict[str, str]) -> None:
+    """Omitting the tool name with several configured is a client error."""
+    resp = client.post("/v1/search", json=SEARCH_PAYLOAD, headers=api_key_header)
+    assert resp.status_code == 400
+    assert "search tools are configured" in resp.json()["detail"]
+
+
+def test_search_unknown_tool_is_400(client: TestClient, api_key_header: dict[str, str]) -> None:
+    """Naming a tool that is not configured is a client error."""
+    resp = client.post("/v1/search/nope", json=SEARCH_PAYLOAD, headers=api_key_header)
+    assert resp.status_code == 400
+    assert "Unknown search tool" in resp.json()["detail"]
+
+
+def test_search_master_key_requires_user(client: TestClient, master_key_header: dict[str, str]) -> None:
+    """POST /v1/search with the master key requires a 'user' field."""
+    with _mock_search():
+        resp = client.post("/v1/search/exa-search", json=SEARCH_PAYLOAD, headers=master_key_header)
+    assert resp.status_code == 400
+    assert "user" in resp.json()["detail"].lower()
+
+
+def test_search_master_key_with_user(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """POST /v1/search with the master key plus a user field succeeds."""
+    payload = {**SEARCH_PAYLOAD, "user": test_user["user_id"]}
+    with _mock_search():
+        resp = client.post("/v1/search/exa-search", json=payload, headers=master_key_header)
+    assert resp.status_code == 200
+
+
+def test_search_provider_error_is_502(client: TestClient, api_key_header: dict[str, str]) -> None:
+    """An upstream failure surfaces as 502 without leaking the provider message."""
+    with _mock_search(side_effect=SearchProviderError("exa search returned HTTP 401: bad key exa-secret")):
+        resp = client.post("/v1/search/exa-search", json=SEARCH_PAYLOAD, headers=api_key_header)
+    assert resp.status_code == 502
+    detail = resp.json()["detail"]
+    assert "exa-secret" not in detail
+    assert "provider" in detail.lower()
+
+
+def test_search_empty_query_is_422(client: TestClient, api_key_header: dict[str, str]) -> None:
+    resp = client.post("/v1/search/exa-search", json={"query": ""}, headers=api_key_header)
+    assert resp.status_code == 422
+
+
+def test_search_max_results_above_cap_is_422(client: TestClient, api_key_header: dict[str, str]) -> None:
+    payload = {**SEARCH_PAYLOAD, "max_results": 50}
+    resp = client.post("/v1/search/exa-search", json=payload, headers=api_key_header)
+    assert resp.status_code == 422
+
+
+def test_search_logs_usage_with_provider_reported_cost(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """A search writes a zero-token usage row billed at the provider's own charge."""
+    user_id = api_key_obj["user_id"]
+
+    with _mock_search():
+        resp = client.post("/v1/search/exa-search", json=SEARCH_PAYLOAD, headers=api_key_header)
+    assert resp.status_code == 200
+
+    logs = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header).json()
+    search_logs = [log for log in logs if log["endpoint"] == "/v1/search"]
+    assert len(search_logs) == 1
+    entry = search_logs[0]
+    assert entry["status"] == "success"
+    assert entry["model"] == "exa-search"
+    assert entry["provider"] == "exa"
+    assert entry["prompt_tokens"] == 0
+    assert entry["completion_tokens"] == 0
+    assert entry["total_tokens"] == 0
+    assert entry["cost"] == pytest.approx(0.007)
+
+
+def test_search_falls_back_to_configured_flat_pricing(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """With no provider-reported cost, the configured per-request rate is billed."""
+    # Flat per-request convention: the stored rate is USD per million requests.
+    client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "exa:exa-search",
+            "input_price_per_million": 5000.0,
+            "output_price_per_million": 0.0,
+        },
+        headers=master_key_header,
+    )
+    user_id = api_key_obj["user_id"]
+
+    with _mock_search(SearchOutcome(results=_HITS)):
+        resp = client.post("/v1/search/exa-search", json=SEARCH_PAYLOAD, headers=api_key_header)
+    assert resp.status_code == 200
+
+    logs = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header).json()
+    search_logs = [log for log in logs if log["endpoint"] == "/v1/search"]
+    assert search_logs[0]["cost"] == pytest.approx(0.005)
+
+
+def test_search_logs_error_and_refunds_on_failure(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """A failed search is logged as an error and leaves no reservation behind."""
+    user_id = api_key_obj["user_id"]
+
+    with _mock_search(side_effect=SearchProviderError("exa is down")):
+        resp = client.post("/v1/search/exa-search", json=SEARCH_PAYLOAD, headers=api_key_header)
+    assert resp.status_code == 502
+
+    logs = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header).json()
+    error_logs = [log for log in logs if log["endpoint"] == "/v1/search" and log["status"] == "error"]
+    assert len(error_logs) == 1
+    assert "exa is down" in error_logs[0]["error_message"]
+
+    user = client.get(f"/v1/users/{user_id}", headers=master_key_header).json()
+    assert user["reserved"] == pytest.approx(0.0)
+
+
+def test_search_is_budget_enforced(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """A user already at their budget cap cannot run a search."""
+    client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "exa:exa-search",
+            "input_price_per_million": 5000.0,
+            "output_price_per_million": 0.0,
+        },
+        headers=master_key_header,
+    )
+    budget = client.post("/v1/budgets", json={"max_budget": 0.001}, headers=master_key_header).json()
+    client.post(
+        "/v1/users",
+        json={"user_id": "broke-user", "budget_id": budget["budget_id"]},
+        headers=master_key_header,
+    )
+    key = client.post(
+        "/v1/keys",
+        json={"key_name": "broke-key", "user_id": "broke-user"},
+        headers=master_key_header,
+    ).json()
+
+    with _mock_search():
+        resp = client.post(
+            "/v1/search/exa-search",
+            json=SEARCH_PAYLOAD,
+            headers={API_KEY_HEADER: f"Bearer {key['key']}"},
+        )
+    assert resp.status_code == 403
+
+
+def test_search_is_not_registered_in_hybrid_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Search is a standalone-mode surface: hybrid has no local search config."""
+    monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
+    app = create_app(GatewayConfig(mode="hybrid", platform={"base_url": "http://localhost:8100/api/v1"}))
+    try:
+        with TestClient(app) as hybrid_client:
+            resp = hybrid_client.post("/v1/search/exa-search", json=SEARCH_PAYLOAD)
+        assert resp.status_code == 404
+    finally:
+        reset_config()
+        reset_db()

--- a/tests/integration/test_search_endpoint.py
+++ b/tests/integration/test_search_endpoint.py
@@ -18,6 +18,8 @@ from gateway.core.database import reset_db
 from gateway.main import create_app
 from gateway.services.search_backend import SearchHit, SearchOutcome, SearchProviderError
 
+SEARCH_ENDPOINT = "/v1/search"
+
 SEARCH_PAYLOAD: dict[str, Any] = {"query": "what is otari"}
 
 _HITS = [
@@ -45,6 +47,21 @@ def test_config(postgres_url: str) -> GatewayConfig:
             "exa-fast": {"provider": "exa", "api_key": "exa-secret", "options": {"type": "fast"}},
         },
     )
+
+
+def _search_rows(client: TestClient, headers: dict[str, str], user_id: str) -> list[dict[str, Any]]:
+    """The user's search usage rows, from the admin view that exposes every column.
+
+    ``/v1/users/{id}/usage`` omits ``counts_toward_budget``, which the refusal
+    rows below have to assert on.
+    """
+    resp = client.get(
+        "/v1/usage",
+        params={"user_id": user_id, "endpoint": SEARCH_ENDPOINT},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    return [dict(row) for row in resp.json()]
 
 
 def _mock_search(outcome: SearchOutcome | None = None, *, side_effect: Exception | None = None) -> Any:
@@ -235,13 +252,15 @@ def test_search_logs_an_unknown_tool_refusal(
     resp = client.post("/v1/search/nope", json=SEARCH_PAYLOAD, headers=api_key_header)
     assert resp.status_code == 400
 
-    logs = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header).json()
-    search_logs = [log for log in logs if log["endpoint"] == "/v1/search"]
+    search_logs = _search_rows(client, master_key_header, user_id)
     assert len(search_logs) == 1
     entry = search_logs[0]
     assert entry["status"] == "error"
     assert entry["model"] == "nope"
     assert entry["cost"] is None
+    # Never an imported-looking row: the dashboard offers those for bulk delete
+    # and set-price, which must not reach a row the gateway wrote itself.
+    assert entry["counts_toward_budget"] is True
     assert "Unknown search tool" in entry["error_message"]
 
 
@@ -265,14 +284,50 @@ def test_search_logs_an_allowlist_refusal(
         )
     assert resp.status_code == 403
 
-    logs = client.get("/v1/users/denied-user/usage", headers=master_key_header).json()
-    search_logs = [log for log in logs if log["endpoint"] == "/v1/search"]
+    search_logs = _search_rows(client, master_key_header, "denied-user")
     assert len(search_logs) == 1
     entry = search_logs[0]
     assert entry["status"] == "error"
     assert entry["model"] == "exa-search"
     assert entry["provider"] == "exa"
     assert entry["cost"] is None
+    assert entry["counts_toward_budget"] is True
+
+
+def test_a_budget_exempt_keys_search_refusal_still_counts_toward_budget(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """An exempt key's refusal row must not look like imported usage.
+
+    A key flagged ``exclude_from_budget`` writes ``counts_toward_budget=False``
+    on its served rows, and it can still be refused by the allow-list gate. The
+    flag is pinned True for every gateway-written refusal (see
+    ``log_gateway_rejection``), so the dashboard never offers one for bulk delete.
+    """
+    client.post("/v1/users", json={"user_id": "exempt-search-user"}, headers=master_key_header)
+    key = client.post(
+        "/v1/keys",
+        json={
+            "key_name": "exempt-search-key",
+            "user_id": "exempt-search-user",
+            "allowed_models": ["openai:gpt-4o"],
+            "exclude_from_budget": True,
+        },
+        headers=master_key_header,
+    ).json()
+
+    with _mock_search():
+        resp = client.post(
+            "/v1/search/exa-search",
+            json=SEARCH_PAYLOAD,
+            headers={API_KEY_HEADER: f"Bearer {key['key']}"},
+        )
+    assert resp.status_code == 403
+
+    search_logs = _search_rows(client, master_key_header, "exempt-search-user")
+    assert len(search_logs) == 1
+    assert search_logs[0]["counts_toward_budget"] is True
 
 
 def test_search_does_not_warn_about_provider_pricing(

--- a/tests/integration/test_search_endpoint.py
+++ b/tests/integration/test_search_endpoint.py
@@ -223,6 +223,58 @@ def test_search_honors_the_keys_model_allowlist(
     assert allowed.status_code == 200
 
 
+def test_search_logs_an_unknown_tool_refusal(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    api_key_obj: dict[str, Any],
+) -> None:
+    """A 400 for a tool that is not configured is still visible as dropped traffic."""
+    user_id = api_key_obj["user_id"]
+
+    resp = client.post("/v1/search/nope", json=SEARCH_PAYLOAD, headers=api_key_header)
+    assert resp.status_code == 400
+
+    logs = client.get(f"/v1/users/{user_id}/usage", headers=master_key_header).json()
+    search_logs = [log for log in logs if log["endpoint"] == "/v1/search"]
+    assert len(search_logs) == 1
+    entry = search_logs[0]
+    assert entry["status"] == "error"
+    assert entry["model"] == "nope"
+    assert entry["cost"] is None
+    assert "Unknown search tool" in entry["error_message"]
+
+
+def test_search_logs_an_allowlist_refusal(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """A 403 from the key's allowed-models list writes a usage row, with no cost."""
+    client.post("/v1/users", json={"user_id": "denied-user"}, headers=master_key_header)
+    key = client.post(
+        "/v1/keys",
+        json={"key_name": "denied-key", "user_id": "denied-user", "allowed_models": ["openai:gpt-4o"]},
+        headers=master_key_header,
+    ).json()
+
+    with _mock_search():
+        resp = client.post(
+            "/v1/search/exa-search",
+            json=SEARCH_PAYLOAD,
+            headers={API_KEY_HEADER: f"Bearer {key['key']}"},
+        )
+    assert resp.status_code == 403
+
+    logs = client.get("/v1/users/denied-user/usage", headers=master_key_header).json()
+    search_logs = [log for log in logs if log["endpoint"] == "/v1/search"]
+    assert len(search_logs) == 1
+    entry = search_logs[0]
+    assert entry["status"] == "error"
+    assert entry["model"] == "exa-search"
+    assert entry["provider"] == "exa"
+    assert entry["cost"] is None
+
+
 def test_search_does_not_warn_about_provider_pricing(
     client: TestClient,
     api_key_header: dict[str, str],

--- a/tests/unit/test_search_backend.py
+++ b/tests/unit/test_search_backend.py
@@ -1,0 +1,257 @@
+"""Unit tests for the ``POST /v1/search`` backend.
+
+Covers tool resolution against ``config.search_tools`` and the Exa adapter:
+request translation from the LiteLLM-shaped request to Exa's native body, and
+response translation back. The provider is stubbed with an
+``httpx.MockTransport`` so no network call is made.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import replace
+from typing import Any
+
+import httpx
+import pytest
+
+from gateway.core.config import GatewayConfig
+from gateway.services.search_backend import (
+    SearchProviderError,
+    SearchQuery,
+    SearchTool,
+    SearchToolError,
+    build_exa_payload,
+    resolve_search_tool,
+    run_search,
+)
+
+_EXA_TOOL = SearchTool(
+    name="exa-search",
+    provider="exa",
+    api_key="exa-secret",
+    api_base="https://api.exa.ai",
+    timeout_s=30.0,
+    options={},
+)
+
+
+def _config(**search_tools: dict[str, Any]) -> GatewayConfig:
+    return GatewayConfig(search_tools=dict(search_tools))
+
+
+def _patch_transport(monkeypatch: pytest.MonkeyPatch, handler: Callable[[httpx.Request], httpx.Response]) -> None:
+    """Replace the module's ``httpx.AsyncClient`` with one backed by ``handler``."""
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient  # capture before patching to avoid recursion
+
+    def factory(*_args: object, **_kwargs: object) -> httpx.AsyncClient:
+        return real_async_client(transport=transport)
+
+    monkeypatch.setattr("gateway.services.search_backend.httpx.AsyncClient", factory)
+
+
+# --------------------------------------------------------------------------- #
+# Tool resolution
+# --------------------------------------------------------------------------- #
+
+
+def test_sole_tool_resolves_without_a_name() -> None:
+    tool = resolve_search_tool(_config(**{"exa-search": {"provider": "exa", "api_key": "k"}}), None)
+    assert tool.name == "exa-search"
+    assert tool.provider == "exa"
+    assert tool.api_base == "https://api.exa.ai"
+
+
+def test_provider_defaults_to_the_tool_name() -> None:
+    tool = resolve_search_tool(_config(exa={"api_key": "k"}), "exa")
+    assert tool.provider == "exa"
+
+
+def test_api_base_override_is_normalized() -> None:
+    tool = resolve_search_tool(_config(exa={"api_key": "k", "api_base": "https://proxy.internal/"}), "exa")
+    assert tool.api_base == "https://proxy.internal"
+
+
+def test_no_configured_tools_is_a_tool_error() -> None:
+    with pytest.raises(SearchToolError, match="No search tools are configured"):
+        resolve_search_tool(_config(), None)
+
+
+def test_unknown_tool_name_is_a_tool_error() -> None:
+    with pytest.raises(SearchToolError, match="Unknown search tool 'nope'"):
+        resolve_search_tool(_config(exa={"api_key": "k"}), "nope")
+
+
+def test_omitted_name_with_several_tools_is_a_tool_error() -> None:
+    config = _config(exa={"api_key": "k"}, **{"exa-fast": {"provider": "exa", "api_key": "k"}})
+    with pytest.raises(SearchToolError, match="Several search tools are configured"):
+        resolve_search_tool(config, None)
+
+
+# --------------------------------------------------------------------------- #
+# Exa request translation
+# --------------------------------------------------------------------------- #
+
+
+def test_payload_defaults() -> None:
+    payload = build_exa_payload(_EXA_TOOL, SearchQuery(query="otari gateway"))
+    assert payload["query"] == "otari gateway"
+    assert payload["numResults"] == 10
+    assert payload["contents"] == {"text": {"maxCharacters": 4096}}
+    assert "includeDomains" not in payload
+    assert "userLocation" not in payload
+
+
+def test_payload_maps_request_fields() -> None:
+    payload = build_exa_payload(
+        _EXA_TOOL,
+        SearchQuery(
+            query="q",
+            max_results=3,
+            domain_filter=("arxiv.org", "-spam.example"),
+            country="US",
+            max_tokens_per_page=100,
+        ),
+    )
+    assert payload["numResults"] == 3
+    assert payload["includeDomains"] == ["arxiv.org"]
+    assert payload["excludeDomains"] == ["spam.example"]
+    assert payload["userLocation"] == "US"
+    assert payload["contents"]["text"]["maxCharacters"] == 400
+
+
+def test_payload_clamps_result_count_from_tool_options() -> None:
+    """A tool's own numResults cannot escape the cap the request field enforces."""
+    tool = replace(_EXA_TOOL, options={"numResults": 500})
+    assert build_exa_payload(tool, SearchQuery(query="q"))["numResults"] == 20
+
+
+def test_payload_clamps_page_size_to_exas_ceiling() -> None:
+    payload = build_exa_payload(_EXA_TOOL, SearchQuery(query="q", max_tokens_per_page=100_000))
+    assert payload["contents"]["text"]["maxCharacters"] == 10_000
+
+
+def test_tool_options_are_defaults_and_never_displace_the_query() -> None:
+    tool = replace(_EXA_TOOL, options={"type": "fast", "query": "operator-injected"})
+    payload = build_exa_payload(tool, SearchQuery(query="caller wins"))
+    assert payload["type"] == "fast"
+    assert payload["query"] == "caller wins"
+
+
+def test_tool_pinned_contents_survive_when_the_caller_asks_for_no_page_size() -> None:
+    tool = replace(_EXA_TOOL, options={"contents": {"text": {"maxCharacters": 200}}})
+    payload = build_exa_payload(tool, SearchQuery(query="q"))
+    assert payload["contents"]["text"]["maxCharacters"] == 200
+
+
+def test_caller_page_size_overrides_tool_pinned_contents() -> None:
+    tool = replace(_EXA_TOOL, options={"contents": {"text": {"maxCharacters": 200}}})
+    payload = build_exa_payload(tool, SearchQuery(query="q", max_tokens_per_page=50))
+    assert payload["contents"]["text"]["maxCharacters"] == 200
+
+
+# --------------------------------------------------------------------------- #
+# Exa response translation
+# --------------------------------------------------------------------------- #
+
+
+_EXA_BODY: dict[str, Any] = {
+    "requestId": "req-1",
+    "results": [
+        {
+            "title": "Otari",
+            "url": "https://example.com/otari",
+            "text": "An OpenAI-compatible LLM gateway.",
+            "publishedDate": "2026-01-02T00:00:00.000Z",
+        },
+        {"title": "No URL", "text": "dropped"},
+        {"url": "https://example.com/highlights", "highlights": ["first hit. ", "second hit."]},
+    ],
+    "costDollars": {"total": 0.007, "search": {"neural": 0.007}},
+}
+
+
+@pytest.mark.asyncio
+async def test_run_search_normalizes_results_and_cost(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["api_key"] = request.headers.get("x-api-key")
+        return httpx.Response(200, json=_EXA_BODY)
+
+    _patch_transport(monkeypatch, handler)
+    outcome = await run_search(_EXA_TOOL, SearchQuery(query="otari"))
+
+    assert seen["url"] == "https://api.exa.ai/search"
+    assert seen["api_key"] == "exa-secret"
+    assert outcome.cost_usd == 0.007
+    # The result without a URL is dropped: it cannot be cited or followed.
+    assert [hit.url for hit in outcome.results] == [
+        "https://example.com/otari",
+        "https://example.com/highlights",
+    ]
+    assert outcome.results[0].title == "Otari"
+    assert outcome.results[0].snippet == "An OpenAI-compatible LLM gateway."
+    assert outcome.results[0].date == "2026-01-02T00:00:00.000Z"
+    # Highlights stand in as the snippet when no page text was returned.
+    assert outcome.results[1].snippet == "first hit. second hit."
+
+
+@pytest.mark.asyncio
+async def test_run_search_reports_no_cost_when_the_provider_omits_it(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_transport(monkeypatch, lambda _r: httpx.Response(200, json={"results": []}))
+    outcome = await run_search(_EXA_TOOL, SearchQuery(query="otari"))
+    assert outcome.results == []
+    assert outcome.cost_usd is None
+
+
+@pytest.mark.asyncio
+async def test_run_search_raises_on_upstream_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_transport(monkeypatch, lambda _r: httpx.Response(401, text="invalid api key"))
+    with pytest.raises(SearchProviderError, match="HTTP 401"):
+        await run_search(_EXA_TOOL, SearchQuery(query="otari"))
+
+
+@pytest.mark.asyncio
+async def test_run_search_raises_on_malformed_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_transport(monkeypatch, lambda _r: httpx.Response(200, json={"unexpected": True}))
+    with pytest.raises(SearchProviderError, match="no 'results' list"):
+        await run_search(_EXA_TOOL, SearchQuery(query="otari"))
+
+
+@pytest.mark.asyncio
+async def test_run_search_raises_when_the_provider_is_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    _patch_transport(monkeypatch, handler)
+    with pytest.raises(SearchProviderError, match="request failed"):
+        await run_search(_EXA_TOOL, SearchQuery(query="otari"))
+
+
+# --------------------------------------------------------------------------- #
+# Startup validation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "search_tools,expected",
+    [
+        ({"exa": {"api_key": "k"}}, None),
+        ({"web": {"provider": "exa", "api_key": "k"}}, None),
+        ({"web": {"api_key": "k"}}, "is not a supported search provider"),
+        ({"exa": {}}, "api_key is required"),
+        ({"exa": {"api_key": "k", "options": "nope"}}, "options must be a mapping"),
+        ({"exa": {"api_key": "k", "timeout": "soon"}}, "timeout must be a number"),
+        ({"ex/a": {"provider": "exa", "api_key": "k"}}, "must not contain '/'"),
+    ],
+)
+def test_validate_search_tools(search_tools: dict[str, Any], expected: str | None) -> None:
+    config = GatewayConfig(search_tools=search_tools)
+    if expected is None:
+        config.validate_search_tools()
+        return
+    with pytest.raises(ValueError, match=expected):
+        config.validate_search_tools()

--- a/tests/unit/test_search_backend.py
+++ b/tests/unit/test_search_backend.py
@@ -8,12 +8,13 @@ response translation back. The provider is stubbed with an
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
 from dataclasses import replace
 from typing import Any
 
 import httpx
 import pytest
+import pytest_asyncio
 
 from gateway.core.config import GatewayConfig
 from gateway.services.search_backend import (
@@ -22,6 +23,8 @@ from gateway.services.search_backend import (
     SearchTool,
     SearchToolError,
     build_exa_payload,
+    close_search_client,
+    get_search_client,
     resolve_search_tool,
     run_search,
 )
@@ -49,6 +52,18 @@ def _patch_transport(monkeypatch: pytest.MonkeyPatch, handler: Callable[[httpx.R
         return real_async_client(transport=transport)
 
     monkeypatch.setattr("gateway.services.search_backend.httpx.AsyncClient", factory)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _fresh_pooled_client() -> AsyncIterator[None]:
+    """Drop the module's pooled client around each test.
+
+    The client is process-wide by design, so without this a mock transport (and
+    the event loop it was built on) would leak into the next test.
+    """
+    await close_search_client()
+    yield
+    await close_search_client()
 
 
 # --------------------------------------------------------------------------- #
@@ -152,6 +167,26 @@ def test_caller_page_size_overrides_tool_pinned_contents() -> None:
     assert payload["contents"]["text"]["maxCharacters"] == 200
 
 
+@pytest.mark.parametrize("pinned", [None, False])
+def test_tool_can_opt_out_of_page_content(pinned: object) -> None:
+    """Pinning contents.text to null/false suppresses the per-page content charge."""
+    tool = replace(_EXA_TOOL, options={"contents": {"text": pinned, "highlights": True}})
+    payload = build_exa_payload(tool, SearchQuery(query="q"))
+    assert payload["contents"] == {"highlights": True}
+
+
+def test_opting_out_of_page_content_drops_an_empty_contents_block() -> None:
+    tool = replace(_EXA_TOOL, options={"contents": {"text": None}})
+    assert "contents" not in build_exa_payload(tool, SearchQuery(query="q"))
+
+
+def test_page_content_opt_out_survives_a_caller_page_size() -> None:
+    """The opt-out is the operator's: a request cannot re-enable the charge."""
+    tool = replace(_EXA_TOOL, options={"contents": {"text": None, "highlights": True}})
+    payload = build_exa_payload(tool, SearchQuery(query="q", max_tokens_per_page=256))
+    assert payload["contents"] == {"highlights": True}
+
+
 def test_caller_page_size_keeps_the_tools_other_text_options() -> None:
     """Only the size is the caller's to set; pinned siblings are merged, not replaced."""
     tool = replace(
@@ -244,6 +279,43 @@ async def test_run_search_raises_when_the_provider_is_unreachable(monkeypatch: p
 
 
 # --------------------------------------------------------------------------- #
+# Pooled client
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_searches_share_one_pooled_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Connections survive between searches instead of a handshake per request."""
+    timeouts: list[object] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        timeouts.append(request.extensions.get("timeout", {}).get("connect"))
+        return httpx.Response(200, json={"results": []})
+
+    _patch_transport(monkeypatch, handler)
+    await run_search(_EXA_TOOL, SearchQuery(query="one"))
+    first = get_search_client()
+    await run_search(replace(_EXA_TOOL, timeout_s=5.0), SearchQuery(query="two"))
+
+    assert get_search_client() is first
+    # The client is shared, so the per-tool timeout has to ride on the request.
+    assert timeouts == [30.0, 5.0]
+
+
+@pytest.mark.asyncio
+async def test_closing_the_pooled_client_lets_the_next_search_rebuild_it(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Shutdown closes the client; a later search must not reuse the closed one."""
+    _patch_transport(monkeypatch, lambda _r: httpx.Response(200, json={"results": []}))
+    await run_search(_EXA_TOOL, SearchQuery(query="one"))
+    closed = get_search_client()
+    await close_search_client()
+    assert closed.is_closed
+
+    await run_search(_EXA_TOOL, SearchQuery(query="two"))
+    assert get_search_client() is not closed
+
+
+# --------------------------------------------------------------------------- #
 # Startup validation
 # --------------------------------------------------------------------------- #
 
@@ -257,6 +329,9 @@ async def test_run_search_raises_when_the_provider_is_unreachable(monkeypatch: p
         ({"exa": {}}, "api_key is required"),
         ({"exa": {"api_key": "k", "options": "nope"}}, "options must be a mapping"),
         ({"exa": {"api_key": "k", "timeout": "soon"}}, "timeout must be a number"),
+        ({"exa": {"api_key": "k", "timeout": 0}}, "timeout must be greater than 0"),
+        ({"exa": {"api_key": "k", "timeout": -5}}, "timeout must be greater than 0"),
+        ({"exa": {"api_key": "k", "timeout": 0.5}}, None),
         ({"ex/a": {"provider": "exa", "api_key": "k"}}, "must not contain '/'"),
     ],
 )

--- a/tests/unit/test_search_backend.py
+++ b/tests/unit/test_search_backend.py
@@ -140,15 +140,27 @@ def test_tool_options_are_defaults_and_never_displace_the_query() -> None:
 
 
 def test_tool_pinned_contents_survive_when_the_caller_asks_for_no_page_size() -> None:
-    tool = replace(_EXA_TOOL, options={"contents": {"text": {"maxCharacters": 200}}})
+    tool = replace(_EXA_TOOL, options={"contents": {"text": {"maxCharacters": 800}}})
     payload = build_exa_payload(tool, SearchQuery(query="q"))
-    assert payload["contents"]["text"]["maxCharacters"] == 200
+    assert payload["contents"]["text"]["maxCharacters"] == 800
 
 
 def test_caller_page_size_overrides_tool_pinned_contents() -> None:
-    tool = replace(_EXA_TOOL, options={"contents": {"text": {"maxCharacters": 200}}})
+    """The caller's size wins; 800 would survive if the override were a no-op."""
+    tool = replace(_EXA_TOOL, options={"contents": {"text": {"maxCharacters": 800}}})
     payload = build_exa_payload(tool, SearchQuery(query="q", max_tokens_per_page=50))
     assert payload["contents"]["text"]["maxCharacters"] == 200
+
+
+def test_caller_page_size_keeps_the_tools_other_text_options() -> None:
+    """Only the size is the caller's to set; pinned siblings are merged, not replaced."""
+    tool = replace(
+        _EXA_TOOL,
+        options={"contents": {"text": {"maxCharacters": 800, "verbosity": "full"}, "highlights": True}},
+    )
+    payload = build_exa_payload(tool, SearchQuery(query="q", max_tokens_per_page=50))
+    assert payload["contents"]["text"] == {"maxCharacters": 200, "verbosity": "full"}
+    assert payload["contents"]["highlights"] is True
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Description

Otari exposed web search only as an in-loop tool (`otari_web_search`), so a caller that wants a direct search request had to hold its own provider key and fell off the gateway's billing path entirely. That is the gap blocking MLPA's move from the LiteLLM proxy onto otari: it proxies an Exa search endpoint today and needs an equivalent surface here to keep search on one gateway.

This adds `POST /v1/search` and `POST /v1/search/{search_tool_name}`, registered standalone-only alongside the other pass-throughs. Both run the same scaffold as a completion (auth, rate limit, budget reservation, usage log, reconcile or refund) and both log `endpoint="/v1/search"`, so one Activity filter covers every search. Exa is wired end to end.

**Configuration.** Search tools are declared under `search_tools:` in `config.yml`, keyed by the name callers pass as `search_tool_name` (or in the path), and validated at startup so an unsupported provider or a missing `api_key` fails before the first request:

```yaml
search_tools:
  exa-search:
    provider: exa
    api_key: ${EXA_API_KEY}
    options:
      type: fast
```

`options` is the escape hatch for provider-native knobs the request body has no field for. Request-derived fields win over it, and `query` always comes from the caller.

**Wire shape** (issue open question 1): LiteLLM's `/v1/search`, itself shaped after Perplexity's Search API, so a client migrating off that proxy needs no request changes. Translation to and from Exa's native shape lives in `search_backend.py`; the route never sees a provider payload.

**Billing** (issue open question 2): the same budget as completions, one `UsageLog` row, no separate line item. Search bills per request rather than per token, so the row carries zero tokens and a cost taken from Exa's own reported `costDollars.total` when present, falling back to a flat per-request rate configured for `<provider>:<tool>` under the same convention moderations uses. Since the provider meters itself, search is exempt from `require_pricing`, like moderations and audio.

`find_model_pricing` grows a `use_defaults` flag that the route sets to `False`. The genai-prices fallback also matches on a bare name, so a search tool an operator happened to name after a real model would otherwise inherit that model's per-million-token rate and be billed under a per-request convention.

**Dashboard.** No change was needed for search to show up: the Activity endpoint filter is a free-form pass-through (`web/src/api/hooks.ts:653`) rather than an allowlist, and a zero-token row renders as it should (`formatTokens(0)` gives `"0"`, `formatCost(0.007)` gives `"$0.0070"`). Credentials come from `config.yml` only; dashboard CRUD for search-tool credentials is left for a follow-up, which the issue allows ("credentials from config or the dashboard").

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #400

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Local results: 1059 unit passed / 1 skipped, 839 integration passed / 9 skipped, `ruff` and `mypy --strict` clean, `make openapi-check` and `make postman-check` clean. Note for anyone reproducing locally: `test_error_detail_leakage` and `test_streaming_error_event` fail if `OPENAI_API_KEY` is set in the environment, because they then reach the live API instead of failing locally. Both pass with it unset, which is how CI runs.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

Implemented by Claude through back-and-forth with @njbrake. The design decisions (LiteLLM-compatible wire shape, shared budget, config-only credentials for now) are his; the code and prose are Claude's.

- [x] I am an AI Agent filling out this form (check box if true)
