### PR TITLE
fix(ci): flag regen PRs on failing checks, not just age

### DIFF
--- a/.github/workflows/sdk-regen-staleness.yml
+++ b/.github/workflows/sdk-regen-staleness.yml
@@ -1,9 +1,10 @@
 name: SDK Regen PR Staleness
 
 # Alerts when an SDK regeneration PR (opened by otari-sdk-codegen.yml on the
-# sdk-codegen/client-core branch) sits unmerged beyond the freshness window,
-# which signals an SDK lagging the Otari spec. Keeps a single tracking issue on
-# this repo in sync: opened/updated while any PR is stale, closed once none are.
+# sdk-codegen/client-core branch) needs attention, which signals an SDK lagging
+# the Otari spec. A PR is flagged when its checks are failing (at any age) or it
+# has been open past the freshness window. Keeps a single tracking issue on this
+# repo in sync: opened/updated while any PR is flagged, closed once none are.
 #
 # Reading PRs on the SDK repos needs a token with pull-requests:read on
 # mozilla-ai/otari-sdk-{python,ts,go,rust}; the SDK_CODEGEN_TOKEN used by the
@@ -12,8 +13,10 @@ name: SDK Regen PR Staleness
 
 on:
   schedule:
-    # Mondays at 13:00 UTC.
-    - cron: '0 13 * * 1'
+    # Daily at 13:00 UTC. Weekly undercut the failing-checks trigger: detecting a
+    # red PR "immediately" is still up to seven days late if the check only runs
+    # on Mondays. The job is a handful of API reads, so daily is cheap.
+    - cron: '0 13 * * *'
   workflow_dispatch:
     inputs:
       max_age_days:

--- a/.github/workflows/sdk-regen-staleness.yml
+++ b/.github/workflows/sdk-regen-staleness.yml
@@ -13,10 +13,14 @@ name: SDK Regen PR Staleness
 
 on:
   schedule:
-    # Daily at 13:00 UTC. Weekly undercut the failing-checks trigger: detecting a
-    # red PR "immediately" is still up to seven days late if the check only runs
-    # on Mondays. The job is a handful of API reads, so daily is cheap.
-    - cron: '0 13 * * *'
+    # Mondays at 13:00 UTC. Deliberately weekly, not daily, even though the
+    # failing-checks trigger below would detect a break sooner if polled more
+    # often. The script reuses only a currently-open tracking issue, so a
+    # condition that flaps red/green opens a fresh issue each cycle, and CI is
+    # flaky enough (a GitHub Actions outage alone can redden every job) that
+    # daily polling would turn transient failures into recurring alerts. Weekly
+    # trades detection latency for an alert that stays worth reading.
+    - cron: '0 13 * * 1'
   workflow_dispatch:
     inputs:
       max_age_days:

