### PR TITLE
fix(routing): fall back on every provider failure

### DIFF
--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -107,9 +107,9 @@ Content-Type: application/json
 }
 ```
 
-Otari iterates `attempts` in order. On a retryable failure it moves to the
-next entry; on success it stops. The `attempt_id` of the entry that ultimately
-succeeded (or the last one tried, on total failure) is what Otari echoes
+Otari iterates `attempts` in order. On a provider failure before a response is
+committed, it moves to the next entry; on success it stops. The `attempt_id` of
+the entry that ultimately succeeded (or the last one tried, on total failure) is what Otari echoes
 back via `X-Correlation-ID` and reports through `/gateway/usage`.
 
 `extra_params` (optional, omitted for most providers) carries provider-specific
@@ -363,8 +363,8 @@ one per attempt, sharing the same `request_id` (recoverable via the original
 resolve response). The platform is responsible for correlating them.
 
 `is_final_attempt` tells the platform that the gateway will not try another
-planned fallback. It is `false` for a retryable failure followed by another
-attempt, and `true` for success, fallback exhaustion, a non-retryable failure,
+planned fallback. It is `false` for a provider failure followed by another
+attempt, and `true` for success, fallback exhaustion, a gateway-side refusal,
 or a failure after a tool loop has locked in to one provider. The marker lets
 the platform ignore later planned attempts that were never tried instead of
 waiting forever for usage reports that will never arrive.
@@ -376,8 +376,8 @@ waiting forever for usage reports that will never arrive.
 | `timeout` | `httpx.TimeoutException`, `asyncio.TimeoutError`, `TimeoutError`, or the OpenAI/Anthropic SDKs' own `APITimeoutError` |
 | `conn_err` | `httpx.NetworkError`, or the OpenAI/Anthropic SDKs' own `APIConnectionError` |
 | `http_<code>` | Provider returned an HTTP status code (e.g. `http_429`, `http_401`) |
-| `http_<code>_billing` | Provider returned a 400, 402, or 422 whose message identifies account billing exhaustion (e.g. Anthropic's "credit balance is too low", DeepSeek's "Insufficient Balance"). Reported as `http_400_billing` etc., keeping an empty provider wallet separable from a malformed request. Otari treats these as retryable, so the request walks on to the next attempt unless the failing attempt had already locked in (a tool loop whose upstream returned a first assistant message cannot be replayed on another provider, so its failure is terminal) |
-| `unknown` | Any other exception class |
+| `http_<code>_billing` | Provider returned a 400 or 422 whose message identifies account billing exhaustion (e.g. Anthropic's "credit balance is too low"), or any 402 Payment Required, including one whose SDK discarded the response message. Reported as `http_400_billing` etc., keeping an empty provider wallet separable from a malformed request. Like every provider error before lock-in, it advances to the next attempt. |
+| `unknown` | Any other exception class. It still advances to the next candidate. |
 
 Treat `error_class` as an open set of strings, not a closed enum: new tags are
 added as Otari learns to separate failure causes, and a handler that rejects an
@@ -426,8 +426,7 @@ The mechanism is a per-attempt **first-chunk gate**. For each attempt:
 
 1. Open the upstream stream (`acompletion(stream=True, ...)`). If this raises
    (provider returned `401` / `5xx` / network error before the stream even
-   opened), classify the error: retryable failures move to the next attempt;
-   non-retryable failures propagate.
+   opened), record the error and move to the next attempt.
 2. Wait for the first chunk with a bounded timeout. Non-final attempts use the
    per-attempt failover budget (`STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS`,
    default 2000 ms). The sole/final attempt has no next attempt to fall over to,

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -49,7 +49,7 @@ curl http://localhost:8000/v1/chat/completions \
   -d '{"model": "fast", "messages": [{"role": "user", "content": "hello"}]}'
 ```
 
-If `openai:gpt-5-mini` returns a retryable failure, Anthropic serves the request
+If `openai:gpt-5-mini` fails before it has produced a response, Anthropic serves the request
 instead and the caller never sees the difference: the response `model` says
 `fast`, and the billed usage row names the model that actually served. The
 attempt that failed gets its own row too, with `status: "absorbed"`, so the
@@ -477,9 +477,7 @@ searches it ran, and that charge lands on its error row.
 
 | Situation | Result |
 | --- | --- |
-| Selected candidate fails retryably | Next candidate is tried |
-| Selected candidate returns 400 or 422 | No failover: every provider would reject it |
-| Provider returns 401 or 403 | No failover. You own these credentials, so this is a misconfiguration to fix, not a reason to move traffic and spend to another provider and hide it |
+| Selected candidate fails before responding | Next candidate is tried |
 | A tool loop already produced its first assistant message | No failover: that state cannot be replayed on a different provider |
 | Guardrails service or sandbox unreachable | No failover: the same service serves every candidate |
 | All candidates fail | 502, or 504 if the last failure was a timeout |

--- a/src/gateway/api/routes/_attempts.py
+++ b/src/gateway/api/routes/_attempts.py
@@ -49,18 +49,6 @@ from gateway.types.attempt import Attempt
 
 T = TypeVar("T")
 
-# Statuses worth trying the next candidate for, when the credentials are the
-# operator's own. Deliberately narrower than the hybrid set: 401/403 are absent.
-#
-# The hybrid walker retries them because a workspace's upstream key can be
-# rotated or revoked out from under the platform, so the next attempt may hold a
-# working credential. A standalone operator configured every provider in this
-# gateway's own config, so a 401 means *they* have a broken key: failing over
-# would move that traffic (and its spend) to another provider and hide the
-# misconfiguration behind a working response. Fail loudly instead.
-_LOCAL_RETRYABLE_STATUS_CODES = {404, 405, 408, 409, 410, 429, 500, 502, 503, 504}
-_LOCAL_NON_RETRYABLE_STATUS_CODES = {400, 401, 403, 422}
-
 ALL_ATTEMPTS_FAILED_DETAIL = "All upstream providers failed"
 ALL_ATTEMPTS_TIMED_OUT_DETAIL = "All upstream providers timed out"
 # Fixed, non-leaky: an empty plan is a gateway bug, and the message must not
