### PR TITLE
feat(messages): support Anthropic context compaction

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -54,8 +54,8 @@ For a full client setup example, see [Use with opencode](use-with-opencode.md).
 
 | Method | Path | Description | Auth |
 |--------|------|-------------|------|
-| `POST` | `/v1/messages` | Anthropic Messages API-compatible endpoint. Supports streaming, tool use, and extended thinking. Routes to any provider in the catalog (non-Anthropic models are translated to/from the Messages format automatically). | Standalone: API key or master key. Connected: `Authorization` bearer token from otari.ai. |
-| `POST` | `/v1/messages/count_tokens` | Anthropic-compatible input-token count for a Messages request. Returns `{"input_tokens": N}`. Counts locally (no provider call, no budget debit); the count is an approximation. Used by clients such as Claude Code for context-window management. | Standalone: API key or master key. Connected: `Authorization` bearer token from otari.ai. |
+| `POST` | `/v1/messages` | Anthropic Messages API-compatible endpoint. Supports streaming, tool use, extended thinking, and Anthropic context management (`context_management` and `betas`, including compaction). Routes to any provider in the catalog (non-Anthropic models are translated to/from the Messages format automatically). | Standalone: API key or master key. Connected: `Authorization` bearer token from otari.ai. |
+| `POST` | `/v1/messages/count_tokens` | Anthropic-compatible input-token count for a Messages request. Returns `{"input_tokens": N}`. Counts locally (no provider call, no budget debit); the count is an approximation. `context_management` and `betas` are accepted for wire compatibility, but the local estimate does not apply provider-side context edits. Used by clients such as Claude Code for context-window management. | Standalone: API key or master key. Connected: `Authorization` bearer token from otari.ai. |
 
 > `/v1/messages` uses the Anthropic Messages request shape regardless of which upstream provider serves the model. For example, `max_tokens` is still required even when `model` is `openai:...`.
 

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -911,8 +911,22 @@
         "type": "object"
       },
       "CountTokensRequest": {
-        "description": "Anthropic ``/v1/messages/count_tokens`` request.\n\nA subset of :class:`MessagesRequest`: the input fields that affect the token\ncount, minus ``max_tokens`` and the streaming/sampling controls, since the\nendpoint only counts input tokens. Clients such as Claude Code call this on\nevery turn to keep their prompt within the model's context window.",
+        "description": "Anthropic ``/v1/messages/count_tokens`` request.\n\nA subset of :class:`MessagesRequest`: the input fields that affect the token\ncount, minus ``max_tokens`` and the streaming/sampling controls, since the\nendpoint only counts input tokens. ``context_management`` and ``betas`` are\naccepted for wire compatibility, but the local estimate does not apply\nprovider-side context edits. Clients such as Claude Code call this on every\nturn to keep their prompt within the model's context window.",
         "properties": {
+          "betas": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Betas"
+          },
           "cache_control": {
             "anyOf": [
               {
@@ -924,6 +938,18 @@
               }
             ],
             "title": "Cache Control"
+          },
+          "context_management": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Context Management"
           },
           "messages": {
             "items": {

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -93,8 +93,10 @@ class CountTokensRequest(BaseModel):
 
     A subset of :class:`MessagesRequest`: the input fields that affect the token
     count, minus ``max_tokens`` and the streaming/sampling controls, since the
-    endpoint only counts input tokens. Clients such as Claude Code call this on
-    every turn to keep their prompt within the model's context window.
+    endpoint only counts input tokens. ``context_management`` and ``betas`` are
+    accepted for wire compatibility, but the local estimate does not apply
+    provider-side context edits. Clients such as Claude Code call this on every
+    turn to keep their prompt within the model's context window.
     """
 
     model: str
@@ -105,6 +107,8 @@ class CountTokensRequest(BaseModel):
     thinking: dict[str, Any] | None = None
     metadata: dict[str, Any] | None = None
     cache_control: dict[str, Any] | None = None
+    context_management: dict[str, Any] | None = None
+    betas: list[str] | None = None
 
 
 class CountTokensResponse(BaseModel):

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -176,19 +176,29 @@ _ERROR_KIND_TO_ANTHROPIC_TYPE = {
 }
 
 
+def _billable_messages_usage(usage: Any) -> GatewayUsage:
+    """Use per-iteration totals when Anthropic reports compaction sampling."""
+    billable_parts = list(getattr(usage, "iterations", None) or []) or [usage]
+    input_tokens = sum((getattr(part, "input_tokens", None) or 0) for part in billable_parts)
+    output_tokens = sum((getattr(part, "output_tokens", None) or 0) for part in billable_parts)
+    return GatewayUsage(
+        prompt_tokens=input_tokens,
+        completion_tokens=output_tokens,
+        total_tokens=input_tokens + output_tokens,
+        cache_read_tokens=sum(
+            (getattr(part, "cache_read_input_tokens", None) or 0) for part in billable_parts
+        ),
+        cache_write_tokens=sum(
+            (getattr(part, "cache_creation_input_tokens", None) or 0) for part in billable_parts
+        ),
+        cache_write_1h_tokens=sum(_cache_write_1h_tokens(part) for part in billable_parts),
+        cache_tokens_in_prompt=False,
+    )
+
+
 def _messages_stream_usage(event: MessageStreamEvent) -> CompletionUsage | None:
     if isinstance(event, MessageDeltaEvent):
-        input_tokens = event.usage.input_tokens or 0
-        output_tokens = event.usage.output_tokens or 0
-        return GatewayUsage(
-            prompt_tokens=input_tokens,
-            completion_tokens=output_tokens,
-            total_tokens=input_tokens + output_tokens,
-            cache_read_tokens=event.usage.cache_read_input_tokens or 0,
-            cache_write_tokens=event.usage.cache_creation_input_tokens or 0,
-            cache_write_1h_tokens=_cache_write_1h_tokens(event.usage),
-            cache_tokens_in_prompt=False,
-        )
+        return _billable_messages_usage(event.usage)
     if isinstance(event, MessageStartEvent):
         usage = event.message.usage
         input_tokens = usage.input_tokens or 0
@@ -274,15 +284,7 @@ class _MessagesAdapter:
     def extract_usage(self, result: MessageResponse) -> CompletionUsage | None:
         if not result.usage:
             return None
-        return GatewayUsage(
-            prompt_tokens=result.usage.input_tokens,
-            completion_tokens=result.usage.output_tokens,
-            total_tokens=result.usage.input_tokens + result.usage.output_tokens,
-            cache_read_tokens=result.usage.cache_read_input_tokens or 0,
-            cache_write_tokens=result.usage.cache_creation_input_tokens or 0,
-            cache_write_1h_tokens=_cache_write_1h_tokens(result.usage),
-            cache_tokens_in_prompt=False,
-        )
+        return _billable_messages_usage(result.usage)
 
     async def call_provider(self, kwargs: dict[str, Any]) -> MessageResponse:
         return await amessages(**kwargs)  # type: ignore[return-value]

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -114,6 +114,12 @@ def _content_to_dicts(content: list[Any]) -> list[dict[str, Any]]:
     return out
 
 
+class _MessagesUsageAccumulator(TypedDict):
+    input: int
+    output: int
+    iterations: list[Any]
+
+
 def _fold_usage(result: MessageResponse, input_total: int, output_total: int) -> None:
     """Replace ``result.usage`` token counts with the loop's running totals.
 
@@ -253,16 +259,19 @@ class _MessagesToolLoopStrategy:
         result: MessageResponse = await amessages(**kwargs)  # type: ignore[assignment]
         return result
 
-    def new_usage_accumulator(self) -> dict[str, int]:
-        return {"input": 0, "output": 0}
+    def new_usage_accumulator(self) -> _MessagesUsageAccumulator:
+        return {"input": 0, "output": 0, "iterations": []}
 
-    def accumulate_usage(self, acc: dict[str, int], result: MessageResponse) -> None:
+    def accumulate_usage(self, acc: _MessagesUsageAccumulator, result: MessageResponse) -> None:
         if result.usage:
             acc["input"] += result.usage.input_tokens or 0
             acc["output"] += result.usage.output_tokens or 0
+            acc["iterations"].extend(result.usage.iterations or [])
 
-    def fold_usage(self, result: MessageResponse, acc: dict[str, int]) -> None:
+    def fold_usage(self, result: MessageResponse, acc: _MessagesUsageAccumulator) -> None:
         _fold_usage(result, acc["input"], acc["output"])
+        if result.usage is not None and acc["iterations"]:
+            result.usage.iterations = acc["iterations"]
 
     def exit_before_split(self, result: MessageResponse) -> bool:
         return False

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -17,9 +17,10 @@ from __future__ import annotations
 import json
 from collections.abc import AsyncGenerator, AsyncIterator, Callable
 from contextlib import aclosing
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from any_llm import amessages
+from any_llm.types.messages import BetaContextManagementResponse
 
 from gateway.log_config import logger
 from gateway.services._tool_loop import StreamAction, run_tool_loop, run_tool_loop_stream
@@ -126,26 +127,45 @@ def _fold_usage(result: MessageResponse, input_total: int, output_total: int) ->
     result.usage.output_tokens = output_total
 
 
-def _maybe_fold_message_delta_usage(event: Any, acc_output_tokens: int) -> Any:
-    """Return ``event`` with cumulative output_tokens folded in.
+class _MessagesStreamAccumulator(TypedDict):
+    output_tokens: int
+    started: int
+    next_index: int
+    iterations: list[Any]
+    applied_edits: list[Any]
 
-    Pass-through for any event type other than ``message_delta``. For a
-    ``message_delta`` carrying a usage block, replaces ``output_tokens`` with
-    ``current + acc_output_tokens`` so the stream consumer sees the full
-    tool-loop output count instead of only the final iteration's. No-op when
-    ``acc_output_tokens`` is zero (single-iteration streams stay byte-exact).
-    """
-    if acc_output_tokens <= 0:
-        return event
+
+def _maybe_fold_message_delta(event: Any, acc: _MessagesStreamAccumulator) -> Any:
+    """Fold usage and context-management telemetry from hidden iterations."""
     if getattr(event, "type", None) != "message_delta":
         return event
     usage = getattr(event, "usage", None)
     if usage is None or not hasattr(usage, "model_copy"):
         return event
-    new_usage = usage.model_copy(
-        update={"output_tokens": (getattr(usage, "output_tokens", 0) or 0) + acc_output_tokens}
-    )
-    return event.model_copy(update={"usage": new_usage})
+
+    usage_update: dict[str, Any] = {}
+    if acc["output_tokens"] > 0:
+        usage_update["output_tokens"] = (getattr(usage, "output_tokens", 0) or 0) + acc["output_tokens"]
+    if acc["iterations"]:
+        usage_update["iterations"] = [*acc["iterations"], *(getattr(usage, "iterations", None) or [])]
+
+    event_update: dict[str, Any] = {}
+    if usage_update:
+        event_update["usage"] = usage.model_copy(update=usage_update)
+    if acc["applied_edits"]:
+        context_management = getattr(event, "context_management", None)
+        applied_edits = [
+            *acc["applied_edits"],
+            *(getattr(context_management, "applied_edits", None) or []),
+        ]
+        if context_management is not None and hasattr(context_management, "model_copy"):
+            event_update["context_management"] = context_management.model_copy(
+                update={"applied_edits": applied_edits}
+            )
+        else:
+            event_update["context_management"] = BetaContextManagementResponse(applied_edits=applied_edits)
+
+    return event.model_copy(update=event_update) if event_update else event
 
 
 def _reindexed(event: Any, visible_index: int) -> Any:
@@ -300,11 +320,10 @@ class _MessagesToolLoopStrategy:
     def new_stream_state(self) -> _MessagesStreamState:
         return _MessagesStreamState()
 
-    def new_stream_accumulator(self) -> dict[str, int]:
-        # output_tokens: from dropped intermediate ``message_delta`` events. The
-        # final iteration's forwarded ``message_delta`` is modified to carry the
-        # cumulative total so streaming usage reporting downstream sees the full
-        # tool-loop output, not just the final round's tokens.
+    def new_stream_accumulator(self) -> _MessagesStreamAccumulator:
+        # output_tokens and telemetry come from dropped intermediate
+        # ``message_delta`` events. The final forwarded delta carries the
+        # accumulated values so clients see the complete logical response.
         #
         # started / next_index: the client is shown ONE message even though the
         # gateway may have consumed several upstream ones, so only the first
@@ -312,14 +331,20 @@ class _MessagesToolLoopStrategy:
         # continuously. Without this a tool-loop stream contains two
         # ``message_start`` events and reuses block index 0, which every SDK
         # stream accumulator rejects.
-        return {"output_tokens": 0, "started": 0, "next_index": 0}
+        return {
+            "output_tokens": 0,
+            "started": 0,
+            "next_index": 0,
+            "iterations": [],
+            "applied_edits": [],
+        }
 
     def observe(
         self,
         state: _MessagesStreamState,
         event: MessageStreamEvent,
         pool: ToolBackend,
-        acc: dict[str, int],
+        acc: _MessagesStreamAccumulator,
     ) -> tuple[StreamAction, MessageStreamEvent]:
         event_type = getattr(event, "type", None)
 
@@ -389,7 +414,7 @@ class _MessagesToolLoopStrategy:
         return StreamAction.FORWARD, event
 
     @staticmethod
-    def _visible_for(state: _MessagesStreamState, acc: dict[str, int], idx: int) -> int:
+    def _visible_for(state: _MessagesStreamState, acc: _MessagesStreamAccumulator, idx: int) -> int:
         """The client-visible index for an upstream block index, assigned in order."""
         if idx not in state.visible_index:
             state.visible_index[idx] = acc["next_index"]
@@ -423,19 +448,26 @@ class _MessagesToolLoopStrategy:
         if state.stop_reason == "tool_use" and state.owned_specs:
             await _execute_stream_owned(state, pool)
 
-    def terminal_events(self, state: _MessagesStreamState, acc: dict[str, int]) -> list[MessageStreamEvent]:
-        return [_maybe_fold_message_delta_usage(term, acc["output_tokens"]) for term in state.deferred_terminal]
+    def terminal_events(
+        self,
+        state: _MessagesStreamState,
+        acc: _MessagesStreamAccumulator,
+    ) -> list[MessageStreamEvent]:
+        return [_maybe_fold_message_delta(term, acc) for term in state.deferred_terminal]
 
-    def accumulate_stream_usage(self, acc: dict[str, int], state: _MessagesStreamState) -> None:
-        # All-owned continuation: fold this iteration's output_tokens (from
-        # the dropped terminal) into the running total for the final fold.
+    def accumulate_stream_usage(self, acc: _MessagesStreamAccumulator, state: _MessagesStreamState) -> None:
         for term in state.deferred_terminal:
-            if getattr(term, "type", None) == "message_delta":
-                usage = getattr(term, "usage", None)
-                if usage is not None:
-                    acc["output_tokens"] += getattr(usage, "output_tokens", 0) or 0
+            if getattr(term, "type", None) != "message_delta":
+                continue
+            usage = getattr(term, "usage", None)
+            if usage is not None:
+                acc["output_tokens"] += getattr(usage, "output_tokens", 0) or 0
+                acc["iterations"].extend(getattr(usage, "iterations", None) or [])
+            context_management = getattr(term, "context_management", None)
+            if context_management is not None:
+                acc["applied_edits"].extend(getattr(context_management, "applied_edits", None) or [])
 
-    def synthetic_events(self, state: _MessagesStreamState, acc: dict[str, int]) -> list[Any]:
+    def synthetic_events(self, state: _MessagesStreamState, acc: _MessagesStreamAccumulator) -> list[Any]:
         # This format has no native vocabulary for a server-side tool call, so the
         # gateway's calls stay invisible on the wire. Documented in docs/tools.md.
         return []

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -359,6 +359,10 @@ class _MessagesToolLoopStrategy:
                 state.tool_use_json_bufs[idx] += getattr(delta, "partial_json", "") or ""
             elif dtype == "text_delta":
                 block_dict["text"] = (block_dict.get("text") or "") + (getattr(delta, "text", "") or "")
+            elif dtype == "compaction_delta":
+                block_dict["content"] = (block_dict.get("content") or "") + (
+                    getattr(delta, "content", "") or ""
+                )
             elif dtype == "thinking_delta":
                 block_dict["thinking"] = (block_dict.get("thinking") or "") + (
                     getattr(delta, "thinking", "") or ""

--- a/tests/integration/test_messages_endpoint.py
+++ b/tests/integration/test_messages_endpoint.py
@@ -11,6 +11,7 @@ from any_llm.types.messages import (
 )
 from fastapi.testclient import TestClient
 
+from gateway.api.routes.messages import CountTokensRequest
 from gateway.core.config import API_KEY_HEADER
 
 
@@ -285,6 +286,33 @@ def test_count_tokens_basic(
     data = response.json()
     assert isinstance(data["input_tokens"], int)
     assert data["input_tokens"] > 0
+
+
+def test_count_tokens_accepts_context_management_and_betas(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """Token-count requests accept the same context-management controls as messages."""
+    assert "context_management" in CountTokensRequest.model_fields
+    assert "betas" in CountTokensRequest.model_fields
+
+    response = client.post(
+        "/v1/messages/count_tokens",
+        json={
+            "model": "anthropic:claude-opus-5",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "context_management": {
+                "edits": [
+                    {"type": "compact_20260112", "trigger": {"type": "input_tokens", "value": 50_000}}
+                ]
+            },
+            "betas": ["compact-2026-01-12"],
+        },
+        headers=master_key_header,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["input_tokens"] > 0
 
 
 def test_count_tokens_requires_auth(client: TestClient) -> None:

--- a/tests/integration/test_messages_route_dispatch.py
+++ b/tests/integration/test_messages_route_dispatch.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from any_llm.types.messages import (
     ContentBlockDeltaEvent,
+    ContentBlockStartEvent,
     MessageDelta,
     MessageDeltaEvent,
     MessageDeltaUsage,
@@ -30,6 +31,11 @@ from any_llm.types.messages import (
     TextDelta,
 )
 from fastapi.testclient import TestClient
+
+_CONTEXT_MANAGEMENT = {
+    "edits": [{"type": "compact_20260112", "trigger": {"type": "input_tokens", "value": 50_000}}]
+}
+_BETAS = ["compact-2026-01-12"]
 
 
 def _text_response(
@@ -56,6 +62,42 @@ def _text_response(
             service_tier=None,
         ),
         container=None,
+    )
+
+
+def _compaction_response() -> MessageResponse:
+    return MessageResponse.model_validate(
+        {
+            "id": "msg_compaction",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-opus-5",
+            "content": [{"type": "compaction", "content": "Conversation summary"}],
+            "stop_reason": "compaction",
+            "stop_sequence": None,
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "iterations": [
+                    {
+                        "type": "compaction",
+                        "input_tokens": 100,
+                        "output_tokens": 20,
+                        "cache_creation_input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                    }
+                ],
+            },
+            "context_management": {
+                "applied_edits": [
+                    {
+                        "type": "clear_tool_uses_20250919",
+                        "cleared_input_tokens": 42,
+                        "cleared_tool_uses": 2,
+                    }
+                ]
+            },
+        }
     )
 
 
@@ -132,6 +174,39 @@ def test_cache_control_and_non_stream_usage_round_trip(
     usage = resp.json()["usage"]
     assert usage["cache_creation_input_tokens"] == 13
     assert usage["cache_read_input_tokens"] == 8
+
+
+def test_context_management_non_stream_contract(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """Context management reaches any-llm and beta response data reaches the client."""
+    captured: dict[str, Any] = {}
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        captured.update(kwargs)
+        return _compaction_response()
+
+    with patch("gateway.api.routes.messages.amessages", new=fake_amessages):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "anthropic:claude-opus-5",
+                "messages": [{"role": "user", "content": "Summarize when needed"}],
+                "max_tokens": 100,
+                "context_management": _CONTEXT_MANAGEMENT,
+                "betas": _BETAS,
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert captured["context_management"] == _CONTEXT_MANAGEMENT
+    assert captured["betas"] == _BETAS
+    body = resp.json()
+    assert body["content"] == [{"type": "compaction", "content": "Conversation summary"}]
+    assert body["context_management"]["applied_edits"][0]["cleared_input_tokens"] == 42
+    assert body["usage"]["iterations"][0]["type"] == "compaction"
 
 
 def test_gateway_internal_fields_are_stripped_from_upstream_kwargs(
@@ -777,6 +852,102 @@ def test_stream_cache_usage_reaches_client(
     usage = message_start["message"]["usage"]
     assert usage["cache_creation_input_tokens"] == 13
     assert usage["cache_read_input_tokens"] == 8
+
+
+def test_context_management_stream_contract(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """Compaction events and telemetry survive the streaming route unchanged."""
+    captured: dict[str, Any] = {}
+
+    async def fake_amessages(**kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        captured.update(kwargs)
+        return _stream_iter(
+            MessageStartEvent.model_validate(
+                {
+                    "type": "message_start",
+                    "message": {
+                        "id": "msg_compaction",
+                        "type": "message",
+                        "role": "assistant",
+                        "model": "claude-opus-5",
+                        "content": [],
+                        "stop_reason": None,
+                        "stop_sequence": None,
+                        "usage": {"input_tokens": 10, "output_tokens": 0},
+                    },
+                }
+            ),
+            ContentBlockStartEvent.model_validate(
+                {
+                    "type": "content_block_start",
+                    "index": 0,
+                    "content_block": {"type": "compaction", "content": None},
+                }
+            ),
+            ContentBlockDeltaEvent.model_validate(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "compaction_delta", "content": "Conversation summary"},
+                }
+            ),
+            MessageDeltaEvent.model_validate(
+                {
+                    "type": "message_delta",
+                    "delta": {"stop_reason": "compaction", "stop_sequence": None},
+                    "usage": {
+                        "output_tokens": 5,
+                        "iterations": [
+                            {
+                                "type": "compaction",
+                                "input_tokens": 100,
+                                "output_tokens": 20,
+                                "cache_creation_input_tokens": 0,
+                                "cache_read_input_tokens": 0,
+                            }
+                        ],
+                    },
+                    "context_management": {
+                        "applied_edits": [
+                            {
+                                "type": "clear_thinking_20251015",
+                                "cleared_input_tokens": 21,
+                                "cleared_thinking_turns": 1,
+                            }
+                        ]
+                    },
+                }
+            ),
+            _stream_message_stop(),
+        )
+
+    with patch("gateway.api.routes.messages.amessages", new=fake_amessages):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "anthropic:claude-opus-5",
+                "messages": [{"role": "user", "content": "Summarize when needed"}],
+                "max_tokens": 100,
+                "stream": True,
+                "context_management": _CONTEXT_MANAGEMENT,
+                "betas": _BETAS,
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert captured["context_management"] == _CONTEXT_MANAGEMENT
+    assert captured["betas"] == _BETAS
+    payloads = [json.loads(line.removeprefix("data: ")) for line in resp.text.splitlines() if line.startswith("data: ")]
+    compaction_start = next(payload for payload in payloads if payload["type"] == "content_block_start")
+    assert compaction_start["content_block"] == {"type": "compaction"}
+    compaction_delta = next(payload for payload in payloads if payload["type"] == "content_block_delta")
+    assert compaction_delta["delta"] == {"type": "compaction_delta", "content": "Conversation summary"}
+    message_delta = next(payload for payload in payloads if payload["type"] == "message_delta")
+    assert message_delta["context_management"]["applied_edits"][0]["cleared_input_tokens"] == 21
+    assert message_delta["usage"]["iterations"][0]["type"] == "compaction"
 
 
 def test_stream_mcp_servers_dispatches_through_tool_loop_stream(

--- a/tests/integration/test_messages_route_dispatch.py
+++ b/tests/integration/test_messages_route_dispatch.py
@@ -85,7 +85,14 @@ def _compaction_response() -> MessageResponse:
                         "output_tokens": 20,
                         "cache_creation_input_tokens": 0,
                         "cache_read_input_tokens": 0,
-                    }
+                    },
+                    {
+                        "type": "message",
+                        "input_tokens": 10,
+                        "output_tokens": 5,
+                        "cache_creation_input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                    },
                 ],
             },
             "context_management": {
@@ -906,7 +913,14 @@ def test_context_management_stream_contract(
                                 "output_tokens": 20,
                                 "cache_creation_input_tokens": 0,
                                 "cache_read_input_tokens": 0,
-                            }
+                            },
+                            {
+                                "type": "message",
+                                "input_tokens": 10,
+                                "output_tokens": 5,
+                                "cache_creation_input_tokens": 0,
+                                "cache_read_input_tokens": 0,
+                            },
                         ],
                     },
                     "context_management": {

--- a/tests/integration/test_messages_streaming_usage.py
+++ b/tests/integration/test_messages_streaming_usage.py
@@ -41,6 +41,8 @@ from .conftest import MODEL_NAME
 _PRICING = {"input_price_per_million": 2.5, "output_price_per_million": 10.0}
 _INPUT_TOKENS = 42
 _OUTPUT_TOKENS = 7
+_COMPACTION_INPUT_TOKENS = 100
+_COMPACTION_OUTPUT_TOKENS = 20
 
 
 def _seed_budgeted_user(client: TestClient, headers: dict[str, str], user_id: str) -> None:
@@ -93,17 +95,19 @@ def _text_delta(text: str) -> ContentBlockDeltaEvent:
     )
 
 
-def _message_delta() -> MessageDeltaEvent:
+def _message_delta(*, iterations: list[dict[str, Any]] | None = None) -> MessageDeltaEvent:
     # The trailing usage-bearing event any-llm now emits on streaming (#256).
     return MessageDeltaEvent(
         type="message_delta",
         delta=MessageDelta(stop_reason=cast(Any, "end_turn"), stop_sequence=None),
-        usage=MessageDeltaUsage(
-            input_tokens=None,
-            output_tokens=_OUTPUT_TOKENS,
-            cache_creation_input_tokens=None,
-            cache_read_input_tokens=None,
-            server_tool_use=None,
+        usage=MessageDeltaUsage.model_validate(
+            {
+                "input_tokens": None,
+                "output_tokens": _OUTPUT_TOKENS,
+                "cache_creation_input_tokens": None,
+                "cache_read_input_tokens": None,
+                "iterations": iterations,
+            }
         ),
     )
 
@@ -113,6 +117,33 @@ async def _stream_with_usage(**_kwargs: Any) -> AsyncIterator[MessageStreamEvent
         yield _message_start()
         yield _text_delta("hello")
         yield _message_delta()
+        yield MessageStopEvent(type="message_stop")
+
+    return _gen()
+
+
+async def _stream_with_compaction_usage(**_kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+    async def _gen() -> AsyncIterator[MessageStreamEvent]:
+        yield _message_start()
+        yield _text_delta("hello")
+        yield _message_delta(
+            iterations=[
+                {
+                    "type": "compaction",
+                    "input_tokens": _COMPACTION_INPUT_TOKENS,
+                    "output_tokens": _COMPACTION_OUTPUT_TOKENS,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+                {
+                    "type": "message",
+                    "input_tokens": _INPUT_TOKENS,
+                    "output_tokens": _OUTPUT_TOKENS,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                },
+            ]
+        )
         yield MessageStopEvent(type="message_stop")
 
     return _gen()
@@ -166,4 +197,38 @@ def test_messages_streaming_records_tokens_and_cost(
     assert row.status == "success"
     assert row.prompt_tokens == _INPUT_TOKENS
     assert row.completion_tokens == _OUTPUT_TOKENS
+    assert row.cost is not None and row.cost > 0.0
+
+
+def test_messages_streaming_bills_compaction_iterations(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    db_session_factory: Callable[[], Session],
+) -> None:
+    user_id = "stream-usage-messages-compaction"
+    _seed_budgeted_user(client, master_key_header, user_id)
+    _configure_pricing(client, master_key_header, MODEL_NAME)
+
+    with patch("gateway.api.routes.messages.amessages", new=_stream_with_compaction_usage):
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": MODEL_NAME,
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 64,
+                "stream": True,
+                "metadata": {"user_id": user_id},
+            },
+            headers=master_key_header,
+        )
+        assert response.status_code == 200, response.text
+        body = response.text
+
+    assert "message_stop" in body
+
+    row = _poll_usage_row(db_session_factory, user_id)
+    assert row is not None, "streaming /v1/messages must bill compaction usage"
+    assert row.status == "success"
+    assert row.prompt_tokens == _INPUT_TOKENS + _COMPACTION_INPUT_TOKENS
+    assert row.completion_tokens == _OUTPUT_TOKENS + _COMPACTION_OUTPUT_TOKENS
     assert row.cost is not None and row.cost > 0.0

--- a/tests/integration/test_transaction_safety.py
+++ b/tests/integration/test_transaction_safety.py
@@ -141,6 +141,7 @@ async def test_is_model_free_catches_unsupported_provider_error(async_db: AsyncS
 
 @pytest.mark.asyncio
 async def test_is_model_free_accepts_string_provider_from_any_llm(async_db: AsyncSession) -> None:
+    """_is_model_free stays fail-closed when any-llm returns a registry-only string provider."""
     with patch("gateway.services.budget_service.AnyLLM.split_model_provider", return_value=("registry-only", "model")):
         result = await _is_model_free(async_db, "registry-only:model")
 

--- a/tests/integration/test_transaction_safety.py
+++ b/tests/integration/test_transaction_safety.py
@@ -140,6 +140,14 @@ async def test_is_model_free_catches_unsupported_provider_error(async_db: AsyncS
 
 
 @pytest.mark.asyncio
+async def test_is_model_free_accepts_string_provider_from_any_llm(async_db: AsyncSession) -> None:
+    with patch("gateway.services.budget_service.AnyLLM.split_model_provider", return_value=("registry-only", "model")):
+        result = await _is_model_free(async_db, "registry-only:model")
+
+    assert result is False
+
+
+@pytest.mark.asyncio
 async def test_is_model_free_catches_sqlalchemy_error(async_db: AsyncSession) -> None:
     """_is_model_free returns False on SQLAlchemy errors during pricing lookup."""
     with patch(

--- a/tests/unit/test_mcp_loop_messages.py
+++ b/tests/unit/test_mcp_loop_messages.py
@@ -11,6 +11,8 @@ from typing import Any, cast
 
 import pytest
 from any_llm.types.messages import (
+    CompactionBlock,
+    CompactionDelta,
     ContentBlockDeltaEvent,
     ContentBlockStartEvent,
     ContentBlockStopEvent,
@@ -595,6 +597,22 @@ def _text_delta(index: int, text: str) -> ContentBlockDeltaEvent:
     )
 
 
+def _compaction_block_start(index: int) -> ContentBlockStartEvent:
+    return ContentBlockStartEvent(
+        type="content_block_start",
+        index=index,
+        content_block=cast(Any, CompactionBlock(type="compaction", content=None)),
+    )
+
+
+def _compaction_delta(index: int, content: str) -> ContentBlockDeltaEvent:
+    return ContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=index,
+        delta=cast(Any, CompactionDelta(type="compaction_delta", content=content)),
+    )
+
+
 def _content_block_stop(index: int) -> ContentBlockStopEvent:
     return ContentBlockStopEvent(type="content_block_stop", index=index)
 
@@ -710,6 +728,65 @@ async def test_stream_runs_owned_tool_and_continues(monkeypatch: pytest.MonkeyPa
     # sent the matching tool_result, because the loop consumed it.
     assert not any(getattr(getattr(e, "content_block", None), "type", None) == "tool_use" for e in events)
     assert pool.calls == [("fetch_url", {"u": "x"})]
+
+
+@pytest.mark.asyncio
+async def test_stream_replays_compaction_content_when_tool_loop_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context_management = {
+        "edits": [{"type": "compact_20260112", "trigger": {"type": "input_tokens", "value": 50_000}}]
+    }
+    iter_streams = iter(
+        [
+            _async_iter(
+                _msg_start_event(),
+                _compaction_block_start(0),
+                _compaction_delta(0, "Conversation "),
+                _compaction_delta(0, "summary"),
+                _content_block_stop(0),
+                _tool_use_block_start(1, "tu_1", "fetch_url"),
+                _input_json_delta(1, '{"u": "x"}'),
+                _content_block_stop(1),
+                _msg_delta_event("tool_use"),
+                _msg_stop_event(),
+            ),
+            _async_iter(
+                _msg_start_event(),
+                _text_block_start(0),
+                _text_delta(0, "done"),
+                _content_block_stop(0),
+                _msg_delta_event("end_turn"),
+                _msg_stop_event(),
+            ),
+        ]
+    )
+    calls: list[dict[str, Any]] = []
+
+    async def fake_amessages(**kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        calls.append(kwargs)
+        return next(iter_streams)
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    async for _event in anthropic_tool_loop_stream(
+        completion_kwargs={
+            "model": "fake",
+            "messages": [{"role": "user", "content": "go"}],
+            "max_tokens": 100,
+            "context_management": context_management,
+            "betas": ["compact-2026-01-12"],
+        },
+        pool=cast(Any, _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})),
+        max_iterations=5,
+    ):
+        pass
+
+    assistant_content = calls[1]["messages"][-2]["content"]
+    assert assistant_content[0] == {"type": "compaction", "content": "Conversation summary"}
+    assert assistant_content[1]["type"] == "tool_use"
+    assert calls[1]["context_management"] == context_management
+    assert calls[1]["betas"] == ["compact-2026-01-12"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mcp_loop_messages.py
+++ b/tests/unit/test_mcp_loop_messages.py
@@ -231,6 +231,61 @@ async def test_loop_executes_owned_tool_and_completes(monkeypatch: pytest.Monkey
 
 
 @pytest.mark.asyncio
+async def test_loop_replays_compaction_block_with_context_management(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context_management = {
+        "edits": [{"type": "compact_20260112", "trigger": {"type": "input_tokens", "value": 50_000}}]
+    }
+    responses = iter(
+        [
+            MessageResponse.model_validate(
+                {
+                    "id": "msg_compaction_tool",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "fake",
+                    "content": [
+                        {"type": "compaction", "content": "Conversation summary"},
+                        {"type": "tool_use", "id": "tu_1", "name": "fetch_url", "input": {"u": "x"}},
+                    ],
+                    "stop_reason": "tool_use",
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": 10, "output_tokens": 2},
+                }
+            ),
+            _message_response(stop_reason="end_turn", content=[_text_block("done")]),
+        ]
+    )
+    calls: list[dict[str, Any]] = []
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        calls.append(kwargs)
+        return next(responses)
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+
+    out = await anthropic_tool_loop(
+        completion_kwargs={
+            "model": "fake",
+            "messages": [{"role": "user", "content": "fetch x"}],
+            "max_tokens": 100,
+            "context_management": context_management,
+            "betas": ["compact-2026-01-12"],
+        },
+        pool=cast(Any, _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})),
+        max_iterations=5,
+    )
+
+    assert out.stop_reason == "end_turn"
+    assert calls[1]["context_management"] == context_management
+    assert calls[1]["betas"] == ["compact-2026-01-12"]
+    assistant_content = calls[1]["messages"][-2]["content"]
+    assert assistant_content[0] == {"type": "compaction", "content": "Conversation summary"}
+    assert assistant_content[1]["type"] == "tool_use"
+
+
+@pytest.mark.asyncio
 async def test_loop_accumulates_usage_across_iterations(monkeypatch: pytest.MonkeyPatch) -> None:
     responses = iter(
         [

--- a/tests/unit/test_mcp_loop_messages.py
+++ b/tests/unit/test_mcp_loop_messages.py
@@ -17,9 +17,7 @@ from any_llm.types.messages import (
     ContentBlockStartEvent,
     ContentBlockStopEvent,
     InputJSONDelta,
-    MessageDelta,
     MessageDeltaEvent,
-    MessageDeltaUsage,
     MessageResponse,
     MessageStartEvent,
     MessageStopEvent,
@@ -563,17 +561,27 @@ def _msg_start_event() -> MessageStartEvent:
     )
 
 
-def _msg_delta_event(stop_reason: str, output_tokens: int = 1) -> MessageDeltaEvent:
-    return MessageDeltaEvent(
-        type="message_delta",
-        delta=MessageDelta(stop_reason=cast(Any, stop_reason), stop_sequence=None),
-        usage=MessageDeltaUsage(
-            input_tokens=None,
-            output_tokens=output_tokens,
-            cache_creation_input_tokens=None,
-            cache_read_input_tokens=None,
-            server_tool_use=None,
-        ),
+def _msg_delta_event(
+    stop_reason: str,
+    output_tokens: int = 1,
+    *,
+    iterations: list[dict[str, Any]] | None = None,
+    applied_edits: list[dict[str, Any]] | None = None,
+) -> MessageDeltaEvent:
+    return MessageDeltaEvent.model_validate(
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+            "usage": {
+                "input_tokens": None,
+                "output_tokens": output_tokens,
+                "cache_creation_input_tokens": None,
+                "cache_read_input_tokens": None,
+                "server_tool_use": None,
+                "iterations": iterations,
+            },
+            "context_management": {"applied_edits": applied_edits} if applied_edits is not None else None,
+        }
     )
 
 
@@ -748,7 +756,26 @@ async def test_stream_replays_compaction_content_when_tool_loop_continues(
                 _tool_use_block_start(1, "tu_1", "fetch_url"),
                 _input_json_delta(1, '{"u": "x"}'),
                 _content_block_stop(1),
-                _msg_delta_event("tool_use"),
+                _msg_delta_event(
+                    "tool_use",
+                    output_tokens=3,
+                    iterations=[
+                        {
+                            "type": "compaction",
+                            "input_tokens": 100,
+                            "output_tokens": 20,
+                            "cache_creation_input_tokens": 0,
+                            "cache_read_input_tokens": 0,
+                        }
+                    ],
+                    applied_edits=[
+                        {
+                            "type": "clear_tool_uses_20250919",
+                            "cleared_input_tokens": 42,
+                            "cleared_tool_uses": 2,
+                        }
+                    ],
+                ),
                 _msg_stop_event(),
             ),
             _async_iter(
@@ -756,7 +783,26 @@ async def test_stream_replays_compaction_content_when_tool_loop_continues(
                 _text_block_start(0),
                 _text_delta(0, "done"),
                 _content_block_stop(0),
-                _msg_delta_event("end_turn"),
+                _msg_delta_event(
+                    "end_turn",
+                    output_tokens=5,
+                    iterations=[
+                        {
+                            "type": "message",
+                            "input_tokens": 10,
+                            "output_tokens": 5,
+                            "cache_creation_input_tokens": 0,
+                            "cache_read_input_tokens": 0,
+                        }
+                    ],
+                    applied_edits=[
+                        {
+                            "type": "clear_thinking_20251015",
+                            "cleared_input_tokens": 21,
+                            "cleared_thinking_turns": 1,
+                        }
+                    ],
+                ),
                 _msg_stop_event(),
             ),
         ]
@@ -769,24 +815,35 @@ async def test_stream_replays_compaction_content_when_tool_loop_continues(
 
     monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
 
-    async for _event in anthropic_tool_loop_stream(
-        completion_kwargs={
-            "model": "fake",
-            "messages": [{"role": "user", "content": "go"}],
-            "max_tokens": 100,
-            "context_management": context_management,
-            "betas": ["compact-2026-01-12"],
-        },
-        pool=cast(Any, _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})),
-        max_iterations=5,
-    ):
-        pass
+    events = [
+        event
+        async for event in anthropic_tool_loop_stream(
+            completion_kwargs={
+                "model": "fake",
+                "messages": [{"role": "user", "content": "go"}],
+                "max_tokens": 100,
+                "context_management": context_management,
+                "betas": ["compact-2026-01-12"],
+            },
+            pool=cast(Any, _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})),
+            max_iterations=5,
+        )
+    ]
 
     assistant_content = calls[1]["messages"][-2]["content"]
     assert assistant_content[0] == {"type": "compaction", "content": "Conversation summary"}
     assert assistant_content[1]["type"] == "tool_use"
     assert calls[1]["context_management"] == context_management
     assert calls[1]["betas"] == ["compact-2026-01-12"]
+
+    final_delta = next(event for event in events if event.type == "message_delta")
+    assert final_delta.usage.output_tokens == 8
+    assert [iteration.type for iteration in final_delta.usage.iterations or []] == ["compaction", "message"]
+    assert final_delta.context_management is not None
+    assert [edit.type for edit in final_delta.context_management.applied_edits] == [
+        "clear_tool_uses_20250919",
+        "clear_thinking_20251015",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mcp_loop_messages.py
+++ b/tests/unit/test_mcp_loop_messages.py
@@ -92,6 +92,7 @@ def _message_response(
     content: list[Any] | None = None,
     input_tokens: int = 1,
     output_tokens: int = 1,
+    iterations: list[dict[str, Any]] | None = None,
 ) -> MessageResponse:
     return MessageResponse(
         id="msg_1",
@@ -101,14 +102,14 @@ def _message_response(
         content=content or [],
         stop_reason=cast(Any, stop_reason),
         stop_sequence=None,
-        usage=MessageUsage(
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            cache_creation_input_tokens=None,
-            cache_read_input_tokens=None,
-            cache_creation=None,
-            server_tool_use=None,
-            service_tier=None,
+        usage=MessageUsage.model_validate(
+            {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cache_creation_input_tokens": None,
+                "cache_read_input_tokens": None,
+                "iterations": iterations,
+            }
         ),
         container=None,
     )
@@ -294,12 +295,37 @@ async def test_loop_accumulates_usage_across_iterations(monkeypatch: pytest.Monk
                 content=[_tool_use("tu_1", "fetch_url", {})],
                 input_tokens=10,
                 output_tokens=2,
+                iterations=[
+                    {
+                        "type": "compaction",
+                        "input_tokens": 100,
+                        "output_tokens": 20,
+                        "cache_creation_input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                    },
+                    {
+                        "type": "message",
+                        "input_tokens": 10,
+                        "output_tokens": 2,
+                        "cache_creation_input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                    },
+                ],
             ),
             _message_response(
                 stop_reason="end_turn",
                 content=[_text_block("done")],
                 input_tokens=12,
                 output_tokens=3,
+                iterations=[
+                    {
+                        "type": "message",
+                        "input_tokens": 12,
+                        "output_tokens": 3,
+                        "cache_creation_input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                    }
+                ],
             ),
         ]
     )
@@ -317,6 +343,11 @@ async def test_loop_accumulates_usage_across_iterations(monkeypatch: pytest.Monk
     assert out.usage is not None
     assert out.usage.input_tokens == 22
     assert out.usage.output_tokens == 5
+    assert [iteration.type for iteration in out.usage.iterations or []] == [
+        "compaction",
+        "message",
+        "message",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_provider_instances.py
+++ b/tests/unit/test_provider_instances.py
@@ -6,7 +6,7 @@ import logging
 
 import pytest
 import yaml
-from any_llm import LLMProvider
+from any_llm import AnyLLM, LLMProvider
 from any_llm.exceptions import AnyLLMError
 
 from gateway.api.routes.pricing import _candidate_model_keys
@@ -278,6 +278,14 @@ def test_resolve_alias_instance() -> None:
     assert resolved.dispatch_model == "openai:qwen3"
 
 
+def test_resolve_registry_only_provider_remains_unsupported(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Otari provider resolution remains enum-backed despite any-llm's wider split type."""
+    monkeypatch.setattr(AnyLLM, "split_model_provider", lambda _selector: ("registry-only", "model"))
+
+    with pytest.raises(ValueError, match="registry-only"):
+        resolve_provider_selector(GatewayConfig(), "registry-only:model")
+
+
 def test_resolve_unknown_provider_raises() -> None:
     # An unconfigured prefix that is not a real provider surfaces any-llm's error
     # (caught as (ValueError, AnyLLMError) by the budget gate).
@@ -385,6 +393,12 @@ def test_normalize_pricing_key_provider_slash_to_colon() -> None:
     assert normalize_pricing_key(GatewayConfig(), "openai/gpt-4o") == "openai:gpt-4o"
 
 
+def test_normalize_pricing_key_accepts_string_provider_from_any_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(AnyLLM, "split_model_provider", lambda _selector: ("registry-only", "model"))
+
+    assert normalize_pricing_key(GatewayConfig(), "registry-only/model") == "registry-only:model"
+
+
 def test_normalize_pricing_key_unparseable_returned_unchanged() -> None:
     assert normalize_pricing_key(GatewayConfig(), "bare-model") == "bare-model"
 
@@ -444,3 +458,9 @@ def test_candidate_model_keys_normalizes_instance_slash_to_colon() -> None:
 
 def test_candidate_model_keys_real_provider_unchanged() -> None:
     assert _candidate_model_keys("openai:gpt-4o") == ["openai:gpt-4o", "openai/gpt-4o"]
+
+
+def test_candidate_model_keys_accepts_string_provider_from_any_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(AnyLLM, "split_model_provider", lambda _selector: ("registry-only", "model"))
+
+    assert _candidate_model_keys("registry-only:model") == ["registry-only:model", "registry-only/model"]

--- a/tests/unit/test_usage_cache_tokens.py
+++ b/tests/unit/test_usage_cache_tokens.py
@@ -149,6 +149,51 @@ def test_messages_non_stream_captures_read_and_write() -> None:
     assert usage.cache_write_tokens == 15
 
 
+def test_messages_non_stream_bills_compaction_iterations() -> None:
+    from any_llm.types.messages import MessageResponse, MessageUsage
+
+    result = MessageResponse.model_construct(
+        usage=MessageUsage.model_validate(
+            {
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "cache_read_input_tokens": 2,
+                "cache_creation_input_tokens": 3,
+                "iterations": [
+                    {
+                        "type": "compaction",
+                        "input_tokens": 100,
+                        "output_tokens": 20,
+                        "cache_read_input_tokens": 30,
+                        "cache_creation_input_tokens": 7,
+                        "cache_creation": {
+                            "ephemeral_5m_input_tokens": 3,
+                            "ephemeral_1h_input_tokens": 4,
+                        },
+                    },
+                    {
+                        "type": "message",
+                        "input_tokens": 10,
+                        "output_tokens": 5,
+                        "cache_read_input_tokens": 2,
+                        "cache_creation_input_tokens": 3,
+                    },
+                ],
+            }
+        )
+    )
+
+    usage = _MessagesAdapter().extract_usage(result)
+
+    assert isinstance(usage, GatewayUsage)
+    assert usage.prompt_tokens == 110
+    assert usage.completion_tokens == 25
+    assert usage.total_tokens == 135
+    assert usage.cache_read_tokens == 32
+    assert usage.cache_write_tokens == 10
+    assert cache_write_1h_tokens_of(usage) == 4
+
+
 def test_messages_non_stream_captures_1h_cache_write_breakdown() -> None:
     """Anthropic's optional TTL breakdown is retained for its distinct rate."""
     from anthropic.types.cache_creation import CacheCreation
@@ -187,6 +232,46 @@ def test_messages_stream_delta_captures_read_and_write() -> None:
     assert isinstance(usage, GatewayUsage)
     assert usage.cache_read_tokens == 5
     assert usage.cache_write_tokens == 2
+
+
+def test_messages_stream_delta_bills_compaction_iterations() -> None:
+    from any_llm.types.messages import MessageDeltaEvent, MessageDeltaUsage
+
+    event = MessageDeltaEvent.model_construct(
+        usage=MessageDeltaUsage.model_validate(
+            {
+                "input_tokens": None,
+                "output_tokens": 5,
+                "cache_read_input_tokens": None,
+                "cache_creation_input_tokens": None,
+                "iterations": [
+                    {
+                        "type": "compaction",
+                        "input_tokens": 100,
+                        "output_tokens": 20,
+                        "cache_read_input_tokens": 30,
+                        "cache_creation_input_tokens": 7,
+                    },
+                    {
+                        "type": "message",
+                        "input_tokens": 10,
+                        "output_tokens": 5,
+                        "cache_read_input_tokens": 2,
+                        "cache_creation_input_tokens": 3,
+                    },
+                ],
+            }
+        )
+    )
+
+    usage = _messages_stream_usage(event)
+
+    assert isinstance(usage, GatewayUsage)
+    assert usage.prompt_tokens == 110
+    assert usage.completion_tokens == 25
+    assert usage.total_tokens == 135
+    assert usage.cache_read_tokens == 32
+    assert usage.cache_write_tokens == 10
 
 
 def test_responses_captures_cached_tokens() -> None:


### PR DESCRIPTION
## Description

Fix streaming compaction replay through gateway-managed tool loops, including multi-chunk summaries and hidden-iteration telemetry. Bill compaction sampling from Anthropic's per-iteration usage, and add `context_management` and `betas` to the token-count request schema for wire compatibility. Add contract coverage for non-streaming, streaming, and tool-loop paths.

Four provider-parsing tests backfill behavior introduced by #505; this PR does not upgrade any-llm.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #486

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** OpenAI GPT-5.6 Sol via Pi

**Any additional AI details you'd like to share:** AI inspected the existing diff, ran lint, type checking, eight targeted tests, and generated-artifact checks, then drafted and updated the PR description. The full `make test` suite was not run.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added Anthropic context compaction support to the Messages API.
- Preserved compaction content and context telemetry across streaming, non-streaming, and gateway-managed tool loops.
- Included compaction sampling and cache usage in token and cost metering.
- Added `context_management` and `betas` to token-count requests.
- Added contract and regression tests for compaction, tool loops, streaming usage, and provider parsing.
- Updated API documentation.

## Validation

- Added coverage for non-streaming, streaming, tool-loop, token-count, billing, and provider-parsing paths.
- The full test suite was not run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
