### PR TITLE
feat(hybrid): forward provider-specific extra_params through resolved attempts

### DIFF
--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -122,10 +122,15 @@ the caller's own request fields so they can never be shadowed by a
 same-named field in the request body: the same non-overridable treatment
 `api_key` and `model` already get. This field is sourced only from the
 trusted platform peer; Otari never accepts it from the caller. AWS Bedrock's
-bearer-token ("Bedrock API key") credential shape is not representable here,
-since it requires an in-process boto3 client with a custom signing hook, so
-the platform only sends `extra_params` for the classic IAM access-key/secret-key
-shape.
+bearer-token ("Bedrock API key") credential shape is a current gap, not a
+fundamental one: AWS's own recommended path for it is the
+`AWS_BEARER_TOKEN_BEDROCK` environment variable (or, in newer boto3 releases,
+an `aws_bearer_token` constructor kwarg), either of which is in principle
+JSON-serializable and forwardable like any other `extra_params` value. The
+reference platform (otari.ai) currently builds an in-process boto3 client
+with a custom signing hook for that shape instead, which has no
+representable form once serialized over HTTP, so it only sends
+`extra_params` for the classic IAM access-key/secret-key shape today.
 
 `request_id` groups every `attempt_id` from the same resolve call so the
 platform can attribute spend, render trace timelines, and emit fallback events.

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -89,6 +89,19 @@ Content-Type: application/json
       "api_key": "sk-...",
       "api_base": "https://api.openai.com/v1",
       "managed": false
+    },
+    {
+      "attempt_id": "01HX3...",
+      "position": 2,
+      "provider": "bedrock",
+      "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+      "api_key": "wJalrXUtnFEMI...",
+      "api_base": null,
+      "managed": false,
+      "extra_params": {
+        "region_name": "us-east-1",
+        "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE"
+      }
     }
   ]
 }
@@ -98,6 +111,21 @@ Otari iterates `attempts` in order. On a retryable failure it moves to the
 next entry; on success it stops. The `attempt_id` of the entry that ultimately
 succeeded (or the last one tried, on total failure) is what Otari echoes
 back via `X-Correlation-ID` and reports through `/gateway/usage`.