@@ -79,30 +67,22 @@ class AttemptFailure(NamedTuple):
 
 
 def classify_local_attempt_error(exc: BaseException) -> tuple[bool, str]:
-    """Classify a locally credentialed provider failure as ``(retryable, class)``.
+    """Classify a locally credentialed provider failure as ``(True, class)``.
 
-    Mirrors the hybrid classifier's shape so logs and reported error classes are
-    comparable, but applies :data:`_LOCAL_RETRYABLE_STATUS_CODES`. Transport
-    failures (timeout, connection error) are retryable in both.
+    The walker advances on every provider failure before lock-in. The boolean
+    remains for its generic callback shape; classifications only label logs and
+    usage rows. Gateway-side failures are caught before this function runs.
     """
     kind, status_code = upstream_exception_shape(exc)
     if kind is not None:
         return True, kind
 
     if isinstance(status_code, int):
-        # Checked first, as in the hybrid classifier: a provider reporting
-        # account billing exhaustion as a 400/402/422 is an account condition on
-        # *this* provider, not a malformed request, so the next candidate is
-        # worth trying even though the bare status is non-retryable.
         if is_provider_billing_error(exc):
             return True, f"http_{status_code}_billing"
-        if status_code in _LOCAL_NON_RETRYABLE_STATUS_CODES:
-            return False, f"http_{status_code}"
-        if status_code in _LOCAL_RETRYABLE_STATUS_CODES or 500 <= status_code <= 599:
-            return True, f"http_{status_code}"
-        return False, f"http_{status_code}"
+        return True, f"http_{status_code}"
 
-    return False, "unknown"
+    return True, "unknown"
 
 
 async def walk_attempts(
@@ -124,15 +104,14 @@ async def walk_attempts(
     produced its first assistant message.
 
     ``on_terminal`` is called with the candidate the walk actually stopped on,
-    before the terminal error is raised. The caller cannot infer it: only a
-    retryable exhaustion reaches the last candidate, while a non-retryable status,
-    a tool-loop lock-in, a gateway-side refusal for one candidate (a refused
-    reservation top-up, an unpriced fallback) or the tool-iteration cap all stop
-    the walk early, and attributing the failure to the end of the plan would name
-    a provider that was never called.
+    before the terminal error is raised. The caller cannot infer it: exhaustion
+    reaches the last candidate, while a tool-loop lock-in, a gateway-side refusal
+    for one candidate (a refused reservation top-up, an unpriced fallback), or the
+    tool-iteration cap can stop the walk early. In those cases, attributing the
+    failure to the end of the plan would name a provider that was never called.
 
-    ``on_absorbed`` is awaited for each attempt the walk *recovers* from, i.e. a
-    retryable failure with another candidate left to try. It exists so the caller can
+    ``on_absorbed`` is awaited for each provider failure the walk *recovers* from
+    with another candidate left to try. It exists so the caller can
     record the failure without it counting as a request error, since the request
     itself is still going to be served. It is not called for a terminal failure: that
     one is the request's outcome and the caller logs it as such.

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -2982,11 +2982,9 @@ def raise_all_streaming_attempts_failed(
 
     Gateway-side backend failures (sandbox / web_search eager-open) get a 502
     with a backend-specific detail so operators don't chase a fake provider
-    outage. Provider failures are classified when there is a single attempt,
-    or when the failure is a non-retryable invalid request (400/422): that
-    short-circuits the fallback and is definitive regardless of attempt count,
-    matching the non-streaming path. Otherwise the multi-attempt aggregate
-    surfaces (504 when the last failure was a timeout, else 502).
+    outage. A single attempt preserves its classified provider error. Once a
+    multi-attempt route is exhausted, it surfaces the aggregate result: 504
+    when the last failure was a timeout, otherwise 502.
     """
     if isinstance(exc, SandboxNotReachableError):
         logger.error("Sandbox unreachable request_id=%s: %s", route.request_id, exc)
