### PR TITLE
feat(code-execution): publish the wire contract and type the sandbox client

### DIFF
--- a/docs/code-execution-protocol.md
+++ b/docs/code-execution-protocol.md
@@ -39,28 +39,52 @@ below is unchanged either way, which is what lets the same backend serve both.
 
 ## Operations
 
-Five operations, of which the first three are the whole execution path. A
+Six operations, of which the first three are the whole execution path. A
 backend MUST implement those three; the file operations are OPTIONAL and are
 used only by clients that move files in or out of a session.
 
 | Operation | Purpose | Request | Response |
 |---|---|---|---|
 | `CreateSession` | Lease a session | Optional lifetime hints | A session handle |
-| `Execute` | Run one tool call in a session | A tool call | A result block |
+| `Execute` | Run one tool call in a session | A tool call | A result block, plus execution metadata |
 | `DestroySession` | Release a session | A session id | Empty |
 | `ListFiles` | Enumerate a session's workspace | A session id, a path | File metadata |
 | `GetFile` | Read one file from the workspace | A session id, a path | File bytes |
+| `PutFile` | Write one file into the workspace | A session id, a path, file bytes | The stored path and size |
 
 ### CreateSession
 
-Leases a session and returns a handle. The handle's `session_id` addresses the
-session in every later operation. A backend MAY apply an idle timeout and a
-maximum lifetime, and MAY accept the client's hints for them or clamp them to
-its own ceilings; a client MUST NOT assume a session outlives the values the
-handle reports.
+Leases a session and returns a handle.
 
-A backend MAY refuse when at capacity. This is a retryable condition, distinct
-from a malformed request.
+Request fields, both OPTIONAL lifetime hints:
+
+| Field | Meaning |
+|---|---|
+| `idle_timeout_seconds` | Reclaim the session after this long without activity |
+| `max_lifetime_seconds` | Reclaim the session this long after creation |
+
+Response fields:
+
+| Field | Required | Meaning |
+|---|---|---|
+| `session_id` | yes | A string addressing this session in every later operation |
+| `idle_timeout_seconds` | no | The idle timeout actually in force |
+| `max_lifetime_seconds` | no | The maximum lifetime actually in force |
+| `created_at` | no | When the session was created |
+| `last_activity_at` | no | When the session was last used |
+
+`session_id` is a string, not a number: a client may use it to address the
+session without reformatting it.
+
+A backend MAY accept the client's lifetime hints or clamp them to its own
+ceilings, and reports what is in force. A client MUST NOT assume a session
+outlives the values the handle reports.
+
+A backend MAY refuse when at capacity. This is a retryable condition in
+principle, distinct from a malformed request, and a backend SHOULD signal it
+distinctly so a client can tell the two apart. Note that Otari does not
+currently retry it: it surfaces as a failed request rather than a backoff, so a
+backend should not rely on the client re-offering the work.
 
 ### Execute
 
@@ -92,11 +116,13 @@ that are never released (an abandoned client, a crashed one), which is why the
 lifetime bounds on the handle exist. Releasing a session that does not exist is
 not an error worth distinguishing: it is already in the desired state.
 
-### ListFiles and GetFile
+### ListFiles, GetFile, and PutFile
 
-Enumerate and read files under the session's workspace, so a client can retrieve
-artifacts the code produced. Both MUST confine access to the addressed session's
-own workspace: a path escaping it MUST be refused rather than served.
+Enumerate, read, and write files under the session's workspace, so a client can
+seed inputs and retrieve artifacts the code produced. All three MUST confine
+access to the addressed session's own workspace: a path escaping it MUST be
+refused rather than served or written. A backend MAY cap the size of a written
+file and MUST refuse one that exceeds the cap rather than truncating it.
 
 ## Tool kinds
 
@@ -119,25 +145,55 @@ MUST still accept the kind it is asked for and MUST refuse an unknown one.
 
 ## Result blocks
 
-Every `Execute` returns a **result block** whose shape matches Anthropic's
-`code_execution_20250825` content blocks, so a consumer that already parses
-Anthropic responses needs no translation layer:
+An `Execute` response carries the outcome in a **result block**, under a
+`result_block` field, alongside execution metadata:
+
+| Field | Required | Meaning |
+|---|---|---|
+| `result_block` | yes | The outcome of the call (below) |
+| `tool_use_id` | yes | The call's correlation id, echoed from the request or generated |
+| `execution_time_ms` | no | How long the backend spent executing |
+
+The result block itself matches Anthropic's `code_execution_20250825` content
+blocks, so a consumer that already parses Anthropic responses needs no
+translation layer for it. A full response:
 
 ```json
 {
-  "type": "code_execution_tool_result",
   "tool_use_id": "srvtoolu_...",
-  "content": {
-    "type": "code_execution_result",
-    "stdout": "...",
-    "stderr": "...",
-    "return_code": 0,
-    "content": [
-      {"type": "code_execution_output", "file_id": "...", "filename": "chart.png"}
-    ]
+  "execution_time_ms": 84,
+  "result_block": {
+    "type": "code_execution_tool_result",
+    "tool_use_id": "srvtoolu_...",
+    "content": {
+      "type": "code_execution_result",
+      "stdout": "...",
+      "stderr": "...",
+      "return_code": 0,
+      "content": [
+        {"type": "code_execution_output", "file_id": "...", "filename": "chart.png"}
+      ]
+    }
   }
 }
 ```
+
+Note the envelope: the result block is nested under `result_block`, not returned
+bare. A backend that returns the block at the top level is not conforming, and a
+client validating against this contract will reject it.
+
+Result-block fields:
+
+| Field | Required | Meaning |
+|---|---|---|
+| `type` | yes | The tool kind that ran (below) |
+| `tool_use_id` | yes | The call's correlation id |
+| `content` | yes | The outcome payload |
+
+`content` is REQUIRED even for a run that produced nothing: a run with no output
+returns a `content` whose `stdout` and `stderr` are empty and whose
+`return_code` is `0`, not a block with `content` omitted. Its own fields are all
+OPTIONAL and default as shown in the example.
 
 The block's `type` corresponds to the tool kind that ran:
 `code_execution_tool_result`, `bash_code_execution_tool_result`, or
@@ -154,6 +210,13 @@ Two details are easy to get wrong, and both are load-bearing:
   a backend reports that the code failed. An `Execute` that ran code and
   collected its failure output is a *successful* operation; only a backend that
   could not run the call at all fails the operation itself.