--- a/scripts/check_stale_regen_prs.py
+++ b/scripts/check_stale_regen_prs.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Alert when an SDK regeneration PR sits unmerged beyond a threshold.
+"""Alert when an SDK regeneration PR needs attention.
 
 The gateway opens a regeneration PR against each SDK repo whenever the OpenAPI
 spec changes (``.github/workflows/otari-sdk-codegen.yml``, branch
 ``sdk-codegen/client-core``). That PR is the human review gate: the generated
 core can land in the spec without the matching hand-written shell wiring, so the
-PR is meant to be reviewed and merged, not left open. A regeneration PR that
-lingers means an SDK is lagging the spec.
+PR is meant to be reviewed and merged, not left open.
 
-This script lists the open regeneration PR (if any) on each SDK repo, flags the
-ones older than ``--max-age-days``, and renders a report. With ``--apply`` it
-also keeps a single tracking issue on the gateway repo in sync: opened/updated
-while any PR is stale, closed once none are.
+A PR is flagged for either of two reasons:
+
+* **Failing checks.** Flagged immediately, at any age. A red regeneration PR
+  cannot be merged, so age tells you nothing you did not already know.
+* **Age.** Open longer than ``--max-age-days`` while otherwise mergeable.
+
+Age alone used to be the only trigger, and it lagged badly: in #438 all four
+PRs were red for over two weeks, and the alert reported "open 18 days" rather
+than "these cannot merge, here is what broke". Checking the rollup surfaces the
+actionable fact on the first run after a break.
 
 Pure selection/rendering is unit-tested; the ``gh`` calls are thin wrappers.
 
@@ -44,6 +49,14 @@ DEFAULT_TRACKING_REPO = "mozilla-ai/otari"
 # Marks the single tracking issue this script owns, so reruns update it in place.
 TRACKING_LABEL = "sdk-regen-stale"
 
+# Check conclusions that mean the PR is genuinely broken. CANCELLED, SKIPPED and
+# NEUTRAL are deliberately absent: a fail-fast matrix cancels its siblings when
+# one leg fails, and reporting those as separate breakages just adds noise on top
+# of the real failure, which is reported anyway.
+FAILING_CONCLUSIONS = frozenset(
+    {"FAILURE", "TIMED_OUT", "STARTUP_FAILURE", "ACTION_REQUIRED", "ERROR"}
+)
+
 
 def parse_iso8601(value: str) -> datetime:
     """Parse a GitHub ISO-8601 timestamp (``...Z``) into an aware UTC datetime."""
@@ -56,31 +69,88 @@ def pr_age_days(pr: dict[str, Any], now: datetime) -> float:
     return (now - created).total_seconds() / 86400.0
 
 
-def select_stale(prs: list[dict[str, Any]], max_age_days: float, now: datetime) -> list[dict[str, Any]]:
-    """Return ``prs`` older than ``max_age_days``, oldest-first.
+def check_state(pr: dict[str, Any]) -> str:
+    """Roll a PR's checks up to ``failing``, ``pending``, ``passing`` or ``unknown``.
 
-    A PR at the threshold is not yet stale; it must exceed it.
+    ``unknown`` means no checks are reported at all, which is not treated as a
+    problem: a repo may simply have no CI wired to that branch.
     """
-    stale = [pr for pr in prs if pr_age_days(pr, now) > max_age_days]
-    return sorted(stale, key=lambda pr: pr["createdAt"])
+    rollup = pr.get("statusCheckRollup") or []
+    if not rollup:
+        return "unknown"
+    failing = False
+    pending = False
+    for entry in rollup:
+        # CheckRun reports status/conclusion; the older StatusContext reports state.
+        conclusion = (entry.get("conclusion") or "").upper()
+        status = (entry.get("status") or "").upper()
+        state = (entry.get("state") or "").upper()
+        if conclusion in FAILING_CONCLUSIONS or state in FAILING_CONCLUSIONS:
+            failing = True
+        elif state == "PENDING" or (status and status != "COMPLETED"):
+            pending = True
+    if failing:
+        return "failing"
+    if pending:
+        return "pending"
+    return "passing"
 
 
-def render_report(stale: list[dict[str, Any]], max_age_days: float, now: datetime) -> str:
-    """Render a markdown report of the stale regeneration PRs."""
-    if not stale:
-        return "All SDK regeneration PRs are within the freshness window (or none are open)."
-    lines = [
-        f"The following SDK regeneration PRs have been open longer than {max_age_days:g} "
-        "days, signalling an SDK lagging the gateway spec. Review and merge them, or "
-        "close any that are obsolete.",
-        "",
-        "| Repo | PR | Age (days) | Opened |",
-        "| --- | --- | --- | --- |",
+def flag_reasons(pr: dict[str, Any], max_age_days: float, now: datetime) -> list[str]:
+    """Why ``pr`` needs attention; empty when it does not.
+
+    Both reasons can apply at once, and a red PR is flagged regardless of age.
+    """
+    reasons = []
+    if check_state(pr) == "failing":
+        reasons.append("checks failing")
+    age = pr_age_days(pr, now)
+    if age > max_age_days:
+        reasons.append(f"open {age:.1f} days")
+    return reasons
+
+
+def select_flagged(
+    prs: list[dict[str, Any]], max_age_days: float, now: datetime
+) -> list[dict[str, Any]]:
+    """Return the PRs needing attention, oldest-first, annotated with ``reasons``.
+
+    A PR at the age threshold is not yet stale; it must exceed it.
+    """
+    flagged = [
+        {**pr, "reasons": reasons}
+        for pr in prs
+        if (reasons := flag_reasons(pr, max_age_days, now))
     ]
-    for pr in stale:
+    return sorted(flagged, key=lambda pr: pr["createdAt"])
+
+
+def render_report(flagged: list[dict[str, Any]], max_age_days: float, now: datetime) -> str:
+    """Render a markdown report of the regeneration PRs needing attention."""
+    if not flagged:
+        return "All SDK regeneration PRs are green and within the freshness window (or none are open)."
+    red = [pr for pr in flagged if check_state(pr) == "failing"]
+    lead = (
+        "The following SDK regeneration PRs need attention, signalling an SDK lagging "
+        f"the gateway spec. A PR is listed if its checks are failing (at any age) or it "
+        f"has been open longer than {max_age_days:g} days."
+    )
+    if red:
+        lead += (
+            f" **{len(red)} of {len(flagged)} cannot merge until CI is fixed**; start there, "
+            "since age is a symptom rather than the cause."
+        )
+    lines = [
+        lead,
+        "",
+        "| Repo | PR | Age (days) | Checks | Why |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for pr in flagged:
         age = pr_age_days(pr, now)
         lines.append(
-            f"| {pr['repo']} | [#{pr['number']}]({pr['url']}) | {age:.1f} | {pr['createdAt']} |"
+            f"| {pr['repo']} | [#{pr['number']}]({pr['url']}) | {age:.1f} | "
+            f"{check_state(pr)} | {', '.join(pr['reasons'])} |"
         )
     return "\n".join(lines)
 
@@ -116,7 +186,9 @@ def fetch_open_regen_prs(repo: str, branch: str) -> list[dict[str, Any]]:
             "--state",
             "open",
             "--json",
-            "number,title,url,createdAt",
+            # statusCheckRollup drives the failing-checks trigger; without it a
+            # red PR is only noticed once it also crosses the age threshold.
+            "number,title,url,createdAt,statusCheckRollup",
         ]
     )
     prs: list[dict[str, Any]] = json.loads(out) if out.strip() else []
