### PR TITLE
feat(responses): support compaction in managed tool loops

### DIFF
--- a/src/gateway/services/mcp_loop_responses.py
+++ b/src/gateway/services/mcp_loop_responses.py
@@ -214,6 +214,25 @@ def _web_search_items_for(owned: list[Any]) -> list[ResponseFunctionWebSearch]:
     return items
 
 
+def _compaction_items(output: list[Any]) -> list[Any]:
+    """Return provider compaction items in output order."""
+    return [item for item in output if getattr(item, "type", None) == "compaction"]
+
+
+def _replay_items(output: list[Any], owned: list[Any]) -> list[Any]:
+    """Keep compaction and owned function calls in provider output order."""
+    owned_call_ids = {getattr(item, "call_id", None) for item in owned}
+    return [
+        item
+        for item in output
+        if getattr(item, "type", None) == "compaction"
+        or (
+            getattr(item, "type", None) == "function_call"
+            and getattr(item, "call_id", None) in owned_call_ids
+        )
+    ]
+
+
 async def _execute_stream_owned(state: "_ResponsesStreamState", pool: ToolBackend) -> list[dict[str, Any]]:
     """Run the stream's gateway-owned function calls, returning their output items.
 
@@ -264,12 +283,28 @@ def _without_output_items(event: Any, call_ids: set[str]) -> Any:
         return event
 
 
+def _prepend_output_items(event: Any, items: list[Any]) -> Any:
+    """Prepend hidden-iteration output items to a terminal response."""
+    if not items:
+        return event
+    response_obj = getattr(event, "response", None)
+    if response_obj is None:
+        return event
+    try:
+        output = list(items) + list(getattr(response_obj, "output", None) or [])
+        return event.model_copy(update={"response": response_obj.model_copy(update={"output": output})})
+    except (AttributeError, TypeError):
+        logger.warning("Could not add hidden Responses output items to response.completed")
+        return event
+
+
 class _ResponsesStreamState:
     """Per-iteration bookkeeping for the Responses streaming loop."""
 
     def __init__(self) -> None:
         # output_index -> {"call_id", "name", "arguments"}
         self.function_calls: dict[int, dict[str, Any]] = {}
+        self.compaction_items: dict[int, Any] = {}
         self.deferred_completed: ResponseStreamEvent | None = None
         self.owned_specs: list[dict[str, Any]] = []
         # Output items the gateway runs itself. Their events are swallowed: the
@@ -305,8 +340,9 @@ class _ResponsesToolLoopStrategy:
 
     def new_usage_accumulator(self) -> dict[str, Any]:
         # ``searches`` collects the gateway-run searches so the final response can
-        # announce them natively; see ``fold_usage``.
-        return {"input": 0, "output": 0, "total": 0, "searches": []}
+        # announce them natively; ``compactions`` keeps replay state produced by
+        # hidden iterations available to the caller. See ``fold_usage``.
+        return {"input": 0, "output": 0, "total": 0, "searches": [], "compactions": []}
 
     def accumulate_usage(self, acc: dict[str, Any], result: Response) -> None:
         if result.usage:
@@ -319,11 +355,12 @@ class _ResponsesToolLoopStrategy:
         # Prepend a native ``web_search_call`` item per gateway-run search. The
         # loop consumed the raw ``function_call`` items, so without this the caller
         # has no way to know a search happened; they come first because they did.
-        if acc["searches"]:
+        hidden_output = list(acc["compactions"]) + list(acc["searches"])
+        if hidden_output:
             try:
-                result.output = list(acc["searches"]) + list(result.output or [])
+                result.output = hidden_output + list(result.output or [])
             except (AttributeError, TypeError):
-                logger.warning("Could not add web_search_call items to the response output")
+                logger.warning("Could not add hidden tool-loop items to the response output")
 
     def exit_before_split(self, result: Response) -> bool:
         return False
@@ -370,12 +407,15 @@ class _ResponsesToolLoopStrategy:
         pool: ToolBackend,
         acc: dict[str, Any] | None = None,
     ) -> None:
-        # All-owned: continue. Append the assistant's function_call items AND
-        # the matching function_call_output items so the next call's input has
-        # the full transcript.
-        transcript.extend(_items_to_dicts(owned))
+        # All-owned: continue. Replay compaction items and the assistant's
+        # function calls in their original output order, then append matching
+        # function_call_output items. Stateless compaction requires the opaque
+        # compaction item on every continuation.
+        output = list(result.output or [])
+        transcript.extend(_items_to_dicts(_replay_items(output, owned)))
         transcript.extend(await _execute_function_calls(pool, owned))
         if acc is not None:
+            acc["compactions"].extend(_compaction_items(output))
             acc["searches"].extend(_web_search_items_for(owned))
 
     # ---- streaming hooks ----
@@ -387,7 +427,7 @@ class _ResponsesToolLoopStrategy:
     def new_stream_state(self) -> _ResponsesStreamState:
         return _ResponsesStreamState()
 
-    def new_stream_accumulator(self) -> dict[str, int]:
+    def new_stream_accumulator(self) -> dict[str, Any]:
         # Each iteration's ``response.completed`` carries that iteration's
         # usage on ``event.response.usage``. When the loop continues, that
         # event is dropped and its usage would be lost from streaming token
@@ -401,14 +441,20 @@ class _ResponsesToolLoopStrategy:
         # ``sequence_number`` is renumbered continuously. Without this a tool-loop
         # stream repeats ``response.created`` and restarts sequence numbers, which
         # the SDK's stream helper treats as a protocol error.
-        return {"output_tokens": 0, "started": 0, "next_sequence": 0, "next_output_index": 0}
+        return {
+            "output_tokens": 0,
+            "started": 0,
+            "next_sequence": 0,
+            "next_output_index": 0,
+            "compactions": [],
+        }
 
     def observe(
         self,
         state: _ResponsesStreamState,
         event: ResponseStreamEvent,
         pool: ToolBackend,
-        acc: dict[str, int],
+        acc: dict[str, Any],
     ) -> tuple[StreamAction, ResponseStreamEvent]:
         etype = getattr(event, "type", None)
 
@@ -418,10 +464,19 @@ class _ResponsesToolLoopStrategy:
             acc["started"] = 1
             return StreamAction.FORWARD, self._resequenced(event, acc)
 
-        if etype == "response.output_item.added":
+        if etype in {"response.output_item.added", "response.output_item.done"}:
             item = getattr(event, "item", None)
             output_index = getattr(event, "output_index", None)
-            if item is not None and output_index is not None and getattr(item, "type", None) == "function_call":
+            if item is not None and isinstance(output_index, int) and getattr(item, "type", None) == "compaction":
+                # The done event replaces the added snapshot when both arrive,
+                # ensuring the replay uses the complete encrypted payload.
+                state.compaction_items[output_index] = item
+            if (
+                etype == "response.output_item.added"
+                and item is not None
+                and output_index is not None
+                and getattr(item, "type", None) == "function_call"
+            ):
                 name = getattr(item, "name", "")
                 state.function_calls[output_index] = {
                     "call_id": getattr(item, "call_id", ""),
@@ -512,7 +567,7 @@ class _ResponsesToolLoopStrategy:
         if state.owned_specs:
             await _execute_stream_owned(state, pool)
 
-    def terminal_events(self, state: _ResponsesStreamState, acc: dict[str, int]) -> list[ResponseStreamEvent]:
+    def terminal_events(self, state: _ResponsesStreamState, acc: dict[str, Any]) -> list[ResponseStreamEvent]:
         if state.deferred_completed is None:
             return []
         # The terminal event carries the whole response, whose ``output`` still lists
@@ -521,12 +576,13 @@ class _ResponsesToolLoopStrategy:
         # client just accumulated, and hand it a call it cannot dispatch.
         hidden = _hidden_call_ids(state)
         folded = _without_output_items(state.deferred_completed, hidden) if hidden else state.deferred_completed
+        folded = _prepend_output_items(folded, acc["compactions"])
         folded = _maybe_fold_response_completed_usage(folded, acc["output_tokens"])
         # The terminal event is the last thing the client sees, so it continues the
         # same sequence as the events forwarded before it.
         return [self._resequenced(folded, acc)]
 
-    def accumulate_stream_usage(self, acc: dict[str, int], state: _ResponsesStreamState) -> None:
+    def accumulate_stream_usage(self, acc: dict[str, Any], state: _ResponsesStreamState) -> None:
         # All-owned continuation: fold this iteration's output_tokens from the
         # dropped ``response.completed`` event into the running total.
         if state.deferred_completed is not None:
@@ -534,9 +590,10 @@ class _ResponsesToolLoopStrategy:
             iter_usage = getattr(iter_response, "usage", None) if iter_response is not None else None
             if iter_usage is not None:
                 acc["output_tokens"] += getattr(iter_usage, "output_tokens", 0) or 0
+        acc["compactions"].extend(state.compaction_items[index] for index in sorted(state.compaction_items))
 
     def synthetic_events(
-        self, state: _ResponsesStreamState, acc: dict[str, int]
+        self, state: _ResponsesStreamState, acc: dict[str, Any]
     ) -> list[ResponseStreamEvent]:
         """Announce gateway-run searches in the Responses API's native vocabulary.
 
