### PR TITLE
test(messages): cover automatic cache passthrough

### DIFF
--- a/tests/integration/test_messages_route_dispatch.py
+++ b/tests/integration/test_messages_route_dispatch.py
@@ -147,7 +147,9 @@ def test_cache_control_and_non_stream_usage_round_trip(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """Block and automatic cache controls reach Anthropic unchanged."""
+    """Block and automatic cache controls reach Anthropic unchanged, and cache
+    usage reaches the client.
+    """
     system_block = {
         "type": "text",
         "text": "Stable system instructions",

--- a/tests/integration/test_messages_route_dispatch.py
+++ b/tests/integration/test_messages_route_dispatch.py
@@ -36,6 +36,7 @@ _CONTEXT_MANAGEMENT = {
     "edits": [{"type": "compact_20260112", "trigger": {"type": "input_tokens", "value": 50_000}}]
 }
 _BETAS = ["compact-2026-01-12"]
+_AUTOMATIC_CACHE_CONTROL = {"type": "ephemeral", "ttl": "1h"}
 
 
 def _text_response(
@@ -146,7 +147,7 @@ def test_cache_control_and_non_stream_usage_round_trip(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """Cache markers reach Anthropic unchanged and cache usage reaches the client."""
+    """Block and automatic cache controls reach Anthropic unchanged."""
     system_block = {
         "type": "text",
         "text": "Stable system instructions",
@@ -171,6 +172,7 @@ def test_cache_control_and_non_stream_usage_round_trip(
                 "system": [system_block],
                 "messages": [{"role": "user", "content": [message_block]}],
                 "max_tokens": 100,
+                "cache_control": _AUTOMATIC_CACHE_CONTROL,
             },
             headers=api_key_header,
         )
@@ -178,6 +180,7 @@ def test_cache_control_and_non_stream_usage_round_trip(
     assert resp.status_code == 200, resp.text
     assert captured["system"] == [system_block]
     assert captured["messages"] == [{"role": "user", "content": [message_block]}]
+    assert captured["cache_control"] == _AUTOMATIC_CACHE_CONTROL
     usage = resp.json()["usage"]
     assert usage["cache_creation_input_tokens"] == 13
     assert usage["cache_read_input_tokens"] == 8
@@ -837,13 +840,15 @@ def test_stream_no_tools_returns_sse_response(
     assert tool_loop_called is False
 
 
-def test_stream_cache_usage_reaches_client(
+def test_stream_cache_control_and_usage_round_trip(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """Cache usage from the provider remains present in the SSE message_start event."""
+    """Automatic cache control reaches Anthropic and usage remains in SSE."""
+    captured: dict[str, Any] = {}
 
-    async def fake_amessages(**_kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+    async def fake_amessages(**kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        captured.update(kwargs)
         return _stream_iter(
             _stream_message_start(cache_creation_input_tokens=13, cache_read_input_tokens=8),
             _stream_message_stop(),
@@ -857,11 +862,13 @@ def test_stream_cache_usage_reaches_client(
                 "messages": [{"role": "user", "content": "hi"}],
                 "max_tokens": 100,
                 "stream": True,
+                "cache_control": _AUTOMATIC_CACHE_CONTROL,
             },
             headers=api_key_header,
         )
 
     assert resp.status_code == 200, resp.text
+    assert captured["cache_control"] == _AUTOMATIC_CACHE_CONTROL
     payloads = [json.loads(line.removeprefix("data: ")) for line in resp.text.splitlines() if line.startswith("data: ")]
     message_start = next(payload for payload in payloads if payload["type"] == "message_start")
     usage = message_start["message"]["usage"]


### PR DESCRIPTION
## Description

Top-level `MessagesRequest.cache_control` lacked route-level regression coverage. Extend the existing prompt-caching tests to assert that automatic cache control reaches `amessages` unchanged for streaming and non-streaming requests.

Validation: `uv run pytest tests/integration/test_messages_route_dispatch.py -q` (33 passed), `make lint`, and `make typecheck`.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

Fixes #531

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). Targeted tests, lint, and typecheck passed; the full suite was not run.
- [x] Documentation was updated where necessary. No documentation change is needed for this test-only change.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). The API contract is unchanged.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** GPT-5.6 Sol / Pi

**Any additional AI details you'd like to share:** The agent inspected the existing cache coverage, extended both route paths, and ran the listed validation commands.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added regression tests for top-level `cache_control` on `/v1/messages` requests.
- Covered streaming and non-streaming requests.
- Verified that `cache_control` reaches `amessages` unchanged.
- Preserved existing cache-usage checks.

These tests help prevent regressions in automatic prompt caching at the gateway boundary.

## Validation

- Targeted integration tests passed.
- Lint and typecheck passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->