### PR TITLE
fix(lint): apply every enclosing layer's rules in the architecture check

### DIFF
--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -36,7 +36,9 @@ class LayerRule(TypedDict):
 # Rules are keyed by the layer's path below src/. Only "forbidden" is enforced;
 # "allowed" documents the layer contract for reviewers. Cross-cutting top-level
 # modules (gateway.log_config, gateway.metrics, ...) are always importable and
-# are not listed.
+# are not listed. Restrictions accumulate down the tree, so a file under
+# gateway/api/routes answers to a gateway/api entry as well as its own; a nested
+# layer can add restrictions but cannot opt out of an enclosing layer's.
 RULES: dict[str, LayerRule] = {
     "gateway/services": {
         "allowed": ["gateway.repositories", "gateway.models", "gateway.core", "gateway.auth"],
@@ -117,11 +119,17 @@ def check_file(file_path: Path, src_root: Path) -> list[tuple[int, str, str]]:
 
     """
     relative_path = file_path.relative_to(src_root).as_posix()
-    rule = next(
-        (layer_rule for fragment, layer_rule in RULES.items() if relative_path.startswith(fragment + "/")),
-        None,
+    # Restrictions accumulate: a file answers to its own layer's rules and to
+    # every enclosing layer's, so declaration order cannot silently shadow
+    # either a nested rule or a broader one. Most specific first, so a violation
+    # is attributed to the closest layer that forbids it.
+    matches = sorted(
+        ((fragment, layer_rule) for fragment, layer_rule in RULES.items() if relative_path.startswith(fragment + "/")),
+        key=lambda match: len(match[0]),
+        reverse=True,
     )
-    if rule is None or not rule["forbidden"]:
+    forbidden = [(prefix, layer_rule["description"]) for _, layer_rule in matches for prefix in layer_rule["forbidden"]]
+    if not forbidden:
         return []
 
     try:
@@ -137,8 +145,9 @@ def check_file(file_path: Path, src_root: Path) -> list[tuple[int, str, str]]:
         if not isinstance(node, ast.Import | ast.ImportFrom):
             continue
         for module in _imported_modules(node, file_path, src_root):
-            if any(_matches(module, forbidden) for forbidden in rule["forbidden"]):
-                violations.append((node.lineno, module, f"Forbidden import in {rule['description']}"))
+            offended = next((description for prefix, description in forbidden if _matches(module, prefix)), None)
+            if offended is not None:
+                violations.append((node.lineno, module, f"Forbidden import in {offended}"))
                 break
     return violations
 

--- a/tests/unit/test_check_architecture.py
+++ b/tests/unit/test_check_architecture.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 _SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_architecture.py"
 
 
@@ -45,6 +47,41 @@ def test_service_importing_api_via_from_gateway_is_flagged(tmp_path: Path) -> No
 def test_service_relative_import_of_api_is_flagged(tmp_path: Path) -> None:
     file_path = _write(tmp_path, "gateway/services/thing.py", "from ..api import deps\n")
     assert check.check_file(file_path, tmp_path) == [(1, "gateway.api", "Forbidden import in Services")]
+
+
+def test_relative_import_above_src_root_is_ignored(tmp_path: Path) -> None:
+    file_path = _write(tmp_path, "gateway/services/thing.py", "from ... import something\n")
+    assert check.check_file(file_path, tmp_path) == []
+
+
+def test_nested_and_enclosing_layer_rules_both_apply(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A broader gateway/api rule declared first must neither shadow the nested
+    # routes rule nor stop applying to files under it, whatever the order.
+    broadened = {
+        "gateway/api": {"allowed": [], "forbidden": ["gateway.db"], "description": "API"},
+        **check.RULES,
+    }
+    monkeypatch.setattr(check, "RULES", broadened)
+    file_path = _write(
+        tmp_path,
+        "gateway/api/routes/users.py",
+        "from gateway.db import engine\nfrom sqlalchemy.orm import Session\n",
+    )
+    assert check.check_file(file_path, tmp_path) == [
+        (1, "gateway.db", "Forbidden import in API"),
+        (2, "sqlalchemy.orm", "Forbidden import in API routes"),
+    ]
+
+
+def test_violation_is_attributed_to_the_closest_layer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Both layers forbid it; the nested layer owns the message.
+    broadened = {
+        "gateway/api": {"allowed": [], "forbidden": ["sqlalchemy.orm"], "description": "API"},
+        **check.RULES,
+    }
+    monkeypatch.setattr(check, "RULES", broadened)
+    file_path = _write(tmp_path, "gateway/api/routes/users.py", "from sqlalchemy.orm import Session\n")
+    assert check.check_file(file_path, tmp_path) == [(1, "sqlalchemy.orm", "Forbidden import in API routes")]
 
 
 def test_forbidden_prefix_requires_a_module_boundary(tmp_path: Path) -> None:


### PR DESCRIPTION
## Description

_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

Follow-up to #475, from reviewing that PR after it merged.

`check_file()` picked the first `RULES` entry whose fragment prefixed the file path, so with nested fragments declaration order decided which rule applied and the other was silently dropped: no violation reported, exit 0, enforcement gone with no signal at all.

The first attempt here picked the most specific entry instead, which only relocated the problem: a broader `"gateway/api"` rule would then stop applying to everything under `gateway/api/routes`, the bulk of that layer. Reproduced against both versions, with a hypothetical `gateway/api` rule forbidding `gateway.db` on a routes file that imports both `gateway.db` and `sqlalchemy.orm`:

```
first-match wins   -> only gateway.db flagged      (the routes rule is shadowed)
most-specific wins -> only sqlalchemy.orm flagged  (the api rule is shadowed)
accumulate         -> both flagged
```

So restrictions now accumulate. A file answers to its own layer's rules and to every enclosing layer's, so no declaration order can shadow anything in either direction, and a nested layer can add restrictions but cannot opt out of an enclosing one. Violations are attributed to the closest layer that forbids the import, so existing messages are unchanged. `allowed` is documentation only, so no relaxation mechanism is given up.

Nothing regresses on the current tree. No two fragments nest today, and a differential run of the merged checker against this one over 18 synthetic files (relative imports, relative imports escaping the source root, function-scoped imports, `from gateway import api, models`, `from sqlalchemy import orm`, dot-boundary near-misses, a deliberate syntax error, `api/deps.py`, `ports`/`adapters`, `core/`) agrees on every case. The reason to fix it now is that #475 deliberately added the empty `gateway/ports` and `gateway/adapters` entries as scaffolding for future boundary rules, and adding a layer rule is precisely the change that would trip this.

Changes:

- `check_file()` collects the forbidden lists of every matching layer, most specific first.
- The `RULES` comment states the accumulate semantics, since rule authors read that block rather than `check_file`.
- `test_nested_and_enclosing_layer_rules_both_apply` and `test_violation_is_attributed_to_the_closest_layer` cover both directions plus attribution. Each fails on one of the two earlier behaviours.
- `test_relative_import_above_src_root_is_ignored` covers `from ... import x` walking above the source root, which `_resolve_relative()` already handled but nothing pinned. This was a CodeRabbit suggestion on #475.

Deliberately out of scope: the sync-ORM rule still covers only `gateway/api/routes/`, so `gateway/api/deps.py` and `gateway/api/main.py` remain unchecked. That is a policy question rather than a bug. It is now a safe change to make on top of this, which was not true before.

Verification: `make lint`, `uv run mypy` (282 files), and `uv run pytest tests/unit/test_check_architecture.py` (14 passed) all green locally.

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

Follow-up to #475; no separate issue.

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 5)

**Any additional AI details you'd like to share:**

Found while reviewing #475 with Claude Code after it merged, and the incomplete first attempt was caught by reviewing this PR the same way. Both the original bug and the half-fix were reproduced by executing the respective checker versions before the fix was written; lint, typecheck, and the unit tests were run locally.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
