### PR TITLE
docs(pipeline): clarify that hybrid mode still routes

### DIFF
--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -1019,8 +1019,11 @@ async def resolve_request_context(
         # mode sends the caller's selector straight upstream (config aliases are
         # already inert here for the same reason), so a policy name would reach
         # the platform as an unknown model and come back as a confusing upstream
-        # 404. Routing policies are standalone-only until the platform protocol
-        # carries them.
+        # 404. What is standalone-only is this gateway's own policies, the ones
+        # under `routing.policies` in config.yml. Hybrid mode still routes: the
+        # platform owns the decision there, and its resolve response carries the
+        # outcome as an ordered ``attempts`` list plus ``fallback_enabled`` for
+        # ``run_platform_attempts`` to walk.
         if model in config.policy_names():
             raise adapter.error(400, policy_in_hybrid_mode_detail(model), ErrorKind.INVALID_REQUEST)
         user_token = _extract_platform_user_token(raw_request)


### PR DESCRIPTION
## Description

The comment on the hybrid-mode policy-name gate in `resolve_request_context` read:

> Routing policies are standalone-only until the platform protocol carries them.

The platform protocol does carry them. `GatewayResolveResponse` returns an ordered `attempts` list plus `fallback_enabled`, and `run_platform_attempts` walks it, so a hybrid-mode request can fan out across several candidates with fallback exactly as a standalone routed request does.

What is actually standalone-only is this gateway's own `routing.policies` config, which is precisely what the gate rejects (`model in config.policy_names()`). The gate is correct; only the explanation was wrong.

Read as written, the comment says hybrid mode has no routing at all. That is misleading in a specific way: it sends you looking for hybrid-mode per-attempt behaviour on the standalone side, where `CompiledPlan`, `RoutingAttribution`, and the `absorbed` row status live, none of which are ever populated in hybrid mode. It cost real time during a design review in otari-ai, which is what prompted this.

Comment text only. No behaviour change, no API change.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None. Fallout from the v0 observation-schema review in mozilla-ai/otari-ai#1482.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). Not applicable: comment text only, no behaviour to cover.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). `make lint` and `make typecheck` pass. I did not run `make test`, which needs a PostgreSQL container; nothing executable changed.
- [x] Documentation was updated where necessary. This change is the documentation.
- [ ] If the API contract changed, I regenerated the OpenAPI spec. Not applicable: an inline comment inside a helper, not a route docstring, so it does not reach the spec or the Postman collection.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

The stale comment was found because it misled the model during a schema review on otari-ai#1482: it was cited as evidence that hybrid mode has no routing, a reviewer caught it, and this PR fixes the source of the confusion. Every claim in the replacement text was checked against the code at `ee2aadd`.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Clarified hybrid-mode routing behavior in an inline comment.
- Documented that platform routing supports ordered attempts and fallback behavior.
- Clarified that `routing.policies` applies only to standalone mode.
- No runtime or API behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->