@@ -147,17 +219,17 @@ def _find_tracking_issue(tracking_repo: str, token: str | None) -> int | None:
 
 
 def sync_tracking_issue(
-    tracking_repo: str, stale: list[dict[str, Any]], body: str, token: str | None = None
+    tracking_repo: str, flagged: list[dict[str, Any]], body: str, token: str | None = None
 ) -> None:
-    """Open/update the tracking issue while PRs are stale; close it once none are.
+    """Open/update the tracking issue while PRs are flagged; close it once none are.
 
     A single issue (identified by the ``sdk-regen-stale`` label) is reused across
     runs so the alert does not pile up duplicates. ``token`` authenticates the
     issue operations on ``tracking_repo``.
     """
     existing = _find_tracking_issue(tracking_repo, token)
-    title = "SDK regeneration PRs are stale"
-    if stale:
+    title = "SDK regeneration PRs need attention"
+    if flagged:
         if existing is None:
             # --force upserts the label so `gh issue create --label` cannot fail on a
             # missing label in a fresh repo.
@@ -170,7 +242,7 @@ def sync_tracking_issue(
             _gh(["issue", "edit", str(existing), "--repo", tracking_repo, "--body", body], token=token)
     elif existing is not None:
         _gh(["issue", "comment", str(existing), "--repo", tracking_repo,
-             "--body", "All regeneration PRs are merged or within the freshness window. Closing."],
+             "--body", "All regeneration PRs are green and merged or within the freshness window. Closing."],
             token=token)
         _gh(["issue", "close", str(existing), "--repo", tracking_repo], token=token)
 
@@ -184,7 +256,7 @@ def _write_step_summary(report: str) -> None:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Alert on stale SDK regeneration PRs.")
+    parser = argparse.ArgumentParser(description="Alert on SDK regeneration PRs needing attention.")
     parser.add_argument("--repos", nargs="+", default=list(DEFAULT_SDK_REPOS))
     parser.add_argument("--branch", default=DEFAULT_BRANCH)
     parser.add_argument("--max-age-days", type=float, default=DEFAULT_MAX_AGE_DAYS)
@@ -201,8 +273,8 @@ def main() -> int:
     for repo in args.repos:
         all_prs.extend(fetch_open_regen_prs(repo, args.branch))
 
-    stale = select_stale(all_prs, args.max_age_days, now)
-    report = render_report(stale, args.max_age_days, now)
+    flagged = select_flagged(all_prs, args.max_age_days, now)
+    report = render_report(flagged, args.max_age_days, now)
     print(report)
     _write_step_summary(report)
 
@@ -210,7 +282,7 @@ def main() -> int:
         # PR reads above used the ambient GH_TOKEN (the cross-repo PAT); the
         # tracking issue on this repo uses OTARI_GH_TOKEN when supplied.
         sync_tracking_issue(
-            args.tracking_repo, stale, report, token=os.environ.get("OTARI_GH_TOKEN")
+            args.tracking_repo, flagged, report, token=os.environ.get("OTARI_GH_TOKEN")
         )
 
     return 0

--- a/tests/unit/test_check_stale_regen_prs.py
+++ b/tests/unit/test_check_stale_regen_prs.py
@@ -1,4 +1,4 @@
-"""Unit tests for the stale SDK regeneration PR alert (pure selection/render)."""
+"""Unit tests for the SDK regeneration PR alert (pure selection/render)."""
 
 import importlib.util
 import sys
@@ -24,7 +24,16 @@ check = _load()
 _NOW = datetime(2026, 6, 11, tzinfo=timezone.utc)
 
 
-def _pr(repo: str, number: int, age_days: float) -> dict[str, Any]:
+def _run(conclusion: str = "SUCCESS", status: str = "COMPLETED") -> dict[str, Any]:
+    return {"__typename": "CheckRun", "name": "CI", "status": status, "conclusion": conclusion}
+
+
+def _pr(
+    repo: str,
+    number: int,
+    age_days: float,
+    rollup: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     created = _NOW - timedelta(days=age_days)
     return {
         "repo": repo,
@@ -32,6 +41,7 @@ def _pr(repo: str, number: int, age_days: float) -> dict[str, Any]:
         "title": "Regenerate SDK client core",
         "url": f"https://github.com/{repo}/pull/{number}",
         "createdAt": created.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "statusCheckRollup": [_run()] if rollup is None else rollup,
     }
 
 
@@ -40,48 +50,135 @@ def test_parse_iso8601_handles_z_suffix() -> None:
     assert parsed == datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
 
 
-def test_select_stale_keeps_only_prs_past_threshold() -> None:
-    prs = [
-        _pr("mozilla-ai/otari-sdk-python", 1, age_days=10),
-        _pr("mozilla-ai/otari-sdk-go", 2, age_days=3),
-    ]
-    stale = check.select_stale(prs, max_age_days=7, now=_NOW)
-    assert [pr["number"] for pr in stale] == [1]
+# --- check_state ---------------------------------------------------------
 
 
-def test_select_stale_threshold_is_strict() -> None:
-    # A PR exactly at the threshold is not yet stale; just past it is.
-    at_threshold = _pr("mozilla-ai/otari-sdk-ts", 5, age_days=7)
-    just_over = _pr("mozilla-ai/otari-sdk-ts", 6, age_days=7.01)
-    stale = check.select_stale([at_threshold, just_over], max_age_days=7, now=_NOW)
-    assert [pr["number"] for pr in stale] == [6]
+def test_check_state_passing_when_all_succeed() -> None:
+    assert check.check_state(_pr("a/b", 1, 1, [_run(), _run()])) == "passing"
 
 
-def test_select_stale_sorts_oldest_first() -> None:
+def test_check_state_failing_on_any_failure() -> None:
+    assert check.check_state(_pr("a/b", 1, 1, [_run(), _run("FAILURE")])) == "failing"
+
+
+def test_check_state_pending_when_a_run_is_incomplete() -> None:
+    pr = _pr("a/b", 1, 1, [_run(), _run(conclusion="", status="IN_PROGRESS")])
+    assert check.check_state(pr) == "pending"
+
+
+def test_check_state_failure_outranks_pending() -> None:
+    pr = _pr("a/b", 1, 1, [_run("FAILURE"), _run(conclusion="", status="QUEUED")])
+    assert check.check_state(pr) == "failing"
+
+
+def test_check_state_ignores_cancelled_and_skipped() -> None:
+    """A fail-fast matrix cancels siblings; that is noise, not a separate break."""
+    pr = _pr("a/b", 1, 1, [_run("SUCCESS"), _run("CANCELLED"), _run("SKIPPED")])
+    assert check.check_state(pr) == "passing"
+
+
+def test_check_state_handles_status_context_entries() -> None:
+    pr = _pr("a/b", 1, 1, [{"__typename": "StatusContext", "state": "FAILURE"}])
+    assert check.check_state(pr) == "failing"
+
+
+def test_check_state_unknown_without_any_checks() -> None:
+    assert check.check_state(_pr("a/b", 1, 1, [])) == "unknown"
+
+
+def test_check_state_unknown_is_not_flagged() -> None:
+    assert check.flag_reasons(_pr("a/b", 1, age_days=1, rollup=[]), 7, _NOW) == []
+
+
+# --- selection -----------------------------------------------------------
+
+
+def test_failing_pr_is_flagged_regardless_of_age() -> None:
+    """The #438 case: red on day one, but age would not have caught it for a week."""
+    pr = _pr("mozilla-ai/otari-sdk-go", 1, age_days=0.5, rollup=[_run("FAILURE")])
+    flagged = check.select_flagged([pr], max_age_days=7, now=_NOW)
+    assert [p["number"] for p in flagged] == [1]
+    assert flagged[0]["reasons"] == ["checks failing"]
+
+
+def test_green_young_pr_is_not_flagged() -> None:
+    assert check.select_flagged([_pr("a/b", 1, age_days=3)], max_age_days=7, now=_NOW) == []
+
+
+def test_green_old_pr_is_flagged_on_age() -> None:
+    flagged = check.select_flagged([_pr("a/b", 1, age_days=10)], max_age_days=7, now=_NOW)
+    assert flagged[0]["reasons"] == ["open 10.0 days"]
+
+
+def test_old_and_failing_pr_reports_both_reasons() -> None:
+    pr = _pr("a/b", 1, age_days=18, rollup=[_run("FAILURE")])
+    flagged = check.select_flagged([pr], max_age_days=7, now=_NOW)
+    assert flagged[0]["reasons"] == ["checks failing", "open 18.0 days"]
+
+
+def test_age_threshold_is_strict() -> None:
+    at_threshold = _pr("a/b", 5, age_days=7)
+    just_over = _pr("a/b", 6, age_days=7.01)
+    flagged = check.select_flagged([at_threshold, just_over], max_age_days=7, now=_NOW)
+    assert [p["number"] for p in flagged] == [6]
+
+
+def test_pending_checks_do_not_flag_a_young_pr() -> None:
+    pr = _pr("a/b", 1, age_days=1, rollup=[_run(conclusion="", status="IN_PROGRESS")])
+    assert check.select_flagged([pr], max_age_days=7, now=_NOW) == []
+
+
+def test_select_flagged_sorts_oldest_first() -> None:
     prs = [
         _pr("a/b", 1, age_days=9),
         _pr("c/d", 2, age_days=30),
         _pr("e/f", 3, age_days=15),
     ]