@@ -2995,9 +2993,7 @@ def raise_all_streaming_attempts_failed(
         logger.error("Web search backend unreachable request_id=%s: %s", route.request_id, exc)
         raise adapter.error(502, WEB_SEARCH_UNREACHABLE_DETAIL, ErrorKind.API) from exc
     logger.error("All streaming attempts failed request_id=%s: %s", route.request_id, exc)
-    mapping = classify_provider_error(exc)
-    invalid_request = mapping is not None and mapping.status_code == status.HTTP_400_BAD_REQUEST
-    if invalid_request or len(route.attempts) <= 1:
+    if len(route.attempts) <= 1:
         raise adapter.provider_error(exc) from exc
     kind, _ = upstream_exception_shape(exc)
     if kind == "timeout":

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -1192,7 +1192,8 @@ async def resolve_request_context(
                 db,
                 user_id,
                 estimate,
-                model=model,
+                model=gate_model,
+                pricing_provider=gate_instance,
                 strategy=config.budget_strategy,
                 counts_toward_budget=not budget_exempt,
             )

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -47,35 +47,15 @@ T = TypeVar("T")
 # listing it keeps the intent explicit and robust to changes in that predicate.
 _USAGE_NON_RETRYABLE_STATUS_CODES = {401, 402, 404, 409, 422}
 
-# Status codes that cause the gateway to move on to the next attempt in a
-# multi-attempt route. 401/403 are included because users configure
-# multi-attempt routing policies on the platform precisely to handle
-# credential outages — when they've opted in, an auth failure on one provider
-# should fall through to the next, not surface to the client. Single-attempt
-# requests still see auth errors directly because there's nothing to fall
-# back to.
-#
-# 404/405/409/410 mean "this model or endpoint is unavailable at THIS provider"
-# (deprecated, renamed, retired, or never offered). Recovering from a model
-# being retired is one of the main reasons users configure fallback, so these
-# fall through to the next entry rather than failing the whole request. They are
-# distinct from 400/422, which mean the request itself is malformed and would be
-# rejected by every provider, so falling through on those just wastes attempts.
-# The one exception is a provider that reports account billing exhaustion as a
-# 400/422 rather than the 402 the condition deserves: that is an account
-# condition, not a malformed request, and the next provider would serve it fine.
-# See :func:`is_provider_billing_error`.
-_FALLBACK_RETRYABLE_STATUS_CODES = {401, 403, 404, 405, 408, 409, 410, 429, 500, 502, 503, 504}
-_FALLBACK_NON_RETRYABLE_STATUS_CODES = {400, 422}
-
-# Statuses on which the billing probe runs. Anthropic reports "credit balance is
-# too low" as a 400 ``invalid_request_error``; DeepSeek uses 402 for
-# "Insufficient Balance"; OpenAI's "billing hard limit reached" is a 400. 429 is
-# deliberately excluded: OpenAI's ``insufficient_quota`` arrives as a 429, which
-# is already both failover-eligible and surfaced to the caller as a rate limit,
-# so backing off remains a sane client action and reclassifying it would only
-# change the wording.
-_BILLING_CANDIDATE_STATUS_CODES = {400, 402, 422}
+# Statuses on which the billing-message probe runs. A 402 is payment required by
+# definition, so it is handled directly in ``is_provider_billing_error`` without
+# depending on a provider's error text. Anthropic reports "credit balance is too
+# low" as a 400 ``invalid_request_error`` and OpenAI's "billing hard limit
+# reached" is a 400. 429 is deliberately excluded: OpenAI's
+# ``insufficient_quota`` arrives as a 429, which is already both failover-eligible
+# and surfaced to the caller as a rate limit, so backing off remains a sane client
+# action and reclassifying it would only change the wording.
+_BILLING_MESSAGE_CANDIDATE_STATUS_CODES = {400, 422}
 
 # Lowercase substrings that identify account-level billing exhaustion in an
 # upstream provider message. Deliberately narrow: a false positive turns a
@@ -94,15 +74,6 @@ _BILLING_MESSAGE_PROBES: tuple[str, ...] = (
     "exceeded your current quota",  # openai
     "insufficient credits",  # openrouter, together
 )
-
-# Phrases accepted only on a 402, whose reason phrase ("Payment Required") is
-# itself the billing signal. httpx stringifies any 402 as "Client error '402
-# Payment Required' for url ...", so on a 402 this probe is really a
-# status-code check with a phrase-shaped spelling. It is kept out of
-# :data:`_BILLING_MESSAGE_PROBES` because a 400/422 that merely echoes a
-# caller-supplied "payment required" string back in its message is a malformed
-# request, not an empty wallet.
-_BILLING_402_MESSAGE_PROBES = ("payment required",)
 
 # Streaming first-chunk timeouts (hybrid-mode fallback). Plain LLM streams
 # rarely take long to produce a first token, so a tight cap keeps failed-
@@ -266,8 +237,8 @@ async def run_platform_attempts(
     falling through. A tool-use loop's intermediate state (provider-specific
     ``tool_call`` ids / reasoning blocks) cannot be transparently replayed
     on a different provider. Pre-lock-in failures still walk the attempts
-    list and fall through to the next provider per the retryable
-    classification.
+    list and fall through to the next provider. Classification only labels the
+    attempt for logging and platform usage reporting.
 
     ``MaxToolIterationsExceeded`` is treated as a gateway-side cap hit, not
     an upstream failure — it raises a distinct 422 and does not advance to
@@ -392,7 +363,7 @@ async def run_platform_attempts(
         on_success(attempt)
         return result
 
-    # All attempts exhausted with retryable errors.
+    # All attempts exhausted after provider failures.
     logger.error(
         "All upstream attempts failed request_id=%s failures=%s",
         route.request_id,
@@ -825,49 +796,41 @@ def is_provider_billing_error(exc: BaseException) -> bool:
     account balance is per-provider, so the next attempt in the route can very
     plausibly succeed.
 
-    Gated on :data:`_BILLING_CANDIDATE_STATUS_CODES` so the probe can only ever
-    reinterpret a status that is otherwise a dead end, and matched against the
-    narrow :data:`_BILLING_MESSAGE_PROBES` (plus
-    :data:`_BILLING_402_MESSAGE_PROBES` on a 402) so an unrecognized phrasing
-    falls through to the existing generic handling instead of being
-    misclassified.
+    A 402 is always a billing error: HTTP defines it as payment required, even
+    when a provider SDK discards the response reason and body. The 400/422 probe
+    stays deliberately narrow so error reports do not falsely label malformed
+    requests as account billing exhaustion.
     """
     _kind, status_code = upstream_exception_shape(exc)
-    if status_code not in _BILLING_CANDIDATE_STATUS_CODES:
-        return False
-    probes = _BILLING_MESSAGE_PROBES
     if status_code == 402:
-        probes += _BILLING_402_MESSAGE_PROBES
+        return True
+    if status_code not in _BILLING_MESSAGE_CANDIDATE_STATUS_CODES:
+        return False
     message = upstream_error_message(exc).lower()
-    return any(probe in message for probe in probes)
+    return any(probe in message for probe in _BILLING_MESSAGE_PROBES)
 
 
 def _classify_upstream_error(exc: BaseException) -> tuple[bool, str]:
-    """Classify an upstream provider error.
+    """Classify an upstream provider error for observability.
 
-    Returns ``(retryable, error_class)``. ``error_class`` is a short string used
-    for logging and reporting back to the platform. Streaming-only failures still
-    pass through this classifier; the caller decides whether to actually retry.
+    All provider failures that reach an attempt walker before lock-in advance to
+    the next candidate. The boolean stays in the return shape for the generic
+    streaming iterator, but is always ``True`` here. Gateway-side failures,
+    cancellations, and tool loops that already produced an assistant response are
+    handled by the walker before this classifier runs.
     """
     kind, status_code = upstream_exception_shape(exc)
     if kind is not None:
         return True, kind
 
     if isinstance(status_code, int):
-        # Checked before the non-retryable set: a billing 400/402/422 is an
-        # account condition on THIS provider, so the route's next attempt is
-        # worth making. The distinct error_class keeps "we ran out of credit"
-        # separable from "the request was malformed" in logs and in what the
-        # gateway reports back to the platform.
+        # Keep account exhaustion distinguishable in logs and in reports to the
+        # platform, even though every provider error now advances the plan.
         if is_provider_billing_error(exc):
             return True, f"http_{status_code}_billing"
-        if status_code in _FALLBACK_NON_RETRYABLE_STATUS_CODES:
-            return False, f"http_{status_code}"
-        if status_code in _FALLBACK_RETRYABLE_STATUS_CODES or 500 <= status_code <= 599:
-            return True, f"http_{status_code}"
-        return False, f"http_{status_code}"
+        return True, f"http_{status_code}"
 
-    return False, "unknown"
+    return True, "unknown"
 
 
 async def _resolve_platform_mcp_servers(

--- a/src/gateway/models/routing.py
+++ b/src/gateway/models/routing.py
@@ -10,7 +10,7 @@ Two axes, deliberately separate:
 * ``select`` decides where the plan *starts*. Entries are evaluated in order and
   the first whose ``when`` matches wins; the ``default`` entry is the
   fallthrough. A ``router`` entry hands ordering to a router backend instead.
-* ``on_failure`` is what gets tried *after* a retryable failure, in order.
+* ``on_failure`` is what gets tried *after* a provider failure, in order.
 
 Collapsing them into one list would make "did this entry not apply, or did it
 fail?" ambiguous, and that ambiguity would surface in every log line and every
@@ -282,7 +282,7 @@ class PolicySpec(BaseModel):
     select: list[SelectEntry] = Field(min_length=1)
     on_failure: list[str] = Field(
         default_factory=list,
-        description="Selectors to try, in order, after a retryable failure on the selected candidate.",
+        description="Selectors to try, in order, after a provider failure on the selected candidate.",
     )
     guardrails: list[PolicyGuardrail] = Field(default_factory=list)
     # No `limits` yet, deliberately. The only per-request deadline that exists is

--- a/src/gateway/services/budget_service.py
+++ b/src/gateway/services/budget_service.py
@@ -117,20 +117,31 @@ async def get_budget_state(db: AsyncSession, user_id: str) -> BudgetState:
     )
 
 
-async def _is_model_free(db: AsyncSession, model: str) -> bool:
+async def _is_model_free(
+    db: AsyncSession,
+    model: str,
+    *,
+    pricing_provider: str | None = None,
+) -> bool:
     """Check if a model is free (both input and output prices are 0).
 
     Args:
         db: Database session
         model: Model identifier (e.g., "provider/model" or "model")
+        pricing_provider: Resolved provider instance, when ``model`` is already
+            the bare model name.
 
     Returns:
         True if the model is free, False otherwise or if pricing not found
 
     """
     try:
-        provider, model_name = AnyLLM.split_model_provider(model)
-        pricing = await find_model_pricing(db, provider_key(provider) or None, model_name)
+        if pricing_provider is None:
+            provider, model_name = AnyLLM.split_model_provider(model)
+            pricing_provider = provider_key(provider) or None
+        else:
+            model_name = model
+        pricing = await find_model_pricing(db, pricing_provider, model_name)
         if pricing:
             return pricing.input_price_per_million == 0 and pricing.output_price_per_million == 0
     except (AnyLLMError, ValueError, SQLAlchemyError) as e:
@@ -208,6 +219,7 @@ async def reserve_budget(
     estimate: float,
     *,
     model: str | None = None,
+    pricing_provider: str | None = None,
     strategy: str = "for_update",
     counts_toward_budget: bool = True,
 ) -> ReservationHandle:
@@ -274,7 +286,7 @@ async def reserve_budget(
 
     # Free models do not consume budget; nothing to reserve. Reconciliation will
     # add their (zero) cost to spend.
-    if model and await _is_model_free(db, model):
+    if model and await _is_model_free(db, model, pricing_provider=pricing_provider):
         return no_reservation
 
     if budget.max_budget is None:

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -1815,13 +1815,11 @@ def test_hybrid_mode_streaming_single_attempt_classifies_provider_error(
     assert response.json() == {"detail": "The requested model was not found on the provider"}
 
 
-def test_hybrid_mode_streaming_multi_attempt_classifies_non_retryable_invalid_request(
+def test_hybrid_mode_streaming_falls_through_on_provider_400(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A non-retryable invalid request (400) short-circuits the streaming
-    fallback and is surfaced as a classified 400 even with multiple attempts,
-    matching the non-streaming path rather than the aggregate 502."""
+    """A provider 400 advances through every streaming candidate before aggregate failure."""
     usage_reports: list[dict[str, Any]] = []
 
     async def fake_post_platform(
@@ -1880,14 +1878,13 @@ def test_hybrid_mode_streaming_multi_attempt_classifies_non_retryable_invalid_re
         headers={"Authorization": "Bearer user_test_token"},
     )
 
-    assert response.status_code == 400
-    assert response.json() == {
-        "detail": "The provider rejected the request as invalid (check the model name and parameters)"
-    }
-    # Non-retryable: the fallback must short-circuit after the first attempt.
-    assert len(calls) == 1
-    assert len(usage_reports) == 1
-    assert usage_reports[0]["is_final_attempt"] is True
+    assert response.status_code == 502
+    assert response.json() == {"detail": "All upstream providers failed"}
+    assert len(calls) == 2
+    assert sorted((r["correlation_id"], r["is_final_attempt"], r.get("error_class")) for r in usage_reports) == [
+        ("att-a", False, "http_400"),
+        ("att-b", True, "http_400"),
+    ]
 
 
 class _FakeSandboxBackend:

--- a/tests/integration/test_hybrid_mode_messages.py
+++ b/tests/integration/test_hybrid_mode_messages.py
@@ -393,16 +393,13 @@ def test_hybrid_mode_returns_502_and_reports_every_attempt_when_all_fail(
     ]
 
 
-def test_hybrid_mode_non_retryable_error_raises_immediately(
+def test_hybrid_mode_falls_through_on_provider_400(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A 400 from the upstream is non-retryable — the runner stops the
-    iteration at the first attempt rather than walking the rest of the route,
-    and surfaces the classified 400 (a malformed request no provider would
-    accept) rather than a generic 502.
-    """
+    """A provider 400 advances to the next candidate like every pre-lock-in failure."""
     calls: list[dict[str, Any]] = []
+    usage_reports: list[dict[str, Any]] = []
 
     async def fake_post_platform(
         url: str,
@@ -420,6 +417,7 @@ def test_hybrid_mode_non_retryable_error_raises_immediately(
                     ]
                 ),
             )
+        usage_reports.append(body)
         return httpx.Response(204)
 
     async def fake_amessages(**kwargs: Any) -> MessageResponse:
@@ -443,13 +441,15 @@ def test_hybrid_mode_non_retryable_error_raises_immediately(
         headers={"Authorization": "Bearer user_test_token"},
     )
 
-    assert response.status_code == 400
-    # The classified 400 is delivered in the Anthropic error envelope with the
-    # matching error.type, not a bare {"detail": <str>}.
-    detail = response.json()["detail"]
-    assert detail["type"] == "error"
-    assert detail["error"]["type"] == "invalid_request_error"
-    assert len(calls) == 1, "Non-retryable error must short-circuit the attempts loop"
+    assert response.status_code == 502
+    assert response.json() == {
+        "detail": {"type": "error", "error": {"type": "api_error", "message": "All upstream providers failed"}}
+    }
+    assert len(calls) == 2
+    assert sorted((r["correlation_id"], r["is_final_attempt"], r.get("error_class")) for r in usage_reports) == [
+        ("att-1", False, "http_400"),
+        ("att-2", True, "http_400"),
+    ]
 
 
 def test_hybrid_mode_resolves_workspace_mcp_server_ids(

--- a/tests/integration/test_routing_policies.py
+++ b/tests/integration/test_routing_policies.py
@@ -275,8 +275,8 @@ def test_all_candidates_failing_is_a_generic_502(client: TestClient) -> None:
     assert resp.status_code == 502
 
 
-def test_a_malformed_request_does_not_burn_the_chain(client: TestClient) -> None:
-    """A 400 would be rejected by every provider, so only one call should happen."""
+def test_a_provider_400_burns_the_chain(client: TestClient) -> None:
+    """Provider failures fall through before a response is committed."""
     _create_user(client)
     calls: list[str] = []
 
@@ -287,14 +287,12 @@ def test_a_malformed_request_does_not_burn_the_chain(client: TestClient) -> None
     with patch("gateway.api.routes.chat.acompletion", new=bad_request):
         resp = _chat(client, "fast")
 
-    assert resp.status_code == 400
-    assert calls == ["openai:gpt-5-mini"]
+    assert resp.status_code == 502
+    assert calls == ["openai:gpt-5-mini", "anthropic:claude-haiku-4-5"]
 
 
-def test_an_auth_failure_does_not_fail_over(client: TestClient) -> None:
-    """The operator owns both keys here, so a 401 is their misconfiguration.
-    Failing over would move the spend to another provider and hide it.
-    """
+def test_an_auth_failure_burns_the_chain(client: TestClient) -> None:
+    """A provider authentication failure also advances the policy."""
     _create_user(client)
     calls: list[str] = []
 
@@ -307,12 +305,9 @@ def test_an_auth_failure_does_not_fail_over(client: TestClient) -> None:
     with patch("gateway.api.routes.chat.acompletion", new=AsyncMock(side_effect=_http_error(401))):
         direct = _chat(client, "openai:gpt-5-mini")
 
-    assert calls == ["openai:gpt-5-mini"]
-    # Whatever a provider 401 maps to for a plain model, it maps to the same
-    # through a policy. (It is deliberately not surfaced as a 401: the caller's
-    # own key was fine, and saying "unauthorized" would point them at the wrong
-    # thing.)
-    assert resp.status_code == direct.status_code
+    assert calls == ["openai:gpt-5-mini", "anthropic:claude-haiku-4-5"]
+    assert resp.status_code == 502
+    assert direct.status_code == 502
 
 
 def test_streaming_fails_over_before_any_bytes_are_flushed(client: TestClient) -> None:
@@ -1043,11 +1038,8 @@ def test_a_blocking_policy_guardrail_refuses_the_request(guarded_client: TestCli
 # ---------------------------------------------------------------------------
 
 
-def test_a_terminal_failure_names_the_candidate_that_actually_failed(client: TestClient) -> None:
-    """A 401 does not fail over, so the request stops on candidate 1. Attributing
-    it to the end of the plan would blame a provider that was never called, in a
-    row that feeds the by-provider breakdown and the error taxonomy.
-    """
+def test_an_exhausted_failure_names_the_last_candidate(client: TestClient) -> None:
+    """An exhausted chain attributes its terminal row to the final provider."""
     _create_user(client)
     calls: list[str] = []
 
@@ -1058,12 +1050,12 @@ def test_a_terminal_failure_names_the_candidate_that_actually_failed(client: Tes
     with patch("gateway.api.routes.chat.acompletion", new=unauthorized):
         _chat(client, "fast")
 
-    assert calls == ["openai:gpt-5-mini"]
+    assert calls == ["openai:gpt-5-mini", "anthropic:claude-haiku-4-5"]
     errors = [r for r in _usage_rows(client) if r["status"] == "error"]
     assert len(errors) == 1
-    assert errors[0]["provider"] == "openai"
-    assert errors[0]["model"] == "gpt-5-mini"
-    assert errors[0]["attempt_position"] == 1
+    assert errors[0]["provider"] == "anthropic"
+    assert errors[0]["model"] == "claude-haiku-4-5"
+    assert errors[0]["attempt_position"] == 2
 
 
 def test_a_streamed_fallover_correlates_both_of_its_rows(client: TestClient) -> None:

--- a/tests/integration/test_transaction_safety.py
+++ b/tests/integration/test_transaction_safety.py
@@ -1,6 +1,7 @@
 """Tests for transaction safety: rollback on commit failure and narrowed exception handling."""
 
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -146,6 +147,18 @@ async def test_is_model_free_accepts_string_provider_from_any_llm(async_db: Asyn
         result = await _is_model_free(async_db, "registry-only:model")
 
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_is_model_free_uses_the_resolved_provider_instance(async_db: AsyncSession) -> None:
+    """Policies are named locally, while their selected targets may use instances."""
+    pricing = SimpleNamespace(input_price_per_million=0, output_price_per_million=0)
+    lookup = AsyncMock(return_value=pricing)
+    with patch("gateway.services.budget_service.find_model_pricing", lookup):
+        result = await _is_model_free(async_db, "Kimi-K3", pricing_provider="otari.ai")
+
+    assert result is True
+    lookup.assert_awaited_once_with(async_db, "otari.ai", "Kimi-K3")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_attempt_walker.py
+++ b/tests/unit/test_attempt_walker.py
@@ -1,11 +1,8 @@
 """Unit tests for the credential-agnostic attempt walker (issue #463).
 
-Two things are being pinned. First, the walk itself: order, when it advances,
-when it refuses to, and what status an exhausted plan produces. Second, the
-deliberate difference from the hybrid walker: 401/403 are terminal here, because
-a standalone operator owns every credential in their own config and failing over
-a broken key would move that traffic to another provider and hide the
-misconfiguration.
+The walk advances through every provider failure before lock-in, but stops for
+gateway-side refusals and a tool loop that has already produced an assistant
+response. The tests pin that boundary, ordering, and exhausted-plan status.
 """
 
 import asyncio
@@ -127,10 +124,11 @@ async def test_single_attempt_success() -> None:
 
 
 @pytest.mark.asyncio
-async def test_advances_past_a_retryable_failure() -> None:
+@pytest.mark.parametrize("status", [402, 503])
+async def test_advances_past_a_retryable_failure(status: int) -> None:
     chosen, result = await _walk(
         [_attempt(1, "gpt-5-mini"), _attempt(2, "claude-haiku-4-5", instance="anthropic")],
-        [_http_error(503), "ok"],
+        [_http_error(status), "ok"],
     )
     assert chosen.position == 2
     assert chosen.model == "claude-haiku-4-5"
@@ -138,8 +136,7 @@ async def test_advances_past_a_retryable_failure() -> None:
 
 
 @pytest.mark.asyncio
-async def test_stops_on_a_malformed_request_without_advancing() -> None:
-    """A 400 would be rejected by every provider, so falling through is waste."""
+async def test_advances_past_a_provider_rejection() -> None:
     second_ran = False
 
     async def run_attempt(attempt: Attempt, call_kwargs: dict[str, Any], mark_locked_in: Any) -> Any:
@@ -149,16 +146,27 @@ async def test_stops_on_a_malformed_request_without_advancing() -> None:
         second_ran = True
         return "ok"
 
-    with pytest.raises(HTTPException) as exc_info:
-        await walk_attempts(
-            attempts=[_attempt(1, "a"), _attempt(2, "b")],
-            base_request_fields={},
-            run_attempt=run_attempt,
-            max_tool_iterations=10,
-        )
+    chosen, result = await walk_attempts(
+        attempts=[_attempt(1, "a"), _attempt(2, "b")],
+        base_request_fields={},
+        run_attempt=run_attempt,
+        max_tool_iterations=10,
+    )
 
-    assert second_ran is False
-    assert exc_info.value.status_code == 400
+    assert second_ran is True
+    assert chosen.position == 2
+    assert result == "ok"
+
+
+@pytest.mark.asyncio
+async def test_advances_past_an_unclassified_provider_failure() -> None:
+    chosen, result = await _walk(
+        [_attempt(1, "gpt-5-mini"), _attempt(2, "claude-haiku-4-5", instance="anthropic")],
+        [RuntimeError("provider SDK lost its error metadata"), "ok"],
+    )
+
+    assert chosen.position == 2
+    assert result == "ok"
 
 
 @pytest.mark.asyncio
@@ -308,31 +316,21 @@ async def test_empty_plan_is_a_500_that_leaks_nothing() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Local classification: the deliberate divergence from hybrid
+# Local classification
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("status", [401, 403])
-def test_auth_failures_are_terminal_for_local_credentials(status: int) -> None:
-    """The hybrid walker retries these because a workspace key may have been
-    rotated upstream. Locally the operator owns the key, so a 401 is their bug:
-    failing over would move the spend and hide it.
-    """
+@pytest.mark.parametrize("status", [400, 401, 403, 413, 422])
+def test_provider_status_failures_fall_through_for_local_credentials(status: int) -> None:
     retryable, error_class = classify_local_attempt_error(_http_error(status))
-    assert retryable is False
+    assert retryable is True
     assert error_class == f"http_{status}"
 
 
-@pytest.mark.parametrize("status", [404, 405, 408, 409, 410, 429, 500, 502, 503, 504])
+@pytest.mark.parametrize("status", [402, 404, 405, 408, 409, 410, 429, 500, 502, 503, 504])
 def test_transient_and_model_gone_statuses_fall_through(status: int) -> None:
     retryable, _ = classify_local_attempt_error(_http_error(status))
     assert retryable is True
-
-
-@pytest.mark.parametrize("status", [400, 422])
-def test_malformed_request_statuses_are_terminal(status: int) -> None:
-    retryable, _ = classify_local_attempt_error(_http_error(status))
-    assert retryable is False
 
 
 @pytest.mark.parametrize(
@@ -346,7 +344,7 @@ def test_transport_failures_are_retryable(exc: BaseException, expected: str) -> 
 
 
 @pytest.mark.asyncio
-async def test_a_401_does_not_advance_the_plan() -> None:
+async def test_a_401_advances_the_plan() -> None:
     second_ran = False
 
     async def run_attempt(attempt: Attempt, call_kwargs: dict[str, Any], mark_locked_in: Any) -> Any:
@@ -356,14 +354,15 @@ async def test_a_401_does_not_advance_the_plan() -> None:
         second_ran = True
         return "ok"
 
-    with pytest.raises(HTTPException):
-        await walk_attempts(
-            attempts=[_attempt(1, "a"), _attempt(2, "b")],
-            base_request_fields={},
-            run_attempt=run_attempt,
-            max_tool_iterations=10,
-        )
-    assert second_ran is False
+    chosen, result = await walk_attempts(
+        attempts=[_attempt(1, "a"), _attempt(2, "b")],
+        base_request_fields={},
+        run_attempt=run_attempt,
+        max_tool_iterations=10,
+    )
+    assert second_ran is True
+    assert chosen.position == 2
+    assert result == "ok"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_classify_upstream_error.py
+++ b/tests/unit/test_classify_upstream_error.py
@@ -225,10 +225,8 @@ def test_billing_exhaustion_detected_through_original_exception() -> None:
     assert error_class == "http_400_billing"
 
 
-def test_malformed_400_is_still_terminal_after_the_billing_probe() -> None:
-    """The billing probe must not sweep up a genuinely malformed request: an
-    unrecognized 400 message stays terminal so it does not waste an attempt
-    against every provider in the route."""
+def test_unrecognized_400_falls_through_without_billing_classification() -> None:
+    """An unrecognized 400 remains an ordinary HTTP error, not a billing error."""
     exc = _MessageStatusError(400, "messages.3: tool_use ids were found without tool_result blocks")
     assert _classify_upstream_error(exc) == (True, "http_400")
 

--- a/tests/unit/test_classify_upstream_error.py
+++ b/tests/unit/test_classify_upstream_error.py
@@ -35,13 +35,10 @@ def test_retryable_status_codes_fall_through(status: int) -> None:
     assert error_class == f"http_{status}"
 
 
-@pytest.mark.parametrize("status", [400, 422, 413, 414, 431])
-def test_malformed_request_status_codes_are_terminal(status: int) -> None:
-    # 400/422 are explicitly terminal; other "bad request" shapes (413/414/431)
-    # are request-level problems that every provider would reject, so they must
-    # not waste fallback attempts.
+@pytest.mark.parametrize("status", [400, 413, 414, 422, 431])
+def test_provider_status_codes_fall_through(status: int) -> None:
     retryable, error_class = _classify_upstream_error(_http_error(status))
-    assert retryable is False
+    assert retryable is True
     assert error_class == f"http_{status}"
 
 
@@ -59,9 +56,9 @@ def test_network_and_timeout_errors_are_retryable(exc: BaseException, expected_c
     assert error_class == expected_class
 
 
-def test_error_without_status_is_unknown_and_terminal() -> None:
+def test_error_without_status_is_unknown_and_falls_through() -> None:
     retryable, error_class = _classify_upstream_error(ValueError("no status here"))
-    assert retryable is False
+    assert retryable is True
     assert error_class == "unknown"
 
 
@@ -140,7 +137,7 @@ def test_unwraps_original_exception_for_unified_any_llm_errors(sdk_error: type, 
     timeout/connection error arrives wrapped in a generic ``AnyLLMError``
     subclass rather than the SDK type directly. The classifier must still
     recognize it by unwrapping ``original_exception``, or this regresses back
-    to the exact "unknown"/non-retryable bug this module fixes.
+    to the exact "unknown" classification that this module handles.
     """
     request = httpx.Request("POST", "http://upstream")
     wrapped = _WrappedByAnyLLM(sdk_error(request=request))
@@ -153,20 +150,20 @@ def test_unwraps_original_exception_for_unified_any_llm_errors(sdk_error: type, 
 def test_unwrap_terminates_on_self_referential_original_exception() -> None:
     """Defensive: a (pathological, shouldn't-happen-in-practice) exception
     whose ``original_exception`` points back to itself must not loop forever;
-    it should fall through to the same terminal ``unknown`` classification as
-    any other unrecognized exception.
+    it should fall through to the same ``unknown`` classification as any other
+    unrecognized exception.
     """
     exc = _WrappedByAnyLLM(ValueError("placeholder"))
     exc.original_exception = exc  # self-reference, must not loop
 
     retryable, error_class = _classify_upstream_error(exc)
-    assert retryable is False
+    assert retryable is True
     assert error_class == "unknown"
 
 
 @pytest.mark.parametrize("sdk_error", [AnthropicAPIStatusError, OpenAIAPIStatusError])
-@pytest.mark.parametrize("status, retryable", [(404, True), (410, True), (400, False), (422, False)])
-def test_classifies_provider_sdk_status_errors(sdk_error: type, status: int, retryable: bool) -> None:
+@pytest.mark.parametrize("status", [400, 404, 410, 422])
+def test_classifies_provider_sdk_status_errors(sdk_error: type, status: int) -> None:
     # any_llm propagates the provider SDK's own ``APIStatusError`` (it does not
     # wrap upstream failures), and that exception exposes ``status_code``
     # directly on itself. The other tests here use ``httpx.HTTPStatusError``,
@@ -179,7 +176,7 @@ def test_classifies_provider_sdk_status_errors(sdk_error: type, status: int, ret
     assert getattr(exc, "status_code", None) == status  # guards the production exception shape
 
     classified_retryable, error_class = _classify_upstream_error(exc)
-    assert classified_retryable is retryable
+    assert classified_retryable is True
     assert error_class == f"http_{status}"
 
 
@@ -233,7 +230,7 @@ def test_malformed_400_is_still_terminal_after_the_billing_probe() -> None:
     unrecognized 400 message stays terminal so it does not waste an attempt
     against every provider in the route."""
     exc = _MessageStatusError(400, "messages.3: tool_use ids were found without tool_result blocks")
-    assert _classify_upstream_error(exc) == (False, "http_400")
+    assert _classify_upstream_error(exc) == (True, "http_400")
 
 
 def test_billing_probe_does_not_reinterpret_other_statuses() -> None:
@@ -244,17 +241,13 @@ def test_billing_probe_does_not_reinterpret_other_statuses() -> None:
     assert _classify_upstream_error(_MessageStatusError(429, "insufficient_quota")) == (True, "http_429")
 
 
-def test_payment_required_phrase_only_counts_on_a_402() -> None:
-    """The words "payment required" are the 402 reason phrase, which httpx puts in
-    every stringified 402, so they are a status signal rather than a provider
-    phrase. On a 400/422 the same words are far more likely to be a
-    caller-supplied value the provider echoed back, which must stay a terminal
-    malformed request."""
-    request = httpx.Request("POST", "https://api.example.com/v1/chat/completions")
-    response = httpx.Response(402, request=request, json={"error": {"message": "out of funds"}})
-    with pytest.raises(httpx.HTTPStatusError) as raised:
-        response.raise_for_status()
-    assert _classify_upstream_error(raised.value) == (True, "http_402_billing")
+def test_bare_402_is_billing_even_when_the_provider_message_is_lost() -> None:
+    """A provider SDK can retain the status while discarding the response body.
+
+    HTTP 402 still means payment required, so a fallback must not depend on a
+    provider-specific phrase surviving that conversion.
+    """
+    assert _classify_upstream_error(_MessageStatusError(402, "provider error")) == (True, "http_402_billing")
 
     echoed = _MessageStatusError(400, "Invalid value: 'payment required'. Supported values are: 'none', 'auto'.")
-    assert _classify_upstream_error(echoed) == (False, "http_400")
+    assert _classify_upstream_error(echoed) == (True, "http_400")

--- a/tests/unit/test_pipeline_vision_billing.py
+++ b/tests/unit/test_pipeline_vision_billing.py
@@ -29,6 +29,7 @@ class _Recorder:
 
     def __init__(self) -> None:
         self.usage_logged: list[dict[str, Any]] = []
+        self.reserve_calls: list[dict[str, Any]] = []
         self.reconciled: list[float] = []
         self.refunded = 0
 
@@ -54,6 +55,7 @@ class _Recorder:
             return None
 
         async def fake_reserve(*args: Any, **kwargs: Any) -> ReservationHandle:
+            self.reserve_calls.append(kwargs)
             return ReservationHandle(user_id="user-1", estimate=0.0, reserved=True, strategy="for_update")
 
         async def fake_increase(*args: Any, **kwargs: Any) -> None:
@@ -145,3 +147,20 @@ async def test_vision_side_call_billed_on_successful_setup(monkeypatch: pytest.M
     assert len(recorder.usage_logged) == 1
     assert recorder.reconciled == [0.01]
     assert recorder.refunded == 0
+
+
+@pytest.mark.asyncio
+async def test_reservation_uses_the_resolved_provider_for_pricing(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder = _Recorder()
+    recorder.install(monkeypatch, topup_status=None)
+
+    await _resolve(_config())
+
+    assert recorder.reserve_calls == [
+        {
+            "model": "gpt-4",
+            "pricing_provider": "openai",
+            "strategy": "for_update",
+            "counts_toward_budget": True,
+        }
+    ]


### PR DESCRIPTION
## Description

Make pre-response provider failures advance through the configured fallback chain, including provider 4xx responses and SDK errors that carry no usable metadata. Preserve the required terminal cases: gateway-side refusals, cancellation, and post-lock-in tool-loop failures.

Also resolve the selected provider instance for the budget free-model lookup, preventing policy-name and provider-instance pricing warnings.

Prose by Codex; decisions are njbrake.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). `make test` requires Docker/PostgreSQL, unavailable in this environment; focused unit tests passed.
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Codex

**Any additional AI details you'd like to share:** Focused tests, lint, typecheck, and generated-spec freshness checks were run locally.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated provider routing to continue through the fallback chain after any failure before a response is committed.
- Preserved terminal handling for gateway refusals, cancellation, and post-lock-in tool-loop failures.
- Fixed free-model budget checks to use the resolved provider instance.
- Updated documentation and expanded unit and integration test coverage.
- Focused tests passed. The full suite was not run because Docker/PostgreSQL was unavailable.

## Technical notes

- All `402` responses now count as billing failures.
- Provider and SDK errors without usable metadata now advance to the next candidate.
- Streaming failures now fall through during stream setup and return an aggregate error when all attempts fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->