+
+  Concretely, this rules out the error variant of Anthropic's content-block
+  union: a version 1 backend MUST NOT return a `content` of type
+  `code_execution_tool_result_error` carrying an `error_code`. Report the
+  failure through `return_code` and `stderr` instead. A client reading this
+  contract has no reason to inspect `content.type`, so an error variant would be
+  read as an empty successful run, and the call would be billed as one.
 
 For a `text_editor_code_execution` `create`, the file's content is not echoed
 back in the result: it is already on the originating tool-use input as
@@ -197,9 +260,9 @@ a backend (or a proxy in front of one) MAY require it. In Otari's hybrid mode
 this is how the platform's authenticated proxy admits the request and derives
 tenancy from the caller's workspace, so the backend behind it never has to.
 
-Tenancy, when a backend is multi-tenant, is injected by whatever authenticated
-the caller. A backend that expects tenancy MUST fail closed when it is absent
-rather than defaulting to some placeholder tenant.
+Tenancy, when a backend is multi-tenant, is injected by whichever component
+authenticates the caller. A backend that expects tenancy MUST fail closed when
+it is absent, rather than defaulting to a placeholder tenant.
 
 ## HTTP/JSON binding
 
@@ -213,6 +276,7 @@ document. Payloads are JSON; the operation names above map to:
 | `DestroySession` | `DELETE /sessions/{session_id}` |
 | `ListFiles` | `GET /sessions/{session_id}/files/list` |
 | `GetFile` | `GET /sessions/{session_id}/files?path=...` |
+| `PutFile` | `POST /sessions/{session_id}/files` (multipart: `file`, optional `path`) |
 
 Paths are relative to the backend's base URL, which Otari takes from
 `sandbox_url` (`OTARI_SANDBOX_URL`). Field names on the wire are exactly the
@@ -222,12 +286,13 @@ Status codes:
 
 | Condition | Status |
 |---|---|
-| Session created | `201` |
+| Session created, file written | `201` |
 | Execute succeeded (including code that failed) | `200` |
 | Session destroyed | `204` |
-| Unknown session | `404` |
+| Unknown session, or unknown file | `404` |
 | Malformed request, or unknown tool kind | `400` or `422` |
 | Path outside the session workspace | `403` |
+| File larger than the backend's cap | `413` |
 | At capacity, session not leased | `503` |
 
 A bearer credential, where the deployment uses one, is sent as