-    stale = check.select_stale(prs, max_age_days=7, now=_NOW)
-    # createdAt ascending == oldest first.
-    assert [pr["number"] for pr in stale] == [2, 3, 1]
+    flagged = check.select_flagged(prs, max_age_days=7, now=_NOW)
+    assert [p["number"] for p in flagged] == [2, 3, 1]
 
 
-def test_select_stale_empty_when_all_fresh() -> None:
-    prs = [_pr("a/b", 1, age_days=1), _pr("c/d", 2, age_days=6)]
-    assert check.select_stale(prs, max_age_days=7, now=_NOW) == []
+def test_select_flagged_does_not_mutate_input() -> None:
+    pr = _pr("a/b", 1, age_days=10)
+    check.select_flagged([pr], max_age_days=7, now=_NOW)
+    assert "reasons" not in pr
 
 
-def test_render_report_lists_each_stale_pr() -> None:
-    prs = [_pr("mozilla-ai/otari-sdk-python", 12, age_days=10)]
+# --- rendering -----------------------------------------------------------
+
+
+def test_render_report_lists_each_flagged_pr() -> None:
+    prs = check.select_flagged(
+        [_pr("mozilla-ai/otari-sdk-python", 12, age_days=10)], max_age_days=7, now=_NOW
+    )
     report = check.render_report(prs, max_age_days=7, now=_NOW)
     assert "mozilla-ai/otari-sdk-python" in report
     assert "[#12](https://github.com/mozilla-ai/otari-sdk-python/pull/12)" in report
