### PR TITLE
fix(web-search): serialize extraction and return its retained heap

### DIFF
--- a/src/gateway/heap.py
+++ b/src/gateway/heap.py
@@ -1,0 +1,65 @@
+"""Return freed heap to the kernel after allocation-heavy work.
+
+glibc's allocator keeps freed chunks in its per-thread arenas instead of handing
+them back, so a burst of large, short-lived allocations leaves the process
+resident at its high-water mark long after the memory is dead. Web-search
+extraction is the gateway's worst case: each search parses up to
+``web_search_max_results`` pages of HTML (capped at 5 MB each) through libxml2,
+whose allocations are large enough to strand tens of megabytes per search. The
+resident set climbs to a plateau and stays there, which reads as a leak on a
+memory graph even though nothing is reachable.
+
+:func:`release_free_heap` asks glibc to give that back. It is a mitigation, not
+a repair: the churn itself is libxml2's, and this only stops the allocator from
+hoarding what is already free.
+
+Availability is resolved once, at import. ``malloc_trim`` is a GNU extension, so
+this is a no-op on musl and macOS rather than an error: callers treat releasing
+memory as best-effort and must not branch on whether it happened.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import platform
+from typing import Callable
+
+from gateway.log_config import logger
+
+
+def _resolve_malloc_trim() -> Callable[[int], int] | None:
+    """Look up ``malloc_trim`` in the running libc, or return None if absent."""
+    if platform.system() != "Linux":
+        return None
+    try:
+        libc = ctypes.CDLL("libc.so.6")
+        trim = libc.malloc_trim
+    except (OSError, AttributeError):
+        # Not glibc (musl names its libc differently and omits the symbol).
+        return None
+    trim.argtypes = [ctypes.c_size_t]
+    trim.restype = ctypes.c_int
+    return trim
+
+
+_MALLOC_TRIM = _resolve_malloc_trim()
+
+
+def malloc_trim_available() -> bool:
+    """Whether this platform can return free heap to the kernel."""
+    return _MALLOC_TRIM is not None
+
+
+def release_free_heap() -> None:
+    """Best-effort release of free heap held by the allocator.
+
+    Safe to call from the event loop: the call walks the arena free lists and
+    completes in single-digit milliseconds for the heap sizes the gateway
+    reaches. Never raises, so callers can treat it as fire-and-forget.
+    """
+    if _MALLOC_TRIM is None:
+        return
+    try:
+        _MALLOC_TRIM(0)
+    except Exception as exc:  # noqa: BLE001 — releasing memory must never fail a request
+        logger.debug("malloc_trim failed: %s", exc)

--- a/src/gateway/metrics.py
+++ b/src/gateway/metrics.py
@@ -10,6 +10,7 @@ from prometheus_client import (
     Counter,
     Gauge,
     Histogram,
+    ProcessCollector,
     generate_latest,
 )
 from starlette.responses import Response
@@ -19,6 +20,12 @@ if TYPE_CHECKING:
     from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 REGISTRY = CollectorRegistry()
+
+# process_resident_memory_bytes and friends. The gateway keeps its own registry
+# rather than prometheus_client's default one, which is where these live by
+# default, so without this /metrics reports no process memory at all and the
+# only way to see the resident set is a shell inside the container.
+PROCESS_COLLECTOR = ProcessCollector(registry=REGISTRY)
 
 REQUESTS = Counter(
     "gateway_requests",

--- a/src/gateway/services/file_extractors.py
+++ b/src/gateway/services/file_extractors.py
@@ -19,10 +19,17 @@ import io
 import mimetypes
 import os
 import tempfile
+import threading
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from gateway.log_config import logger
+
+# The shared MarkItDown, built on first use by _get_converter. Typed loosely
+# because markitdown ships no stubs (see the mypy override in pyproject.toml).
+_converter: Any | None = None
+_converter_lock = threading.Lock()
 
 # MIME → file extension hints for formats markitdown keys off the suffix.
 _MIME_TO_EXT: dict[str, str] = {
@@ -59,10 +66,31 @@ def _resolve_extension(mime_type: str, filename: str | None) -> str:
     return mimetypes.guess_extension(mime) or ".bin"
 
 
+def _get_converter() -> Any | None:
+    """Return the process-wide MarkItDown, building it on first use.
+
+    Built once and shared. Constructing a ``MarkItDown`` initializes magika,
+    which loads an ONNX model and starts its own inference thread pool; none of
+    that is released when the instance is dropped, so building one per call grew
+    the resident set by several megabytes and nine threads *per extraction*. The
+    lock matters because extractions run concurrently in the default executor:
+    an unlocked check lets every racing caller build its own before the first
+    finishes, which is the leak this fixes.
+    """
+    global _converter
+    with _converter_lock:
+        if _converter is None:
+            try:
+                from markitdown import MarkItDown
+            except ImportError:
+                return None
+            _converter = MarkItDown(enable_plugins=False)
+    return _converter
+
+
 def _extract_sync(data: bytes, extension: str) -> ExtractionResult:
-    try:
-        from markitdown import MarkItDown
-    except ImportError:
+    converter = _get_converter()
+    if converter is None:
         return ExtractionResult("", False, "markitdown not installed")
 
     # markitdown's stable API is path-based; write to a temp file with the right
@@ -73,7 +101,7 @@ def _extract_sync(data: bytes, extension: str) -> ExtractionResult:
     try:
         tmp.write(data)
         tmp.close()
-        result = MarkItDown(enable_plugins=False).convert(tmp.name)
+        result = converter.convert(tmp.name)
     except Exception as exc:  # noqa: BLE001 — surface as a failed extraction, not a 500
         logger.warning("markitdown extraction failed for %s: %s", extension, exc)
         return ExtractionResult("", False, f"extraction error: {exc}")

--- a/src/gateway/services/file_extractors.py
+++ b/src/gateway/services/file_extractors.py
@@ -70,12 +70,12 @@ def _get_converter() -> Any | None:
     """Return the process-wide MarkItDown, building it on first use.
 
     Built once and shared. Constructing a ``MarkItDown`` initializes magika,
