### PR TITLE
fix(sdk-codegen): make the gateway the source of truth for endpoint coverage

### DIFF
--- a/.github/workflows/otari-sdk-codegen.yml
+++ b/.github/workflows/otari-sdk-codegen.yml
@@ -112,6 +112,14 @@ jobs:
           mkdir -p "$(dirname "$target")"
           cp -r "dist/${{ matrix.language }}" "$target"
 
+      - name: Sync the endpoint-coverage manifest into the SDK repo
+        # scripts/sdk_codegen/sdk-endpoints.txt is the canonical copy, validated
+        # against docs/public/openapi.json by tests/unit/test_sdk_endpoint_coverage.py
+        # in this repo. Pushing it here makes the SDK copies generated artifacts,
+        # so the four repos cannot drift apart the way they did when each was
+        # hand-maintained under a "keep these identical" comment.
+        run: cp scripts/sdk_codegen/sdk-endpoints.txt sdk-repo/sdk-endpoints.txt
+
       - name: Open PR on ${{ matrix.sdk_repo }}
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:

--- a/scripts/sdk_codegen/README.md
+++ b/scripts/sdk_codegen/README.md
@@ -57,11 +57,29 @@ policy and the spec-version to minimum-SDK-version matrix.
 ## Endpoint-coverage drift gate
 
 Because the core is generated but the shell is hand-written, a new gateway
