### PR TITLE
fix(sdk-codegen): allow non_snake_case in the generated Rust core

### DIFF
--- a/scripts/sdk_codegen/generate.py
+++ b/scripts/sdk_codegen/generate.py
@@ -151,6 +151,11 @@ _RUST_MODULE_HEADER = """\
 //! lived in its own crate. Do not add hand-written code here.
 #![allow(unused_imports)]
 #![allow(dead_code)]
+// Schemas whose names carry their defining module (Pydantic disambiguates
+// duplicate class names that way, e.g. anthropic__types__thinking_block__
+// ThinkingBlock) generate module names with double underscores, which rustc's
+// non_snake_case lint rejects under the SDK crate's -D warnings.
+#![allow(non_snake_case)]
 #![allow(clippy::all)]
 #![allow(clippy::pedantic)]
 #![allow(clippy::nursery)]


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Fixes a Rust codegen output break that is currently red on mozilla-ai/otari-sdk-rust#50.

Schemas whose names carry their defining module (Pydantic disambiguates duplicate class names that way, for example `anthropic__types__thinking_block__ThinkingBlock`, which arrived with the Anthropic context-compaction work) generate Rust module names with double underscores. `non_snake_case` is a rustc lint, not a clippy one, so the existing `#![allow(clippy::...)]` block in the generated core's header does not cover it, and the SDK crate builds with `-D warnings`.

Verified by applying the new header verbatim to otari-sdk-rust on top of the current regen branch: `cargo clippy --all-features --all-targets -- -D warnings` passes, along with fmt, the full test suite, and docs.

Heads up on ordering: `scripts/sdk_codegen/**` is in the codegen workflow's trigger paths, so merging this re-runs codegen and force-pushes all four `sdk-codegen/client-core` branches. The four SDK manifest PRs (otari-sdk-go#24, otari-sdk-ts#34, otari-sdk-rust#52, otari-sdk-python#24) should land first so the regen rebases onto green mains.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

Part of #438.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). No new test: the change is a literal in the generated-core header, and the existing `generate (rust)` CI job exercises it end to end.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). Ran `make lint`, `make typecheck`, and `tests/unit/test_sdk_codegen.py` (33 passed, 1 skipped), not the full suite.
- [ ] Documentation was updated where necessary. Not applicable; the rationale is a comment beside the attribute.
- [ ] If the API contract changed, I regenerated the OpenAPI spec. Not applicable; no API contract change.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

Root-caused from the failing CI on the four stale SDK regen PRs in #438. The fix was validated against a real checkout of otari-sdk-rust before this PR was opened.

- [x] I am an AI Agent filling out this form (check box if true)
