### PR TITLE
fix(hybrid): prevent pending cost calculations when fallback attempts stop

### DIFF
--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -257,7 +257,7 @@ Content-Type: application/json
   "correlation_id": "01HX1...",       // = the attempt_id from the resolve response
   "status": "success" | "error",
   "is_final_attempt": true,            // no later planned fallback will run
-  "usage": {                           // present on success only
+  "usage": {                           // present on success when usage is available
     "prompt_tokens": 13,
     "completion_tokens": 7,
     "total_tokens": 20,
@@ -271,6 +271,10 @@ Content-Type: application/json
                                        // label (see below). Omitted when absent.
 }
 ```
+
+A successful attempt that completes without provider usage data still sends a
+final report, but omits `usage` so the platform can record it as unavailable
+rather than as an explicit zero-token result.
 
 `session_label` is an optional caller-supplied label for cost attribution (per
 run, experiment, or conversation). A caller sets it on the request body

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -256,6 +256,7 @@ Content-Type: application/json
 {
   "correlation_id": "01HX1...",       // = the attempt_id from the resolve response
   "status": "success" | "error",
+  "is_final_attempt": true,            // no later planned fallback will run
   "usage": {                           // present on success only
     "prompt_tokens": 13,
     "completion_tokens": 7,
@@ -306,6 +307,13 @@ dropping it. See companion issue mozilla-ai/otari-ai#1168.
 A multi-attempt request that iterates two attempts produces two usage reports,
 one per attempt, sharing the same `request_id` (recoverable via the original
 resolve response). The platform is responsible for correlating them.
+
+`is_final_attempt` tells the platform that the gateway will not try another
+planned fallback. It is `false` for a retryable failure followed by another
+attempt, and `true` for success, fallback exhaustion, a non-retryable failure,
+or a failure after a tool loop has locked in to one provider. The marker lets
+the platform ignore later planned attempts that were never tried instead of
+waiting forever for usage reports that will never arrive.
 
 `error_class` is a short tag describing why the attempt was abandoned:
 

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -2038,6 +2038,7 @@ def build_streaming_response(
                     outcome="success",
                     usage=usage_data,
                     session_label=session_label,
+                    is_final_attempt=True,
                 ),
                 platform_correlation_id,
             )
@@ -2111,6 +2112,7 @@ def build_streaming_response(
                     outcome="error",
                     usage=None,
                     session_label=session_label,
+                    is_final_attempt=True,
                 ),
                 platform_correlation_id,
             )
@@ -2339,7 +2341,7 @@ async def run_single_attempt_stream(
 
 async def _flush_pending_usage_reports(
     config: GatewayConfig,
-    pending_error_reports: list[tuple[str, str, Any, str | None]],
+    pending_error_reports: list[tuple[str, str, Any, str | None, bool]],
     request_id: str,
     session_label: str | None = None,
 ) -> None:
@@ -2364,8 +2366,16 @@ async def _flush_pending_usage_reports(
         results = await asyncio.wait_for(
             asyncio.gather(
                 *(
-                    _report_platform_usage(config, attempt_id, outcome, usage, error_class, session_label)
-                    for attempt_id, outcome, usage, error_class in pending_error_reports
+                    _report_platform_usage(
+                        config,
+                        attempt_id,
+                        outcome,
+                        usage,
+                        error_class,
+                        session_label,
+                        is_final_attempt,
+                    )
+                    for attempt_id, outcome, usage, error_class, is_final_attempt in pending_error_reports
                 ),
                 return_exceptions=True,
             ),
@@ -2468,7 +2478,7 @@ async def run_streaming_with_fallback(
     # for the success path (it flushes once the SSE response completes), but
     # also stash the error reports so they can be flushed inline on the
     # all-failed path below.
-    pending_error_reports: list[tuple[str, str, Any, str | None]] = []
+    pending_error_reports: list[tuple[str, str, Any, str | None, bool]] = []
 
     async def _on_attempt_failed(attempt: ResolvedAttempt, failure: StreamingAttemptFailure) -> None:
         background_tasks.add_task(
@@ -2479,8 +2489,11 @@ async def run_streaming_with_fallback(
             None,
             failure.error_class,
             session_label,
+            failure.is_final_attempt,
         )
-        pending_error_reports.append((attempt.attempt_id, "error", None, failure.error_class))
+        pending_error_reports.append(
+            (attempt.attempt_id, "error", None, failure.error_class, failure.is_final_attempt)
+        )
         record_abandoned_attempt(attempt.provider, attempt.model, failure.reason, attempt.position)
         logger.warning(
             "Streaming attempt failed request_id=%s position=%d provider=%s model=%s error=%s",
@@ -2630,13 +2643,14 @@ async def run_platform_non_stream(
     # can't fire its fallback-exhausted accounting. Keep the background task for
     # the success-response path (non-blocking), but also stash the error reports
     # so they can be flushed inline if the request ends in an exception.
-    pending_error_reports: list[tuple[str, str, Any, str | None]] = []
+    pending_error_reports: list[tuple[str, str, Any, str | None, bool]] = []
 
     def _report_attempt_outcome(
         attempt: ResolvedAttempt,
         outcome: str,
         usage: Any,
         error_class: str | None,
+        is_final_attempt: bool,
     ) -> None:
         background_tasks.add_task(
             _report_platform_usage,
@@ -2646,9 +2660,10 @@ async def run_platform_non_stream(
             usage,
             error_class,
             session_label,
+            is_final_attempt,
         )
         if outcome != "success":
-            pending_error_reports.append((attempt.attempt_id, outcome, usage, error_class))
+            pending_error_reports.append((attempt.attempt_id, outcome, usage, error_class, is_final_attempt))
 
     def _on_attempt_success(attempt: ResolvedAttempt) -> None:
         response.headers["X-Correlation-ID"] = attempt.attempt_id

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -2062,8 +2062,23 @@ def build_streaming_response(
             await reconcile_reservation(db, reservation, actual_cost or 0.0)
 
     async def _on_no_usage() -> None:
-        # Stream completed but the provider sent no usage data. Settle the
+        # Stream completed but the provider sent no usage data. Report the
+        # terminal success upstream in hybrid mode; standalone settles the
         # reservation per stream_missing_usage_policy instead of billing $0.
+        if platform_active:
+            assert platform_correlation_id is not None
+            _schedule_usage_report(
+                _report_platform_usage(
+                    config=config,
+                    correlation_id=platform_correlation_id,
+                    outcome="success",
+                    usage=None,
+                    session_label=session_label,
+                    is_final_attempt=True,
+                ),
+                platform_correlation_id,
+            )
+            return
         if db is None or log_writer is None or reservation is None:
             return
         policy = config.stream_missing_usage_policy

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -214,6 +214,14 @@ class ProviderErrorMapping(NamedTuple):
     detail: str
 
 
+class _PendingUsageReport(NamedTuple):
+    attempt_id: str
+    outcome: str
+    usage: Any
+    error_class: str | None
+    is_final_attempt: bool
+
+
 def _upstream_error_param(exc: BaseException) -> str | None:
     """Pull the offending request field off an upstream exception, if it names one.
 
@@ -2356,7 +2364,7 @@ async def run_single_attempt_stream(
 
 async def _flush_pending_usage_reports(
     config: GatewayConfig,
-    pending_error_reports: list[tuple[str, str, Any, str | None, bool]],
+    pending_error_reports: list[_PendingUsageReport],
     request_id: str,
     session_label: str | None = None,
 ) -> None:
@@ -2383,14 +2391,14 @@ async def _flush_pending_usage_reports(
                 *(
                     _report_platform_usage(
                         config,
-                        attempt_id,
-                        outcome,
-                        usage,
-                        error_class,
+                        report.attempt_id,
+                        report.outcome,
+                        report.usage,
+                        report.error_class,
                         session_label,
-                        is_final_attempt=is_final_attempt,
+                        is_final_attempt=report.is_final_attempt,
                     )
-                    for attempt_id, outcome, usage, error_class, is_final_attempt in pending_error_reports
+                    for report in pending_error_reports
                 ),
                 return_exceptions=True,
             ),
@@ -2493,7 +2501,7 @@ async def run_streaming_with_fallback(
     # for the success path (it flushes once the SSE response completes), but
     # also stash the error reports so they can be flushed inline on the
     # all-failed path below.
-    pending_error_reports: list[tuple[str, str, Any, str | None, bool]] = []
+    pending_error_reports: list[_PendingUsageReport] = []
 
     async def _on_attempt_failed(attempt: ResolvedAttempt, failure: StreamingAttemptFailure) -> None:
         background_tasks.add_task(
@@ -2507,7 +2515,13 @@ async def run_streaming_with_fallback(
             is_final_attempt=failure.is_final_attempt,
         )
         pending_error_reports.append(
-            (attempt.attempt_id, "error", None, failure.error_class, failure.is_final_attempt)
+            _PendingUsageReport(
+                attempt_id=attempt.attempt_id,
+                outcome="error",
+                usage=None,
+                error_class=failure.error_class,
+                is_final_attempt=failure.is_final_attempt,
+            )
         )
         record_abandoned_attempt(attempt.provider, attempt.model, failure.reason, attempt.position)
         logger.warning(
@@ -2658,7 +2672,7 @@ async def run_platform_non_stream(
     # can't fire its fallback-exhausted accounting. Keep the background task for
     # the success-response path (non-blocking), but also stash the error reports
     # so they can be flushed inline if the request ends in an exception.
-    pending_error_reports: list[tuple[str, str, Any, str | None, bool]] = []
+    pending_error_reports: list[_PendingUsageReport] = []
 
     def _report_attempt_outcome(
         attempt: ResolvedAttempt,
@@ -2678,7 +2692,15 @@ async def run_platform_non_stream(
             is_final_attempt=is_final_attempt,
         )
         if outcome != "success":
-            pending_error_reports.append((attempt.attempt_id, outcome, usage, error_class, is_final_attempt))
+            pending_error_reports.append(
+                _PendingUsageReport(
+                    attempt_id=attempt.attempt_id,
+                    outcome=outcome,
+                    usage=usage,
+                    error_class=error_class,
+                    is_final_attempt=is_final_attempt,
+                )
+            )
 
     def _on_attempt_success(attempt: ResolvedAttempt) -> None:
         response.headers["X-Correlation-ID"] = attempt.attempt_id

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -2373,7 +2373,7 @@ async def _flush_pending_usage_reports(
                         usage,
                         error_class,
                         session_label,
-                        is_final_attempt,
+                        is_final_attempt=is_final_attempt,
                     )
                     for attempt_id, outcome, usage, error_class, is_final_attempt in pending_error_reports
                 ),
@@ -2489,7 +2489,7 @@ async def run_streaming_with_fallback(
             None,
             failure.error_class,
             session_label,
-            failure.is_final_attempt,
+            is_final_attempt=failure.is_final_attempt,
         )
         pending_error_reports.append(
             (attempt.attempt_id, "error", None, failure.error_class, failure.is_final_attempt)
@@ -2660,7 +2660,7 @@ async def run_platform_non_stream(
             usage,
             error_class,
             session_label,
-            is_final_attempt,
+            is_final_attempt=is_final_attempt,
         )
         if outcome != "success":
             pending_error_reports.append((attempt.attempt_id, outcome, usage, error_class, is_final_attempt))

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -276,6 +276,7 @@ async def run_platform_attempts(
         except HTTPException:
             raise
         except MaxToolIterationsExceeded as exc:
+            report_attempt_outcome(attempt, "error", None, None, True)
             logger.warning(
                 "Tool loop iteration cap hit request_id=%s position=%d cap=%d",
                 route.request_id,
@@ -289,9 +290,10 @@ async def run_platform_attempts(
         except (SandboxNotReachableError, WebSearchNotReachableError):
             # Gateway-side backend failure, not an upstream provider error:
             # the same backend serves every attempt, so falling through cannot
-            # help, and reporting it as a provider attempt error would be
-            # wrong. Propagate raw so ``run_platform_non_stream`` maps it to a
+            # help. Report a terminal outcome without a provider error class,
+            # then propagate raw so ``run_platform_non_stream`` maps it to a
             # 502 with the backend-specific detail.
+            report_attempt_outcome(attempt, "error", None, None, True)
             raise
         except BaseException as exc:
             retryable, error_class = classify_error(exc)

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -828,14 +828,14 @@ async def _report_platform_usage(
     if normalized_label:
         payload["session_label"] = normalized_label
     if outcome == "success":
-        token_usage = usage or CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
-        payload["usage"] = {
-            "prompt_tokens": token_usage.prompt_tokens,
-            "completion_tokens": token_usage.completion_tokens,
-            "total_tokens": token_usage.total_tokens,
-            "cache_read_tokens": cache_read_tokens_of(token_usage),
-            "cache_write_tokens": cache_write_tokens_of(token_usage),
-        }
+        if usage is not None:
+            payload["usage"] = {
+                "prompt_tokens": usage.prompt_tokens,
+                "completion_tokens": usage.completion_tokens,
+                "total_tokens": usage.total_tokens,
+                "cache_read_tokens": cache_read_tokens_of(usage),
+                "cache_write_tokens": cache_write_tokens_of(usage),
+            }
     elif error_class is not None:
         payload["error_class"] = error_class
 

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -197,7 +197,7 @@ async def run_platform_attempts(
     run_attempt: Callable[[dict[str, Any], Callable[[], None]], Awaitable[T]],
     extract_usage: Callable[[T], Any],
     classify_error: Callable[[BaseException], tuple[bool, str]],
-    report_attempt_outcome: Callable[[ResolvedAttempt, str, Any, str | None], None],
+    report_attempt_outcome: Callable[[ResolvedAttempt, str, Any, str | None, bool], None],
     on_success: Callable[[ResolvedAttempt], None],
     max_tool_iterations: int,
 ) -> T:
@@ -250,8 +250,9 @@ async def run_platform_attempts(
     failures: list[_AttemptFailure] = []
     last_exc: BaseException | None = None
 
-    for attempt in attempts:
+    for index, attempt in enumerate(attempts):
         completion_kwargs = default_attempt_kwargs(attempt, base_request_fields)
+        is_last_planned_attempt = index == len(attempts) - 1
 
         # Per-attempt lock-in flag. Flipped the moment the upstream returns
         # its first assistant message via the ``_mark_locked_in`` callback
@@ -294,7 +295,8 @@ async def run_platform_attempts(
             raise
         except BaseException as exc:
             retryable, error_class = classify_error(exc)
-            report_attempt_outcome(attempt, "error", None, error_class)
+            is_final_attempt = locked_in or not retryable or is_last_planned_attempt
+            report_attempt_outcome(attempt, "error", None, error_class, is_final_attempt)
             logger.warning(
                 "Provider call failed request_id=%s position=%d provider=%s model=%s "
                 "error=%s retryable=%s locked_in=%s",
@@ -326,7 +328,7 @@ async def run_platform_attempts(
             continue
 
         # Success on this attempt.
-        report_attempt_outcome(attempt, "success", extract_usage(result), None)
+        report_attempt_outcome(attempt, "success", extract_usage(result), None, True)
         on_success(attempt)
         return result
 
@@ -792,11 +794,13 @@ async def _report_platform_usage(
     usage: CompletionUsage | None,
     error_class: str | None = None,
     session_label: str | None = None,
+    is_final_attempt: bool = False,
 ) -> None:
     """POST a usage record back to the platform with bounded retries.
 
-    Best-effort — failures are swallowed after ``max_retries`` so they don't
-    impact the user's response path. Non-retryable status codes (auth /
+    ``is_final_attempt`` tells the platform that no later planned fallback will
+    run. Failures are swallowed after ``max_retries`` so they don't impact the
+    user's response path. Non-retryable status codes (auth /
     payment-required / not-found / conflict / unprocessable) short-circuit the
     retry loop.
     """
@@ -809,7 +813,11 @@ async def _report_platform_usage(
     usage_url = _platform_url(platform_base_url, "/gateway/usage")
     headers = {"X-Gateway-Token": config.platform_token or ""}
 
-    payload: dict[str, Any] = {"correlation_id": correlation_id, "status": outcome}
+    payload: dict[str, Any] = {
+        "correlation_id": correlation_id,
+        "status": outcome,
+        "is_final_attempt": is_final_attempt,
+    }
     # Forward the caller's session label so the platform can attribute this
     # attempt's spend. Blank is treated as absent; the body field already caps
     # length, so the platform never has to truncate.

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -794,7 +794,8 @@ async def _report_platform_usage(
     usage: CompletionUsage | None,
     error_class: str | None = None,
     session_label: str | None = None,
-    is_final_attempt: bool = False,
+    *,
+    is_final_attempt: bool,
 ) -> None:
     """POST a usage record back to the platform with bounded retries.
 

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -21,6 +21,7 @@ from gateway.api.routes._pipeline import (
     NO_RESOLVABLE_PROVIDER_DETAIL,
     PROVIDER_ERROR_DETAIL,
     ErrorKind,
+    _flush_pending_usage_reports,
     classify_provider_error,
     prepare_gateway_tools,
     raise_all_streaming_attempts_failed,
@@ -389,8 +390,21 @@ async def create_response(
     if ctx.hybrid_mode:
         route = ctx.route
         assert route is not None  # guaranteed by the hybrid-mode preamble
-        for attempt in route.attempts:
-            _ensure_provider_supports_responses(LLMProvider(attempt.provider))
+        try:
+            for attempt in route.attempts:
+                _ensure_provider_supports_responses(LLMProvider(attempt.provider))
+        except HTTPException:
+            if route.attempts:
+                # No provider call ran, so attach the preflight rejection to
+                # the first attempt and mark it final so later entries are unused.
+                first_attempt = route.attempts[0]
+                await _flush_pending_usage_reports(
+                    config,
+                    [(first_attempt.attempt_id, "error", None, None, True)],
+                    route.request_id,
+                    request_body.session_label,
+                )
+            raise
     else:
         resolved = await resolve_dispatch_provider(ctx, config, request_body.model, adapter=_ADAPTER)
         # ``provider`` is the underlying implementation handed to any-llm;

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -22,6 +22,7 @@ from gateway.api.routes._pipeline import (
     PROVIDER_ERROR_DETAIL,
     ErrorKind,
     _flush_pending_usage_reports,
+    _PendingUsageReport,
     classify_provider_error,
     prepare_gateway_tools,
     raise_all_streaming_attempts_failed,
@@ -400,7 +401,15 @@ async def create_response(
                 first_attempt = route.attempts[0]
                 await _flush_pending_usage_reports(
                     config,
-                    [(first_attempt.attempt_id, "error", None, None, True)],
+                    [
+                        _PendingUsageReport(
+                            attempt_id=first_attempt.attempt_id,
+                            outcome="error",
+                            usage=None,
+                            error_class=None,
+                            is_final_attempt=True,
+                        )
+                    ],
                     route.request_id,
                     request_body.session_label,
                 )

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -35,11 +35,13 @@ class StreamingAttemptFailure:
     is the coarse phase bucket for metrics: ``build_error`` when opening the
     stream failed, ``timeout`` when the first-chunk wait elapsed, or
     ``upstream_error`` when the upstream raised before yielding a chunk.
+    ``is_final_attempt`` is true when no later planned fallback will run.
     """
 
     error_class: str
     exception: BaseException
     reason: str
+    is_final_attempt: bool
 
 
 @dataclass(frozen=True)
@@ -236,7 +238,15 @@ async def iterate_streaming_attempts(
             stream = await build_stream(attempt)
         except BaseException as exc:
             retryable, error_class = classify_error(exc)
-            await on_attempt_failed(attempt, StreamingAttemptFailure(error_class, exc, reason="build_error"))
+            await on_attempt_failed(
+                attempt,
+                StreamingAttemptFailure(
+                    error_class,
+                    exc,
+                    reason="build_error",
+                    is_final_attempt=is_final_attempt or not retryable,
+                ),
+            )
             last_exception = exc
             if not retryable:
                 raise
@@ -263,14 +273,27 @@ async def iterate_streaming_attempts(
         except asyncio.TimeoutError as exc:
             await on_attempt_failed(
                 attempt,
-                StreamingAttemptFailure("timeout", exc, reason="timeout"),
+                StreamingAttemptFailure(
+                    "timeout",
+                    exc,
+                    reason="timeout",
+                    is_final_attempt=is_final_attempt,
+                ),
             )
             await _close_stream_quietly(stream)
             last_exception = exc
             continue
         except BaseException as exc:
             retryable, error_class = classify_error(exc)
-            await on_attempt_failed(attempt, StreamingAttemptFailure(error_class, exc, reason="upstream_error"))
+            await on_attempt_failed(
+                attempt,
+                StreamingAttemptFailure(
+                    error_class,
+                    exc,
+                    reason="upstream_error",
+                    is_final_attempt=is_final_attempt or not retryable,
+                ),
+            )
             await _close_stream_quietly(stream)
             last_exception = exc
             if not retryable:

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -1916,6 +1916,8 @@ def test_platform_mode_sandbox_unreachable_returns_502(
     from gateway.api.routes._pipeline import SANDBOX_UNREACHABLE_DETAIL
     from gateway.services.sandbox_backend import SandboxNotReachableError
 
+    usage_reports: list[dict[str, Any]] = []
+
     async def fake_post_platform(
         url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
     ) -> httpx.Response:
@@ -1923,6 +1925,7 @@ def test_platform_mode_sandbox_unreachable_returns_502(
             return _single_attempt_resolve_response(request_id="sbx-down")
         if url.endswith("/gateway/code-execution/resolve"):
             return httpx.Response(200, json={"enabled": True})
+        usage_reports.append(body)
         return httpx.Response(204)
 
     class _DownSandboxBackend:
@@ -1950,6 +1953,13 @@ def test_platform_mode_sandbox_unreachable_returns_502(
 
     assert response.status_code == 502
     assert response.json() == {"detail": SANDBOX_UNREACHABLE_DETAIL}
+    assert usage_reports == [
+        {
+            "correlation_id": "sbx-down",
+            "status": "error",
+            "is_final_attempt": True,
+        }
+    ]
 
 
 def test_platform_mode_web_search_unreachable_returns_502(
@@ -1963,6 +1973,8 @@ def test_platform_mode_web_search_unreachable_returns_502(
     from gateway.api.routes._pipeline import WEB_SEARCH_UNREACHABLE_DETAIL
     from gateway.services.web_search_backend import WebSearchNotReachableError
 
+    usage_reports: list[dict[str, Any]] = []
+
     async def fake_post_platform(
         url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
     ) -> httpx.Response:
@@ -1970,6 +1982,7 @@ def test_platform_mode_web_search_unreachable_returns_502(
             return _single_attempt_resolve_response(request_id="ws-down")
         if url.endswith("/gateway/web-search/resolve"):
             return httpx.Response(200, json={"enabled": True})
+        usage_reports.append(body)
         return httpx.Response(204)
 
     class _DownWebSearchBackend:
@@ -1997,3 +2010,10 @@ def test_platform_mode_web_search_unreachable_returns_502(
 
     assert response.status_code == 502
     assert response.json() == {"detail": WEB_SEARCH_UNREACHABLE_DETAIL}
+    assert usage_reports == [
+        {
+            "correlation_id": "ws-down",
+            "status": "error",
+            "is_final_attempt": True,
+        }
+    ]

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -142,6 +142,7 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
         {
             "correlation_id": "7af2c39d-4eb8-4b3f-8242-46a97f7d5e68",
             "status": "success",
+            "is_final_attempt": True,
             "usage": {
                 "prompt_tokens": 10,
                 "completion_tokens": 7,
@@ -1002,6 +1003,9 @@ def test_hybrid_mode_streaming_reports_every_attempt_when_all_fail(
         ("att-a", "error", "http_500"),
         ("att-b", "error", "http_500"),
     ]
+    reports_by_id = {report["correlation_id"]: report for report in usage_reports}
+    assert reports_by_id["att-a"]["is_final_attempt"] is False
+    assert reports_by_id["att-b"]["is_final_attempt"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -1636,6 +1640,7 @@ def test_hybrid_mode_streaming_multi_attempt_classifies_non_retryable_invalid_re
     """A non-retryable invalid request (400) short-circuits the streaming
     fallback and is surfaced as a classified 400 even with multiple attempts,
     matching the non-streaming path rather than the aggregate 502."""
+    usage_reports: list[dict[str, Any]] = []
 
     async def fake_post_platform(
         url: str,
@@ -1671,6 +1676,7 @@ def test_hybrid_mode_streaming_multi_attempt_classifies_non_retryable_invalid_re
                     ],
                 },
             )
+        usage_reports.append(body)
         return httpx.Response(204)
 
     calls: list[dict[str, Any]] = []
@@ -1698,6 +1704,8 @@ def test_hybrid_mode_streaming_multi_attempt_classifies_non_retryable_invalid_re
     }
     # Non-retryable: the fallback must short-circuit after the first attempt.
     assert len(calls) == 1
+    assert len(usage_reports) == 1
+    assert usage_reports[0]["is_final_attempt"] is True
 
 
 class _FakeSandboxBackend:

--- a/tests/integration/test_hybrid_mode_messages.py
+++ b/tests/integration/test_hybrid_mode_messages.py
@@ -188,6 +188,7 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
         {
             "correlation_id": "att-1",
             "status": "success",
+            "is_final_attempt": True,
             "usage": {
                 "prompt_tokens": 10,
                 "completion_tokens": 7,
@@ -654,12 +655,14 @@ def test_hybrid_mode_tool_loop_no_fallback_after_lock_in(
     gateway must NOT try the second attempt — that would replay a
     provider-specific transcript on a different provider.
     """
+    usage_reports: list[dict[str, Any]] = []
 
     async def fake_post_platform(
         url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
     ) -> httpx.Response:
         if url.endswith("/gateway/provider-keys/resolve"):
             return _two_attempt_resolve_response_anthropic_first(request_id="tool-req-2")
+        usage_reports.append(body)
         return httpx.Response(204)
 
     calls: list[str] = []
@@ -714,6 +717,8 @@ def test_hybrid_mode_tool_loop_no_fallback_after_lock_in(
     # Both calls were to attempt 1 (rounds 1 and 2 of the tool loop). The
     # second attempt is never tried because lock-in fired on round 1.
     assert calls == ["sk-ant-broken", "sk-ant-broken"]
+    assert len(usage_reports) == 1
+    assert usage_reports[0]["is_final_attempt"] is True
 
 
 # ---------- hybrid-mode tool-loop streaming contract ----------

--- a/tests/integration/test_hybrid_mode_responses.py
+++ b/tests/integration/test_hybrid_mode_responses.py
@@ -328,10 +328,10 @@ def test_hybrid_mode_provider_without_responses_support_returns_400(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The ``SUPPORTS_RESPONSES`` provider guard must still fire in hybrid
-    mode — once credentials are resolved, the guard checks the primary
-    attempt's provider before any upstream call.
+    """The ``SUPPORTS_RESPONSES`` guard rejects an unsupported fallback before
+    any upstream call and marks the first planned attempt as terminal.
     """
+    usage_reports: list[dict[str, Any]] = []
 
     async def fake_post_platform(
         url: str,
@@ -343,9 +343,13 @@ def test_hybrid_mode_provider_without_responses_support_returns_400(
             return httpx.Response(
                 200,
                 json=_resolve_payload(
-                    [_attempt(0, "att-1", "claude-3-5-sonnet-20241022", "sk-1", provider="anthropic")]
+                    [
+                        _attempt(0, "att-1", "gpt-4o-mini", "sk-1"),
+                        _attempt(1, "att-2", "claude-3-5-sonnet-20241022", "sk-2", provider="anthropic"),
+                    ]
                 ),
             )
+        usage_reports.append(body)
         return httpx.Response(204)
 
     monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
@@ -358,6 +362,13 @@ def test_hybrid_mode_provider_without_responses_support_returns_400(
 
     assert response.status_code == 400
     assert "does not support the Responses API" in response.json()["detail"]
+    assert usage_reports == [
+        {
+            "correlation_id": "att-1",
+            "status": "error",
+            "is_final_attempt": True,
+        }
+    ]
 
 
 # ---------- tool-loop fallback (pre-lock-in) ----------

--- a/tests/integration/test_hybrid_mode_responses.py
+++ b/tests/integration/test_hybrid_mode_responses.py
@@ -142,6 +142,7 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
         {
             "correlation_id": "att-1",
             "status": "success",
+            "is_final_attempt": True,
             "usage": {
                 "prompt_tokens": 10,
                 "completion_tokens": 7,
@@ -270,12 +271,17 @@ def test_hybrid_mode_falls_through_on_first_attempt_failure(
     outcomes = [report["status"] for report in usage_reports]
     assert "error" in outcomes
     assert "success" in outcomes
+    reports_by_id = {report["correlation_id"]: report for report in usage_reports}
+    assert reports_by_id["att-primary"]["is_final_attempt"] is False
+    assert reports_by_id["att-fallback"]["is_final_attempt"] is True
 
 
 def test_hybrid_mode_returns_502_when_all_attempts_fail(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    usage_reports: list[dict[str, Any]] = []
+
     async def fake_post_platform(
         url: str,
         headers: dict[str, str],
@@ -292,6 +298,7 @@ def test_hybrid_mode_returns_502_when_all_attempts_fail(
                     ]
                 ),
             )
+        usage_reports.append(body)
         return httpx.Response(204)
 
     async def fake_aresponses(**kwargs: Any) -> Response:
@@ -312,6 +319,9 @@ def test_hybrid_mode_returns_502_when_all_attempts_fail(
 
     assert response.status_code == 502
     assert response.json() == {"detail": "All upstream providers failed"}
+    reports_by_id = {report["correlation_id"]: report for report in usage_reports}
+    assert reports_by_id["att-1"]["is_final_attempt"] is False
+    assert reports_by_id["att-2"]["is_final_attempt"] is True
 
 
 def test_hybrid_mode_provider_without_responses_support_returns_400(
@@ -595,6 +605,7 @@ def test_hybrid_mode_tool_loop_streaming_sets_correlation_id_and_reports_usage(
     success_reports = [r for r in usage_reports if r.get("status") == "success"]
     assert success_reports, "expected a success usage report for the hybrid-mode tool-loop stream"
     assert success_reports[0]["correlation_id"] == "stream-att-1"
+    assert success_reports[0]["is_final_attempt"] is True
 
 
 def test_hybrid_mode_supports_responses_guard_checks_every_attempt(

--- a/tests/unit/test_flush_pending_usage_reports.py
+++ b/tests/unit/test_flush_pending_usage_reports.py
@@ -12,7 +12,7 @@ from gateway.core.config import GatewayConfig
 
 
 def test_flush_delivers_all_reports_when_fast(monkeypatch: pytest.MonkeyPatch) -> None:
-    sent: list[tuple[str, str, str | None, str | None]] = []
+    sent: list[tuple[str, str, str | None, str | None, bool]] = []
 
     async def fake_report(
         config: Any,
@@ -21,8 +21,9 @@ def test_flush_delivers_all_reports_when_fast(monkeypatch: pytest.MonkeyPatch) -
         usage: Any,
         error_class: str | None,
         session_label: str | None = None,
+        is_final_attempt: bool = False,
     ) -> None:
-        sent.append((cid, outcome, error_class, session_label))
+        sent.append((cid, outcome, error_class, session_label, is_final_attempt))
 
     monkeypatch.setattr(_pipeline, "_report_platform_usage", fake_report)
     config = GatewayConfig(platform={"base_url": "http://platform.test"})
@@ -30,7 +31,7 @@ def test_flush_delivers_all_reports_when_fast(monkeypatch: pytest.MonkeyPatch) -
     asyncio.run(
         _pipeline._flush_pending_usage_reports(
             config,
-            [("att-1", "error", None, "http_500"), ("att-2", "error", None, "http_429")],
+            [("att-1", "error", None, "http_500", False), ("att-2", "error", None, "http_429", True)],
             "req-1",
             "my-run-personas",
         )
@@ -38,8 +39,8 @@ def test_flush_delivers_all_reports_when_fast(monkeypatch: pytest.MonkeyPatch) -
 
     # Every flushed report carries the per-request session label.
     assert sorted(sent) == [
-        ("att-1", "error", "http_500", "my-run-personas"),
-        ("att-2", "error", "http_429", "my-run-personas"),
+        ("att-1", "error", "http_500", "my-run-personas", False),
+        ("att-2", "error", "http_429", "my-run-personas", True),
     ]
 
 
@@ -58,6 +59,7 @@ def test_flush_is_bounded_and_does_not_wait_for_a_slow_report(monkeypatch: pytes
         usage: Any,
         error_class: str | None,
         session_label: str | None = None,
+        is_final_attempt: bool = False,
     ) -> None:
         await asyncio.sleep(10)
         completed.append(cid)
@@ -69,7 +71,7 @@ def test_flush_is_bounded_and_does_not_wait_for_a_slow_report(monkeypatch: pytes
     asyncio.run(
         _pipeline._flush_pending_usage_reports(
             config,
-            [("att-1", "error", None, "http_500")],
+            [("att-1", "error", None, "http_500", True)],
             "req-1",
         )
     )

--- a/tests/unit/test_flush_pending_usage_reports.py
+++ b/tests/unit/test_flush_pending_usage_reports.py
@@ -31,7 +31,22 @@ def test_flush_delivers_all_reports_when_fast(monkeypatch: pytest.MonkeyPatch) -
     asyncio.run(
         _pipeline._flush_pending_usage_reports(
             config,
-            [("att-1", "error", None, "http_500", False), ("att-2", "error", None, "http_429", True)],
+            [
+                _pipeline._PendingUsageReport(
+                    attempt_id="att-1",
+                    outcome="error",
+                    usage=None,
+                    error_class="http_500",
+                    is_final_attempt=False,
+                ),
+                _pipeline._PendingUsageReport(
+                    attempt_id="att-2",
+                    outcome="error",
+                    usage=None,
+                    error_class="http_429",
+                    is_final_attempt=True,
+                ),
+            ],
             "req-1",
             "my-run-personas",
         )
@@ -71,7 +86,15 @@ def test_flush_is_bounded_and_does_not_wait_for_a_slow_report(monkeypatch: pytes
     asyncio.run(
         _pipeline._flush_pending_usage_reports(
             config,
-            [("att-1", "error", None, "http_500", True)],
+            [
+                _pipeline._PendingUsageReport(
+                    attempt_id="att-1",
+                    outcome="error",
+                    usage=None,
+                    error_class="http_500",
+                    is_final_attempt=True,
+                )
+            ],
             "req-1",
         )
     )

--- a/tests/unit/test_pipeline_settlement.py
+++ b/tests/unit/test_pipeline_settlement.py
@@ -342,6 +342,46 @@ def _build_platform(stream: AsyncIterator[ChatCompletionChunk]) -> Any:
     )
 
 
+@pytest.mark.parametrize("yields_chunk", [True, False], ids=["no-usage-chunk", "zero-chunk"])
+@pytest.mark.asyncio
+async def test_platform_stream_without_usage_reports_final_success(
+    monkeypatch: pytest.MonkeyPatch,
+    yields_chunk: bool,
+) -> None:
+    reports: list[dict[str, Any]] = []
+
+    async def completed_report() -> None:
+        return None
+
+    def fake_report(**kwargs: Any) -> Any:
+        reports.append(kwargs)
+        return completed_report()
+
+    def fake_schedule(report: Any, correlation_id: str) -> None:
+        assert correlation_id == "corr-1"
+        report.close()
+
+    monkeypatch.setattr(pipeline, "_report_platform_usage", fake_report)
+    monkeypatch.setattr(pipeline, "_schedule_usage_report", fake_schedule)
+
+    async def stream() -> AsyncIterator[ChatCompletionChunk]:
+        if yields_chunk:
+            yield _chunk()
+
+    await _drain(_build_platform(stream()))
+
+    assert len(reports) == 1
+    report = reports[0]
+    assert isinstance(report.pop("config"), GatewayConfig)
+    assert report == {
+        "correlation_id": "corr-1",
+        "outcome": "success",
+        "usage": None,
+        "session_label": None,
+        "is_final_attempt": True,
+    }
+
+
 @pytest.mark.asyncio
 async def test_platform_usage_report_task_is_tracked_until_done(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_run_platform_attempts.py
+++ b/tests/unit/test_run_platform_attempts.py
@@ -216,7 +216,13 @@ async def test_report_platform_usage_does_not_retry_on_402(monkeypatch: pytest.M
     sleep_mock = AsyncMock()
     monkeypatch.setattr(asyncio, "sleep", sleep_mock)
 
-    await _platform._report_platform_usage(config, "corr-1", "success", None)
+    await _platform._report_platform_usage(
+        config,
+        "corr-1",
+        "success",
+        None,
+        is_final_attempt=True,
+    )
 
     assert post_mock.call_count == 1
     sleep_mock.assert_not_awaited()
@@ -254,7 +260,14 @@ async def test_report_platform_usage_forwards_session_label(
     post_mock = AsyncMock(return_value=httpx.Response(204))
     monkeypatch.setattr(_platform, "_post_platform", post_mock)
 
-    await _platform._report_platform_usage(config, "corr-1", "success", None, session_label=session_label)
+    await _platform._report_platform_usage(
+        config,
+        "corr-1",
+        "success",
+        None,
+        session_label=session_label,
+        is_final_attempt=True,
+    )
 
     body = post_mock.call_args.kwargs["body"]
     if expected is None:

--- a/tests/unit/test_run_platform_attempts.py
+++ b/tests/unit/test_run_platform_attempts.py
@@ -130,6 +130,75 @@ async def test_locked_in_failure_not_counted_as_abandoned() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fallback_reports_nonfinal_error_and_final_success() -> None:
+    attempts = [
+        ResolvedAttempt(
+            attempt_id="a0", position=0, provider="openai", model="gpt-4o", api_key="bad", managed=False
+        ),
+        ResolvedAttempt(
+            attempt_id="a1", position=1, provider="openai", model="gpt-4o", api_key="good", managed=False
+        ),
+    ]
+    route = ResolvedRoute(request_id="r", fallback_enabled=True, attempts=attempts)
+    reports: list[tuple[Any, ...]] = []
+
+    async def _run_attempt(kwargs: dict[str, Any], _on_first_response: Any) -> str:
+        if kwargs["api_key"] == "bad":
+            raise RuntimeError("primary failed")
+        return "ok"
+
+    result = await run_platform_attempts(
+        route=route,
+        attempts=attempts,
+        base_request_fields={},
+        run_attempt=_run_attempt,
+        extract_usage=lambda _result: None,
+        classify_error=lambda _exc: (True, "http_500"),
+        report_attempt_outcome=lambda *args: reports.append(args),
+        on_success=lambda _attempt: None,
+        max_tool_iterations=1,
+    )
+
+    assert result == "ok"
+    assert reports == [
+        (attempts[0], "error", None, "http_500", False),
+        (attempts[1], "success", None, None, True),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_nonretryable_error_marks_first_attempt_final() -> None:
+    attempts = [
+        ResolvedAttempt(
+            attempt_id="a0", position=0, provider="openai", model="gpt-4o", api_key="bad", managed=False
+        ),
+        ResolvedAttempt(
+            attempt_id="a1", position=1, provider="openai", model="gpt-4o", api_key="unused", managed=False
+        ),
+    ]
+    route = ResolvedRoute(request_id="r", fallback_enabled=True, attempts=attempts)
+    reports: list[tuple[Any, ...]] = []
+
+    async def _run_attempt(_kwargs: dict[str, Any], _on_first_response: Any) -> str:
+        raise RuntimeError("invalid request")
+
+    with pytest.raises(HTTPException):
+        await run_platform_attempts(
+            route=route,
+            attempts=attempts,
+            base_request_fields={},
+            run_attempt=_run_attempt,
+            extract_usage=lambda _result: None,
+            classify_error=lambda _exc: (False, "http_400"),
+            report_attempt_outcome=lambda *args: reports.append(args),
+            on_success=lambda _attempt: None,
+            max_tool_iterations=1,
+        )
+
+    assert reports == [(attempts[0], "error", None, "http_400", True)]
+
+
+@pytest.mark.asyncio
 async def test_report_platform_usage_does_not_retry_on_402(monkeypatch: pytest.MonkeyPatch) -> None:
     """A 402 from the usage-report endpoint is a permanent rejection (the org
     wallet is overdrawn or missing and won't recover within the retry window).
@@ -192,3 +261,27 @@ async def test_report_platform_usage_forwards_session_label(
         assert "session_label" not in body
     else:
         assert body["session_label"] == expected
+
+
+@pytest.mark.asyncio
+async def test_report_platform_usage_forwards_final_attempt_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = cast(
+        GatewayConfig,
+        SimpleNamespace(
+            platform={"base_url": "http://platform", "usage_max_retries": 3},
+            platform_token="gw-test",
+        ),
+    )
+    post_mock = AsyncMock(return_value=httpx.Response(204))
+    monkeypatch.setattr(_platform, "_post_platform", post_mock)
+
+    await _platform._report_platform_usage(
+        config,
+        "corr-1",
+        "error",
+        None,
+        error_class="http_400",
+        is_final_attempt=True,
+    )
+
+    assert post_mock.call_args.kwargs["body"]["is_final_attempt"] is True

--- a/tests/unit/test_run_platform_attempts.py
+++ b/tests/unit/test_run_platform_attempts.py
@@ -20,6 +20,9 @@ from gateway.api.routes import _platform
 from gateway.api.routes._platform import ResolvedAttempt, ResolvedRoute, run_platform_attempts
 from gateway.core.config import GatewayConfig
 from gateway.metrics import REGISTRY
+from gateway.services.mcp_loop import MaxToolIterationsExceeded
+from gateway.services.sandbox_backend import SandboxNotReachableError
+from gateway.services.web_search_backend import WebSearchNotReachableError
 
 
 def _abandoned_sample(provider: str, model: str, reason: str, position: int) -> float:
@@ -127,6 +130,82 @@ async def test_locked_in_failure_not_counted_as_abandoned() -> None:
         )
 
     assert _abandoned_sample("anthropic", "claude-locked", "upstream_error", 0) == before
+
+
+@pytest.mark.asyncio
+async def test_locked_in_retryable_failure_marks_attempt_final() -> None:
+    attempts = [
+        ResolvedAttempt(
+            attempt_id="a0", position=0, provider="anthropic", model="claude-primary", api_key="bad", managed=False
+        ),
+        ResolvedAttempt(
+            attempt_id="a1", position=1, provider="openai", model="gpt-fallback", api_key="unused", managed=False
+        ),
+    ]
+    route = ResolvedRoute(request_id="r", fallback_enabled=True, attempts=attempts)
+    reports: list[tuple[Any, ...]] = []
+
+    async def _run_attempt(_kwargs: dict[str, Any], on_first_response: Any) -> Any:
+        on_first_response()
+        raise RuntimeError("failed after lock-in")
+
+    with pytest.raises(HTTPException):
+        await run_platform_attempts(
+            route=route,
+            attempts=attempts,
+            base_request_fields={},
+            run_attempt=_run_attempt,
+            extract_usage=lambda _r: None,
+            classify_error=lambda _exc: (True, "http_500"),
+            report_attempt_outcome=lambda *args: reports.append(args),
+            on_success=lambda _attempt: None,
+            max_tool_iterations=1,
+        )
+
+    assert reports == [(attempts[0], "error", None, "http_500", True)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("terminal_error", "expected_error"),
+    [
+        (MaxToolIterationsExceeded("iteration cap reached"), HTTPException),
+        (SandboxNotReachableError("sandbox unavailable"), SandboxNotReachableError),
+        (WebSearchNotReachableError("web search unavailable"), WebSearchNotReachableError),
+    ],
+)
+async def test_gateway_terminal_error_marks_current_attempt_final(
+    terminal_error: BaseException,
+    expected_error: type[BaseException],
+) -> None:
+    attempts = [
+        ResolvedAttempt(
+            attempt_id="a0", position=0, provider="openai", model="gpt-primary", api_key="bad", managed=False
+        ),
+        ResolvedAttempt(
+            attempt_id="a1", position=1, provider="openai", model="gpt-fallback", api_key="unused", managed=False
+        ),
+    ]
+    route = ResolvedRoute(request_id="r", fallback_enabled=True, attempts=attempts)
+    reports: list[tuple[Any, ...]] = []
+
+    async def _run_attempt(_kwargs: dict[str, Any], _on_first_response: Any) -> Any:
+        raise terminal_error
+
+    with pytest.raises(expected_error):
+        await run_platform_attempts(
+            route=route,
+            attempts=attempts,
+            base_request_fields={},
+            run_attempt=_run_attempt,
+            extract_usage=lambda _r: None,
+            classify_error=lambda _exc: (False, "unused"),
+            report_attempt_outcome=lambda *args: reports.append(args),
+            on_success=lambda _attempt: None,
+            max_tool_iterations=1,
+        )
+
+    assert reports == [(attempts[0], "error", None, None, True)]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_run_platform_attempts.py
+++ b/tests/unit/test_run_platform_attempts.py
@@ -356,6 +356,29 @@ async def test_report_platform_usage_forwards_session_label(
 
 
 @pytest.mark.asyncio
+async def test_report_platform_usage_omits_unavailable_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    config = cast(
+        GatewayConfig,
+        SimpleNamespace(
+            platform={"base_url": "http://platform", "usage_max_retries": 3},
+            platform_token="gw-test",
+        ),
+    )
+    post_mock = AsyncMock(return_value=httpx.Response(204))
+    monkeypatch.setattr(_platform, "_post_platform", post_mock)
+
+    await _platform._report_platform_usage(
+        config,
+        "corr-1",
+        "success",
+        None,
+        is_final_attempt=True,
+    )
+
+    assert "usage" not in post_mock.call_args.kwargs["body"]
+
+
+@pytest.mark.asyncio
 async def test_report_platform_usage_forwards_final_attempt_marker(monkeypatch: pytest.MonkeyPatch) -> None:
     config = cast(
         GatewayConfig,

--- a/tests/unit/test_streaming_attempts.py
+++ b/tests/unit/test_streaming_attempts.py
@@ -137,6 +137,57 @@ async def test_non_final_slow_attempt_fails_over_at_the_budget() -> None:
 
 
 @pytest.mark.asyncio
+async def test_retryable_stream_failure_is_not_marked_final_when_fallback_remains() -> None:
+    final_markers: list[bool] = []
+    attempts = [
+        _attempt("primary", build_error=_RetryableError("primary down")),
+        _attempt("fallback", chunks=("fallback-chunk",)),
+    ]
+
+    async def build_stream(attempt: SimpleNamespace) -> AsyncIterator[str]:
+        if attempt.build_error is not None:
+            raise attempt.build_error
+        return _stream(attempt.delay, attempt.chunks)
+
+    async def on_attempt_failed(_attempt: SimpleNamespace, failure: StreamingAttemptFailure) -> None:
+        final_markers.append(failure.is_final_attempt)
+
+    chosen, stream = await iterate_streaming_attempts(
+        attempts=attempts,
+        build_stream=build_stream,
+        classify_error=lambda _exc: (True, "http_500"),
+        on_attempt_failed=on_attempt_failed,
+        first_chunk_timeout_seconds=_BUDGET_SECONDS,
+    )
+
+    assert chosen.name == "fallback"
+    assert await _drain(stream) == ["fallback-chunk"]
+    assert final_markers == [False]
+
+
+@pytest.mark.asyncio
+async def test_sole_stream_failure_is_marked_final() -> None:
+    final_markers: list[bool] = []
+
+    async def build_stream(_attempt: SimpleNamespace) -> AsyncIterator[str]:
+        raise _RetryableError("only attempt failed")
+
+    async def on_attempt_failed(_attempt: SimpleNamespace, failure: StreamingAttemptFailure) -> None:
+        final_markers.append(failure.is_final_attempt)
+
+    with pytest.raises(_RetryableError):
+        await iterate_streaming_attempts(
+            attempts=[_attempt("only")],
+            build_stream=build_stream,
+            classify_error=lambda _exc: (True, "http_500"),
+            on_attempt_failed=on_attempt_failed,
+            first_chunk_timeout_seconds=_BUDGET_SECONDS,
+        )
+
+    assert final_markers == [True]
+
+
+@pytest.mark.asyncio
 async def test_final_attempt_of_chain_gets_the_grace() -> None:
     """The last attempt in a chain has no successor, so it gets the terminal grace
     even though an earlier attempt failed over into it."""


### PR DESCRIPTION
## Description

In hybrid mode, the platform evaluates the routing policy and returns an ordered list of provider attempts that the gateway can try in sequence. The gateway sends a usage report after each attempt it actually makes.

Previously, if a request succeeded or stopped before reaching the end of that list, the platform could not tell that the remaining attempts would not run. It could continue waiting for their usage reports, leaving the request’s cost calculation pending indefinitely.

This PR adds `is_final_attempt` to usage reports. It is `false` when the gateway will try another fallback after a retryable failure. It is `true` when the request has succeeded or no further fallback attempts will be made.

The marker is included in both background and inline error reporting. Tests cover streaming and non-streaming requests across success, fallback, and failure paths.

The hybrid-mode protocol documentation has also been updated. This is the gateway-side companion to the platform changes in mozilla-ai/otari-ai#1543.

Verification: `make lint`, `make typecheck`, `make test` (2099 passed, 9 skipped), `make openapi-check`, and `make postman-check`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Related to mozilla-ai/otari-ai#1508 and mozilla-ai/otari-ai#1543.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). No inbound OpenAPI schema changed; `make openapi-check` and `make postman-check` pass.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Pi coding agent (GPT-5.6)

**Any additional AI details you'd like to share:**

Implemented with test-driven development from the platform review finding. Tests were written and observed failing before each production path was updated.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added an `is_final_attempt` boolean to hybrid-mode usage reports.
- Set `is_final_attempt` to `false` only for retryable failures that still trigger another fallback attempt.
- Set `is_final_attempt` to `true` for successful requests and for all terminal outcomes where no further fallback will run.
- Applied the marker to streaming and non-streaming reporting, including background and inline error reporting.
- Updated the hybrid-mode protocol documentation and clarified how usage reports behave when token usage data is unavailable.
- Added and expanded unit and integration tests for success, fallback, retryable failure, and non-retryable/terminal failure paths.

## Technical notes

- Updated reporting so successful attempts can still send a final usage report with `usage=None` when token usage data is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