-endpoint can land in the spec without a corresponding shell method. Each SDK
-repo runs an endpoint-coverage drift gate against the gateway's published spec
-to catch this: if the generated core gains endpoints the SDK does not yet
-surface, the gate fails, signalling that the SDK needs a regeneration plus shell
-wiring for the new surface.
+endpoint can land in the spec without a corresponding shell method. The drift
+gate catches that.
+
+`sdk-endpoints.txt` in this directory is the **canonical** manifest: every
+endpoint in `docs/public/openapi.json` must be listed under `[covered]` (a
+public SDK wrapper surfaces it) or `[excluded]` (deliberately not surfaced,
+with a reason). `tests/unit/test_sdk_endpoint_coverage.py` enforces both
+directions against the spec **from the same commit**, so a gateway PR that adds
+an endpoint fails the gateway's own build until the endpoint is classified.
+`endpoint_manifest.py` holds the parsing and comparison logic.
+
+The codegen workflow copies the manifest into each SDK repo alongside the
+generated core, so the four copies are generated artifacts. Edit the copy here;
+edits in an SDK repo are overwritten on the next regeneration.
+
+This arrangement is deliberate. The gate used to live only in the SDK repos,
+where each copy fetched the gateway's spec from `main` over the network at test
+time. That made the check a moving target: an unchanged SDK commit passed one
+day and failed the next, and because SDK CI only runs on push or PR, all four
+`main` branches sat red and unnoticed for over two weeks
+([#438](https://github.com/mozilla-ai/otari/issues/438)). Validating here
+instead means drift fails in the repo that causes it, at the moment it is
+caused, against a spec that cannot change underneath the assertion.
 
 ## Local usage
 

--- a/scripts/sdk_codegen/endpoint_manifest.py
+++ b/scripts/sdk_codegen/endpoint_manifest.py
@@ -1,0 +1,91 @@
+"""Endpoint-coverage manifest: parsing and drift detection.
+
+``sdk-endpoints.txt`` (next to this module) records which gateway OpenAPI
+endpoints the SDKs surface. It is the canonical copy: the codegen workflow
+pushes it into each SDK repo alongside the generated core, so the copies there
+are generated artifacts rather than four hand-kept files.
+
+Keeping it here means drift is caught in the repo that causes it. A gateway PR
+that adds an endpoint fails ``tests/unit/test_sdk_endpoint_coverage.py`` until
+the endpoint is classified, instead of silently reddening four downstream repos
+whose CI happens not to run that week.
+
+Format: ``[covered]`` / ``[excluded]`` sections, one ``METHOD /path`` per line
+with an optional ``# reason`` trailer. Blank lines and ``#`` lines are ignored.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+MANIFEST_PATH = Path(__file__).resolve().parent / "sdk-endpoints.txt"
+
+# Verbs that denote an API operation; OpenAPI path items also carry keys like
+# "parameters" and "summary", which are not endpoints.
+HTTP_METHODS = frozenset({"get", "post", "put", "patch", "delete"})
+
+# Liveness/readiness routes are gateway plumbing, not an SDK surface, so they
+# are filtered out rather than needing an [excluded] entry apiece.
+_META_PREFIX = "/health"
+
+
+def parse_manifest(text: str) -> tuple[set[str], set[str]]:
+    """Return the ``(covered, excluded)`` endpoint sets from manifest text.
+
+    Entries are normalized to ``METHOD /path`` with an uppercase method, so
+    comparison against a spec is case-insensitive on the verb.
+    """
+    covered: set[str] = set()
+    excluded: set[str] = set()
+    section: set[str] | None = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line == "[covered]":
+            section = covered
+            continue
+        if line == "[excluded]":
+            section = excluded
+            continue
+        entry = line.split("#", 1)[0].strip()
+        if not entry or section is None:
+            continue
+        method, path = entry.split(None, 1)
+        section.add(f"{method.upper()} {path.strip()}")
+    return covered, excluded
+
+
+def spec_endpoints(spec: dict[str, Any]) -> set[str]:
+    """Extract ``METHOD /path`` pairs from an OpenAPI doc, dropping meta routes."""
+    endpoints: set[str] = set()
+    for path, operations in spec.get("paths", {}).items():
+        if path == _META_PREFIX or path.startswith(f"{_META_PREFIX}/"):
+            continue
+        for method in operations:
+            if method.lower() in HTTP_METHODS:
+                endpoints.add(f"{method.upper()} {path}")
+    return endpoints
+
+
+def load_manifest(path: Path | None = None) -> tuple[set[str], set[str]]:
+    """Read and parse the manifest, defaulting to the canonical copy."""
+    return parse_manifest((path or MANIFEST_PATH).read_text(encoding="utf-8"))
+
+
+def load_spec(path: Path) -> dict[str, Any]:
+    """Read an OpenAPI document from ``path``."""
+    spec: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    return spec
+
+
+def unaccounted(endpoints: set[str], covered: set[str], excluded: set[str]) -> list[str]:
+    """Spec endpoints listed in neither section, sorted."""
+    return sorted(endpoints - (covered | excluded))
+
+
+def stale(endpoints: set[str], covered: set[str], excluded: set[str]) -> list[str]:
+    """Manifest entries no longer present in the spec, sorted."""
+    return sorted((covered | excluded) - endpoints)

--- a/scripts/sdk_codegen/sdk-endpoints.txt
+++ b/scripts/sdk_codegen/sdk-endpoints.txt
@@ -1,0 +1,142 @@
+# Endpoint-coverage drift manifest for the otari SDKs.
+#
+# CANONICAL COPY. This file is the single source of truth. The codegen workflow
+# (.github/workflows/otari-sdk-codegen.yml) pushes it into all four SDK repos
+# alongside the generated core, so the copies there are generated artifacts.
+# Edit this file; never edit the copies, they are overwritten on every regen.
+#
+# tests/unit/test_sdk_endpoint_coverage.py checks it against
+# docs/public/openapi.json from the same commit: every "METHOD path" the spec
+# exposes (excluding /health* meta routes) must appear under [covered] or
+# [excluded], and every entry here must still exist in the spec. So adding a
+# gateway endpoint fails the gateway's own build until it is classified here.
+# That is the point: drift fails in the repo that causes it, at the moment it
+# is caused, rather than surfacing later in four downstream repos.
+#
+#   [covered]   a public SDK wrapper surfaces this endpoint
+#   [excluded]  deliberately not surfaced; give a reason
+#
+# Lines are "METHOD /path" with an optional "# reason" trailer; blank lines and
+# comment lines are ignored.
+
+[covered]
+# Inference
+POST /v1/chat/completions
+POST /v1/responses
+POST /v1/messages
+POST /v1/messages/count_tokens
+POST /v1/embeddings
+POST /v1/moderations
+POST /v1/rerank
+GET /v1/models
+# Batches
+POST /v1/batches
+GET /v1/batches
+GET /v1/batches/{batch_id}
+POST /v1/batches/{batch_id}/cancel
+GET /v1/batches/{batch_id}/results
+# Control plane: keys
+POST /v1/keys
+GET /v1/keys
+GET /v1/keys/{key_id}
+PATCH /v1/keys/{key_id}
+DELETE /v1/keys/{key_id}
+# Control plane: users
+POST /v1/users
+GET /v1/users
+GET /v1/users/{user_id}
+PATCH /v1/users/{user_id}
+DELETE /v1/users/{user_id}
+GET /v1/users/{user_id}/usage
+# Control plane: budgets
+POST /v1/budgets
+GET /v1/budgets
+GET /v1/budgets/{budget_id}
+PATCH /v1/budgets/{budget_id}
+DELETE /v1/budgets/{budget_id}
+# Control plane: pricing
+POST /v1/pricing
+GET /v1/pricing
+GET /v1/pricing/{model_key}
+GET /v1/pricing/{model_key}/history
+DELETE /v1/pricing/{model_key}
+# Control plane: usage
+GET /v1/usage
+# Images
+POST /v1/images/generations
+# Audio
+POST /v1/audio/speech
+POST /v1/audio/transcriptions
+
+[excluded]
+GET /v1/models/{model_id}      # redundant, list_models covers discovery
+# Files API: added to the gateway spec, not yet wrapped by any SDK shell.
+POST /v1/files                       # not yet wrapped
+GET /v1/files                        # not yet wrapped
+GET /v1/files/{file_id}              # not yet wrapped
+GET /v1/files/{file_id}/content      # not yet wrapped
+DELETE /v1/files/{file_id}           # not yet wrapped
+
+# Dashboard / admin management surface: present in the gateway spec, not yet
+# wrapped by any SDK shell. Deferred here so the drift gate stays green; move to
+# [covered] when a shell surfaces them. Kept identical across all four SDKs.
+# Model aliases
+GET /v1/aliases                                 # not yet wrapped
+POST /v1/aliases                                # not yet wrapped
+DELETE /v1/aliases/{name}                       # not yet wrapped
+# Provider credentials (runtime provider management)
+GET /v1/provider-credentials                    # not yet wrapped
+POST /v1/provider-credentials                   # not yet wrapped
+POST /v1/provider-credentials/test              # not yet wrapped
+PATCH /v1/provider-credentials/{instance}       # not yet wrapped
+DELETE /v1/provider-credentials/{instance}      # not yet wrapped
+POST /v1/provider-credentials/{instance}/test   # not yet wrapped
+# Providers catalogue
+GET /v1/providers                               # not yet wrapped
+GET /v1/providers/catalog                       # not yet wrapped
+# Runtime settings
+GET /v1/settings                                # not yet wrapped
+PATCH /v1/settings                              # not yet wrapped
+# Model discovery / metadata
+GET /v1/models/discoverable                     # not yet wrapped
+GET /v1/models/metadata                         # not yet wrapped
+# Other control-plane extensions of already-covered resources
+GET /v1/usage/count                             # not yet wrapped
+POST /v1/keys/{key_id}/rotate                   # not yet wrapped
+GET /v1/budgets/{budget_id}/reset-logs          # not yet wrapped
+
+# --- Second wave of gateway endpoints (added after the initial manifest) ---
+# Dashboard session auth: browser cookie flow for the admin UI, not an SDK surface.
+POST /v1/auth/session                           # dashboard-only
+DELETE /v1/auth/session                         # dashboard-only
+# OTLP ingest: OpenTelemetry collector receivers, not an SDK surface.
+POST /v1/logs                                   # otel ingest
+POST /v1/traces                                 # otel ingest
+# Usage analytics and maintenance
+GET /v1/usage/summary                           # not yet wrapped
+GET /v1/usage/summary.csv                       # not yet wrapped
+GET /v1/usage/series                            # not yet wrapped
+DELETE /v1/usage                                # not yet wrapped
+POST /v1/usage/external-events                  # not yet wrapped
+POST /v1/usage/set-price                        # not yet wrapped
+# Routing policies
+GET /v1/routing/policies                        # not yet wrapped
+POST /v1/routing/policies                       # not yet wrapped
+DELETE /v1/routing/policies/{name}              # not yet wrapped
+POST /v1/routing/policies/explain               # not yet wrapped
+# Pricing refresh workflow
+POST /v1/pricing/refresh                        # not yet wrapped
+POST /v1/pricing/refresh/confirm                # not yet wrapped
+POST /v1/pricing/refresh/reject                 # not yet wrapped
+# Providers
+GET /v1/providers/catalog/{provider_id}         # not yet wrapped
+GET /v1/providers/health                        # not yet wrapped
+POST /v1/provider-credentials/reencrypt         # not yet wrapped
+# Built-in tool settings and search
+GET /v1/tool-settings                           # not yet wrapped
+PATCH /v1/tool-settings                         # not yet wrapped
+POST /v1/tool-settings/{service}/test           # not yet wrapped
+POST /v1/search                                 # not yet wrapped
+POST /v1/search/{search_tool_name}              # not yet wrapped
+# Settings
+POST /v1/settings/master-key/rotate             # not yet wrapped

--- a/tests/unit/test_endpoint_manifest.py
+++ b/tests/unit/test_endpoint_manifest.py
@@ -1,0 +1,89 @@
+"""Unit tests for the endpoint-manifest parser and drift helpers.
+
+Covers the pure logic in ``scripts/sdk_codegen/endpoint_manifest.py``. The gate
+that applies it to the real spec lives in ``test_sdk_endpoint_coverage.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "sdk_codegen"))
+
+import endpoint_manifest as em  # noqa: E402
+
+MANIFEST = """\
+# leading comment
+[covered]
+POST /v1/chat/completions
+GET /v1/models
+
+[excluded]
+GET /v1/models/{model_id}    # redundant
+post /v1/lowercase-verb
+"""
+
+
+def test_parse_splits_sections() -> None:
+    covered, excluded = em.parse_manifest(MANIFEST)
+    assert covered == {"POST /v1/chat/completions", "GET /v1/models"}
+    assert "GET /v1/models/{model_id}" in excluded
+
+
+def test_parse_strips_reason_trailers() -> None:
+    _, excluded = em.parse_manifest(MANIFEST)
+    assert "GET /v1/models/{model_id}" in excluded
+    assert not any("redundant" in entry for entry in excluded)
+
+
+def test_parse_uppercases_the_verb() -> None:
+    _, excluded = em.parse_manifest(MANIFEST)
+    assert "POST /v1/lowercase-verb" in excluded
+
+
+def test_parse_ignores_entries_before_any_section() -> None:
+    covered, excluded = em.parse_manifest("GET /v1/orphan\n[covered]\nGET /v1/real\n")
+    assert covered == {"GET /v1/real"}
+    assert not excluded
+
+
+def test_spec_endpoints_skips_meta_and_non_verbs() -> None:
+    spec = {
+        "paths": {
+            "/health": {"get": {}},
+            "/health/ready": {"get": {}},
+            "/healthz-not-meta": {"get": {}},
+            "/v1/keys": {"get": {}, "post": {}, "parameters": [], "summary": "x"},
+        }
+    }
+    assert em.spec_endpoints(spec) == {
+        "GET /healthz-not-meta",
+        "GET /v1/keys",
+        "POST /v1/keys",
+    }
+
+
+def test_spec_endpoints_handles_missing_paths() -> None:
+    assert em.spec_endpoints({}) == set()
+
+
+def test_unaccounted_reports_only_unlisted() -> None:
+    endpoints = {"GET /a", "GET /b", "GET /c"}
+    assert em.unaccounted(endpoints, {"GET /a"}, {"GET /b"}) == ["GET /c"]
+
+
+def test_unaccounted_is_empty_when_fully_classified() -> None:
+    endpoints = {"GET /a", "GET /b"}
+    assert em.unaccounted(endpoints, {"GET /a"}, {"GET /b"}) == []
+
+
+def test_stale_reports_entries_absent_from_spec() -> None:
+    assert em.stale({"GET /a"}, {"GET /a"}, {"GET /gone"}) == ["GET /gone"]
+
+
+def test_canonical_manifest_parses_and_is_disjoint() -> None:
+    covered, excluded = em.load_manifest()
+    assert covered and excluded
+    assert not covered & excluded

