### PR TITLE
feat(dashboard): stop the activity log refreshing itself

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -192,7 +192,11 @@ gateway.
   **N new** appears once requests have landed since the page was drawn; press it to
   load them. It is a count only, so the table stays where you left it until you say
   otherwise. It is offered on the first page of a window that is still open, the
-  only place where loading newer rows would bring them into view.
+  only place where loading newer rows would bring them into view. If that count
+  cannot be read, the strip says **Newer rows unknown** rather than falling silent,
+  which would leave a busy gateway looking like an idle one. Paging re-reads the
+  row total along with the rows, so a log that has grown since you opened it does
+  not leave its oldest entries stranded past the end of the paginator.
   The **Routing** column names the policy a caller asked for, if any, plus where
   this row sits in that policy's plan and how it turned out: "served on attempt 2
   of 2 (a fallback candidate)", or, on an attempt a fallback recovered from,

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -160,35 +160,39 @@ gateway.
 
 - **Activity**: the per-request log of what the gateway served, with filters.
   Use it to inspect individual requests, their models, and their outcomes.
-  A usage row is written when a request settles, so the log would otherwise only
-  describe the past. Requests still running appear in the same table, pinned above
-  the settled rows with the status **in progress** and, in place of a total time, a
-  wait that ticks up as you watch. When the request lands, the row resolves in
-  place into the success or error row it became, so a 30-second call to a local
-  model reads as progress rather than as nothing happening. Completions,
+  The table is a snapshot, and it holds still: it loads when you open the page and
+  reloads when you ask it to, by pressing refresh or by changing a filter, the
+  window, or the page. Nothing reorders itself while you are reading, which on a
+  busy gateway is the difference between a log you can inspect and a feed you
+  cannot. Two controls beside the refresh button carry what is happening
+  meanwhile.
+  **N in flight** counts the requests the gateway is serving right now, and opens
+  the list of them: what model, for which user, and a wait that ticks up as you
+  watch. A usage row is only written when a request settles, so without this a
+  30-second call to a local model would read as nothing happening. The control is
+  there only while something is running, with one exception: a list you have opened
+  stays open when the last request lands, reading **0 in flight**, rather than
+  vanishing at the moment you were waiting for. Close it and it goes. Completions,
   embeddings, image generations, audio, and searches all appear, each from the
   moment it clears the budget and access checks until its response has been fully
   sent (a streamed answer stays listed for as long as it is still producing
   tokens). Batches are the exception: the work runs on the provider's side after
   the submission returns, so there is no in-flight window to show. A request
-  refused on budget, access, or model-resolution grounds never appears as in
-  progress: it was never running, and it lands in the log with its reason. A
-  completion refused later, by an input guardrail or a bad tool declaration, can be
-  listed for as long as that check takes, since the gateway really is working on it
-  by then. An in-progress row is not part of any page of the
-  log, so it is never counted in the paginator, never selectable for a bulk delete
-  or reprice, and has no request detail to open until it settles. It is dropped
-  from view rather than shown misleadingly whenever the current view could not
-  honestly include it: on page 2 onward, in a window that ends in the past, and
-  under any filter on something the request has not got yet (status, priced, tool,
-  source, session). The model, user, key, endpoint, and provider filters do apply
-  to it. The log refreshes on its own as requests land, at most every 10 seconds,
-  so a busy gateway does not re-query it continuously. Live rows are read from the
-  process that answers the poll, so a deployment running several otari processes
-  behind a load balancer shows one process's traffic at a time, and which one it
-  shows can change between polls. There is no deployment-wide total: the
-  `gateway_active_requests` Prometheus metric is close but not the same number, as
-  it counts every HTTP request a process is handling, dashboard polls included.
+  refused on budget, access, or model-resolution grounds never appears here: it was
+  never running, and it lands in the log with its reason. A completion refused
+  later, by an input guardrail or a bad tool declaration, can be listed for as long
+  as that check takes, since the gateway really is working on it by then. The count
+  is gateway-wide and is not narrowed by the filters above it: a request in
+  progress has no outcome, cost, or token count for those filters to match on. It
+  is read from the process that answers the poll, so a deployment running several
+  otari processes behind a load balancer shows one process's traffic at a time, and
+  which one it shows can change between polls. There is no deployment-wide total:
+  the `gateway_active_requests` Prometheus metric is close but not the same number,
+  as it counts every HTTP request a process is handling, dashboard polls included.
+  **N new** appears once requests have landed since the page was drawn; press it to
+  load them. It is a count only, so the table stays where you left it until you say
+  otherwise. It is offered on the first page of a window that is still open, the
+  only place where loading newer rows would bring them into view.
   The **Routing** column names the policy a caller asked for, if any, plus where
   this row sits in that policy's plan and how it turned out: "served on attempt 2
   of 2 (a fallback candidate)", or, on an attempt a fallback recovered from,

--- a/web/src/api/hooks.ts
+++ b/web/src/api/hooks.ts
@@ -831,10 +831,9 @@ export function useUsageLogs(filters: UsageFilters, page: number, pageSize: numb
     // arrive faster than anyone can inspect them, so a page that refetched on its
     // own reshuffled the table out from under whoever was reading it. It refetches
     // only when asked: a mount, the refresh button, or a change of filters, window,
-    // or page (all of which are in the key). `refetchOnWindowFocus` is off for the
-    // same reason: returning to the tab is not a request for newer rows.
+    // or page (all of which are in the key). Nothing here opts back into the
+    // provider's refetch-on-focus default, which is already off (`provider.tsx`).
     // `useLiveUsageCount` is how the page still says that newer rows exist.
-    refetchOnWindowFocus: false,
     staleTime: 10_000,
   });
 }
@@ -851,7 +850,6 @@ export function useUsageCount(filters: UsageFilters, enabled = true) {
     queryFn: () => apiFetch<UsageCount>(`/v1/usage/count?${usageParams(filters).toString()}`),
     enabled,
     placeholderData: keepPreviousData,
-    refetchOnWindowFocus: false,
     staleTime: 10_000,
   });
 }

--- a/web/src/api/hooks.ts
+++ b/web/src/api/hooks.ts
@@ -827,20 +827,59 @@ export function useUsageLogs(filters: UsageFilters, page: number, pageSize: numb
       return apiFetch<UsageEntry[]>(`/v1/usage?${params.toString()}`);
     },
     placeholderData: keepPreviousData,
-    // A request log moves constantly; keep it fresh but don't refetch on every focus.
+    // The log is a snapshot an operator reads, not a feed. On a busy gateway rows
+    // arrive faster than anyone can inspect them, so a page that refetched on its
+    // own reshuffled the table out from under whoever was reading it. It refetches
+    // only when asked: a mount, the refresh button, or a change of filters, window,
+    // or page (all of which are in the key). `refetchOnWindowFocus` is off for the
+    // same reason: returning to the tab is not a request for newer rows.
+    // `useLiveUsageCount` is how the page still says that newer rows exist.
+    refetchOnWindowFocus: false,
     staleTime: 10_000,
   });
 }
 
 // Total rows matching the same filters, for the paginator's "N of M". A separate
 // request so /v1/usage stays a bare array; run alongside the list.
+//
+// Deliberately as frozen as the log it counts (see `useUsageLogs`): the total
+// describes the page on screen, so a total that moved on its own would disagree
+// with the rows the operator can actually page through.
 export function useUsageCount(filters: UsageFilters, enabled = true) {
   return useQuery({
     queryKey: [USAGE, "count", filters],
     queryFn: () => apiFetch<UsageCount>(`/v1/usage/count?${usageParams(filters).toString()}`),
     enabled,
     placeholderData: keepPreviousData,
+    refetchOnWindowFocus: false,
     staleTime: 10_000,
+  });
+}
+
+// How often the live row count re-reads. Slow, because nothing on screen moves
+// when it changes: it only sizes the "N new" badge, which an operator glances at
+// rather than watches. TanStack does not poll a backgrounded tab, so an idle
+// dashboard costs nothing.
+const NEW_ROW_POLL_MS = 15_000;
+
+// The same count as `useUsageCount`, polled, so a frozen page can say how far
+// behind it has fallen without moving a single row.
+//
+// A separate cache entry rather than a `refetchInterval` on `useUsageCount`: the
+// two readings serve opposite purposes (one is pinned to the rendered page, the
+// other is deliberately ahead of it), and two observers of one query key cannot
+// disagree about how fresh their data is. The duplicate `COUNT(*)` at mount is
+// one indexed count, which is what makes polling it affordable in the first place.
+export function useLiveUsageCount(filters: UsageFilters, enabled = true) {
+  return useQuery({
+    queryKey: [USAGE, "count", "live", filters],
+    queryFn: () => apiFetch<UsageCount>(`/v1/usage/count?${usageParams(filters).toString()}`),
+    enabled,
+    refetchInterval: NEW_ROW_POLL_MS,
+    staleTime: 0,
+    // A failed count is not worth surfacing: it sits beside a refresh button that
+    // fetches the real thing, and the next poll retries anyway.
+    retry: false,
   });
 }
 