@@ -581,16 +638,21 @@ class _ResponsesToolLoopStrategy:
         state: _ResponsesStreamState,
         pool: ToolBackend,
     ) -> None:
-        transcript.extend(
-            {
-                "type": "function_call",
-                "call_id": spec["call_id"],
-                "name": spec["name"],
-                "arguments": spec["arguments"] or "{}",
-            }
-            for spec in state.owned_specs
-        )
-
+        replay_items: list[Any] = []
+        for output_index in sorted(set(state.compaction_items) | set(state.function_calls)):
+            if output_index in state.compaction_items:
+                replay_items.append(state.compaction_items[output_index])
+            if output_index in state.function_calls:
+                spec = state.function_calls[output_index]
+                replay_items.append(
+                    {
+                        "type": "function_call",
+                        "call_id": spec["call_id"],
+                        "name": spec["name"],
+                        "arguments": spec["arguments"] or "{}",
+                    }
+                )
+        transcript.extend(_items_to_dicts(replay_items))
         transcript.extend(await _execute_stream_owned(state, pool))
 
 

--- a/tests/integration/test_responses_route_dispatch.py
+++ b/tests/integration/test_responses_route_dispatch.py
@@ -8,6 +8,7 @@ string — the Responses API doesn't use the Anthropic-style error envelope).
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 from typing import Any, cast
 from unittest.mock import AsyncMock, patch