--- a/tests/unit/test_sdk_endpoint_coverage.py
+++ b/tests/unit/test_sdk_endpoint_coverage.py
@@ -1,0 +1,74 @@
+"""Endpoint-coverage drift gate for the SDK manifest.
+
+Checks ``scripts/sdk_codegen/sdk-endpoints.txt`` against
+``docs/public/openapi.json`` from the same commit. Adding a gateway endpoint
+fails here until it is classified as ``[covered]`` or ``[excluded]``.
+
+This lives in the gateway rather than in the four SDK repos on purpose. The SDK
+copies of the manifest are pushed by the codegen workflow, and their own checks
+cannot see a spec change until a regen lands, so a gateway-side gate is what
+catches drift at the moment it is introduced. Both files are read from disk, so
+the result depends only on the commit under test.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "sdk_codegen"))
+
+import endpoint_manifest as em  # noqa: E402
+
+SPEC_PATH = REPO_ROOT / "docs" / "public" / "openapi.json"
+
+
+@pytest.fixture(scope="module")
+def manifest() -> tuple[set[str], set[str]]:
+    return em.load_manifest()
+
+
+@pytest.fixture(scope="module")
+def endpoints() -> set[str]:
+    return em.spec_endpoints(em.load_spec(SPEC_PATH))
+
+
+def test_manifest_is_well_formed(manifest: tuple[set[str], set[str]]) -> None:
+    covered, excluded = manifest
+    assert covered, "manifest [covered] section is empty"
+    overlap = sorted(covered & excluded)
+    assert not overlap, f"endpoints listed in both sections: {overlap}"
+
+
+def test_spec_endpoints_are_accounted_for(
+    manifest: tuple[set[str], set[str]], endpoints: set[str]
+) -> None:
+    covered, excluded = manifest
+    missing = em.unaccounted(endpoints, covered, excluded)
+    assert not missing, (
+        f"docs/public/openapi.json exposes {len(missing)} endpoint(s) absent from "
+        f"scripts/sdk_codegen/sdk-endpoints.txt: {missing}. Add each under [covered] "
+        "if an SDK wrapper surfaces it, or under [excluded] with a reason if not. "
+        "The codegen workflow pushes this manifest to the SDK repos, so classifying "
+        "it here is what keeps all four in step."
+    )
+
+
+def test_manifest_has_no_stale_entries(
+    manifest: tuple[set[str], set[str]], endpoints: set[str]
+) -> None:
+    """A manifest entry the spec no longer exposes is a leftover, not a deferral.
+
+    Unlike the old per-SDK check, the manifest and the spec are in the same
+    commit here, so a mismatch is always an editing slip and always fixable in
+    the PR that caused it. That makes failing appropriate where warning was not.
+    """
+    covered, excluded = manifest
+    leftovers = em.stale(endpoints, covered, excluded)
+    assert not leftovers, (
+        f"scripts/sdk_codegen/sdk-endpoints.txt lists {len(leftovers)} endpoint(s) "
+        f"the spec no longer exposes: {leftovers}. Remove them, or restore the routes."
+    )


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Makes the gateway the single source of truth for the SDK endpoint-coverage manifest, so drift fails in the repo that causes it. Follow-up to #438.

The gate used to live only in the four SDK repos, where each copy fetched `docs/public/openapi.json` from `main` over the network at test time. Two consequences, both of which bit us:

**It was a moving target.** An unchanged SDK commit passed one day and failed the next. Combined with SDK CI only running on push or PR, all four `main` branches were red from around July 21 and nobody saw it until a regen PR's CI happened to rerun on August 6.

**Four hand-kept copies drift.** The file's own header said "all four otari SDKs keep this list identical". They did not: otari-sdk-rust's copy had diverged in ordering and comments. Same endpoint set, but nothing was enforcing that.

Now `scripts/sdk_codegen/sdk-endpoints.txt` is canonical, `tests/unit/test_sdk_endpoint_coverage.py` checks it against the spec **from the same commit**, and the codegen workflow pushes it into each SDK repo as a generated artifact. Adding a gateway endpoint fails this repo's build until it is classified, which is the intended friction: one line, decided by the person who added the endpoint.

Both directions are enforced. Unaccounted spec endpoints fail, and so do stale manifest entries. The old per-SDK check only warned on stale entries because the manifest and spec could legitimately be out of step across repos; here they are in one commit, so a mismatch is always an editing slip and always fixable in the same PR.

Verified the gate is not vacuous: injecting a fake endpoint into the spec fails `test_spec_endpoints_are_accounted_for`, and adding a bogus manifest line fails `test_manifest_has_no_stale_entries`, both with actionable messages.

The seeded manifest is byte-identical to the go/python/ts copies and endpoint-identical to rust's, so no coverage decision changes here.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

Follow-up to #438.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). Added `tests/unit/test_endpoint_manifest.py` (10 parser tests) and `tests/unit/test_sdk_endpoint_coverage.py` (3 gate tests).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). Ran `make lint`, `make typecheck`, and the full unit suite (1299 passed, 1 skipped).
- [x] Documentation was updated where necessary. `scripts/sdk_codegen/README.md` explains the new arrangement and why.
- [ ] If the API contract changed, I regenerated the OpenAPI spec. Not applicable; no API contract change.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

Came out of root-causing #438. The SDK-side copies still have their own network-fetching tests; a follow-up PR in each SDK repo makes those offline now that this gate is authoritative.

- [x] I am an AI Agent filling out this form (check box if true)
