### PR TITLE
fix(dashboard): fit the share card's hero to its value and rebuild the wide layout

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -254,7 +254,9 @@ gateway.
   `otari.ai:fireworks/accounts/deepseek-v4-flash` reads as `deepseek-v4-flash`. A
   spend figure is marked with an asterisk whenever the window holds requests with
   no configured price, and a stat the window has no value for is left off rather
-  than published as a dash. Copy the image straight to the clipboard, or download
+  than published as a dash. From $100 up, a spend figure on the card is rounded to
+  whole dollars: at the size the lead figure is set, the cents cost more width than
+  they carry. The page's own tiles and tables keep them. Copy the image straight to the clipboard, or download
   it; copying needs a secure (https) origin, so on a plain-HTTP LAN address only
   the download is offered.
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -256,9 +256,9 @@ gateway.
   no configured price, and a stat the window has no value for is left off rather
   than published as a dash. From $100 up, a spend figure on the card is rounded to
   whole dollars: at the size the lead figure is set, the cents cost more width than
-  they carry. The page's own tiles and tables keep them. Copy the image straight to the clipboard, or download
-  it; copying needs a secure (https) origin, so on a plain-HTTP LAN address only
-  the download is offered.
+  they carry. The page's own tiles and tables keep them. Copy the image straight
+  to the clipboard, or download it; copying needs a secure (https) origin, so on a
+  plain-HTTP LAN address only the download is offered.
 
 ### Copying ids
 

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -260,8 +260,11 @@ test.describe("dashboard core flows", () => {
     // Every row count must render in both shapes: the frame is fixed, so the rows
     // divide a height budget, and a band collapsing to zero is the regression.
     // Width is checked too, and for the same reason: a wide card once set its hero
-    // at the square card's size, which ran the number off both edges of the frame
-    // and printed it over the model rows. Only scrollWidth showed that.
+    // at the square card's size, which ran the number off both edges of the frame.
+    // This seed cannot reproduce that on its own (it prices nothing, so the hero is
+    // a two-digit request count), and the unit suite covers the sizing itself; the
+    // check is here so any future arrangement that spills sideways is caught in the
+    // one place the card is measured after a real layout.
     for (const shape of ["Square", "Wide"]) {
       await dialog.getByRole("button", { name: shape }).click();
       for (const rows of ["1", "9"]) {

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -259,6 +259,9 @@ test.describe("dashboard core flows", () => {
 
     // Every row count must render in both shapes: the frame is fixed, so the rows
     // divide a height budget, and a band collapsing to zero is the regression.
+    // Width is checked too, and for the same reason: a wide card once set its hero
+    // at the square card's size, which ran the number off both edges of the frame
+    // and printed it over the model rows. Only scrollWidth showed that.
     for (const shape of ["Square", "Wide"]) {
       await dialog.getByRole("button", { name: shape }).click();
       for (const rows of ["1", "9"]) {
@@ -270,9 +273,10 @@ test.describe("dashboard core flows", () => {
           if (node === null) {
             return { heights: [] as number[], overflows: false, missing: true };
           }
+          const box = node.getBoundingClientRect();
           return {
             heights: Array.from(node.children).map((c) => Math.round(c.getBoundingClientRect().height)),
-            overflows: node.scrollHeight > Math.round(node.getBoundingClientRect().height),
+            overflows: node.scrollHeight > Math.round(box.height) || node.scrollWidth > Math.round(box.width),
             missing: false,
           };
         });

--- a/web/src/components/ShareCard.test.tsx
+++ b/web/src/components/ShareCard.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import type { CardStat } from "@/lib/shareCard";
 
-import { CARD_SIZES, ShareCard, truncateModel } from "./ShareCard";
+import { CARD_SIZES, ShareCard, emWidth, fitHeroSize, truncateModel } from "./ShareCard";
 
 function renderCard(overrides: Partial<Parameters<typeof ShareCard>[0]> = {}) {
   return render(
@@ -130,15 +130,70 @@ describe("ShareCard height budget", () => {
     expect(screen.getByText("1,204")).toBeInTheDocument();
   });
 
+  const heroPx = (container: HTMLElement) => {
+    const node = container.querySelector<HTMLElement>('[style*="font-weight: 700"]');
+    return Number.parseFloat(node?.style.fontSize ?? "");
+  };
+
   it("gives the hero less height when the list is long, since nothing else can yield", () => {
     const short = renderCard({ models: models(3) });
-    const shortHero = short.container.querySelector<HTMLElement>('[style*="font-size: 200px"]');
-    expect(shortHero).not.toBeNull();
+    const shortHero = heroPx(short.container);
     short.unmount();
 
     const long = renderCard({ models: models(9) });
-    expect(long.container.querySelector('[style*="font-size: 200px"]')).toBeNull();
-    expect(long.container.querySelector('[style*="font-size: 150px"]')).not.toBeNull();
+    expect(heroPx(long.container)).toBeLessThan(shortHero);
+  });
+
+  it("sizes the hero to the value, so a four-figure spend does not run off the card", () => {
+    // The bug this replaces: a fixed 200px hero put "$2,390.99" 23px past the edge
+    // of a square card, and clean off a wide one.
+    const short = renderCard({ hero: { id: "cost", label: "Spend", value: "$412" } });
+    const shortHero = heroPx(short.container);
+    short.unmount();
+
+    const long = renderCard({ hero: { id: "cost", label: "Spend", value: "$1,234,567.89" } });
+    const longHero = heroPx(long.container);
+    expect(longHero).toBeLessThan(shortHero);
+    expect(emWidth("$1,234,567.89") * longHero).toBeLessThanOrEqual(CARD_SIZES.square.width - 72 * 2);
+  });
+
+  it("keeps the wide card's hero inside its own column", () => {
+    const { container } = render(
+      <ShareCard
+        ratio="landscape"
+        theme="dark"
+        title="Where my tokens went"
+        scope="s"
+        hero={{ id: "cost", label: "Spend", value: "$2,390.99" }}
+        models={models(5)}
+        stats={[{ id: "requests", label: "Requests", value: "12,204" }]}
+      />,
+    );
+    // 400 is the hero column; the wide card lays the claim beside the rows, so a
+    // hero sized against the full card width would print over them.
+    expect(emWidth("$2,390.99") * heroPx(container)).toBeLessThanOrEqual(400);
+  });
+});
+
+describe("fitHeroSize", () => {
+  it("gives a short value the full cap", () => {
+    expect(fitHeroSize("$412", 936, 168)).toBe(168);
+  });
+
+  it("steps a long value down until it fits", () => {
+    const size = fitHeroSize("$1,234,567.89", 400, 120);
+    expect(size).toBeLessThan(120);
+    expect(emWidth("$1,234,567.89") * size).toBeLessThanOrEqual(400);
+  });
+
+  it("stops shrinking rather than letting the headline disappear", () => {
+    expect(fitHeroSize("$123,456,789,012,345", 400, 120)).toBe(56);
+  });
+
+  it("estimates within a few percent of the real thing", () => {
+    // Measured in Chromium at 200px: "$2,390.99" is 959px wide and "12,204" is 660.
+    expect(emWidth("$2,390.99") * 200).toBeCloseTo(959, -2);
+    expect(emWidth("12,204") * 200).toBeCloseTo(660, -2);
   });
 });
 

--- a/web/src/components/ShareCard.test.tsx
+++ b/web/src/components/ShareCard.test.tsx
@@ -130,6 +130,19 @@ describe("ShareCard height budget", () => {
     expect(screen.getByText("1,204")).toBeInTheDocument();
   });
 
+  it("reserves the title's second line before the estimator's own error can clip it", () => {
+    // The slot clips what it does not reserve, and emWidth undercounts prose by
+    // ~10% against the Arial-metric stacks the card falls back to. A 60-character
+    // title measures over one line of a wide card in those fonts, so a slot sized
+    // from the bare estimate published a title with its second line missing.
+    const title = "our whole team summer token spend, mostly on our own models";
+    const { container } = renderCard({ ratio: "landscape", title });
+    const slot = container.querySelector<HTMLElement>('[role="img"]')?.children[0] as HTMLElement;
+    // Two line boxes, plus the few pixels of ink slack the slot carries.
+    expect(Number.parseFloat(slot.style.height)).toBeGreaterThanOrEqual(2 * Math.round(36 * 1.2));
+    expect(Number.parseFloat(slot.style.height)).toBeLessThan(3 * Math.round(36 * 1.2));
+  });
+
   const heroPx = (container: HTMLElement) => {
     const node = container.querySelector<HTMLElement>('[style*="font-weight: 700"]');
     return Number.parseFloat(node?.style.fontSize ?? "");

--- a/web/src/components/ShareCard.tsx
+++ b/web/src/components/ShareCard.tsx
@@ -28,6 +28,65 @@ export type CardRatio = keyof typeof CARD_SIZES;
 /** Minimum type size at 1080 scale. Below this, the feed's downscale makes it noise. */
 const FLOOR_PX = 28;
 
+/**
+ * Approximate the width of `text`, in em, at the card's font.
+ *
+ * The card is rendered off-screen and rasterized in the same tick, so there is
+ * nothing to measure: a layout pass would have to happen between deciding the
+ * type size and drawing it. These per-class averages land within ~2% of Inter and
+ * of the system stacks it falls back to for the strings the card actually sets
+ * (formatted numbers, and a title of ordinary prose), which is enough to choose a
+ * size that fits. Callers add a safety factor rather than trusting it exactly.
+ */
+export function emWidth(text: string): number {
+  let em = 0;
+  for (const char of text) {
+    if (char === "," || char === "." || char === " " || char === "'" || char === "|") {
+      em += 0.28;
+    } else if (char === "-" || char === "*") {
+      em += 0.35;
+    } else if (char === "$") {
+      em += 0.58;
+    } else if (char >= "0" && char <= "9") {
+      em += 0.6;
+    } else if (char >= "A" && char <= "Z") {
+      em += 0.65;
+    } else if (char >= "a" && char <= "z") {
+      em += 0.52;
+    } else {
+      em += 0.6;
+    }
+  }
+  return em;
+}
+
+/**
+ * Twice the legibility floor: the point past which a value has stopped reading as
+ * the headline. It is set low enough that a value long enough to reach it still
+ * fits the narrower of the two frames, since a floor that clamps *up* into an
+ * overflow would reintroduce the bug this fitting exists to fix.
+ */
+const MIN_HERO = FLOOR_PX * 2;
+
+/**
+ * The largest type size at which `text` still fits `available` px, capped at `cap`.
+ *
+ * The hero is user data with no length bound: a hobby gateway's "$4.20" and a
+ * team's "1,204,881" go in the same slot. A single fixed size cannot serve both,
+ * and the one that was here (200px) put "$2,390.99" 23px past the edge of a square
+ * card and clean off a wide one. Size follows the value instead, so the cap is
+ * what a *short* value gets and a long one steps down from there.
+ */
+export function fitHeroSize(text: string, available: number, cap: number): number {
+  if (text.length === 0) {
+    return cap;
+  }
+  // 1.02 covers the estimator's error; MIN_HERO keeps a freak value legible rather
+  // than letting it shrink until it stops being the headline.
+  const fitted = Math.floor(available / (emWidth(text) * 1.02));
+  return Math.max(MIN_HERO, Math.min(cap, fitted));
+}
+
 /** Both palettes share this shape; `as const` alone would make them incompatible types. */
 export interface CardPalette {
   ground: string;
@@ -119,25 +178,69 @@ export function ShareCard(props: ShareCardProps) {
   const { width, height } = CARD_SIZES[ratio];
   const isLandscape = ratio === "landscape";
   const maxTokens = models.reduce((most, model) => Math.max(most, model.tokens), 0);
-  // The card is a fixed frame, so the row list has a fixed height budget and the
-  // rows divide it. Hard-coded row heights broke both ways: at three rows a square
-  // card left ~350px of blank space that read as a hole, and at nine rows the
-  // content overflowed and flex-shrink collapsed the title to zero height.
-  // Dividing a budget instead means every row count in the picker (1/3/5/9)
-  // renders, in both shapes, with the surplus staying ordinary margin.
+
+  // The two shapes are not one layout at two sizes. A wide card has 550px of usable
+  // height against a square card's 936, and the square's arrangement (hero, then
+  // rows, then a full-width stats band) needs about 800 of them, so the wide card
+  // ran its hero over the title above and its rows through the rule below. Wide
+  // splits into columns instead: the claim (hero plus its supporting stats) on the
+  // left, the evidence (the model rows) on the right, which gives the rows the
+  // whole middle height and gives the numbers a column narrow enough to size type
+  // against. Every constant below is one of the two shapes' real dimensions, and
+  // the row height is what is left after the fixed bands are subtracted, so a
+  // change to any of them moves the rows rather than silently overflowing.
+  const pad = isLandscape ? 40 : 72;
+  const contentWidth = width - pad * 2;
+  const contentHeight = height - pad * 2;
+  const bandGap = isLandscape ? 24 : 32;
+  const titleSize = isLandscape ? 36 : 40;
+  // Reserved rather than measured: the title is free text (up to 60 characters),
+  // and a slot that grew with it would push the hero down by a line. Two lines is
+  // the cap in both shapes; a wide card fits 60 characters on one.
+  const titleLines = Math.min(2, Math.max(1, Math.ceil((emWidth(title) * titleSize) / contentWidth)));
+  const titleSlot = titleLines * Math.round(titleSize * 1.2);
+  const footerSlot = 40;
+  /** The "tokens per model" caption plus the gap above it. */
+  const captionSlot = 42;
+
   const rowCount = Math.max(models.length, 1);
-  const rowsBudget = isLandscape ? 210 : 340;
+  const heroLabelSize = isLandscape ? 36 : 44;
+  // The wide card's hero column, sized so the widest supporting stat line
+  // ("$2,391  AVG LATENCY") still fits it.
+  const heroColumn = 400;
+  // A long list needs the hero to give up some height; nothing else on a square
+  // card can yield.
+  const heroCap = isLandscape ? 120 : rowCount > 5 ? 132 : 168;
+  const heroSize = fitHeroSize(hero?.value ?? "", isLandscape ? heroColumn : contentWidth, heroCap);
+  const heroBlock = Math.round(heroSize * 0.95) + 10 + Math.round(heroLabelSize * 1.1);
+
+  // Wide keeps its stats beside the hero, so only the square card spends a band on
+  // them. Both counts are subtracted here so the rows get exactly what is left.
+  const hasStatsBand = !isLandscape && stats.length > 0;
+  const statsBandHeight = hasStatsBand ? 2 + 32 + Math.round(64 * 1.05) + Math.round(FLOOR_PX * 1.2) : 0;
+  const bandCount = hasStatsBand ? 4 : 3;
+  const middleHeight = contentHeight - titleSlot - footerSlot - statsBandHeight - bandGap * (bandCount - 1);
+  // On a wide card the hero sits beside the rows and costs them no height at all.
+  const rowsArea = middleHeight - captionSlot - (isLandscape || hero === undefined ? 0 : heroBlock + 32);
+
   const rowGap = rowCount > 5 ? 8 : rowCount > 3 ? 12 : 18;
   // Floored at 34 so the 28px name still has room, capped so a single row does not
-  // become a band.
-  const rowHeight = Math.max(34, Math.min(isLandscape ? 40 : 56, Math.floor((rowsBudget - rowGap * (rowCount - 1)) / rowCount)));
-  // A long list needs the hero to give up some height; nothing else can yield.
-  // The 34px floor deliberately wins over rowsBudget: at nine rows the list needs
-  // 9*34 + 8*8 = 370px against a 340 budget, and the surplus comes out of the
-  // flexible middle block rather than shrinking a row below its own text. The e2e
-  // asserts no band collapses, which is what keeps that trade honest if heroSize
-  // or the padding ever moves.
-  const heroSize = rowCount > 5 ? 150 : 200;
+  // become a band. The floor deliberately wins over the budget: at the tightest
+  // combination the surplus comes out of the band gaps rather than shrinking a row
+  // below its own text. The e2e asserts no band collapses, which is what keeps that
+  // trade honest if these numbers ever move.
+  const rowHeight = Math.max(
+    34,
+    Math.min(isLandscape ? 44 : 56, Math.floor((rowsArea - rowGap * (rowCount - 1)) / rowCount)),
+  );
+  // The rows' fixed columns. Narrower on a wide card, where the row column is 680px
+  // rather than the square's 936 and the bar is what would otherwise vanish: it did,
+  // taking the token counts off the edge of the card with it.
+  const nameWidth = isLandscape ? 330 : 360;
+  const nameMax = isLandscape ? 22 : 28;
+  const valueWidth = isLandscape ? 100 : 120;
+  const rowInnerGap = isLandscape ? 16 : 20;
+
   // Only when a caveated stat is actually on the card, so the legend never
   // explains a mark the viewer cannot see.
   const showsCaveat = (hero?.caveated ?? false) || stats.some((stat) => stat.caveated);
@@ -148,6 +251,108 @@ export function ShareCard(props: ShareCardProps) {
         ? "* some requests unpriced"
         : undefined;
 
+  // On a wide card this column carries the whole claim: the hero and, under it,
+  // the stats a square card gives a band of its own.
+  const claimColumn = (
+    <div
+      style={{
+        // The fixed column is the hero's, so the empty state is not made to wrap
+        // inside a width chosen for a number that is not there.
+        flex: isLandscape && hero !== undefined ? `0 0 ${heroColumn}px` : "0 0 auto",
+        width: isLandscape && hero !== undefined ? heroColumn : undefined,
+      }}
+    >
+      {hero !== undefined ? (
+        <>
+          <div style={{ fontSize: heroSize, fontWeight: 700, lineHeight: 0.95 }}>{hero.value}</div>
+          <div
+            style={{ fontSize: heroLabelSize, fontWeight: 500, lineHeight: 1.1, color: palette.muted, marginTop: 10 }}
+          >
+            {hero.label}
+            {hero.caveated ? "*" : ""}
+          </div>
+        </>
+      ) : (
+        <div style={{ fontSize: 44, color: palette.muted }}>No usage in this range</div>
+      )}
+
+      {isLandscape && stats.length > 0 ? (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, marginTop: 28 }}>
+          {stats.map((stat) => (
+            <div key={stat.id} style={{ display: "flex", alignItems: "baseline", gap: 12 }}>
+              <span style={{ fontSize: 40, fontWeight: 600, lineHeight: 1.05 }}>
+                {stat.value}
+                {stat.caveated ? "*" : ""}
+              </span>
+              <span
+                style={{
+                  fontSize: FLOOR_PX,
+                  color: palette.muted,
+                  textTransform: "uppercase",
+                  letterSpacing: 1,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {stat.label}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+
+  const rowsColumn =
+    models.length === 0 ? null : (
+      <div
+        style={{
+          flex: isLandscape ? "1 1 0" : "0 0 auto",
+          minWidth: 0,
+          width: isLandscape ? undefined : "100%",
+          display: "flex",
+          flexDirection: "column",
+          gap: rowGap,
+        }}
+      >
+        {models.map((model) => (
+          <div
+            key={model.key ?? "__other__"}
+            data-share-row
+            style={{ display: "flex", alignItems: "center", gap: rowInnerGap, height: rowHeight }}
+          >
+            <span style={{ fontSize: FLOOR_PX, width: nameWidth, flexShrink: 0, whiteSpace: "nowrap" }}>
+              {truncateModel(model.label, nameMax)}
+            </span>
+            <span
+              style={{
+                flex: "1 1 0",
+                minWidth: 0,
+                height: Math.min(26, Math.round(rowHeight * 0.46)),
+                background: palette.track,
+                borderRadius: 13,
+              }}
+            >
+              <span
+                style={{
+                  display: "block",
+                  height: "100%",
+                  borderRadius: 10,
+                  width: maxTokens > 0 ? `${(model.tokens / maxTokens) * 100}%` : "0%",
+                  background: palette.bar,
+                }}
+              />
+            </span>
+            <span
+              style={{ fontSize: FLOOR_PX, color: palette.muted, width: valueWidth, flexShrink: 0, textAlign: "right" }}
+            >
+              {formatTokens(model.tokens)}
+            </span>
+          </div>
+        ))}
+        <div style={{ fontSize: FLOOR_PX, color: palette.muted }}>tokens per model</div>
+      </div>
+    );
+
   return (
     <div
       role="img"
@@ -155,83 +360,63 @@ export function ShareCard(props: ShareCardProps) {
       style={{
         width,
         height,
-        padding: 72,
+        padding: pad,
         boxSizing: "border-box",
         background: palette.ground,
         color: palette.ink,
         display: "flex",
         flexDirection: "column",
-        gap: 40,
+        gap: bandGap,
         fontFamily: "'Inter', system-ui, sans-serif",
       }}
     >
       {/* Fixed-height title slot so a one- or two-line title never shifts the
           hero below it. */}
-      <div style={{ flexShrink: 0, maxHeight: 96, fontSize: 40, fontWeight: 600, lineHeight: 1.2, overflow: "hidden" }}>{title}</div>
+      <div
+        style={{
+          flexShrink: 0,
+          height: titleSlot,
+          fontSize: titleSize,
+          fontWeight: 600,
+          lineHeight: 1.2,
+          overflow: "hidden",
+        }}
+      >
+        {title}
+      </div>
 
       {/* The hero and the model rows are one unit: the claim and its evidence.
           This block takes all the card's leftover height (flex: 1) and centres
           that unit inside it, so the slack collects above and below rather than
           being shared out between the number and the rows that explain it, which
-          is what `justify-content: space-between` on the card would otherwise do. */}
+          is what `justify-content: space-between` on the card would otherwise do.
+          The wide card's two columns live in one inner row, so they stay top
+          aligned with each other while the pair still centres as a unit: centring
+          each column on its own left a single model row floating in the middle of
+          an otherwise empty half. */}
       <div
         style={{
           flex: "1 1 auto",
           minHeight: 0,
           display: "flex",
-          flexDirection: isLandscape ? "row" : "column",
+          flexDirection: "column",
           justifyContent: "center",
-          gap: isLandscape ? 48 : 32,
-          alignItems: isLandscape ? "center" : "flex-start",
         }}
       >
-        {hero !== undefined ? (
-          <div style={{ flex: isLandscape ? "1 1 0" : "0 0 auto" }}>
-            <div style={{ fontSize: heroSize, fontWeight: 700, lineHeight: 0.82 }}>{hero.value}</div>
-            <div style={{ fontSize: 44, fontWeight: 500, lineHeight: 1.1, color: palette.muted, marginTop: 8 }}>
-              {hero.label}
-              {hero.caveated ? "*" : ""}
-            </div>
-          </div>
-        ) : (
-          <div style={{ fontSize: 44, color: palette.muted }}>No usage in this range</div>
-        )}
-
-        <div style={{ flex: isLandscape ? "1 1 0" : "0 0 auto", width: "100%", display: "flex", flexDirection: "column", gap: 32 }}>
-          {models.length > 0 ? (
-            <div style={{ display: "flex", flexDirection: "column", gap: rowGap, width: "100%" }}>
-              {models.map((model) => (
-                <div
-                  key={model.key ?? "__other__"}
-                  data-share-row
-                  style={{ display: "flex", alignItems: "center", gap: 20, height: rowHeight }}
-                >
-                  <span style={{ fontSize: FLOOR_PX, width: 360, whiteSpace: "nowrap" }}>
-                    {truncateModel(model.label)}
-                  </span>
-                  <span style={{ flex: 1, height: Math.min(26, Math.round(rowHeight * 0.46)), background: palette.track, borderRadius: 13 }}>
-                    <span
-                      style={{
-                        display: "block",
-                        height: "100%",
-                        borderRadius: 10,
-                        width: maxTokens > 0 ? `${(model.tokens / maxTokens) * 100}%` : "0%",
-                        background: palette.bar,
-                      }}
-                    />
-                  </span>
-                  <span style={{ fontSize: FLOOR_PX, color: palette.muted, width: 120, textAlign: "right" }}>
-                    {formatTokens(model.tokens)}
-                  </span>
-                </div>
-              ))}
-              <div style={{ fontSize: FLOOR_PX, color: palette.muted }}>tokens per model</div>
-            </div>
-          ) : null}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: isLandscape ? "row" : "column",
+            alignItems: "flex-start",
+            gap: isLandscape ? 40 : 32,
+          }}
+        >
+          {claimColumn}
+          {rowsColumn}
         </div>
       </div>
 
-      {stats.length > 0 ? (
+      {hasStatsBand ? (
         <div style={{ flexShrink: 0, display: "flex", gap: 64, borderTop: `2px solid ${palette.rule}`, paddingTop: 32 }}>
           {stats.map((stat) => (
             <div key={stat.id}>

--- a/web/src/components/ShareCard.tsx
+++ b/web/src/components/ShareCard.tsx
@@ -33,10 +33,12 @@ const FLOOR_PX = 28;
  *
  * The card is rendered off-screen and rasterized in the same tick, so there is
  * nothing to measure: a layout pass would have to happen between deciding the
- * type size and drawing it. These per-class averages land within ~2% of Inter and
- * of the system stacks it falls back to for the strings the card actually sets
- * (formatted numbers, and a title of ordinary prose), which is enough to choose a
- * size that fits. Callers add a safety factor rather than trusting it exactly.
+ * type size and drawing it. These per-class averages are tuned on the formatted
+ * numbers the hero sets, where they track Inter to within ~1%, but the card is
+ * rasterized in whatever the viewer's stack resolves and no font is bundled, so
+ * the error against a real frame runs to ~10% low on prose and ~19% high on digits
+ * for the common fallbacks. Callers own that margin: size *down* from this and the
+ * error is slack, size a clipping box from it and the error costs content.
  */
 export function emWidth(text: string): number {
   let em = 0;
@@ -62,9 +64,10 @@ export function emWidth(text: string): number {
 
 /**
  * Twice the legibility floor: the point past which a value has stopped reading as
- * the headline. It is set low enough that a value long enough to reach it still
- * fits the narrower of the two frames, since a floor that clamps *up* into an
- * overflow would reintroduce the bug this fitting exists to fix.
+ * the headline. It covers every value this card can actually be handed, including
+ * eleven digits of request count in the narrower wide column. A value long enough
+ * to be clamped *up* by this floor does overflow, so it is set as low as legibility
+ * allows: reaching it takes roughly $100T of spend, which no formatter here emits.
  */
 const MIN_HERO = FLOOR_PX * 2;
 
@@ -197,8 +200,21 @@ export function ShareCard(props: ShareCardProps) {
   // Reserved rather than measured: the title is free text (up to 60 characters),
   // and a slot that grew with it would push the hero down by a line. Two lines is
   // the cap in both shapes; a wide card fits 60 characters on one.
-  const titleLines = Math.min(2, Math.max(1, Math.ceil((emWidth(title) * titleSize) / contentWidth)));
-  const titleSlot = titleLines * Math.round(titleSize * 1.2);
+  //
+  // The wrap is decided at 0.85 of the real width because the slot clips what it
+  // does not reserve, and the estimator runs low on prose: its per-class averages
+  // are numeric-accurate but undercount lowercase-heavy text by ~10% against the
+  // Arial-metric stacks this falls back to, which on a wide card silently dropped
+  // the second line of a 60-character title. Reserving a line that goes unused
+  // costs the rows some height; clipping one loses the words.
+  const titleLines = Math.min(2, Math.max(1, Math.ceil((emWidth(title) * titleSize) / (contentWidth * 0.85))));
+  // An exact pixel line height, not a unitless 1.2, so the slot is a whole number
+  // of line boxes rather than of a value the browser resolved for itself. The 4px
+  // is for ink, not layout: a font whose descenders run past their own line box
+  // (Liberation Sans does, by 3px at this size) would otherwise have the tail of a
+  // second-line "g" clipped by the slot that hides a third line.
+  const titleLine = Math.round(titleSize * 1.2);
+  const titleSlot = titleLines * titleLine + 4;
   const footerSlot = 40;
   /** The "tokens per model" caption plus the gap above it. */
   const captionSlot = 42;
@@ -378,7 +394,7 @@ export function ShareCard(props: ShareCardProps) {
           height: titleSlot,
           fontSize: titleSize,
           fontWeight: 600,
-          lineHeight: 1.2,
+          lineHeight: `${titleLine}px`,
           overflow: "hidden",
         }}
       >

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -9,6 +9,7 @@ import {
   formatReleaseDate,
   formatTokens,
   formatUsd,
+  formatUsdHeadline,
 } from "@/lib/format";
 
 describe("formatNumber", () => {
@@ -25,6 +26,19 @@ describe("formatUsd", () => {
     expect(formatUsd(1240.5)).toBe("$1,240.50");
     // No sub-cent precision here (unlike formatCost): tiles stay readable.
     expect(formatUsd(0.004)).toBe("$0.00");
+  });
+});
+
+describe("formatUsdHeadline", () => {
+  it("drops the cents once they stop carrying anything", () => {
+    expect(formatUsdHeadline(2390.99)).toBe("$2,391");
+    expect(formatUsdHeadline(100)).toBe("$100");
+    expect(formatUsdHeadline(-2390.99)).toBe("-$2,391");
+  });
+
+  it("keeps them below $100, where they are a quarter of the number", () => {
+    expect(formatUsdHeadline(99.99)).toBe("$99.99");
+    expect(formatUsdHeadline(4.2)).toBe("$4.20");
   });
 });
 

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -95,6 +95,21 @@ export function formatUsd(value: number): string {
   return usdCompact.format(value);
 }
 
+const usdWhole = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+// Dollars set as a headline rather than read off a table. From $100 up the cents
+// are receipt detail: they add two of the widest glyphs on the line to carry a
+// precision nobody checks at a glance, and on the share card that width comes
+// straight out of the type size. Below $100 they still say something, since the
+// difference between $4.10 and $4.99 is a quarter of the number.
+export function formatUsdHeadline(value: number): string {
+  return Math.abs(value) >= 100 ? usdWhole.format(value) : usdCompact.format(value);
+}
+
 // Compact token counts for aggregate tiles: 12.4M / 84.2k / 512.
 export function formatTokens(value: number): string {
   if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;

--- a/web/src/lib/shareCard.ts
+++ b/web/src/lib/shareCard.ts
@@ -1,6 +1,6 @@
 import type { UsageGroupRow, UsageSeriesPoint, UsageTotals } from "@/api/types";
 
-import { formatNumber, formatPct, formatTokens, formatUsd } from "./format";
+import { formatNumber, formatPct, formatTokens, formatUsdHeadline } from "./format";
 import { billedTokenTotal, cacheHitRate, costNeedsCaveat, formatLatency } from "./usageTotals";
 
 // Derivations for the share card. Everything here is pure so the numbers the card
@@ -87,7 +87,10 @@ export function availableStats(inputs: StatInputs): CardStat[] {
   }
 
   if (!hideDollars && totals.cost > 0) {
-    stats.push({ id: "cost", label: "Spend", value: formatUsd(totals.cost), caveated: costNeedsCaveat(totals) });
+    // Headline dollars, not the page's tile format: the card sets this at up to
+    // 168px, where "$2,390.99" is a third wider than "$2,391" for two digits that
+    // carry nothing at that size.
+    stats.push({ id: "cost", label: "Spend", value: formatUsdHeadline(totals.cost), caveated: costNeedsCaveat(totals) });
   }
   if (totals.request_count > 0) {
     stats.push({ id: "requests", label: "Requests", value: formatNumber(totals.request_count) });


### PR DESCRIPTION
## Description

The share card's hero was set at a fixed 200px, so a four-figure spend ran off the frame. `$2,390.99` is 959px wide against the square card's 936px of content, and against the wide card's 504px hero column it ran off both edges and printed over the model rows. The hero is now fitted to its value against the width it actually has, capped at 168px on square (132 for a long model list) and 120 on wide: a short value gets the cap, a long one steps down. The card is rasterized in the same tick it is rendered, so there is nothing to measure; `emWidth` estimates per character class and lands within ~1% of Chromium for the numeric strings the hero sets (pinned in a test).

Dollar figures on the card now drop their cents from $100 up (`$2,391`). At hero size the cents cost a third of the width for a precision nobody checks. The page's own tiles and tables keep them.

The wide card was broken in both axes, not only horizontally: the hero also ran over the title and the model rows crossed the stats rule, because 630px of frame cannot hold the square card's arrangement of hero, then rows, then a full-width stats band. Wide is two columns now, the claim (hero plus its supporting stats) beside the evidence (the model rows). That gives the rows the whole middle height and the hero a column narrow enough to size type against. Wide rows also get narrower name and value columns, so the bar no longer collapses to zero and push the token counts off the edge.

Row height now falls out of subtracting the real band heights from the frame rather than two hand-tuned budget constants.

The second commit fixes a regression the first one introduced: sizing the title slot from the estimator traded a clipped pixel for a clipped word. `emWidth` runs about 10% low on prose against the Arial-metric stacks the card falls back to, so a wide-card title scored as one line wrapped to two and lost the second line to the slot's overflow (105 of 1000 generated titles under Arial metrics, none before the slot became a fixed height). The wrap is now decided at 0.85 of the real width, and the slot takes an exact pixel line height plus 4px for fonts whose descenders run past their own line box.

**Verification.** Rendered in headless Chromium across both shapes x 1/3/5/9 rows x both themes, plus the empty state, long titles, `$4.20` and `$1,234,567`: no frame overflows in either axis and no element spilling its box, repeated under three font stacks. Before this, wide laid out 1364px of content in a 1200px frame.

One judgment call: wide truncates model names to 22 characters (`claude-sonn...5-20260514`) to keep the bar visible. Widening that column pushes the bar back toward the state this fixes.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None; found while using the feature.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Notes on the checklist, since this is a dashboard-only change: the tests are Vitest specs beside the code (`web/src/components/ShareCard.test.tsx`, `web/src/lib/format.test.ts`) plus a widened assertion in the Playwright spec, not `tests/unit` or `tests/integration`, which are the Python suites. `make lint` and `make typecheck` pass; the checks that actually cover this diff are `npm --prefix web test` (594 passing) and `npm --prefix web run typecheck`, both green. No Python was touched, so the API contract is unchanged and the OpenAPI spec needs no regeneration. `docs/dashboard.md` gained two lines for the user-visible rounding change.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5, via the Claude Code CLI.

**Any additional AI details you'd like to share:**

The diff and this description were written by the model through back-and-forth with @njbrake, who directed the work and made the design calls. The layout numbers were not guessed: each candidate was rendered in headless Chromium and measured, and the second commit exists because a separate review pass caught a regression the first one introduced.

- [x] I am an AI Agent filling out this form (check box if true)