### PR TITLE
fix(chat): forward service_tier to the provider instead of dropping it

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -445,7 +445,7 @@
         "type": "object"
       },
       "ChatCompletionRequest": {
-        "description": "OpenAI-compatible chat completion request.\n\nThe completion-param fields are derived from any-llm's ``CompletionParams``\n(see ``_schema_derive``) so the schema cannot silently drop a param any-llm\nforwards. Fields below either tighten a derived field (``messages``,\n``response_format``) or add gateway-internal behavior (``mcp_servers``,\n``mcp_server_ids``, ``guardrails``, ``tools_header``, ``max_tool_iterations``)\nthat is stripped before the request is forwarded upstream.",
+        "description": "OpenAI-compatible chat completion request.\n\nThe completion-param fields are derived from any-llm's ``CompletionParams``\n(see ``_schema_derive``) so the schema cannot silently drop a param any-llm\nforwards. Fields below either tighten a derived field (``messages``,\n``response_format``), declare an OpenAI wire param ``CompletionParams`` does\nnot model (``service_tier``, forwarded as an any-llm ``**kwargs`` param), or\nadd gateway-internal behavior (``mcp_servers``, ``mcp_server_ids``,\n``guardrails``, ``tools_header``, ``max_tool_iterations``) that is stripped\nbefore the request is forwarded upstream.",
         "properties": {
           "frequency_penalty": {
             "anyOf": [
@@ -652,6 +652,17 @@
               }
             ],
             "title": "Seed"
+          },
+          "service_tier": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Service Tier"
           },
           "session_label": {
             "anyOf": [

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -90,10 +90,14 @@ class ChatCompletionRequest(derive_request_base(CompletionParams)):  # type: ign
     # provider call. Declared here so it survives ``model_dump`` and rides
     # any-llm's ``**kwargs`` passthrough into the provider request. Left as a
     # free-form string rather than an enum: the tier vocabulary is
-    # provider-specific ("flex"/"priority"/"scale" on OpenAI,
-    # "standard_only"/"priority" on Anthropic) and grows independently of this
+    # provider-specific ("auto"/"default"/"flex"/"scale"/"priority" on OpenAI,
+    # "auto"/"standard_only" on Anthropic) and grows independently of this
     # gateway, so the provider is the right place to reject an unknown value.
     # ``ResponsesParams`` already declares it, so /v1/responses never had the gap.
+    #
+    # Stopgap: remove this declaration once ``CompletionParams`` models the param
+    # and the SDK pin is bumped (mozilla-ai/any-llm#1269, tracked in #565). Until
+    # then it also shadows whatever annotation any-llm picks for it.
     service_tier: str | None = None
 
     @field_validator("messages")

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -70,9 +70,11 @@ class ChatCompletionRequest(derive_request_base(CompletionParams)):  # type: ign
     The completion-param fields are derived from any-llm's ``CompletionParams``
     (see ``_schema_derive``) so the schema cannot silently drop a param any-llm
     forwards. Fields below either tighten a derived field (``messages``,
-    ``response_format``) or add gateway-internal behavior (``mcp_servers``,
-    ``mcp_server_ids``, ``guardrails``, ``tools_header``, ``max_tool_iterations``)
-    that is stripped before the request is forwarded upstream.
+    ``response_format``), declare an OpenAI wire param ``CompletionParams`` does
+    not model (``service_tier``, forwarded as an any-llm ``**kwargs`` param), or
+    add gateway-internal behavior (``mcp_servers``, ``mcp_server_ids``,
+    ``guardrails``, ``tools_header``, ``max_tool_iterations``) that is stripped
+    before the request is forwarded upstream.
     """
 
     messages: list[dict[str, Any]] = Field(min_length=1)
@@ -82,6 +84,17 @@ class ChatCompletionRequest(derive_request_base(CompletionParams)):  # type: ign
     # any-llm types ``stream`` as ``bool | None``; keep the OpenAI wire contract
     # (a non-nullable boolean defaulting to false) for stable SDK generation.
     stream: bool = False
+    # Part of the OpenAI chat wire contract, but absent from any-llm's
+    # ``CompletionParams``, so derivation cannot supply it and the derived base
+    # (pydantic's default ``extra="ignore"``) dropped a caller's value before the
+    # provider call. Declared here so it survives ``model_dump`` and rides
+    # any-llm's ``**kwargs`` passthrough into the provider request. Left as a
+    # free-form string rather than an enum: the tier vocabulary is
+    # provider-specific ("flex"/"priority"/"scale" on OpenAI,
+    # "standard_only"/"priority" on Anthropic) and grows independently of this
+    # gateway, so the provider is the right place to reject an unknown value.
+    # ``ResponsesParams`` already declares it, so /v1/responses never had the gap.
+    service_tier: str | None = None
 
     @field_validator("messages")
     @classmethod

--- a/tests/integration/test_provider_kwargs_override.py
+++ b/tests/integration/test_provider_kwargs_override.py
@@ -212,3 +212,91 @@ async def test_completion_params_reach_provider(
     assert captured_kwargs, f"acompletion was never called (status {response.status_code})"
     for name, value in params.items():
         assert captured_kwargs.get(name) == value, f"{name} was dropped before the provider call"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+async def test_service_tier_reaches_provider(
+    client_with_model_in_provider: TestClient,
+    stream: bool,
+) -> None:
+    """``service_tier`` must reach ``acompletion``, streaming or not.
+
+    It is part of the OpenAI chat wire contract but absent from any-llm's
+    ``CompletionParams``, so derivation cannot supply it: the derived base ignores
+    unknown fields, and a caller's tier was silently dropped while the provider's
+    own ``service_tier`` still came back on the response, making the request look
+    honored. ``ChatCompletionRequest`` declares the field by hand for that reason,
+    so this guards the hand-declared path the derivation guard cannot cover.
+    """
+    captured_kwargs: dict[str, Any] = {}
+
+    async def mock_acompletion(**kwargs: Any) -> None:
+        captured_kwargs.update(kwargs)
+        raise _MockCompletionError
+
+    master_key_header = {API_KEY_HEADER: "Bearer test-master-key"}
+
+    create_user = client_with_model_in_provider.post(
+        "/v1/users",
+        json={"user_id": "test-user", "alias": "Test User"},
+        headers=master_key_header,
+    )
+    assert create_user.status_code == 200
+
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
+        response = client_with_model_in_provider.post(
+            "/v1/chat/completions",
+            json={
+                "model": "openai:gpt-4",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "user": "test-user",
+                "service_tier": "flex",
+                "stream": stream,
+            },
+            headers=master_key_header,
+        )
+
+    assert captured_kwargs, f"acompletion was never called (status {response.status_code})"
+    assert captured_kwargs.get("service_tier") == "flex", "service_tier was dropped before the provider call"
+
+
+@pytest.mark.asyncio
+async def test_unset_service_tier_does_not_reach_provider(
+    client_with_model_in_provider: TestClient,
+) -> None:
+    """An unset ``service_tier`` stays out of the kwargs rather than forcing a null.
+
+    ``exclude_unset=True`` covers this for every derived field; the hand-declared
+    one has to hold the same line, or every request would pin the provider (and
+    every OpenAI-compatible upstream that rejects a null tier) to an explicit
+    ``service_tier=None``.
+    """
+    captured_kwargs: dict[str, Any] = {}
+
+    async def mock_acompletion(**kwargs: Any) -> None:
+        captured_kwargs.update(kwargs)
+        raise _MockCompletionError
+
+    master_key_header = {API_KEY_HEADER: "Bearer test-master-key"}
+
+    create_user = client_with_model_in_provider.post(
+        "/v1/users",
+        json={"user_id": "test-user", "alias": "Test User"},
+        headers=master_key_header,
+    )
+    assert create_user.status_code == 200
+
+    with patch("gateway.api.routes.chat.acompletion", new=mock_acompletion):
+        response = client_with_model_in_provider.post(
+            "/v1/chat/completions",
+            json={
+                "model": "openai:gpt-4",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "user": "test-user",
+            },
+            headers=master_key_header,
+        )
+
+    assert captured_kwargs, f"acompletion was never called (status {response.status_code})"
+    assert "service_tier" not in captured_kwargs


### PR DESCRIPTION
## Description

`service_tier` is part of the OpenAI chat wire contract but absent from
any-llm's `CompletionParams`, which `ChatCompletionRequest` derives its
field set from. The derived base uses pydantic's default `extra="ignore"`,
so a caller's tier validated fine and then vanished before the provider
call; meanwhile the provider's own `service_tier` still came back on the
response, so the request looked honored when it was not.

Declare the field by hand so it survives `model_dump(exclude_unset=True)`
and rides any-llm's `**kwargs` passthrough into the provider request
(`acompletion` forwards unknown kwargs to the provider API call, and both
the OpenAI and Anthropic SDKs accept `service_tier`). `/v1/responses` never
had the gap: `ResponsesParams` declares the param already.

Typed as a free-form string rather than an enum because the tier vocabulary
is provider-specific and grows independently of this gateway, so the
provider is the right place to reject an unknown value.



## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None.

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

`make lint`, `make typecheck` and the full `pytest tests/unit tests/integration` run are green (2708 passed, 10 skipped). The request schema gained a field, so `docs/public/openapi.json` was regenerated; `make openapi-check` and `make postman-check` pass.

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5, via Claude Code.

**Any additional AI details you'd like to share:**

The change was written and validated with Claude Code. It was previously part of a
longer branch of mine; that branch has been rebased onto current `main` and split so
each PR carries one self-contained change, reviewable on its own.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Preserve `service_tier` in chat requests and forward it to providers when set. Providers can validate their supported tier values.

## Testing

Added coverage for streaming and non-streaming requests, including requests without `service_tier`. Regenerated OpenAPI documentation and confirmed all required checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->