@@ -851,10 +890,12 @@ export function useUsageCount(filters: UsageFilters, enabled = true) {
 // costs nothing.
 const IN_FLIGHT_POLL_MS = 2_000;
 
-// Requests the gateway is serving right now, rendered as in-progress rows above
-// the activity log. The read takes no filters: a request in progress has no
-// outcome, cost, or token count for the log's filters to match on, so which of
-// them the current view may show is decided at the call site.
+// Requests the gateway is serving right now, rendered as a live count beside the
+// activity log's refresh control rather than as rows in it: the log is a frozen
+// snapshot, and rows that reordered themselves every two seconds were the reason
+// a busy gateway's activity page could not be read at all. The read takes no
+// filters: a request in progress has no outcome, cost, or token count for the
+// log's filters to match on, so it is reported gateway-wide.
 //
 // Never cached across mounts (`staleTime: 0`) and never kept as placeholder data:
 // a stale in-flight list is worse than none, since it claims work is running that

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -185,9 +185,10 @@ export function DataTable<Row extends object>({
   // element each time re-points the portal, and React answers that by
   // unmounting the panel and mounting it again into the new node. That replays
   // the reveal animation and throws away whatever state the panel held. The
-  // activity page hands this component a rebuilt rows array every two seconds
-  // while it polls for in-flight requests, so an expanded row sat there
-  // flashing and re-opening on a timer for as long as a request was running.
+  // activity page once rebuilt its rows array every two seconds, from a poll for
+  // requests in flight, and an expanded row sat there flashing and re-opening on
+  // a timer for as long as one was running. Any caller that re-derives its rows
+  // on a timer would do the same.
   const hostRef = useRef<{ row: HTMLTableRowElement; cell: HTMLTableCellElement } | null>(null);
   const ensureHost = () => {
     if (!hostRef.current) {

--- a/web/src/pages/ActivityPage.test.tsx
+++ b/web/src/pages/ActivityPage.test.tsx
@@ -1705,6 +1705,62 @@ describe("ActivityPage live traffic", () => {
     }
   });
 
+  it("re-reads the total when the operator pages, so newer rows do not strand the old ones", async () => {
+    // The total is not in the count's key, so a frozen page would keep whichever
+    // value it loaded with. `TablePagination` derives `isLast` from the total
+    // whenever it has one, so an understated total disables Next short of the real
+    // end and leaves the oldest rows unreachable. On main the settle-refetch hid
+    // this by re-reading the count on any traffic; nothing does now except this.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      let serverTotal = 100;
+      mockApi({ rows: [entry()], total: () => serverTotal });
+      renderPage(<ActivityPage />, "/activity?range=24h&size=50");
+
+      await screen.findByText("gpt-4o");
+      await waitFor(() => expect(screen.getByText(/of 100/)).toBeInTheDocument());
+
+      // Twenty land, taking the log to three pages of fifty.
+      serverTotal = 120;
+      await user.click(screen.getByRole("button", { name: /next page/i }));
+
+      await waitFor(() => expect(screen.getByText(/of 120/)).toBeInTheDocument());
+      // The third page is reachable, so the oldest twenty are not stranded behind a
+      // boundary computed from a total that has moved on.
+      expect(screen.getByRole("button", { name: /next page/i })).toBeEnabled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("says so when it cannot tell whether newer rows exist", async () => {
+    // A badge that is simply absent reads as "nothing has landed". On a table that
+    // no longer moves by itself, that makes a flooded gateway look like an idle one.
+    let countAsks = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      // The pinned count and the polled one share a URL, so fail every count after
+      // the first: the page keeps a total and loses any way to tell if it is current.
+      if (url.includes("/v1/usage/count")) {
+        countAsks += 1;
+        return countAsks === 1 ? jsonResponse({ total: 1 }) : jsonResponse({ detail: "nope" }, 500);
+      }
+      if (url.includes("/v1/usage/in-flight")) return jsonResponse({ requests: [], total: 0 });
+      if (url.includes("/v1/usage/summary")) {
+        return jsonResponse({ by_model: [], by_user: [], by_api_key: [], by_source: [], series: [] });
+      }
+      return jsonResponse([entry()]);
+    });
+
+    renderPage(<ActivityPage />, "/activity?range=24h");
+
+    await screen.findByText("gpt-4o");
+    await waitFor(() => expect(screen.getByText("Newer rows unknown")).toBeInTheDocument());
+    // Still no false badge, and the log itself is not reported as broken.
+    expect(screen.queryByRole("button", { name: /new · load/ })).not.toBeInTheDocument();
+  });
+
   it("does not poll for newer rows on a page that cannot show them", async () => {
     // Newer rows land at the top of page 1, so on page 3 a badge offering to load
     // them would be a promise the refresh does not keep.

--- a/web/src/pages/ActivityPage.test.tsx
+++ b/web/src/pages/ActivityPage.test.tsx
@@ -1427,7 +1427,6 @@ describe("ActivityPage suggestion scoping", () => {
   });
 });
 
-
 // ---------------------------------------------------------------------------
 // Requests in flight, and the frozen log (issue #526)
 // ---------------------------------------------------------------------------
@@ -1720,6 +1719,30 @@ describe("ActivityPage live traffic", () => {
 
       expect(countCalls(calls).length).toBe(before);
       expect(screen.queryByRole("button", { name: /new/ })).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("drops the badge when the operator pages past the rows it offers", async () => {
+    // `page` is not part of the live count's key, so paging forward disables the
+    // poll but leaves its last payload in the cache. Read unguarded, that keeps
+    // the badge on screen for pages where pressing it loads the current page and
+    // the newer rows stay at the top of page 1, out of sight.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      let serverTotal = 100;
+      mockApi({ rows: [entry()], total: () => serverTotal });
+      renderPage(<ActivityPage />, "/activity?range=24h");
+
+      await screen.findByText("gpt-4o");
+      serverTotal = 120;
+      await vi.advanceTimersByTimeAsync(16_000);
+      await screen.findByRole("button", { name: /20 new/ });
+
+      await user.click(screen.getByRole("button", { name: "Next page" }));
+      await waitFor(() => expect(screen.queryByRole("button", { name: /new/ })).not.toBeInTheDocument());
     } finally {
       vi.useRealTimers();
     }

--- a/web/src/pages/ActivityPage.test.tsx
+++ b/web/src/pages/ActivityPage.test.tsx
@@ -52,15 +52,23 @@ interface FetchCall {
 function mockApi(
   opts: {
     rows?: UsageEntry[];
-    total?: number;
+    // A thunk when a test needs the count to move under a page that is already
+    // rendered, which is what the "N new" badge is derived from.
+    total?: number | (() => number);
     groupRows?: UsageEntry[];
     users?: string[];
-    inFlight?: InFlightResponse;
+    inFlight?: InFlightResponse | (() => InFlightResponse);
   } = {},
 ) {
   const rows = opts.rows ?? [];
-  const total = opts.total ?? rows.length;
-  const inFlight = opts.inFlight ?? { requests: [], total: 0 };
+  const total = () => {
+    const t = opts.total ?? rows.length;
+    return typeof t === "function" ? t() : t;
+  };
+  const inFlight = () => {
+    const f = opts.inFlight ?? { requests: [], total: 0 };
+    return typeof f === "function" ? f() : f;
+  };
   const calls: FetchCall[] = [];
 
   const mock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
@@ -75,12 +83,12 @@ function mockApi(
       return jsonResponse({ matched: 1, updated: 1, unchanged: 0 });
     }
     if (url.includes("/v1/usage/count")) {
-      return jsonResponse({ total });
+      return jsonResponse({ total: total() });
     }
     // Ahead of the bare /v1/usage arm below, which would otherwise answer this
-    // with the row array and hand the in-flight panel the wrong shape.
+    // with the row array and hand the in-flight control the wrong shape.
     if (url.includes("/v1/usage/in-flight")) {
-      return jsonResponse(inFlight);
+      return jsonResponse(inFlight());
     }
     if (url.includes("/v1/usage/summary")) {
       const models = Array.from(new Set(rows.map((r) => r.model)));
@@ -163,6 +171,10 @@ function listCalls(calls: FetchCall[]): string[] {
         !c.url.includes("/set-price"),
     )
     .map((c) => c.url);
+}
+
+function countCalls(calls: FetchCall[]): string[] {
+  return calls.filter((c) => c.method === "GET" && c.url.includes("/v1/usage/count")).map((c) => c.url);
 }
 
 describe("ActivityPage", () => {
@@ -1415,8 +1427,9 @@ describe("ActivityPage suggestion scoping", () => {
   });
 });
 
+
 // ---------------------------------------------------------------------------
-// Requests in flight (issue #526)
+// Requests in flight, and the frozen log (issue #526)
 // ---------------------------------------------------------------------------
 
 function inFlightRequest(overrides: Partial<InFlightRequest> = {}): InFlightRequest {
@@ -1434,51 +1447,207 @@ function inFlightRequest(overrides: Partial<InFlightRequest> = {}): InFlightRequ
   };
 }
 
-// The live row an operator reads: the request's own cells, an "in progress"
-// status, and the wait so far in the Total time column. Found through the status
-// pill rather than by row role and name, because react-aria names a row after its
-// row-header cell (the model), not after everything in it.
-function liveRow(): HTMLElement {
-  const row = screen.getByText("in progress").closest("tr");
-  if (row === null) throw new Error('the "in progress" pill is not inside a table row');
-  return row;
+// The live control, found by role: its label is assembled from the count and the
+// word "in flight" as separate text nodes, so no single text node carries it.
+function liveControl(): HTMLElement | null {
+  return screen.queryByRole("button", { name: /in flight/ });
 }
 
-function noLiveRow(): boolean {
-  return screen.queryByText("in progress") === null;
-}
-
-describe("ActivityPage in-flight rows", () => {
+describe("ActivityPage live traffic", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("shows a request that has not settled yet as a row in the log", async () => {
-    // The reason the feature exists: on a slow local backend the log stays empty
-    // for the whole call, so without this the page reads as "nothing is happening"
-    // while a request is mid-flight.
-    mockApi({ rows: [], inFlight: { requests: [inFlightRequest()], total: 1 } });
+  it("reports what is running as a count beside refresh, not as rows in the log", async () => {
+    // The reason the count exists: a usage row is only written once a request
+    // settles, so on a slow backend the log stays empty for a whole 30s call and
+    // reads as "nothing is happening".
+    //
+    // The reason it is not a row: the poll behind it runs every two seconds, and
+    // rows that re-derived themselves on that timer reordered the top of the table
+    // continuously on any gateway with real traffic.
+    mockApi({ rows: [entry()], inFlight: { requests: [inFlightRequest()], total: 1 } });
     renderPage(<ActivityPage />, "/activity?range=24h");
 
-    await waitFor(() => expect(liveRow()).toBeInTheDocument());
-    const row = liveRow();
-    expect(within(row).getByText("ollama:qwen3")).toBeInTheDocument();
-    expect(within(row).getByText("alice")).toBeInTheDocument();
-    expect(within(row).getByText("in progress")).toBeInTheDocument();
-    // The wait so far, seeded from the server's own measurement so it does not
-    // depend on the browser clock agreeing with the gateway's.
-    expect(within(row).getByText(/^12s$/)).toBeInTheDocument();
-    // No outcome to report yet, so the outcome columns stay empty rather than
-    // inventing a zero cost or a zero token count.
-    expect(within(row).getAllByText("—").length).toBeGreaterThan(0);
+    await waitFor(() => expect(liveControl()).toBeInTheDocument());
+    expect(liveControl()).toHaveAccessibleName(/1 in flight/);
+
+    // One body row, the settled one. The live request is not among them.
+    const bodyRows = screen.getAllByRole("row").slice(1);
+    expect(bodyRows).toHaveLength(1);
+    expect(within(bodyRows[0]).getByText("gpt-4o")).toBeInTheDocument();
+    expect(screen.queryByText("ollama:qwen3")).not.toBeInTheDocument();
+  });
+
+  it("lists the running requests, with the wait so far, when the count is opened", async () => {
+    const user = userEvent.setup();
+    mockApi({
+      rows: [],
+      inFlight: {
+        requests: [inFlightRequest({ policy_name: "cheap-first", elapsed_ms: 95_000 })],
+        total: 1,
+      },
+    });
+    renderPage(<ActivityPage />, "/activity?range=24h");
+
+    await waitFor(() => expect(liveControl()).toBeInTheDocument());
+    await user.click(liveControl()!);
+
+    const panel = await screen.findByRole("dialog");
+    expect(within(panel).getByText("ollama:qwen3")).toBeInTheDocument();
+    expect(within(panel).getByText(/alice/)).toBeInTheDocument();
+    expect(within(panel).getByText(/cheap-first/)).toBeInTheDocument();
+    // Seeded from the server's own measurement, so the wait does not depend on the
+    // browser clock agreeing with the gateway's, and long enough to read in minutes
+    // because a stuck local model is the case this exists for.
+    expect(within(panel).getByText(/^1m 35s$/)).toBeInTheDocument();
+  });
+
+  it("says how many running requests the response left out", async () => {
+    // The endpoint caps what it serializes, so the count and the list can differ;
+    // reading the list length as the total would under-report live traffic.
+    const user = userEvent.setup();
+    mockApi({ rows: [], inFlight: { requests: [inFlightRequest()], total: 7 } });
+    renderPage(<ActivityPage />, "/activity?range=24h");
+
+    await waitFor(() => expect(liveControl()).toHaveAccessibleName(/7 in flight/));
+    await user.click(liveControl()!);
+
+    const panel = await screen.findByRole("dialog");
+    expect(within(panel).getByText(/6 further requests are in flight beyond the 1 listed/)).toBeInTheDocument();
+  });
+
+  it("keeps an opened list open when the last request lands", async () => {
+    // Otherwise the list an operator opened to watch a slow request is torn out
+    // from under them at the moment it finishes, which is the moment they were
+    // waiting for. It stays, reading "0 in flight", until they close it.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      let live: InFlightResponse = { requests: [inFlightRequest()], total: 1 };
+      mockApi({ rows: [], inFlight: () => live });
+      renderPage(<ActivityPage />, "/activity?range=24h");
+
+      await waitFor(() => expect(liveControl()).toBeInTheDocument());
+      // Held as a node: react-aria marks the rest of the page `aria-hidden` while
+      // the popover is open, so the trigger is unreachable by role until it closes.
+      const control = liveControl()!;
+      await user.click(control);
+      const panel = await screen.findByRole("dialog");
+      expect(within(panel).getByText("ollama:qwen3")).toBeInTheDocument();
+
+      live = { requests: [], total: 0 };
+      await vi.advanceTimersByTimeAsync(3_000);
+
+      await waitFor(() => expect(control).toHaveTextContent(/0 in flight/));
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByText(/Nothing running right now/)).toBeInTheDocument();
+
+      // Closed by the operator, and only then does the control go.
+      await user.keyboard("{Escape}");
+      await waitFor(() => expect(liveControl()).not.toBeInTheDocument());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows no live control while the gateway is idle", async () => {
+    mockApi({ rows: [entry()], inFlight: { requests: [], total: 0 } });
+    renderPage(<ActivityPage />, "/activity?range=24h");
+
+    await screen.findByText("gpt-4o");
+    expect(liveControl()).not.toBeInTheDocument();
+  });
+
+  it("drops the live control when the in-flight poll starts failing", async () => {
+    // TanStack keeps the last successful payload after a failed refetch, so without
+    // an explicit error arm the count would sit there with its waits climbing
+    // against a frozen anchor, claiming work is running that may have landed
+    // minutes ago. That is the state the hook already refuses to cache across
+    // mounts, so it must not be reachable this way either.
+    let failing = false;
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("/v1/usage/in-flight")) {
+        return failing
+          ? jsonResponse({ detail: "gateway restarting" }, 503)
+          : jsonResponse({ requests: [inFlightRequest()], total: 1 });
+      }
+      if (url.includes("/v1/usage/count")) return jsonResponse({ total: 0 });
+      if (url.includes("/v1/usage/summary")) {
+        return jsonResponse({ by_model: [], by_user: [], by_api_key: [], by_source: [], series: [] });
+      }
+      return jsonResponse([]);
+    });
+
+    renderPage(<ActivityPage />, "/activity?range=24h");
+    await waitFor(() => expect(liveControl()).toBeInTheDocument());
+
+    failing = true;
+    await waitFor(() => expect(liveControl()).not.toBeInTheDocument(), { timeout: 20000 });
+  }, 30_000);
+
+  it("reports live traffic gateway-wide, whatever the table is filtered to", async () => {
+    // The endpoint takes no filters (a request in progress has no status, cost, or
+    // token count to filter on), so the count is not narrowed to the current view
+    // and the request itself must stay bare. A status filter that empties the table
+    // therefore leaves the live count alone rather than hiding it.
+    const { calls } = mockApi({ rows: [], inFlight: { requests: [inFlightRequest()], total: 1 } });
+    renderPage(<ActivityPage />, "/activity?range=7d&status=error&model=gpt-4o");
+
+    await screen.findByText("No requests match these filters.");
+    await waitFor(() => expect(liveControl()).toBeInTheDocument());
+
+    const requested = calls.map((c) => c.url).filter((url) => url.includes("/v1/usage/in-flight"));
+    expect(requested.length).toBeGreaterThan(0);
+    for (const url of requested) {
+      expect(url).toBe("/v1/usage/in-flight");
+    }
+  });
+
+  it("leaves the paginator counting settled rows only", async () => {
+    // The live request is not part of any page's slice, so folding it into "N of M"
+    // would make the count disagree with the log the operator can page through.
+    mockApi({ rows: [entry()], total: 1, inFlight: { requests: [inFlightRequest()], total: 1 } });
+    renderPage(<ActivityPage />, "/activity?range=24h");
+
+    await waitFor(() => expect(liveControl()).toBeInTheDocument());
+    expect(screen.getByText(/1\s*[–-]\s*1 of 1/)).toBeInTheDocument();
+  });
+
+  it("does not re-read the log when a tracked request settles", async () => {
+    // The freeze, and the whole point of it: on a busy gateway requests settle
+    // continuously, and re-reading the log on each one reshuffled the table every
+    // few seconds under whoever was trying to read it. The settled request appears
+    // at the next refresh instead.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      let live: InFlightResponse = { requests: [inFlightRequest()], total: 1 };
+      const { calls } = mockApi({ rows: [entry()], inFlight: () => live });
+      renderPage(<ActivityPage />, "/activity?range=24h");
+
+      await waitFor(() => expect(liveControl()).toBeInTheDocument());
+      const before = listCalls(calls).length;
+
+      // The request settles: the next poll no longer carries it.
+      live = { requests: [], total: 0 };
+      await vi.advanceTimersByTimeAsync(3_000);
+      await waitFor(() => expect(liveControl()).not.toBeInTheDocument());
+
+      // Several further polls, so this is not just a question of timing.
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(listCalls(calls).length).toBe(before);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("leaves an expanded row alone while it polls for in-flight requests", async () => {
-    // Regression: the poll runs every 2s and its result re-derived the live
-    // rows, so the table got a rebuilt rows array on a timer. DataTable rebuilt
-    // its detail host to match, which remounted the panel: an operator who
-    // expanded a row while a request was running watched it flash and slide
-    // open again every couple of seconds.
+    // Regression: the poll runs every 2s and its result used to re-derive the
+    // table's rows, so DataTable rebuilt its detail host to match and an operator
+    // who expanded a row watched the panel flash and slide open again every couple
+    // of seconds. The poll no longer touches the rows array at all.
     vi.useFakeTimers({ shouldAdvanceTime: true });
     try {
       const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
@@ -1506,245 +1675,73 @@ describe("ActivityPage in-flight rows", () => {
     }
   });
 
-  it("adds no row while the gateway is idle", async () => {
-    mockApi({ rows: [entry()], inFlight: { requests: [], total: 0 } });
-    renderPage(<ActivityPage />, "/activity?range=24h");
+  it("offers newer rows as a badge, and loads them only when it is pressed", async () => {
+    // The freeze's other half: a page that never moves must still be able to say it
+    // has fallen behind, or a quiet gateway and a flooded one look identical.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      let serverTotal = 4;
+      const { calls } = mockApi({ rows: [entry()], total: () => serverTotal });
+      renderPage(<ActivityPage />, "/activity?range=24h");
 
-    await screen.findByText("gpt-4o");
-    expect(noLiveRow()).toBe(true);
-  });
+      await screen.findByText("gpt-4o");
+      expect(screen.queryByRole("button", { name: /new/ })).not.toBeInTheDocument();
 
-  it("pins the live row above the settled ones", async () => {
-    // Newest-first like the rest of the table, so a request the operator just
-    // triggered appears at the top and stays put as it resolves.
-    mockApi({ rows: [entry({ id: "settled-1" })], inFlight: { requests: [inFlightRequest()], total: 1 } });
-    renderPage(<ActivityPage />, "/activity?range=24h");
+      // 87 requests land while the operator reads the page.
+      serverTotal = 91;
+      const listsBefore = listCalls(calls).length;
+      await vi.advanceTimersByTimeAsync(16_000);
+      const badge = await screen.findByRole("button", { name: /87 new/ });
 
-    await waitFor(() => expect(liveRow()).toBeInTheDocument());
-    const bodyRows = screen.getAllByRole("row").slice(1); // drop the header row
-    expect(within(bodyRows[0]).getByText("in progress")).toBeInTheDocument();
-    expect(within(bodyRows[1]).getByText("gpt-4o")).toBeInTheDocument();
-  });
+      // Nothing was re-read to discover that: the log is still the one on screen.
+      expect(listCalls(calls).length).toBe(listsBefore);
 
-  it("names the policy and formats a long wait in minutes", async () => {
-    mockApi({
-      rows: [],
-      inFlight: {
-        requests: [inFlightRequest({ policy_name: "cheap-first", elapsed_ms: 95_000 })],
-        total: 1,
-      },
-    });
-    renderPage(<ActivityPage />, "/activity?range=24h");
-
-    await waitFor(() => expect(liveRow()).toBeInTheDocument());
-    expect(within(liveRow()).getByText("cheap-first")).toBeInTheDocument();
-    expect(within(liveRow()).getByText(/^1m 35s$/)).toBeInTheDocument();
-  });
-
-  it("leaves the paginator counting settled rows only", async () => {
-    // The live row is not part of any page's slice, so folding it into "N of M"
-    // would make the count disagree with the log the operator can page through.
-    mockApi({ rows: [entry()], total: 1, inFlight: { requests: [inFlightRequest()], total: 1 } });
-    renderPage(<ActivityPage />, "/activity?range=24h");
-
-    await waitFor(() => expect(liveRow()).toBeInTheDocument());
-    expect(screen.getByText(/1\s*[–-]\s*1 of 1/)).toBeInTheDocument();
-  });
-
-  it("says how many in-flight requests the response left out", async () => {
-    // The endpoint caps what it serializes, so the count and the list can differ;
-    // reading the list length as the total would under-report live traffic.
-    mockApi({ rows: [], inFlight: { requests: [inFlightRequest()], total: 7 } });
-    renderPage(<ActivityPage />, "/activity?range=24h");
-
-    await waitFor(() => expect(liveRow()).toBeInTheDocument());
-    expect(screen.getByText(/6 further requests are in flight beyond the 1 listed/)).toBeInTheDocument();
-  });
-
-  it("drops live rows when a filter they cannot be judged against is set", async () => {
-    // A request in progress has no outcome, so it can neither match nor fail a
-    // status filter; showing it anyway would put a row in the table that
-    // contradicts the filter chip above it.
-    mockApi({ rows: [], inFlight: { requests: [inFlightRequest()], total: 1 } });
-    renderPage(<ActivityPage />, "/activity?range=24h&status=error");
-
-    await screen.findByText("No requests match these filters.");
-    expect(noLiveRow()).toBe(true);
-  });
-
-  it("applies the identity filters to live rows", async () => {
-    mockApi({ rows: [], inFlight: { requests: [inFlightRequest({ model: "ollama:qwen3" })], total: 1 } });
-    renderPage(<ActivityPage />, "/activity?range=24h&model=openai:gpt-4o");
-
-    await screen.findByText("No requests match these filters.");
-    expect(noLiveRow()).toBe(true);
-  });
-
-  it("does not send the activity filters to the in-flight endpoint", async () => {
-    // The endpoint takes no filters: a request in progress has no status, cost, or
-    // token count to filter on. Which live rows the current view may show is
-    // decided client-side (this URL's status filter suppresses them all), so the
-    // request itself must stay bare.
-    const { calls } = mockApi({ rows: [], inFlight: { requests: [inFlightRequest()], total: 1 } });
-    renderPage(<ActivityPage />, "/activity?range=7d&status=error&model=gpt-4o");
-
-    const requested = () => calls.map((c) => c.url).filter((url) => url.includes("/v1/usage/in-flight"));
-    await waitFor(() => expect(requested().length).toBeGreaterThan(0));
-    for (const url of requested()) {
-      expect(url).toBe("/v1/usage/in-flight");
+      await user.click(badge);
+      await waitFor(() => expect(listCalls(calls).length).toBeGreaterThan(listsBefore));
+      // Loaded: the pinned count has caught up, so there is nothing left to offer.
+      await waitFor(() => expect(screen.queryByRole("button", { name: /new/ })).not.toBeInTheDocument());
+    } finally {
+      vi.useRealTimers();
     }
   });
 
-  it("re-reads the log once a tracked request settles", async () => {
-    // Otherwise the request vanishes from the panel and does not appear in the log
-    // until the operator presses refresh, which reads as a lost request.
-    let live: InFlightResponse = { requests: [inFlightRequest()], total: 1 };
-    const calls: FetchCall[] = [];
+  it("does not poll for newer rows on a page that cannot show them", async () => {
+    // Newer rows land at the top of page 1, so on page 3 a badge offering to load
+    // them would be a promise the refresh does not keep.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const { calls } = mockApi({ rows: [entry()], total: 500 });
+      renderPage(<ActivityPage />, "/activity?range=24h&page=2");
 
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-      const url = String(input);
-      calls.push({ url, method: "GET", body: undefined });
-      if (url.includes("/v1/usage/in-flight")) return jsonResponse(live);
-      if (url.includes("/v1/usage/count")) return jsonResponse({ total: 0 });
-      if (url.includes("/v1/usage/summary")) {
-        return jsonResponse({
-          start_date: "",
-          end_date: "",
-          bucket: "day",
-          totals: {
-            cost: 0,
-            prompt_tokens: 0,
-            completion_tokens: 0,
-            total_tokens: 0,
-            cache_read_tokens: 0,
-            cache_write_tokens: 0,
-            request_count: 0,
-            error_count: 0,
-            avg_latency_ms: null,
-          },
-          by_model: [],
-          by_user: [],
-          by_api_key: [],
-          by_source: [],
-          series: [],
-        });
-      }
-      return jsonResponse([]);
-    });
+      await screen.findByText("gpt-4o");
+      const before = countCalls(calls).length;
+      await vi.advanceTimersByTimeAsync(40_000);
 
-    renderPage(<ActivityPage />, "/activity?range=24h");
-    await waitFor(() => expect(liveRow()).toBeInTheDocument());
-    const before = listCalls(calls).length;
-
-    // The request settles: the next poll no longer carries it.
-    live = { requests: [], total: 0 };
-    await waitFor(() => expect(noLiveRow()).toBe(true), { timeout: 4000 });
-    await waitFor(() => {
-      expect(listCalls(calls).length).toBeGreaterThan(before);
-    });
+      expect(countCalls(calls).length).toBe(before);
+      expect(screen.queryByRole("button", { name: /new/ })).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
-  it("does not re-read the log on every poll when replicas alternate", async () => {
-    // The registry is per-process, so a deployment running several otari processes
-    // behind a load balancer answers consecutive polls from different processes: a
-    // request that is still running is absent from the next poll and reads as
-    // settled. Unthrottled, that refetches the log and its COUNT(*) every two
-    // seconds for as long as the gateway has any traffic at all.
-    const calls: FetchCall[] = [];
-    let polls = 0;
+  it("does not poll for newer rows in a window that has already ended", async () => {
+    // A window bounded in the past can gain no rows, so the poll would be pure cost.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const { calls } = mockApi({ rows: [entry()], total: 1 });
+      renderPage(
+        <ActivityPage />,
+        "/activity?start_date=2026-01-01T00:00:00Z&end_date=2026-01-02T00:00:00Z",
+      );
 
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-      const url = String(input);
-      calls.push({ url, method: "GET", body: undefined });
-      if (url.includes("/v1/usage/in-flight")) {
-        polls += 1;
-        // Both requests run for the whole test; only which process answered changes.
-        return jsonResponse({
-          requests: [inFlightRequest({ id: polls % 2 === 1 ? "process-a-1" : "process-b-1" })],
-          total: 1,
-        });
-      }
-      if (url.includes("/v1/usage/count")) return jsonResponse({ total: 0 });
-      if (url.includes("/v1/usage/summary")) {
-        return jsonResponse({ by_model: [], by_user: [], by_api_key: [], by_source: [], series: [] });
-      }
-      return jsonResponse([]);
-    });
+      await screen.findByText("gpt-4o");
+      const before = countCalls(calls).length;
+      await vi.advanceTimersByTimeAsync(40_000);
 
-    renderPage(<ActivityPage />, "/activity?range=24h");
-    await waitFor(() => expect(liveRow()).toBeInTheDocument());
-    const before = listCalls(calls).length;
-
-    // Two further polls, each of which looks like a settle to the id heuristic.
-    await waitFor(() => expect(polls).toBeGreaterThanOrEqual(3), { timeout: 8000 });
-
-    // One refetch, not one per poll: the first apparent settle is served and the
-    // rest fall inside the throttle window.
-    expect(listCalls(calls).length - before).toBeLessThanOrEqual(1);
-  }, 15_000);
-
-  it("drops the live rows when the in-flight poll starts failing", async () => {
-    // TanStack keeps the last successful payload after a failed refetch, so
-    // without an explicit error arm the rows would stay on screen with their waits
-    // climbing against a frozen anchor, claiming work is running that may have
-    // landed minutes ago. That is the state the hook already refuses to cache
-    // across mounts, so it must not be reachable this way either.
-    let failing = false;
-
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-      const url = String(input);
-      if (url.includes("/v1/usage/in-flight")) {
-        return failing
-          ? jsonResponse({ detail: "gateway restarting" }, 503)
-          : jsonResponse({ requests: [inFlightRequest({ model: "vanishing-model" })], total: 1 });
-      }
-      if (url.includes("/v1/usage/count")) return jsonResponse({ total: 0 });
-      if (url.includes("/v1/usage/summary")) {
-        return jsonResponse({ by_model: [], by_user: [], by_api_key: [], by_source: [], series: [] });
-      }
-      return jsonResponse([]);
-    });
-
-    renderPage(<ActivityPage />, "/activity?range=24h");
-    await waitFor(() => expect(screen.getByText("vanishing-model")).toBeInTheDocument());
-
-    failing = true;
-    await waitFor(() => expect(screen.queryByText("vanishing-model")).not.toBeInTheDocument(), { timeout: 20000 });
-    expect(noLiveRow()).toBe(true);
-  }, 30_000);
-
-  it("still picks up a settle that the throttle deferred", async () => {
-    // Two requests landing inside one throttle window is the ordinary case on any
-    // gateway with traffic. The second settle must be deferred, not discarded: its
-    // id is gone from the next poll, so nothing re-detects it, and the row it
-    // became would stay missing from the log until an unrelated later settle.
-    let live: InFlightResponse = { requests: [inFlightRequest({ id: "A", model: "model-a" })], total: 1 };
-    let rows: UsageEntry[] = [];
-
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-      const url = String(input);
-      if (url.includes("/v1/usage/in-flight")) return jsonResponse(live);
-      if (url.includes("/v1/usage/count")) return jsonResponse({ total: rows.length });
-      if (url.includes("/v1/usage/summary")) {
-        return jsonResponse({ by_model: [], by_user: [], by_api_key: [], by_source: [], series: [] });
-      }
-      return jsonResponse(rows);
-    });
-
-    renderPage(<ActivityPage />, "/activity?range=24h");
-    await waitFor(() => expect(screen.getByText("model-a")).toBeInTheDocument());
-
-    // A settles, which arms the throttle.
-    live = { requests: [], total: 0 };
-    rows = [entry({ id: "row-a", model: "settled-a" })];
-    await waitFor(() => expect(screen.getByText("settled-a")).toBeInTheDocument(), { timeout: 8000 });
-
-    // B runs and settles well inside the window A's refetch opened.
-    live = { requests: [inFlightRequest({ id: "B", model: "model-b" })], total: 1 };
-    await waitFor(() => expect(screen.getByText("model-b")).toBeInTheDocument(), { timeout: 8000 });
-    live = { requests: [], total: 0 };
-    rows = [entry({ id: "row-b", model: "settled-b" }), entry({ id: "row-a", model: "settled-a" })];
-
-    await waitFor(() => expect(screen.getByText("settled-b")).toBeInTheDocument(), { timeout: 25000 });
-  }, 45_000);
+      expect(countCalls(calls).length).toBe(before);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/web/src/pages/ActivityPage.tsx
+++ b/web/src/pages/ActivityPage.tsx
@@ -1235,6 +1235,14 @@ export function ActivityPage() {
   // operator forward and offer rows that pressing it cannot bring into view.
   const newRows =
     newRowsRelevant && total != null && liveCount.data ? Math.max(0, liveCount.data.total - total) : 0;
+
+  // Whether the page can still tell newer rows from none. The badge's absence
+  // otherwise reads as "nothing has landed", which on a table that no longer moves
+  // by itself makes a flooded gateway look identical to an idle one. Said in the
+  // control strip rather than the error banner: the count failing costs the
+  // operator a hint, not the log they came for, and `retry: false` means a single
+  // blip would otherwise raise a page-level alarm the next poll silently clears.
+  const newRowsUnknown = newRowsRelevant && liveCount.isError;
   // Neither the default preset nor the unbounded "All" is itself a filter: only an
   // explicit sub-window or a bounded non-default preset narrows the window, so a
   // brand-new gateway reads "never used" on both its 24h default and on "All",
@@ -1586,6 +1594,14 @@ export function ActivityPage() {
                   {newRows.toLocaleString()} new · load
                 </Button>
               ) : null}
+              {newRowsUnknown ? (
+                <span
+                  className="text-xs text-[var(--otari-muted)]"
+                  title="The row count could not be read, so this page cannot tell whether newer requests have landed. Refresh to load whatever is there."
+                >
+                  Newer rows unknown
+                </span>
+              ) : null}
               <RefreshButton onRefresh={refresh} isFetching={usage.isFetching} updatedAt={usage.dataUpdatedAt} />
             </span>
           }
@@ -1703,7 +1719,19 @@ export function ActivityPage() {
         pageSize={pageSize}
         total={total}
         rowsOnPage={rows.length}
-        onPageChange={(next) => url.patch({ page: next })}
+        // Paging re-reads the count as well as the rows. The total is a property of
+        // the filters, not of the page, so it is not in the count's key and a frozen
+        // page would carry whichever value it loaded with. That understates a table
+        // traffic has grown, and `TablePagination` derives `isLast` from the total
+        // whenever it has one, so the operator hits a wall short of the real end and
+        // the oldest rows sit past it, unreachable until a manual refresh. Paging is
+        // a deliberate act, so re-reading here keeps the total describing a set the
+        // operator can actually navigate, without putting a self-moving number under
+        // a table that deliberately holds still.
+        onPageChange={(next) => {
+          url.patch({ page: next });
+          void count.refetch();
+        }}
         onPageSizeChange={(size) => url.patch({ size, page: 0 })}
         isFetching={usage.isFetching}
         hasNextFallback={rows.length === pageSize}

--- a/web/src/pages/ActivityPage.tsx
+++ b/web/src/pages/ActivityPage.tsx
@@ -1,10 +1,11 @@
-import { Button } from "@heroui/react";
+import { Button, Popover } from "@heroui/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
 import {
   useDeleteUsage,
   useInFlightRequests,
+  useLiveUsageCount,
   useSetPricing,
   useSetUsagePrice,
   useRequestGroups,
@@ -13,7 +14,7 @@ import {
   useUsageSummary,
 } from "@/api/hooks";
 import type {
-  InFlightRequest,
+  InFlightResponse,
   SummaryDimension,
   UsageEntry,
   UsageFilters,
@@ -116,50 +117,20 @@ function timeAgo(iso: string): string {
 //
 // A usage row is written when a request settles, so the log alone can only
 // describe the past: on a slow backend a 30-second call is invisible for its whole
-// duration. A tracked request is therefore rendered as a row in this same table,
-// pinned above the settled rows and carrying the status below, so that when it
-// lands the row resolves in place into the success or error row it became. The
-// synthetic row is shaped as a `UsageEntry` so the table's columns, widths,
-// selection, and detail machinery need no separate code path: the outcome fields
-// are null, which the shared formatters already render as their own placeholder.
-const IN_FLIGHT_STATUS = "in progress";
-
-// Browser-local timestamp the wait counts up from, present only on a synthetic
-// row. Derived from the poll's `dataUpdatedAt` minus the server's own `elapsed_ms`,
-// so the wait never depends on the browser clock agreeing with the gateway's.
-type ActivityRow = UsageEntry & { inFlightStartedAtMs?: number };
-
-const isInFlightRow = (row: ActivityRow): boolean => row.status === IN_FLIGHT_STATUS;
-
-function inFlightRow(request: InFlightRequest, startedAtMs: number): ActivityRow {
-  return {
-    inFlightStartedAtMs: startedAtMs,
-    id: request.id,
-    user_id: request.user_id,
-    api_key_id: request.api_key_id,
-    timestamp: request.started_at,
-    model: request.model,
-    provider: request.provider,
-    endpoint: request.endpoint,
-    prompt_tokens: null,
-    completion_tokens: null,
-    total_tokens: null,
-    cache_read_tokens: null,
-    cache_write_tokens: null,
-    cost: null,
-    status: IN_FLIGHT_STATUS,
-    error_message: null,
-    status_code: null,
-    policy_name: request.policy_name,
-    latency_ms: null,
-    source: "gateway",
-    source_label: null,
-    // Never selectable: bulk delete and reprice target logged rows, and this one
-    // does not exist in the table yet. `true` is what the page's existing
-    // disabled-key rule keys on, so no extra case is needed there.
-    counts_toward_budget: true,
-  };
-}
+// duration. What is running right now is therefore reported beside the refresh
+// control, as a count that opens the list, rather than as rows pinned above the
+// log.
+//
+// Rows are what this replaced, and the reason is the same one that froze the log
+// (see `useUsageLogs`): the live rows re-derived themselves on a 2s poll, so on a
+// gateway with real traffic the top of the table reordered itself continuously
+// and an operator could not read a row before it moved. Off to one side, the same
+// information costs the table nothing, and an operator who wants the live view
+// opens it deliberately.
+//
+// The trade this makes: a request no longer resolves in place from live row into
+// settled row. It leaves the list when it lands and appears in the log at the
+// next refresh.
 
 // Coarser than the settled Total time column: this is a wall-clock wait an
 // operator is watching rather than a measurement, so sub-second precision is
@@ -171,11 +142,10 @@ function formatElapsed(ms: number): string {
   return `${minutes}m ${String(seconds % 60).padStart(2, "0")}s`;
 }
 
-// The wait, ticking between the 2s polls: on the one row whose whole point is that
-// it has not finished, a number that only moved when a response landed would read
-// as stalled. Each live row owns its interval so the `columns` array stays
-// referentially stable and DataTable's per-row cache is not rebuilt every second
-// (see the DataTable docstring).
+// The wait, ticking between the 2s polls: on an entry whose whole point is that it
+// has not finished, a number that only moved when a response landed would read as
+// stalled. Rendered only inside the open live list, so nothing ticks on a page
+// whose operator has not asked to watch one.
 function InFlightWait({ startedAtMs }: { startedAtMs: number }) {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
@@ -186,18 +156,99 @@ function InFlightWait({ startedAtMs }: { startedAtMs: number }) {
   return <span className="tabular-nums">{formatElapsed(Math.max(0, now - startedAtMs))}</span>;
 }
 
+// The live count, and the list behind it. Reports the gateway as a whole and says
+// so: the endpoint takes no filters, so scoping the label to the current view
+// would claim a narrowing that was never applied.
+//
+// The list is rendered only while the popover is open, so the per-entry 1s ticks
+// exist only for as long as someone is reading them; closed, this is one number
+// that changes every couple of seconds well away from the table.
+//
+// The Button is a direct child of the popover root rather than wrapped in
+// `Popover.Trigger`, which renders its own `role="button"` div and would nest one
+// control inside another. HeroUI's Button is a react-aria Button, so the root
+// wires it up through context.
+//
+// Open state is held here, and the whole control renders only while there is
+// something to report *or* the list is open. An idle gateway therefore shows no
+// control at all, but a list an operator has opened is not torn out from under
+// them when the request they were watching lands: it stays, reading "0 in flight",
+// until they close it. That is also why the count is controlled rather than left
+// to `DialogTrigger`'s own state, which unmounting would discard.
+function InFlightControl({ data, updatedAt }: { data: InFlightResponse; updatedAt: number }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const shown = data.requests;
+  const hidden = Math.max(0, data.total - shown.length);
+  if (data.total === 0 && !isOpen) return null;
+  return (
+    <Popover isOpen={isOpen} onOpenChange={setIsOpen}>
+      <Button size="sm" variant="outline">
+        {/* Decorative: the count beside it carries the same meaning in text, so
+            nothing is encoded in motion alone. That is also why it can stop
+            outright under `prefers-reduced-motion`, being the one element on the
+            page that would otherwise animate indefinitely. Still at zero, where
+            a pulse would suggest activity that is not there. */}
+        <span
+          className={`mr-1.5 inline-block h-1.5 w-1.5 rounded-full motion-reduce:animate-none ${
+            data.total > 0 ? "animate-pulse bg-[var(--otari-brand-dark)]" : "bg-[var(--otari-muted)]"
+          }`}
+          aria-hidden="true"
+        />
+        {data.total.toLocaleString()} in flight
+      </Button>
+      <Popover.Content placement="bottom end">
+        <Popover.Dialog>
+          <div className="flex w-80 flex-col gap-2">
+            <Popover.Heading className="text-sm font-medium">In flight</Popover.Heading>
+            <p className="text-xs text-[var(--otari-muted)]">
+              Running right now, across the whole gateway; longest-running first. Not narrowed by the filters above.
+            </p>
+            {shown.length === 0 ? (
+              <p className="text-sm text-[var(--otari-muted)]">
+                Nothing running right now. Newly settled requests join the log at the next refresh.
+              </p>
+            ) : (
+              <ul className="flex flex-col gap-1.5">
+                {shown.map((request) => (
+                  <li key={request.id} className="flex items-baseline justify-between gap-3 text-sm">
+                    <span className="min-w-0">
+                      <span className="block truncate">{request.model}</span>
+                      <span className="block truncate text-xs text-[var(--otari-muted)]">
+                        {request.user_id ?? "—"}
+                        {request.policy_name ? ` · ${request.policy_name}` : ""}
+                      </span>
+                    </span>
+                    <InFlightWait startedAtMs={updatedAt - request.elapsed_ms} />
+                  </li>
+                ))}
+              </ul>
+            )}
+            {/* Only when the endpoint's cap actually bit, which takes more
+                concurrency than a live list can usefully show anyway. */}
+            {hidden > 0 ? (
+              <p className="text-xs text-[var(--otari-muted)]">
+                {hidden.toLocaleString()} further {hidden === 1 ? "request is" : "requests are"} in flight beyond the{" "}
+                {shown.length.toLocaleString()} listed.
+              </p>
+            ) : null}
+          </div>
+        </Popover.Dialog>
+      </Popover.Content>
+    </Popover>
+  );
+}
+
 // Stable row-key getter and row class so DataTable's per-row cache holds
 // across re-renders (see the DataTable docstring); an inline arrow here would
 // rebuild every row on each selection click.
-const getActivityRowKey = (e: ActivityRow): string => e.id;
+const getActivityRowKey = (e: UsageEntry): string => e.id;
 
 // An absorbed attempt is a failure a routing policy recovered from, so the
 // request it belongs to succeeded. Styling it like an error would make a working
 // fallback chain read as an outage, which is the same reason the server keeps it
 // out of error_count. Amber says "something happened here" without saying "this
 // request failed".
-const activityRowClassName = (e: ActivityRow): string | undefined => {
-  if (isInFlightRow(e)) return "bg-[var(--otari-brand-tint)]";
+const activityRowClassName = (e: UsageEntry): string | undefined => {
   if (e.status === "error") return "bg-red-50";
   if (e.status === "absorbed") return "bg-amber-50";
   return undefined;
@@ -240,11 +291,6 @@ const TOOL_OPTIONS: { label: string; value: string }[] = [
 const TOOL_BREAKDOWN: SummaryDimension[] = ["tool"];
 
 const DEFAULT_PAGE_SIZE = 50;
-
-// Floor on how often a settled in-flight request may pull the log again. Matches
-// the log's own `staleTime` in `useUsageLogs`, so this never delays a refresh the
-// query would have served from cache anyway.
-const SETTLED_REFETCH_MIN_MS = 10_000;
 
 // The only breakdown this page reads: the in-window models behind the typeahead.
 // The typeahead reads `by_model`; the source picker's option list piggybacks on
@@ -331,16 +377,6 @@ function StatusPill({ status }: { status: string }) {
         : "border-[var(--otari-line)] bg-[var(--otari-brand-tint)] text-[var(--otari-brand-dark)]";
   return (
     <span className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium ${cls}`}>
-      {/* The pulse is decorative: "in progress" beside it carries the same meaning
-          in text, so nothing here is encoded in motion alone. That is also why it
-          can stop outright under `prefers-reduced-motion`: this is the one element
-          on the page that would otherwise animate indefinitely. */}
-      {status === IN_FLIGHT_STATUS ? (
-        <span
-          className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-[var(--otari-brand-dark)] motion-reduce:animate-none"
-          aria-hidden="true"
-        />
-      ) : null}
       {status}
     </span>
   );
@@ -994,52 +1030,19 @@ export function ActivityPage() {
 
   // Requests in progress, read unfiltered: the endpoint has no filters, because a
   // request that has not finished has no outcome, cost, or token count to filter
-  // on. Which of them belong in the current view is decided below.
+  // on. Reported gateway-wide beside the refresh control, not as rows.
   const inFlight = useInFlightRequests();
 
-  // A tracked request that has left the in-flight list just settled, so its row
-  // exists in the log now. Pull it in, so the operator watches the live row turn
-  // into its settled one rather than vanish until they press refresh. Keyed on
-  // ids, not on the count: one request finishing while another starts leaves the
-  // count unchanged.
+  // How far behind the frozen page has fallen. Polled while the count it is
+  // compared against is not (see `useUsageCount`), so the difference is "rows that
+  // have landed since this page was drawn".
   //
-  // Rate-limited, because the registry is per-process: a deployment running
-  // several otari processes behind a load balancer answers consecutive polls from
-  // different processes, so a request that is still running reads as settled on
-  // every poll. Unthrottled that refetches the log and its `COUNT(*)` every two
-  // seconds for as long as the gateway has any traffic at all. The ceiling matches
-  // the log's own `staleTime`, so a genuine settle still refreshes promptly and
-  // the flapping case costs one extra pair of reads per interval instead of one
-  // per poll.
-  //
-  // Deferred rather than dropped when the throttle bites: a settle is remembered
-  // on `settlePending` and served by the first poll past the window. Discarding it
-  // instead lost the row entirely, because the id is gone from the next poll and
-  // nothing re-detects it: two requests landing inside one 10-second window left
-  // the second one's row missing from the log until an unrelated later settle or a
-  // manual refresh. The flapping case is unchanged (it re-flags every poll either
-  // way, and still costs one refetch per interval).
-  //
-  // Keyed on `dataUpdatedAt` as well as the payload, so a deferred settle is
-  // reconsidered on the next poll: an idle registry answers every poll with the
-  // same `{requests: [], total: 0}`, which structural sharing hands back as the
-  // same object, so `data` alone stops changing the moment the last request lands.
-  const seenInFlightIds = useRef<Set<string>>(new Set());
-  const lastSettledRefetch = useRef(0);
-  const settlePending = useRef(false);
-  useEffect(() => {
-    if (!inFlight.data) return;
-    const live = new Set((inFlight.data.requests ?? []).map((request) => request.id));
-    if ([...seenInFlightIds.current].some((id) => !live.has(id))) settlePending.current = true;
-    seenInFlightIds.current = live;
-    if (!settlePending.current) return;
-    const now = Date.now();
-    if (now - lastSettledRefetch.current < SETTLED_REFETCH_MIN_MS) return;
-    settlePending.current = false;
-    lastSettledRefetch.current = now;
-    void usage.refetch();
-    void count.refetch();
-  }, [inFlight.data, inFlight.dataUpdatedAt, usage.refetch, count.refetch]);
+  // Only asked for where it can be acted on. On page 2 onward, refreshing does not
+  // bring newer rows into view (they land at the top of page 1), so a badge
+  // offering to load them would be a promise the button does not keep; a window
+  // that ends in the past can gain no rows at all, so the poll would be pure cost.
+  const newRowsRelevant = page === 0 && !filters.end_date;
+  const liveCount = useLiveUsageCount(filters, newRowsRelevant);
 
   // Model suggestions: models with usage in the window (other filters applied, the
   // model filter omitted so the full list stays offered).
@@ -1187,66 +1190,14 @@ export function ActivityPage() {
 
   const rows = usage.data ?? [];
 
-  // The live rows to pin above this page, and how many the endpoint left out.
-  //
-  // Kept separate from `rows` throughout: `rows` is what the paginator counts and
-  // what the bulk actions target, and a request that has not been logged belongs
-  // in neither. Newest-first like the rest of the table, so the row an operator
-  // just triggered appears at the top and stays there as it resolves (the endpoint
-  // serves the longest-running first, which is the order the cap applies in).
-  //
-  // Suppressed rather than shown wherever the current view cannot honestly include
-  // them: page 2 onward (they are not part of any page's slice), a window that ends
-  // in the past, and any filter on something a request has not got yet (outcome,
-  // price, tools, provenance). The identity filters can be applied, so they are.
-  const { inFlightRows, inFlightHidden } = useMemo(() => {
-    const none = { inFlightRows: [] as ActivityRow[], inFlightHidden: 0 };
-    // A failed poll leaves the list unknown, not unchanged. TanStack keeps the last
-    // successful payload, so without the `isError` arm the rows would stay on
-    // screen with their waits still climbing against a frozen anchor, asserting
-    // that work is running which may have landed minutes ago. That is the state
-    // `useInFlightRequests` already refuses to cache across mounts, so it must not
-    // be reached by a different route either. The failure reaches the operator
-    // through the page's error banner rather than as rows quietly disappearing.
-    if (!inFlight.data || inFlight.isError || page > 0) return none;
-    if (filters.end_date || statusFilter || pricedFilter || toolFilter || sourceFilter || sessionFilter) return none;
-    const matching = inFlight.data.requests.filter(
-      (request) =>
-        (modelFilters.length === 0 || modelFilters.includes(request.model)) &&
-        (userFilters.length === 0 || (request.user_id !== null && userFilters.includes(request.user_id))) &&
-        (apiKeyFilters.length === 0 || (request.api_key_id !== null && apiKeyFilters.includes(request.api_key_id))) &&
-        (!endpointFilter || request.endpoint === endpointFilter) &&
-        (!providerFilter || request.provider === providerFilter),
-    );
-    return {
-      inFlightRows: matching
-        .map((request) => inFlightRow(request, inFlight.dataUpdatedAt - request.elapsed_ms))
-        .reverse(),
-      // Only meaningful when nothing was filtered out locally; a filtered view
-      // cannot say how many of the requests the endpoint dropped would have matched.
-      inFlightHidden: matching.length === inFlight.data.requests.length ? inFlight.data.total - matching.length : 0,
-    };
-  }, [
-    inFlight.data,
-    inFlight.dataUpdatedAt,
-    inFlight.isError,
-    page,
-    filters.end_date,
-    statusFilter,
-    pricedFilter,
-    toolFilter,
-    sourceFilter,
-    sessionFilter,
-    modelFilters,
-    userFilters,
-    apiKeyFilters,
-    endpointFilter,
-    providerFilter,
-  ]);
-
-  // What the table renders: live rows pinned above the logged page.
-  const tableRows = useMemo<ActivityRow[]>(() => [...inFlightRows, ...rows], [inFlightRows, rows]);
-  const inFlightIds = useMemo(() => new Set(inFlightRows.map((row) => row.id)), [inFlightRows]);
+  // What the live control may report. A failed poll leaves the list unknown, not
+  // unchanged: TanStack keeps the last successful payload, so without the
+  // `isError` arm the count would sit there with its waits climbing against a
+  // frozen anchor, asserting that work is running which may have landed minutes
+  // ago. That is the state `useInFlightRequests` already refuses to cache across
+  // mounts, so it must not be reachable by this route either. The failure reaches
+  // the operator through the page's error banner instead.
+  const liveNow = inFlight.isError ? undefined : inFlight.data;
 
   // What served each routed request on this page. Built from the page itself where
   // possible (a group's attempts are written milliseconds apart, so they are
@@ -1272,6 +1223,13 @@ export function ActivityPage() {
 
   const totalIsExact = count.isSuccess && !count.isPlaceholderData;
   const total = totalIsExact ? (count.data?.total ?? 0) : null;
+
+  // Rows that have landed since this page was drawn, as the gap between the polled
+  // count and the pinned one. Clamped at zero because the gap can close from the
+  // other side: a bulk delete, or a rolling window whose start has moved past rows
+  // the pinned count still includes, both make the live figure the smaller one, and
+  // "-14 new" is not a thing to show an operator.
+  const newRows = total != null && liveCount.data ? Math.max(0, liveCount.data.total - total) : 0;
   // Neither the default preset nor the unbounded "All" is itself a filter: only an
   // explicit sub-window or a bounded non-default preset narrows the window, so a
   // brand-new gateway reads "never used" on both its 24h default and on "All",
@@ -1345,10 +1303,9 @@ export function ActivityPage() {
   ];
 
   // Selection targets imported rows only; enforced gateway rows are disabled so
-  // bulk delete / set-price can never reach them. Over `tableRows`, so a live row
-  // is disabled too: it carries `counts_toward_budget` true for exactly that.
+  // bulk delete / set-price can never reach them.
   const selectableKeys = useMemo(() => rows.filter((r) => !r.counts_toward_budget).map((r) => r.id), [rows]);
-  const disabledKeys = useMemo(() => tableRows.filter((r) => r.counts_toward_budget).map((r) => r.id), [tableRows]);
+  const disabledKeys = useMemo(() => rows.filter((r) => r.counts_toward_budget).map((r) => r.id), [rows]);
   const selectedIds = resolveSelectedIds(selection.selectedKeys, selectableKeys);
   const pageSelectedCount = selectedIds.length;
   const hasSelection = selection.allMatching || pageSelectedCount > 0;
@@ -1476,6 +1433,12 @@ export function ActivityPage() {
   const refresh = () => {
     void usage.refetch();
     void count.refetch();
+    // Re-read alongside the count it is compared against, or the badge would keep
+    // offering rows the refresh just loaded. Guarded for the same reason as the
+    // source summary below: refetch() ignores `enabled`.
+    if (newRowsRelevant) {
+      void liveCount.refetch();
+    }
     void inFlight.refetch();
     void contextSummary.refetch();
     void modelSummary.refetch();
@@ -1511,7 +1474,7 @@ export function ActivityPage() {
   // Memoized on its per-render inputs (the key labels and the routing outcomes,
   // both themselves memoized) so DataTable's per-row cache holds: a fresh array
   // every render would rebuild all rows per click.
-  const columns = useMemo<DataTableColumn<ActivityRow>[]>(() => {
+  const columns = useMemo<DataTableColumn<UsageEntry>[]>(() => {
     const apiKeyLabel = (entry: UsageEntry): string =>
       entry.api_key_id === null ? "—" : (entry.api_key_name ?? `${entry.api_key_id.slice(0, 8)}…`);
     return [
@@ -1568,14 +1531,7 @@ export function ActivityPage() {
         id: "latency",
         header: "Total time",
         align: "end",
-        // A live row has no total yet, so the column carries the wait so far. Same
-        // column deliberately: it is the number an operator is already reading down.
-        cell: (e) =>
-          e.inFlightStartedAtMs === undefined ? (
-            formatLatency(e.latency_ms)
-          ) : (
-            <InFlightWait startedAtMs={e.inFlightStartedAtMs} />
-          ),
+        cell: (e) => formatLatency(e.latency_ms),
       },
       { id: "status", header: "Status", cell: (e) => <StatusPill status={e.status} /> },
     ];
@@ -1609,7 +1565,25 @@ export function ActivityPage() {
           windowEnd={win.end}
           loading={contextSummary.isLoading}
           ariaLabel="Activity request volume over the selected window"
-          action={<RefreshButton onRefresh={refresh} isFetching={usage.isFetching} updatedAt={usage.dataUpdatedAt} />}
+          action={
+            <span className="inline-flex items-center gap-2">
+              {/* Both live signals sit here, beside the control that acts on them:
+                  the table below never moves on its own, so this strip is the only
+                  place the page says anything is still happening. */}
+              {/* Rendered whenever the poll is answering at all, not only when it
+                  reports traffic: the control hides itself while idle, but has to
+                  stay mounted to keep an open list open across the moment the last
+                  request lands. It still goes on a failed poll, where `liveNow` is
+                  undefined, since there is nothing trustworthy left to report. */}
+              {liveNow ? <InFlightControl data={liveNow} updatedAt={inFlight.dataUpdatedAt} /> : null}
+              {newRows > 0 ? (
+                <Button size="sm" variant="outline" onPress={refresh} isDisabled={usage.isFetching}>
+                  {newRows.toLocaleString()} new · load
+                </Button>
+              ) : null}
+              <RefreshButton onRefresh={refresh} isFetching={usage.isFetching} updatedAt={usage.dataUpdatedAt} />
+            </span>
+          }
         />
         <FilterChips chips={filterChips} onClearAll={clearEntityFilters}>
           <FilterSelect id="filter-status" label="Status" value={statusFilter} onChange={(value) => url.patch({ status: value })}>
@@ -1705,7 +1679,7 @@ export function ActivityPage() {
       <DataTable
         ariaLabel="Activity log"
         columns={columns}
-        rows={tableRows}
+        rows={rows}
         getRowKey={getActivityRowKey}
         isLoading={usage.isLoading}
         emptyContent={anyFilter ? "No requests match these filters." : "No requests recorded yet."}
@@ -1713,26 +1687,11 @@ export function ActivityPage() {
         selectedKeys={selection.selectedKeys}
         onSelectionChange={selection.onSelectionChange}
         disabledKeys={disabledKeys}
-        // A live row has no detail to open: every field the panel reads (tokens,
-        // cost, the pricing breakdown, the attempt plan) is written when the
-        // request settles. Clicking it does nothing until it does.
-        onRowAction={(key) => {
-          if (inFlightIds.has(key)) return;
-          setExpandedId((current) => (current === key ? null : key));
-        }}
+        onRowAction={(key) => setExpandedId((current) => (current === key ? null : key))}
         rowClassName={activityRowClassName}
         detailKey={expandedId}
         renderDetail={renderDetail}
       />
-
-      {/* Only when the endpoint's cap actually bit, which takes more concurrency
-          than a live view can usefully list anyway. */}
-      {inFlightHidden > 0 ? (
-        <p className="text-xs text-[var(--otari-muted)]">
-          {inFlightHidden.toLocaleString()} further {inFlightHidden === 1 ? "request is" : "requests are"} in flight
-          beyond the {inFlightRows.length.toLocaleString()} listed; the longest-running are shown.
-        </p>
-      ) : null}
 
       <TablePagination
         page={page}

--- a/web/src/pages/ActivityPage.tsx
+++ b/web/src/pages/ActivityPage.tsx
@@ -1226,10 +1226,15 @@ export function ActivityPage() {
 
   // Rows that have landed since this page was drawn, as the gap between the polled
   // count and the pinned one. Clamped at zero because the gap can close from the
-  // other side: a bulk delete, or a rolling window whose start has moved past rows
-  // the pinned count still includes, both make the live figure the smaller one, and
-  // "-14 new" is not a thing to show an operator.
-  const newRows = total != null && liveCount.data ? Math.max(0, liveCount.data.total - total) : 0;
+  // other side: a bulk delete makes the live figure the smaller one, and "-14 new"
+  // is not a thing to show an operator.
+  //
+  // Gated on the same condition as the poll: `page` is not part of the live count's
+  // key, so disabling the query on page 2 stops it refetching but still hands back
+  // the payload it cached on page 1. Without this the badge would follow the
+  // operator forward and offer rows that pressing it cannot bring into view.
+  const newRows =
+    newRowsRelevant && total != null && liveCount.data ? Math.max(0, liveCount.data.total - total) : 0;
   // Neither the default preset nor the unbounded "All" is itself a filter: only an
   // explicit sub-window or a bounded non-default preset narrows the window, so a
   // brand-new gateway reads "never used" on both its 24h default and on "All",


### PR DESCRIPTION
## Description

On a busy gateway the activity table reloaded every few seconds, so rows reordered under an operator faster than they could be inspected. The cause was a settle-detector that refetched `/v1/usage` and its `COUNT(*)` whenever a tracked request left the in-flight list. On a gateway with continuous traffic that throttle was always saturated, so the table reshuffled every 10 seconds indefinitely.

The log is now a snapshot: it loads on mount and reloads when asked, by the refresh button or by a change of filters, window, or page.

Requests in flight move out of the table and into a count beside the refresh control, which opens the live list. The 2s poll still runs, but it touches one number well away from the rows. This drops the synthetic in-flight rows, their filter-suppression rules, and the throttled settle-refetch that existed only to make those rows resolve in place. Because the endpoint takes no filters, the count is now reported gateway-wide and the list says so, replacing the old client-side filtering of live rows. A list an operator has opened stays open when the last request lands, reading "0 in flight", rather than vanishing at the moment they were waiting for.

A frozen page still has to say it has fallen behind, so a second, polled `COUNT(*)` sizes an "N new, load" badge against the pinned count. It runs only on the first page of a window that is still open, the one place where loading newer rows brings them into view.

**Trade made:** a request no longer resolves in place from live row into settled row. It leaves the list when it lands and joins the log at the next refresh.

**Known gap, not addressed here:** `useUsageCount`'s key does not include `page`, so once traffic lands the pinned total drifts from the rows you page into. This predates the PR, but the settle-refetch used to mask it and now nothing does. Worth a follow-up decision: refetch the count on a page change, or let the paginator read the live count.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Related: #427 (closed) described the Activity page working as a monitor but not as a browser; this addresses the refresh half of that.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Notes on the two above: this is a dashboard-only change, so the checks run were the `web/` ones (`npm --prefix web run typecheck`, `npm --prefix web test`, `npm --prefix web run build`), all clean, 585 tests across 40 files. No Python, route, or schema changed, so there is no OpenAPI or Postman artifact to regenerate. `docs/dashboard.md` is updated in the same change, since the bundled guide ships with the dashboard it documents.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5, via the Claude Code CLI.

**Any additional AI details you'd like to share:**

The design was chosen by @njbrake from three options put to him (keep the live rows pinned, freeze the whole page as a stamped snapshot, or move the live view behind a count), along with the decision to add the staleness badge and to keep an opened list open at zero. The code and prose are the model's; the reasoning and the calls are his.

The PR was then reviewed by a separate agent with no part in writing it, which found the "N new" badge leaking onto later pages (fixed in 9e2a373, with a regression test) and corrected a claim in an earlier draft of this description about `refetchOnWindowFocus`, which is already off app-wide in `provider.tsx` and was never a second cause. CodeRabbit independently flagged the same badge bug.

- [x] I am an AI Agent filling out this form (check box if true)