### PR TITLE
fix(dashboard): bound and await sign-out so it can't clobber a fresh sign-in

### DIFF
--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { ApiError, apiFetch } from "./client";
+import { ApiError, apiFetch, createSession, deleteSession } from "./client";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -83,5 +83,51 @@ describe("apiFetch", () => {
     await expect(apiFetch("/v1/models")).rejects.toMatchObject({
       message: expect.stringContaining("could not reach the gateway"),
     });
+  });
+});
+
+describe("createSession", () => {
+  it("bounds the request the same way apiFetch does", async () => {
+    const seen: (AbortSignal | null | undefined)[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+      seen.push(init?.signal);
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    });
+
+    await createSession("test-key");
+
+    expect(seen[0]).toBeInstanceOf(AbortSignal);
+  });
+
+  it("maps a timeout to the same bounded-request message apiFetch uses", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new DOMException("timed out", "TimeoutError"));
+
+    await expect(createSession("test-key")).rejects.toMatchObject({
+      status: 0,
+      message: expect.stringContaining("did not respond within 30s"),
+    });
+  });
+});
+
+describe("deleteSession", () => {
+  it("bounds the request the same way apiFetch does", async () => {
+    const seen: (AbortSignal | null | undefined)[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+      seen.push(init?.signal);
+      return Promise.resolve(new Response(null, { status: 204 }));
+    });
+
+    await deleteSession();
+
+    expect(seen[0]).toBeInstanceOf(AbortSignal);
+  });
+
+  it("still resolves, rather than throwing, when the request times out", async () => {
+    // deleteSession is best-effort and swallows failures: AuthContext.logout
+    // relies on this promise always settling, timeout or not, to clear
+    // isSigningOut and unblock a subsequent sign-in (see #557).
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new DOMException("timed out", "TimeoutError"));
+
+    await expect(deleteSession()).resolves.toBeUndefined();
   });
 });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -49,8 +49,12 @@ export async function createSession(key: string): Promise<boolean> {
       method: "POST",
       headers: { Accept: "application/json", "Content-Type": "application/json" },
       body: JSON.stringify({ master_key: key }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
-  } catch {
+  } catch (error) {
+    if (isTimeout(error)) {
+      throw new ApiError(0, TIMEOUT_MESSAGE);
+    }
     throw new ApiError(0, "Network error: could not reach the gateway.");
   }
   if (response.status === 401 || response.status === 403) {
@@ -65,9 +69,12 @@ export async function createSession(key: string): Promise<boolean> {
 // Best-effort server-side sign-out: revokes the cookie's session and expires
 // the cookie. Uses raw fetch (not apiFetch) and swallows failures so the
 // 401-bounce path can call it without re-entering the unauthorized handler.
+// Bounded like every other management call: an unbounded sign-out could
+// otherwise stay in flight past a subsequent sign-in and clobber its fresh
+// cookie with this call's expiring one (see #557).
 export async function deleteSession(): Promise<void> {
   try {
-    await fetch("/v1/auth/session", { method: "DELETE" });
+    await fetch("/v1/auth/session", { method: "DELETE", signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
   } catch {
     // Signing out locally still proceeds; the session expires on its TTL.
   }

--- a/web/src/auth/AuthContext.test.tsx
+++ b/web/src/auth/AuthContext.test.tsx
@@ -6,13 +6,13 @@ import { useAuth } from "@/auth/AuthContext";
 import { Provider } from "@/provider";
 
 function Harness() {
-  const { isAuthenticated, logout } = useAuth();
+  const { isAuthenticated, isSigningOut, logout } = useAuth();
   return isAuthenticated ? (
     <button type="button" onClick={logout}>
       Sign out
     </button>
   ) : (
-    <div>SIGNED OUT</div>
+    <div>{isSigningOut ? "SIGNED OUT (revocation pending)" : "SIGNED OUT"}</div>
   );
 }
 
@@ -64,6 +64,33 @@ describe("AuthProvider", () => {
     await waitFor(() => {
       const call = fetchMock.mock.calls.find(([url]) => url === "/v1/auth/session");
       expect(call?.[1]?.method).toBe("DELETE");
+    });
+  });
+
+  it("marks isSigningOut while the revocation is in flight, and clears it once resolved", async () => {
+    window.localStorage.setItem("otari.dashboard.hasSession", "1");
+    let resolveDelete!: () => void;
+    const deletePending = new Promise<Response>((resolve) => {
+      resolveDelete = () => resolve(new Response(null, { status: 204 }));
+    });
+    vi.spyOn(globalThis, "fetch").mockReturnValue(deletePending);
+    const user = userEvent.setup();
+
+    render(
+      <Provider>
+        <Harness />
+      </Provider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Sign out" }));
+
+    // Local sign-out is synchronous and unconditional...
+    expect(screen.getByText("SIGNED OUT (revocation pending)")).toBeInTheDocument();
+
+    // ...but isSigningOut only clears once the DELETE actually resolves.
+    resolveDelete();
+    await waitFor(() => {
+      expect(screen.getByText("SIGNED OUT")).toBeInTheDocument();
     });
   });
 });

--- a/web/src/auth/AuthContext.test.tsx
+++ b/web/src/auth/AuthContext.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -13,6 +13,22 @@ function Harness() {
     </button>
   ) : (
     <div>{isSigningOut ? "SIGNED OUT (revocation pending)" : "SIGNED OUT"}</div>
+  );
+}
+
+function RepeatableLogoutHarness() {
+  // Unlike Harness, this exposes a "Trigger logout" button that stays
+  // rendered regardless of isAuthenticated, so a test can call logout()
+  // more than once - Harness's button disappears the instant the first
+  // call flips isAuthenticated false.
+  const { isSigningOut, logout } = useAuth();
+  return (
+    <div>
+      <button type="button" onClick={logout}>
+        Trigger logout
+      </button>
+      <div>{isSigningOut ? "SIGNING OUT" : "IDLE"}</div>
+    </div>
   );
 }
 
@@ -91,6 +107,58 @@ describe("AuthProvider", () => {
     resolveDelete();
     await waitFor(() => {
       expect(screen.getByText("SIGNED OUT")).toBeInTheDocument();
+    });
+  });
+
+  it("keeps isSigningOut true until every concurrent logout's revocation settles", async () => {
+    // A manual sign-out and a stray 401-triggered auto-logout can both call
+    // logout() close together. If the flag cleared on whichever deleteSession
+    // resolves first, an earlier call finishing first would reopen the #557
+    // race while a later, still-pending one could still land and clobber a
+    // fresh sign-in's cookie.
+    let resolveFirst!: () => void;
+    let resolveSecond!: () => void;
+    const firstPending = new Promise<Response>((resolve) => {
+      resolveFirst = () => resolve(new Response(null, { status: 204 }));
+    });
+    const secondPending = new Promise<Response>((resolve) => {
+      resolveSecond = () => resolve(new Response(null, { status: 204 }));
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockReturnValueOnce(firstPending)
+      .mockReturnValueOnce(secondPending);
+    const user = userEvent.setup();
+
+    render(
+      <Provider>
+        <RepeatableLogoutHarness />
+      </Provider>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Trigger logout" });
+    await user.click(trigger);
+    await user.click(trigger);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(screen.getByText("SIGNING OUT")).toBeInTheDocument();
+
+    // The second (later) call resolves first: the flag must stay true, since
+    // the first call is still pending. Flush the resolved promise's
+    // microtasks (its .finally()) without waiting on a condition that's
+    // already true, so this actually exercises the settle path rather than
+    // passing trivially.
+    resolveSecond();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText("SIGNING OUT")).toBeInTheDocument();
+
+    // Only once the first call also resolves does the flag clear.
+    resolveFirst();
+    await waitFor(() => {
+      expect(screen.getByText("IDLE")).toBeInTheDocument();
     });
   });
 });

--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -13,6 +13,12 @@ const STORAGE_KEY = "otari.dashboard.hasSession";
 
 interface AuthContextValue {
   isAuthenticated: boolean;
+  // True while a sign-out's server-side revocation is still in flight. The
+  // sign-in screen uses this to refuse a new credential until the old
+  // session has finished tearing down, so a stalled DELETE cannot outlive a
+  // fresh sign-in and clobber its cookie with this call's expiring one
+  // (see #557).
+  isSigningOut: boolean;
   login: () => void;
   logout: () => void;
 }
@@ -31,10 +37,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient();
 
   const [isAuthenticated, setAuthenticated] = useState<boolean>(readStoredMarker);
+  const [isSigningOut, setSigningOut] = useState(false);
 
   const logout = useCallback(() => {
-    // Best-effort server-side revocation; local sign-out proceeds regardless.
-    void deleteSession();
+    // Local sign-out is unconditional and synchronous, exactly as before:
+    // the UI returns to the sign-in screen at once regardless of how the
+    // server-side revocation below turns out.
     setAuthenticated(false);
     // Drop any admin data cached under the old session so it can't render to a
     // later, possibly different, session in the same tab.
@@ -44,6 +52,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } catch {
       // Ignore storage errors (e.g. private mode); in-memory state still clears.
     }
+    // Best-effort server-side revocation, now bounded (see client.ts) and
+    // tracked: isSigningOut gates the sign-in form so a new session cannot
+    // be minted while this DELETE might still land and clear its cookie.
+    setSigningOut(true);
+    void deleteSession().finally(() => setSigningOut(false));
   }, [queryClient]);
 
   // Called after POST /v1/auth/session succeeded, i.e. the browser already
@@ -66,8 +79,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [logout]);
 
   const value = useMemo<AuthContextValue>(
-    () => ({ isAuthenticated, login, logout }),
-    [isAuthenticated, login, logout],
+    () => ({ isAuthenticated, isSigningOut, login, logout }),
+    [isAuthenticated, isSigningOut, login, logout],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
 import { deleteSession, setUnauthorizedHandler } from "@/api/client";
@@ -38,6 +38,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const [isAuthenticated, setAuthenticated] = useState<boolean>(readStoredMarker);
   const [isSigningOut, setSigningOut] = useState(false);
+  // logout() can fire more than once concurrently: a manual sign-out and a
+  // stray 401-triggered auto-logout (unauthorizedHandler) can both land
+  // close together, each starting its own deleteSession(). Counting the
+  // in-flight revocations, rather than a single finally() clearing the flag
+  // unconditionally, means isSigningOut only drops once every pending one has
+  // settled - not just whichever happens to resolve first.
+  const pendingSignOutsRef = useRef(0);
 
   const logout = useCallback(() => {
     // Local sign-out is unconditional and synchronous, exactly as before:
@@ -54,9 +61,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
     // Best-effort server-side revocation, now bounded (see client.ts) and
     // tracked: isSigningOut gates the sign-in form so a new session cannot
-    // be minted while this DELETE might still land and clear its cookie.
+    // be minted while any revocation might still land and clear its cookie.
+    pendingSignOutsRef.current += 1;
     setSigningOut(true);
-    void deleteSession().finally(() => setSigningOut(false));
+    void deleteSession().finally(() => {
+      pendingSignOutsRef.current -= 1;
+      if (pendingSignOutsRef.current === 0) {
+        setSigningOut(false);
+      }
+    });
   }, [queryClient]);
 
   // Called after POST /v1/auth/session succeeded, i.e. the browser already

--- a/web/src/components/Login.test.tsx
+++ b/web/src/components/Login.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -9,6 +9,17 @@ import { Provider } from "@/provider";
 function Harness() {
   const { isAuthenticated } = useAuth();
   return isAuthenticated ? <div>SIGNED IN</div> : <Login />;
+}
+
+function SignOutThenLoginHarness() {
+  const { isAuthenticated, logout } = useAuth();
+  return isAuthenticated ? (
+    <button type="button" onClick={logout}>
+      Sign out
+    </button>
+  ) : (
+    <Login />
+  );
 }
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -76,5 +87,53 @@ describe("Login", () => {
     expect(await screen.findByText("Invalid master key.")).toBeInTheDocument();
     expect(screen.queryByText("SIGNED IN")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Sign in" })).toBeInTheDocument();
+  });
+
+  it("refuses a new credential while a prior sign-out's revocation is still in flight (#557)", async () => {
+    window.localStorage.setItem("otari.dashboard.hasSession", "1");
+
+    let resolveDelete!: () => void;
+    const deletePending = new Promise<Response>((resolve) => {
+      resolveDelete = () => resolve(new Response(null, { status: 204 }));
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+      if (init?.method === "DELETE") {
+        return deletePending;
+      }
+      return Promise.resolve(jsonResponse({ expires_at: "2026-07-30T00:00:00Z" }));
+    });
+    const user = userEvent.setup();
+
+    render(
+      <Provider>
+        <SignOutThenLoginHarness />
+      </Provider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Sign out" }));
+
+    // Local sign-out lands immediately, before the DELETE resolves.
+    const keyField = await screen.findByLabelText("Master key");
+    await user.type(keyField, "sk-new");
+
+    const submitButton = screen.getByRole("button", { name: "Finishing sign-out…" });
+    expect(submitButton).toBeDisabled();
+    await user.click(submitButton);
+
+    // Blocked: no sign-in POST was attempted while the old sign-out was pending.
+    expect(fetchMock.mock.calls.some(([, init]) => init?.method === "POST")).toBe(false);
+
+    resolveDelete();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Sign in" })).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+    // Back to authenticated: SignOutThenLoginHarness renders the "Sign out"
+    // button again once isAuthenticated flips true.
+    expect(await screen.findByRole("button", { name: "Sign out" })).toBeInTheDocument();
+    const postCall = fetchMock.mock.calls.find(([, init]) => init?.method === "POST");
+    expect(postCall?.[1]?.body).toBe(JSON.stringify({ master_key: "sk-new" }));
   });
 });

--- a/web/src/components/Login.tsx
+++ b/web/src/components/Login.tsx
@@ -6,14 +6,17 @@ import { useAuth } from "@/auth/AuthContext";
 import { ErrorBanner } from "@/components/ui";
 
 export function Login() {
-  const { login } = useAuth();
+  const { login, isSigningOut } = useAuth();
   const [value, setValue] = useState("");
   const [error, setError] = useState<unknown>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const submit = async () => {
     const trimmed = value.trim();
-    if (!trimmed || isSubmitting) {
+    // isSigningOut blocks a new sign-in until a prior sign-out's server-side
+    // revocation has finished (or timed out): otherwise its expiring cookie
+    // could land after this one mints a fresh session and clobber it (#557).
+    if (!trimmed || isSubmitting || isSigningOut) {
       return;
     }
     setIsSubmitting(true);
@@ -79,8 +82,8 @@ export function Login() {
               </p>
             </details>
             <ErrorBanner error={error} />
-            <Button type="submit" variant="primary" fullWidth isDisabled={!value.trim() || isSubmitting}>
-              {isSubmitting ? "Signing in…" : "Sign in"}
+            <Button type="submit" variant="primary" fullWidth isDisabled={!value.trim() || isSubmitting || isSigningOut}>
+              {isSigningOut ? "Finishing sign-out…" : isSubmitting ? "Signing in…" : "Sign in"}
             </Button>
           </form>
 


### PR DESCRIPTION
## Description
`DELETE /v1/auth/session` (`deleteSession`) had no `AbortSignal`, and its promise was never awaited in `AuthContext.logout` (`void deleteSession()`). A stalled sign-out could stay in flight past a subsequent sign-in.

The damage comes from the response, not the request: `delete_session` always ends with `clear_session_cookie(response)`, an expiring `Set-Cookie`. If that response lands after a later `POST /v1/auth/session` has already minted a new session cookie, the browser drops the fresh cookie in favor of the expiring one. The new session stays alive and unreferenced server-side, and the operator is bounced to the sign-in screen for no visible reason.

Fix, matching the approach suggested in the issue:

- `deleteSession`/`createSession` (`web/src/api/client.ts`) now pass `AbortSignal.timeout(REQUEST_TIMEOUT_MS)`, the same bound `apiFetch` already uses for every other management call.
- `AuthContext` (`web/src/auth/AuthContext.tsx`) exposes a new `isSigningOut` flag: `true` from the moment `logout()` fires the `DELETE`, `false` once it resolves (now bounded by the timeout above). Local sign-out itself stays synchronous and unconditional, exactly as before — the UI still returns to the sign-in screen immediately.
- `Login`'s submit (`web/src/components/Login.tsx`) is gated on `isSigningOut`, so a new sign-in cannot start while a prior sign-out's revocation might still be in flight and clobber the new session's cookie when it eventually lands.

## PR Type

- [x] Bug Fix

## Relevant issues
Fixes #557

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`npm run typecheck`, `npm test` — this PR only touches `web/`, so the Python `make lint`/`make typecheck`/`make test` targets don't apply; the dashboard CI workflow runs `npm run typecheck`, `npm test`, and `npm run build` instead, and I ran the first two directly).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). — N/A, no API contract change.

## AI Usage

- [x] AI was used for drafting/refactoring.

**AI Model/Tool used:** Claude Sonnet 5 (Claude Code)

**Any additional AI details you'd like to share:** I picked this one up off the good-first-issue-style backlog, read through the repro and the suggested fix in the issue, and worked through the implementation with Claude Code: deciding the `isSigningOut` gate belongs on the sign-in form rather than blocking sign-out itself, choosing to keep local sign-out synchronous/unconditional so the UX doesn't regress, and writing out both the isolated state-transition test and the full blocked-then-unblocked flow test. I reviewed and tested the diff before opening this PR.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevents stale sign-out requests from affecting a newly created session.
- Shows sign-out progress while local sign-out completes immediately.
- Blocks login until all sign-out requests finish.
- Adds request timeouts and regression tests for session handling and login flow.

## Technical notes

- Adds `isSigningOut` to `AuthContext`.
- Applies timeout-bounded `AbortSignal`s to `createSession` and `deleteSession`.
- Tracks concurrent sign-out requests until all requests settle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->