-    which loads an ONNX model and starts its own inference thread pool; none of
-    that is released when the instance is dropped, so building one per call grew
-    the resident set by several megabytes and nine threads *per extraction*. The
-    lock matters because extractions run concurrently in the default executor:
-    an unlocked check lets every racing caller build its own before the first
-    finishes, which is the leak this fixes.
+    which loads an ONNX model and starts its own inference thread pool, costing
+    several megabytes and nine threads. The threads go back when the instance is
+    collected but the memory does not, so building one per call grew the resident
+    set without bound. The lock matters because extractions run concurrently in
+    the default executor: an unlocked check lets every racing caller build its
+    own before the first finishes, which is the leak this fixes.
     """
     global _converter
     with _converter_lock:
@@ -89,7 +89,14 @@ def _get_converter() -> Any | None:
 
 
 def _extract_sync(data: bytes, extension: str) -> ExtractionResult:
-    converter = _get_converter()
+    # Building the converter initializes magika (ONNX model load), which can fail
+    # for reasons other than a missing package. Keep that a failed extraction so
+    # the caller still gets its PDF-rasterize / vision fallback.
+    try:
+        converter = _get_converter()
+    except Exception as exc:  # noqa: BLE001 — surface as a failed extraction, not a 500
+        logger.warning("markitdown converter unavailable: %s", exc)
+        return ExtractionResult("", False, f"extraction error: {exc}")
     if converter is None:
         return ExtractionResult("", False, "markitdown not installed")
 

--- a/src/gateway/services/web_search_backend.py
+++ b/src/gateway/services/web_search_backend.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from contextlib import AsyncExitStack
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
@@ -39,6 +40,7 @@ import httpx
 import trafilatura
 from opentelemetry import trace
 
+from gateway.heap import release_free_heap
 from gateway.services.tool_usage import ToolUsageTally
 from gateway.services.url_safety import UnsafeURLError, validate_outbound_fetch_url
 
@@ -47,6 +49,35 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
+
+# trafilatura is not safe to call from several threads at once. Extracting
+# concurrently corrupts the allocator's bookkeeping and aborts the whole
+# process with a glibc "double free or corruption" / "free(): invalid pointer";
+# a 24-search loop over real pages died about one run in three, with and without
+# the heap release below.
+#
+# Serializing the parse is not free. lxml drops the GIL, so extraction really did
+# run in parallel: over five heavy pages a search went from roughly 520ms to
+# roughly 880ms in testing. That is the price of not aborting the process, which
+# would take every in-flight request with it. Only the parse is serialized; the
+# per-page fetches still overlap, and they dominate on a normal-sized page. The
+# lock is module-level rather than per backend instance because the unsafe state
+# is trafilatura's own module globals.
+_EXTRACT_LOCK = threading.Lock()
+
+
+def _extract_markdown(html: str) -> str | None:
+    """Extract Markdown from one page, serialized against every other caller."""
+    with _EXTRACT_LOCK:
+        result = trafilatura.extract(
+            html,
+            output_format="markdown",
+            include_comments=False,
+            include_tables=True,
+            favor_recall=True,
+        )
+    return str(result) if result else None
+
 
 WEB_SEARCH_TOOL_NAME = "web_search"
 
@@ -358,7 +389,14 @@ class WebSearchBackend:
             if content:
                 result["extracted_content"] = content
 
-        await asyncio.gather(*(one(r) for r in results), return_exceptions=False)
+        try:
+            await asyncio.gather(*(one(r) for r in results), return_exceptions=False)
+        finally:
+            # Parsing several pages of HTML strands tens of megabytes per search
+            # in glibc's arenas; without this the resident set plateaus at its
+            # high-water mark for the life of the process. Runs on the failure
+            # path too, which allocated just the same.
+            release_free_heap()
 
     async def _fetch_and_extract(self, url: str) -> str | None:
         assert self._client is not None
@@ -382,17 +420,10 @@ class WebSearchBackend:
             return None
 
         # trafilatura.extract is synchronous and CPU-bound on large inputs; run
-        # in a thread so the event loop stays responsive while many pages are
-        # extracted in parallel.
+        # in a thread so the event loop stays responsive while the other pages
+        # in this search are still being fetched.
         try:
-            extracted = await asyncio.to_thread(
-                trafilatura.extract,
-                html,
-                output_format="markdown",
-                include_comments=False,
-                include_tables=True,
-                favor_recall=True,
-            )
+            extracted = await asyncio.to_thread(_extract_markdown, html)
         except Exception as exc:  # noqa: BLE001 — trafilatura raises broad
             logger.debug("web_search: extract failed for %s: %s", url, exc)
             return None

--- a/src/gateway/services/web_search_backend.py
+++ b/src/gateway/services/web_search_backend.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import AsyncExitStack
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
@@ -50,32 +51,47 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
 
-# trafilatura is not safe to call from several threads at once. Extracting
-# concurrently corrupts the allocator's bookkeeping and aborts the whole
-# process with a glibc "double free or corruption" / "free(): invalid pointer";
-# a 24-search loop over real pages died about one run in three, with and without
-# the heap release below.
+# trafilatura is not safe to call from several threads at once: it parses through
+# lxml parsers held in its own module globals (``trafilatura.utils.HTML_PARSER``,
+# ``trafilatura.xml.CONTROL_PARSER``), and sharing an lxml parser across threads
+# corrupts the allocator's bookkeeping. Extracting a search's pages concurrently
+# aborted the process outright with a glibc "double free or corruption" in a
+# minority of runs over real pages, so every extraction is confined to one
+# dedicated worker.
 #
-# Serializing the parse is not free. lxml drops the GIL, so extraction really did
-# run in parallel: over five heavy pages a search went from roughly 520ms to
-# roughly 880ms in testing. That is the price of not aborting the process, which
-# would take every in-flight request with it. Only the parse is serialized; the
-# per-page fetches still overlap, and they dominate on a normal-sized page. The
-# lock is module-level rather than per backend instance because the unsafe state
-# is trafilatura's own module globals.
-_EXTRACT_LOCK = threading.Lock()
+# A dedicated executor rather than a lock around ``asyncio.to_thread``: the
+# default executor is shared with file extraction, PDF rasterizing and OCR
+# (:mod:`gateway.services.file_extractors`), and threads blocked waiting for a
+# lock still occupy their slot in that pool. Queued searches would then stall
+# unrelated uploads behind them for seconds. One worker gives the same
+# serialization while holding one thread total. Module-level, because the unsafe
+# state is trafilatura's own module globals and is shared across event loops.
+#
+# Serializing does cost throughput, since lxml drops the GIL and extraction
+# genuinely ran in parallel. Aborting the process takes every in-flight request
+# with it, so that is the better trade.
+_extract_executor: ThreadPoolExecutor | None = None
+_extract_executor_lock = threading.Lock()
+
+
+def _get_extract_executor() -> ThreadPoolExecutor:
+    """The single worker every page extraction runs on, created on first search."""
+    global _extract_executor
+    with _extract_executor_lock:
+        if _extract_executor is None:
+            _extract_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="otari-extract")
+    return _extract_executor
 
 
 def _extract_markdown(html: str) -> str | None:
-    """Extract Markdown from one page, serialized against every other caller."""
-    with _EXTRACT_LOCK:
-        result = trafilatura.extract(
-            html,
-            output_format="markdown",
-            include_comments=False,
-            include_tables=True,
-            favor_recall=True,
-        )
+    """Extract Markdown from one page. Only ever called on the extraction worker."""
+    result = trafilatura.extract(
+        html,
+        output_format="markdown",
+        include_comments=False,
+        include_tables=True,
+        favor_recall=True,
+    )
     return str(result) if result else None
 
 
@@ -420,10 +436,11 @@ class WebSearchBackend:
             return None
 
         # trafilatura.extract is synchronous and CPU-bound on large inputs; run
-        # in a thread so the event loop stays responsive while the other pages
-        # in this search are still being fetched.
+        # it off the loop so the loop stays responsive while the other pages in
+        # this search are still being fetched.
         try:
-            extracted = await asyncio.to_thread(_extract_markdown, html)
+            loop = asyncio.get_running_loop()
+            extracted = await loop.run_in_executor(_get_extract_executor(), _extract_markdown, html)
         except Exception as exc:  # noqa: BLE001 — trafilatura raises broad
             logger.debug("web_search: extract failed for %s: %s", url, exc)
             return None

--- a/tests/unit/test_file_extractors.py
+++ b/tests/unit/test_file_extractors.py
@@ -1,0 +1,93 @@
+"""Unit tests for `gateway.services.file_extractors` converter reuse.
+
+The extraction results themselves are markitdown's business; what is tested here
+is that the gateway builds exactly one converter. Constructing a ``MarkItDown``
+initializes magika, which loads an ONNX model and starts an inference thread
+pool that is never released, so one-per-call leaked memory and threads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from gateway.services import file_extractors
+
+
+@pytest.fixture(autouse=True)
+def _reset_converter() -> Any:
+    file_extractors._converter = None
+    yield
+    file_extractors._converter = None
+
+
+def test_converter_is_built_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    built = 0
+
+    class FakeMarkItDown:
+        def __init__(self, **_: Any) -> None:
+            nonlocal built
+            built += 1
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "markitdown",
+        type("m", (), {"MarkItDown": FakeMarkItDown}),
+    )
+
+    first = file_extractors._get_converter()
+    second = file_extractors._get_converter()
+
+    assert first is second
+    assert built == 1
+
+
+def test_concurrent_callers_share_one_converter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The real leak: unlocked, every racing extraction builds its own."""
+    built = 0
+
+    class SlowMarkItDown:
+        def __init__(self, **_: Any) -> None:
+            nonlocal built
+            built += 1
+            # Widen the race window an unlocked implementation would lose.
+            import time
+
+            time.sleep(0.05)
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "markitdown",
+        type("m", (), {"MarkItDown": SlowMarkItDown}),
+    )
+
+    async def main() -> list[Any]:
+        results: list[Any] = await asyncio.gather(
+            *(asyncio.to_thread(file_extractors._get_converter) for _ in range(8))
+        )
+        return results
+
+    converters = asyncio.run(main())
+
+    assert built == 1, "a racing caller built a second converter"
+    assert all(c is converters[0] for c in converters)
+
+
+def test_missing_markitdown_reports_cleanly(monkeypatch: pytest.MonkeyPatch) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def no_markitdown(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "markitdown":
+            raise ImportError("not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", no_markitdown)
+
+    assert file_extractors._get_converter() is None
+    result = file_extractors._extract_sync(b"data", ".txt")
+    assert result.ok is False
+    assert "markitdown not installed" in result.detail

--- a/tests/unit/test_file_extractors.py
+++ b/tests/unit/test_file_extractors.py
@@ -75,6 +75,30 @@ def test_concurrent_callers_share_one_converter(monkeypatch: pytest.MonkeyPatch)
     assert all(c is converters[0] for c in converters)
 
 
+def test_failing_converter_build_degrades_instead_of_raising(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A magika/ONNX load failure must stay a failed extraction.
+
+    The caller relies on ``ok=False`` to reach its PDF-rasterize / vision
+    fallback; an exception escaping here skips the whole request's
+    normalization instead of just this one document.
+    """
+
+    class Exploding:
+        def __init__(self, **_: Any) -> None:
+            raise RuntimeError("magika model failed to load")
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "markitdown",
+        type("m", (), {"MarkItDown": Exploding}),
+    )
+
+    result = file_extractors._extract_sync(b"data", ".txt")
+
+    assert result.ok is False
+    assert "magika model failed to load" in result.detail
+
+
 def test_missing_markitdown_reports_cleanly(monkeypatch: pytest.MonkeyPatch) -> None:
     import builtins
 

