### PR TITLE
chore: add CODEOWNERS for open-core boundary guardrails

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS — open-core boundary guardrails.
+# Auto-requests a boundary-aware reviewer on the paths that define the open-core
+# boundary, so it can't drift unreviewed. No catch-all: only the guardrails are owned.
+
+/ARCHITECTURE.md                @mozilla-ai/otari-team
+/scripts/check_architecture.py  @mozilla-ai/otari-team
+/.github/CODEOWNERS             @mozilla-ai/otari-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# CODEOWNERS — open-core boundary guardrails.
+# CODEOWNERS: open-core boundary guardrails.
 # Auto-requests a boundary-aware reviewer on the paths that define the open-core
 # boundary, so it can't drift unreviewed. No catch-all: only the guardrails are owned.
 


### PR DESCRIPTION
## Description

Adds `.github/CODEOWNERS` so a boundary-aware reviewer is auto-requested on the paths that define the open-core boundary — `ARCHITECTURE.md` and `scripts/check_architecture.py` — so the boundary can't drift unreviewed. Owner is `@mozilla-ai/otari-team` (already has `maintain` on this repo). There is no catch-all owner; only the guardrail paths are owned, and enforcement is auto-request only (no merge-blocking ruleset).

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

None — repository governance.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). — N/A: CODEOWNERS config, no code paths to test.
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). — N/A: no code changed.
- [x] Documentation was updated where necessary. — None needed.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). — N/A: no API change.

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Claude Opus)

**Any additional AI details you'd like to share:** The CODEOWNERS file and this PR description were drafted with AI assistance and reviewed by the author.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added `.github/CODEOWNERS`.
- Assigned `@mozilla-ai/otari-team` to `ARCHITECTURE.md`, `scripts/check_architecture.py`, and `.github/CODEOWNERS`.
- Ensures open-core boundary changes receive an automatic review request from the responsible team.
- Does not add catch-all ownership or merge-blocking rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->