@@ -15,7 +16,14 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from any_llm.types.responses import Response, ResponseStreamEvent
 from fastapi.testclient import TestClient
-from openai.types.responses import ResponseCompletedEvent, ResponseTextDeltaEvent, ResponseUsage
+from openai.types.responses import (
+    ResponseCompactionItem,
+    ResponseCompletedEvent,
+    ResponseOutputItemAddedEvent,
+    ResponseOutputItemDoneEvent,
+    ResponseTextDeltaEvent,
+    ResponseUsage,
+)
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
 _MODEL = "openai:gpt-4o-mini"
@@ -71,6 +79,45 @@ def test_no_tools_falls_through_to_plain_aresponses(
     assert resp.status_code == 200, resp.text
     # No tools in the upstream kwargs since none were requested.
     assert "tools" not in captured
+    assert "context_management" not in captured
+
+
+def test_context_management_and_compaction_output_pass_through(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    context_management = [{"type": "compaction", "compact_threshold": 200_000}]
+    compaction = ResponseCompactionItem(
+        id="cmp_direct",
+        type="compaction",
+        encrypted_content="opaque-direct",
+    )
+    captured: dict[str, Any] = {}
+
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        captured.update(kwargs)
+        return _response(output=[compaction])
+
+    with patch("gateway.api.routes.responses.aresponses", new=fake_aresponses):
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": _MODEL,
+                "input": "hi",
+                "context_management": context_management,
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert captured["context_management"] == context_management
+    assert resp.json()["output"] == [
+        {
+            "id": "cmp_direct",
+            "encrypted_content": "opaque-direct",
+            "type": "compaction",
+        }
+    ]
 
 
 def test_bare_string_input_not_corrupted_by_normalization(
@@ -660,6 +707,73 @@ def test_stream_no_tools_returns_sse_response(
     assert resp.status_code == 200, resp.text
     assert resp.headers["content-type"].startswith("text/event-stream")
     assert tool_loop_called is False
+
+
+def test_stream_context_management_and_compaction_events_pass_through(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    context_management = [{"type": "compaction", "compact_threshold": 200_000}]
+    compaction = ResponseCompactionItem(
+        id="cmp_stream",
+        type="compaction",
+        encrypted_content="opaque-stream",
+    )
+    captured: dict[str, Any] = {}
+
+    async def fake_aresponses(**kwargs: Any) -> AsyncIterator[ResponseStreamEvent]:
+        captured.update(kwargs)
+        return _stream_iter(
+            ResponseOutputItemAddedEvent(
+                type="response.output_item.added",
+                item=compaction,
+                output_index=0,
+                sequence_number=0,
+            ),
+            ResponseOutputItemDoneEvent(
+                type="response.output_item.done",
+                item=compaction,
+                output_index=0,
+                sequence_number=1,
+            ),
+            ResponseCompletedEvent(
+                type="response.completed",
+                response=_response(output=[compaction]),
+                sequence_number=2,
+            ),
+        )
+
+    with patch("gateway.api.routes.responses.aresponses", new=fake_aresponses):
+        resp = client.post(
+            "/v1/responses",
+            json={
+                "model": _MODEL,
+                "input": "hi",
+                "stream": True,
+                "context_management": context_management,
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert captured["context_management"] == context_management
+    payloads = [
+        json.loads(line.removeprefix("data: "))
+        for line in resp.iter_lines()
+        if line.startswith("data: {")
+    ]
+    compactions = [
+        payload
+        for payload in payloads
+        if payload.get("item", {}).get("type") == "compaction"
+    ]
+    assert [payload["type"] for payload in compactions] == [
+        "response.output_item.added",
+        "response.output_item.done",
+    ]
+    assert all(payload["item"]["encrypted_content"] == "opaque-stream" for payload in compactions)
+    completed = next(payload for payload in payloads if payload["type"] == "response.completed")
+    assert completed["response"]["output"][0]["type"] == "compaction"
 
 
 def test_stream_mcp_servers_dispatches_through_tool_loop_stream(

--- a/tests/unit/test_mcp_loop_responses.py
+++ b/tests/unit/test_mcp_loop_responses.py
@@ -14,6 +14,7 @@ from typing import Any, cast
 import pytest
 from any_llm.types.responses import Response, ResponseStreamEvent
 from openai.types.responses import (
+    ResponseCompactionItem,
     ResponseCompletedEvent,
     ResponseFunctionCallArgumentsDeltaEvent,
     ResponseFunctionCallArgumentsDoneEvent,
@@ -81,6 +82,14 @@ def _function_call(
         call_id=call_id,
         name=name,
         arguments=arguments,
+    )
+
+
+def _compaction(item_id: str = "cmp_1") -> ResponseCompactionItem:
+    return ResponseCompactionItem(
+        id=item_id,
+        type="compaction",
+        encrypted_content=f"opaque-{item_id}",
     )
 
 
@@ -221,6 +230,43 @@ async def test_loop_executes_owned_function_call_and_completes(monkeypatch: pyte
     assert output_item["call_id"] == "call_1"
     assert output_item["output"] == "ok"
     assert out.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_loop_replays_and_returns_compaction_from_hidden_iteration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compaction = _compaction()
+    responses = iter(
+        [
+            _response(output=[compaction, _function_call("call_1", "fetch_url", "{}")]),
+            _response(output=[], status="completed"),
+        ]
+    )
+    captured_inputs: list[list[Any]] = []
+
+    async def fake_aresponses(**kwargs: Any) -> Response:
+        captured_inputs.append(list(kwargs["input_data"]))
+        return next(responses)
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    out = await responses_tool_loop(
+        completion_kwargs={"model": "fake", "input_data": "go"},
+        pool=cast(Any, _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})),
+        max_iterations=5,
+    )
+
+    replay = captured_inputs[1][-3:]
+    assert [item["type"] for item in replay] == [
+        "compaction",
+        "function_call",
+        "function_call_output",
+    ]
+    assert replay[0]["encrypted_content"] == "opaque-cmp_1"
+    assert [getattr(item, "type", None) for item in out.output] == ["compaction"]
+    assert isinstance(out.output[0], ResponseCompactionItem)
+    assert out.output[0].encrypted_content == "opaque-cmp_1"
 
 
 @pytest.mark.asyncio
@@ -628,6 +674,63 @@ async def test_stream_runs_owned_function_call_and_continues(monkeypatch: pytest
     seqs = [e.sequence_number for e in events if getattr(e, "sequence_number", None) is not None]
     assert seqs == list(range(len(seqs)))
     assert pool.calls == [("fetch_url", {"u": "x"})]
+
+
+@pytest.mark.asyncio
+async def test_stream_replays_and_returns_compaction_from_hidden_iteration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compaction = _compaction()
+    function_call = _function_call("call_1", "fetch_url", "{}")
+    iter_streams = iter(
+        [
+            _async_iter(
+                _output_item_added(0, compaction),
+                _output_item_done(0, compaction),
+                _output_item_added(1, function_call),
+                _function_call_args_done(1, "fc_item_1", "fetch_url", "{}"),
+                _output_item_done(1, function_call),
+                _response_completed(output=[compaction, function_call]),
+            ),
+            _async_iter(
+                _text_delta("msg_1", 0, "done"),
+                _response_completed(),
+            ),
+        ]
+    )
+    captured_inputs: list[list[Any]] = []
+
+    async def fake_aresponses(**kwargs: Any) -> AsyncIterator[ResponseStreamEvent]:
+        captured_inputs.append(list(kwargs["input_data"]))
+        return next(iter_streams)
+
+    monkeypatch.setattr(responses_loop_module, "aresponses", fake_aresponses)
+
+    events = [
+        event
+        async for event in responses_tool_loop_stream(
+            completion_kwargs={"model": "fake", "input_data": "go"},
+            pool=cast(Any, _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})),
+            max_iterations=5,
+        )
+    ]
+
+    replay = captured_inputs[1][-3:]
+    assert [item["type"] for item in replay] == [
+        "compaction",
+        "function_call",
+        "function_call_output",
+    ]
+    assert replay[0]["encrypted_content"] == "opaque-cmp_1"
+    assert [
+        event.type
+        for event in events
+        if getattr(getattr(event, "item", None), "type", None) == "compaction"
+    ] == ["response.output_item.added", "response.output_item.done"]
+    completed = next(event for event in events if event.type == "response.completed")
+    assert [getattr(item, "type", None) for item in completed.response.output] == ["compaction"]
+    assert isinstance(completed.response.output[0], ResponseCompactionItem)
+    assert completed.response.output[0].encrypted_content == "opaque-cmp_1"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Current `main` supports context compaction for direct Responses calls through any-llm 1.24.0. Gateway-managed tool loops still omitted intermediate compaction items when running a tool, so `/v1/responses` did not yet have end-to-end compaction support.

Replay compaction items in provider output order before function-call outputs, and include compaction state from internal iterations in the final streaming and non-streaming response. Adds direct passthrough coverage and managed-tool regression tests.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #495

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** OpenAI GPT-5.6 Sol via Pi

**Any additional AI details you'd like to share:** AI inspected the related Otari and any-llm changes, implemented the tool-loop replay behavior, and added contract and regression coverage. `make lint`, `make typecheck`, 81 targeted tests, and generated OpenAPI and Postman checks passed. The full `make test` suite was not run.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added OpenAI Responses compaction support for direct requests and gateway-managed tool loops.
- Preserved compaction output in streaming and non-streaming responses.
- Replayed compaction items before matching function-call outputs during tool-loop continuations.
- Exposed compaction state from internal iterations for stateless follow-up requests.
- Added integration and unit tests for request forwarding, event streaming, and tool-loop behavior.
- Updated behavior for any-llm 1.24.0.

## Benefits

Clients now receive complete compaction state across direct requests and managed tool loops without changing requests that omit `context_management`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->