### PR TITLE
fix(dashboard): stop the expanded table row remounting on every poll

### DIFF
--- a/web/src/components/DataTable.test.tsx
+++ b/web/src/components/DataTable.test.tsx
@@ -267,8 +267,8 @@ describe("DataTable", () => {
   it("keeps the detail panel attached through row reorders, removal, and return", async () => {
     // The host <tr> lives outside react-aria's collection, so react's row
     // reconciliation (sorting, filtering, pagination) must not strand or
-    // duplicate it: the insert effect re-runs on row changes and its cleanup
-    // removes the host when the target row disappears.
+    // duplicate it: the insert effect re-runs on row changes and detaches the
+    // host when the target row disappears.
     const renderDetail = (r: Row) => <div>{`detail for ${r.name}`}</div>;
     const detailFor = (name: string) =>
       screen.getByRole("row", { name: new RegExp(name) }).nextElementSibling?.textContent ?? null;
@@ -318,6 +318,37 @@ describe("DataTable", () => {
     await waitFor(() => expect(screen.getByText("detail for Bravo")).toBeInTheDocument());
     expect(document.querySelector(".otari-detail-row")).toBe(host);
     expect(mounts).toBe(1);
+  });
+
+  it("remounts the detail panel when it jumps to a different row", async () => {
+    // The other half of the poll fix: the host node is stable now, so nothing
+    // else stops the panel being reconciled across a jump from one row to the
+    // next (clicking another row while one is open, no close in between). A
+    // panel that seeds state from its row at mount, as RouterReadiness does
+    // with its user picker, would then narrate the new row with the old row's
+    // state.
+    let mounts = 0;
+    function Panel({ row }: { row: Row }) {
+      const [seeded] = useState(row.name);
+      useEffect(() => {
+        mounts += 1;
+      }, []);
+      return <div>{`detail for ${row.name}, seeded from ${seeded}`}</div>;
+    }
+    const renderDetail = (r: Row) => <Panel row={r} />;
+
+    const { rerender } = render(<DataTable {...base({ detailKey: "b", renderDetail })} />);
+    await waitFor(() => expect(screen.getByText(/detail for Bravo/)).toBeInTheDocument());
+
+    rerender(<DataTable {...base({ detailKey: "c", renderDetail })} />);
+    await waitFor(() => expect(screen.getByText(/detail for Charlie/)).toBeInTheDocument());
+    expect(screen.getByText("detail for Charlie, seeded from Charlie")).toBeInTheDocument();
+    expect(mounts).toBe(2);
+    // Still one host, now sitting under the row it belongs to.
+    expect(document.querySelectorAll(".otari-detail-row")).toHaveLength(1);
+    expect(document.querySelector('tbody tr[data-key="c"]')?.nextSibling).toBe(
+      document.querySelector(".otari-detail-row"),
+    );
   });
 
   it("still fires onRowAction on a row click while a selection is active", async () => {

--- a/web/src/components/DataTable.test.tsx
+++ b/web/src/components/DataTable.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { Selection, SortDescriptor } from "react-aria-components";
 import { describe, expect, it, vi } from "vitest";
 
@@ -291,6 +291,33 @@ describe("DataTable", () => {
     rerender(<DataTable {...base({ detailKey: "b", renderDetail })} />);
     await waitFor(() => expect(detailFor("Bravo")).toContain("detail for Bravo"));
     expect(document.querySelectorAll(".otari-detail-row")).toHaveLength(1);
+  });
+
+  it("keeps the open detail panel mounted when the rows array is rebuilt unchanged", async () => {
+    // Regression (activity pane): the in-flight poll rebuilds the rows array
+    // every 2s with the same row objects in it. Re-inserting the host on that
+    // re-render remounted the panel, replaying its open animation and resetting
+    // any state inside it, so an expanded row flashed and re-opened on a timer
+    // for as long as the operator watched a request run.
+    let mounts = 0;
+    function Panel({ row }: { row: Row }) {
+      useEffect(() => {
+        mounts += 1;
+      }, []);
+      return <div>{`detail for ${row.name}`}</div>;
+    }
+    const renderDetail = (r: Row) => <Panel row={r} />;
+
+    const { rerender } = render(<DataTable {...base({ detailKey: "b", renderDetail })} />);
+    await waitFor(() => expect(screen.getByText("detail for Bravo")).toBeInTheDocument());
+    const host = document.querySelector(".otari-detail-row");
+    expect(mounts).toBe(1);
+
+    // Same rows, new array: what a poll that changed nothing produces.
+    rerender(<DataTable {...base({ rows: [...ROWS], detailKey: "b", renderDetail })} />);
+    await waitFor(() => expect(screen.getByText("detail for Bravo")).toBeInTheDocument());
+    expect(document.querySelector(".otari-detail-row")).toBe(host);
+    expect(mounts).toBe(1);
   });
 
   it("still fires onRowAction on a row click while a selection is active", async () => {

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -426,7 +426,14 @@ export function DataTable<Row extends object>({
       </Container>
       {detailHost && detailRow && renderDetail
         ? createPortal(
-            <div className="otari-detail-reveal">
+            // Keyed by the row it belongs to. The host node is stable now, so
+            // without this the panel would be reconciled across a jump from one
+            // row to another and keep the previous row's state (RouterReadiness
+            // seeds its user picker from its props once, at mount). A poll that
+            // rebuilds `rows` leaves detailKey alone, so the fix above still
+            // holds: only a different row remounts, which is also what replays
+            // the reveal animation under the newly opened row.
+            <div key={detailKey} className="otari-detail-reveal">
               <div>{renderDetail(detailRow)}</div>
             </div>,
             detailHost,

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -180,27 +180,47 @@ export function DataTable<Row extends object>({
     [detailKey, renderDetail, rows, getRowKey],
   );
 
-  // Host <tr> management: find the target row by its data-key and insert the
+  // The portal host, built once per table and reused. Identity has to survive
+  // the effect below re-running, which it does on every row change: a fresh
+  // element each time re-points the portal, and React answers that by
+  // unmounting the panel and mounting it again into the new node. That replays
+  // the reveal animation and throws away whatever state the panel held. The
+  // activity page hands this component a rebuilt rows array every two seconds
+  // while it polls for in-flight requests, so an expanded row sat there
+  // flashing and re-opening on a timer for as long as a request was running.
+  const hostRef = useRef<{ row: HTMLTableRowElement; cell: HTMLTableCellElement } | null>(null);
+  const ensureHost = () => {
+    if (!hostRef.current) {
+      const row = document.createElement("tr");
+      row.className = "otari-detail-row";
+      // Out of the grid semantics: without this the host is an implicit ARIA row
+      // with the detail text as its name, confusing row counts and name lookups.
+      // Its content stays in the accessibility tree as ordinary elements.
+      row.setAttribute("role", "presentation");
+      const cell = document.createElement("td");
+      row.appendChild(cell);
+      hostRef.current = { row, cell };
+    }
+    return hostRef.current;
+  };
+
+  // Host <tr> management: find the target row by its data-key and position the
   // host right after it. react-aria commits its real rows in a second render
   // pass, so the target may not exist yet when this effect first runs (e.g.
   // mounting with a detailKey already set); the MutationObserver finishes the
-  // insertion as soon as the row appears. The deps re-run it (re-inserting at
-  // the right spot) whenever the row set, order, or target changes, and
-  // cleanup always removes the host, so a vanished target (filtered out, page
-  // flipped) leaves nothing behind.
+  // insertion as soon as the row appears. The deps re-run it (re-positioning
+  // the host) whenever the row set, order, or target changes, and the host is
+  // detached as soon as there is no target to sit under, so a vanished target
+  // (filtered out, page flipped) leaves nothing behind.
   useLayoutEffect(() => {
-    setDetailHost(null);
     const root = rootRef.current;
-    if (!root || detailKey == null || !detailRow) return;
-    const hostRow = document.createElement("tr");
-    hostRow.className = "otari-detail-row";
-    // Out of the grid semantics: without this the host is an implicit ARIA row
-    // with the detail text as its name, confusing row counts and name lookups.
-    // Its content stays in the accessibility tree as ordinary elements.
-    hostRow.setAttribute("role", "presentation");
-    const hostCell = document.createElement("td");
+    if (!root || detailKey == null || !detailRow) {
+      hostRef.current?.row.remove();
+      setDetailHost(null);
+      return;
+    }
+    const { row: hostRow, cell: hostCell } = ensureHost();
     hostCell.colSpan = columnCount;
-    hostRow.appendChild(hostCell);
 
     const tryInsert = (): boolean => {
       const target = root.querySelector(`tbody tr[data-key="${CSS.escape(detailKey)}"]`);
@@ -208,7 +228,10 @@ export function DataTable<Row extends object>({
       // The optimistic "opening" highlight has served its purpose once the
       // panel actually lands.
       for (const el of root.querySelectorAll(".otari-detail-opening")) el.classList.remove("otari-detail-opening");
-      target.after(hostRow);
+      // Only move it when it is not already there. Re-inserting an attached
+      // node detaches and re-attaches its subtree, which cancels and restarts
+      // the reveal animation running inside it.
+      if (target.nextSibling !== hostRow) target.after(hostRow);
       setDetailHost(hostCell);
       return true;
     };
@@ -223,11 +246,13 @@ export function DataTable<Row extends object>({
       });
       observer.observe(root, { childList: true, subtree: true });
     }
-    return () => {
-      observer?.disconnect();
-      hostRow.remove();
-    };
+    return () => observer?.disconnect();
   }, [detailKey, detailRow, columnCount, rows, sortDescriptor]);
+
+  // Detach on unmount. Deliberately not part of the effect above, whose cleanup
+  // runs on every dependency change: removing the host there is what made a
+  // re-render remount the panel.
+  useEffect(() => () => hostRef.current?.row.remove(), []);
 
   // Row activation with instant acknowledgment: the detail panel can only land
   // after react-aria's O(rows) interaction render (~1.6 ms/row), so the clicked

--- a/web/src/pages/ActivityPage.test.tsx
+++ b/web/src/pages/ActivityPage.test.tsx
@@ -1473,6 +1473,39 @@ describe("ActivityPage in-flight rows", () => {
     expect(within(row).getAllByText("—").length).toBeGreaterThan(0);
   });
 
+  it("leaves an expanded row alone while it polls for in-flight requests", async () => {
+    // Regression: the poll runs every 2s and its result re-derived the live
+    // rows, so the table got a rebuilt rows array on a timer. DataTable rebuilt
+    // its detail host to match, which remounted the panel: an operator who
+    // expanded a row while a request was running watched it flash and slide
+    // open again every couple of seconds.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      const { calls } = mockApi({
+        rows: [entry({ id: "settled-1" })],
+        inFlight: { requests: [inFlightRequest()], total: 1 },
+      });
+      renderPage(<ActivityPage />, "/activity?range=24h");
+
+      const row = (await screen.findByText("gpt-4o")).closest("tr")!;
+      await user.click(row);
+      const panel = screen.getByText("Request detail").closest(".otari-detail-row");
+      expect(panel).not.toBeNull();
+
+      const polls = () => calls.filter((c) => c.url.includes("/v1/usage/in-flight")).length;
+      const before = polls();
+      await vi.advanceTimersByTimeAsync(5_000);
+      await waitFor(() => expect(polls()).toBeGreaterThan(before + 1));
+
+      // Same node, still open: the panel was never torn down and rebuilt.
+      expect(screen.getByText("Request detail").closest(".otari-detail-row")).toBe(panel);
+      expect(document.querySelectorAll(".otari-detail-row")).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("adds no row while the gateway is idle", async () => {
     mockApi({ rows: [entry()], inFlight: { requests: [], total: 0 } });
     renderPage(<ActivityPage />, "/activity?range=24h");


### PR DESCRIPTION
## Description

Expanding a row in the Activity pane while a request is running made that row flash and slide open again every couple of seconds.

`DataTable` puts its inline detail panel in a portal host `<tr>` inserted next to the target row. The layout effect that does the insertion lists `rows` in its deps and its cleanup always removed the host, so every re-run built a fresh `<tr>`/`<td>` and re-pointed the portal at it. React answers that by unmounting the panel and mounting it into the new node, which replays the 180ms reveal animation and drops the panel's state (including the routing-plan lookup). The activity page polls for in-flight requests every 2s and hands the table a rebuilt rows array each time, so this fired on a timer for as long as a request was running.

The host is now built once and held in a ref, so the portal target survives the effect re-running. The effect only repositions it, and only when it is not already in place: re-inserting an attached node detaches and re-attaches its subtree, which cancels and restarts the animation inside it. Detaching moved out of the effect cleanup into the no-target branch plus a mount-scoped effect, so a vanished target (filtered out, page flipped) still leaves nothing behind.

No change to the in-flight polling itself. I checked whether the 2s rows-array churn was worth stabilizing and it is not: react-aria caches rendered rows on the row object, so a new-but-equal array costs zero cell re-renders and the same wall time as a stable one.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None filed; reported directly.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Notes on the checklist: this is a dashboard-only change, so the relevant checks are `npm --prefix web run typecheck` (clean) and `npm --prefix web test` (577 passing). Two regression tests were added, both of which fail on `main`: a unit test in `DataTable.test.tsx` that a no-op rows rebuild must not remount the panel, and a page-level test in `ActivityPage.test.tsx` that expands a row with a request in flight and advances past two polls. No user-facing behavior is documented for this, no API contract changed, so no docs or OpenAPI regeneration were needed.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via the Claude Code CLI.

**AI Model/Tool details:**

The root cause analysis, the fix, and both regression tests were produced by the model through back-and-forth with @njbrake. The prose here is the model's; the direction and the decisions are his. One suggested extra change (memoizing the in-flight rows to stop the 2s array churn) was measured, found to buy nothing, and dropped at his call, so the diff is only the actual fix.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Kept expanded detail panels mounted when table rows update.
- Removed detail-panel hosts when the target row disappears or the table unmounts.
- Remounted the panel when users switch to a different row.
- Added regression tests for row updates and activity polling.

## Benefit

Expanded activity panels now keep their state and DOM node during polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->