### PR TITLE
Disable auto_assign_reviewers in configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -59,7 +59,7 @@ reviews:
 
   # Leave on so reviewer suggestions work as the maintainer team grows.
   suggested_reviewers: true
-  auto_assign_reviewers: true
+  auto_assign_reviewers: false
 
   in_progress_fortune: false
   poem: false


### PR DESCRIPTION
## Description
<!-- What does this PR do and why? -->
This PR is to make it so that CodeRabbit doesn't auto assign PRs to people. After we've used it for a few months, I've found it a bit annoying.

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
<!-- e.g. "Fixes #123" -->

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [ ] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**


**Any additional AI details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Disabled automatic pull request reviewer assignment in `.coderabbit.yaml`.

This gives maintainers control over reviewer selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->