### PR TITLE
fix(usage): pin offset-less usage window bounds to UTC

### DIFF
--- a/src/gateway/api/routes/usage.py
+++ b/src/gateway/api/routes/usage.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, verify_api_key_or_master_key, verify_master_key
 from gateway.core.config import GatewayConfig
-from gateway.core.sql import MAX_FILTER_VALUES, match_any
+from gateway.core.sql import MAX_FILTER_VALUES, match_any, utc_bound
 from gateway.inflight import get_registry
 from gateway.models.entities import APIKey, UsageLog, User
 from gateway.services.external_usage_service import (
@@ -353,12 +353,17 @@ def _usage_filters(
 
     Keeping this in one place guarantees the paginator's total (``/count``)
     always matches the rows ``list_usage`` returns for the same filters.
+
+    Bounds are pinned to UTC here rather than only in ``_resolve_window``, which
+    the summary endpoints route through but the list and count endpoints do not:
+    an offset-less bound would otherwise resolve against the process's local
+    timezone, so the same query would size a different set of rows per deployment.
     """
     conditions: list[ColumnElement[bool]] = []
     if start_date is not None:
-        conditions.append(UsageLog.timestamp >= start_date)
+        conditions.append(UsageLog.timestamp >= utc_bound(start_date))
     if end_date is not None:
-        conditions.append(UsageLog.timestamp < end_date)
+        conditions.append(UsageLog.timestamp < utc_bound(end_date))
     if user_id is not None and user_id != []:
         conditions.append(match_any(UsageLog.user_id, user_id))
     if status is not None:

--- a/src/gateway/services/usage_admin_service.py
+++ b/src/gateway/services/usage_admin_service.py
@@ -27,7 +27,7 @@ from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.core.sql import MAX_FILTER_VALUES, match_any
+from gateway.core.sql import MAX_FILTER_VALUES, match_any, utc_bound
 from gateway.core.usage import GatewayUsage
 from gateway.log_config import logger
 from gateway.models.entities import ModelPricing, UsageLog
@@ -179,9 +179,9 @@ def _selection_conditions(selection: UsageSelection) -> list[ColumnElement[bool]
     if selection.source_label is not None:
         conditions.append(UsageLog.source_label == selection.source_label)
     if selection.start_date is not None:
-        conditions.append(UsageLog.timestamp >= selection.start_date)
+        conditions.append(UsageLog.timestamp >= utc_bound(selection.start_date))
     if selection.end_date is not None:
-        conditions.append(UsageLog.timestamp < selection.end_date)
+        conditions.append(UsageLog.timestamp < utc_bound(selection.end_date))
     if selection.priced is True:
         conditions.append(UsageLog.cost.is_not(None))
     elif selection.priced is False:

--- a/tests/unit/test_usage_filter_bounds.py
+++ b/tests/unit/test_usage_filter_bounds.py
@@ -1,0 +1,74 @@
+"""Unit tests for UTC pinning of the usage window bounds.
+
+The date query params and selection bodies advertise ISO 8601, so a caller that
+omits the offset hands in a naive datetime. asyncpg encodes ``timestamptz`` with
+``astimezone``, which reads a naive value as the process's local time, so the same
+bound would select a different set of rows per deployment. `/v1/usage/summary`
+routes through `_resolve_window` and was already pinned; the list, count, and bulk
+mutation paths do not, so they pin the bound themselves.
+
+The count an operator confirms and the delete that re-derives its target set from
+the same body have to mean the same instant, so both sides are asserted here.
+"""
+
+from datetime import UTC, datetime, timedelta, timezone
+from typing import Any
+
+from gateway.api.routes.usage import _usage_filters
+from gateway.services.usage_admin_service import UsageSelection, _selection_conditions
+
+_NAIVE_START = datetime(2026, 8, 12, 8, 0)
+_NAIVE_END = datetime(2026, 8, 13, 8, 0)
+
+
+def _bound_values(conditions: list[Any]) -> list[datetime]:
+    """The datetime each timestamp comparison binds, in the order they were built.
+
+    A selection carries non-comparison conditions too (the imported-only guards),
+    so anything that does not bind a datetime is skipped rather than unwrapped.
+    """
+    bounds = []
+    for condition in conditions:
+        value = getattr(getattr(condition, "right", None), "value", None)
+        if isinstance(value, datetime):
+            bounds.append(value)
+    return bounds
+
+
+def test_list_and_count_filters_pin_a_naive_bound_to_utc() -> None:
+    conditions = _usage_filters(
+        start_date=_NAIVE_START,
+        end_date=_NAIVE_END,
+        user_id=None,
+        status=None,
+        model=None,
+        endpoint=None,
+    )
+    assert _bound_values(conditions) == [
+        _NAIVE_START.replace(tzinfo=UTC),
+        _NAIVE_END.replace(tzinfo=UTC),
+    ]
+
+
+def test_list_and_count_filters_leave_an_offset_bound_alone() -> None:
+    """A caller that sent an offset meant that instant, so it passes through."""
+    offset = timezone(timedelta(hours=-4))
+    aware_start = _NAIVE_START.replace(tzinfo=offset)
+    conditions = _usage_filters(
+        start_date=aware_start,
+        end_date=None,
+        user_id=None,
+        status=None,
+        model=None,
+        endpoint=None,
+    )
+    assert _bound_values(conditions) == [aware_start]
+
+
+def test_bulk_selection_pins_the_same_bound_as_the_count() -> None:
+    """The delete re-derives its target set server-side, so it has to agree."""
+    selection = UsageSelection(by_filter=True, start_date=_NAIVE_START, end_date=_NAIVE_END)
+    assert _bound_values(_selection_conditions(selection)) == [
+        _NAIVE_START.replace(tzinfo=UTC),
+        _NAIVE_END.replace(tzinfo=UTC),
+    ]


### PR DESCRIPTION
## Description

`/v1/usage/summary` routes its window bounds through `_resolve_window`, which makes a naive datetime UTC-aware. `GET /v1/usage` and `/v1/usage/count` do not, and neither does the selection body behind `DELETE /v1/usage` and `POST /v1/usage/set-price`.

The date params advertise ISO 8601, so a caller that omits the offset hands in a naive datetime. asyncpg encodes `timestamptz` with `astimezone`, which reads a naive value as the process's local time, so the same bound sized a different set of rows per deployment and `/count` could disagree with the summary reported for the same window.

Both sides move together on purpose: the dashboard sizes its "select all N matching" affordance from `/count`, then sends the filter body for the server to re-derive the target set, so a bound the two read differently would delete a set the operator was never shown.

`utc_bound` already exists in `core.sql` from #567, which is where a condition shared by a route filter and a service selection belongs, since a service may not import the API layer.

No behavior change on a UTC host, which is what a container normally runs. On a non-UTC host, a scripted delete using offset-less dates now selects a slightly different window, which is the correction rather than a regression.

The three added tests assert the bound the filter actually binds, so they hold in a UTC CI container where the bug itself is invisible. Reverting the source fix fails two of them.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None. Follows from the review of #567, which introduced `utc_bound` and fixed the same problem on the agent-telemetry endpoints.

## Checklist

- [ ] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

On the checklist, so the record is exact:

- `make lint`, `make typecheck`, `make openapi-check`, and `make postman-check` pass. The full suite is green against PostgreSQL 18: 2811 passed, 16 skipped.
- No documentation change was needed, and the API contract is unchanged: the only docstring touched is on a private helper, and both generated artifacts verify clean.
- The first box is the author's own attestation, left for the author rather than checked by the agent that drafted this.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

Found while reviewing #567: the agent-telemetry read endpoints had the same defect, and the fix there was scoped to that feature. This applies it to the usage family.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this pull request was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._
