### PR TITLE
fix(messages): classify bridged context_management/betas as a 400, not a 500

### DIFF
--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -186,6 +186,10 @@ PROVIDER_BILLING_DETAIL = (
     "Top up the provider account, or route this model to a provider that has credit."
 )
 PROVIDER_RATE_LIMITED_DETAIL = "The provider rate-limited this request"
+PROVIDER_CONTEXT_MANAGEMENT_UNSUPPORTED_DETAIL = (
+    "context_management and betas require a model backed by Anthropic's native Messages API. "
+    "Route to an Anthropic model, or leave the betas/context_management fields unset for this model."
+)
 ALL_PROVIDERS_FAILED_DETAIL = "All upstream providers failed"
 ALL_PROVIDERS_TIMED_OUT_DETAIL = "All upstream providers timed out"
 SANDBOX_NOT_CONFIGURED_DETAIL = (
@@ -287,6 +291,16 @@ def _is_reasoning_effort_tools_conflict(exc: BaseException) -> bool:
     return "function tools" in upstream_error_message(exc).lower()
 
 
+# any-llm's default Messages path raises a bare NotImplementedError carrying this
+# exact message when a request sets context_management/betas against a provider
+# without a native Anthropic Messages API (see AnyLLM._amessages). classify_provider_error
+# gates on `isinstance(exc, NotImplementedError)` plus this message so an unrelated
+# NotImplementedError is not mistaken for this specific, actionable rejection.
+_CONTEXT_MANAGEMENT_UNSUPPORTED_MSG = (
+    "context_management and betas require a provider with a native Anthropic Messages API"
+)
+
+
 def classify_provider_error(exc: BaseException) -> ProviderErrorMapping | None:
     """Map an upstream provider exception to a safe, specific (status, detail).
 
@@ -306,6 +320,20 @@ def classify_provider_error(exc: BaseException) -> ProviderErrorMapping | None:
     kind, status_code = upstream_exception_shape(exc)
     if kind == "timeout":
         return ProviderErrorMapping(status.HTTP_504_GATEWAY_TIMEOUT, PROVIDER_TIMEOUT_DETAIL)
+    # any-llm's default Messages path rejects a request that sets
+    # context_management/betas against a provider without a native Anthropic
+    # Messages API (see AnyLLM._amessages). It currently raises a bare
+    # NotImplementedError (no HTTP status); once ANY_LLM_UNIFIED_EXCEPTIONS=1
+    # becomes the default, that NotImplementedError is wrapped in a generic
+    # ProviderError, so the message is the stable signal and upstream_error_message
+    # surfaces it both directly and through original_exception. Either way this is
+    # a request-shape problem, not a transient provider fault: it will never
+    # succeed by retrying, so it must surface as a 400 with an actionable detail
+    # rather than falling through to the generic 500. Gated on the fixed message
+    # so an unrelated NotImplementedError -- already an unclassifiable 500 path --
+    # is not repurposed as this specific error.
+    if _CONTEXT_MANAGEMENT_UNSUPPORTED_MSG in upstream_error_message(exc):
+        return ProviderErrorMapping(status.HTTP_400_BAD_REQUEST, PROVIDER_CONTEXT_MANAGEMENT_UNSUPPORTED_DETAIL)
     if status_code is None:
         return None
     # Account billing exhaustion, which several providers report as a 400/422

--- a/tests/unit/test_provider_error_classification.py
+++ b/tests/unit/test_provider_error_classification.py
@@ -15,6 +15,7 @@ from openai import APITimeoutError as OpenAIAPITimeoutError
 from gateway.api.routes._pipeline import (
     PROVIDER_BAD_REQUEST_DETAIL,
     PROVIDER_BILLING_DETAIL,
+    PROVIDER_CONTEXT_MANAGEMENT_UNSUPPORTED_DETAIL,
     PROVIDER_CREDENTIALS_DETAIL,
     PROVIDER_MODEL_NOT_FOUND_DETAIL,
     PROVIDER_RATE_LIMITED_DETAIL,
@@ -27,6 +28,13 @@ from gateway.api.routes._platform import _provider_failure_http_exc
 from gateway.services.mcp_loop import MaxToolIterationsExceeded
 
 _RAW = "raw provider detail SECRET token=abc123"
+
+# The exact bare NotImplementedError any-llm's default Messages path raises when a
+# request sets context_management/betas against a provider without a native
+# Anthropic Messages API (see AnyLLM._amessages).
+_CONTEXT_MANAGEMENT_MSG = (
+    "context_management and betas require a provider with a native Anthropic Messages API"
+)
 
 # The exact upstream OpenAI message for the tools + reasoning_effort rejection.
 _REASONING_TOOLS_MSG = (
@@ -129,6 +137,57 @@ def test_status_read_from_attached_response() -> None:
 @pytest.mark.parametrize("exc", [_StatusError(500), _StatusError(503), Exception(_RAW), ValueError(_RAW)])
 def test_unclassifiable_returns_none(exc: BaseException) -> None:
     assert classify_provider_error(exc) is None
+
+
+def test_bridged_context_management_maps_to_actionable_400() -> None:
+    """A request that sets context_management/betas against a bridged provider is
+    rejected by any-llm's default Messages path with a bare NotImplementedError
+    that carries no HTTP status. It must surface as a 400 with an actionable
+    detail, not fall through to the generic 500, because retrying is guaranteed
+    to fail identically."""
+    exc = NotImplementedError(_CONTEXT_MANAGEMENT_MSG)
+    assert classify_provider_error(exc) == (400, PROVIDER_CONTEXT_MANAGEMENT_UNSUPPORTED_DETAIL)
+
+
+def test_context_management_detail_does_not_imply_retry() -> None:
+    """The detail must point at the real cause (native Anthropic model or unset
+    fields), never tell the caller to try again."""
+    mapping = classify_provider_error(NotImplementedError(_CONTEXT_MANAGEMENT_MSG))
+    assert mapping is not None
+    assert "retry" not in mapping.detail.lower()
+    assert "temporar" not in mapping.detail.lower()
+
+
+def test_unrelated_not_implemented_error_stays_unclassifiable() -> None:
+    """An unrelated NotImplementedError is not this specific rejection and keeps
+    its generic 500 path."""
+    assert classify_provider_error(NotImplementedError("some other NotImplementedError")) is None
+
+
+class _ProviderErrorWrapping(Exception):
+    """Mimics what otari receives once ``ANY_LLM_UNIFIED_EXCEPTIONS=1`` becomes
+    the default: any-llm's ``convert_exception`` classifies the raw
+    NotImplementedError message into a generic ``ProviderError`` (no
+    ``status_code``, class name matching nothing), preserving the raw exception
+    on ``original_exception``."""
+
+    def __init__(self, original_exception: BaseException) -> None:
+        super().__init__(str(original_exception))
+        self.original_exception = original_exception
+
+
+def test_bridged_context_management_maps_to_400_when_wrapped_by_unified_exceptions() -> None:
+    """The signal survives any-llm's unified-exceptions wrapper, so the fix is
+    forward-compatible with ``ANY_LLM_UNIFIED_EXCEPTIONS=1`` (see the shared
+    ``original_exception`` unwrap in ``upstream_error_message``)."""
+    exc = _ProviderErrorWrapping(NotImplementedError(_CONTEXT_MANAGEMENT_MSG))
+    assert classify_provider_error(exc) == (400, PROVIDER_CONTEXT_MANAGEMENT_UNSUPPORTED_DETAIL)
+
+
+def test_context_management_maps_to_400_in_failure_status_code() -> None:
+    """The usage-log status follows the classification: this request-shape error
+    is recorded as 400, not the generic 502."""
+    assert failure_status_code(NotImplementedError(_CONTEXT_MANAGEMENT_MSG)) == 400
 
 
 def test_no_classified_detail_leaks_raw_message() -> None:


### PR DESCRIPTION
## Description

A `/v1/messages` request that sets `context_management` or `betas` against a model whose provider is not a native Anthropic Messages API (a bridged/translated provider) is rejected by any-llm's default `_amessages` with a bare `NotImplementedError` that carries no HTTP status. `classify_provider_error` only recognizes exceptions it can extract a status code from, so this fell through to the generic 500, telling the caller to retry a request that is guaranteed to fail identically every time.

This special-cases that rejection and maps it to HTTP 400 with an actionable detail naming the real cause, so the caller sees a request-shape error instead of a misleading transient failure.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #530

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the lint and unit test checks locally (`make lint`, `make typecheck`, `make test-unit`).
- [ ] Documentation was updated where necessary (no docs change needed: this is a runtime error-path fix, not part of the OpenAPI spec, so no spec/Postman regen).
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**
Claude Code

**Any additional AI details you'd like to share:**
Fix drafted and verified by Claude in collaboration with njbrake. The gate is message-based and forward-compatible with `ANY_LLM_UNIFIED_EXCEPTIONS=1` once any-llm makes it the default: `convert_exception` wraps the raw `NotImplementedError` in a generic `ProviderError`, but the message still surfaces via `original_exception`, so the same check matches in both configurations.

The full integration suite (`make test`) needs Postgres/Testcontainers that this environment lacks; the changed code is a leaf classification function covered by focused unit tests, and the existing integration tests for native-Anthropic pass-through are unaffected.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Return HTTP 400 when bridged or translated providers reject `context_management` or `betas`.
- Provide actionable guidance that these fields require a native Anthropic Messages API provider.
- Add unit tests for direct and wrapped `NotImplementedError` cases.
- Keep unrelated provider errors unclassified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->