### PR TITLE
fix(billing): record charge lines for embeddings, images, moderations, and rerank

### DIFF
--- a/src/gateway/api/routes/_passthrough.py
+++ b/src/gateway/api/routes/_passthrough.py
@@ -68,6 +68,11 @@ ResultT = TypeVar("ResultT")
 
 PASSTHROUGH_PROVIDER_ERROR_DETAIL = "The request could not be completed by the provider"
 
+# A route's non-token charge lines: the meters dict and the auditable breakdown,
+# matching the shape ``calculate_metered_cost`` and ``price_tool_calls`` already
+# write for the chat and tool-charge paths.
+BillingMeters = tuple[dict[str, Any], list[dict[str, Any]]]
+
 
 def resolve_passthrough_user_id(
     auth_result: tuple[APIKey | None, bool],
@@ -130,6 +135,7 @@ async def run_passthrough(
     enforce_require_pricing: bool = False,
     usage_tokens: Callable[[ResultT], tuple[int | None, int | None, int | None]] | None = None,
     compute_cost: Callable[[ResultT, ModelPricing | None], float | None] | None = None,
+    compute_meters: Callable[[ResultT, ModelPricing | None, float], BillingMeters | None] | None = None,
     map_provider_error: Callable[[Exception], HTTPException | None] | None = None,
     reserve_before_resolve: bool = False,
     relabel: bool = True,
@@ -167,6 +173,11 @@ async def run_passthrough(
             total)`` token counts for the usage log. Defaults to ``(0, 0, 0)``.
         compute_cost: Maps the result and pricing to the final USD cost, or
             ``None`` to leave the log's cost unset and reconcile at 0.0.
+        compute_meters: Maps the result, pricing, and the cost ``compute_cost``
+            just returned to this request's billing meters and charge lines, or
+            ``None`` to leave both unset. Only called when ``compute_cost``
+            returned a cost, so a route with no priced unit never needs to guard
+            against a missing cost itself.
         map_provider_error: Route-specific provider-exception mapping checked
             before the generic 502 (the error log and refund happen either way).
         reserve_before_resolve: Preserve the audio routes' historical ordering,
@@ -389,6 +400,9 @@ async def run_passthrough(
         cost = compute_cost(result, pricing) if compute_cost else None
         if cost is not None:
             usage_log.cost = cost
+            billing = compute_meters(result, pricing, cost) if compute_meters else None
+            if billing is not None:
+                usage_log.billing_meters, usage_log.pricing_breakdown = billing
 
         await log_writer.put(usage_log)
         await reconcile_reservation(db, reservation, cost if cost is not None else 0.0)

--- a/src/gateway/api/routes/embeddings.py
+++ b/src/gateway/api/routes/embeddings.py
@@ -73,7 +73,11 @@ async def create_embedding(
         tokens = result.usage.prompt_tokens
         rate = pricing.input_price_per_million
         breakdown = [{"meter": "input", "units": tokens, "rate_per_million": rate, "cost": cost}]
-        return {"input_tokens": tokens}, breakdown
+        # ``total_input_tokens`` rather than a route-local name: it is the meter the
+        # billed-token SQL and the dashboard's token bar already read by name, so
+        # the row's own meter becomes the source they use instead of the raw-column
+        # fallback (same value here, but the fallback stops being load-bearing).
+        return {"total_input_tokens": tokens}, breakdown
 
     async def call_provider(resolved: ResolvedProvider) -> CreateEmbeddingResponse:
         embedding_kwargs: dict[str, Any] = {

--- a/src/gateway/api/routes/embeddings.py
+++ b/src/gateway/api/routes/embeddings.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
-from gateway.api.routes._passthrough import run_passthrough
+from gateway.api.routes._passthrough import BillingMeters, run_passthrough
 from gateway.core.config import GatewayConfig
 from gateway.models.entities import APIKey, ModelPricing
 from gateway.services.budget_service import estimate_cost
@@ -65,6 +65,16 @@ async def create_embedding(
             return input_token_cost(result.usage.prompt_tokens, pricing)
         return None
 
+    def compute_meters(
+        result: CreateEmbeddingResponse, pricing: ModelPricing | None, cost: float
+    ) -> BillingMeters | None:
+        if not result.usage or pricing is None:
+            return None
+        tokens = result.usage.prompt_tokens
+        rate = pricing.input_price_per_million
+        breakdown = [{"meter": "input", "units": tokens, "rate_per_million": rate, "cost": cost}]
+        return {"input_tokens": tokens}, breakdown
+
     async def call_provider(resolved: ResolvedProvider) -> CreateEmbeddingResponse:
         embedding_kwargs: dict[str, Any] = {
             "model": resolved.model,
@@ -93,5 +103,6 @@ async def create_embedding(
         enforce_require_pricing=True,
         usage_tokens=usage_tokens,
         compute_cost=compute_cost,
+        compute_meters=compute_meters,
     )
     return outcome.result

--- a/src/gateway/api/routes/images.py
+++ b/src/gateway/api/routes/images.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, Request, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
-from gateway.api.routes._passthrough import run_passthrough
+from gateway.api.routes._passthrough import BillingMeters, run_passthrough
 from gateway.api.routes._schema_derive import derive_request_base
 from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
@@ -63,6 +63,13 @@ async def create_image(
         n_images = len(result.data) if result.data else requested_images
         return per_image_cost(n_images, pricing)
 
+    def compute_meters(result: ImagesResponse, pricing: ModelPricing | None, cost: float) -> BillingMeters | None:
+        if pricing is None:
+            return None
+        n_images = len(result.data) if result.data else requested_images
+        breakdown = [{"meter": "images", "units": n_images, "unit_rate": pricing.input_price_per_million, "cost": cost}]
+        return {"images": n_images}, breakdown
+
     async def call_provider(resolved: ResolvedProvider) -> ImagesResponse:
         # Forward every field the schema accepts (it is derived from
         # ImageGenerationParams), so a new any-llm param is passed through without
@@ -92,6 +99,7 @@ async def create_image(
         estimate=estimate,
         enforce_require_pricing=True,
         compute_cost=compute_cost,
+        compute_meters=compute_meters,
         relabel=False,
     )
     return outcome.result.model_dump()

--- a/src/gateway/api/routes/moderations.py
+++ b/src/gateway/api/routes/moderations.py
@@ -68,8 +68,14 @@ async def create_moderation(
     def compute_cost(result: ModerationResponse, pricing: ModelPricing | None) -> float:
         return flat_request_cost(pricing)
 
-    def compute_meters(result: ModerationResponse, pricing: ModelPricing | None, cost: float) -> BillingMeters:
-        breakdown = [{"meter": "request", "units": 1, "unit_rate": flat_request_cost(pricing), "cost": cost}]
+    def compute_meters(result: ModerationResponse, pricing: ModelPricing | None, cost: float) -> BillingMeters | None:
+        # An unpriced moderation is $0 by design, which is the common case here, so
+        # record nothing rather than a zero charge line the dashboard would render
+        # as a "billed meters" block explaining a charge that never happened. One
+        # request is billed, so the per-request rate is the cost itself.
+        if not cost:
+            return None
+        breakdown = [{"meter": "request", "units": 1, "unit_rate": cost, "cost": cost}]
         return {"requests": 1}, breakdown
 
     def usage_tokens(result: ModerationResponse) -> tuple[int | None, int | None, int | None]:

--- a/src/gateway/api/routes/moderations.py
+++ b/src/gateway/api/routes/moderations.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
-from gateway.api.routes._passthrough import run_passthrough
+from gateway.api.routes._passthrough import BillingMeters, run_passthrough
 from gateway.core.config import GatewayConfig
 from gateway.models.entities import APIKey, ModelPricing
 from gateway.services.log_writer import LogWriter
@@ -68,6 +68,10 @@ async def create_moderation(
     def compute_cost(result: ModerationResponse, pricing: ModelPricing | None) -> float:
         return flat_request_cost(pricing)
 
+    def compute_meters(result: ModerationResponse, pricing: ModelPricing | None, cost: float) -> BillingMeters:
+        breakdown = [{"meter": "request", "units": 1, "unit_rate": flat_request_cost(pricing), "cost": cost}]
+        return {"requests": 1}, breakdown
+
     def usage_tokens(result: ModerationResponse) -> tuple[int | None, int | None, int | None]:
         return (None, 0, None)
 
@@ -95,6 +99,7 @@ async def create_moderation(
         estimate=flat_request_cost,
         usage_tokens=usage_tokens,
         compute_cost=compute_cost,
+        compute_meters=compute_meters,
         map_provider_error=_map_unsupported_moderation,
     )
     return outcome.result

--- a/src/gateway/api/routes/rerank.py
+++ b/src/gateway/api/routes/rerank.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
-from gateway.api.routes._passthrough import run_passthrough
+from gateway.api.routes._passthrough import BillingMeters, run_passthrough
 from gateway.core.config import GatewayConfig
 from gateway.models.entities import APIKey, ModelPricing
 from gateway.services.budget_service import estimate_cost
@@ -64,6 +64,14 @@ async def create_rerank(
             return input_token_cost(total_tokens, pricing)
         return None
 
+    def compute_meters(result: RerankResponse, pricing: ModelPricing | None, cost: float) -> BillingMeters | None:
+        total_tokens = result.usage.total_tokens if result.usage else None
+        if not pricing or not total_tokens:
+            return None
+        rate = pricing.input_price_per_million
+        breakdown = [{"meter": "input", "units": total_tokens, "rate_per_million": rate, "cost": cost}]
+        return {"input_tokens": total_tokens}, breakdown
+
     async def call_provider(resolved: ResolvedProvider) -> RerankResponse:
         rerank_kwargs: dict[str, Any] = {
             "model": resolved.model,
@@ -96,5 +104,6 @@ async def create_rerank(
         enforce_require_pricing=True,
         usage_tokens=usage_tokens,
         compute_cost=compute_cost,
+        compute_meters=compute_meters,
     )
     return outcome.result

--- a/src/gateway/api/routes/rerank.py
+++ b/src/gateway/api/routes/rerank.py
@@ -70,7 +70,10 @@ async def create_rerank(
             return None
         rate = pricing.input_price_per_million
         breakdown = [{"meter": "input", "units": total_tokens, "rate_per_million": rate, "cost": cost}]
-        return {"input_tokens": total_tokens}, breakdown
+        # See embeddings: the canonical meter name is what the billed-token SQL and
+        # the dashboard read. Rerank logs the same count as its prompt tokens, so
+        # this reports the value the fallback already produced.
+        return {"total_input_tokens": total_tokens}, breakdown
 
     async def call_provider(resolved: ResolvedProvider) -> RerankResponse:
         rerank_kwargs: dict[str, Any] = {

--- a/tests/integration/test_embeddings_endpoint.py
+++ b/tests/integration/test_embeddings_endpoint.py
@@ -228,3 +228,37 @@ def test_embeddings_cost_tracked_with_pricing(
     assert len(embedding_logs) >= 1
     assert embedding_logs[0]["cost"] is not None
     assert embedding_logs[0]["cost"] > 0
+
+
+def test_embeddings_billing_meters_tracked_with_pricing(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/embeddings records auditable charge lines alongside cost."""
+    client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "openai:text-embedding-3-small",
+            "input_price_per_million": 0.02,
+            "output_price_per_million": 0.0,
+        },
+        headers=master_key_header,
+    )
+
+    mock_resp = _mock_embedding_response()
+
+    with patch("gateway.api.routes.embeddings.aembedding", new_callable=AsyncMock, return_value=mock_resp):
+        resp = client.post(
+            "/v1/embeddings",
+            json={"model": "openai:text-embedding-3-small", "input": "hello"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+
+    usage_resp = client.get("/v1/usage", params={"endpoint": "/v1/embeddings"}, headers=master_key_header)
+    logs = usage_resp.json()
+    assert len(logs) >= 1
+    assert logs[0]["billing_meters"] == {"input_tokens": 10}
+    breakdown = logs[0]["pricing_breakdown"]
+    assert breakdown == [{"meter": "input", "units": 10, "rate_per_million": 0.02, "cost": pytest.approx(2e-7)}]

--- a/tests/integration/test_embeddings_endpoint.py
+++ b/tests/integration/test_embeddings_endpoint.py
@@ -259,6 +259,6 @@ def test_embeddings_billing_meters_tracked_with_pricing(
     usage_resp = client.get("/v1/usage", params={"endpoint": "/v1/embeddings"}, headers=master_key_header)
     logs = usage_resp.json()
     assert len(logs) >= 1
-    assert logs[0]["billing_meters"] == {"input_tokens": 10}
+    assert logs[0]["billing_meters"] == {"total_input_tokens": 10}
     breakdown = logs[0]["pricing_breakdown"]
     assert breakdown == [{"meter": "input", "units": 10, "rate_per_million": 0.02, "cost": pytest.approx(2e-7)}]

--- a/tests/integration/test_images_endpoint.py
+++ b/tests/integration/test_images_endpoint.py
@@ -223,3 +223,37 @@ def test_images_cost_tracked_with_pricing(
     assert image_logs[0]["cost"] > 0
     # Cost should be n_images * input_price_per_million = 2 * 0.04 = 0.08
     assert image_logs[0]["cost"] == pytest.approx(0.08)
+
+
+def test_images_billing_meters_tracked_with_pricing(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/images/generations records auditable charge lines alongside cost."""
+    client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "openai:dall-e-3",
+            "input_price_per_million": 0.04,
+            "output_price_per_million": 0.0,
+        },
+        headers=master_key_header,
+    )
+
+    mock_resp = _mock_images_response(n=2)
+
+    with patch("gateway.api.routes.images.aimage_generation", new_callable=AsyncMock, return_value=mock_resp):
+        resp = client.post(
+            "/v1/images/generations",
+            json={"model": "openai:dall-e-3", "prompt": "a cute cat", "n": 2},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+
+    usage_resp = client.get("/v1/usage", params={"endpoint": "/v1/images/generations"}, headers=master_key_header)
+    logs = usage_resp.json()
+    assert len(logs) >= 1
+    assert logs[0]["billing_meters"] == {"images": 2}
+    breakdown = logs[0]["pricing_breakdown"]
+    assert breakdown == [{"meter": "images", "units": 2, "unit_rate": 0.04, "cost": pytest.approx(0.08)}]

--- a/tests/integration/test_moderations_endpoint.py
+++ b/tests/integration/test_moderations_endpoint.py
@@ -392,6 +392,33 @@ def test_moderations_billing_meters_tracked_with_pricing(
     ]
 
 
+def test_moderations_unpriced_records_no_charge_lines(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """An unpriced moderation is free by design, so it records no charge line."""
+    with patch(
+        "gateway.api.routes.moderations.amoderation",
+        new_callable=AsyncMock,
+        return_value=_mock_moderation_response(),
+    ):
+        resp = client.post(
+            "/v1/moderations",
+            json={"model": "openai:unpriced-moderation-model", "input": "hello"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+
+    usage_resp = client.get(
+        "/v1/usage", params={"endpoint": "/v1/moderations", "status": "success"}, headers=master_key_header
+    )
+    latest = usage_resp.json()[0]
+    assert latest["cost"] == 0.0
+    assert latest["billing_meters"] is None
+    assert latest["pricing_breakdown"] is None
+
+
 def test_moderations_no_warning_when_pricing_missing(
     client: TestClient,
     api_key_header: dict[str, str],

--- a/tests/integration/test_moderations_endpoint.py
+++ b/tests/integration/test_moderations_endpoint.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 from gateway.types.moderation import ModerationResponse, ModerationResult
@@ -347,6 +348,48 @@ def test_moderations_cost_tracked_with_pricing(
     latest = moderation_logs[-1]
     assert latest["cost"] is not None
     assert latest["cost"] > 0
+
+
+def test_moderations_billing_meters_tracked_with_pricing(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/moderations records auditable charge lines alongside cost."""
+    client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "openai:omni-moderation-latest",
+            "input_price_per_million": 2.0,
+            "output_price_per_million": 0.0,
+        },
+        headers=master_key_header,
+    )
+
+    mock_resp = _mock_moderation_response()
+
+    with patch(
+        "gateway.api.routes.moderations.amoderation",
+        new_callable=AsyncMock,
+        return_value=mock_resp,
+    ):
+        resp = client.post(
+            "/v1/moderations",
+            json={"model": "openai:omni-moderation-latest", "input": "hello"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+
+    usage_resp = client.get(
+        "/v1/usage", params={"endpoint": "/v1/moderations", "status": "success"}, headers=master_key_header
+    )
+    logs = usage_resp.json()
+    assert len(logs) >= 1
+    latest = logs[0]
+    assert latest["billing_meters"] == {"requests": 1}
+    assert latest["pricing_breakdown"] == [
+        {"meter": "request", "units": 1, "unit_rate": pytest.approx(0.000002), "cost": pytest.approx(0.000002)}
+    ]
 
 
 def test_moderations_no_warning_when_pricing_missing(

--- a/tests/integration/test_rerank_endpoint.py
+++ b/tests/integration/test_rerank_endpoint.py
@@ -263,3 +263,35 @@ def test_rerank_cost_tracked_with_pricing(
     assert len(rerank_logs) >= 1
     assert rerank_logs[0]["cost"] is not None
     assert rerank_logs[0]["cost"] > 0
+
+
+def test_rerank_billing_meters_tracked_with_pricing(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/rerank records auditable charge lines alongside cost."""
+    client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "cohere:rerank-v3.5",
+            "input_price_per_million": 2.0,
+            "output_price_per_million": 0.0,
+        },
+        headers=master_key_header,
+    )
+
+    with patch(
+        "gateway.api.routes.rerank.arerank",
+        new_callable=AsyncMock,
+        return_value=_mock_rerank_response(),
+    ):
+        resp = client.post("/v1/rerank", json=RERANK_PAYLOAD, headers=api_key_header)
+    assert resp.status_code == 200
+
+    usage_resp = client.get("/v1/usage", params={"endpoint": "/v1/rerank"}, headers=master_key_header)
+    logs = usage_resp.json()
+    assert len(logs) >= 1
+    assert logs[0]["billing_meters"] == {"input_tokens": 100}
+    breakdown = logs[0]["pricing_breakdown"]
+    assert breakdown == [{"meter": "input", "units": 100, "rate_per_million": 2.0, "cost": pytest.approx(0.0002)}]

--- a/tests/integration/test_rerank_endpoint.py
+++ b/tests/integration/test_rerank_endpoint.py
@@ -292,6 +292,6 @@ def test_rerank_billing_meters_tracked_with_pricing(
     usage_resp = client.get("/v1/usage", params={"endpoint": "/v1/rerank"}, headers=master_key_header)
     logs = usage_resp.json()
     assert len(logs) >= 1
-    assert logs[0]["billing_meters"] == {"input_tokens": 100}
+    assert logs[0]["billing_meters"] == {"total_input_tokens": 100}
     breakdown = logs[0]["pricing_breakdown"]
     assert breakdown == [{"meter": "input", "units": 100, "rate_per_million": 2.0, "cost": pytest.approx(0.0002)}]


### PR DESCRIPTION
## Description

Passthrough usage rows for embeddings, images, moderations, and rerank set `cost` but never `billing_meters` or `pricing_breakdown`, unlike the chat/messages/responses path (`calculate_metered_cost`) and the imported-usage repricing path, both of which set all three together. Every one of those rows carried a bare cost with no auditable per-meter breakdown.

Root cause: `run_passthrough` (`_passthrough.py`) only ever wrote `usage_log.cost` from `compute_cost`; nothing in the shared scaffold or in the four routes wrote the two audit fields.

Fix: added a `compute_meters` callback to `run_passthrough`, mirroring `compute_cost`'s signature and only invoked once a cost has been priced, and implemented it per route: input tokens for embeddings/rerank, image count for images, a flat per-request charge for moderations.

Not covered: audio (transcriptions/speech) is one of the four surfaces this issue names, but it never calls `compute_cost` at all today (no per-second/per-minute pricing model exists yet for it), so there is no cost for a meters breakdown to attach to. Audio billing needs its own pricing unit first, hence `Refs #432` rather than `Fixes #432`.

## Relevant issues

Refs #432

## Verification

- New regression tests (`test_embeddings_billing_meters_tracked_with_pricing` and the `images`/`moderations`/`rerank` equivalents) fail on `main` (`billing_meters` is `None`) and pass on this branch.
- Full suite passes: `make test` (2596 unit + integration tests), `make lint`, `make typecheck`.
- Did not check: audio billing, out of scope as noted above.

## PR Type

- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [x] AI was used for drafting/refactoring.

**AI Model/Tool used:** Claude (Anthropic), in an agentic coding session directed and verified by the account owner.

**Any additional AI details you'd like to share:** None.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added billing details for passthrough embeddings, images, moderations, and rerank requests.
- Added usage tracking for input tokens, image count, and moderation requests.
- Avoided billing lines for unpriced moderation requests.
- Added integration tests for all four routes.

## Benefits

Usage logs now show how passthrough charges are calculated. This improves billing visibility and auditability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->