-    assert "| Repo | PR | Age (days) | Opened |" in report
+    assert "| Repo | PR | Age (days) | Checks | Why |" in report
 
 
-def test_render_report_when_none_stale() -> None:
+def test_render_report_leads_with_the_red_prs() -> None:
+    prs = check.select_flagged(
+        [
+            _pr("a/b", 1, age_days=18, rollup=[_run("FAILURE")]),
+            _pr("c/d", 2, age_days=18),
+        ],
+        max_age_days=7,
+        now=_NOW,
+    )
+    report = check.render_report(prs, max_age_days=7, now=_NOW)
+    assert "1 of 2 cannot merge until CI is fixed" in report
+    assert "| failing |" in report
+    assert "| passing |" in report
+
+
+def test_render_report_omits_the_ci_lead_when_all_are_green() -> None:
+    prs = check.select_flagged([_pr("a/b", 1, age_days=10)], max_age_days=7, now=_NOW)
+    report = check.render_report(prs, max_age_days=7, now=_NOW)
+    assert "cannot merge until CI is fixed" not in report
+
+
+def test_render_report_when_none_flagged() -> None:
     report = check.render_report([], max_age_days=7, now=_NOW)
     assert "within the freshness window" in report
     assert "|" not in report  # no table rendered


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Makes the regen alert fire on the actual problem. Follow-up to #438.

