### PR TITLE
chore(deps): upgrade any-llm-sdk to 1.24.0

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -2452,6 +2452,20 @@
       "MessagesRequest": {
         "description": "Anthropic Messages API-compatible request.\n\nThe wire fields are derived from any-llm's ``MessagesParams`` (see\n``_schema_derive``) so the schema cannot silently drop a param any-llm\nforwards. Gateway-internal fields (``mcp_servers``, ``mcp_server_ids``,\n``guardrails``, ``tools_header``, ``max_tool_iterations``) opt the request\ninto gateway-managed MCP / sandbox / web_search / guardrails without\nchanging the upstream wire shape. They're stripped before the request is\nforwarded.",
         "properties": {
+          "betas": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Betas"
+          },
           "cache_control": {
             "anyOf": [
               {
@@ -2463,6 +2477,18 @@
               }
             ],
             "title": "Cache Control"
+          },
+          "context_management": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Context Management"
           },
           "guardrails": {
             "anyOf": [
@@ -3869,6 +3895,21 @@
               }
             ],
             "title": "Background"
+          },
+          "context_management": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Context Management"
           },
           "conversation": {
             "anyOf": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ version = "0.0.0"
 description = "otari, an OpenAI-compatible LLM gateway"
 requires-python = ">=3.13"
 dependencies = [
-    "any-llm-sdk[all]>=1.22.1",
+    "any-llm-sdk[all]>=1.24.0",
     "alembic>=1.13.0",
     "aiosqlite>=0.19.0",
     "asyncpg>=0.29.0",

--- a/src/gateway/api/routes/pricing.py
+++ b/src/gateway/api/routes/pricing.py
@@ -20,7 +20,7 @@ from gateway.services.pricing_refresh_service import (
     reject_price_refresh,
 )
 from gateway.services.pricing_service import normalize_effective_at
-from gateway.services.provider_kwargs import normalize_pricing_key, split_selector
+from gateway.services.provider_kwargs import normalize_pricing_key, provider_key, split_selector
 
 router = APIRouter(prefix="/v1/pricing", tags=["pricing"])
 
@@ -162,7 +162,7 @@ def _candidate_model_keys(raw_key: str) -> list[str]:
     except (ValueError, AnyLLMError):
         return candidates
 
-    provider_value = provider.value if provider else None
+    provider_value = provider_key(provider)
     if not provider_value:
         return candidates
 

--- a/src/gateway/services/budget_service.py
+++ b/src/gateway/services/budget_service.py
@@ -17,6 +17,7 @@ from gateway.models.entities import Budget, BudgetResetLog, ModelPricing, User
 from gateway.repositories.users_repository import get_active_user
 from gateway.services.metered_pricing import estimate_metered_cost
 from gateway.services.pricing_service import find_model_pricing
+from gateway.services.provider_kwargs import provider_key
 from gateway.types.budget_state import BudgetState
 
 
@@ -129,8 +130,7 @@ async def _is_model_free(db: AsyncSession, model: str) -> bool:
     """
     try:
         provider, model_name = AnyLLM.split_model_provider(model)
-        provider_str = provider.value if provider else None
-        pricing = await find_model_pricing(db, provider_str, model_name)
+        pricing = await find_model_pricing(db, provider_key(provider) or None, model_name)
         if pricing:
             return pricing.input_price_per_million == 0 and pricing.output_price_per_million == 0
     except (AnyLLMError, ValueError, SQLAlchemyError) as e:

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -267,7 +267,7 @@ class _MessagesToolLoopStrategy:
         if event_type == "content_block_start":
             block = event.content_block  # type: ignore[union-attr]
             idx = event.index  # type: ignore[union-attr]
-            if hasattr(block, "model_dump"):
+            if block is not None and hasattr(block, "model_dump"):
                 state.blocks_by_index[idx] = block.model_dump(exclude_none=True)
             else:
                 state.blocks_by_index[idx] = dict(block) if isinstance(block, dict) else {}

--- a/src/gateway/services/provider_kwargs.py
+++ b/src/gateway/services/provider_kwargs.py
@@ -140,6 +140,16 @@ class ResolvedProvider:
         return f"{self.provider.value}:{self.model}"
 
 
+def provider_key(provider: str | LLMProvider) -> str:
+    """The wire name of an any-llm provider.
+
+    ``AnyLLM.split_model_provider`` returns an ``LLMProvider`` member where one
+    exists and a bare name for registry-only gateways (any-llm >= 1.24), so
+    callers that only need the name go through here instead of ``.value``.
+    """
+    return provider.value if isinstance(provider, LLMProvider) else provider
+
+
 def split_selector(model_selector: str) -> tuple[str, str] | None:
     """Split a selector on its first ``:`` or ``/`` delimiter.
 
@@ -211,7 +221,11 @@ def resolve_provider_selector(
             alias=model_selector if alias is not None else None,
         )
 
-    provider, model = AnyLLM.split_model_provider(selector)
+    # A registry-only gateway (a name with no ``LLMProvider`` member) is not
+    # something otari can key pricing/budgets on, so it is rejected here exactly
+    # as an unknown provider was before any-llm widened this return type.
+    split_provider, model = AnyLLM.split_model_provider(selector)
+    provider = LLMProvider(split_provider)
     return ResolvedProvider(
         instance=provider.value,
         provider=provider,
@@ -255,4 +269,4 @@ def normalize_pricing_key(config: GatewayConfig, raw_key: str) -> str:
     # rather than 500 the whole listing.
     except (ValueError, AnyLLMError):
         return raw_key
-    return f"{provider.value}:{model}"
+    return f"{provider_key(provider)}:{model}"

--- a/tests/unit/test_provider_instances.py
+++ b/tests/unit/test_provider_instances.py
@@ -18,6 +18,7 @@ from gateway.services.provider_kwargs import (
     get_provider_kwargs,
     keyless_placeholder_api_key,
     normalize_pricing_key,
+    provider_key,
     resolve_provider_selector,
     split_selector,
 )
@@ -393,6 +394,21 @@ def test_normalize_pricing_key_orphaned_instance_does_not_raise() -> None:
     # (e.g. a stored provider that could not be decrypted and was skipped) must be
     # returned unchanged, not raise AnyLLMError and 500 the models listing.
     assert normalize_pricing_key(GatewayConfig(), "home-lab:qwen3") == "home-lab:qwen3"
+
+
+# ---------------------------------------------------------------------------
+# provider_key
+# ---------------------------------------------------------------------------
+
+
+def test_provider_key_from_enum_member() -> None:
+    assert provider_key(LLMProvider.OPENAI) == "openai"
+
+
+def test_provider_key_from_registry_only_name() -> None:
+    # any-llm >= 1.24 returns a bare name for a gateway that has a registry entry
+    # but no LLMProvider member, so pricing/budget keys must accept that form.
+    assert provider_key("some-registry-gateway") == "some-registry-gateway"
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "any-llm-sdk"
-version = "1.22.1"
+version = "1.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
@@ -204,9 +204,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/de/a29738e1c8702a79a514f9521430fe77686fb9f9122980f4899a7baf58b5/any_llm_sdk-1.22.1.tar.gz", hash = "sha256:b07c6fcef6d7fc13e0f0419bc1464f9316b17e663c34382fb7722a906241f635", size = 164931, upload-time = "2026-07-22T15:43:29.12Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/38/da47437de8f3447f8aa1acee55f71d3a9a0c4f53369ad0355cf6d1871c1f/any_llm_sdk-1.24.0.tar.gz", hash = "sha256:06391e27e0d81a0ea70580d8f8535c308d943079a8be62e65ffeb621dcb92ea9", size = 180139, upload-time = "2026-08-05T14:37:39.96Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/5a/85c558cc9fb6fd8a7fd3e7523c9c20545316190d22372026ddbf53cdc0c9/any_llm_sdk-1.22.1-py3-none-any.whl", hash = "sha256:950339b68ca1d99fb123c523d246140e1c947b0ff26e3fb9bc37194a49f3b509", size = 217209, upload-time = "2026-07-22T15:43:27.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/72/ab48a0e533669f483ef97018f664ba8dec659a8446c9ca3c7d3d2d519137/any_llm_sdk-1.24.0-py3-none-any.whl", hash = "sha256:bfdc633172330b2a76f178dd0fbb207b87cf2bed06bbe9460c0691c24435f597", size = 233211, upload-time = "2026-08-05T14:37:38.495Z" },
 ]
 
 [package.optional-dependencies]
@@ -952,7 +952,7 @@ dev = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0" },
     { name = "alembic", specifier = ">=1.13.0" },
-    { name = "any-llm-sdk", extras = ["all"], specifier = ">=1.22.1" },
+    { name = "any-llm-sdk", extras = ["all"], specifier = ">=1.24.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.42.0" },
     { name = "click", specifier = ">=8.1.0" },
@@ -2305,14 +2305,14 @@ wheels = [
 
 [[package]]
 name = "openresponses-types"
-version = "2.3.0.post1"
+version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/26/b612c3215f5599714fa94d63eb5ee59b4eb66dbdeeaf86bb4d848359484d/openresponses_types-2.3.0.post1.tar.gz", hash = "sha256:11b8896d3621d2ac2439f6ff106f34ddcb1bbd517c317a6c852a9df2e98a0753", size = 19254, upload-time = "2026-01-22T20:02:03.933Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/eb/cb4a855a27c6cf04af2d47c896b6549040a86bb75e6a59cb687a8bcf19aa/openresponses_types-2.4.0.tar.gz", hash = "sha256:cd55e7fa17230d8edd46e254ef34666ca6f250b7efa3712a110aac546c7dc8d5", size = 22101, upload-time = "2026-08-05T12:22:46.167Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/5f/e16dad89ed24f586da5b01b9b206d3adbf21fe1af8e4dc55d5b93158fde6/openresponses_types-2.3.0.post1-py3-none-any.whl", hash = "sha256:88f6abcef9cad839203abff420dd080978bf6eb33cc06ddc5d78da4ccdba7613", size = 13847, upload-time = "2026-01-22T20:02:02.582Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ef/2605d7219b0fa648e66ab15043bae492f4e8d3c4de4fdad85fc5eadb95a3/openresponses_types-2.4.0-py3-none-any.whl", hash = "sha256:186406592bc115bf12d9ee88320f8051ab1ade0a8fa8941fd1e44b0be16684f1", size = 15097, upload-time = "2026-08-05T12:22:45.044Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Bumps `any-llm-sdk[all]` to [1.24.0](https://github.com/mozilla-ai/any-llm/releases/tag/1.24.0) and adapts the gateway to the one breaking signature change.

`AnyLLM.split_model_provider` now returns `tuple[str | LLMProvider, str]`: registry-only OpenAI-compatible gateways resolve to a bare name with no enum member. Four call sites used `.value` on that, so they now go through a new `provider_key()` helper in `provider_kwargs.py`. `resolve_provider_selector` still coerces to `LLMProvider`, so a registry-only name stays a rejected selector, the same outcome an unknown provider got before. That is deliberate: those names can't serve as pricing or budget keys today, and the registry-only set is currently empty (all 12 registry entries have enum members), so the widening is forward-looking. Exposing them as configurable instances is a separate change.

Also narrows a `None` out of the Anthropic `content_block` union in `mcp_loop_messages.observe`; both branches already fell through to `{}`, so behavior is unchanged.

Regenerated `docs/public/openapi.json`, which picks up `betas` and `context_management` on `MessagesRequest` and `context_management` on `ResponsesRequest`. `_schema_derive` forwards these automatically. The Postman collection regenerated byte-identical.

**Verification:** `make lint`, `make typecheck`, and `make test` all pass locally (2242 passed, 10 skipped) against a local PostgreSQL via `TEST_DATABASE_URL`. Note that `test_error_detail_leakage` and `test_streaming_error_event` fail in any environment with a real `OPENAI_API_KEY` set, because the invalid-model requests then reach OpenAI and return 404 instead of the expected 502. Both pass with the key unset, which is what CI sees.

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

None.

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

The upgrade, the `provider_key()` adaptation, the regenerated spec, and this description were produced by Claude through back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
