### PR TITLE
fix(models): tolerate a provider that reports no model `created`

### DIFF
--- a/src/gateway/api/routes/models.py
+++ b/src/gateway/api/routes/models.py
@@ -2,7 +2,7 @@
 
 import calendar
 from collections.abc import Sequence
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
@@ -37,6 +37,9 @@ from gateway.services.pricing_service import (
     normalize_effective_at,
 )
 from gateway.services.provider_kwargs import normalize_pricing_key
+
+if TYPE_CHECKING:
+    from any_llm.types.model import Model
 
 router = APIRouter(prefix="/v1", tags=["models"])
 
@@ -85,6 +88,21 @@ def _owner_from_key(model_key: str) -> str:
     """The provider a ``provider:model`` key names, or "unknown" for a bare name."""
     provider, separator, _ = model_key.partition(":")
     return provider if separator else "unknown"
+
+
+def _created_timestamp(model: "Model") -> int:
+    """A discovered model's creation timestamp, or 0 when the provider omits one.
+
+    ``Model.created`` is typed ``int`` but the OpenAI SDK builds response models
+    without validation, so an OpenAI-compatible provider that reports ``null``
+    (or a non-numeric value) reaches us as-is. Falling back to 0 matches what the
+    other catalog phases publish for models with no known creation time; raising
+    here would fail the whole listing over one provider's payload.
+    """
+    try:
+        return int(model.created)
+    except (TypeError, ValueError):
+        return 0
 
 
 def _context_window_for_key(model_key: str) -> int | None:
@@ -462,7 +480,7 @@ async def list_models(
             pricing = pricing_map.pop(model_key, None)
             merged[model_key] = ModelObject(
                 id=model_key,
-                created=model.created,
+                created=_created_timestamp(model),
                 owned_by=provider_name,
                 pricing=ModelPricingInfo(
                     input_price_per_million=pricing.input_price_per_million,
@@ -714,7 +732,7 @@ async def get_model(
         model_key = f"{discovered_provider}:{discovered_model.id}"
         obj = ModelObject(
             id=model_key,
-            created=discovered_model.created,
+            created=_created_timestamp(discovered_model),
             owned_by=discovered_provider,
             pricing=ModelPricingInfo(
                 input_price_per_million=pricing.input_price_per_million,

--- a/tests/integration/test_model_discovery.py
+++ b/tests/integration/test_model_discovery.py
@@ -413,6 +413,59 @@ def test_list_models_discovery_error_graceful(
     assert resp.json()["object"] == "list"
 
 
+def test_list_models_tolerates_a_provider_without_created(
+    discovery_client: TestClient,
+    discovery_master_header: dict[str, str],
+) -> None:
+    """A provider reporting no ``created`` must not fail the whole listing.
+
+    ``Model.created`` is typed ``int`` but the OpenAI SDK builds response models
+    without validation, so an OpenAI-compatible provider answering ``null`` gets
+    that far. Constructing the ModelObject used to raise and 500 the endpoint.
+    """
+    from any_llm.types.model import Model
+
+    fake_models = [
+        Model.construct(id="local-model", object="model", created=None, owned_by="openai"),
+        Model(**_make_openai_model("gpt-4o")),
+    ]
+
+    with (
+        patch(
+            "gateway.services.model_discovery_service._supports_list_models",
+            return_value=True,
+        ),
+        patch(
+            "gateway.services.model_discovery_service.alist_models",
+            new_callable=AsyncMock,
+            return_value=fake_models,
+        ),
+    ):
+        resp = discovery_client.get("/v1/models", headers=discovery_master_header)
+
+    assert resp.status_code == 200
+    by_id = {m["id"]: m for m in resp.json()["data"]}
+    assert by_id["openai:local-model"]["created"] == 0
+    assert by_id["openai:gpt-4o"]["created"] == 1700000000
+
+
+def test_get_model_tolerates_a_provider_without_created(
+    discovery_client: TestClient,
+    discovery_master_header: dict[str, str],
+) -> None:
+    """The same missing ``created`` must not fail GET /v1/models/{id}."""
+    from any_llm.types.model import Model
+
+    get_model_cache().set(
+        "openai",
+        [Model.construct(id="local-model", object="model", created=None, owned_by="openai")],
+    )
+
+    resp = discovery_client.get("/v1/models/openai:local-model", headers=discovery_master_header)
+    assert resp.status_code == 200
+    assert resp.json()["created"] == 0
+
+
 def test_get_model_from_discovery_cache(
     discovery_client: TestClient,
     discovery_master_header: dict[str, str],


### PR DESCRIPTION
## Description

`Model.created` is typed `int`, but the OpenAI SDK builds response models with
`construct_type` and no validation, so an OpenAI-compatible provider answering
`"created": null` reaches the route as `None`. Passing that into `ModelObject`
raised a pydantic `ValidationError`, so one such model turned the whole
`GET /v1/models` listing into a 500 (same for `GET /v1/models/{id}`). Local
OpenAI-compatible servers are the common source: several omit `created`
entirely or send `null`.

Coerce through `_created_timestamp()`, falling back to 0 as the other catalog
phases already do for models with no known creation time. Raising here would
fail an entire listing over one provider's payload, and `created` is
informational in this response, so degrading that single field is the
proportionate response. The helper catches `TypeError`/`ValueError`, which
also covers a non-numeric value arriving by the same unvalidated path.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None.

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

`make lint` and `make typecheck` are green, as is the full `pytest tests/unit tests/integration` run (2707 passed, 10 skipped). New integration coverage in `tests/integration/test_model_discovery.py` pins both routes: a provider reporting `created: null` now lists alongside a well-formed model and reports `created: 0` instead of 500ing. No schema or route signature changed, so the OpenAPI spec is untouched.

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5, via Claude Code.

**Any additional AI details you'd like to share:**

The change was written and validated with Claude Code, on a branch off current `main`
carrying this one self-contained fix.

- [x] I am an AI Agent filling out this form (check box if true)