The alert measured PR age only. In #438 all four regeneration PRs were red from the day the gateway gained new endpoints, but the alert reported "open 18.0 days", which describes a symptom and buries the cause. Worse, age is a lagging indicator by construction: a PR that breaks on day one stays unreported for a week.

Now a PR is flagged when its checks are failing **at any age**, or when it exceeds `--max-age-days`. Both reasons can apply, and the report says which, with a `Checks` column and a lead line pointing at the red ones first.

Two supporting changes:

- `statusCheckRollup` is added to the `gh pr list` query, which is what makes the CI trigger possible.
- The weekly schedule is kept. Daily was considered and rejected: the script reuses only a currently-open tracking issue, so a flapping condition opens a fresh issue each cycle, and CI is flaky enough (the GitHub Actions outage on 2026-08-06 reddened six unrelated jobs) that daily polling would convert transient failures into recurring alerts. Detection latency is still up to a week, which is the accepted cost of an alert that stays worth reading.

`CANCELLED`, `SKIPPED` and `NEUTRAL` deliberately do not count as failures: a fail-fast matrix cancels its siblings when one leg fails, and reporting those as separate breakages just adds noise on top of the real failure, which is reported anyway. This is not hypothetical, it is exactly what otari-sdk-python's rollup looked like in #438.

A PR with no checks at all reports `unknown` and is not flagged on that basis, so a repo with no CI wired to the branch does not alarm every day.

Verified against the live repos (reports all clear, since the regen PRs are merged) and with a simulated red PR to check the rendering.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

Follow-up to #438.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). `tests/unit/test_check_stale_regen_prs.py` goes from 7 tests to 21, covering the rollup states, both flag reasons, and the rendering.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). Ran `make lint`, `make typecheck`, and the full unit suite (1300 passed, 1 skipped).
- [ ] Documentation was updated where necessary. The workflow header comment and the script docstring both describe the new triggers; no user-facing docs cover this job.
- [ ] If the API contract changed, I regenerated the OpenAPI spec. Not applicable; no API contract change.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

Came out of root-causing #438, where the alert's own output was the clue: it had been correct and useless at the same time.

- [x] I am an AI Agent filling out this form (check box if true)
