### PR TITLE
fix(errors): classify provider billing exhaustion instead of calling it a bad request

### DIFF
--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -314,7 +314,13 @@ resolve response). The platform is responsible for correlating them.
 | `timeout` | `httpx.TimeoutException`, `asyncio.TimeoutError`, `TimeoutError`, or the OpenAI/Anthropic SDKs' own `APITimeoutError` |
 | `conn_err` | `httpx.NetworkError`, or the OpenAI/Anthropic SDKs' own `APIConnectionError` |
 | `http_<code>` | Provider returned an HTTP status code (e.g. `http_429`, `http_401`) |
+| `http_<code>_billing` | Provider returned a 400, 402, or 422 whose message identifies account billing exhaustion (e.g. Anthropic's "credit balance is too low", DeepSeek's "Insufficient Balance"). Reported as `http_400_billing` etc., keeping an empty provider wallet separable from a malformed request. Otari treats these as retryable and moves to the next attempt |
 | `unknown` | Any other exception class |
+
+Treat `error_class` as an open set of strings, not a closed enum: new tags are
+added as Otari learns to separate failure causes, and a handler that rejects an
+unrecognized value would 422 the report, which is non-retryable and so silently
+drops it.
 
 Otari calls the OpenAI/Anthropic SDKs directly rather than httpx, and both SDKs
 catch `httpx.TimeoutException`/network errors internally and re-raise as their

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -314,7 +314,7 @@ resolve response). The platform is responsible for correlating them.
 | `timeout` | `httpx.TimeoutException`, `asyncio.TimeoutError`, `TimeoutError`, or the OpenAI/Anthropic SDKs' own `APITimeoutError` |
 | `conn_err` | `httpx.NetworkError`, or the OpenAI/Anthropic SDKs' own `APIConnectionError` |
 | `http_<code>` | Provider returned an HTTP status code (e.g. `http_429`, `http_401`) |
-| `http_<code>_billing` | Provider returned a 400, 402, or 422 whose message identifies account billing exhaustion (e.g. Anthropic's "credit balance is too low", DeepSeek's "Insufficient Balance"). Reported as `http_400_billing` etc., keeping an empty provider wallet separable from a malformed request. Otari treats these as retryable and moves to the next attempt |
+| `http_<code>_billing` | Provider returned a 400, 402, or 422 whose message identifies account billing exhaustion (e.g. Anthropic's "credit balance is too low", DeepSeek's "Insufficient Balance"). Reported as `http_400_billing` etc., keeping an empty provider wallet separable from a malformed request. Otari treats these as retryable, so the request walks on to the next attempt unless the failing attempt had already locked in (a tool loop whose upstream returned a first assistant message cannot be replayed on another provider, so its failure is terminal) |
 | `unknown` | Any other exception class |
 
 Treat `error_class` as an open set of strings, not a closed enum: new tags are

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -93,6 +93,7 @@ Hello, nice to meet you!
 |---------|--------------|
 | HTTP 502 `The provider rejected the gateway's credentials` | The `api_key` Otari sent to OpenAI is invalid or lacks access. Check the `api_key` (or `OPENAI_API_KEY`) configured on the gateway. |
 | HTTP 404 `The requested model was not found on the provider` | The name after `openai:` is not a model your key can access, or the model name is misspelled. |
+| HTTP 502 `The upstream provider account is out of credit or over its billing limit.` | The provider rejected the call because the account Otari billed has no credit left or has hit its billing limit (for example OpenAI's "billing hard limit reached", or Anthropic's "credit balance is too low", which arrives as a 400). Top up the provider account, or point the model at a provider that has credit. The usage log keeps the status the provider actually returned, so these stay countable. |
 | HTTP 502 `LLM provider error` | Generic fallback: Otari reached the provider but the upstream call failed in a way it could not classify (for example a missing provider key, a provider-side 5xx, or a connection error). |
 | HTTP 402 `No pricing configured for model ...` | Otari could not resolve pricing for that model and `require_pricing` rejected the request. Add a `pricing:` entry, enable `default_pricing: true` for bundled fallback pricing, or use a model that already has pricing coverage. |
 | HTTP 401 `Invalid master key` on `/v1/keys` | You passed a client (`gw-...`) key, or the wrong master key, instead of the configured master key. |

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -260,8 +260,9 @@ def classify_provider_error(exc: BaseException) -> ProviderErrorMapping | None:
         return ProviderErrorMapping(status.HTTP_504_GATEWAY_TIMEOUT, PROVIDER_TIMEOUT_DETAIL)
     if status_code is None:
         return None