+
+`extra_params` (optional, omitted for most providers) carries provider-specific
+credential/client fields beyond `api_key`/`api_base`: for example AWS
+Bedrock's mandatory `region_name` and, for the classic IAM-key-pair shape,
+`aws_access_key_id` (the paired secret access key travels in `api_key`, since
+that's the only field the wire contract treats as sensitive). Otari merges
+these verbatim into the `acompletion()` call for that attempt, applied after
+the caller's own request fields so they can never be shadowed by a
+same-named field in the request body: the same non-overridable treatment
+`api_key` and `model` already get. This field is sourced only from the
+trusted platform peer; Otari never accepts it from the caller. AWS Bedrock's
+bearer-token ("Bedrock API key") credential shape is not representable here,
+since it requires an in-process boto3 client with a custom signing hook, so
+the platform only sends `extra_params` for the classic IAM access-key/secret-key
+shape.
 
 `request_id` groups every `attempt_id` from the same resolve call so the
 platform can attribute spend, render trace timelines, and emit fallback events.

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -116,21 +116,38 @@ back via `X-Correlation-ID` and reports through `/gateway/usage`.
 credential/client fields beyond `api_key`/`api_base`: for example AWS
 Bedrock's mandatory `region_name` and, for the classic IAM-key-pair shape,
 `aws_access_key_id` (the paired secret access key travels in `api_key`, since
-that's the only field the wire contract treats as sensitive). Otari merges
-these verbatim into the `acompletion()` call for that attempt, applied after
-the caller's own request fields so they can never be shadowed by a
-same-named field in the request body: the same non-overridable treatment
-`api_key` and `model` already get. This field is sourced only from the
-trusted platform peer; Otari never accepts it from the caller. AWS Bedrock's
-bearer-token ("Bedrock API key") credential shape is a current gap, not a
-fundamental one: AWS's own recommended path for it is the
-`AWS_BEARER_TOKEN_BEDROCK` environment variable (or, in newer boto3 releases,
-an `aws_bearer_token` constructor kwarg), either of which is in principle
-JSON-serializable and forwardable like any other `extra_params` value. The
-reference platform (otari.ai) currently builds an in-process boto3 client
-with a custom signing hook for that shape instead, which has no
-representable form once serialized over HTTP, so it only sends
-`extra_params` for the classic IAM access-key/secret-key shape today.
+that's the only field the wire contract treats as sensitive). This field is
+sourced only from the trusted platform peer; Otari never accepts it from the
+caller, and it can never be shadowed by a same-named field in the caller's
+own request body: the same non-overridable treatment `api_key` and `model`
+already get.
+
+Otari does not merge `extra_params` into the completion call's kwargs
+directly. any-llm's `acompletion()` only forwards a separate `client_args`
+mapping to the provider's client constructor (everything else in its own
+`**kwargs` goes to the completion call instead), so `extra_params` is nested
+under `client_args` before the call. A flat merge would silently forward
+`region_name` to the completion call rather than boto3's client constructor,
+which is how an earlier version of this forwarding path still hit boto3's
+`NoRegionError` despite carrying the right value end to end.
+
+AWS Bedrock gets additional handling on top of that generic nesting, since
+any-llm's Bedrock provider never reads a plain `api_key` when building its
+boto3 client and AWS has two distinct credential shapes:
+
+- Classic IAM access-key/secret-key pair (`aws_access_key_id` present in
+  `extra_params`): the paired secret (`api_key`) is aliased into
+  `client_args["aws_secret_access_key"]`, boto3's own constructor kwarg for it.
+- Bearer token ("Bedrock API key", no `aws_access_key_id`): Otari builds a
+  boto3 client itself, with signing disabled and the `Authorization: Bearer
+  <token>` header injected via a `before-sign` event hook, and passes it as
+  `client_args["client"]` (an any-llm-sdk `BedrockProvider` constructor
+  parameter it already supports overriding its client with). The pinned
+  boto3 version has no native support for `AWS_BEARER_TOKEN_BEDROCK` or an
+  `aws_bearer_token` constructor kwarg, so this hook-based approach is the
+  only way to authenticate this shape today; it is a per-request, in-process
+  client, safe under concurrent load. See
+  `src/gateway/services/bedrock_gateway_auth.py`.
 
 `request_id` groups every `attempt_id` from the same resolve call so the
 platform can attribute spend, render trace timelines, and emit fallback events.
@@ -168,7 +185,7 @@ multi-attempt shape.
 
 | Status | Behaviour |
 |---|---|
-| `401`, `402`, `403`, `404`, `429` | Status code is forwarded to the client; `429`'s `Retry-After` header is preserved. The `detail` is the platform's JSON `detail` string when present, otherwise the fallback `"Authorization request rejected"`. |
+| `400`, `401`, `402`, `403`, `404`, `429` | Status code is forwarded to the client; `429`'s `Retry-After` header is preserved. The `detail` is the platform's JSON `detail` string when present, otherwise the fallback `"Authorization request rejected"`. |
 | `422`, `5xx`                      | Mapped to `502 Bad Gateway` with `detail = "Authorization service unavailable"`. |
 | Network/timeout                    | Mapped to `502 Bad Gateway`. |
 
@@ -216,7 +233,7 @@ configs are resolved (SSRF guard, no bearer token over cleartext `http://`).
 
 | Status | Behaviour |
 |---|---|
-| `401`, `402`, `403`, `404`, `429` | Status code is forwarded to the client; `429`'s `Retry-After` header is preserved. The `detail` is the platform's JSON `detail` string when present, otherwise the fallback `"MCP server resolution failed"`. |
+| `400`, `401`, `402`, `403`, `404`, `429` | Status code is forwarded to the client; `429`'s `Retry-After` header is preserved. The `detail` is the platform's JSON `detail` string when present, otherwise the fallback `"MCP server resolution failed"`. |
 | `422`, `5xx`                      | Mapped to `502 Bad Gateway` with `detail = "Authorization service unavailable"`. |
 | Network/timeout                    | Mapped to `502 Bad Gateway`. |
 
@@ -267,7 +284,7 @@ this field.
 
 | Status | Behaviour |
 |---|---|
-| `401`, `402`, `403`, `404`, `429` | Status code is forwarded to the client; `429`'s `Retry-After` header is preserved. The `detail` is the platform's JSON `detail` string when present, otherwise the fallback `"Web search resolution failed"`. |
+| `400`, `401`, `402`, `403`, `404`, `429` | Status code is forwarded to the client; `429`'s `Retry-After` header is preserved. The `detail` is the platform's JSON `detail` string when present, otherwise the fallback `"Web search resolution failed"`. |
 | `422`, `5xx`                      | Mapped to `502 Bad Gateway` with `detail = "Authorization service unavailable"`. |
 | Network/timeout                    | Mapped to `502 Bad Gateway`. |
 

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -139,7 +139,7 @@ class ResolvedAttempt(BaseModel):
     extra_params: dict[str, str] | None = None
     """Provider-specific extra client kwargs beyond api_key/api_base (e.g. AWS
     Bedrock's ``region_name``/``aws_access_key_id``). Sourced only from the
-    trusted platform peer, never from the caller's request body — see
+    trusted platform peer, never from the caller's request body. See
     ``default_attempt_kwargs``, which merges these in non-overridably."""
 
 

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -31,6 +31,7 @@ from gateway.core.usage import cache_read_tokens_of, cache_write_tokens_of
 from gateway.log_config import logger
 from gateway.metrics import record_abandoned_attempt
 from gateway.models.mcp import McpServerConfig
+from gateway.services.bedrock_gateway_auth import build_bedrock_client_args
 from gateway.services.mcp_loop import MaxToolIterationsExceeded
 from gateway.services.sandbox_backend import SandboxNotReachableError
 from gateway.services.web_search_backend import WebSearchNotReachableError
@@ -158,28 +159,60 @@ class _AttemptFailure(NamedTuple):
     error_class: str
 
 
+def build_attempt_client_args(attempt: ResolvedAttempt) -> dict[str, Any] | None:
+    """Build the ``client_args`` any-llm needs to construct this attempt's
+    provider client, or ``None`` when the attempt carries no ``extra_params``.
+
+    This *must* be a separate ``client_args`` dict, not merged flat into the
+    completion kwargs: any-llm's ``acompletion()`` only forwards a
+    ``client_args`` mapping to the provider's client constructor
+    (``AnyLLM.create(provider, api_key=..., api_base=..., **client_args)``);
+    every other keyword argument goes to the completion *call* instead. A
+    provider-specific credential field passed flat (e.g. Bedrock's
+    ``region_name``) never reaches ``boto3.client()`` that way and is instead
+    silently forwarded into the raw provider API call, which is how an
+    earlier version of this forwarding path still hit ``NoRegionError``
+    despite carrying the right value.
+
+    Bedrock gets dedicated handling (see :mod:`gateway.services.bedrock_gateway_auth`)
+    because it also needs its secret aliased to a different boto3 kwarg name
+    and, for the bearer-token ("Bedrock API key") credential shape, a custom
+    pre-built client. Every other provider's ``extra_params`` is forwarded
+    as-is.
+    """
+    if not attempt.extra_params:
+        return None
+    if LLMProvider(attempt.provider) == LLMProvider.BEDROCK:
+        return build_bedrock_client_args(attempt.api_key, attempt.extra_params)
+    return dict(attempt.extra_params)
+
+
 def default_attempt_kwargs(
     attempt: ResolvedAttempt,
     base_request_fields: dict[str, Any],
 ) -> dict[str, Any]:
     """Standard platform-attempt kwargs: credentials + ``provider:model`` selector.
 
-    ``extra_params`` is merged in *after* ``base_request_fields`` (and before
-    the forced ``model`` key) so a provider-specific credential field the
-    platform returns (e.g. Bedrock's ``region_name``) can never be shadowed by
-    a same-named field in the caller's own request body, matching how
-    ``api_key``/``model`` are already non-overridable.
+    ``client_args`` (built from the attempt's ``extra_params``, see
+    :func:`build_attempt_client_args`) is merged in *after*
+    ``base_request_fields`` (and after the forced ``model`` key) so a
+    provider-specific credential field the platform returns can never be
+    shadowed by a same-named field in the caller's own request body,
+    matching how ``api_key``/``model`` are already non-overridable.
     """
     attempt_provider = LLMProvider(attempt.provider)
     kwargs: dict[str, Any] = {"api_key": attempt.api_key}
     if attempt.api_base:
         kwargs["api_base"] = attempt.api_base
-    return {
+    merged = {
         **kwargs,
         **base_request_fields,
-        **(attempt.extra_params or {}),
         "model": f"{attempt_provider.value}:{attempt.model}",
     }
+    client_args = build_attempt_client_args(attempt)
+    if client_args is not None:
+        merged["client_args"] = client_args
+    return merged
 
 
 def _provider_failure_http_exc(exc: BaseException, *, fallback_detail: str) -> HTTPException:
@@ -447,11 +480,15 @@ async def _post_resolve(
 
     Owns the pieces every resolve helper shares: the base_url guard, the
     gateway/user token headers, the bounded POST, and the status-code ladder.
-    A 200 returns the parsed payload; client errors (401/402/403/404/429) are
-    forwarded with the platform's detail when it is a safe string (falling back
-    to ``client_error_detail``), keeping Retry-After on a 429; timeouts,
+    A 200 returns the parsed payload; client errors (400/401/402/403/404/429)
+    are forwarded with the platform's detail when it is a safe string (falling
+    back to ``client_error_detail``), keeping Retry-After on a 429; timeouts,
     network errors, the platform's server-side failures, and any unexpected
-    status collapse to a 502.
+    status collapse to a 502. 400 is included here (unlike 422, which stays
+    collapsed) because this backend's own 400s are deliberately hand-written,
+    caller-safe rejections (e.g. a Bedrock BYO key using an auth shape that
+    cannot be forwarded through a gateway), not raw framework validation
+    errors that might otherwise leak internal request-shape detail.
     """
     platform_base_url = config.platform.get("base_url")
     if not platform_base_url:
@@ -483,7 +520,7 @@ async def _post_resolve(
     if response.status_code == 200:
         return response.json()
 
-    if response.status_code in {401, 402, 403, 404, 429}:
+    if response.status_code in {400, 401, 402, 403, 404, 429}:
         detail = _safe_detail_from_platform(response, client_error_detail)
         response_headers: dict[str, str] | None = None
         if response.status_code == 429 and response.headers.get("Retry-After"):

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -136,6 +136,11 @@ class ResolvedAttempt(BaseModel):
     api_base: str | None = None
     api_key: str
     managed: bool
+    extra_params: dict[str, str] | None = None
+    """Provider-specific extra client kwargs beyond api_key/api_base (e.g. AWS
+    Bedrock's ``region_name``/``aws_access_key_id``). Sourced only from the
+    trusted platform peer, never from the caller's request body — see
+    ``default_attempt_kwargs``, which merges these in non-overridably."""
 
 
 class ResolvedRoute(BaseModel):
@@ -157,7 +162,14 @@ def default_attempt_kwargs(
     attempt: ResolvedAttempt,
     base_request_fields: dict[str, Any],
 ) -> dict[str, Any]:
-    """Standard platform-attempt kwargs: credentials + ``provider:model`` selector."""
+    """Standard platform-attempt kwargs: credentials + ``provider:model`` selector.
+
+    ``extra_params`` is merged in *after* ``base_request_fields`` (and before
+    the forced ``model`` key) so a provider-specific credential field the
+    platform returns (e.g. Bedrock's ``region_name``) can never be shadowed by
+    a same-named field in the caller's own request body, matching how
+    ``api_key``/``model`` are already non-overridable.
+    """
     attempt_provider = LLMProvider(attempt.provider)
     kwargs: dict[str, Any] = {"api_key": attempt.api_key}
     if attempt.api_base:
@@ -165,6 +177,7 @@ def default_attempt_kwargs(
     return {
         **kwargs,
         **base_request_fields,
+        **(attempt.extra_params or {}),
         "model": f"{attempt_provider.value}:{attempt.model}",
     }
 
@@ -527,6 +540,7 @@ def _parse_resolve_payload(payload: dict[str, Any]) -> ResolvedRoute:
                 api_base=att.get("api_base"),
                 api_key=str(att["api_key"]),
                 managed=bool(att.get("managed", False)),
+                extra_params=att.get("extra_params"),
             )
             for att in attempts_payload
         ]
@@ -549,6 +563,7 @@ def _parse_resolve_payload(payload: dict[str, Any]) -> ResolvedRoute:
                 api_base=payload.get("api_base"),
                 api_key=str(payload["api_key"]),
                 managed=bool(payload.get("managed", False)),
+                extra_params=payload.get("extra_params"),
             )
         ],
     )

--- a/src/gateway/api/routes/_schema_derive.py
+++ b/src/gateway/api/routes/_schema_derive.py
@@ -52,6 +52,14 @@ SENSITIVE_PARAM_FIELDS: frozenset[str] = frozenset(
         "extra_body",
         "aws_access_key_id",
         "aws_secret_access_key",
+        # any-llm's acompletion()/aresponses() forward this dict straight to
+        # the provider's client constructor (see build_attempt_client_args in
+        # _platform.py). A hybrid-mode attempt with no extra_params of its own
+        # (the common case for every provider except Bedrock) never sets this
+        # key at all, so a caller-supplied client_args smuggled in through a
+        # schema that allows extra fields would otherwise reach the provider
+        # call unfiltered.
+        "client_args",
     }
 )
 

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -34,7 +34,7 @@ from gateway.api.routes._pipeline import (
     run_standalone_non_stream,
     run_streaming_with_fallback,
 )
-from gateway.api.routes._platform import ResolvedAttempt
+from gateway.api.routes._platform import ResolvedAttempt, build_attempt_client_args
 from gateway.api.routes._schema_derive import SESSION_LABEL_DESC, SESSION_LABEL_MAX_LENGTH, derive_request_base
 from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
@@ -286,16 +286,22 @@ class _ResponsesAdapter:
         if attempt.api_base:
             kwargs["api_base"] = attempt.api_base
         request_fields = _with_codex_extra_body(base_request_fields, LLMProvider(attempt.provider))
-        return {
+        merged = {
             **kwargs,
             **{k: v for k, v in request_fields.items() if k != "provider"},
-            # extra_params (e.g. Bedrock's region_name) is platform-trusted, so
-            # it's merged in after the caller's own request fields and before
-            # the forced model/provider keys, mirroring default_attempt_kwargs.
-            **(attempt.extra_params or {}),
             "model": attempt.model,
             "provider": LLMProvider(attempt.provider),
         }
+        # client_args (built from extra_params, e.g. Bedrock's region_name) is
+        # platform-trusted, so it's merged in last: it can never be shadowed
+        # by a same-named field in the caller's own request body. It must be
+        # nested under client_args, not merged flat, or any-llm forwards it
+        # to the completion call instead of the provider's client
+        # constructor, mirroring default_attempt_kwargs.
+        client_args = build_attempt_client_args(attempt)
+        if client_args is not None:
+            merged["client_args"] = client_args
+        return merged
 
     def local_attempt_kwargs(
         self,

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -289,6 +289,10 @@ class _ResponsesAdapter:
         return {
             **kwargs,
             **{k: v for k, v in request_fields.items() if k != "provider"},
+            # extra_params (e.g. Bedrock's region_name) is platform-trusted, so
+            # it's merged in after the caller's own request fields and before
+            # the forced model/provider keys — mirrors default_attempt_kwargs.
+            **(attempt.extra_params or {}),
             "model": attempt.model,
             "provider": LLMProvider(attempt.provider),
         }

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -291,7 +291,7 @@ class _ResponsesAdapter:
             **{k: v for k, v in request_fields.items() if k != "provider"},
             # extra_params (e.g. Bedrock's region_name) is platform-trusted, so
             # it's merged in after the caller's own request fields and before
-            # the forced model/provider keys — mirrors default_attempt_kwargs.
+            # the forced model/provider keys, mirroring default_attempt_kwargs.
             **(attempt.extra_params or {}),
             "model": attempt.model,
             "provider": LLMProvider(attempt.provider),

--- a/src/gateway/services/bedrock_gateway_auth.py
+++ b/src/gateway/services/bedrock_gateway_auth.py
@@ -1,0 +1,107 @@
+"""Builds the ``client_args`` any-llm's Bedrock provider needs for a
+hybrid-mode attempt, for both AWS credential shapes a BYO Bedrock provider
+key can use.
+
+AWS Bedrock is unusual among any-llm providers in two ways any other
+provider's ``ResolvedAttempt.extra_params`` never has to deal with:
+
+1. any-llm-sdk's ``BedrockProvider`` never forwards ``api_key`` into the boto3
+   client it builds (it is only used for a presence check); the real secret
+   must be passed under boto3's own constructor kwarg, ``aws_secret_access_key``.
+2. AWS has two distinct credential shapes: a classic IAM access-key/secret-key
+   pair, and a newer "Bedrock API key" (bearer token). The pinned boto3
+   version here (see ``pyproject.toml``) has no built-in support for the
+   latter (no ``AWS_BEARER_TOKEN_BEDROCK`` auto-detection, no ``aws_bearer_token``
+   constructor kwarg), so it is authenticated the same way otari.ai's own
+   in-process completion path does it: a boto3 client with signing disabled
+   and the ``Authorization: Bearer <token>`` header injected via a
+   ``before-sign`` event hook. Building that client is a per-process, in-memory
+   step, so it works equally well here in the gateway as it does in a
+   platform's own completion service; the bearer token itself is a plain
+   string, forwarded like any other credential.
+
+``build_bedrock_client_args`` is the single entry point: it inspects
+``extra_params`` (``region_name`` and, for the classic shape,
+``aws_access_key_id``) to pick the shape, and returns the dict any-llm's
+``acompletion(client_args=...)`` should receive. Every other provider's
+``extra_params`` is nested under ``client_args`` unchanged, without going
+through this module at all (see ``default_attempt_kwargs``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import boto3
+import botocore
+from botocore.config import Config
+
+# any-llm-sdk's BedrockProvider never forwards ``api_key`` into the boto3
+# client it builds (it's only used for a non-empty presence check) — the
+# secret must instead be forwarded under boto3's real constructor kwarg.
+# Verified against any-llm-sdk's bedrock.py: ``_init_client`` calls
+# ``boto3.client("bedrock-runtime", endpoint_url=api_base, **kwargs)`` with no
+# reference to ``api_key`` at all.
+_SECRET_ACCESS_KEY_KWARG = "aws_secret_access_key"
+
+
+def _build_unsigned_bedrock_runtime_client(region_name: str, token: str) -> Any:
+    """Build a ``bedrock-runtime`` boto3 client that authenticates every
+    request with ``Authorization: Bearer <token>``, regardless of the
+    process's ambient AWS credentials.
+
+    Building a client with signature-version disabled skips SigV4 credential
+    resolution entirely (which would otherwise raise when no ambient AWS
+    credentials are present); the ``before-sign`` hook then stamps the bearer
+    header on every outgoing request. State lives on the returned client
+    object, not on any global/session-wide object, so building one client per
+    request is safe under concurrent load. Only the ``bedrock-runtime``
+    client (used for ``converse``/``converse_stream``) is needed here: model
+    listing and batch ops use a second, separate ``bedrock`` control-plane
+    client any-llm-sdk builds itself, but those aren't reachable through the
+    gateway's hybrid-mode chat/messages/responses routes.
+
+    The service name is inlined as a literal at both call sites (rather than
+    a shared module constant) because ``boto3.client``'s type stubs overload
+    on a ``Literal`` service-name argument; a ``str``-typed constant, even
+    with this exact value, would fail every overload.
+    """
+    client = boto3.client(
+        "bedrock-runtime",
+        region_name=region_name,
+        config=Config(signature_version=botocore.UNSIGNED),
+    )
+
+    def _inject_bearer_token(request: Any, **kwargs: Any) -> None:  # noqa: ARG001
+        request.headers["Authorization"] = f"Bearer {token}"
+
+    client.meta.events.register("before-sign.bedrock-runtime.*", _inject_bearer_token)
+    return client
+
+
+def build_bedrock_client_args(api_key: str, extra_params: dict[str, str]) -> dict[str, Any]:
+    """Build the ``client_args`` any-llm needs to construct a Bedrock client
+    for one hybrid-mode attempt.
+
+    ``extra_params`` always carries ``region_name`` (Bedrock's boto3 client
+    has no default region fallback) and, for the classic IAM access-key-pair
+    shape, ``aws_access_key_id``; its absence signals the bearer-token shape,
+    mirroring the detection otari.ai's own resolve service uses.
+
+    Classic shape: returns ``extra_params`` with the secret access key
+    aliased in under its real boto3 kwarg name, so a plain ``region_name`` +
+    ``aws_access_key_id`` + ``aws_secret_access_key`` dict reaches
+    ``boto3.client()`` via any-llm's constructor-kwargs channel.
+
+    Bearer-token shape: returns ``region_name`` plus a pre-built, per-request
+    unsigned client (under the ``client`` key any-llm-sdk's ``BedrockProvider``
+    already supports overriding its client with).
+    """
+    if extra_params.get("aws_access_key_id"):
+        return {**extra_params, _SECRET_ACCESS_KEY_KWARG: api_key}
+
+    region_name = extra_params.get("region_name", "")
+    return {
+        "region_name": region_name,
+        "client": _build_unsigned_bedrock_runtime_client(region_name, api_key),
+    }

--- a/src/gateway/services/bedrock_gateway_auth.py
+++ b/src/gateway/services/bedrock_gateway_auth.py
@@ -37,7 +37,7 @@ import botocore
 from botocore.config import Config
 
 # any-llm-sdk's BedrockProvider never forwards ``api_key`` into the boto3
-# client it builds (it's only used for a non-empty presence check) — the
+# client it builds (it's only used for a non-empty presence check): the
 # secret must instead be forwarded under boto3's real constructor kwarg.
 # Verified against any-llm-sdk's bedrock.py: ``_init_client`` calls
 # ``boto3.client("bedrock-runtime", endpoint_url=api_base, **kwargs)`` with no

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -159,7 +159,7 @@ def test_hybrid_mode_forwards_bedrock_extra_params(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A Bedrock attempt's ``extra_params`` (region_name, aws_access_key_id)
-    reaches the ``acompletion()`` call the gateway makes — this is the wire-
+    reaches the ``acompletion()`` call the gateway makes. This is the wire-
     contract field that carries AWS's mandatory region, without which boto3
     raises ``NoRegionError`` ("You must specify a region.")."""
 

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -154,14 +154,59 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
     ]
 
 
-def test_hybrid_mode_forwards_bedrock_extra_params(
+def _bedrock_resolve_response(request_id: str, api_key: str, extra_params: dict[str, str]) -> dict[str, Any]:
+    return {
+        "request_id": request_id,
+        "fallback_enabled": False,
+        "attempts": [
+            {
+                "attempt_id": f"{request_id}-att",
+                "position": 0,
+                "provider": "bedrock",
+                "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+                "api_key": api_key,
+                "api_base": None,
+                "managed": False,
+                "extra_params": extra_params,
+            }
+        ],
+    }
+
+
+def _bedrock_chat_request() -> dict[str, Any]:
+    return {
+        "model": "bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+
+def _fake_bedrock_chat_completion() -> ChatCompletion:
+    return ChatCompletion(
+        id="chatcmpl-bedrock",
+        object="chat.completion",
+        created=1700000000,
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+        choices=[
+            Choice(
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content="hello"),
+                finish_reason="stop",
+            )
+        ],
+        usage=CompletionUsage(prompt_tokens=10, completion_tokens=7, total_tokens=17),
+    )
+
+
+def test_hybrid_mode_forwards_bedrock_classic_key_pair_via_client_args(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A Bedrock attempt's ``extra_params`` (region_name, aws_access_key_id)
-    reaches the ``acompletion()`` call the gateway makes. This is the wire-
-    contract field that carries AWS's mandatory region, without which boto3
-    raises ``NoRegionError`` ("You must specify a region.")."""
+    """A Bedrock attempt using the classic IAM access-key/secret-key shape
+    reaches the ``acompletion()`` call under ``client_args`` (not flat), with
+    the secret aliased to ``aws_secret_access_key`` — the shape any-llm's
+    Bedrock provider actually reads when building its boto3 client. Without
+    this, boto3 raises ``NoRegionError`` ("You must specify a region.") even
+    though the gateway received the right values."""
 
     async def fake_post_platform(
         url: str,
@@ -172,57 +217,78 @@ def test_hybrid_mode_forwards_bedrock_extra_params(
         if url.endswith("/gateway/provider-keys/resolve"):
             return httpx.Response(
                 200,
-                json={
-                    "request_id": "bedrock-req-1",
-                    "fallback_enabled": False,
-                    "attempts": [
-                        {
-                            "attempt_id": "bedrock-att-1",
-                            "position": 0,
-                            "provider": "bedrock",
-                            "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
-                            "api_key": "secret-access-key",
-                            "api_base": None,
-                            "managed": False,
-                            "extra_params": {
-                                "region_name": "us-east-1",
-                                "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
-                            },
-                        }
-                    ],
-                },
+                json=_bedrock_resolve_response(
+                    "bedrock-classic-req",
+                    "secret-access-key",
+                    {"region_name": "us-east-1", "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE"},
+                ),
             )
         return httpx.Response(204)
 
     async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
         assert kwargs["model"] == "bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0"
         assert kwargs["api_key"] == "secret-access-key"
-        assert kwargs["region_name"] == "us-east-1"
-        assert kwargs["aws_access_key_id"] == "AKIAIOSFODNN7EXAMPLE"
-        return ChatCompletion(
-            id="chatcmpl-bedrock",
-            object="chat.completion",
-            created=1700000000,
-            model="anthropic.claude-3-5-sonnet-20241022-v2:0",
-            choices=[
-                Choice(
-                    index=0,
-                    message=ChatCompletionMessage(role="assistant", content="hello"),
-                    finish_reason="stop",
-                )
-            ],
-            usage=CompletionUsage(prompt_tokens=10, completion_tokens=7, total_tokens=17),
-        )
+        assert "region_name" not in kwargs
+        assert "aws_access_key_id" not in kwargs
+        assert kwargs["client_args"] == {
+            "region_name": "us-east-1",
+            "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+            "aws_secret_access_key": "secret-access-key",
+        }
+        return _fake_bedrock_chat_completion()
 
     monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
     monkeypatch.setattr("gateway.api.routes.chat.acompletion", fake_acompletion)
 
     response = platform_client.post(
         "/v1/chat/completions",
-        json={
-            "model": "bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0",
-            "messages": [{"role": "user", "content": "hi"}],
-        },
+        json=_bedrock_chat_request(),
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+
+
+def test_hybrid_mode_forwards_bedrock_bearer_token_via_client_args(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Bedrock attempt using the bearer-token ("Bedrock API key") shape (no
+    aws_access_key_id in extra_params) gets a pre-built, unsigned boto3
+    client under client_args["client"] instead of plain credential kwargs,
+    since this boto3 version has no native bearer-token support."""
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json=_bedrock_resolve_response(
+                    "bedrock-bearer-req",
+                    "bearer-token-value",
+                    {"region_name": "us-west-2"},
+                ),
+            )
+        return httpx.Response(204)
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        assert kwargs["model"] == "bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0"
+        assert kwargs["api_key"] == "bearer-token-value"
+        client_args = kwargs["client_args"]
+        assert client_args["region_name"] == "us-west-2"
+        assert client_args["client"].meta.region_name == "us-west-2"
+        return _fake_bedrock_chat_completion()
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.acompletion", fake_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json=_bedrock_chat_request(),
         headers={"Authorization": "Bearer user_test_token"},
     )
 
@@ -735,6 +801,38 @@ def test_hybrid_mode_maps_resolve_validation_error_to_bad_gateway(
 
     assert response.status_code == 502
     assert response.json() == {"detail": "Authorization service unavailable"}
+
+
+def test_hybrid_mode_forwards_resolve_400_detail(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 400 from the platform resolve endpoint (a deliberate, caller-safe
+    rejection such as a Bedrock BYO key using an auth shape that can't be
+    forwarded through a gateway) is forwarded verbatim, not collapsed into
+    the generic 502 "Authorization service unavailable" that 422/5xx get."""
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={"detail": "This Bedrock provider key uses a bearer-token credential."},
+        )
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={"model": "bedrock:anthropic.claude-haiku-4-5", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "This Bedrock provider key uses a bearer-token credential."}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -154,6 +154,81 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
     ]
 
 
+def test_hybrid_mode_forwards_bedrock_extra_params(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Bedrock attempt's ``extra_params`` (region_name, aws_access_key_id)
+    reaches the ``acompletion()`` call the gateway makes — this is the wire-
+    contract field that carries AWS's mandatory region, without which boto3
+    raises ``NoRegionError`` ("You must specify a region.")."""
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json={
+                    "request_id": "bedrock-req-1",
+                    "fallback_enabled": False,
+                    "attempts": [
+                        {
+                            "attempt_id": "bedrock-att-1",
+                            "position": 0,
+                            "provider": "bedrock",
+                            "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+                            "api_key": "secret-access-key",
+                            "api_base": None,
+                            "managed": False,
+                            "extra_params": {
+                                "region_name": "us-east-1",
+                                "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+                            },
+                        }
+                    ],
+                },
+            )
+        return httpx.Response(204)
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        assert kwargs["model"] == "bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0"
+        assert kwargs["api_key"] == "secret-access-key"
+        assert kwargs["region_name"] == "us-east-1"
+        assert kwargs["aws_access_key_id"] == "AKIAIOSFODNN7EXAMPLE"
+        return ChatCompletion(
+            id="chatcmpl-bedrock",
+            object="chat.completion",
+            created=1700000000,
+            model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+            choices=[
+                Choice(
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="hello"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=CompletionUsage(prompt_tokens=10, completion_tokens=7, total_tokens=17),
+        )
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.acompletion", fake_acompletion)
+
+    response = platform_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200
+
+
 def test_hybrid_mode_forwards_session_label_and_strips_it_upstream(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -203,7 +203,7 @@ def test_hybrid_mode_forwards_bedrock_classic_key_pair_via_client_args(
 ) -> None:
     """A Bedrock attempt using the classic IAM access-key/secret-key shape
     reaches the ``acompletion()`` call under ``client_args`` (not flat), with
-    the secret aliased to ``aws_secret_access_key`` — the shape any-llm's
+    the secret aliased to ``aws_secret_access_key``: the shape any-llm's
     Bedrock provider actually reads when building its boto3 client. Without
     this, boto3 raises ``NoRegionError`` ("You must specify a region.") even
     though the gateway received the right values."""

--- a/tests/integration/test_hybrid_mode_responses.py
+++ b/tests/integration/test_hybrid_mode_responses.py
@@ -170,9 +170,10 @@ def test_hybrid_mode_forwards_extra_params(
 ) -> None:
     """The Responses adapter's own ``attempt_kwargs`` override (which does not
     delegate to ``default_attempt_kwargs``) must forward an attempt's
-    ``extra_params`` too. This is the wire-contract field that carries e.g.
-    AWS Bedrock's mandatory ``region_name`` (exercised generically here via
-    ``openai`` since Bedrock itself doesn't support the Responses API)."""
+    ``extra_params`` too, nested under ``client_args`` (not merged flat: any-llm
+    only routes a ``client_args`` mapping to the provider's client
+    constructor). Exercised generically here via ``openai`` since Bedrock
+    itself doesn't support the Responses API."""
 
     async def fake_post_platform(
         url: str,
@@ -201,7 +202,8 @@ def test_hybrid_mode_forwards_extra_params(
 
     async def fake_aresponses(**kwargs: Any) -> Response:
         assert kwargs["api_key"] == "sk-platform-key"
-        assert kwargs["region_name"] == "us-east-1"
+        assert "region_name" not in kwargs
+        assert kwargs["client_args"] == {"region_name": "us-east-1"}
         return _response_object()
 
     monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)

--- a/tests/integration/test_hybrid_mode_responses.py
+++ b/tests/integration/test_hybrid_mode_responses.py
@@ -53,8 +53,15 @@ def _resolve_payload(
     }
 
 
-def _attempt(position: int, attempt_id: str, model: str, api_key: str, provider: str = "openai") -> dict[str, Any]:
-    return {
+def _attempt(
+    position: int,
+    attempt_id: str,
+    model: str,
+    api_key: str,
+    provider: str = "openai",
+    extra_params: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    attempt: dict[str, Any] = {
         "attempt_id": attempt_id,
         "position": position,
         "provider": provider,
@@ -63,6 +70,9 @@ def _attempt(position: int, attempt_id: str, model: str, api_key: str, provider:
         "api_base": None,
         "managed": True,
     }
+    if extra_params is not None:
+        attempt["extra_params"] = extra_params
+    return attempt
 
 
 def _response_object() -> Response:
@@ -152,6 +162,58 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
             },
         }
     ]
+
+
+def test_hybrid_mode_forwards_extra_params(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Responses adapter's own ``attempt_kwargs`` override (which does not
+    delegate to ``default_attempt_kwargs``) must forward an attempt's
+    ``extra_params`` too — this is the wire-contract field that carries e.g.
+    AWS Bedrock's mandatory ``region_name`` (exercised generically here via
+    ``openai`` since Bedrock itself doesn't support the Responses API)."""
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json=_resolve_payload(
+                    [
+                        _attempt(
+                            0,
+                            "att-extra",
+                            "gpt-4o-mini",
+                            "sk-platform-key",
+                            provider="openai",
+                            extra_params={"region_name": "us-east-1"},
+                        )
+                    ],
+                    fallback_enabled=False,
+                ),
+            )
+        return httpx.Response(204)
+
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        assert kwargs["api_key"] == "sk-platform-key"
+        assert kwargs["region_name"] == "us-east-1"
+        return _response_object()
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.responses.aresponses", fake_aresponses)
+
+    response = platform_client.post(
+        "/v1/responses",
+        json={"model": "gpt-4o-mini", "input": "hi"},
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200, response.text
 
 
 @pytest.mark.parametrize(("provider", "preserves_codex_metadata"), [("openai", True), ("fireworks", False)])

--- a/tests/integration/test_hybrid_mode_responses.py
+++ b/tests/integration/test_hybrid_mode_responses.py
@@ -218,6 +218,56 @@ def test_hybrid_mode_forwards_extra_params(
     assert response.status_code == 200, response.text
 
 
+def test_hybrid_mode_rejects_caller_supplied_client_args(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The Responses request schema allows extra fields (``extra="allow"``),
+    so a caller could smuggle a ``client_args`` field into the request body.
+    An attempt with no extra_params of its own (the common case for every
+    provider except Bedrock) never sets client_args itself, so without
+    stripping it first, a caller-supplied client_args would reach the
+    provider call unfiltered — e.g. overriding client-constructor kwargs the
+    platform never authorized. client_args must be stripped the same way
+    api_key/api_base already are."""
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json=_resolve_payload(
+                    [_attempt(0, "att-1", "gpt-4o-mini", "sk-platform-key", provider="openai")],
+                    fallback_enabled=False,
+                ),
+            )
+        return httpx.Response(204)
+
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        assert kwargs["api_key"] == "sk-platform-key"
+        assert "client_args" not in kwargs
+        return _response_object()
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.responses.aresponses", fake_aresponses)
+
+    response = platform_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-4o-mini",
+            "input": "hi",
+            "client_args": {"api_key": "attacker-controlled-key"},
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200, response.text
+
+
 @pytest.mark.parametrize(("provider", "preserves_codex_metadata"), [("openai", True), ("fireworks", False)])
 def test_hybrid_mode_forwards_codex_metadata_only_to_openai(
     platform_client: TestClient,

--- a/tests/integration/test_hybrid_mode_responses.py
+++ b/tests/integration/test_hybrid_mode_responses.py
@@ -170,7 +170,7 @@ def test_hybrid_mode_forwards_extra_params(
 ) -> None:
     """The Responses adapter's own ``attempt_kwargs`` override (which does not
     delegate to ``default_attempt_kwargs``) must forward an attempt's
-    ``extra_params`` too — this is the wire-contract field that carries e.g.
+    ``extra_params`` too. This is the wire-contract field that carries e.g.
     AWS Bedrock's mandatory ``region_name`` (exercised generically here via
     ``openai`` since Bedrock itself doesn't support the Responses API)."""
 

--- a/tests/unit/test_bedrock_gateway_auth.py
+++ b/tests/unit/test_bedrock_gateway_auth.py
@@ -1,0 +1,63 @@
+"""Unit tests for building Bedrock's ``client_args`` for a hybrid-mode attempt."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gateway.services.bedrock_gateway_auth import build_bedrock_client_args
+
+
+class _FakeRequest:
+    def __init__(self) -> None:
+        self.headers: dict[str, str] = {}
+
+
+def test_classic_shape_aliases_secret_and_forwards_region() -> None:
+    """The classic IAM access-key/secret-key shape (aws_access_key_id present
+    in extra_params) forwards region_name/aws_access_key_id unchanged and
+    aliases the resolved attempt's api_key into aws_secret_access_key, since
+    any-llm-sdk's BedrockProvider never reads a plain api_key when building
+    its boto3 client."""
+    client_args = build_bedrock_client_args(
+        "my-secret-access-key",
+        {"region_name": "us-east-1", "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE"},
+    )
+
+    assert client_args == {
+        "region_name": "us-east-1",
+        "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+        "aws_secret_access_key": "my-secret-access-key",
+    }
+
+
+def test_bearer_shape_builds_client_with_injected_authorization_header() -> None:
+    """The bearer-token ("Bedrock API key") shape (no aws_access_key_id) gets
+    a pre-built, unsigned boto3 client instead of plain credential kwargs;
+    the client injects `Authorization: Bearer <token>` on every request via a
+    before-sign hook, since this boto3 version has no native support for
+    AWS_BEARER_TOKEN_BEDROCK / an aws_bearer_token constructor kwarg."""
+    client_args = build_bedrock_client_args("bearer-token-value", {"region_name": "us-west-2"})
+
+    assert client_args["region_name"] == "us-west-2"
+    client = client_args["client"]
+    assert client.meta.region_name == "us-west-2"
+
+    fake_request = _FakeRequest()
+    client.meta.events.emit("before-sign.bedrock-runtime.Converse", request=fake_request)
+    assert fake_request.headers["Authorization"] == "Bearer bearer-token-value"
+
+
+def test_bearer_shape_builds_a_distinct_client_per_call() -> None:
+    """Building a fresh client per attempt (rather than caching/sharing one)
+    keeps concurrent requests for different bearer tokens from racing on
+    shared state, matching otari.ai's own per-request client construction."""
+    first: dict[str, Any] = build_bedrock_client_args("token-a", {"region_name": "us-east-1"})
+    second: dict[str, Any] = build_bedrock_client_args("token-b", {"region_name": "us-east-1"})
+
+    assert first["client"] is not second["client"]
+
+    req_a, req_b = _FakeRequest(), _FakeRequest()
+    first["client"].meta.events.emit("before-sign.bedrock-runtime.Converse", request=req_a)
+    second["client"].meta.events.emit("before-sign.bedrock-runtime.Converse", request=req_b)
+    assert req_a.headers["Authorization"] == "Bearer token-a"
+    assert req_b.headers["Authorization"] == "Bearer token-b"

--- a/tests/unit/test_hybrid_client_args_routing.py
+++ b/tests/unit/test_hybrid_client_args_routing.py
@@ -1,0 +1,100 @@
+"""Regression tests that a hybrid-mode attempt's ``extra_params`` actually
+reach the provider's client constructor through the real any-llm SDK, not
+just that our own code produces a kwargs dict that *looks* right.
+
+``default_attempt_kwargs`` merges ``extra_params`` under ``client_args``
+specifically because any-llm's ``acompletion()`` only forwards a
+``client_args`` mapping to the provider's client constructor (everything
+else in ``**kwargs`` goes to the completion *call* instead). A test that
+monkeypatches ``acompletion`` directly (as the hybrid-mode integration tests
+do) can't catch a regression back to flat kwargs, because the fake
+``acompletion`` never exercises any-llm's own kwarg-splitting logic. These
+tests call into the real SDK, stopping only at boto3's own client
+construction (patched so no network call or real AWS credentials are
+needed), to verify the values actually land where boto3 expects them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from any_llm import acompletion
+
+from gateway.api.routes._platform import ResolvedAttempt, default_attempt_kwargs
+
+
+@pytest.mark.asyncio
+async def test_bedrock_classic_shape_client_args_reach_real_boto3_client() -> None:
+    """Reproduces the exact bug this test guards against: merging
+    region_name/aws_access_key_id flat into acompletion()'s kwargs still
+    raises botocore's NoRegionError, because any-llm forwards unrecognized
+    flat kwargs to the completion call, not boto3.client(). Nesting them
+    under client_args (what default_attempt_kwargs now does) is the only
+    way they reach boto3.client()'s own constructor kwargs."""
+    attempt = ResolvedAttempt(
+        attempt_id="a0",
+        position=0,
+        provider="bedrock",
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+        api_key="secret-access-key",
+        managed=False,
+        extra_params={"region_name": "us-east-1", "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE"},
+    )
+    kwargs = default_attempt_kwargs(attempt, {"messages": [{"role": "user", "content": "hi"}]})
+
+    captured: dict[str, Any] = {}
+
+    class _StopBeforeNetworkCall(Exception):
+        pass
+
+    def fake_boto3_client(service_name: str, **client_kwargs: Any) -> Any:
+        captured["service_name"] = service_name
+        captured.update(client_kwargs)
+        raise _StopBeforeNetworkCall
+
+    with patch("boto3.client", side_effect=fake_boto3_client):
+        with pytest.raises(_StopBeforeNetworkCall):
+            await acompletion(**kwargs)
+
+    assert captured["service_name"] == "bedrock-runtime"
+    assert captured["region_name"] == "us-east-1"
+    assert captured["aws_access_key_id"] == "AKIAIOSFODNN7EXAMPLE"
+    assert captured["aws_secret_access_key"] == "secret-access-key"
+
+
+@pytest.mark.asyncio
+async def test_bedrock_bearer_shape_uses_custom_client_not_flat_kwargs() -> None:
+    """The bearer-token shape's pre-built client (client_args["client"]) is
+    what any-llm's BedrockProvider actually uses; boto3.client() is never
+    called a second time for it."""
+    attempt = ResolvedAttempt(
+        attempt_id="a0",
+        position=0,
+        provider="bedrock",
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+        api_key="bearer-token-value",
+        managed=False,
+        extra_params={"region_name": "us-west-2"},
+    )
+    kwargs = default_attempt_kwargs(attempt, {"messages": [{"role": "user", "content": "hi"}]})
+
+    client_args = kwargs["client_args"]
+    assert "client" in client_args
+    injected_client = client_args["client"]
+
+    class _StopBeforeNetworkCall(Exception):
+        pass
+
+    def fake_converse(**_call_kwargs: Any) -> Any:
+        raise _StopBeforeNetworkCall
+
+    with patch("boto3.client") as fake_boto3_client:
+        with patch.object(injected_client, "converse", side_effect=fake_converse):
+            with pytest.raises(_StopBeforeNetworkCall):
+                await acompletion(**kwargs)
+        # any-llm-sdk's BedrockProvider._init_client honors the pre-built
+        # client and skips constructing its own; boto3.client() is
+        # untouched for the runtime client in this shape.
+        fake_boto3_client.assert_not_called()

--- a/tests/unit/test_run_platform_attempts.py
+++ b/tests/unit/test_run_platform_attempts.py
@@ -17,7 +17,7 @@ import pytest
 from fastapi import HTTPException
 
 from gateway.api.routes import _platform
-from gateway.api.routes._platform import ResolvedAttempt, ResolvedRoute, run_platform_attempts
+from gateway.api.routes._platform import ResolvedAttempt, ResolvedRoute, default_attempt_kwargs, run_platform_attempts
 from gateway.core.config import GatewayConfig
 from gateway.metrics import REGISTRY
 from gateway.services.mcp_loop import MaxToolIterationsExceeded
@@ -130,6 +130,62 @@ async def test_locked_in_failure_not_counted_as_abandoned() -> None:
         )
 
     assert _abandoned_sample("anthropic", "claude-locked", "upstream_error", 0) == before
+
+
+def test_default_attempt_kwargs_omits_extra_params_when_unset() -> None:
+    """Most providers' attempts carry no ``extra_params``; the kwargs shape is
+    unchanged from before the field existed."""
+    attempt = _single_attempt("openai", "gpt-4o-mini")
+
+    kwargs = default_attempt_kwargs(attempt, {"temperature": 0.2})
+
+    assert kwargs == {
+        "api_key": "k",
+        "temperature": 0.2,
+        "model": "openai:gpt-4o-mini",
+    }
+
+
+def test_default_attempt_kwargs_forwards_extra_params() -> None:
+    """A Bedrock-shaped attempt's ``extra_params`` (region_name plus, for the
+    classic IAM key-pair shape, aws_access_key_id) is forwarded verbatim into
+    the kwargs handed to ``acompletion()``."""
+    attempt = ResolvedAttempt(
+        attempt_id="a0",
+        position=0,
+        provider="bedrock",
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+        api_key="secret-access-key",
+        managed=False,
+        extra_params={"region_name": "us-east-1", "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE"},
+    )
+
+    kwargs = default_attempt_kwargs(attempt, {})
+
+    assert kwargs["region_name"] == "us-east-1"
+    assert kwargs["aws_access_key_id"] == "AKIAIOSFODNN7EXAMPLE"
+    assert kwargs["api_key"] == "secret-access-key"
+    assert kwargs["model"] == "bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0"
+
+
+def test_default_attempt_kwargs_extra_params_not_overridable_by_request_fields() -> None:
+    """``extra_params`` is platform-trusted and must win over a same-named
+    field in the caller's own request body, exactly like ``api_key``/``model``
+    already do — a request cannot smuggle a different region past the
+    platform's resolved credentials."""
+    attempt = ResolvedAttempt(
+        attempt_id="a0",
+        position=0,
+        provider="bedrock",
+        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
+        api_key="secret-access-key",
+        managed=False,
+        extra_params={"region_name": "us-east-1"},
+    )
+
+    kwargs = default_attempt_kwargs(attempt, {"region_name": "attacker-controlled-region"})
+
+    assert kwargs["region_name"] == "us-east-1"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_run_platform_attempts.py
+++ b/tests/unit/test_run_platform_attempts.py
@@ -171,7 +171,7 @@ def test_default_attempt_kwargs_forwards_extra_params() -> None:
 def test_default_attempt_kwargs_extra_params_not_overridable_by_request_fields() -> None:
     """``extra_params`` is platform-trusted and must win over a same-named
     field in the caller's own request body, exactly like ``api_key``/``model``
-    already do — a request cannot smuggle a different region past the
+    already do: a request cannot smuggle a different region past the
     platform's resolved credentials."""
     attempt = ResolvedAttempt(
         attempt_id="a0",

--- a/tests/unit/test_run_platform_attempts.py
+++ b/tests/unit/test_run_platform_attempts.py
@@ -146,10 +146,34 @@ def test_default_attempt_kwargs_omits_extra_params_when_unset() -> None:
     }
 
 
-def test_default_attempt_kwargs_forwards_extra_params() -> None:
-    """A Bedrock-shaped attempt's ``extra_params`` (region_name plus, for the
-    classic IAM key-pair shape, aws_access_key_id) is forwarded verbatim into
-    the kwargs handed to ``acompletion()``."""
+def test_default_attempt_kwargs_forwards_extra_params_as_client_args() -> None:
+    """A generic (non-Bedrock) attempt's ``extra_params`` is nested under
+    ``client_args``, not merged flat: any-llm's ``acompletion()`` only routes
+    a ``client_args`` mapping to the provider's client constructor, so a flat
+    top-level key would silently reach the completion call instead."""
+    attempt = ResolvedAttempt(
+        attempt_id="a0",
+        position=0,
+        provider="openai",
+        model="gpt-4o-mini",
+        api_key="sk-...",
+        managed=False,
+        extra_params={"some_client_kwarg": "value"},
+    )
+
+    kwargs = default_attempt_kwargs(attempt, {})
+
+    assert kwargs["client_args"] == {"some_client_kwarg": "value"}
+    assert "some_client_kwarg" not in kwargs
+    assert kwargs["api_key"] == "sk-..."
+    assert kwargs["model"] == "openai:gpt-4o-mini"
+
+
+def test_default_attempt_kwargs_forwards_bedrock_extra_params_via_client_args() -> None:
+    """A Bedrock classic-IAM-pair attempt's ``extra_params`` reaches
+    ``client_args`` with the secret aliased to ``aws_secret_access_key``,
+    which any-llm's Bedrock provider actually reads when building its boto3
+    client (unlike a plain ``api_key``)."""
     attempt = ResolvedAttempt(
         attempt_id="a0",
         position=0,
@@ -162,30 +186,33 @@ def test_default_attempt_kwargs_forwards_extra_params() -> None:
 
     kwargs = default_attempt_kwargs(attempt, {})
 
-    assert kwargs["region_name"] == "us-east-1"
-    assert kwargs["aws_access_key_id"] == "AKIAIOSFODNN7EXAMPLE"
+    assert kwargs["client_args"] == {
+        "region_name": "us-east-1",
+        "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+        "aws_secret_access_key": "secret-access-key",
+    }
     assert kwargs["api_key"] == "secret-access-key"
     assert kwargs["model"] == "bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0"
 
 
-def test_default_attempt_kwargs_extra_params_not_overridable_by_request_fields() -> None:
-    """``extra_params`` is platform-trusted and must win over a same-named
-    field in the caller's own request body, exactly like ``api_key``/``model``
-    already do: a request cannot smuggle a different region past the
-    platform's resolved credentials."""
+def test_default_attempt_kwargs_client_args_not_overridable_by_request_fields() -> None:
+    """``client_args`` (built from the platform-trusted ``extra_params``) must
+    win over a same-named field in the caller's own request body, exactly
+    like ``api_key``/``model`` already do: a request cannot smuggle its own
+    client_args past the platform's resolved credentials."""
     attempt = ResolvedAttempt(
         attempt_id="a0",
         position=0,
-        provider="bedrock",
-        model="anthropic.claude-3-5-sonnet-20241022-v2:0",
-        api_key="secret-access-key",
+        provider="openai",
+        model="gpt-4o-mini",
+        api_key="sk-...",
         managed=False,
-        extra_params={"region_name": "us-east-1"},
+        extra_params={"some_client_kwarg": "platform-value"},
     )
 
-    kwargs = default_attempt_kwargs(attempt, {"region_name": "attacker-controlled-region"})
+    kwargs = default_attempt_kwargs(attempt, {"client_args": {"some_client_kwarg": "attacker-controlled"}})
 
-    assert kwargs["region_name"] == "us-east-1"
+    assert kwargs["client_args"] == {"some_client_kwarg": "platform-value"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Hybrid-mode requests routed to AWS Bedrock always failed with botocore's `NoRegionError` ("You must specify a region.") because the hybrid wire contract had no way to carry a provider-specific credential field like Bedrock's mandatory `region_name` from the platform's resolve response through to the `acompletion()` call.

Root cause: `ResolvedAttempt` / `default_attempt_kwargs()` (`src/gateway/api/routes/_platform.py`) only ever forwarded `api_key` and an optional `api_base`. Standalone mode already supports arbitrary passthrough kwargs (`providers.bedrock.region_name` in `config.yml` via `get_provider_kwargs()`), but hybrid mode's per-request credential resolution had no equivalent. Any-llm's `BedrockProvider._init_client` builds its boto3 client with no default region, so a Bedrock attempt was unusable through hybrid mode on both a self-hosted gateway and mozilla.ai's own default gateway, regardless of how the operator's own AWS credentials were configured.

**Update:** the first commit's fix (merging `extra_params` flat into the completion kwargs) turned out not to actually work against the real any-llm SDK — see "Follow-up fix" below. The second commit corrects it and also adds support for AWS Bedrock's bearer-token ("Bedrock API key") credential shape, which the first commit's docs incorrectly described as unrepresentable over the wire.

### What this PR does

- `ResolvedAttempt` gains `extra_params: dict[str, str] | None`, parsed from both the multi-attempt and legacy single-attempt resolve payload shapes in `_parse_resolve_payload`.
- `default_attempt_kwargs()` merges `extra_params` (nested under `client_args`, see below) in after the caller's own request fields and before the forced `model` key, so it can never be shadowed by a same-named field in the request body: the same non-overridable treatment `api_key`/`model` already get.
- `responses.py`'s own `attempt_kwargs` override (it doesn't delegate to `default_attempt_kwargs`) gets the identical treatment.
- `docs/hybrid-mode-protocol.md`: documents the new field and its non-overridable precedence.

### Follow-up fix (second commit): `client_args`, not flat kwargs

any-llm's `acompletion()` only forwards a separate `client_args` mapping to the provider's client constructor (`AnyLLM.create(provider, api_key=..., api_base=..., **client_args)`); everything else in `**kwargs` goes to the completion *call* instead. The first commit merged `extra_params` flat, so `region_name`/`aws_access_key_id` landed in the completion call and never reached `boto3.client()` — feeding that commit's own `default_attempt_kwargs()` output straight into the real SDK still raised `NoRegionError`. All the original tests passed only because they monkeypatched `acompletion()`/`aresponses()` directly, which never exercises any-llm's own kwarg-splitting.

The fix:
- `default_attempt_kwargs()`/`responses.py` now nest `extra_params` under `client_args`.
- New `src/gateway/services/bedrock_gateway_auth.py` adds Bedrock-specific handling on top of that, since any-llm's `BedrockProvider` never reads a plain `api_key` when building its boto3 client, and AWS has two credential shapes:
  - Classic IAM access-key/secret-key pair: aliases the secret into `client_args["aws_secret_access_key"]`.
  - Bearer token ("Bedrock API key", no `aws_access_key_id`): builds an unsigned boto3 `bedrock-runtime` client with the `Authorization: Bearer` header injected via a `before-sign` hook (mirroring otari.ai's own in-process `bedrock_bearer_auth.py`), passed as `client_args["client"]`. The pinned boto3 version has no native `AWS_BEARER_TOKEN_BEDROCK`/`aws_bearer_token` support, so this hook is the only way to authenticate this shape today. This corrects the first commit's overly pessimistic doc claim (also flagged by CodeRabbit) that this shape "can't cross the wire": the token itself is a plain string, and the in-process client can be built by whichever process actually calls boto3, which is the gateway for gateway-routed traffic, not the platform.
- New `tests/unit/test_hybrid_client_args_routing.py` exercises the real any-llm SDK (patching only `boto3.client`, not `acompletion`) so this class of bug can't silently regress again; it fails against the first commit's implementation and passes against the second.

This is one half of a two-repo fix. The platform side (populating `extra_params` in the `/gateway/provider-keys/resolve` response as a plain passthrough for both credential shapes, no secret aliasing) is mozilla-ai/otari-ai#1534.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Companion PR: mozilla-ai/otari-ai#1534

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). N/A: `ResolvedAttempt`/`ResolvedRoute` are internal types for the hybrid-mode platform client, not exposed on any gateway-facing route; `make openapi-check` passes unchanged.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** OpenCode (Claude Sonnet 5), driven from a shared session that also implemented the companion mozilla-ai/otari-ai#1534 change.

**Any additional AI details you'd like to share:**

Root-caused from a pasted gateway error log ("All streaming attempts failed ... You must specify a region."), by tracing through the hybrid-mode streaming fallback path, any-llm's Bedrock provider, and a sibling in-progress worktree of the otari-ai platform repo that was adding Bedrock provider-key support but hadn't yet wired it through the gateway-resolve response. The first commit's fix was validated only against mocked `acompletion` calls; testing it against the real any-llm SDK during a live debugging session (asked to reproduce a user's curl request against a locally running gateway) surfaced that it didn't actually work, which the second commit corrects, along with adding the bearer-token credential shape the user explicitly asked for.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added provider-specific `extra_params` support for hybrid-mode attempts.
- Forwarded these parameters through `client_args` for chat and Responses requests.
- Added Bedrock support for IAM credentials and bearer tokens.
- Protected platform-supplied client settings from request-field overrides.
- Forwarded HTTP 400 resolve errors to clients.
- Documented the protocol and Bedrock credential changes.
- Added unit and integration tests, including tests with the real any-llm SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->