### PR TITLE
feat(lint): enforce gateway layer rules via check_architecture.py

### DIFF
--- a/.github/workflows/otari-lint.yml
+++ b/.github/workflows/otari-lint.yml
@@ -36,5 +36,5 @@ jobs:
     - name: Install dependencies
       run: uv sync --dev --frozen
 
-    - name: Run Ruff lint
+    - name: Run lint checks
       run: make lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,9 @@ ORM entities are in `src/gateway/models/entities.py` (User, APIKey, Budget, Usag
 - Serving: standalone mode serves `index.html` at `/` and hashed assets under `/assets` (`src/gateway/main.py`, `src/gateway/dashboard.py`); the get-started tutorial moved to `/welcome`. Hybrid mode has no local management API, so `/` keeps serving the tutorial. Client-side routing uses react-router's `HashRouter` (routes live under `/#/providers`, `/#/models`, `/#/aliases`, `/#/settings`), so hash routes need no server catch-all and the API/asset paths are never shadowed.
 ## Lint / Typecheck Commands
 - Ruff is configured for linting (rules: `E`, `F`, `I`; line length: 120) in `pyproject.toml`.
-- Run lint checks with `make lint` (or `uv run ruff check src tests scripts`).
-- Ruff is also enforced in CI via `.github/workflows/otari-lint.yml`.
+- Run lint checks with `make lint`; it runs the architecture check and then Ruff (`uv run ruff check src tests scripts`). Ruff alone is not equivalent.
+- The architecture check (`scripts/check_architecture.py`, also runnable via `make check-architecture`) enforces the `src/gateway/` layer rules: services must not import the API layer, repositories must not import services or the API layer, API routes must not import `sqlalchemy.orm`, and repository modules end in `_repository.py`.
+- Both are enforced in CI via `.github/workflows/otari-lint.yml` (it calls `make lint`).
 - Primary static checks present in dev dependencies: `ruff`, `mypy`.
 - mypy is configured `strict` over `src`, `tests`, and `scripts` (`pyproject.toml`).
 - Run type checks with `make typecheck` (or `uv run mypy`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ git checkout -b fix/your-description
 After making changes:
 
 ```bash
-make lint        # ruff
+make lint        # architecture check + ruff
 make typecheck   # mypy --strict
 make test        # unit + integration
 ```

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev test test-unit test-integration lint typecheck openapi-check postman postman-check changelog
+.PHONY: help dev test test-unit test-integration lint check-architecture typecheck openapi-check postman postman-check changelog
 
 help:
 	@printf "Available targets:\n"
@@ -6,7 +6,8 @@ help:
 	@printf "  test Run full test suite (unit + integration)\n"
 	@printf "  test-unit Run unit tests\n"
 	@printf "  test-integration Run integration tests\n"
-	@printf "  lint Run Ruff lint checks\n"
+	@printf "  lint Run Ruff lint checks and the architecture check\n"
+	@printf "  check-architecture Enforce gateway layer rules (also run by lint)\n"
 	@printf "  typecheck Run mypy type checks\n"
 	@printf "  openapi-check Verify the OpenAPI spec is up to date\n"
 	@printf "  postman Regenerate the Postman collection from the OpenAPI spec\n"
@@ -28,8 +29,13 @@ test-unit:
 test-integration:
 	uv run pytest -v tests/integration
 
-lint:
+lint: check-architecture
 	uv run ruff check src tests scripts
+
+# Enforce gateway layer rules. Pure stdlib; runs as part of `make lint` (which
+# otari-lint.yml calls on every PR) and stays independently runnable.
+check-architecture:
+	uv run python scripts/check_architecture.py
 
 typecheck:
 	uv run mypy

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Check gateway architectural boundaries.
+
+Enforces:
+1. Service layer boundaries: services must not import the API layer.
+2. API route purity: routes must not use the sync ORM layer (sqlalchemy.orm).
+3. Repository boundaries: repositories must not import services or the API layer.
+4. Naming conventions: repository modules end in _repository.py.
+
+Usage:
+    uv run python scripts/check_architecture.py
+
+Exit codes:
+    0 - No violations
+    1 - Violations found
+"""
+
+import ast
+import sys
+from pathlib import Path
+from typing import TypedDict
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_ROOT = REPO_ROOT / "src"
+GATEWAY_ROOT = SRC_ROOT / "gateway"
+
+
+class LayerRule(TypedDict):
+    """Import rules for one gateway layer."""
+
+    allowed: list[str]
+    forbidden: list[str]
+    description: str
+
+
+# Rules are keyed by the layer's path below src/. Only "forbidden" is enforced;
+# "allowed" documents the layer contract for reviewers. Cross-cutting top-level
+# modules (gateway.log_config, gateway.metrics, ...) are always importable and
+# are not listed.
+RULES: dict[str, LayerRule] = {
+    "gateway/services": {
+        "allowed": ["gateway.repositories", "gateway.models", "gateway.core", "gateway.auth"],
+        "forbidden": ["gateway.api"],
+        "description": "Services",
+    },
+    "gateway/api/routes": {
+        # Routes reuse repository helpers (e.g. get_active_user) per the
+        # repository conventions in AGENTS.md, so gateway.repositories stays
+        # allowed here.
+        "allowed": [
+            "gateway.api",
+            "gateway.services",
+            "gateway.repositories",
+            "gateway.models",
+            "gateway.core",
+            "gateway.auth",
+        ],
+        "forbidden": ["sqlalchemy.orm"],
+        "description": "API routes",
+    },
+    "gateway/repositories": {
+        "allowed": ["gateway.models"],
+        "forbidden": ["gateway.services", "gateway.api"],
+        "description": "Repositories",
+    },
+    # Open-core boundary scaffolding. Ports (domain-named interfaces) and their
+    # adapters get their own layers so future boundary rules have a place to
+    # land (see ARCHITECTURE.md). Intentionally no-op until the first port
+    # arrives: with empty "forbidden" lists nothing is enforced and the check
+    # stays green.
+    "gateway/ports": {
+        "allowed": [],
+        "forbidden": [],
+        "description": "Ports",
+    },
+    "gateway/adapters": {
+        "allowed": [],
+        "forbidden": [],
+        "description": "Adapters",
+    },
+}
+
+
+def _matches(module: str, prefix: str) -> bool:
+    """Return whether a module path is the prefix module itself or lives inside it."""
+    return module == prefix or module.startswith(prefix + ".")
+
+
+def _resolve_relative(node: ast.ImportFrom, file_path: Path, src_root: Path) -> str | None:
+    """Resolve a relative import to an absolute module path, or None if it escapes src_root."""
+    package_parts = file_path.parent.relative_to(src_root).parts
+    drop = node.level - 1
+    if drop >= len(package_parts):
+        return None
+    base = ".".join(package_parts[: len(package_parts) - drop])
+    if node.module:
+        return f"{base}.{node.module}"
+    return base
+
+
+def _imported_modules(node: ast.Import | ast.ImportFrom, file_path: Path, src_root: Path) -> list[str]:
+    """Return the absolute module paths an import statement pulls in."""
+    if isinstance(node, ast.Import):
+        return [alias.name for alias in node.names]
+    base = node.module if node.level == 0 else _resolve_relative(node, file_path, src_root)
+    if base is None:
+        return []
+    # `from pkg import name` may bind the submodule pkg.name, so check it too.
+    return [base] + [f"{base}.{alias.name}" for alias in node.names]
+
+
+def check_file(file_path: Path, src_root: Path) -> list[tuple[int, str, str]]:
+    """Check one Python file below src_root against the layer rules for its location.
+
+    Returns:
+        One (line number, module, message) tuple per offending import statement.
+
+    """
+    relative_path = file_path.relative_to(src_root).as_posix()
+    rule = next(
+        (layer_rule for fragment, layer_rule in RULES.items() if relative_path.startswith(fragment + "/")),
+        None,
+    )
+    if rule is None or not rule["forbidden"]:
+        return []
+
+    try:
+        tree = ast.parse(file_path.read_text(encoding="utf-8"), filename=str(file_path))
+    except SyntaxError as exc:
+        # Unparseable files cannot be checked; ruff fails the same lint run on
+        # them, so warn here rather than duplicating the failure.
+        print(f"  ⚠ Syntax error in {file_path}: {exc}")
+        return []
+
+    violations: list[tuple[int, str, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Import | ast.ImportFrom):
+            continue
+        for module in _imported_modules(node, file_path, src_root):
+            if any(_matches(module, forbidden) for forbidden in rule["forbidden"]):
+                violations.append((node.lineno, module, f"Forbidden import in {rule['description']}"))
+                break
+    return violations
+
+
+# Service modules are purpose-named (guardrails.py, url_safety.py, ...), so
+# there is no *_service.py naming rule to enforce.
+def check_naming_conventions(src_root: Path) -> list[str]:
+    """Check that repository modules follow the *_repository.py convention."""
+    violations: list[str] = []
+    repositories_path = src_root / "gateway" / "repositories"
+    if not repositories_path.is_dir():
+        return violations
+    for repository_file in sorted(repositories_path.rglob("*.py")):
+        if repository_file.name == "__init__.py":
+            continue
+        if not repository_file.name.endswith("_repository.py"):
+            violations.append(f"Repository file {repository_file.relative_to(src_root)} must end with '_repository.py'")
+    return violations
+
+
+def main() -> int:
+    """Run the architecture checks over the gateway package."""
+    if not GATEWAY_ROOT.is_dir():
+        print(f"❌ Gateway package not found at {GATEWAY_ROOT}")
+        return 1
+
+    import_violations: list[tuple[Path, int, str, str]] = []
+    for py_file in sorted(GATEWAY_ROOT.rglob("*.py")):
+        if "__pycache__" in py_file.parts:
+            continue
+        import_violations.extend(
+            (py_file, lineno, module, message) for lineno, module, message in check_file(py_file, SRC_ROOT)
+        )
+
+    naming_violations = check_naming_conventions(SRC_ROOT)
+
+    if import_violations:
+        print("❌ Architecture violations found:\n")
+        for file_path, lineno, module, message in import_violations:
+            print(f"  {file_path.relative_to(REPO_ROOT)}:{lineno}")
+            print(f"    {message}: {module}\n")
+        print(f"Total import violations: {len(import_violations)}")
+
+    if naming_violations:
+        print("\n❌ Naming convention violations:\n")
+        for violation in naming_violations:
+            print(f"  {violation}")
+        print(f"\nTotal naming violations: {len(naming_violations)}")
+
+    if import_violations or naming_violations:
+        print("\n💡 See ARCHITECTURE.md for the intended layering")
+        return 1
+
+    print("✅ No architecture violations found")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_check_architecture.py
+++ b/tests/unit/test_check_architecture.py
@@ -1,0 +1,97 @@
+"""Unit tests for the architecture check (layer rules over src/gateway)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_architecture.py"
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_architecture", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check = _load()
+
+
+def _write(src_root: Path, relative_path: str, content: str) -> Path:
+    file_path = src_root / relative_path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(content)
+    return file_path
+
+
+def test_service_importing_models_is_clean(tmp_path: Path) -> None:
+    file_path = _write(tmp_path, "gateway/services/thing.py", "from gateway.models.entities import User\n")
+    assert check.check_file(file_path, tmp_path) == []
+
+
+def test_service_importing_api_is_flagged(tmp_path: Path) -> None:
+    file_path = _write(tmp_path, "gateway/services/thing.py", "from gateway.api.routes import chat\n")
+    assert check.check_file(file_path, tmp_path) == [(1, "gateway.api.routes", "Forbidden import in Services")]
+
+
+def test_service_importing_api_via_from_gateway_is_flagged(tmp_path: Path) -> None:
+    file_path = _write(tmp_path, "gateway/services/thing.py", "from gateway import api\n")
+    assert check.check_file(file_path, tmp_path) == [(1, "gateway.api", "Forbidden import in Services")]
+
+
+def test_service_relative_import_of_api_is_flagged(tmp_path: Path) -> None:
+    file_path = _write(tmp_path, "gateway/services/thing.py", "from ..api import deps\n")
+    assert check.check_file(file_path, tmp_path) == [(1, "gateway.api", "Forbidden import in Services")]
+
+
+def test_forbidden_prefix_requires_a_module_boundary(tmp_path: Path) -> None:
+    file_path = _write(tmp_path, "gateway/services/thing.py", "import gateway.apilike\n")
+    assert check.check_file(file_path, tmp_path) == []
+
+
+def test_repository_importing_service_is_flagged(tmp_path: Path) -> None:
+    file_path = _write(
+        tmp_path,
+        "gateway/repositories/users_repository.py",
+        "from gateway.services.budget_service import reserve\n",
+    )
+    violations = check.check_file(file_path, tmp_path)
+    assert violations == [(1, "gateway.services.budget_service", "Forbidden import in Repositories")]
+
+
+def test_api_route_importing_sqlalchemy_orm_is_flagged(tmp_path: Path) -> None:
+    file_path = _write(tmp_path, "gateway/api/routes/users.py", "from sqlalchemy.orm import Session\n")
+    assert check.check_file(file_path, tmp_path) == [(1, "sqlalchemy.orm", "Forbidden import in API routes")]
+
+
+def test_api_route_may_import_repositories(tmp_path: Path) -> None:
+    # Routes reuse repository helpers (AGENTS.md), so gateway.repositories is
+    # deliberately not forbidden here.
+    file_path = _write(
+        tmp_path,
+        "gateway/api/routes/users.py",
+        "from gateway.repositories.users_repository import get_active_user\n",
+    )
+    assert check.check_file(file_path, tmp_path) == []
+
+
+def test_ports_and_adapters_scaffolding_is_noop(tmp_path: Path) -> None:
+    ports_file = _write(tmp_path, "gateway/ports/billing.py", "from gateway.api.routes import chat\n")
+    adapters_file = _write(tmp_path, "gateway/adapters/null_billing.py", "from gateway.api.routes import chat\n")
+    assert check.check_file(ports_file, tmp_path) == []
+    assert check.check_file(adapters_file, tmp_path) == []
+
+
+def test_repository_naming_convention(tmp_path: Path) -> None:
+    _write(tmp_path, "gateway/repositories/__init__.py", "")
+    _write(tmp_path, "gateway/repositories/users_repository.py", "")
+    _write(tmp_path, "gateway/repositories/helpers.py", "")
+    violations = check.check_naming_conventions(tmp_path)
+    assert violations == ["Repository file gateway/repositories/helpers.py must end with '_repository.py'"]
+
+
+def test_real_gateway_tree_is_clean() -> None:
+    assert check.main() == 0


### PR DESCRIPTION
## Description

Adds an AST-based architecture check (`scripts/check_architecture.py`) over `src/gateway/` and wires it into `make lint` via a new `check-architecture` target, so the existing lint workflow gates every PR with no workflow changes.

Enforced layer rules (all hold on the current tree):

- `services` must not import the API layer.
- `repositories` must not import services or the API layer.
- API routes must not import `sqlalchemy.orm` (async sessions come from `get_db`).
- Repository modules end in `_repository.py`.

Deliberately not enforced:

- Routes may import repository helpers (e.g. `get_active_user`), per the repo conventions in AGENTS.md.
- No `*_service.py` naming rule: service modules are purpose-named (`guardrails.py`, `url_safety.py`, ...).

Also includes empty, no-op `gateway/ports` and `gateway/adapters` rule entries as scaffolding for future open-core boundary rules (see ARCHITECTURE.md).

Verification: `tests/unit/test_check_architecture.py` adds 11 unit tests covering flagged and allowed imports (including `from gateway import api`, relative imports, and dot-boundary prefixes), the no-op scaffolding, naming, and a real-tree-is-clean gate. A planted `gateway.api` import in a services file fails the check with file:line and a non-zero exit. Docs were updated so `make lint` is no longer described as ruff-only (AGENTS.md, CONTRIBUTING.md, lint workflow step name).

## PR Type
<!-- Check all that apply -->

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

Tracked internally; no public issue.

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:**

Drafted under maintainer direction and review; lint, typecheck, and the full test suite were run locally and code-review feedback was applied before push.

- [x] I am an AI Agent filling out this form (check box if true)