--- a/docs/code-execution-protocol.md
+++ b/docs/code-execution-protocol.md
@@ -1,0 +1,250 @@
+# Code-execution protocol
+
+**Contract version: 1.**
+
+When a request uses the `otari_code_execution` tool, Otari does not run the code
+itself. It leases a session from a **code-execution backend**, runs each tool
+call against that session, and releases it. This document specifies the contract
+between the two, so that a backend other than the reference implementation can
+be built against something canonical.
+
+The reference backend is
+[otari-sandbox-container](https://github.com/mozilla-ai/otari-sandbox-container),
+a single container that stands alone with no orchestrator. mozilla.ai operates a
+second, pool-backed backend for [otari.ai](https://otari.ai). Both implement this
+contract, and Otari cannot tell which one answered.
+
+> **Transport is not yet fixed.** This specification describes operations and
+> payload semantics, deliberately independent of how they are carried. Today
+> there is exactly one binding, HTTP/JSON, described under
+> [HTTP/JSON binding](#httpjson-binding) and implemented by every backend that
+> exists. That binding is **provisional**: while only one transport has ever been
+> implemented, committing the versioned contract to it would be premature. The
+> operations and payloads below are the stable part; the binding may gain
+> siblings.
+
+## Roles
+
+| Role | Who | Responsibility |
+|---|---|---|
+| Client | Otari | Leases a session, submits tool calls, releases the session |
+| Backend | `otari-sandbox-container` or another implementation | Executes untrusted, model-generated code and returns results |
+| Control plane | The platform, in hybrid mode | Authorizes the caller, enforces per-workspace policy, injects tenancy, meters usage |
+
+The backend does not authorize callers, enforce quota, or meter usage. In
+standalone mode there is no control plane at all: Otari addresses a backend it
+was configured with. In hybrid mode the platform interposes a proxy that
+authenticates the caller and enforces policy before forwarding; the contract
+below is unchanged either way, which is what lets the same backend serve both.
+
+## Operations
+
+Five operations, of which the first three are the whole execution path. A
+backend MUST implement those three; the file operations are OPTIONAL and are
+used only by clients that move files in or out of a session.
+
+| Operation | Purpose | Request | Response |
+|---|---|---|---|
+| `CreateSession` | Lease a session | Optional lifetime hints | A session handle |
+| `Execute` | Run one tool call in a session | A tool call | A result block |
+| `DestroySession` | Release a session | A session id | Empty |
+| `ListFiles` | Enumerate a session's workspace | A session id, a path | File metadata |
+| `GetFile` | Read one file from the workspace | A session id, a path | File bytes |
+
+### CreateSession
+
+Leases a session and returns a handle. The handle's `session_id` addresses the
+session in every later operation. A backend MAY apply an idle timeout and a
+maximum lifetime, and MAY accept the client's hints for them or clamp them to
+its own ceilings; a client MUST NOT assume a session outlives the values the
+handle reports.
+
+A backend MAY refuse when at capacity. This is a retryable condition, distinct
+from a malformed request.
+
+### Execute
+
+Runs one tool call against a leased session and returns its result. Requests
+carry:
+
+| Field | Required | Meaning |
+|---|---|---|
+| `tool` | yes | Which tool kind to run (see [Tool kinds](#tool-kinds)) |
+| `input` | yes | The tool's input, shaped per its kind |
+| `timeout_seconds` | no | How long the backend may spend executing |
+| `tool_use_id` | no | Correlation id; the backend generates one if absent |
+
+**Sessions are stateful.** Interpreter state (variables, imports) and the
+workspace filesystem persist across calls within a session, and are destroyed
+with it. This is the reason the contract is sessioned rather than one-shot, and
+it is a guarantee clients rely on: a model may build up state over several calls
+in a single request.
+
+`timeout_seconds` bounds the backend's execution, not the client's patience. A
+client MUST allow more wall-clock than it grants, since its own budget also
+covers transport and the backend's teardown; otherwise a legitimate
+near-limit execution is reported as an unreachable backend.
+
+### DestroySession
+
+Releases the session and destroys its state. A backend SHOULD reclaim sessions
+that are never released (an abandoned client, a crashed one), which is why the
+lifetime bounds on the handle exist. Releasing a session that does not exist is
+not an error worth distinguishing: it is already in the desired state.
+
+### ListFiles and GetFile
+
+Enumerate and read files under the session's workspace, so a client can retrieve
+artifacts the code produced. Both MUST confine access to the addressed session's
+own workspace: a path escaping it MUST be refused rather than served.
+
+## Tool kinds
+
+`Execute` dispatches on one of three tool kinds, each with its own input shape.
+
+| Tool kind | Input | Runs |
+|---|---|---|
+| `code_execution` | `code` | Source in a persistent interpreter |
+| `bash_code_execution` | `command` | A shell command |
+| `text_editor_code_execution` | `command`, `path`, and command-specific fields | A file view or edit |
+
+`text_editor_code_execution` mirrors Anthropic's text-editor command set:
+`view`, `create`, `str_replace`, `insert`, `undo_edit`. Its command-specific
+fields (`file_text`, `old_str`, `new_str`, `insert_line`, `view_range`) are
+validated per command, not per request.
+
+A client is not required to expose every kind. Otari currently drives only
+`code_execution`, and advertises exactly that one tool to the model; a backend
+MUST still accept the kind it is asked for and MUST refuse an unknown one.
+
+## Result blocks
+
+Every `Execute` returns a **result block** whose shape matches Anthropic's
+`code_execution_20250825` content blocks, so a consumer that already parses
+Anthropic responses needs no translation layer:
+
+```json
+{
+  "type": "code_execution_tool_result",
+  "tool_use_id": "srvtoolu_...",
+  "content": {
+    "type": "code_execution_result",
+    "stdout": "...",
+    "stderr": "...",
+    "return_code": 0,
+    "content": [
+      {"type": "code_execution_output", "file_id": "...", "filename": "chart.png"}
+    ]
+  }
+}
+```
+
+The block's `type` corresponds to the tool kind that ran:
+`code_execution_tool_result`, `bash_code_execution_tool_result`, or
+`text_editor_code_execution_tool_result`.
+
+Two details are easy to get wrong, and both are load-bearing:
+
+- **`content` is a single object, not a list.** The outer `content` is one
+  `code_execution_result`; the *inner* `content` is the list, of file references
+  the execution produced. Code that treats the outer field as a list of mixed
+  content blocks will not parse a conforming response.
+- **Failure is reported in the payload, not out of band.** There is no
+  top-level error flag. A non-zero `return_code`, or output on `stderr`, is how
+  a backend reports that the code failed. An `Execute` that ran code and
+  collected its failure output is a *successful* operation; only a backend that
+  could not run the call at all fails the operation itself.
+
+For a `text_editor_code_execution` `create`, the file's content is not echoed
+back in the result: it is already on the originating tool-use input as
+`file_text`.
+
+### Version pinning, and why this contract has its own version
+
+The result shapes are pinned to Anthropic's `code_execution_20250825` blocks.
+Anthropic's own tool has since moved on to later versions with different result
+shapes, which is precisely why this contract carries a version of its own: a
+backend implements *contract version 1*, and stays conforming regardless of what
+any upstream model provider's tool version does next. Re-pinning to a newer
+upstream shape would be a new contract version, not a silent change to this one.
+
+## Extension policy
+
+This contract evolves **additively**, and both sides MUST tolerate that:
+
+- A backend MAY return fields not described here.
+- A consumer MUST ignore fields it does not recognise, rather than rejecting the
+  response. Otari's client models drop unknown keys.
+- A new tool kind, or a new result-block `type`, MAY be added. A client MUST NOT
+  reject a result block solely because its `type` is unfamiliar; Otari treats
+  `type` as an opaque string and reads the payload.
+- Removing a field, renaming one, or changing the meaning of an existing one is
+  a **breaking** change and requires a new contract version.
+
+The practical consequence: a backend built against version 1 keeps working as
+the contract grows, and a client written against version 1 keeps parsing newer
+backends.
+
+## Authentication and tenancy
+
+The contract itself carries no authentication. The reference backend has none:
+it assumes a single trusted client reached over a private network, and must not
+be exposed to an untrusted one.
+
+Authentication is therefore a property of the deployment, not of the contract. A
+client MAY be configured to present a bearer credential on every operation, and
+a backend (or a proxy in front of one) MAY require it. In Otari's hybrid mode
+this is how the platform's authenticated proxy admits the request and derives
+tenancy from the caller's workspace, so the backend behind it never has to.
+
+Tenancy, when a backend is multi-tenant, is injected by whatever authenticated
+the caller. A backend that expects tenancy MUST fail closed when it is absent
+rather than defaulting to some placeholder tenant.
+
+## HTTP/JSON binding
+
+The one binding that exists today. Provisional, per the note at the top of this
+document. Payloads are JSON; the operation names above map to:
+
+| Operation | Method and path |
+|---|---|
+| `CreateSession` | `POST /sessions` |
+| `Execute` | `POST /sessions/{session_id}/exec` |
+| `DestroySession` | `DELETE /sessions/{session_id}` |
+| `ListFiles` | `GET /sessions/{session_id}/files/list` |
+| `GetFile` | `GET /sessions/{session_id}/files?path=...` |
+
+Paths are relative to the backend's base URL, which Otari takes from
+`sandbox_url` (`OTARI_SANDBOX_URL`). Field names on the wire are exactly the
+names used above.
+
+Status codes:
+
+| Condition | Status |
+|---|---|
+| Session created | `201` |
+| Execute succeeded (including code that failed) | `200` |
+| Session destroyed | `204` |
+| Unknown session | `404` |
+| Malformed request, or unknown tool kind | `400` or `422` |
+| Path outside the session workspace | `403` |
+| At capacity, session not leased | `503` |
+
+A bearer credential, where the deployment uses one, is sent as
+`Authorization: Bearer <token>`.
+
+Server-streamed output (incremental `stdout` and `stderr` while code runs) fits
+this binding over SSE or chunked responses and is a planned addition; it is not
+part of version 1. Bidirectional interactive execution, where input is fed while
+output is read on one connection, is the case this binding strains at, and is
+the open question behind not yet fixing the transport.
+
+## Configuration
+
+| Setting | Env var | Meaning |
+|---|---|---|
+| `sandbox_url` | `OTARI_SANDBOX_URL` | Base URL of the backend. Unset, `otari_code_execution` requests are rejected. |
+| `sandbox_purpose_hint` | `OTARI_SANDBOX_PURPOSE_HINT` | Default purpose hint for the tool, when a request supplies none. |
+
+See [Configuration](configuration.md) for the full settings reference and
+[Built-in tools](tools.md) for the user-facing view of the tool.

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,7 @@ Calling the gateway from your own code.
 ### For platform builders
 
 - [Hybrid-mode protocol](hybrid-mode-protocol.md): the Otari/platform wire contract, for building a platform that Otari connects to.
+- [Code-execution protocol](code-execution-protocol.md): the Otari/sandbox contract, for building a code-execution backend that Otari dispatches to.
 
 ### For contributors
 

--- a/src/gateway/services/sandbox_backend.py
+++ b/src/gateway/services/sandbox_backend.py
@@ -7,7 +7,9 @@ container lives in its own repo
 Docker Hub (``mzdotai/otari-sandbox-container``). It runs a Python REPL
 with a curated set of data-science libraries pre-installed.
 
-Wire shape against the sandbox container:
+The contract this drives is specified in ``docs/code-execution-protocol.md``;
+the shapes it returns are typed in :mod:`gateway.types.code_execution`. The
+three operations used here:
 
 * ``POST /sessions``         → creates a session, returns ``session_id``
 * ``POST /sessions/{id}/exec``  with ``{tool: "code_execution",
@@ -37,8 +39,10 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 from opentelemetry import trace
+from pydantic import ValidationError
 
 from gateway.services.tool_usage import ToolUsageTally
+from gateway.types.code_execution import ExecResponse, ResultBlock, SessionHandle
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -141,8 +145,8 @@ class SandboxBackend:
             )
             response = await self._client.post(f"{self._sandbox_url}/sessions", json={})
             response.raise_for_status()
-            self._session_id = response.json()["session_id"]
-        except (httpx.HTTPError, KeyError, ValueError) as exc:
+            self._session_id = SessionHandle.model_validate(response.json()).session_id
+        except (httpx.HTTPError, ValidationError, ValueError) as exc:
             await self._stack.aclose()
             raise SandboxNotReachableError(f"failed to create sandbox session at {self._sandbox_url}: {exc}") from exc
         return self
@@ -218,78 +222,50 @@ class SandboxBackend:
                     timeout=self._timeout_s + _EXEC_TIMEOUT_BUFFER_S,
                 )
                 response.raise_for_status()
-                body = response.json()
-            except (httpx.HTTPError, ValueError) as exc:
+                # A malformed body is a contract violation, indistinguishable to the
+                # caller from an unreachable backend: both mean this exec produced no
+                # usable result, so they raise the same error.
+                exec_response = ExecResponse.model_validate(response.json())
+            except (httpx.HTTPError, ValidationError, ValueError) as exc:
                 span.record_exception(exc)
                 span.set_status(trace.StatusCode.ERROR, str(exc))
                 raise SandboxNotReachableError(f"sandbox exec failed: {exc}") from exc
 
-            result_block = body.get("result_block")
-            if not isinstance(result_block, dict):
-                err = SandboxNotReachableError(f"sandbox returned malformed result: {body!r}")
-                span.record_exception(err)
-                span.set_status(trace.StatusCode.ERROR, str(err))
-                raise err
-
-            result = _flatten_result_block(result_block)
+            result = _flatten_result_block(exec_response.result_block)
             if result.startswith("[tool error]"):
                 span.set_status(trace.StatusCode.ERROR, result)
             return result
 
 
-def _flatten_result_block(block: dict[str, Any]) -> str:
-    """Render the sandbox's structured result as a single string for the model.
+def _flatten_result_block(block: ResultBlock) -> str:
+    """Render the structured result as a single string for the model.
 
-    The sandbox returns an Anthropic-shaped tool-result block — see
-    https://github.com/mozilla-ai/otari-sandbox-container/blob/main/sandbox/models.py:
+    The tool loop hands the model one string per tool call, so the block's
+    fields collapse into labelled sections. Errors come through as a non-zero
+    ``return_code`` or a non-empty ``stderr``; the contract has no top-level
+    ``is_error`` flag.
 
-        {
-          "type": "code_execution_tool_result"
-                  | "bash_code_execution_tool_result"
-                  | "text_editor_code_execution_tool_result",
-          "tool_use_id": "...",
-          "content": {
-            "type": "code_execution_result",
-            "stdout": "...",
-            "stderr": "...",
-            "return_code": 0,
-            "content": [file refs]
-          }
-        }
-
-    Note ``content`` is a single ``CodeExecutionResultContent`` object, NOT a
-    list of mixed blocks. Errors come through as a non-zero ``return_code``
-    or a non-empty ``stderr``; there is no top-level ``is_error`` flag.
-
-    Full structured output (file refs, separate exit codes per step) is a
-    future enhancement that lands alongside the Anthropic-content-block lift.
+    Passing the full structured result through to the caller (file refs as
+    content blocks, per-step exit codes) is a future enhancement that lands
+    alongside the Anthropic-content-block lift.
     """
-    content = block.get("content")
-    if not isinstance(content, dict):
-        return str(block)
-
-    stdout = content.get("stdout") or ""
-    stderr = content.get("stderr") or ""
-    return_code = content.get("return_code")
-    file_refs = content.get("content") or []
+    content = block.content
 
     parts: list[str] = []
-    if stdout:
-        parts.append(f"stdout:\n{stdout}")
-    if stderr:
-        parts.append(f"stderr:\n{stderr}")
-    if return_code not in (None, 0):
-        parts.append(f"return_code: {return_code}")
-    if isinstance(file_refs, list) and file_refs:
-        names = [f.get("filename", "?") for f in file_refs if isinstance(f, dict)]
-        if names:
-            parts.append("files: " + ", ".join(names))
+    if content.stdout:
+        parts.append(f"stdout:\n{content.stdout}")
+    if content.stderr:
+        parts.append(f"stderr:\n{content.stderr}")
+    if content.return_code not in (None, 0):
+        parts.append(f"return_code: {content.return_code}")
+    if content.content:
+        parts.append("files: " + ", ".join(ref.filename or "?" for ref in content.content))
 
     flattened = "\n".join(parts)
     if not flattened:
         return "(no output)"
     # Treat non-zero return_code or stderr-only output as error-shaped so the
     # model gets a clear signal it can recover from.
-    if (return_code not in (None, 0)) or (stderr and not stdout):
+    if (content.return_code not in (None, 0)) or (content.stderr and not content.stdout):
         return f"[tool error] {flattened}"
     return flattened

--- a/src/gateway/services/sandbox_backend.py
+++ b/src/gateway/services/sandbox_backend.py
@@ -11,7 +11,8 @@ The contract this drives is specified in ``docs/code-execution-protocol.md``;
 the shapes it returns are typed in :mod:`gateway.types.code_execution`. The
 three operations used here:
 
-* ``POST /sessions``         → creates a session, returns ``session_id``
+* ``POST /sessions``         → creates a session, returns a handle carrying
+                              ``session_id``
 * ``POST /sessions/{id}/exec``  with ``{tool: "code_execution",
                                         input: {code: "…"},
                                         timeout_seconds: int}``
@@ -100,6 +101,26 @@ class SandboxNotReachableError(RuntimeError):
     """Raised when the sandbox container can't be reached or returns malformed data."""
 
 
+def _contract_violation(exc: ValidationError) -> str:
+    """Summarise a schema violation without quoting the payload.
+
+    Pydantic's ``ValidationError`` subclasses ``ValueError``, so every handler
+    below must catch it *before* the clause that catches ``ValueError``.
+    Reordering them silently routes schema violations through the generic
+    handler and reintroduces the leak this exists to prevent.
+
+    Pydantic renders the offending values into ``str(exc)`` (``input_value=...``),
+    and a result block carries arbitrary program output from model-generated
+    code, so rendering it would put that output into logs and spans. The field
+    locations and error types are the diagnostically useful part and carry none
+    of it.
+    """
+    fields = ", ".join(
+        f"{'.'.join(str(part) for part in error['loc']) or '(root)'}: {error['type']}" for error in exc.errors()
+    )
+    return f"response does not match the code-execution contract ({fields})"
+
+
 class SandboxBackend:
     """Async context manager that owns one sandbox session for a request's lifetime.
 
@@ -146,7 +167,12 @@ class SandboxBackend:
             response = await self._client.post(f"{self._sandbox_url}/sessions", json={})
             response.raise_for_status()
             self._session_id = SessionHandle.model_validate(response.json()).session_id
-        except (httpx.HTTPError, ValidationError, ValueError) as exc:
+        except ValidationError as exc:
+            await self._stack.aclose()
+            raise SandboxNotReachableError(
+                f"failed to create sandbox session at {self._sandbox_url}: {_contract_violation(exc)}"
+            ) from None
+        except (httpx.HTTPError, ValueError) as exc:
             await self._stack.aclose()
             raise SandboxNotReachableError(f"failed to create sandbox session at {self._sandbox_url}: {exc}") from exc
         return self
@@ -226,7 +252,15 @@ class SandboxBackend:
                 # caller from an unreachable backend: both mean this exec produced no
                 # usable result, so they raise the same error.
                 exec_response = ExecResponse.model_validate(response.json())
-            except (httpx.HTTPError, ValidationError, ValueError) as exc:
+            except ValidationError as exc:
+                # Raised `from None`, and the summary is built rather than rendered,
+                # so neither the message nor the chained traceback carries the
+                # payload into the span. See _contract_violation.
+                err = SandboxNotReachableError(f"sandbox exec failed: {_contract_violation(exc)}")
+                span.record_exception(err)
+                span.set_status(trace.StatusCode.ERROR, str(err))
+                raise err from None
+            except (httpx.HTTPError, ValueError) as exc:
                 span.record_exception(exc)
                 span.set_status(trace.StatusCode.ERROR, str(exc))
                 raise SandboxNotReachableError(f"sandbox exec failed: {exc}") from exc

--- a/src/gateway/types/code_execution.py
+++ b/src/gateway/types/code_execution.py
@@ -10,6 +10,13 @@ extension policy says a backend may return additional fields and a consumer
 must ignore the ones it does not recognise, so unknown keys are dropped rather
 than rejected, and the spec doc (not this module) is the full contract.
 
+The same policy is why these models are liberal about the values they accept.
+A field the gateway only renders absorbs a null or an unusable shape and keeps
+going, because a payload that carries usable output must not be discarded over
+a stream the backend chose to serialise as `null`. Validation is reserved for
+the parts the gateway cannot proceed without: it fails on a missing session id
+or a missing result payload, not on a cosmetic field.
+
 The types live here, not next to ``services/sandbox_backend``, because they are
 leaf types with no service dependencies, and ``check_architecture.py`` keeps
 that direction one-way.
@@ -17,7 +24,9 @@ that direction one-way.
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Annotated, Any
+
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 
 __all__ = [
     "CodeExecutionFileRef",
@@ -26,6 +35,32 @@ __all__ = [
     "ResultBlock",
     "SessionHandle",
 ]
+
+
+def _blank_if_null(value: Any) -> Any:
+    """Absorb an explicit ``null`` into the empty string.
+
+    A backend that models an absent stream as an optional field serialises it
+    as ``null`` rather than omitting it, which a plain ``str`` would reject.
+    """
+    return "" if value is None else value
+
+
+def _file_refs_only(value: Any) -> Any:
+    """Keep the entries that can describe a file, discard the rest.
+
+    The nested ``content`` is the file-reference list, but for a text-editor
+    view the same field carries the file's text instead, and it may be ``null``
+    when nothing was produced. Neither names a file, so neither contributes a
+    filename, and neither is worth failing an otherwise successful call over.
+    """
+    if not isinstance(value, list):
+        return []
+    return [entry for entry in value if isinstance(entry, dict)]
+
+
+_RenderedStr = Annotated[str, BeforeValidator(_blank_if_null)]
+_FileRefs = Annotated[list["CodeExecutionFileRef"], BeforeValidator(_file_refs_only)]
 
 
 class _ContractModel(BaseModel):
@@ -48,7 +83,7 @@ class SessionHandle(_ContractModel):
 class CodeExecutionFileRef(_ContractModel):
     """A file the execution produced (a chart, a generated CSV)."""
 
-    filename: str = ""
+    filename: _RenderedStr = ""
 
 
 class CodeExecutionResult(_ContractModel):
@@ -59,13 +94,13 @@ class CodeExecutionResult(_ContractModel):
     ``content`` is the file-reference list.
     """
 
-    stdout: str = ""
-    stderr: str = ""
+    stdout: _RenderedStr = ""
+    stderr: _RenderedStr = ""
     # Optional as well as defaulted: a backend that sends an explicit `null`
     # means "no exit status", which the renderer treats the same as 0. Making
     # this a bare `int` would reject that payload outright.
     return_code: int | None = 0
-    content: list[CodeExecutionFileRef] = Field(default_factory=list)
+    content: _FileRefs = Field(default_factory=list)
 
 
 class ResultBlock(_ContractModel):

--- a/src/gateway/types/code_execution.py
+++ b/src/gateway/types/code_execution.py
@@ -1,0 +1,86 @@
+"""The code-execution wire contract, as the gateway consumes it.
+
+Otari does not run code itself: it drives a code-execution backend over the
+contract specified in ``docs/code-execution-protocol.md``. These are the
+response shapes the gateway reads, so ``SandboxBackend`` parses a validated
+object instead of walking untyped dicts.
+
+Only the fields the gateway actually reads are modelled. The contract's
+extension policy says a backend may return additional fields and a consumer
+must ignore the ones it does not recognise, so unknown keys are dropped rather
+than rejected, and the spec doc (not this module) is the full contract.
+
+The types live here, not next to ``services/sandbox_backend``, because they are
+leaf types with no service dependencies, and ``check_architecture.py`` keeps
+that direction one-way.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "CodeExecutionFileRef",
+    "CodeExecutionResult",
+    "ExecResponse",
+    "ResultBlock",
+    "SessionHandle",
+]
+
+
+class _ContractModel(BaseModel):
+    """Base for every contract shape: tolerant of fields we do not know.
+
+    ``extra="ignore"`` is Pydantic's default; it is spelled out because it is
+    the extension policy rather than an incidental default, and a future
+    ``model_config`` edit should not silently drop it.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+
+class SessionHandle(_ContractModel):
+    """A leased session. The gateway needs only the id to address it."""
+
+    session_id: str
+
+
+class CodeExecutionFileRef(_ContractModel):
+    """A file the execution produced (a chart, a generated CSV)."""
+
+    filename: str = ""
+
+
+class CodeExecutionResult(_ContractModel):
+    """The ``content`` payload of a result block.
+
+    Note this is a single object, not a list of mixed content blocks: the
+    contract mirrors Anthropic's ``code_execution_result``, whose nested
+    ``content`` is the file-reference list.
+    """
+
+    stdout: str = ""
+    stderr: str = ""
+    # Optional as well as defaulted: a backend that sends an explicit `null`
+    # means "no exit status", which the renderer treats the same as 0. Making
+    # this a bare `int` would reject that payload outright.
+    return_code: int | None = 0
+    content: list[CodeExecutionFileRef] = Field(default_factory=list)
+
+
+class ResultBlock(_ContractModel):
+    """One tool call's outcome.
+
+    ``type`` is a plain string, deliberately not a closed union of the three
+    tool kinds. The contract may add a fourth kind additively, and an older
+    gateway must keep rendering its result rather than failing to parse it.
+    """
+
+    type: str = ""
+    content: CodeExecutionResult
+
+
+class ExecResponse(_ContractModel):
+    """The response to one execute call."""
+
+    result_block: ResultBlock

--- a/src/gateway/types/code_execution.py
+++ b/src/gateway/types/code_execution.py
@@ -37,13 +37,25 @@ __all__ = [
 ]
 
 
-def _blank_if_null(value: Any) -> Any:
-    """Absorb an explicit ``null`` into the empty string.
+def _rendered_text(value: Any) -> Any:
+    """Coerce whatever a backend put in a render-only field into text.
 
-    A backend that models an absent stream as an optional field serialises it
-    as ``null`` rather than omitting it, which a plain ``str`` would reject.
+    ``null`` becomes empty: a backend that models an absent stream as an
+    optional field serialises it that way rather than omitting it, and a plain
+    ``str`` would reject it.
+
+    Anything else non-string is stringified rather than dropped. Dropping it
+    would be the more dangerous choice: a backend that puts a structure in
+    ``stderr`` is still reporting a failure, and discarding it renders the run
+    as clean, unmarked output that then bills as a success. Stringifying keeps
+    the signal, and matches what the pre-typing renderer did by interpolating
+    the value straight into the rendered section.
     """
-    return "" if value is None else value
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
 
 
 def _file_refs_only(value: Any) -> Any:
@@ -59,7 +71,7 @@ def _file_refs_only(value: Any) -> Any:
     return [entry for entry in value if isinstance(entry, dict)]
 
 
-_RenderedStr = Annotated[str, BeforeValidator(_blank_if_null)]
+_RenderedStr = Annotated[str, BeforeValidator(_rendered_text)]
 _FileRefs = Annotated[list["CodeExecutionFileRef"], BeforeValidator(_file_refs_only)]
 
 

--- a/tests/unit/test_sandbox_backend.py
+++ b/tests/unit/test_sandbox_backend.py
@@ -448,3 +448,133 @@ async def test_call_tool_span_error_status_on_tool_error_result(monkeypatch: pyt
     assert len(spans) == 1
     assert spans[0].status.status_code == StatusCode.ERROR
 
+
+# ----- contract conformance (docs/code-execution-protocol.md) -----
+
+
+def _exec_handlers(result_block: Any, monkeypatch: pytest.MonkeyPatch) -> _MockTransport:
+    return _patched_async_client(
+        {
+            ("POST", "/sessions"): httpx.Response(201, json={"session_id": "s1"}),
+            ("POST", "/sessions/s1/exec"): httpx.Response(200, json={"result_block": result_block}),
+            ("DELETE", "/sessions/s1"): httpx.Response(204),
+        },
+        monkeypatch,
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_result_block_type_still_renders(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A tool kind added to the contract later must not break an older gateway.
+
+    The extension policy allows new result-block types additively, so `type` is
+    read as an opaque string rather than validated against a closed set.
+    """
+    _exec_handlers(
+        {
+            "type": "future_code_execution_tool_result",
+            "tool_use_id": "t1",
+            "content": {"type": "code_execution_result", "stdout": "42\n", "return_code": 0},
+        },
+        monkeypatch,
+    )
+
+    async with SandboxBackend(sandbox_url="http://sandbox:8080") as backend:
+        result = await backend.call_tool(CODE_EXECUTION_TOOL_NAME, {"code": "print(42)"})
+
+    assert result == "stdout:\n42\n"
+
+
+@pytest.mark.asyncio
+async def test_unrecognised_fields_are_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Backends may return fields this gateway does not know; they are dropped."""
+    _exec_handlers(
+        {
+            "type": "code_execution_tool_result",
+            "tool_use_id": "t1",
+            "cpu_milliseconds": 12,
+            "content": {
+                "type": "code_execution_result",
+                "stdout": "ok",
+                "return_code": 0,
+                "sandbox_node": "pod-7",
+            },
+        },
+        monkeypatch,
+    )
+
+    async with SandboxBackend(sandbox_url="http://sandbox:8080") as backend:
+        result = await backend.call_tool(CODE_EXECUTION_TOOL_NAME, {"code": "1"})
+
+    assert result == "stdout:\nok"
+
+
+@pytest.mark.asyncio
+async def test_file_refs_are_listed(monkeypatch: pytest.MonkeyPatch) -> None:
+    _exec_handlers(
+        {
+            "type": "code_execution_tool_result",
+            "tool_use_id": "t1",
+            "content": {
+                "type": "code_execution_result",
+                "stdout": "done",
+                "return_code": 0,
+                "content": [
+                    {"type": "code_execution_output", "file_id": "f1", "filename": "chart.png"},
+                    {"type": "code_execution_output", "file_id": "f2"},
+                ],
+            },
+        },
+        monkeypatch,
+    )
+
+    async with SandboxBackend(sandbox_url="http://sandbox:8080") as backend:
+        result = await backend.call_tool(CODE_EXECUTION_TOOL_NAME, {"code": "savefig()"})
+
+    assert "files: chart.png, ?" in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param({}, id="result_block-absent"),
+        pytest.param({"result_block": "not-an-object"}, id="result_block-not-an-object"),
+        pytest.param({"result_block": {"type": "code_execution_tool_result"}}, id="content-absent"),
+        pytest.param(
+            {"result_block": {"type": "code_execution_tool_result", "content": ["a", "b"]}},
+            id="content-is-a-list",
+        ),
+    ],
+)
+async def test_malformed_exec_response_raises(body: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    """A response that violates the contract yields no usable result, so it raises.
+
+    `content` as a list is called out explicitly: it is the shape a consumer
+    reaches for when it mistakes the payload for Anthropic's mixed content-block
+    list, and a backend that emits it is not conforming.
+    """
+    _patched_async_client(
+        {
+            ("POST", "/sessions"): httpx.Response(201, json={"session_id": "s1"}),
+            ("POST", "/sessions/s1/exec"): httpx.Response(200, json=body),
+            ("DELETE", "/sessions/s1"): httpx.Response(204),
+        },
+        monkeypatch,
+    )
+
+    async with SandboxBackend(sandbox_url="http://sandbox:8080") as backend:
+        with pytest.raises(SandboxNotReachableError, match="sandbox exec failed"):
+            await backend.call_tool(CODE_EXECUTION_TOOL_NAME, {"code": "1"})
+
+
+@pytest.mark.asyncio
+async def test_enter_raises_when_session_handle_lacks_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patched_async_client(
+        {("POST", "/sessions"): httpx.Response(201, json={"created_at": 1.0})},
+        monkeypatch,
+    )
+
+    with pytest.raises(SandboxNotReachableError, match="failed to create"):
+        async with SandboxBackend(sandbox_url="http://sandbox:8080"):
+            pass

--- a/tests/unit/test_sandbox_backend.py
+++ b/tests/unit/test_sandbox_backend.py
@@ -735,3 +735,62 @@ async def test_renderable_fields_absorb_unusable_values(
         result = await backend.call_tool(CODE_EXECUTION_TOOL_NAME, {"code": "1"})
 
     assert result == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        pytest.param(
+            {"stdout": "", "stderr": {"message": "boom"}, "return_code": 0},
+            "[tool error] stderr:\n{'message': 'boom'}",
+            id="stderr-only-is-an-object",
+        ),
+        pytest.param(
+            {"stdout": "ok", "stderr": {"message": "warn"}, "return_code": 0},
+            "stdout:\nok\nstderr:\n{'message': 'warn'}",
+            id="stderr-object-alongside-stdout",
+        ),
+        pytest.param(
+            {"stdout": ["a", "b"], "return_code": 0},
+            "stdout:\n['a', 'b']",
+            id="stdout-is-a-list",
+        ),
+        pytest.param(
+            {"stdout": "ok", "return_code": 0, "content": [{"filename": {"nested": 1}}]},
+            "stdout:\nok\nfiles: {'nested': 1}",
+            id="filename-is-an-object",
+        ),
+    ],
+)
+async def test_structured_values_in_render_only_fields_keep_the_signal(
+    content: dict[str, Any], expected: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A structure where text was expected is rendered, not dropped.
+
+    The first case is why stringifying beats discarding. Blanking a structured
+    `stderr` would leave a stderr-only run with nothing to render, so it would
+    come back `(no output)` with no `[tool error]` marker and bill as a
+    successful call, which is the failure the error-variant exclusion in
+    docs/code-execution-protocol.md exists to prevent.
+
+    The second case pins the surrounding semantics: stderr *alongside* stdout at
+    `return_code: 0` is not error-shaped either way, so only the stderr-only
+    shape distinguishes the two coercions.
+    """
+    _patched_async_client(
+        {
+            ("POST", "/sessions"): httpx.Response(201, json={"session_id": "s1"}),
+            ("POST", "/sessions/s1/exec"): httpx.Response(
+                200,
+                json={"result_block": {"type": "code_execution_tool_result", "content": content}},
+            ),
+            ("DELETE", "/sessions/s1"): httpx.Response(204),
+        },
+        monkeypatch,
+    )
+
+    async with SandboxBackend(sandbox_url="http://sandbox:8080") as backend:
+        result = await backend.call_tool(CODE_EXECUTION_TOOL_NAME, {"code": "1"})
+
+    assert result == expected

--- a/tests/unit/test_sandbox_backend.py
+++ b/tests/unit/test_sandbox_backend.py
@@ -6,6 +6,7 @@ Mocks the HTTP layer with `respx` so the suite needs no sandbox container.
 from __future__ import annotations
 
 import json
+import traceback
 from typing import Any
 
 import httpx
@@ -578,3 +579,159 @@ async def test_enter_raises_when_session_handle_lacks_id(monkeypatch: pytest.Mon
     with pytest.raises(SandboxNotReachableError, match="failed to create"):
         async with SandboxBackend(sandbox_url="http://sandbox:8080"):
             pass
+
+
+@pytest.mark.asyncio
+async def test_documented_exec_response_shape_parses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The full response documented in docs/code-execution-protocol.md.
+
+    Pinned verbatim against the spec's example, envelope included, so the
+    published contract and this client cannot drift apart silently.
+    """
+    _patched_async_client(
+        {
+            ("POST", "/sessions"): httpx.Response(201, json={"session_id": "s1"}),
+            ("POST", "/sessions/s1/exec"): httpx.Response(
+                200,
+                json={
+                    "tool_use_id": "srvtoolu_abc",
+                    "execution_time_ms": 84,
+                    "result_block": {
+                        "type": "code_execution_tool_result",
+                        "tool_use_id": "srvtoolu_abc",
+                        "content": {
+                            "type": "code_execution_result",
+                            "stdout": "3.14\n",
+                            "stderr": "",
+                            "return_code": 0,
+                            "content": [
+                                {
+                                    "type": "code_execution_output",
+                                    "file_id": "file_1",
+                                    "filename": "chart.png",
+                                }
+                            ],
+                        },
+                    },
+                },
+            ),
+            ("DELETE", "/sessions/s1"): httpx.Response(204),
+        },
+        monkeypatch,
+    )
+
+    async with SandboxBackend(sandbox_url="http://sandbox:8080") as backend:
+        result = await backend.call_tool(CODE_EXECUTION_TOOL_NAME, {"code": "print(3.14)"})
+
+    assert result == "stdout:\n3.14\n\nfiles: chart.png"
+
+
+@pytest.mark.asyncio
+async def test_schema_violation_message_omits_the_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A contract violation must not carry program output into logs or spans.
+
+    `stdout` here holds the kind of thing sandboxed code can emit (a credential
+    it was handed). The error names the offending field, never its value.
+    """
+    secret = "sk-live-do-not-log-this"
+    _patched_async_client(
+        {
+            ("POST", "/sessions"): httpx.Response(201, json={"session_id": "s1"}),
+            ("POST", "/sessions/s1/exec"): httpx.Response(
+                200,
+                json={
+                    "result_block": {
+                        "type": "code_execution_tool_result",
+                        # `content` must be an object; a list violates the contract.
+                        "content": [{"stdout": secret}],
+                    }
+                },
+            ),
+            ("DELETE", "/sessions/s1"): httpx.Response(204),
+        },
+        monkeypatch,
+    )
+
+    async with SandboxBackend(sandbox_url="http://sandbox:8080") as backend:
+        with pytest.raises(SandboxNotReachableError) as excinfo:
+            await backend.call_tool(CODE_EXECUTION_TOOL_NAME, {"code": "1"})
+
+    rendered = "".join(traceback.format_exception(excinfo.value))
+    assert secret not in rendered
+    assert "result_block.content" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_session_handle_violation_message_omits_the_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    secret = "sk-live-do-not-log-this"
+    _patched_async_client(
+        {("POST", "/sessions"): httpx.Response(201, json={"session_id": {"nested": secret}})},
+        monkeypatch,
+    )
+
+    with pytest.raises(SandboxNotReachableError) as excinfo:
+        async with SandboxBackend(sandbox_url="http://sandbox:8080"):
+            pass
+
+    rendered = "".join(traceback.format_exception(excinfo.value))
+    assert secret not in rendered
+    assert "session_id" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        pytest.param(
+            {"stdout": "42\n", "stderr": None, "return_code": 0},
+            "stdout:\n42\n",
+            id="stderr-null",
+        ),
+        pytest.param(
+            {"stdout": None, "stderr": "boom", "return_code": 1},
+            "[tool error] stderr:\nboom\nreturn_code: 1",
+            id="stdout-null",
+        ),
+        pytest.param(
+            {"stdout": "done", "return_code": 0, "content": None},
+            "stdout:\ndone",
+            id="file-refs-null",
+        ),
+        pytest.param(
+            {"stdout": "file body", "return_code": 0, "content": "inline text"},
+            "stdout:\nfile body",
+            id="file-refs-not-a-list",
+        ),
+        pytest.param(
+            {"stdout": "ok", "return_code": 0, "content": [{"filename": None}, "bare-id"]},
+            "stdout:\nok\nfiles: ?",
+            id="file-ref-unnameable",
+        ),
+    ],
+)
+async def test_renderable_fields_absorb_unusable_values(
+    content: dict[str, Any], expected: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A payload carrying usable output must not be discarded over a cosmetic field.
+
+    Each case is one the pre-typing renderer absorbed (`... or ""`, an
+    `isinstance` guard, a per-entry filter). Rejecting them would turn a run
+    that produced real output into a failed tool call, and for the eager-open
+    path into a 502.
+    """
+    _patched_async_client(
+        {
+            ("POST", "/sessions"): httpx.Response(201, json={"session_id": "s1"}),
+            ("POST", "/sessions/s1/exec"): httpx.Response(
+                200,
+                json={"result_block": {"type": "code_execution_tool_result", "content": content}},
+            ),
+            ("DELETE", "/sessions/s1"): httpx.Response(204),
+        },
+        monkeypatch,
+    )
+
+    async with SandboxBackend(sandbox_url="http://sandbox:8080") as backend:
+        result = await backend.call_tool(CODE_EXECUTION_TOOL_NAME, {"code": "1"})
+
+    assert result == expected


### PR DESCRIPTION
## Description

The code-execution seam is the sandbox wire contract, not an in-process port ([otari-ai#1429](https://github.com/mozilla-ai/otari-ai/issues/1429)). Two backends already implement it, but it was specified only by the reference backend's Pydantic models, so an external backend builder had nothing canonical to build against.

This publishes it as `docs/code-execution-protocol.md` (alongside the hybrid-mode protocol) and types `SandboxBackend` against the published shapes instead of `body.get("result_block")` plus nested `isinstance` guards.

Drafted **transport-agnostically**: [otari-ai#1601](https://github.com/mozilla-ai/otari-ai/issues/1601) (HTTP/JSON vs proto) is still open, so operations and payload semantics are the versioned part and the HTTP/JSON binding is documented as the one binding that exists today, marked provisional.

Two behaviour changes, both narrowing malformed input to the error that already existed:

- `content` that is not an object now raises `SandboxNotReachableError` instead of returning `str(block)`, a Python repr, to the model.
- A missing `session_id` raises via `ValidationError` rather than `KeyError`.

`ResultBlock.type` stays an opaque string rather than a closed union of the three tool kinds, so a fourth kind added additively keeps rendering on an older gateway.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Addresses the publish-and-type half of [otari-ai#1448](https://github.com/mozilla-ai/otari-ai/issues/1448). Not closing it: entitlement gating waits on the EntitlementPort, and the final IDL/transport waits on [otari-ai#1601](https://github.com/mozilla-ai/otari-ai/issues/1601).

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

No route or schema changes, so the OpenAPI spec is unaffected. `make lint`, `make typecheck`, and the 1530-test unit suite pass; the sandbox-dispatch integration tests pass too.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

The contract in the doc was read off `otari-sandbox-container`'s `sandbox/models.py` and `sandbox/exec_server.py` rather than from the prior prose, which had drifted: `POST /sessions` returns `201` with the full session handle (not a bare `session_id`), and the reference backend never populates the file-reference list today.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a versioned protocol for sandbox code execution.
- Added typed models for sessions, execution results, files, and result blocks.
- Improved sandbox response validation and error handling.
- Preserved support for new result-block types and optional output fields.
- Added documentation links and contract-conformance tests.

## Benefits

- Gives sandbox backend and client teams a shared implementation reference.
- Makes response handling more predictable and safer.
- Supports future tool extensions without breaking existing consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->