### PR TITLE
fix(billing): audio charge lines, no token defaults on non-token routes

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -188,6 +188,13 @@ and counted as failures rather than only in the caller's own logs.
 |--------|------|-------------|------|
 | `POST` | `/v1/images/generations` | Generate images from text prompts. | API key or master key |
 
+Image generation bills per generated image, not per token, so a usage row carries
+zero tokens and an `images` meter. Unlike audio and moderations it is subject to
+`require_pricing`, so an unpriced image model is rejected with 402 under the
+default configuration. See
+[per-image pricing](configuration.md#per-image-pricing-image-generation) for how
+to set the rate.
+
 ### Audio
 
 | Method | Path | Description | Auth |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -195,6 +195,14 @@ and counted as failures rather than only in the caller's own logs.
 | `POST` | `/v1/audio/transcriptions` | Transcribe audio to text (multipart upload). | API key or master key |
 | `POST` | `/v1/audio/speech` | Generate speech from text (TTS). | API key or master key |
 
+Audio bills per request rather than per token, under the same convention as
+[moderations](#moderations) and search, so a usage row carries zero tokens and a
+cost taken from the flat rate configured for the model. Like moderations, audio
+is exempt from `require_pricing`: with no rate configured the request is served
+and logged at $0 with no charge line. See
+[per-request pricing](configuration.md#per-request-pricing-audio-and-moderations)
+for how to set the rate.
+
 ### Files
 
 OpenAI-compatible file storage. Upload a file, then reference it from a chat

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -408,17 +408,35 @@ pricing:
   openai:tts-1:
     input_price_per_million: 15000.0  # $0.015 per speech request
   openai:omni-moderation-latest:
-    input_price_per_million: 0.0      # free, and priced explicitly
+    input_price_per_million: 0.0      # free (same effect as leaving it unset)
 ```
 
 The key is the resolved `provider:model`, the same key every other route uses. [Search tools](#search-tools) follow the same convention under `<provider>:<tool>`.
 
 Two behaviors are worth knowing before you rely on this:
 
-- **Leaving the rate unset is free by design.** These endpoints are exempt from `require_pricing`, so an unpriced model is served, the usage row records a $0 cost, and no charge line is written. That is deliberate: a $0 charge line would render in Activity as a billed meter explaining a charge that never happened. Set a rate to get the charge line.
+- **Leaving the rate unset is free by design.** These endpoints are exempt from `require_pricing`, so an unpriced model is served, the usage row records a $0 cost, and no charge line is written. That is deliberate: a $0 charge line would render in Activity as a billed meter explaining a charge that never happened. Set a nonzero rate to get the charge line; a rate of `0.0` is treated the same as no rate at all.
 - **[Default pricing](#default-pricing) never applies here.** The genai-prices dataset quotes rates in USD per million *tokens*, and some audio models are in it (`openai:gpt-4o-transcribe`, `openai:gpt-4o-mini-tts`). Honoring one would charge a token rate as a request rate, so per-request routes resolve their rate from what you configured and nothing else, whether or not `default_pricing` is on. Search works the same way.
 
-Audio differs from moderations and search in one respect: it reserves $0 against the budget before the call rather than reserving the configured rate. The per-user gate still applies (an unknown, blocked, or already-over-budget user is refused), but the cost lands on the budget at reconciliation instead of being held up front, so concurrent audio requests cannot see each other's holds. Spend stays truthful either way. A duration-based meter that would give audio a real pre-call estimate is tracked in [#376](https://github.com/mozilla-ai/otari/issues/376).
+One dashboard consequence of recording a $0 cost rather than no cost: these rows read as priced, so they do not appear under Activity's `Priced?` filter or in the Usage page's "unpriced requests" count. That count is for rows whose cost is unknown; an audio row with no rate configured is knowingly free, not unknown.
+
+Audio differs from moderations and search in one respect: it reserves $0 against the budget before the call rather than reserving the configured rate. The per-user gate still applies (an unknown, blocked, or already-over-budget user is refused), but the cost lands on the budget at reconciliation instead of being held up front, so concurrent audio requests cannot see each other's holds. That makes the cap soft for audio: requests already in flight can settle past `max_budget`, by at most the configured rate times the number of concurrent audio requests. Spend stays truthful either way, and the next request is refused. A duration-based meter that would give audio a real pre-call estimate is tracked in [#376](https://github.com/mozilla-ai/otari/issues/376).
+
+#### Per-image pricing (image generation)
+
+Image generation (`/v1/images/generations`) bills per generated image, and it overloads `input_price_per_million` with a *third* unit: **raw USD per image**, unscaled. Unlike the per-request rate above, there is no division by a million.
+
+```yaml
+pricing:
+  openai:dall-e-3:
+    input_price_per_million: 0.04   # $0.04 per image
+  openai:gpt-image-1:
+    input_price_per_million: 0.19   # $0.19 per image
+```
+
+The cost is the rate times the number of images returned (falling back to the requested `n` when a provider omits the count), and each usage row records an `images` meter with the matching charge line.
+
+Unlike audio and moderations, image generation is **not** exempt from `require_pricing`: an unpriced image model is rejected with HTTP 402 under the default `require_pricing: true`. It also reserves its estimate before the call, so the rate is held against the budget for the requested image count and reconciled to the delivered count. [Default pricing](#default-pricing) is not consulted here either, for the same unit reason: the dataset carries `openai:gpt-image-1` at 5.0 USD per million tokens, which read as a per-image rate would bill $5.00 for one image.
 
 ### Default pricing
 
@@ -451,9 +469,14 @@ Limitations when enabled:
   the `huggingface:<model>:<backend>` selector (see the model reference in `models.md`). Auto routing and
   the policy suffixes (`:cheapest`, `:fastest`, ...) cannot be priced from the id alone and fall through to
   `require_pricing`.
-- **Per-request routes are excluded.** Audio, moderations, and search bill a flat rate per request, and the
-  dataset's rates are per million tokens, so defaults are not consulted for them. See
-  [per-request pricing](#per-request-pricing-audio-and-moderations).
+- **Routes that do not bill by the token are excluded.** Audio, moderations, and search bill a flat rate per
+  request; image generation bills per image. Every dataset rate is per million tokens, so defaults are not
+  consulted for any of them: honoring one would charge a token rate under a unit that is not a token. For
+  audio, moderations, and search that means an unpriced model stays free (they are exempt from
+  `require_pricing`); for images it means an image model priced only in the dataset now falls through to
+  `require_pricing` and is rejected with 402 rather than billed at roughly a million times its real rate. See
+  [per-request pricing](#per-request-pricing-audio-and-moderations) and
+  [per-image pricing](#per-image-pricing-image-generation).
 
 > **Fail-closed by default.** With `require_pricing: true` (the default), a request for a model
 > that has no pricing entry is rejected with HTTP 402 rather than served free and unmetered; an

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -397,6 +397,29 @@ pricing:
 
 At `min_input_tokens` and above, an entry replaces only the rates it lists for the entire request. Omitted rates inherit the base price. The dashboard's model detail editor exposes the same controls, and each usage row records the resulting billable meters and rate breakdown for auditability.
 
+#### Per-request pricing (audio and moderations)
+
+Audio (`/v1/audio/transcriptions`, `/v1/audio/speech`) and moderations report no token usage, so they bill a flat rate per request instead. `ModelPricing` only has per-million-token columns, so these routes reuse `input_price_per_million` with a different unit: **USD per million requests**. Divide by a million to read it as a per-request charge, so `6000.0` charges $0.006 per request.
+
+```yaml
+pricing:
+  openai:whisper-1:
+    input_price_per_million: 6000.0   # $0.006 per transcription
+  openai:tts-1:
+    input_price_per_million: 15000.0  # $0.015 per speech request
+  openai:omni-moderation-latest:
+    input_price_per_million: 0.0      # free, and priced explicitly
+```
+
+The key is the resolved `provider:model`, the same key every other route uses. [Search tools](#search-tools) follow the same convention under `<provider>:<tool>`.
+
+Two behaviors are worth knowing before you rely on this:
+
+- **Leaving the rate unset is free by design.** These endpoints are exempt from `require_pricing`, so an unpriced model is served, the usage row records a $0 cost, and no charge line is written. That is deliberate: a $0 charge line would render in Activity as a billed meter explaining a charge that never happened. Set a rate to get the charge line.
+- **[Default pricing](#default-pricing) does not price audio.** The genai-prices dataset quotes rates in USD per million *tokens*, and some audio models are in it (`openai:gpt-4o-transcribe`, `openai:gpt-4o-mini-tts`). Honoring one here would charge a token rate as a request rate, so audio resolves its rate from what you configured and nothing else, whether or not `default_pricing` is on. Search behaves the same way.
+
+Audio differs from moderations and search in one respect: it reserves $0 against the budget before the call rather than reserving the configured rate. The per-user gate still applies (an unknown, blocked, or already-over-budget user is refused), but the cost lands on the budget at reconciliation instead of being held up front, so concurrent audio requests cannot see each other's holds. Spend stays truthful either way. A duration-based meter that would give audio a real pre-call estimate is tracked in [#376](https://github.com/mozilla-ai/otari/issues/376).
+
 ### Default pricing
 
 Default pricing is **off by default**. When you enable it (`default_pricing: true` in `config.yml`, or
@@ -428,6 +451,9 @@ Limitations when enabled:
   the `huggingface:<model>:<backend>` selector (see the model reference in `models.md`). Auto routing and
   the policy suffixes (`:cheapest`, `:fastest`, ...) cannot be priced from the id alone and fall through to
   `require_pricing`.
+- **Audio and search are excluded.** Both bill a flat rate per request, and the dataset's rates are per
+  million tokens, so defaults are not consulted for them. See
+  [per-request pricing](#per-request-pricing-audio-and-moderations).
 
 > **Fail-closed by default.** With `require_pricing: true` (the default), a request for a model
 > that has no pricing entry is rejected with HTTP 402 rather than served free and unmetered; an

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -416,7 +416,7 @@ The key is the resolved `provider:model`, the same key every other route uses. [
 Two behaviors are worth knowing before you rely on this:
 
 - **Leaving the rate unset is free by design.** These endpoints are exempt from `require_pricing`, so an unpriced model is served, the usage row records a $0 cost, and no charge line is written. That is deliberate: a $0 charge line would render in Activity as a billed meter explaining a charge that never happened. Set a rate to get the charge line.
-- **[Default pricing](#default-pricing) does not price audio.** The genai-prices dataset quotes rates in USD per million *tokens*, and some audio models are in it (`openai:gpt-4o-transcribe`, `openai:gpt-4o-mini-tts`). Honoring one here would charge a token rate as a request rate, so audio resolves its rate from what you configured and nothing else, whether or not `default_pricing` is on. Search behaves the same way.
+- **[Default pricing](#default-pricing) never applies here.** The genai-prices dataset quotes rates in USD per million *tokens*, and some audio models are in it (`openai:gpt-4o-transcribe`, `openai:gpt-4o-mini-tts`). Honoring one would charge a token rate as a request rate, so per-request routes resolve their rate from what you configured and nothing else, whether or not `default_pricing` is on. Search works the same way.
 
 Audio differs from moderations and search in one respect: it reserves $0 against the budget before the call rather than reserving the configured rate. The per-user gate still applies (an unknown, blocked, or already-over-budget user is refused), but the cost lands on the budget at reconciliation instead of being held up front, so concurrent audio requests cannot see each other's holds. Spend stays truthful either way. A duration-based meter that would give audio a real pre-call estimate is tracked in [#376](https://github.com/mozilla-ai/otari/issues/376).
 
@@ -451,8 +451,8 @@ Limitations when enabled:
   the `huggingface:<model>:<backend>` selector (see the model reference in `models.md`). Auto routing and
   the policy suffixes (`:cheapest`, `:fastest`, ...) cannot be priced from the id alone and fall through to
   `require_pricing`.
-- **Audio and search are excluded.** Both bill a flat rate per request, and the dataset's rates are per
-  million tokens, so defaults are not consulted for them. See
+- **Per-request routes are excluded.** Audio, moderations, and search bill a flat rate per request, and the
+  dataset's rates are per million tokens, so defaults are not consulted for them. See
   [per-request pricing](#per-request-pricing-audio-and-moderations).
 
 > **Fail-closed by default.** With `require_pricing: true` (the default), a request for a model

--- a/src/gateway/api/routes/_passthrough.py
+++ b/src/gateway/api/routes/_passthrough.py
@@ -165,11 +165,12 @@ async def run_passthrough(
             Audio resolves it for per-request charge lines but the reservation
             estimate stays 0 (no measurable cost unit yet, so no pre-call spend).
         pricing_use_defaults: Whether the pricing lookup may fall back to the
-            genai-prices dataset. A route that bills per request passes False for
-            the reason :func:`find_model_pricing` documents: those rates are USD
-            per million *tokens*, so under a per-request convention they would be
-            charged as USD per million *requests* and write a charge line at the
-            wrong unit for a rate nobody configured.
+            genai-prices dataset. A route whose billable unit is not a token
+            passes False for the reason :func:`find_model_pricing` documents:
+            those rates are USD per million *tokens*, so a per-request route
+            would charge them as USD per million *requests* and a per-image route
+            as USD per image, writing a charge line at the wrong unit for a rate
+            nobody configured.
         estimate: Maps the pricing row to the reservation estimate in USD.
             Defaults to 0.0, which still enforces per-user state (user exists,
             not blocked, not already over budget).

--- a/src/gateway/api/routes/_passthrough.py
+++ b/src/gateway/api/routes/_passthrough.py
@@ -161,7 +161,8 @@ async def run_passthrough(
             ``HTTPException`` raised here (e.g. an upload size check) refunds
             the reservation and propagates unchanged.
         lookup_pricing: Whether to resolve :class:`ModelPricing` for the model.
-            Audio has no measurable cost unit yet and skips the lookup.
+            Audio resolves it for per-request charge lines but the reservation
+            estimate stays 0 (no measurable cost unit yet, so no pre-call spend).
         estimate: Maps the pricing row to the reservation estimate in USD.
             Defaults to 0.0, which still enforces per-user state (user exists,
             not blocked, not already over budget).
@@ -292,6 +293,8 @@ async def run_passthrough(
         # unresolvable selector to 400; otherwise the estimate leaks.
         try:
             resolved = resolve_provider_selector(config, model, user_id)
+            if lookup_pricing:
+                pricing = await find_model_pricing(db, resolved.instance, resolved.model)
         except (ValueError, AnyLLMError) as exc:
             await refund_reservation(db, reservation)
             await _log_rejection(

--- a/src/gateway/api/routes/_passthrough.py
+++ b/src/gateway/api/routes/_passthrough.py
@@ -131,6 +131,7 @@ async def run_passthrough(
     user: str | None,
     call_provider: Callable[[ResolvedProvider], Awaitable[ResultT]],
     lookup_pricing: bool = True,
+    pricing_use_defaults: bool = True,
     estimate: Callable[[ModelPricing | None], float] | None = None,
     enforce_require_pricing: bool = False,
     usage_tokens: Callable[[ResultT], tuple[int | None, int | None, int | None]] | None = None,
@@ -163,6 +164,12 @@ async def run_passthrough(
         lookup_pricing: Whether to resolve :class:`ModelPricing` for the model.
             Audio resolves it for per-request charge lines but the reservation
             estimate stays 0 (no measurable cost unit yet, so no pre-call spend).
+        pricing_use_defaults: Whether the pricing lookup may fall back to the
+            genai-prices dataset. A route that bills per request passes False for
+            the reason :func:`find_model_pricing` documents: those rates are USD
+            per million *tokens*, so under a per-request convention they would be
+            charged as USD per million *requests* and write a charge line at the
+            wrong unit for a rate nobody configured.
         estimate: Maps the pricing row to the reservation estimate in USD.
             Defaults to 0.0, which still enforces per-user state (user exists,
             not blocked, not already over budget).
@@ -293,8 +300,6 @@ async def run_passthrough(
         # unresolvable selector to 400; otherwise the estimate leaks.
         try:
             resolved = resolve_provider_selector(config, model, user_id)
-            if lookup_pricing:
-                pricing = await find_model_pricing(db, resolved.instance, resolved.model)
         except (ValueError, AnyLLMError) as exc:
             await refund_reservation(db, reservation)
             await _log_rejection(
@@ -304,6 +309,16 @@ async def run_passthrough(
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
             _raise_for_unresolvable_model(model, exc)
+        if lookup_pricing:
+            # Unlike the branch below, the reservation is already held here, so a
+            # failed lookup must refund before propagating or the estimate leaks.
+            try:
+                pricing = await find_model_pricing(
+                    db, resolved.instance, resolved.model, use_defaults=pricing_use_defaults
+                )
+            except Exception:
+                await refund_reservation(db, reservation)
+                raise
     else:
         try:
             resolved = resolve_provider_selector(config, model, user_id)
@@ -317,7 +332,9 @@ async def run_passthrough(
             )
             _raise_for_unresolvable_model(model, exc)
         if lookup_pricing:
-            pricing = await find_model_pricing(db, resolved.instance, resolved.model)
+            pricing = await find_model_pricing(
+                db, resolved.instance, resolved.model, use_defaults=pricing_use_defaults
+            )
         # Reserve first so user/blocked/budget rejections (404/403) precede the
         # missing-pricing rejection (402); refund if we then reject for no pricing.
         reservation = await _reserve(

--- a/src/gateway/api/routes/_passthrough.py
+++ b/src/gateway/api/routes/_passthrough.py
@@ -177,7 +177,10 @@ async def run_passthrough(
         enforce_require_pricing: When True and ``config.require_pricing`` is
             set, reject unpriced models with 402. The check runs after the
             reservation (so its 404/403 rejections take precedence) and the
-            reservation is refunded before raising.
+            reservation is refunded before raising. Honored only on the
+            resolve-first path: a ``reserve_before_resolve`` route resolves
+            pricing after its reservation and skips this gate, so setting both
+            silently serves an unpriced model. No route sets both today.
         usage_tokens: Maps the provider result to ``(prompt, completion,
             total)`` token counts for the usage log. Defaults to ``(0, 0, 0)``.
         compute_cost: Maps the result and pricing to the final USD cost, or
@@ -318,6 +321,12 @@ async def run_passthrough(
                     db, resolved.instance, resolved.model, use_defaults=pricing_use_defaults
                 )
             except Exception:
+                # The realistic failure is a DB error, which leaves the session
+                # needing a rollback: without one the refund's own UPDATE raises
+                # PendingRollbackError, masking this exception and leaking the
+                # hold this block exists to release. ``reserve_budget`` already
+                # committed, so the rollback discards nothing of its own.
+                await db.rollback()
                 await refund_reservation(db, reservation)
                 raise
     else:

--- a/src/gateway/api/routes/audio.py
+++ b/src/gateway/api/routes/audio.py
@@ -9,12 +9,13 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, get_log_writer, verify_api_key_or_master_key
-from gateway.api.routes._passthrough import run_passthrough
+from gateway.api.routes._passthrough import BillingMeters, run_passthrough
 from gateway.api.routes._schema_derive import derive_request_base
 from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
-from gateway.models.entities import APIKey
+from gateway.models.entities import APIKey, ModelPricing
 from gateway.services.log_writer import LogWriter
+from gateway.services.pricing_service import flat_request_cost
 from gateway.services.provider_kwargs import ResolvedProvider
 
 router = APIRouter(prefix="/v1", tags=["audio"])
@@ -83,10 +84,26 @@ async def create_transcription(
 
         return await atranscription(**transcription_kwargs)
 
+    def compute_cost(result: Transcription, pricing: ModelPricing | None) -> float:
+        # Audio bills per request like moderations: ``input_price_per_million``
+        # stores the per-request rate scaled by 1e6 (see flat_request_cost), and
+        # an unpriced model is free by design.
+        return flat_request_cost(pricing)
+
+    def compute_meters(result: Transcription, pricing: ModelPricing | None, cost: float) -> BillingMeters | None:
+        # One request is one billed meter. Skip the $0 charge line for an unpriced
+        # model, same as moderations: a reader sees no charge line because there
+        # is no charge, not because of a bug.
+        if not cost:
+            return None
+        breakdown = [{"meter": "request", "units": 1, "unit_rate": cost, "cost": cost}]
+        return {"requests": 1}, breakdown
+
     # Audio is exempt from require_pricing and has no measurable cost unit yet
-    # (tokens, seconds, etc.), so the reservation estimate is 0 and cost stays
-    # unset; the reservation still enforces existing per-user state (user
-    # exists, not blocked, not already over budget).
+    # (tokens, seconds, etc.), so the reservation estimate is 0; the reservation
+    # still enforces existing per-user state (user exists, not blocked, not
+    # already over budget). When pricing is configured, the cost is recorded as
+    # an auditable per-request charge line.
     outcome = await run_passthrough(
         endpoint="/v1/audio/transcriptions",
         raw_request=raw_request,
@@ -98,9 +115,11 @@ async def create_transcription(
         model=model,
         user=user,
         call_provider=call_provider,
-        lookup_pricing=False,
+        lookup_pricing=True,
         reserve_before_resolve=True,
         relabel=False,
+        compute_cost=compute_cost,
+        compute_meters=compute_meters,
     )
     return outcome.result.model_dump()
 
@@ -169,9 +188,25 @@ async def create_speech(
         }
         return await aspeech(**speech_kwargs)
 
+    def compute_cost(result: bytes, pricing: ModelPricing | None) -> float:
+        # Speech bills per request like moderations: ``input_price_per_million``
+        # stores the per-request rate scaled by 1e6 (see flat_request_cost), and
+        # an unpriced model is free by design.
+        return flat_request_cost(pricing)
+
+    def compute_meters(result: bytes, pricing: ModelPricing | None, cost: float) -> BillingMeters | None:
+        # One request is one billed meter. Skip the $0 charge line for an unpriced
+        # model, same as moderations: a reader sees no charge line because there
+        # is no charge, not because of a bug.
+        if not cost:
+            return None
+        breakdown = [{"meter": "request", "units": 1, "unit_rate": cost, "cost": cost}]
+        return {"requests": 1}, breakdown
+
     # Audio is exempt from require_pricing and has no measurable cost unit yet
-    # (tokens, seconds, characters, etc.), so the reservation estimate is 0 and
-    # cost stays unset; the reservation still enforces existing per-user state.
+    # (tokens, seconds, characters, etc.), so the reservation estimate is 0; the
+    # reservation still enforces existing per-user state. When pricing is
+    # configured, the cost is recorded as an auditable per-request charge line.
     outcome = await run_passthrough(
         endpoint="/v1/audio/speech",
         raw_request=raw_request,
@@ -183,9 +218,11 @@ async def create_speech(
         model=request.model,
         user=request.user,
         call_provider=call_provider,
-        lookup_pricing=False,
+        lookup_pricing=True,
         reserve_before_resolve=True,
         relabel=False,
+        compute_cost=compute_cost,
+        compute_meters=compute_meters,
     )
 
     content_type = _SPEECH_CONTENT_TYPES.get(request.response_format, "audio/mpeg")

--- a/src/gateway/api/routes/audio.py
+++ b/src/gateway/api/routes/audio.py
@@ -15,7 +15,7 @@ from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
 from gateway.models.entities import APIKey, ModelPricing
 from gateway.services.log_writer import LogWriter
-from gateway.services.pricing_service import flat_request_cost
+from gateway.services.pricing_service import flat_request_cost, per_request_meters
 from gateway.services.provider_kwargs import ResolvedProvider
 
 router = APIRouter(prefix="/v1", tags=["audio"])
@@ -91,13 +91,7 @@ async def create_transcription(
         return flat_request_cost(pricing)
 
     def compute_meters(result: Transcription, pricing: ModelPricing | None, cost: float) -> BillingMeters | None:
-        # One request is one billed meter. Skip the $0 charge line for an unpriced
-        # model, same as moderations: a reader sees no charge line because there
-        # is no charge, not because of a bug.
-        if not cost:
-            return None
-        breakdown = [{"meter": "request", "units": 1, "unit_rate": cost, "cost": cost}]
-        return {"requests": 1}, breakdown
+        return per_request_meters(cost)
 
     # Audio is exempt from require_pricing and has no measurable cost unit yet
     # (tokens, seconds, etc.), so the reservation estimate is 0; the reservation
@@ -199,13 +193,7 @@ async def create_speech(
         return flat_request_cost(pricing)
 
     def compute_meters(result: bytes, pricing: ModelPricing | None, cost: float) -> BillingMeters | None:
-        # One request is one billed meter. Skip the $0 charge line for an unpriced
-        # model, same as moderations: a reader sees no charge line because there
-        # is no charge, not because of a bug.
-        if not cost:
-            return None
-        breakdown = [{"meter": "request", "units": 1, "unit_rate": cost, "cost": cost}]
-        return {"requests": 1}, breakdown
+        return per_request_meters(cost)
 
     # Audio is exempt from require_pricing and has no measurable cost unit yet
     # (tokens, seconds, characters, etc.), so the reservation estimate is 0; the

--- a/src/gateway/api/routes/audio.py
+++ b/src/gateway/api/routes/audio.py
@@ -103,7 +103,10 @@ async def create_transcription(
     # (tokens, seconds, etc.), so the reservation estimate is 0; the reservation
     # still enforces existing per-user state (user exists, not blocked, not
     # already over budget). When pricing is configured, the cost is recorded as
-    # an auditable per-request charge line.
+    # an auditable per-request charge line. Only an explicitly configured rate
+    # counts (pricing_use_defaults=False): genai-prices quotes audio models such
+    # as gpt-4o-transcribe per million tokens, which this per-request convention
+    # would misread as a per-million-request rate.
     outcome = await run_passthrough(
         endpoint="/v1/audio/transcriptions",
         raw_request=raw_request,
@@ -116,6 +119,7 @@ async def create_transcription(
         user=user,
         call_provider=call_provider,
         lookup_pricing=True,
+        pricing_use_defaults=False,
         reserve_before_resolve=True,
         relabel=False,
         compute_cost=compute_cost,
@@ -207,6 +211,10 @@ async def create_speech(
     # (tokens, seconds, characters, etc.), so the reservation estimate is 0; the
     # reservation still enforces existing per-user state. When pricing is
     # configured, the cost is recorded as an auditable per-request charge line.
+    # Only an explicitly configured rate counts (pricing_use_defaults=False):
+    # genai-prices quotes speech models such as gpt-4o-mini-tts per million
+    # tokens, which this per-request convention would misread as a
+    # per-million-request rate.
     outcome = await run_passthrough(
         endpoint="/v1/audio/speech",
         raw_request=raw_request,
@@ -219,6 +227,7 @@ async def create_speech(
         user=request.user,
         call_provider=call_provider,
         lookup_pricing=True,
+        pricing_use_defaults=False,
         reserve_before_resolve=True,
         relabel=False,
         compute_cost=compute_cost,

--- a/src/gateway/api/routes/images.py
+++ b/src/gateway/api/routes/images.py
@@ -85,6 +85,12 @@ async def create_image(
         }
         return await aimage_generation(**image_kwargs)
 
+    # Only an explicitly configured rate counts (pricing_use_defaults=False), for
+    # the same unit mismatch audio, moderations, and search avoid: images bill per
+    # image (per_image_cost reads input_price_per_million as raw USD per image)
+    # while genai-prices quotes USD per million tokens. gpt-image-1 is in that
+    # dataset at 5.0, which would bill $5.00 for one image and, because this route
+    # reserves its estimate, hold that $5.00 against the budget before the call.
     outcome = await run_passthrough(
         endpoint="/v1/images/generations",
         raw_request=raw_request,
@@ -96,6 +102,7 @@ async def create_image(
         model=request.model,
         user=request.user,
         call_provider=call_provider,
+        pricing_use_defaults=False,
         estimate=estimate,
         enforce_require_pricing=True,
         compute_cost=compute_cost,

--- a/src/gateway/api/routes/moderations.py
+++ b/src/gateway/api/routes/moderations.py
@@ -64,7 +64,10 @@ async def create_moderation(
     # Moderations is exempt from require_pricing: it is free at most providers
     # and is intentionally treated as $0 when unpriced (no "No pricing
     # configured" warning). Pricing, when present, is a flat per-request rate
-    # (see flat_request_cost); moderation has no token usage.
+    # (see flat_request_cost); moderation has no token usage. Only an explicitly
+    # configured rate counts (pricing_use_defaults=False below): genai-prices
+    # quotes per million tokens, so a moderation model whose name matches a chat
+    # model in that dataset would otherwise bill a token rate per request.
     def compute_cost(result: ModerationResponse, pricing: ModelPricing | None) -> float:
         return flat_request_cost(pricing)
 
@@ -102,6 +105,7 @@ async def create_moderation(
         model=request.model,
         user=request.user,
         call_provider=call_provider,
+        pricing_use_defaults=False,
         estimate=flat_request_cost,
         usage_tokens=usage_tokens,
         compute_cost=compute_cost,

--- a/src/gateway/api/routes/moderations.py
+++ b/src/gateway/api/routes/moderations.py
@@ -12,7 +12,7 @@ from gateway.api.routes._passthrough import BillingMeters, run_passthrough
 from gateway.core.config import GatewayConfig
 from gateway.models.entities import APIKey, ModelPricing
 from gateway.services.log_writer import LogWriter
-from gateway.services.pricing_service import flat_request_cost
+from gateway.services.pricing_service import flat_request_cost, per_request_meters
 from gateway.services.provider_kwargs import ResolvedProvider
 from gateway.types.moderation import ModerationResponse
 
@@ -72,14 +72,7 @@ async def create_moderation(
         return flat_request_cost(pricing)
 
     def compute_meters(result: ModerationResponse, pricing: ModelPricing | None, cost: float) -> BillingMeters | None:
-        # An unpriced moderation is $0 by design, which is the common case here, so
-        # record nothing rather than a zero charge line the dashboard would render
-        # as a "billed meters" block explaining a charge that never happened. One
-        # request is billed, so the per-request rate is the cost itself.
-        if not cost:
-            return None
-        breakdown = [{"meter": "request", "units": 1, "unit_rate": cost, "cost": cost}]
-        return {"requests": 1}, breakdown
+        return per_request_meters(cost)
 
     def usage_tokens(result: ModerationResponse) -> tuple[int | None, int | None, int | None]:
         return (None, 0, None)

--- a/src/gateway/services/pricing_service.py
+++ b/src/gateway/services/pricing_service.py
@@ -278,11 +278,17 @@ async def find_model_pricing(
     database always takes precedence over defaults. The default fallback is gated
     by ``GatewayConfig.default_pricing`` via :func:`configure_default_pricing`.
 
-    ``use_defaults=False`` skips that fallback for keys that are not models at
-    all. The genai-prices lookup falls back to a provider-agnostic match on the
-    bare name, so a search tool an operator happened to name after a real model
-    would otherwise pick up that model's per-million-token rate and be billed
-    under a per-request convention.
+    ``use_defaults=False`` skips that fallback for any caller whose billable unit
+    is not a token, because every dataset rate is quoted per million *tokens*.
+    Two kinds of caller need it. A key that is not a model at all (a search tool,
+    a gateway-run tool): the genai-prices lookup falls back to a provider-agnostic
+    match on the bare name, so a tool an operator happened to name after a real
+    model would pick up that model's rate. And a real model billed under a
+    non-token unit (audio and moderations per request, images per image):
+    ``gpt-4o-transcribe`` and ``gpt-image-1`` are both in the dataset, and their
+    per-million-token rates, read under :func:`flat_request_cost` or
+    :func:`per_image_cost`, become a per-request or per-image rate, writing a
+    charge line at the wrong unit for a rate nobody configured.
     """
 
     lookup_time = normalize_effective_at(as_of)

--- a/src/gateway/services/pricing_service.py
+++ b/src/gateway/services/pricing_service.py
@@ -333,6 +333,30 @@ def flat_request_cost(pricing: ModelPricing | None) -> float:
     return pricing.input_price_per_million / 1_000_000
 
 
+PerRequestMeters = tuple[dict[str, int], list[dict[str, float | int | str]]]
+
+
+def per_request_meters(cost: float) -> PerRequestMeters | None:
+    """This request's billing meters and charge line, priced per request.
+
+    One request is one billed meter, so the per-request rate is the cost itself.
+    Charge lines carry ``unit_rate`` rather than ``rate_per_million``, the same
+    shape :func:`price_tool_calls` writes, which is what tells a reader and the
+    dashboard which unit convention applies.
+
+    Returns ``None`` when the request is free, the common case on these routes
+    since they are exempt from ``require_pricing`` and an unset or ``0.0`` rate
+    both settle at $0: a zero charge line would render in Activity as a billed
+    meter explaining a charge that never happened. Shared by every route billing
+    per request (audio transcription, audio speech, moderations) so the shape
+    cannot drift between them, for the reason the unit conventions above are
+    named helpers rather than inline expressions.
+    """
+    if not cost:
+        return None
+    return {"requests": 1}, [{"meter": "request", "units": 1, "unit_rate": cost, "cost": cost}]
+
+
 GATEWAY_TOOL_PRICING_PROVIDER = "otari"
 
 

--- a/tests/integration/test_audio_endpoint.py
+++ b/tests/integration/test_audio_endpoint.py
@@ -362,3 +362,136 @@ def test_speech_optional_fields(
     call_kwargs = mock.call_args.kwargs
     assert extra_field in call_kwargs
     assert call_kwargs[extra_field] == values[extra_field]
+
+
+def test_transcription_billing_meters_tracked_with_pricing(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/audio/transcriptions records auditable charge lines alongside cost.
+
+    Audio bills per request like moderations (input_price_per_million holds the
+    per-million-request rate), so a priced model yields one request meter and one
+    charge line.
+    """
+    client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "openai:whisper-1",
+            "input_price_per_million": 2.0,
+            "output_price_per_million": 0.0,
+        },
+        headers=master_key_header,
+    )
+
+    mock_resp = _mock_transcription_response()
+    with patch("gateway.api.routes.audio.atranscription", new_callable=AsyncMock, return_value=mock_resp):
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.mp3", b"audio-data", "audio/mpeg")},
+            data={"model": "openai:whisper-1"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+
+    usage_resp = client.get(
+        "/v1/usage", params={"endpoint": "/v1/audio/transcriptions", "status": "success"}, headers=master_key_header
+    )
+    logs = usage_resp.json()
+    assert len(logs) >= 1
+    latest = logs[0]
+    assert latest["cost"] == pytest.approx(0.000002)
+    assert latest["billing_meters"] == {"requests": 1}
+    assert latest["pricing_breakdown"] == [
+        {"meter": "request", "units": 1, "unit_rate": pytest.approx(0.000002), "cost": pytest.approx(0.000002)}
+    ]
+
+
+def test_transcription_unpriced_records_no_charge_lines(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """An unpriced audio model is free by design, so it records no charge line."""
+    with patch(
+        "gateway.api.routes.audio.atranscription",
+        new_callable=AsyncMock,
+        return_value=_mock_transcription_response(),
+    ):
+        resp = client.post(
+            "/v1/audio/transcriptions",
+            files={"file": ("test.mp3", b"audio-data", "audio/mpeg")},
+            data={"model": "openai:unpriced-audio-model"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+
+    usage_resp = client.get(
+        "/v1/usage", params={"endpoint": "/v1/audio/transcriptions", "status": "success"}, headers=master_key_header
+    )
+    latest = usage_resp.json()[0]
+    assert latest["cost"] == 0.0
+    assert latest["billing_meters"] is None
+    assert latest["pricing_breakdown"] is None
+
+
+def test_speech_billing_meters_tracked_with_pricing(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """POST /v1/audio/speech records auditable charge lines alongside cost."""
+    client.post(
+        "/v1/pricing",
+        json={
+            "model_key": "openai:tts-1",
+            "input_price_per_million": 4.0,
+            "output_price_per_million": 0.0,
+        },
+        headers=master_key_header,
+    )
+
+    with patch("gateway.api.routes.audio.aspeech", new_callable=AsyncMock, return_value=FAKE_AUDIO_BYTES):
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"model": "openai:tts-1", "input": "Hello", "voice": "alloy"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+
+    usage_resp = client.get(
+        "/v1/usage", params={"endpoint": "/v1/audio/speech", "status": "success"}, headers=master_key_header
+    )
+    logs = usage_resp.json()
+    assert len(logs) >= 1
+    latest = logs[0]
+    # input_price_per_million = 4.0 is USD per million requests, so one request is 4e-06.
+    assert latest["cost"] == pytest.approx(0.000004)
+    assert latest["billing_meters"] == {"requests": 1}
+    assert latest["pricing_breakdown"] == [
+        {"meter": "request", "units": 1, "unit_rate": pytest.approx(0.000004), "cost": pytest.approx(0.000004)}
+    ]
+
+
+def test_speech_unpriced_records_no_charge_lines(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """An unpriced speech model is free by design, so it records no charge line."""
+    with patch("gateway.api.routes.audio.aspeech", new_callable=AsyncMock, return_value=FAKE_AUDIO_BYTES):
+        resp = client.post(
+            "/v1/audio/speech",
+            json={"model": "openai:unpriced-speech-model", "input": "Hello", "voice": "alloy"},
+            headers=api_key_header,
+        )
+    assert resp.status_code == 200
+
+    usage_resp = client.get(
+        "/v1/usage", params={"endpoint": "/v1/audio/speech", "status": "success"}, headers=master_key_header
+    )
+    latest = usage_resp.json()[0]
+    assert latest["cost"] == 0.0
+    assert latest["billing_meters"] is None
+    assert latest["pricing_breakdown"] is None

--- a/tests/integration/test_audio_endpoint.py
+++ b/tests/integration/test_audio_endpoint.py
@@ -1,5 +1,6 @@
 """Tests for the POST /v1/audio/transcriptions and POST /v1/audio/speech endpoints."""
 
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -7,7 +8,11 @@ import pytest
 from any_llm.types.audio import Transcription
 from fastapi.testclient import TestClient
 
-from gateway.services.pricing_service import configure_default_pricing, reset_price_cache
+from gateway.services.pricing_service import (
+    configure_default_pricing,
+    default_model_pricing,
+    reset_price_cache,
+)
 
 
 def _mock_transcription_response() -> Transcription:
@@ -514,6 +519,9 @@ def test_transcription_ignores_genai_prices_defaults(
     configure_default_pricing(True)
     reset_price_cache()
     try:
+        # Pin the premise: without a dataset entry to ignore, the assertions below
+        # would pass for the wrong reason and stop guarding anything.
+        assert default_model_pricing("openai", "gpt-4o-transcribe", datetime.now(UTC)) is not None
         with patch(
             "gateway.api.routes.audio.atranscription",
             new_callable=AsyncMock,

--- a/tests/integration/test_audio_endpoint.py
+++ b/tests/integration/test_audio_endpoint.py
@@ -7,6 +7,8 @@ import pytest
 from any_llm.types.audio import Transcription
 from fastapi.testclient import TestClient
 
+from gateway.services.pricing_service import configure_default_pricing, reset_price_cache
+
 
 def _mock_transcription_response() -> Transcription:
     """Build a real Transcription for testing."""
@@ -492,6 +494,47 @@ def test_speech_unpriced_records_no_charge_lines(
         "/v1/usage", params={"endpoint": "/v1/audio/speech", "status": "success"}, headers=master_key_header
     )
     latest = usage_resp.json()[0]
+    assert latest["cost"] == 0.0
+    assert latest["billing_meters"] is None
+    assert latest["pricing_breakdown"] is None
+
+
+def test_transcription_ignores_genai_prices_defaults(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """Default (genai-prices) rates never price audio, even with default_pricing on.
+
+    Those rates are USD per million tokens, but audio bills per request, so
+    honoring one would write a charge line at the wrong unit for a rate the
+    operator never configured. gpt-4o-transcribe is in the dataset, so it is the
+    case that would regress.
+    """
+    configure_default_pricing(True)
+    reset_price_cache()
+    try:
+        with patch(
+            "gateway.api.routes.audio.atranscription",
+            new_callable=AsyncMock,
+            return_value=_mock_transcription_response(),
+        ):
+            resp = client.post(
+                "/v1/audio/transcriptions",
+                files={"file": ("test.mp3", b"audio-data", "audio/mpeg")},
+                data={"model": "openai:gpt-4o-transcribe"},
+                headers=api_key_header,
+            )
+        assert resp.status_code == 200
+    finally:
+        configure_default_pricing(False)
+        reset_price_cache()
+
+    usage_resp = client.get(
+        "/v1/usage", params={"endpoint": "/v1/audio/transcriptions", "status": "success"}, headers=master_key_header
+    )
+    latest = usage_resp.json()[0]
+    assert latest["model"] == "gpt-4o-transcribe"
     assert latest["cost"] == 0.0
     assert latest["billing_meters"] is None
     assert latest["pricing_breakdown"] is None

--- a/tests/integration/test_images_endpoint.py
+++ b/tests/integration/test_images_endpoint.py
@@ -7,6 +7,8 @@ import pytest
 from any_llm.types.image import Image, ImagesResponse
 from fastapi.testclient import TestClient
 
+from gateway.services.pricing_service import configure_default_pricing, reset_price_cache
+
 
 def _mock_images_response(n: int = 1) -> ImagesResponse:
     """Build a real ImagesResponse for testing."""
@@ -257,3 +259,41 @@ def test_images_billing_meters_tracked_with_pricing(
     assert logs[0]["billing_meters"] == {"images": 2}
     breakdown = logs[0]["pricing_breakdown"]
     assert breakdown == [{"meter": "images", "units": 2, "unit_rate": 0.04, "cost": pytest.approx(0.08)}]
+
+
+def test_images_ignores_genai_prices_defaults(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """Default (genai-prices) rates never price image generation.
+
+    Those rates are USD per million tokens, but images bill per image at a raw
+    per-image rate, so honoring one would charge dollars per image for a rate
+    quoted per million tokens: gpt-image-1 is in the dataset at 5.0, which would
+    bill $5.00 for one image (and reserve it before the call).
+    """
+    configure_default_pricing(True)
+    reset_price_cache()
+    try:
+        with patch(
+            "gateway.api.routes.images.aimage_generation",
+            new_callable=AsyncMock,
+            return_value=_mock_images_response(),
+        ):
+            resp = client.post(
+                "/v1/images/generations",
+                json={"model": "openai:gpt-image-1", "prompt": "a cute cat"},
+                headers=api_key_header,
+            )
+        assert resp.status_code == 200
+    finally:
+        configure_default_pricing(False)
+        reset_price_cache()
+
+    usage_resp = client.get("/v1/usage", params={"endpoint": "/v1/images/generations"}, headers=master_key_header)
+    latest = usage_resp.json()[0]
+    assert latest["model"] == "gpt-image-1"
+    assert latest["cost"] is None
+    assert latest["billing_meters"] is None
+    assert latest["pricing_breakdown"] is None

--- a/tests/integration/test_images_endpoint.py
+++ b/tests/integration/test_images_endpoint.py
@@ -1,5 +1,6 @@
 """Tests for the POST /v1/images/generations endpoint."""
 
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -7,7 +8,11 @@ import pytest
 from any_llm.types.image import Image, ImagesResponse
 from fastapi.testclient import TestClient
 
-from gateway.services.pricing_service import configure_default_pricing, reset_price_cache
+from gateway.services.pricing_service import (
+    configure_default_pricing,
+    default_model_pricing,
+    reset_price_cache,
+)
 
 
 def _mock_images_response(n: int = 1) -> ImagesResponse:
@@ -276,6 +281,9 @@ def test_images_ignores_genai_prices_defaults(
     configure_default_pricing(True)
     reset_price_cache()
     try:
+        # Pin the premise: without a dataset entry to ignore, the assertions below
+        # would pass for the wrong reason and stop guarding anything.
+        assert default_model_pricing("openai", "gpt-image-1", datetime.now(UTC)) is not None
         with patch(
             "gateway.api.routes.images.aimage_generation",
             new_callable=AsyncMock,

--- a/tests/integration/test_moderations_endpoint.py
+++ b/tests/integration/test_moderations_endpoint.py
@@ -1,13 +1,18 @@
 """Tests for the POST /v1/moderations endpoint."""
 
 import logging
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
-from gateway.services.pricing_service import configure_default_pricing, reset_price_cache
+from gateway.services.pricing_service import (
+    configure_default_pricing,
+    default_model_pricing,
+    reset_price_cache,
+)
 from gateway.types.moderation import ModerationResponse, ModerationResult
 
 
@@ -463,6 +468,9 @@ def test_moderations_ignores_genai_prices_defaults(
     configure_default_pricing(True)
     reset_price_cache()
     try:
+        # Pin the premise: without a dataset entry to ignore, the assertions below
+        # would pass for the wrong reason and stop guarding anything.
+        assert default_model_pricing("openai", "gpt-4o", datetime.now(UTC)) is not None
         with patch("gateway.api.routes.moderations.amoderation", new_callable=AsyncMock, return_value=resp_obj):
             resp = client.post(
                 "/v1/moderations",

--- a/tests/integration/test_moderations_endpoint.py
+++ b/tests/integration/test_moderations_endpoint.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from gateway.services.pricing_service import configure_default_pricing, reset_price_cache
 from gateway.types.moderation import ModerationResponse, ModerationResult
 
 
@@ -440,3 +441,44 @@ def test_moderations_no_warning_when_pricing_missing(
     assert resp.status_code == 200
     offending = [r for r in caplog.records if "No pricing configured" in r.getMessage()]
     assert offending == []
+
+
+def test_moderations_ignores_genai_prices_defaults(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """Default (genai-prices) rates never price moderations, even with default_pricing on.
+
+    Those rates are USD per million tokens, but moderation bills per request, so
+    honoring one would charge a token rate as a request rate. The dataset has no
+    moderation models, so the case that regresses is an operator pointing this
+    endpoint at a model name the dataset does carry.
+    """
+    resp_obj = ModerationResponse(
+        id="modr-test",
+        model="gpt-4o",
+        results=[ModerationResult(flagged=False, categories={}, category_scores={})],
+    )
+    configure_default_pricing(True)
+    reset_price_cache()
+    try:
+        with patch("gateway.api.routes.moderations.amoderation", new_callable=AsyncMock, return_value=resp_obj):
+            resp = client.post(
+                "/v1/moderations",
+                json={"model": "openai:gpt-4o", "input": "hello"},
+                headers=api_key_header,
+            )
+        assert resp.status_code == 200
+    finally:
+        configure_default_pricing(False)
+        reset_price_cache()
+
+    usage_resp = client.get(
+        "/v1/usage", params={"endpoint": "/v1/moderations", "status": "success"}, headers=master_key_header
+    )
+    latest = usage_resp.json()[0]
+    assert latest["model"] == "gpt-4o"
+    assert latest["cost"] == 0.0
+    assert latest["billing_meters"] is None
+    assert latest["pricing_breakdown"] is None


### PR DESCRIPTION
## Description

Audio transcription and speech recorded a bare cost: neither endpoint passed `compute_cost` to `run_passthrough`, so cost stayed unset and no `billing_meters` or `pricing_breakdown` were written. That left audio the one pass-through surface with no charge lines after #542.

Both endpoints now follow the per-request convention moderations uses: `input_price_per_million` holds the per-request rate scaled by 1e6 (`flat_request_cost`), and an unpriced model is free by design, so no $0 line is written. Audio bills per request because it has no measurable unit yet (tokens, seconds, characters); a duration meter lands with the rate-card work in #376. Pricing was never resolved on the `reserve_before_resolve` branch that only audio takes, so `run_passthrough` resolves it there and refunds the held reservation if the lookup fails.

Enabling that lookup exposed a unit bug on every route that reads `input_price_per_million` as something other than a token rate, because the genai-prices fallback quotes USD per million tokens. All three are fixed here with `pricing_use_defaults=False`, matching the search tools, the tool loop, and `pricing_init`:

- **Audio** (per request, rate scaled 1e6): `gpt-4o-transcribe` is in the dataset, so with `default_pricing` on a transcription recorded cost 2.5e-06 for a rate nobody configured. `gpt-4o-mini-tts` gave speech the same exposure.
- **Moderations** (per request): narrower, since the dataset carries no moderation models, but the provider-agnostic name match makes `openai:gpt-4o` reachable, logging cost 2.5e-06.
- **Images** (raw USD per image, unscaled): `gpt-image-1` is in the dataset at 5.0, so one generation billed $5.00 against a real price near $0.01 to $0.19. The worst of the three: this route reserves its estimate, so the $5.00 was held against the budget before the provider call, and `enforce_require_pricing=True` meant the bogus rate also satisfied the fail-closed gate that exists to catch this. No issue tracked it; it surfaced while reviewing this PR.

**Release note:** an image model priced only from the dataset is now rejected with 402 under `require_pricing` rather than billed at roughly a million times its rate.

Docs cover the per-request and per-image units (the per-image one was undocumented anywhere), the default-pricing exclusion, audio's soft budget cap under concurrency, and the fact that a $0 audio row reads as priced rather than unpriced.

## PR Type

- [x] Bug Fix

## Relevant issues

Fixes #432

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). Not applicable: no route signature or docstring changed, and `make openapi-check` / `make postman-check` both pass.

## AI Usage

- [x] AI was used for drafting/refactoring.

**AI Model/Tool used:** Claude Opus 5 (1M context), via Claude Code, in agentic sessions directed and verified by the account owner.

**Any additional AI details you'd like to share:** The images fix came out of an independent review pass over the audio work, which reproduced each rate against the real genai-prices dataset rather than trusting the code comments.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Audio transcription and speech requests now create auditable billing records. Priced models receive one charge per request, while unpriced models remain free without zero-value charge lines.

The passthrough flow resolves pricing before calculating costs, including reserved requests. Moderation uses only explicitly configured rates. Documentation and integration tests cover these billing rules and prevent token-based defaults from charging non-token endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