-    # Account billing exhaustion, which several providers report as a 400/402/422
-    # rather than a 402. Like a rejected credential this is a gateway-side account
+    # Account billing exhaustion, which several providers report as a 400/422
+    # rather than the 402 the condition deserves (and DeepSeek does report as a
+    # 402). Like a rejected credential this is a gateway-side account
     # fault rather than anything wrong with the caller's request, so it surfaces as
     # a 502 and never as a client-facing 400: telling the caller to "check the model
     # name and parameters" for an empty wallet sends operators debugging the wrong

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -71,7 +71,9 @@ from gateway.api.routes._platform import (
     _resolve_platform_credentials,
     _resolve_platform_mcp_servers,
     _resolve_platform_web_search,
+    is_provider_billing_error,
     run_platform_attempts,
+    upstream_error_message,
     upstream_exception_shape,
 )
 from gateway.api.routes._platform import (
@@ -151,6 +153,10 @@ PROVIDER_REASONING_TOOLS_UNSUPPORTED_DETAIL = (
 )
 PROVIDER_MODEL_NOT_FOUND_DETAIL = "The requested model was not found on the provider"
 PROVIDER_CREDENTIALS_DETAIL = "The provider rejected the gateway's credentials"
+PROVIDER_BILLING_DETAIL = (
+    "The upstream provider account is out of credit or over its billing limit. "
+    "Top up the provider account, or route this model to a provider that has credit."
+)
 PROVIDER_RATE_LIMITED_DETAIL = "The provider rate-limited this request"
 ALL_PROVIDERS_FAILED_DETAIL = "All upstream providers failed"
 ALL_PROVIDERS_TIMED_OUT_DETAIL = "All upstream providers timed out"
@@ -211,26 +217,6 @@ def _upstream_error_param(exc: BaseException) -> str | None:
     return None
 
 
-def _upstream_error_message(exc: BaseException) -> str:
-    """Best-effort human-readable text from an upstream exception (and its wrapper).
-
-    Concatenates the exception's ``message`` attribute and ``str()`` for both the
-    exception and any ``original_exception``, so a substring probe still matches
-    whether otari receives the raw SDK error today or the wrapped
-    ``AnyLLMError`` after any-llm flips to unified exceptions. Used only for
-    fixed-string classification, never echoed back to the caller.
-    """
-    parts: list[str] = []
-    for candidate in (exc, getattr(exc, "original_exception", None)):
-        if candidate is None:
-            continue
-        message = getattr(candidate, "message", None)
-        if isinstance(message, str):
-            parts.append(message)
-        parts.append(str(candidate))
-    return " ".join(parts)
-
-
 def _is_reasoning_effort_tools_conflict(exc: BaseException) -> bool:
     """True when a 400/422 is the 'function tools + reasoning_effort' rejection.
 
@@ -250,7 +236,7 @@ def _is_reasoning_effort_tools_conflict(exc: BaseException) -> bool:
     """
     if _upstream_error_param(exc) != "reasoning_effort":
         return False
-    return "function tools" in _upstream_error_message(exc).lower()
+    return "function tools" in upstream_error_message(exc).lower()
 
 
 def classify_provider_error(exc: BaseException) -> ProviderErrorMapping | None:
@@ -274,6 +260,15 @@ def classify_provider_error(exc: BaseException) -> ProviderErrorMapping | None:
         return ProviderErrorMapping(status.HTTP_504_GATEWAY_TIMEOUT, PROVIDER_TIMEOUT_DETAIL)
     if status_code is None:
         return None
+    # Account billing exhaustion, which several providers report as a 400/402/422
+    # rather than a 402. Like a rejected credential this is a gateway-side account
+    # fault rather than anything wrong with the caller's request, so it surfaces as
+    # a 502 and never as a client-facing 400: telling the caller to "check the model
+    # name and parameters" for an empty wallet sends operators debugging the wrong
+    # thing. Checked ahead of the status branches so it wins over both the generic
+    # bad-request detail and the 402 fall-through to a bare 502.
+    if is_provider_billing_error(exc):
+        return ProviderErrorMapping(status.HTTP_502_BAD_GATEWAY, PROVIDER_BILLING_DETAIL)
     if status_code in (400, 422):
         # Preserve the actionable remedy for the one 400/422 a caller can fix by
         # retrying: function tools combined with a non-'none' reasoning_effort.

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -60,9 +60,9 @@ _USAGE_NON_RETRYABLE_STATUS_CODES = {401, 402, 404, 409, 422}
 # distinct from 400/422, which mean the request itself is malformed and would be
 # rejected by every provider, so falling through on those just wastes attempts.
 # The one exception is a provider that reports account billing exhaustion as a
-# 400/402/422 rather than a 402: that is an account condition, not a malformed
-# request, and the next provider would serve it fine. See
-# :func:`is_provider_billing_error`.
+# 400/422 rather than the 402 the condition deserves: that is an account
+# condition, not a malformed request, and the next provider would serve it fine.
+# See :func:`is_provider_billing_error`.
 _FALLBACK_RETRYABLE_STATUS_CODES = {401, 403, 404, 405, 408, 409, 410, 429, 500, 502, 503, 504}
 _FALLBACK_NON_RETRYABLE_STATUS_CODES = {400, 422}
 
@@ -82,7 +82,7 @@ _BILLING_CANDIDATE_STATUS_CODES = {400, 402, 422}
 # describe a malformed request. Best-effort against current provider phrasing; a
 # reworded message degrades safely to the generic bad-request handling rather
 # than misclassifying.
-_BILLING_MESSAGE_PROBES = (
+_BILLING_MESSAGE_PROBES: tuple[str, ...] = (
     "credit balance is too low",  # anthropic
     "purchase credits",  # anthropic
     "plans & billing",  # anthropic
@@ -91,8 +91,16 @@ _BILLING_MESSAGE_PROBES = (
     "insufficient_quota",  # openai (error code, echoed in some messages)
     "exceeded your current quota",  # openai
     "insufficient credits",  # openrouter, together
-    "payment required",  # generic 402 bodies
 )
+
+# Phrases accepted only on a 402, whose reason phrase ("Payment Required") is
+# itself the billing signal. httpx stringifies any 402 as "Client error '402
+# Payment Required' for url ...", so on a 402 this probe is really a
+# status-code check with a phrase-shaped spelling. It is kept out of
+# :data:`_BILLING_MESSAGE_PROBES` because a 400/422 that merely echoes a
+# caller-supplied "payment required" string back in its message is a malformed
+# request, not an empty wallet.
+_BILLING_402_MESSAGE_PROBES = ("payment required",)
 
 # Streaming first-chunk timeouts (hybrid-mode fallback). Plain LLM streams
 # rarely take long to produce a first token, so a tight cap keeps failed-
@@ -666,14 +674,19 @@ def is_provider_billing_error(exc: BaseException) -> bool:
 
     Gated on :data:`_BILLING_CANDIDATE_STATUS_CODES` so the probe can only ever
     reinterpret a status that is otherwise a dead end, and matched against the
-    narrow :data:`_BILLING_MESSAGE_PROBES` so an unrecognized phrasing falls
-    through to the existing generic handling instead of being misclassified.
+    narrow :data:`_BILLING_MESSAGE_PROBES` (plus
+    :data:`_BILLING_402_MESSAGE_PROBES` on a 402) so an unrecognized phrasing
+    falls through to the existing generic handling instead of being
+    misclassified.
     """
     _kind, status_code = upstream_exception_shape(exc)
     if status_code not in _BILLING_CANDIDATE_STATUS_CODES:
         return False
+    probes = _BILLING_MESSAGE_PROBES
+    if status_code == 402:
+        probes += _BILLING_402_MESSAGE_PROBES
     message = upstream_error_message(exc).lower()
-    return any(probe in message for probe in _BILLING_MESSAGE_PROBES)
+    return any(probe in message for probe in probes)
 
 
 def _classify_upstream_error(exc: BaseException) -> tuple[bool, str]:

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -59,8 +59,40 @@ _USAGE_NON_RETRYABLE_STATUS_CODES = {401, 402, 404, 409, 422}
 # fall through to the next entry rather than failing the whole request. They are
 # distinct from 400/422, which mean the request itself is malformed and would be
 # rejected by every provider, so falling through on those just wastes attempts.
+# The one exception is a provider that reports account billing exhaustion as a
+# 400/402/422 rather than a 402: that is an account condition, not a malformed
+# request, and the next provider would serve it fine. See
+# :func:`is_provider_billing_error`.
 _FALLBACK_RETRYABLE_STATUS_CODES = {401, 403, 404, 405, 408, 409, 410, 429, 500, 502, 503, 504}
 _FALLBACK_NON_RETRYABLE_STATUS_CODES = {400, 422}
+
+# Statuses on which the billing probe runs. Anthropic reports "credit balance is
+# too low" as a 400 ``invalid_request_error``; DeepSeek uses 402 for
+# "Insufficient Balance"; OpenAI's "billing hard limit reached" is a 400. 429 is
+# deliberately excluded: OpenAI's ``insufficient_quota`` arrives as a 429, which
+# is already both failover-eligible and surfaced to the caller as a rate limit,
+# so backing off remains a sane client action and reclassifying it would only
+# change the wording.
+_BILLING_CANDIDATE_STATUS_CODES = {400, 402, 422}
+
+# Lowercase substrings that identify account-level billing exhaustion in an
+# upstream provider message. Deliberately narrow: a false positive turns a
+# genuinely malformed request into wasted failover attempts against every
+# provider in the route, so a phrase only earns a place here if it cannot plausibly
+# describe a malformed request. Best-effort against current provider phrasing; a
+# reworded message degrades safely to the generic bad-request handling rather
+# than misclassifying.
+_BILLING_MESSAGE_PROBES = (
+    "credit balance is too low",  # anthropic
+    "purchase credits",  # anthropic
+    "plans & billing",  # anthropic
+    "billing hard limit",  # openai
+    "insufficient balance",  # deepseek, moonshot
+    "insufficient_quota",  # openai (error code, echoed in some messages)
+    "exceeded your current quota",  # openai
+    "insufficient credits",  # openrouter, together
+    "payment required",  # generic 402 bodies
+)
 
 # Streaming first-chunk timeouts (hybrid-mode fallback). Plain LLM streams
 # rarely take long to produce a first token, so a tight cap keeps failed-
@@ -599,6 +631,51 @@ def upstream_exception_shape(exc: BaseException) -> tuple[UpstreamErrorKind | No
     return None, None
 
 
+def upstream_error_message(exc: BaseException) -> str:
+    """Best-effort human-readable text from an upstream exception (and its wrapper).
+
+    Concatenates the exception's ``message`` attribute and ``str()`` for both the
+    exception and any ``original_exception``, so a substring probe still matches
+    whether otari receives the raw SDK error today or the wrapped
+    ``AnyLLMError`` after any-llm flips to unified exceptions. Used only for
+    fixed-string classification, never echoed back to the caller.
+    """
+    parts: list[str] = []
+    for candidate in (exc, getattr(exc, "original_exception", None)):
+        if candidate is None:
+            continue
+        message = getattr(candidate, "message", None)
+        if isinstance(message, str):
+            parts.append(message)
+        parts.append(str(candidate))
+    return " ".join(parts)
+
+
+def is_provider_billing_error(exc: BaseException) -> bool:
+    """True when a 4xx is the provider saying "this account is out of money".
+
+    Providers disagree on the status for account billing exhaustion. Anthropic
+    returns a 400 ``invalid_request_error`` carrying "Your credit balance is too
+    low to access the Anthropic API"; OpenAI has a 400 "billing hard limit
+    reached"; DeepSeek uses 402 "Insufficient Balance". A 400 normally means the
+    request itself is malformed, so these would otherwise be reported to the
+    caller as "check the model name and parameters" and, worse, skip failover on
+    the assumption that every provider would reject the same request. The
+    account balance is per-provider, so the next attempt in the route can very
+    plausibly succeed.
+
+    Gated on :data:`_BILLING_CANDIDATE_STATUS_CODES` so the probe can only ever
+    reinterpret a status that is otherwise a dead end, and matched against the
+    narrow :data:`_BILLING_MESSAGE_PROBES` so an unrecognized phrasing falls
+    through to the existing generic handling instead of being misclassified.
+    """
+    _kind, status_code = upstream_exception_shape(exc)
+    if status_code not in _BILLING_CANDIDATE_STATUS_CODES:
+        return False
+    message = upstream_error_message(exc).lower()
+    return any(probe in message for probe in _BILLING_MESSAGE_PROBES)
+
+
 def _classify_upstream_error(exc: BaseException) -> tuple[bool, str]:
     """Classify an upstream provider error.
 
@@ -611,6 +688,13 @@ def _classify_upstream_error(exc: BaseException) -> tuple[bool, str]:
         return True, kind
 
     if isinstance(status_code, int):
+        # Checked before the non-retryable set: a billing 400/402/422 is an
+        # account condition on THIS provider, so the route's next attempt is
+        # worth making. The distinct error_class keeps "we ran out of credit"
+        # separable from "the request was malformed" in logs and in what the
+        # gateway reports back to the platform.
+        if is_provider_billing_error(exc):
+            return True, f"http_{status_code}_billing"
         if status_code in _FALLBACK_NON_RETRYABLE_STATUS_CODES:
             return False, f"http_{status_code}"
         if status_code in _FALLBACK_RETRYABLE_STATUS_CODES or 500 <= status_code <= 599:

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -439,6 +439,114 @@ def test_hybrid_mode_falls_through_on_sdk_wrapped_connection_error(
     assert error_reports[0]["error_class"] == "conn_err"
 
 
+def test_hybrid_mode_falls_through_when_a_provider_account_is_out_of_credit(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The first attempt's provider account has no credit left, which Anthropic
+    reports as a 400 ``invalid_request_error`` rather than a 402. An empty wallet
+    is a condition on that one provider, so the route must fall through to the
+    next attempt instead of treating the 400 as a malformed request every
+    provider would reject. Regression test for the whole point of the billing
+    classification: without it the request dies on attempt 1 with "check the
+    model name and parameters" while a funded provider sits unused.
+    """
+    import openai
+
+    usage_reports: list[dict[str, Any]] = []
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json={
+                    "request_id": "billing-req-1",
+                    "fallback_enabled": True,
+                    "attempts": [
+                        {
+                            "attempt_id": "billing-att-dry",
+                            "position": 0,
+                            "provider": "anthropic",
+                            "model": "claude-haiku-4-5",
+                            "api_key": "sk-dry",
+                            "api_base": None,
+                            "managed": False,
+                        },
+                        {
+                            "attempt_id": "billing-att-funded",
+                            "position": 1,
+                            "provider": "openai",
+                            "model": "gpt-4o-mini",
+                            "api_key": "sk-funded",
+                            "api_base": None,
+                            "managed": False,
+                        },
+                    ],
+                },
+            )
+        usage_reports.append(body)
+        return httpx.Response(204)
+
+    calls: list[str] = []
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        calls.append(kwargs["model"])
+        if kwargs["api_key"] == "sk-dry":
+            request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+            body = {
+                "type": "error",
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": (
+                        "Your credit balance is too low to access the Anthropic API. "
+                        "Please go to Plans & Billing to upgrade or purchase credits."
+                    ),
+                },
+            }
+            raise openai.BadRequestError(
+                f"Error code: 400 - {body}",
+                response=httpx.Response(400, request=request, json=body),
+                body=body["error"],
+            )
+        return ChatCompletion(
+            id="chatcmpl-billing-fallback",
+            object="chat.completion",
+            created=1700000000,
+            model="gpt-4o-mini",
+            choices=[
+                Choice(
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="hello"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=CompletionUsage(prompt_tokens=5, completion_tokens=1, total_tokens=6),
+        )
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.acompletion", fake_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={"model": "anything", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["X-Correlation-ID"] == "billing-att-funded"
+    assert calls == ["anthropic:claude-haiku-4-5", "openai:gpt-4o-mini"]
+
+    error_reports = [r for r in usage_reports if r.get("status") == "error"]
+    assert len(error_reports) == 1
+    assert error_reports[0]["correlation_id"] == "billing-att-dry"
+    assert error_reports[0]["error_class"] == "http_400_billing"
+
+
 def test_hybrid_mode_propagates_resolve_rate_limit_retry_after(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_classify_upstream_error.py
+++ b/tests/unit/test_classify_upstream_error.py
@@ -181,3 +181,64 @@ def test_classifies_provider_sdk_status_errors(sdk_error: type, status: int, ret
     classified_retryable, error_class = _classify_upstream_error(exc)
     assert classified_retryable is retryable
     assert error_class == f"http_{status}"
+
+
+class _MessageStatusError(Exception):
+    """Upstream error carrying both a status code and a provider message, the
+    shape a provider SDK's ``BadRequestError`` reaches the classifier in."""
+
+    def __init__(self, status_code: int, message: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
+
+
+# Anthropic reports an out-of-credit account as a 400 invalid_request_error.
+_ANTHROPIC_BILLING_MSG = (
+    "Your credit balance is too low to access the Anthropic API. "
+    "Please go to Plans & Billing to upgrade or purchase credits."
+)
+
+
+@pytest.mark.parametrize(
+    "status, message",
+    [
+        (400, _ANTHROPIC_BILLING_MSG),
+        (402, "Insufficient Balance"),
+        (422, "insufficient credits for this request"),
+    ],
+)
+def test_billing_exhaustion_falls_through_to_the_next_attempt(status: int, message: str) -> None:
+    """An out-of-credit account is a condition on THIS provider, not a malformed
+    request, so the route's next attempt is worth making. Reported by clawbolt:
+    an Anthropic account ran dry, the 400 was treated as terminal, and traffic
+    never failed over to the other providers configured on the same alias."""
+    retryable, error_class = _classify_upstream_error(_MessageStatusError(status, message))
+    assert retryable is True
+    assert error_class == f"http_{status}_billing"
+
+
+def test_billing_exhaustion_detected_through_original_exception() -> None:
+    """The signal is found when it lives only on ``original_exception`` (the
+    any-llm unified-exception shape)."""
+    wrapped = _WrappedByAnyLLM(_MessageStatusError(400, _ANTHROPIC_BILLING_MSG))
+    wrapped.status_code = 400  # type: ignore[attr-defined]
+    retryable, error_class = _classify_upstream_error(wrapped)
+    assert retryable is True
+    assert error_class == "http_400_billing"
+
+
+def test_malformed_400_is_still_terminal_after_the_billing_probe() -> None:
+    """The billing probe must not sweep up a genuinely malformed request: an
+    unrecognized 400 message stays terminal so it does not waste an attempt
+    against every provider in the route."""
+    exc = _MessageStatusError(400, "messages.3: tool_use ids were found without tool_result blocks")
+    assert _classify_upstream_error(exc) == (False, "http_400")
+
+
+def test_billing_probe_does_not_reinterpret_other_statuses() -> None:
+    """A billing phrase on a status outside the candidate set keeps its normal
+    classification and error_class, so the probe can only ever rescue a 400/402/422
+    dead end."""
+    assert _classify_upstream_error(_MessageStatusError(503, _ANTHROPIC_BILLING_MSG)) == (True, "http_503")
+    assert _classify_upstream_error(_MessageStatusError(429, "insufficient_quota")) == (True, "http_429")

--- a/tests/unit/test_classify_upstream_error.py
+++ b/tests/unit/test_classify_upstream_error.py
@@ -242,3 +242,19 @@ def test_billing_probe_does_not_reinterpret_other_statuses() -> None:
     dead end."""
     assert _classify_upstream_error(_MessageStatusError(503, _ANTHROPIC_BILLING_MSG)) == (True, "http_503")
     assert _classify_upstream_error(_MessageStatusError(429, "insufficient_quota")) == (True, "http_429")
+
+
+def test_payment_required_phrase_only_counts_on_a_402() -> None:
+    """The words "payment required" are the 402 reason phrase, which httpx puts in
+    every stringified 402, so they are a status signal rather than a provider
+    phrase. On a 400/422 the same words are far more likely to be a
+    caller-supplied value the provider echoed back, which must stay a terminal
+    malformed request."""
+    request = httpx.Request("POST", "https://api.example.com/v1/chat/completions")
+    response = httpx.Response(402, request=request, json={"error": {"message": "out of funds"}})
+    with pytest.raises(httpx.HTTPStatusError) as raised:
+        response.raise_for_status()
+    assert _classify_upstream_error(raised.value) == (True, "http_402_billing")
+
+    echoed = _MessageStatusError(400, "Invalid value: 'payment required'. Supported values are: 'none', 'auto'.")
+    assert _classify_upstream_error(echoed) == (False, "http_400")

--- a/tests/unit/test_provider_error_classification.py
+++ b/tests/unit/test_provider_error_classification.py
@@ -14,6 +14,7 @@ from openai import APITimeoutError as OpenAIAPITimeoutError
 
 from gateway.api.routes._pipeline import (
     PROVIDER_BAD_REQUEST_DETAIL,
+    PROVIDER_BILLING_DETAIL,
     PROVIDER_CREDENTIALS_DETAIL,
     PROVIDER_MODEL_NOT_FOUND_DETAIL,
     PROVIDER_RATE_LIMITED_DETAIL,
@@ -252,3 +253,75 @@ def test_reasoning_effort_tools_conflict_does_not_leak_raw_message() -> None:
     assert mapping.detail == PROVIDER_REASONING_TOOLS_UNSUPPORTED_DETAIL
     assert "gpt-5.6-sol" not in mapping.detail
     assert "SECRET" not in mapping.detail
+
+
+# The exact upstream Anthropic message for an out-of-credit account. Anthropic
+# returns this as a 400 invalid_request_error, not a 402.
+_ANTHROPIC_BILLING_MSG = (
+    "Your credit balance is too low to access the Anthropic API. "
+    "Please go to Plans & Billing to upgrade or purchase credits."
+)
+
+
+@pytest.mark.parametrize(
+    ("status_code", "message"),
+    [
+        (400, _ANTHROPIC_BILLING_MSG),
+        (402, "Insufficient Balance"),
+        (400, "Billing hard limit has been reached"),
+        (422, "insufficient credits for this request"),
+    ],
+)
+def test_billing_exhaustion_maps_to_502_billing_detail(status_code: int, message: str) -> None:
+    """A provider saying "this account is out of money" is a gateway-side account
+    fault, so it surfaces as a 502 with the billing remedy rather than a 400
+    telling the caller to check the model name. Reported by clawbolt: an Anthropic
+    account ran dry and every agent turn failed with "check the model name and
+    parameters", sending the operator to debug a model alias for 10 hours."""
+    exc = _ParamError(status_code, None, message)
+    assert classify_provider_error(exc) == (502, PROVIDER_BILLING_DETAIL)
+
+
+def test_billing_exhaustion_read_from_original_exception() -> None:
+    """The signal is picked up when it lives only on ``original_exception`` (the
+    any-llm unified-exception shape)."""
+    original = _ParamError(400, None, _ANTHROPIC_BILLING_MSG)
+    assert classify_provider_error(_WrappedError(400, original)) == (502, PROVIDER_BILLING_DETAIL)
+
+
+def test_billing_probe_is_gated_on_the_status_code() -> None:
+    """A billing-sounding phrase on a status the probe does not cover keeps its
+    existing classification, so the probe can only ever reinterpret a 400/402/422
+    dead end. 500 stays unclassifiable (generic 502); 429 stays a rate limit,
+    which is still an actionable signal for the caller."""
+    assert classify_provider_error(_ParamError(500, None, _ANTHROPIC_BILLING_MSG)) is None
+    assert classify_provider_error(_ParamError(429, None, "insufficient_quota")) == (
+        429,
+        PROVIDER_RATE_LIMITED_DETAIL,
+    )
+
+
+def test_unrecognized_400_message_stays_generic_bad_request() -> None:
+    """A genuinely malformed request is not swept up by the billing probe: an
+    unrecognized phrasing degrades to the existing generic detail rather than
+    being misclassified into wasted failover attempts."""
+    exc = _ParamError(400, None, "messages.3: tool_use ids were found without tool_result blocks")
+    assert classify_provider_error(exc) == (400, PROVIDER_BAD_REQUEST_DETAIL)
+
+
+def test_billing_detail_does_not_leak_raw_message() -> None:
+    """The billing detail is a fixed string; nothing from the upstream body is
+    echoed to the caller."""
+    exc = _ParamError(400, None, _ANTHROPIC_BILLING_MSG + " SECRET token=abc123")
+    mapping = classify_provider_error(exc)
+    assert mapping is not None
+    assert mapping.detail == PROVIDER_BILLING_DETAIL
+    assert "SECRET" not in mapping.detail
+    assert "Anthropic" not in mapping.detail
+
+
+def test_failure_status_code_keeps_the_upstream_status_for_billing() -> None:
+    """The usage log keeps the status the provider actually returned, so "how much
+    of my error rate is an empty wallet" stays answerable even though the caller
+    saw a 502."""
+    assert failure_status_code(_ParamError(400, None, _ANTHROPIC_BILLING_MSG)) == 400


### PR DESCRIPTION
## Description

Providers disagree on the HTTP status for "this account is out of money". Anthropic returns a **400** `invalid_request_error` carrying `Your credit balance is too low to access the Anthropic API`; OpenAI has a 400 `billing hard limit reached`; DeepSeek uses 402 `Insufficient Balance`.

Two things went wrong with that shape:

1. `classify_provider_error` mapped it to `PROVIDER_BAD_REQUEST_DETAIL`, so an operator whose provider account ran dry was told to "check the model name and parameters".
2. `_FALLBACK_NON_RETRYABLE_STATUS_CODES = {400, 422}` treats a 400 as "malformed, every provider would reject this", so a multi-attempt route never fell through to the other providers on the same alias. Recovering from a single provider going bad is one of the main reasons an operator configures fallback.

This came out of a real incident on a self-hosted otari: an Anthropic account ran out of credit, and the downstream app failed every agent turn for about 10 hours with the model-name detail while two other providers sat unused on the same alias. The raw cause was only visible in the gateway's own `_pipeline.py:2353` log line.

### What changed

- New `is_provider_billing_error` in `_platform.py`, gated on 400/402/422 and matched against a narrow tuple of fixed provider phrases. An unrecognized phrasing degrades to the existing generic handling rather than being misclassified, since a false positive would burn an attempt against every provider in the route.
- Billing failures surface as a **502** with a new fixed `PROVIDER_BILLING_DETAIL`, following the reasoning already applied to a rejected credential: a provider rejecting the gateway's account is a gateway-side fault, not the caller's, so it must not come back as a client 4xx. Still a fixed string, so the no-leak guarantee holds (covered by a test).
- `_classify_upstream_error` now returns `(True, "http_<code>_billing")` for these, so the route fails over and an empty wallet stays separable from a malformed request in logs and in what the gateway reports to the platform.
- `failure_status_code` is unchanged: `usage_logs.status_code` keeps the upstream 400, so "how much of my error rate is an empty wallet" stays answerable.
- 429 is deliberately left alone. OpenAI's `insufficient_quota` arrives as a 429, which is already failover-eligible and already tells the caller to back off, so reclassifying would only change wording.
- `_upstream_error_message` moves to `_platform.py` as `upstream_error_message` so the billing probe and the existing reasoning-effort probe share one implementation without `_platform` importing the API layer above it. `make check-architecture` passes.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None filed; found while debugging a downstream outage.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Verification:

- `make lint`: architecture check clean, ruff clean
- `make typecheck`: no issues in 282 source files
- `uv run pytest tests/unit`: 1149 passed, 1 skipped
- The 10 new behaviour tests were confirmed to fail with the predicate stubbed to `return False`, while the two negative-control tests (unrecognized 400 stays generic; probe does not reinterpret 429/500/503) keep passing.
- No OpenAPI change: the detail strings are response bodies, not schema.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

Written while investigating the downstream incident described above, so the fixed provider phrases come from an observed Anthropic body plus documented phrasing for the other providers, not from guesswork alone. The probe list is best-effort by design and degrades safely.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Detects provider billing exhaustion for recognized 400, 402, and 422 responses.
- Reports these errors as safe 502 billing errors instead of malformed-request errors.
- Allows route failover to another provider.
- Preserves upstream status codes in usage logs.
- Keeps 429 handling unchanged.
- Moves shared upstream error handling to `_platform.py`.
- Documents billing error classifications and troubleshooting guidance.
- Adds coverage for recognized, unrecognized, and wrapped billing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->