--- a/tests/unit/test_gateway_metrics.py
+++ b/tests/unit/test_gateway_metrics.py
@@ -1,5 +1,7 @@
 """Unit tests for gateway Prometheus metrics — no database required."""
 
+import os
+
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
@@ -260,6 +262,7 @@ def test_rate_limiter_records_metric_on_429() -> None:
     assert _sample("gateway_rate_limit_hits_total") - before == 1.0
 
 
+@pytest.mark.skipif(not os.path.exists("/proc/stat"), reason="ProcessCollector needs /proc")
 def test_metrics_expose_process_memory() -> None:
     """Without this the only way to read the resident set is a shell in the container."""
     body = generate_latest(REGISTRY).decode()

--- a/tests/unit/test_gateway_metrics.py
+++ b/tests/unit/test_gateway_metrics.py
@@ -3,6 +3,7 @@
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
+from prometheus_client import generate_latest
 
 from gateway.core.config import GatewayConfig
 from gateway.metrics import (
@@ -257,3 +258,11 @@ def test_rate_limiter_records_metric_on_429() -> None:
 
     assert exc_info.value.status_code == 429
     assert _sample("gateway_rate_limit_hits_total") - before == 1.0
+
+
+def test_metrics_expose_process_memory() -> None:
+    """Without this the only way to read the resident set is a shell in the container."""
+    body = generate_latest(REGISTRY).decode()
+
+    assert "process_resident_memory_bytes" in body
+    assert _sample("process_resident_memory_bytes") > 0

--- a/tests/unit/test_heap.py
+++ b/tests/unit/test_heap.py
@@ -1,0 +1,49 @@
+"""Unit tests for `gateway.heap` — no database required."""
+
+from __future__ import annotations
+
+import platform
+
+import pytest
+
+from gateway import heap
+
+
+def test_release_free_heap_never_raises() -> None:
+    """Callers treat this as fire-and-forget, so it must swallow everything."""
+    heap.release_free_heap()
+    heap.release_free_heap()
+
+
+def test_release_free_heap_swallows_a_failing_libc(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(_: int) -> int:
+        raise OSError("malloc_trim exploded")
+
+    monkeypatch.setattr(heap, "_MALLOC_TRIM", boom)
+    heap.release_free_heap()
+
+
+def test_release_free_heap_is_a_noop_without_glibc(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(heap, "_MALLOC_TRIM", None)
+    heap.release_free_heap()
+    assert heap.malloc_trim_available() is False
+
+
+def test_release_free_heap_calls_into_libc(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[int] = []
+
+    def record(pad: int) -> int:
+        calls.append(pad)
+        return 0
+
+    monkeypatch.setattr(heap, "_MALLOC_TRIM", record)
+
+    heap.release_free_heap()
+
+    assert calls == [0], "malloc_trim takes a pad of 0 to release everything it can"
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="malloc_trim is a glibc extension")
+def test_malloc_trim_resolves_on_linux() -> None:
+    """The deployment target is glibc Linux; a silent no-op there would hide the fix."""
+    assert heap.malloc_trim_available() is True

--- a/tests/unit/test_heap.py
+++ b/tests/unit/test_heap.py
@@ -43,7 +43,10 @@ def test_release_free_heap_calls_into_libc(monkeypatch: pytest.MonkeyPatch) -> N
     assert calls == [0], "malloc_trim takes a pad of 0 to release everything it can"
 
 
-@pytest.mark.skipif(platform.system() != "Linux", reason="malloc_trim is a glibc extension")
-def test_malloc_trim_resolves_on_linux() -> None:
+@pytest.mark.skipif(
+    platform.system() != "Linux" or platform.libc_ver()[0] != "glibc",
+    reason="malloc_trim is a glibc extension; musl Linux is a deliberate no-op",
+)
+def test_malloc_trim_resolves_on_glibc() -> None:
     """The deployment target is glibc Linux; a silent no-op there would hide the fix."""
     assert heap.malloc_trim_available() is True

--- a/tests/unit/test_web_search_backend.py
+++ b/tests/unit/test_web_search_backend.py
@@ -860,3 +860,102 @@ async def test_take_last_results_empty_for_an_empty_query(monkeypatch: pytest.Mo
     async with WebSearchBackend(base_url="http://searxng:8080", extract_content=False) as backend:
         await backend.call_tool(WEB_SEARCH_TOOL_NAME, {"query": "   "})
         assert backend.take_last_results() == []
+
+
+@pytest.mark.asyncio
+async def test_extraction_releases_free_heap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Parsing HTML strands memory in glibc's arenas; the search must hand it back."""
+    _patched_async_client(
+        {
+            ("searxng", "/search"): httpx.Response(200, json=SEARXNG_OK_BODY),
+            ("example.com", "/post-a"): httpx.Response(200, text="<html><body><p>A</p></body></html>"),
+            ("example.org", "/post-b"): httpx.Response(200, text="<html><body><p>B</p></body></html>"),
+        },
+        monkeypatch,
+    )
+    calls = 0
+
+    def counting_release() -> None:
+        nonlocal calls
+        calls += 1
+
+    monkeypatch.setattr("gateway.services.web_search_backend.release_free_heap", counting_release)
+    with patch("gateway.services.web_search_backend.trafilatura.extract", return_value="body"):
+        async with WebSearchBackend(base_url="http://searxng:8080", extract_content=True) as backend:
+            await backend.call_tool(WEB_SEARCH_TOOL_NAME, {"query": "claude code"})
+
+    assert calls == 1, "one release per search, after the whole batch of pages"
+
+
+@pytest.mark.asyncio
+async def test_free_heap_released_even_when_extraction_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The failure path allocated just the same, so it must release too."""
+    _patched_async_client(
+        {
+            ("searxng", "/search"): httpx.Response(200, json=SEARXNG_OK_BODY),
+            ("example.com", "/post-a"): httpx.Response(200, text="<html><body><p>A</p></body></html>"),
+            ("example.org", "/post-b"): httpx.Response(200, text="<html><body><p>B</p></body></html>"),
+        },
+        monkeypatch,
+    )
+    calls = 0
+
+    def counting_release() -> None:
+        nonlocal calls
+        calls += 1
+
+    monkeypatch.setattr("gateway.services.web_search_backend.release_free_heap", counting_release)
+    # _fetch_and_extract swallows extractor errors, so raise from the gather itself.
+    monkeypatch.setattr(
+        "gateway.services.web_search_backend.validate_outbound_fetch_url",
+        _raise_cancelled,
+    )
+    async with WebSearchBackend(base_url="http://searxng:8080", extract_content=True) as backend:
+        with pytest.raises(RuntimeError):
+            await backend.call_tool(WEB_SEARCH_TOOL_NAME, {"query": "claude code"})
+
+    assert calls == 1
+
+
+async def _raise_cancelled(_url: str) -> None:
+    raise RuntimeError("guard blew up")
+
+
+def test_extraction_is_serialized_across_threads() -> None:
+    """Concurrent trafilatura.extract corrupts the heap and aborts the process.
+
+    Asserts on the observable contract (never two extractions in flight at once)
+    rather than on the lock object, so a different serialization strategy still
+    passes.
+    """
+    import asyncio as _asyncio
+    import threading as _threading
+
+    from gateway.services.web_search_backend import _extract_markdown
+
+    in_flight = 0
+    overlaps = 0
+    guard = _threading.Lock()
+
+    def tracking_extract(_html: str, **_: Any) -> str:
+        nonlocal in_flight, overlaps
+        with guard:
+            in_flight += 1
+            if in_flight > 1:
+                overlaps += 1
+        import time
+
+        time.sleep(0.02)
+        with guard:
+            in_flight -= 1
+        return "body"
+
+    async def main() -> None:
+        await _asyncio.gather(
+            *(_asyncio.to_thread(_extract_markdown, f"<html>{i}</html>") for i in range(8))
+        )
+
+    with patch("gateway.services.web_search_backend.trafilatura.extract", tracking_extract):
+        _asyncio.run(main())
+
+    assert overlaps == 0, "two extractions ran at once; this aborts the process under real load"

--- a/tests/unit/test_web_search_backend.py
+++ b/tests/unit/test_web_search_backend.py
@@ -924,14 +924,13 @@ async def _raise_cancelled(_url: str) -> None:
 def test_extraction_is_serialized_across_threads() -> None:
     """Concurrent trafilatura.extract corrupts the heap and aborts the process.
 
-    Asserts on the observable contract (never two extractions in flight at once)
-    rather than on the lock object, so a different serialization strategy still
-    passes.
+    Asserts the observable contract (never two extractions in flight at once)
+    rather than the mechanism, so a different serialization strategy still passes.
     """
     import asyncio as _asyncio
     import threading as _threading
 
-    from gateway.services.web_search_backend import _extract_markdown
+    from gateway.services.web_search_backend import _extract_markdown, _get_extract_executor
 
     in_flight = 0
     overlaps = 0
@@ -951,11 +950,51 @@ def test_extraction_is_serialized_across_threads() -> None:
         return "body"
 
     async def main() -> None:
+        loop = _asyncio.get_running_loop()
         await _asyncio.gather(
-            *(_asyncio.to_thread(_extract_markdown, f"<html>{i}</html>") for i in range(8))
+            *(
+                loop.run_in_executor(_get_extract_executor(), _extract_markdown, f"<html>{i}</html>")
+                for i in range(8)
+            )
         )
 
     with patch("gateway.services.web_search_backend.trafilatura.extract", tracking_extract):
         _asyncio.run(main())
 
     assert overlaps == 0, "two extractions ran at once; this aborts the process under real load"
+
+
+def test_extraction_does_not_occupy_the_shared_executor() -> None:
+    """Queued extractions must not stall unrelated asyncio.to_thread work.
+
+    file_extractors' upload path shares the default executor, so a blocking wait
+    held there would put uploads behind the whole search queue.
+    """
+    import asyncio as _asyncio
+    import time as _time
+
+    from gateway.services.web_search_backend import _extract_markdown, _get_extract_executor
+
+    def slow_extract(_html: str, **_: Any) -> str:
+        _time.sleep(0.05)
+        return "body"
+
+    async def main() -> float:
+        loop = _asyncio.get_running_loop()
+        queued = [
+            _asyncio.ensure_future(
+                loop.run_in_executor(_get_extract_executor(), _extract_markdown, f"<html>{i}</html>")
+            )
+            for i in range(40)
+        ]
+        await _asyncio.sleep(0.1)
+        start = _time.perf_counter()
+        await _asyncio.to_thread(lambda: None)
+        elapsed = _time.perf_counter() - start
+        await _asyncio.gather(*queued)
+        return elapsed
+
+    with patch("gateway.services.web_search_backend.trafilatura.extract", slow_extract):
+        elapsed = _asyncio.run(main())
+
+    assert elapsed < 0.5, f"unrelated to_thread work waited {elapsed:.2f}s behind the extraction queue"


### PR DESCRIPTION
## Description

A gateway with web-search intercept sat at a near constant 533MB RSS (518MB of it anonymous) against a 273MB freshly started floor. Driving the real `WebSearchBackend` over local copies of real pages found two faults in the extraction path.

**Retained heap.** Each search parses up to `max_results` pages of HTML through libxml2, whose allocations are large enough that glibc keeps the freed chunks rather than returning them. One search alone added 178MB, and a single `malloc_trim` handed 154MB back, so nothing was reachable. `gateway.heap.release_free_heap` now runs after each search's extraction batch: over 24 searches the process holds at ~148MB instead of ~300MB, and it stays flat under sustained load. No-ops off glibc, so musl and macOS are unaffected.

**Process aborts.** trafilatura is not thread-safe: it parses through lxml parsers held in its own module globals, and the backend called it from five threads at once. A 24-search loop over real pages died with a glibc `double free or corruption` in a minority of runs, independently of the trim. Extraction now runs on a dedicated single-worker executor, which serializes it: 12 of 12 runs clean.

A dedicated executor rather than a lock around `asyncio.to_thread`, because the default pool is shared with file extraction, PDF rasterizing and OCR; threads blocked on a lock still hold their slot, so queued searches stalled unrelated uploads behind them (2267ms versus 0.3ms for an unrelated task). Serializing costs throughput, since lxml drops the GIL and extraction genuinely ran in parallel. An abort takes every in-flight request with it, so that is the better trade.

Two things found along the way:

- `file_extractors` built a `MarkItDown` per call. Each initializes magika, loading an ONNX model plus an inference thread pool: ~5MB and 9 threads per extraction, and the memory never came back. Now built once behind a lock, since racing callers would otherwise each build their own.
- `/metrics` exposed no process memory, because the gateway keeps its own registry rather than prometheus_client's default. `ProcessCollector` adds `process_resident_memory_bytes`.

Measured on aarch64; absolute figures will differ on amd64.

Moving extraction into worker processes was prototyped and rejected for now: CPython's `max_tasks_per_child` deadlocks when multi-megabyte payloads back up the call queue, and the workarounds cost more memory than they saved (roughly 478MB under saturation against 235MB here). The version worth building instead has workers fetch their own URLs so only URLs cross the pipe, which is a security-sensitive change to the SSRF and redirect handling and belongs in its own PR.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None filed; found while investigating memory use on a Railway deployment.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary. No user-facing behaviour or config changed, so no doc updates were needed.
- [x] If the API contract changed, I regenerated the OpenAPI spec. The contract is unchanged; `make openapi-check` passes.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5, via the Claude Code CLI.

**Any additional AI details you'd like to share:**

The diagnosis came from measurement rather than inspection: process RSS split into anonymous versus file-backed, per-dependency import cost, and A/B runs of the real backend against a local corpus of real pages. Several conclusions drawn along the way were wrong and were corrected by later measurement. `MALLOC_ARENA_MAX=2` looked worth ~100MB in a synthetic harness but only ~22MB on the real path, so it is not here. The concurrency abort was briefly dismissed after a single run survived, which was a false negative from one sample. An independent review then caught that the first version of the serialization starved the shared executor, and that moving the converter build outside its `try` had turned a model-load failure into an exception escaping the extractor.

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this PR was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added shared memory management for web-search extraction.
- Serialized page extraction to prevent concurrent failures.
- Reused one `MarkItDown` instance across extraction requests.
- Added process memory metrics to `/metrics`.
- Preserved extraction error handling and scanned-PDF fallback behavior.
- Added tests for memory release, extraction serialization, converter reuse, failure handling, and platform-specific behavior.

These changes reduce memory retention and prevent extraction work from blocking unrelated tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->