### PR TITLE
feat(code-execution): publish the OpenAPI IDL and a backend conformance check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,13 @@ The per-request flow (auth → budget → dispatch → reconciliation) spans sev
   no `make openapi` target; `make openapi-check` only validates. Verify with
   `make openapi-check` and `make postman-check`. The same `openapi-spec` CI job runs both
   checks, so missing this fails CI even when `openapi-check` passes.
+- `docs/public/code-execution-openapi.yaml` is the exception in that directory: it is
+  **hand-maintained**, not generated. It specifies a backend Otari calls, so no app here
+  serves those paths and `generate_openapi.py` neither reads nor writes it. Edit it
+  together with `docs/code-execution-protocol.md`, which is normative for the semantics a
+  schema cannot carry; `tests/unit/test_code_execution_contract.py` fails when the two
+  disagree, and `scripts/check_code_execution_conformance.py` checks a live backend
+  against it.
 - `CHANGELOG.md` and the GitHub Release body are generated from Conventional
   Commits by git-cliff (`cliff.toml`) at release time, not per-PR. Because PRs are
   squash-merged, the PR title is what git-cliff parses; `otari-pr-title.yml`

--- a/docs/code-execution-protocol.md
+++ b/docs/code-execution-protocol.md
@@ -14,14 +14,25 @@ a single container that stands alone with no orchestrator. mozilla.ai operates a
 second, pool-backed backend for [otari.ai](https://otari.ai). Both implement this
 contract, and Otari cannot tell which one answered.
 
-> **Transport is not yet fixed.** This specification describes operations and
-> payload semantics, deliberately independent of how they are carried. Today
-> there is exactly one binding, HTTP/JSON, described under
-> [HTTP/JSON binding](#httpjson-binding) and implemented by every backend that
-> exists. That binding is **provisional**: while only one transport has ever been
-> implemented, committing the versioned contract to it would be premature. The
-> operations and payloads below are the stable part; the binding may gain
-> siblings.
+The contract is HTTP/JSON, described by OpenAPI. Its machine-readable form is
+[`public/code-execution-openapi.yaml`](public/code-execution-openapi.yaml),
+which a backend implementer can generate a server stub or a client from
+directly. The two are normative in different registers, and neither is
+redundant: the OpenAPI document is normative for shapes, paths, and status
+codes; this document is normative for the semantics a schema cannot carry, such
+as session statefulness, how a failed program is reported, and the extension
+policy. `tests/unit/test_code_execution_contract.py` fails when they disagree.
+
+> **Why HTTP, and when that gets revisited.** A transport-neutral IDL (proto,
+> serving gRPC and HTTP/JSON alike) was weighed and declined: it would be a
+> second contract paradigm in a house whose SDKs are already generated from
+> OpenAPI, with no workload today to pay for it. Server-streamed output
+> (incremental `stdout` and `stderr` while code runs) rides HTTP over SSE or
+> chunked responses, so streaming did not decide it. Two triggers reopen the
+> question: the first backend that is not reachable over HTTP, and the first
+> bidirectional interactive workload, meaning a live PTY where input is fed while
+> output is read on one connection. Discrete tool calls, which is all the
+> contract carries today, need neither.
 
 ## Roles
 
@@ -70,8 +81,8 @@ Response fields:
 | `session_id` | yes | A string addressing this session in every later operation |
 | `idle_timeout_seconds` | no | The idle timeout actually in force |
 | `max_lifetime_seconds` | no | The maximum lifetime actually in force |
-| `created_at` | no | When the session was created |
-| `last_activity_at` | no | When the session was last used |
+| `created_at` | no | When the session was created, in POSIX seconds |
+| `last_activity_at` | no | When the session was last used, in POSIX seconds |
 
 `session_id` is a string, not a number: a client may use it to address the
 session without reformatting it.
@@ -108,6 +119,11 @@ in a single request.
 client MUST allow more wall-clock than it grants, since its own budget also
 covers transport and the backend's teardown; otherwise a legitimate
 near-limit execution is reported as an unreachable backend.
+
+A backend MAY impose a ceiling on `timeout_seconds`, and MAY either clamp a
+larger value or refuse the request as malformed, so the contract sets no maximum
+of its own. A client that needs a long-running call cannot assume the value it
+sent was honoured.
 
 ### DestroySession
 
@@ -195,6 +211,11 @@ returns a `content` whose `stdout` and `stderr` are empty and whose
 `return_code` is `0`, not a block with `content` omitted. Its own fields are all
 OPTIONAL and default as shown in the example.
 
+Each entry in the nested `content` list describes one file the execution
+produced, and carries a `file_id` addressing it plus the `filename` the
+execution gave it. Both are REQUIRED on an entry: a reference to a file a client
+can neither name nor fetch is not worth emitting.
+
 The block's `type` corresponds to the tool kind that ran:
 `code_execution_tool_result`, `bash_code_execution_tool_result`, or
 `text_editor_code_execution_tool_result`.
@@ -266,8 +287,7 @@ it is absent, rather than defaulting to a placeholder tenant.
 
 ## HTTP/JSON binding
 
-The one binding that exists today. Provisional, per the note at the top of this
-document. Payloads are JSON; the operation names above map to:
+Payloads are JSON; the operation names above map to:
 
 | Operation | Method and path |
 |---|---|
@@ -289,6 +309,7 @@ Status codes:
 | Session created, file written | `201` |
 | Execute succeeded (including code that failed) | `200` |
 | Session destroyed | `204` |
+| Credential missing or rejected, where the deployment requires one | `401` |
 | Unknown session, or unknown file | `404` |
 | Malformed request, or unknown tool kind | `400` or `422` |
 | Path outside the session workspace | `403` |
@@ -300,9 +321,32 @@ A bearer credential, where the deployment uses one, is sent as
 
 Server-streamed output (incremental `stdout` and `stderr` while code runs) fits
 this binding over SSE or chunked responses and is a planned addition; it is not
-part of version 1. Bidirectional interactive execution, where input is fed while
-output is read on one connection, is the case this binding strains at, and is
-the open question behind not yet fixing the transport.
+part of version 1.
+
+## Reference implementation, and checking conformance
+
+[otari-sandbox-container](https://github.com/mozilla-ai/otari-sandbox-container)
+is the reference backend: a single container, no orchestrator, published as
+`mzdotai/otari-sandbox-container`, and the implementation the contract above was
+read off. It is the one to read when a clause here is ambiguous, and the one to
+start from when building another backend. Two behaviours of it are its own, not
+the contract's: it refuses a `timeout_seconds` above 120 rather than clamping it,
+and it never populates the file-reference list.
+
+To check a backend against the published contract, point the conformance script
+at a running instance:
+
+```bash
+uv run python scripts/check_code_execution_conformance.py --base-url http://localhost:8080
+```
+
+It leases a session, runs a call of each tool kind, exercises the file
+operations, releases the session, and validates every response against
+`docs/public/code-execution-openapi.yaml`. The three session operations are
+required, so a failure there is a non-conforming backend; the file operations are
+optional, and a backend that does not serve them reports as skipped rather than
+failing. Running it is how a second implementation shows it is interchangeable
+with the reference one rather than merely similar to it.
 
 ## Configuration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ Calling the gateway from your own code.
 ### For platform builders
 
 - [Hybrid-mode protocol](hybrid-mode-protocol.md): the Otari/platform wire contract, for building a platform that Otari connects to.
-- [Code-execution protocol](code-execution-protocol.md): the Otari/sandbox contract, for building a code-execution backend that Otari dispatches to.
+- [Code-execution protocol](code-execution-protocol.md): the Otari/sandbox contract, for building a code-execution backend that Otari dispatches to. Its machine-readable form is [`public/code-execution-openapi.yaml`](public/code-execution-openapi.yaml).
 
 ### For contributors
 

--- a/docs/public/code-execution-openapi.yaml
+++ b/docs/public/code-execution-openapi.yaml
@@ -89,12 +89,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/SessionHandle"
         "401":
-          description: |
-            Credential missing or rejected, where the deployment requires one.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/Unauthorized"
         "503":
           description: |
             At capacity, no session leased. Distinct from a malformed request:
@@ -122,6 +117,8 @@ paths:
       responses:
         "204":
           description: Session released, or already gone.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "404":
           description: Unknown session.
           content:
@@ -167,6 +164,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "404":
           description: Unknown session.
           content:
@@ -207,6 +206,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/FileList"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "403":
           description: Path outside the session workspace.
           content:
@@ -252,6 +253,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "403":
           description: Path outside the session workspace.
           content:
@@ -296,6 +299,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/FileUploadResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "403":
           description: Path outside the session workspace.
           content:
@@ -319,6 +324,20 @@ components:
         In Otari's hybrid mode this is how the platform's authenticated proxy
         admits the request and derives tenancy from the caller's workspace, so
         the backend behind it never has to.
+
+  responses:
+    # Declared on every operation, not just session creation: the credential is a
+    # property of the deployment, so a stale or revoked one surfaces wherever the
+    # client happens to call next, most often on a repeated Execute. A generated
+    # client that models it on one operation only would treat the same answer
+    # elsewhere as an unrecognised failure.
+    Unauthorized:
+      description: |
+        Credential missing or rejected, where the deployment requires one.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
 
   parameters:
     SessionId:

--- a/docs/public/code-execution-openapi.yaml
+++ b/docs/public/code-execution-openapi.yaml
@@ -1,0 +1,703 @@
+# The code-execution protocol, contract version 1: the canonical IDL.
+#
+# Unlike the generated artifacts beside it, this file is hand-maintained. It
+# specifies a backend that Otari *calls*, so nothing in this repo serves these
+# paths and there is nothing to generate it from.
+#
+# Read it with `docs/code-execution-protocol.md`, which carries the semantics an
+# OpenAPI document cannot express: that sessions are stateful, that a failed
+# program is still a successful operation, and how the contract may grow.
+# `tests/unit/test_code_execution_contract.py` keeps the two in agreement, and
+# `scripts/check_code_execution_conformance.py` checks a running backend against
+# this file.
+openapi: 3.1.0
+
+info:
+  title: Otari code-execution protocol
+  # The contract version, not a release version: a backend implements contract
+  # version 1 and stays conforming whatever an upstream model provider's own
+  # tool version does next. Re-pinning to a newer upstream result shape would be
+  # contract version 2.
+  version: "1"
+  summary: The contract between Otari and a code-execution backend.
+  description: |
+    When a request uses the `otari_code_execution` tool, Otari does not run the
+    code itself. It leases a session from a code-execution backend, runs each
+    tool call against that session, and releases it.
+
+    Sessions are stateful: interpreter state and the workspace filesystem
+    persist across calls within a session and are destroyed with it.
+
+    Failure of the executed program is reported *in* the payload, through
+    `return_code` and `stderr`, not by failing the operation. Only a backend
+    that could not run the call at all returns an error status.
+
+    The three session operations are required of every backend. The three file
+    operations are optional, and are marked `x-otari-optional` here.
+  license:
+    name: Apache-2.0
+    identifier: Apache-2.0
+  contact:
+    name: Otari
+    url: https://github.com/mozilla-ai/otari
+
+externalDocs:
+  description: The prose contract, normative for semantics
+  url: https://github.com/mozilla-ai/otari/blob/main/docs/code-execution-protocol.md
+
+servers:
+  - url: "{sandbox_url}"
+    description: |
+      A code-execution backend. Otari takes this from its `sandbox_url` setting
+      (`OTARI_SANDBOX_URL`); in hybrid mode it points at the platform's
+      authenticated proxy rather than at the backend directly.
+    variables:
+      sandbox_url:
+        default: http://localhost:8080
+
+# The contract itself carries no authentication: the reference backend has none
+# and assumes a single trusted client on a private network. A deployment MAY
+# require a bearer credential, which is why both an unauthenticated and an
+# authenticated request are declared acceptable here. Tenancy, where a backend
+# is multi-tenant, is injected by whichever component authenticates the caller,
+# so it is a property of the deployment and not specified here.
+security:
+  - {}
+  - bearerAuth: []
+
+paths:
+  /sessions:
+    post:
+      operationId: CreateSession
+      summary: Lease a session
+      description: |
+        Leases a session and returns a handle. A backend MAY accept the
+        lifetime hints or clamp them to its own ceilings, and reports what is in
+        force. A client MUST NOT assume a session outlives the values the handle
+        reports.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSessionRequest"
+      responses:
+        "201":
+          description: Session leased.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionHandle"
+        "401":
+          description: |
+            Credential missing or rejected, where the deployment requires one.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: |
+            At capacity, no session leased. Distinct from a malformed request:
+            retryable in principle, though Otari surfaces it as a failed request
+            rather than backing off, so a backend should not rely on the client
+            re-offering the work.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /sessions/{session_id}:
+    parameters:
+      - $ref: "#/components/parameters/SessionId"
+    delete:
+      operationId: DestroySession
+      summary: Release a session
+      description: |
+        Releases the session and destroys its state. Releasing a session that
+        does not exist is not an error worth distinguishing: it is already in
+        the desired state, so a backend MAY answer `204` for an unknown id.
+
+        A backend SHOULD reclaim sessions that are never released, which is what
+        the lifetime bounds on the handle are for.
+      responses:
+        "204":
+          description: Session released, or already gone.
+        "404":
+          description: Unknown session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /sessions/{session_id}/exec:
+    parameters:
+      - $ref: "#/components/parameters/SessionId"
+    post:
+      operationId: Execute
+      summary: Run one tool call in a session
+      description: |
+        Runs one tool call against a leased session and returns its result.
+
+        `timeout_seconds` bounds the backend's execution, not the client's
+        patience. A client MUST allow more wall-clock than it grants, since its
+        own budget also covers transport and the backend's teardown; otherwise a
+        legitimate near-limit execution is reported as an unreachable backend.
+
+        A client is not required to exercise every tool kind (Otari drives only
+        `code_execution` today), but a backend MUST accept the kind it is asked
+        for and MUST refuse an unknown one.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExecRequest"
+      responses:
+        "200":
+          description: |
+            The call ran. This includes a program that failed: the outcome is in
+            the result block's `return_code` and `stderr`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExecResponse"
+        "400":
+          description: Unknown tool kind.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Unknown session.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "422":
+          description: |
+            Malformed request, including an `input` that does not carry the
+            fields its tool kind and command require.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /sessions/{session_id}/files/list:
+    parameters:
+      - $ref: "#/components/parameters/SessionId"
+    get:
+      operationId: ListFiles
+      summary: Enumerate a session's workspace
+      x-otari-optional: true
+      description: |
+        Optional. Confined to the addressed session's own workspace: a path
+        escaping it MUST be refused rather than served.
+      parameters:
+        - name: path
+          in: query
+          required: false
+          description: A directory relative to the workspace root.
+          schema:
+            type: string
+            default: "."
+      responses:
+        "200":
+          description: The directory's entries.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FileList"
+        "403":
+          description: Path outside the session workspace.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Unknown session, or no such directory.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /sessions/{session_id}/files:
+    parameters:
+      - $ref: "#/components/parameters/SessionId"
+    get:
+      operationId: GetFile
+      summary: Read one file from the workspace
+      x-otari-optional: true
+      description: |
+        Optional. Returns the file's bytes, typed with whatever media type the
+        backend derived. Confined to the addressed session's own workspace.
+      parameters:
+        - name: path
+          in: query
+          required: true
+          description: A file relative to the workspace root.
+          schema:
+            type: string
+            minLength: 1
+      responses:
+        "200":
+          description: The file's bytes.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        "400":
+          description: The path is a directory, not a file.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Path outside the session workspace.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Unknown session, or no such file.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      operationId: PutFile
+      summary: Write one file into the workspace
+      x-otari-optional: true
+      description: |
+        Optional. Seeds an input file for later calls in the session. A backend
+        MAY cap the size of a written file and MUST refuse one over the cap
+        rather than truncating it.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+                  description: The file's bytes.
+                path:
+                  type: string
+                  description: |
+                    Destination relative to the workspace root. Absent, the
+                    backend derives one from the uploaded file's name.
+      responses:
+        "201":
+          description: File written.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FileUploadResult"
+        "403":
+          description: Path outside the session workspace.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "413":
+          description: File larger than the backend's cap.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: |
+        Sent as `Authorization: Bearer <token>` where the deployment uses one.
+        In Otari's hybrid mode this is how the platform's authenticated proxy
+        admits the request and derives tenancy from the caller's workspace, so
+        the backend behind it never has to.
+
+  parameters:
+    SessionId:
+      name: session_id
+      in: path
+      required: true
+      description: The id from the session handle, used verbatim.
+      schema:
+        type: string
+        minLength: 1
+
+  schemas:
+    # Every response schema keeps `additionalProperties: true`: the contract
+    # grows additively, so a backend MAY return fields not described here and a
+    # consumer MUST ignore the ones it does not recognise rather than rejecting
+    # the response.
+
+    CreateSessionRequest:
+      type: object
+      additionalProperties: true
+      description: Lifetime hints, both optional.
+      properties:
+        idle_timeout_seconds:
+          type: [integer, "null"]
+          minimum: 1
+          description: Reclaim the session after this long without activity.
+        max_lifetime_seconds:
+          type: [integer, "null"]
+          minimum: 1
+          description: Reclaim the session this long after creation.
+
+    SessionHandle:
+      type: object
+      additionalProperties: true
+      required: [session_id]
+      properties:
+        session_id:
+          type: string
+          minLength: 1
+          description: |
+            Addresses this session in every later operation. A string, not a
+            number, so a client can use it without reformatting it.
+        idle_timeout_seconds:
+          type: integer
+          description: The idle timeout actually in force.
+        max_lifetime_seconds:
+          type: integer
+          description: The maximum lifetime actually in force.
+        created_at:
+          type: number
+          description: When the session was created, in POSIX seconds.
+        last_activity_at:
+          type: number
+          description: When the session was last used, in POSIX seconds.
+      examples:
+        - session_id: 3f6c1a9e8b2d4c7f
+          created_at: 1786000000.0
+          last_activity_at: 1786000000.0
+          idle_timeout_seconds: 300
+          max_lifetime_seconds: 3600
+
+    ExecRequest:
+      description: |
+        One tool call. The `tool` field selects both the operation and the shape
+        of `input`, which is why this is a discriminated union rather than one
+        object with a free-form `input`.
+      oneOf:
+        - $ref: "#/components/schemas/CodeExecutionRequest"
+        - $ref: "#/components/schemas/BashExecutionRequest"
+        - $ref: "#/components/schemas/TextEditorRequest"
+      discriminator:
+        propertyName: tool
+        mapping:
+          code_execution: "#/components/schemas/CodeExecutionRequest"
+          bash_code_execution: "#/components/schemas/BashExecutionRequest"
+          text_editor_code_execution: "#/components/schemas/TextEditorRequest"
+
+    CodeExecutionRequest:
+      type: object
+      additionalProperties: true
+      required: [tool, input]
+      description: Run source in the session's persistent interpreter.
+      properties:
+        tool:
+          const: code_execution
+        input:
+          $ref: "#/components/schemas/CodeExecutionInput"
+        timeout_seconds:
+          $ref: "#/components/schemas/TimeoutSeconds"
+        tool_use_id:
+          $ref: "#/components/schemas/ToolUseIdRequest"
+      examples:
+        - tool: code_execution
+          input:
+            code: print(2 + 2)
+          timeout_seconds: 60
+
+    BashExecutionRequest:
+      type: object
+      additionalProperties: true
+      required: [tool, input]
+      description: Run a shell command in the session's workspace.
+      properties:
+        tool:
+          const: bash_code_execution
+        input:
+          $ref: "#/components/schemas/BashExecutionInput"
+        timeout_seconds:
+          $ref: "#/components/schemas/TimeoutSeconds"
+        tool_use_id:
+          $ref: "#/components/schemas/ToolUseIdRequest"
+
+    TextEditorRequest:
+      type: object
+      additionalProperties: true
+      required: [tool, input]
+      description: View or edit a file in the session's workspace.
+      properties:
+        tool:
+          const: text_editor_code_execution
+        input:
+          $ref: "#/components/schemas/TextEditorInput"
+        timeout_seconds:
+          $ref: "#/components/schemas/TimeoutSeconds"
+        tool_use_id:
+          $ref: "#/components/schemas/ToolUseIdRequest"
+
+    CodeExecutionInput:
+      type: object
+      additionalProperties: true
+      required: [code]
+      properties:
+        code:
+          type: string
+          minLength: 1
+          description: Source to run in the session's interpreter.
+
+    BashExecutionInput:
+      type: object
+      additionalProperties: true
+      required: [command]
+      properties:
+        command:
+          type: string
+          minLength: 1
+          description: The shell command to run.
+
+    TextEditorInput:
+      type: object
+      additionalProperties: true
+      required: [command, path]
+      description: |
+        Mirrors Anthropic's text-editor command set. The command-specific fields
+        are validated per command, not per request, which a single schema cannot
+        express: `create` needs `file_text`, `str_replace` needs `old_str` and
+        `new_str`, `insert` needs `insert_line` and `new_str`, and `view` and
+        `undo_edit` need neither.
+      properties:
+        command:
+          type: string
+          enum: [view, create, str_replace, insert, undo_edit]
+        path:
+          type: string
+          minLength: 1
+          description: The file, relative to the session's workspace root.
+        file_text:
+          type: [string, "null"]
+          description: The new file's content, for `create`.
+        old_str:
+          type: [string, "null"]
+          description: The text to replace, for `str_replace`.
+        new_str:
+          type: [string, "null"]
+          description: The replacement or inserted text.
+        insert_line:
+          type: [integer, "null"]
+          description: The line to insert after, for `insert`.
+        view_range:
+          type: [array, "null"]
+          items:
+            type: integer
+          minItems: 2
+          maxItems: 2
+          description: An inclusive line range to view, for `view`.
+
+    TimeoutSeconds:
+      type: integer
+      minimum: 1
+      description: |
+        How long the backend may spend executing. A backend MAY impose a ceiling
+        of its own, clamping a larger value or refusing the request as malformed,
+        so the contract sets no maximum.
+
+    ToolUseIdRequest:
+      type: [string, "null"]
+      description: |
+        Correlation id. The backend generates one if absent, and echoes it on
+        the response either way.
+
+    ExecResponse:
+      type: object
+      additionalProperties: true
+      required: [tool_use_id, result_block]
+      description: |
+        The outcome of one tool call. Note the envelope: the result block is
+        nested under `result_block`, not returned bare. A backend that returns
+        the block at the top level is not conforming.
+      properties:
+        tool_use_id:
+          type: string
+          description: The call's correlation id, echoed or generated.
+        result_block:
+          $ref: "#/components/schemas/ResultBlock"
+        execution_time_ms:
+          type: [integer, "null"]
+          minimum: 0
+          description: How long the backend spent executing.
+      examples:
+        - tool_use_id: srvtoolu_...
+          execution_time_ms: 84
+          result_block:
+            type: code_execution_tool_result
+            tool_use_id: srvtoolu_...
+            content:
+              type: code_execution_result
+              stdout: "..."
+              stderr: "..."
+              return_code: 0
+              content:
+                - type: code_execution_output
+                  file_id: "..."
+                  filename: chart.png
+
+    ResultBlock:
+      type: object
+      additionalProperties: true
+      required: [type, tool_use_id, content]
+      description: |
+        Matches Anthropic's `code_execution_20250825` content blocks, so a
+        consumer that already parses Anthropic responses needs no translation
+        layer for it.
+      properties:
+        type:
+          type: string
+          minLength: 1
+          description: |
+            The tool kind that ran: `code_execution_tool_result`,
+            `bash_code_execution_tool_result`, or
+            `text_editor_code_execution_tool_result`.
+
+            Deliberately not an enum. A later contract version may add a tool
+            kind, and a client MUST NOT reject a result block solely because its
+            `type` is unfamiliar; Otari treats it as an opaque string and reads
+            the payload.
+          examples:
+            - code_execution_tool_result
+            - bash_code_execution_tool_result
+            - text_editor_code_execution_tool_result
+        tool_use_id:
+          type: string
+          description: The call's correlation id.
+        content:
+          $ref: "#/components/schemas/CodeExecutionResult"
+
+    CodeExecutionResult:
+      type: object
+      additionalProperties: true
+      description: |
+        The result block's payload. A single object, not a list of mixed content
+        blocks: the *nested* `content` is the list, of files the execution
+        produced. Code that treats the outer field as a list will not parse a
+        conforming response.
+
+        Required on the block even for a run that produced nothing: such a run
+        returns empty streams and a `return_code` of 0, not an omitted payload.
+        Its own fields are all optional and default as described.
+      properties:
+        type:
+          const: code_execution_result
+          default: code_execution_result
+          description: |
+            Contract version 1 rules out the error variant of Anthropic's union:
+            a backend MUST NOT return a payload of type
+            `code_execution_tool_result_error` carrying an `error_code`. Report
+            the failure through `return_code` and `stderr` instead. A client
+            reading this contract has no reason to inspect this field, so an
+            error variant would be read as an empty successful run, and the call
+            would be billed as one.
+        stdout:
+          type: [string, "null"]
+          default: ""
+          description: What the call wrote to stdout.
+        stderr:
+          type: [string, "null"]
+          default: ""
+          description: |
+            What the call wrote to stderr. Output here, or a non-zero
+            `return_code`, is how a backend reports that the code failed; there
+            is no top-level error flag.
+        return_code:
+          type: [integer, "null"]
+          default: 0
+          description: |
+            The call's exit status. An explicit `null` means no exit status, and
+            reads the same as 0.
+        content:
+          type: [array, "null"]
+          default: []
+          items:
+            $ref: "#/components/schemas/CodeExecutionOutputFile"
+          description: |
+            Files the execution produced. Empty when it produced none; the
+            reference backend does not populate it today. For a
+            `text_editor_code_execution` `create`, the file's content is not
+            echoed back here: it is already on the originating tool call's
+            `input.file_text`.
+
+    CodeExecutionOutputFile:
+      type: object
+      additionalProperties: true
+      required: [file_id, filename]
+      description: A file the execution produced, such as a chart or a CSV.
+      properties:
+        type:
+          const: code_execution_output
+          default: code_execution_output
+        file_id:
+          type: string
+          description: Addresses the file for retrieval.
+        filename:
+          type: string
+          description: The name the execution gave it.
+
+    FileList:
+      type: object
+      additionalProperties: true
+      required: [files]
+      properties:
+        files:
+          type: array
+          items:
+            $ref: "#/components/schemas/FileMetadata"
+
+    FileMetadata:
+      type: object
+      additionalProperties: true
+      required: [path, size_bytes]
+      properties:
+        path:
+          type: string
+          description: Relative to the session's workspace root.
+        size_bytes:
+          type: integer
+          minimum: 0
+        mime_type:
+          type: [string, "null"]
+        modified_at:
+          type: number
+          description: When the file was last written, in POSIX seconds.
+
+    FileUploadResult:
+      type: object
+      additionalProperties: true
+      required: [path, size_bytes]
+      properties:
+        path:
+          type: string
+          description: Where the file was stored, relative to the workspace root.
+        size_bytes:
+          type: integer
+          minimum: 0
+
+    Error:
+      type: object
+      additionalProperties: true
+      description: |
+        Informational. A client treats any non-2xx as a failed operation and
+        MUST NOT depend on this body, so a backend is free to carry its own
+        diagnostic shape here.
+      properties:
+        detail:
+          description: What went wrong, in whatever shape the backend reports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,12 @@ s3 = [
 [dependency-groups]
 dev = [
     "boto3-stubs[s3]",
+    # Validating payloads against the published code-execution contract
+    # (docs/public/code-execution-openapi.yaml), in its conformance script and
+    # the test that keeps the spec and the doc in agreement. Nothing at runtime
+    # uses it: the gateway parses that contract with its own Pydantic models.
+    "jsonschema>=4.26.0",
+    "types-jsonschema",
     "moto[s3]>=5.0.0",
     "mypy",
     "pytest>=9.0.3,<10",

--- a/scripts/check_code_execution_conformance.py
+++ b/scripts/check_code_execution_conformance.py
@@ -219,10 +219,28 @@ def _check_unknown_tool_refused(client: httpx.Client, session_id: str, *, timeou
         return Check(name, PASS)
     if response.is_success:
         return Check(name, FAIL, f"ran an unknown tool kind and answered {response.status_code}")
+    if response.status_code >= 500:
+        # A server error is not a refusal: the backend fell over on input it was
+        # supposed to reject.
+        return Check(name, FAIL, f"failed with {response.status_code} instead of refusing the call")
     return Check(name, PASS, f"refused with {response.status_code}; the contract documents 400 or 422")
 
 
-def _check_files(client: httpx.Client, spec: dict[str, Any], session_id: str) -> list[Check]:
+def _session_survives(client: httpx.Client, spec: dict[str, Any], session_id: str, *, timeout_seconds: int) -> bool:
+    """Whether the session is still usable, which a 404 alone does not say."""
+    check = _check_exec(
+        client,
+        spec,
+        session_id,
+        name="session probe",
+        tool="code_execution",
+        tool_input={"code": f'print("{_MARKER}")'},
+        timeout_seconds=timeout_seconds,
+    )
+    return check.status == PASS
+
+
+def _check_files(client: httpx.Client, spec: dict[str, Any], session_id: str, *, timeout_seconds: int) -> list[Check]:
     """The optional file operations, skipped as a group when none are served."""
     body = f"{_MARKER}\n".encode()
     upload = client.post(
@@ -231,6 +249,11 @@ def _check_files(client: httpx.Client, spec: dict[str, Any], session_id: str) ->
         data={"path": _UPLOADED_FILE},
     )
     if upload.status_code in _UNSERVED_STATUSES:
+        # A 404 here is ambiguous: no such route, or no such session. Reporting a
+        # reclaimed session as "these operations are optional and absent" would
+        # pass a backend that dropped the session mid-run, so ask the session.
+        if not _session_survives(client, spec, session_id, timeout_seconds=timeout_seconds):
+            return [Check("File operations", FAIL, "the session was gone before they could be checked")]
         reason = "backend does not serve the optional file operations"
         return [Check(name, SKIP, reason) for name in ("PutFile", "ListFiles", "GetFile")]
 
@@ -269,6 +292,8 @@ def _check_workspace_confinement(client: httpx.Client, session_id: str) -> Check
         return Check(name, FAIL, "served a path outside the session workspace")
     if escape.status_code == 403:
         return Check(name, PASS)
+    if escape.status_code >= 500:
+        return Check(name, FAIL, f"failed with {escape.status_code} instead of refusing the path")
     return Check(name, PASS, f"refused with {escape.status_code}; the contract documents 403")
 
 
@@ -361,7 +386,7 @@ def run_checks(
             )
         )
         checks.append(_check_unknown_tool_refused(client, session_id, timeout_seconds=timeout_seconds))
-        checks.extend(_check_files(client, spec, session_id))
+        checks.extend(_check_files(client, spec, session_id, timeout_seconds=timeout_seconds))
     except httpx.HTTPError as exc:
         checks.append(Check("Execute", FAIL, f"backend stopped answering: {exc}"))
     finally:

--- a/scripts/check_code_execution_conformance.py
+++ b/scripts/check_code_execution_conformance.py
@@ -13,8 +13,9 @@ The three session operations are required of a backend, so a failure there means
 non-conforming. The file operations are optional, and a backend that does not
 serve them reports as skipped.
 
-Requests are validated on the way out as well as responses on the way in, which
-keeps this script from drifting from the spec it checks against.
+JSON requests are validated on the way out as well as responses on the way in,
+which keeps this script from drifting from the spec it checks against. The one
+request that is not JSON, the multipart file upload, is checked by its response.
 
 `jsonschema` is a dev dependency of this repo rather than a runtime one, since
 the gateway parses the contract with its own Pydantic models. Outside a synced
@@ -94,17 +95,29 @@ def schema_errors(spec: dict[str, Any], schema_name: str, payload: Any) -> list[
     ]
 
 
-def _exec_payload(spec: dict[str, Any], tool: str, tool_input: dict[str, Any], timeout_seconds: int) -> dict[str, Any]:
-    payload = {
-        "tool": tool,
-        "input": tool_input,
-        "timeout_seconds": timeout_seconds,
-        "tool_use_id": f"srvtoolu_{_MARKER}",
-    }
-    errors = schema_errors(spec, "ExecRequest", payload)
+def _validated_request(spec: dict[str, Any], schema_name: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Refuse to send a request the contract does not describe.
+
+    A checker that sends a malformed request reports the backend's rejection of
+    it as a backend fault, which is the one verdict it must never get wrong.
+    """
+    errors = schema_errors(spec, schema_name, payload)
     if errors:  # pragma: no cover - a bug in this script, not in a backend
-        raise AssertionError(f"conformance script built a non-conforming ExecRequest: {errors}")
+        raise AssertionError(f"conformance script built a non-conforming {schema_name}: {errors}")
     return payload
+
+
+def _exec_payload(spec: dict[str, Any], tool: str, tool_input: dict[str, Any], timeout_seconds: int) -> dict[str, Any]:
+    return _validated_request(
+        spec,
+        "ExecRequest",
+        {
+            "tool": tool,
+            "input": tool_input,
+            "timeout_seconds": timeout_seconds,
+            "tool_use_id": f"srvtoolu_{_MARKER}",
+        },
+    )
 
 
 def _checked(
@@ -135,7 +148,10 @@ def _check_create_session(
 ) -> tuple[list[Check], str | None]:
     check, handle = _checked(
         "CreateSession",
-        client.post("/sessions", json={"idle_timeout_seconds": idle_hint}),
+        client.post(
+            "/sessions",
+            json=_validated_request(spec, "CreateSessionRequest", {"idle_timeout_seconds": idle_hint}),
+        ),
         expected_status=201,
         spec=spec,
         schema_name="SessionHandle",
@@ -415,13 +431,26 @@ def report(checks: list[Check]) -> int:
     return 0
 
 
+def _execution_budget(value: str) -> int:
+    """An execution budget the contract allows, rejected at the CLI if not.
+
+    Without this, a zero or negative value only fails when the first request is
+    validated, after a session has already been leased, and reports as this
+    script being at fault rather than the invocation.
+    """
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1 second, as the contract requires")
+    return parsed
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--base-url", required=True, help="Base URL of the backend, e.g. http://localhost:8080")
     parser.add_argument("--auth-token", default=None, help="Bearer credential, where the deployment requires one.")
     parser.add_argument(
         "--timeout-seconds",
-        type=int,
+        type=_execution_budget,
         default=_DEFAULT_TIMEOUT_SECONDS,
         help=f"Execution budget granted per call (default: {_DEFAULT_TIMEOUT_SECONDS}).",
     )

--- a/scripts/check_code_execution_conformance.py
+++ b/scripts/check_code_execution_conformance.py
@@ -1,0 +1,418 @@
+"""Check a running code-execution backend against the published contract.
+
+    uv run python scripts/check_code_execution_conformance.py --base-url http://localhost:8080
+
+The contract is `docs/code-execution-protocol.md`, with the schemas in
+`docs/public/code-execution-openapi.yaml`; this drives a live backend through it.
+Two implementations exist (`otari-sandbox-container` as the OSS reference, a
+pool-backed one behind otari.ai), and Otari cannot tell which one answered, so
+this script is what turns that claim into something checkable rather than
+asserted: any third-party backend runs it to show it is interchangeable.
+
+The three session operations are required of a backend, so a failure there means
+non-conforming. The file operations are optional, and a backend that does not
+serve them reports as skipped.
+
+Requests are validated on the way out as well as responses on the way in, which
+keeps this script from drifting from the spec it checks against.
+
+`jsonschema` is a dev dependency of this repo rather than a runtime one, since
+the gateway parses the contract with its own Pydantic models. Outside a synced
+checkout, run with `uv run --with jsonschema,pyyaml,httpx python scripts/...`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+import yaml
+from jsonschema import Draft202012Validator
+
+SPEC_PATH = Path(__file__).resolve().parent.parent / "docs" / "public" / "code-execution-openapi.yaml"
+
+# Echoed by the executed code so a check confirms it ran, and not merely that the
+# backend answered with a well-shaped envelope.
+_MARKER = "otari-conformance-ok"
+_DEFAULT_TIMEOUT_SECONDS = 30
+# The contract's rule for a client's own budget: allow more wall-clock than the
+# execution budget granted, since transport and the backend's teardown come on
+# top of it. See "Execute" in docs/code-execution-protocol.md.
+_TIMEOUT_BUFFER_SECONDS = 10.0
+# A file operation the backend does not serve answers on the route, not on the
+# session: the session was just used successfully, so these statuses mean "not
+# implemented here" rather than "gone".
+_UNSERVED_STATUSES = (404, 405, 501)
+
+PASS = "pass"
+FAIL = "fail"
+SKIP = "skip"
+
+_UPLOADED_FILE = "conformance.txt"
+_EDITED_FILE = "conformance_editor.txt"
+
+
+@dataclass(frozen=True)
+class Check:
+    """One contract requirement, and how the backend answered it."""
+
+    name: str
+    status: str
+    detail: str = ""
+
+
+def load_spec(path: Path = SPEC_PATH) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        spec: dict[str, Any] = yaml.safe_load(handle)
+    return spec
+
+
+def validator_for(spec: dict[str, Any], schema_name: str) -> Draft202012Validator:
+    """A validator for one named schema, with the spec's internal refs resolvable.
+
+    OpenAPI 3.1 schemas are JSON Schema 2020-12, so they validate directly. The
+    document's own `components` travel along inside the schema so that its
+    `#/components/schemas/...` references resolve with no registry to set up.
+    """
+    return Draft202012Validator(
+        {
+            "$ref": f"#/components/schemas/{schema_name}",
+            "components": spec["components"],
+        }
+    )
+
+
+def schema_errors(spec: dict[str, Any], schema_name: str, payload: Any) -> list[str]:
+    validator = validator_for(spec, schema_name)
+    return [
+        f"{'.'.join(str(part) for part in error.absolute_path) or '(root)'}: {error.message}"
+        for error in validator.iter_errors(payload)
+    ]
+
+
+def _exec_payload(spec: dict[str, Any], tool: str, tool_input: dict[str, Any], timeout_seconds: int) -> dict[str, Any]:
+    payload = {
+        "tool": tool,
+        "input": tool_input,
+        "timeout_seconds": timeout_seconds,
+        "tool_use_id": f"srvtoolu_{_MARKER}",
+    }
+    errors = schema_errors(spec, "ExecRequest", payload)
+    if errors:  # pragma: no cover - a bug in this script, not in a backend
+        raise AssertionError(f"conformance script built a non-conforming ExecRequest: {errors}")
+    return payload
+
+
+def _checked(
+    name: str,
+    response: httpx.Response,
+    *,
+    expected_status: int,
+    spec: dict[str, Any],
+    schema_name: str | None,
+) -> tuple[Check, Any]:
+    """Status and schema together, since every operation is checked on both."""
+    if response.status_code != expected_status:
+        return Check(name, FAIL, f"expected {expected_status}, got {response.status_code}"), None
+    if schema_name is None:
+        return Check(name, PASS), None
+    try:
+        body = response.json()
+    except ValueError as exc:
+        return Check(name, FAIL, f"body of the {expected_status} is not JSON: {exc}"), None
+    errors = schema_errors(spec, schema_name, body)
+    if errors:
+        return Check(name, FAIL, f"response does not match {schema_name}: {'; '.join(errors)}"), None
+    return Check(name, PASS), body
+
+
+def _check_create_session(
+    client: httpx.Client, spec: dict[str, Any], *, idle_hint: int
+) -> tuple[list[Check], str | None]:
+    check, handle = _checked(
+        "CreateSession",
+        client.post("/sessions", json={"idle_timeout_seconds": idle_hint}),
+        expected_status=201,
+        spec=spec,
+        schema_name="SessionHandle",
+    )
+    if handle is None:
+        return [check], None
+
+    checks = [check]
+    # A backend may accept the hint or clamp it to a ceiling of its own, so the
+    # reported value may be lower. Higher would break the client's only guarantee
+    # about how long the session lives.
+    reported = handle.get("idle_timeout_seconds")
+    if isinstance(reported, int) and reported > idle_hint:
+        checks.append(
+            Check(
+                "CreateSession honours lifetime hints",
+                FAIL,
+                f"asked for an idle timeout of {idle_hint}s, handle reports {reported}s",
+            )
+        )
+    else:
+        checks.append(Check("CreateSession honours lifetime hints", PASS))
+    session_id: str = handle["session_id"]
+    return checks, session_id
+
+
+def _check_exec(
+    client: httpx.Client,
+    spec: dict[str, Any],
+    session_id: str,
+    *,
+    name: str,
+    tool: str,
+    tool_input: dict[str, Any],
+    timeout_seconds: int,
+    expect_marker: bool = True,
+) -> Check:
+    """One Execute call, checked as an envelope and (usually) as a real run.
+
+    `expect_marker` is off for a call whose output the contract says is not
+    echoed back, such as a text-editor `create`: there the envelope and the exit
+    status are all there is to check.
+    """
+    payload = _exec_payload(spec, tool, tool_input, timeout_seconds)
+    check, body = _checked(
+        name,
+        client.post(
+            f"/sessions/{session_id}/exec",
+            json=payload,
+            timeout=timeout_seconds + _TIMEOUT_BUFFER_SECONDS,
+        ),
+        expected_status=200,
+        spec=spec,
+        schema_name="ExecResponse",
+    )
+    if body is None:
+        return check
+
+    if body["tool_use_id"] != payload["tool_use_id"]:
+        return Check(name, FAIL, "tool_use_id was not echoed from the request")
+    content = body["result_block"]["content"]
+    return_code = content.get("return_code")
+    stdout = content.get("stdout") or ""
+    if return_code not in (None, 0):
+        return Check(name, FAIL, f"return_code {return_code}, stderr: {content.get('stderr') or '(empty)'}")
+    if expect_marker and _MARKER not in stdout:
+        return Check(name, FAIL, f"stdout does not carry the executed marker: {stdout or '(empty)'}")
+    return Check(name, PASS)
+
+
+def _check_unknown_tool_refused(client: httpx.Client, session_id: str, *, timeout_seconds: int) -> Check:
+    name = "Execute refuses an unknown tool kind"
+    # Deliberately not built through _exec_payload: the point is a payload the
+    # contract does not describe.
+    response = client.post(
+        f"/sessions/{session_id}/exec",
+        json={"tool": "no_such_tool_kind", "input": {}, "timeout_seconds": timeout_seconds},
+        timeout=timeout_seconds + _TIMEOUT_BUFFER_SECONDS,
+    )
+    if response.status_code in (400, 422):
+        return Check(name, PASS)
+    if response.is_success:
+        return Check(name, FAIL, f"ran an unknown tool kind and answered {response.status_code}")
+    return Check(name, PASS, f"refused with {response.status_code}; the contract documents 400 or 422")
+
+
+def _check_files(client: httpx.Client, spec: dict[str, Any], session_id: str) -> list[Check]:
+    """The optional file operations, skipped as a group when none are served."""
+    body = f"{_MARKER}\n".encode()
+    upload = client.post(
+        f"/sessions/{session_id}/files",
+        files={"file": (_UPLOADED_FILE, body, "text/plain")},
+        data={"path": _UPLOADED_FILE},
+    )
+    if upload.status_code in _UNSERVED_STATUSES:
+        reason = "backend does not serve the optional file operations"
+        return [Check(name, SKIP, reason) for name in ("PutFile", "ListFiles", "GetFile")]
+
+    put_check, _ = _checked("PutFile", upload, expected_status=201, spec=spec, schema_name="FileUploadResult")
+    checks = [put_check]
+
+    list_check, files = _checked(
+        "ListFiles",
+        client.get(f"/sessions/{session_id}/files/list", params={"path": "."}),
+        expected_status=200,
+        spec=spec,
+        schema_name="FileList",
+    )
+    if files is not None:
+        paths = [entry["path"] for entry in files["files"]]
+        if not any(path.endswith(_UPLOADED_FILE) for path in paths):
+            list_check = Check("ListFiles", FAIL, f"the file just written is absent from the listing: {paths}")
+    checks.append(list_check)
+
+    download = client.get(f"/sessions/{session_id}/files", params={"path": _UPLOADED_FILE})
+    if not download.is_success:
+        checks.append(Check("GetFile", FAIL, f"expected 200, got {download.status_code}"))
+    elif download.content != body:
+        checks.append(Check("GetFile", FAIL, "returned bytes differ from the ones written"))
+    else:
+        checks.append(Check("GetFile", PASS))
+
+    checks.append(_check_workspace_confinement(client, session_id))
+    return checks
+
+
+def _check_workspace_confinement(client: httpx.Client, session_id: str) -> Check:
+    name = "GetFile confines access to the session workspace"
+    escape = client.get(f"/sessions/{session_id}/files", params={"path": "../../etc/passwd"})
+    if escape.is_success:
+        return Check(name, FAIL, "served a path outside the session workspace")
+    if escape.status_code == 403:
+        return Check(name, PASS)
+    return Check(name, PASS, f"refused with {escape.status_code}; the contract documents 403")
+
+
+def _check_destroy_session(client: httpx.Client, spec: dict[str, Any], session_id: str) -> list[Check]:
+    check, _ = _checked(
+        "DestroySession",
+        client.delete(f"/sessions/{session_id}"),
+        expected_status=204,
+        spec=spec,
+        schema_name=None,
+    )
+    checks = [check]
+
+    # Releasing a session that is already gone is not an error worth
+    # distinguishing: it is in the desired state either way. A server error is.
+    name = "DestroySession is idempotent"
+    repeat = client.delete(f"/sessions/{session_id}")
+    if repeat.status_code >= 500:
+        checks.append(Check(name, FAIL, f"releasing an already-released session answered {repeat.status_code}"))
+    else:
+        checks.append(Check(name, PASS))
+    return checks
+
+
+def run_checks(
+    client: httpx.Client,
+    spec: dict[str, Any],
+    *,
+    timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
+) -> list[Check]:
+    """Drive one backend through the contract.
+
+    A backend that answers badly produces a failing check, not an exception; a
+    backend that stops answering at all produces one too, so the checks that did
+    run are still reported.
+    """
+    try:
+        checks, session_id = _check_create_session(client, spec, idle_hint=300)
+    except httpx.HTTPError as exc:
+        return [Check("CreateSession", FAIL, f"backend not reachable: {exc}")]
+    if session_id is None:
+        return checks
+
+    try:
+        checks.append(
+            _check_exec(
+                client,
+                spec,
+                session_id,
+                name="Execute code_execution",
+                tool="code_execution",
+                tool_input={"code": f'print("{_MARKER}")'},
+                timeout_seconds=timeout_seconds,
+            )
+        )
+        checks.append(
+            _check_exec(
+                client,
+                spec,
+                session_id,
+                name="Execute bash_code_execution",
+                tool="bash_code_execution",
+                tool_input={"command": f"echo {_MARKER}"},
+                timeout_seconds=timeout_seconds,
+            )
+        )
+        # `create` then `view`: a create does not echo the file's content back, so
+        # the marker has to come back from the view.
+        checks.append(
+            _check_exec(
+                client,
+                spec,
+                session_id,
+                name="Execute text_editor_code_execution (create)",
+                tool="text_editor_code_execution",
+                tool_input={"command": "create", "path": _EDITED_FILE, "file_text": f"{_MARKER}\n"},
+                timeout_seconds=timeout_seconds,
+                expect_marker=False,
+            )
+        )
+        checks.append(
+            _check_exec(
+                client,
+                spec,
+                session_id,
+                name="Execute text_editor_code_execution (view)",
+                tool="text_editor_code_execution",
+                tool_input={"command": "view", "path": _EDITED_FILE},
+                timeout_seconds=timeout_seconds,
+            )
+        )
+        checks.append(_check_unknown_tool_refused(client, session_id, timeout_seconds=timeout_seconds))
+        checks.extend(_check_files(client, spec, session_id))
+    except httpx.HTTPError as exc:
+        checks.append(Check("Execute", FAIL, f"backend stopped answering: {exc}"))
+    finally:
+        try:
+            checks.extend(_check_destroy_session(client, spec, session_id))
+        except httpx.HTTPError as exc:
+            checks.append(Check("DestroySession", FAIL, f"backend not reachable: {exc}"))
+    return checks
+
+
+def report(checks: list[Check]) -> int:
+    """Print one line per check and return the process exit code."""
+    labels = {PASS: "PASS", FAIL: "FAIL", SKIP: "SKIP"}
+    for check in checks:
+        detail = f"  ({check.detail})" if check.detail else ""
+        print(f"[{labels[check.status]}] {check.name}{detail}")
+
+    failed = sum(1 for check in checks if check.status == FAIL)
+    skipped = sum(1 for check in checks if check.status == SKIP)
+    passed = len(checks) - failed - skipped
+    print(f"\n{passed} passed, {failed} failed, {skipped} skipped")
+    if failed:
+        print("This backend does not conform to code-execution contract version 1.")
+        return 1
+    print("This backend conforms to code-execution contract version 1.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--base-url", required=True, help="Base URL of the backend, e.g. http://localhost:8080")
+    parser.add_argument("--auth-token", default=None, help="Bearer credential, where the deployment requires one.")
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=_DEFAULT_TIMEOUT_SECONDS,
+        help=f"Execution budget granted per call (default: {_DEFAULT_TIMEOUT_SECONDS}).",
+    )
+    parser.add_argument("--spec", type=Path, default=SPEC_PATH, help="Path to the contract's OpenAPI document.")
+    args = parser.parse_args(argv)
+
+    spec = load_spec(args.spec)
+    headers = {"Authorization": f"Bearer {args.auth_token}"} if args.auth_token else {}
+    with httpx.Client(
+        base_url=args.base_url.rstrip("/"),
+        headers=headers,
+        timeout=args.timeout_seconds + _TIMEOUT_BUFFER_SECONDS,
+    ) as client:
+        checks = run_checks(client, spec, timeout_seconds=args.timeout_seconds)
+    return report(checks)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_code_execution_conformance_script.py
+++ b/tests/unit/test_code_execution_conformance_script.py
@@ -260,6 +260,16 @@ def test_unreachable_backend_reports_a_failure_rather_than_raising() -> None:
     assert conformance.report(checks) == 1
 
 
+def test_a_non_positive_execution_budget_is_rejected_at_the_cli() -> None:
+    """Rejected before a session is leased, and blamed on the invocation.
+
+    The contract's minimum is 1 second, so a 0 would otherwise fail on the first
+    request as "this script built a non-conforming payload".
+    """
+    with pytest.raises(SystemExit):
+        conformance.main(["--base-url", "http://sandbox", "--timeout-seconds", "0"])
+
+
 def test_main_reports_and_exits_nonzero_on_a_broken_backend(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/unit/test_code_execution_conformance_script.py
+++ b/tests/unit/test_code_execution_conformance_script.py
@@ -260,14 +260,33 @@ def test_unreachable_backend_reports_a_failure_rather_than_raising() -> None:
     assert conformance.report(checks) == 1
 
 
-def test_a_non_positive_execution_budget_is_rejected_at_the_cli() -> None:
+def test_a_non_positive_execution_budget_is_rejected_at_the_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     """Rejected before a session is leased, and blamed on the invocation.
 
     The contract's minimum is 1 second, so a 0 would otherwise fail on the first
-    request as "this script built a non-conforming payload".
+    request as "this script built a non-conforming payload". Both halves are
+    asserted: a nonzero exit, since `SystemExit(0)` would be a success the CLI
+    never reached, and a backend that saw no traffic, since a session leased
+    before the argument was refused is one the run never releases.
     """
-    with pytest.raises(SystemExit):
+    seen: list[tuple[str, str]] = []
+    real_client = httpx.Client
+
+    def record(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path))
+        return httpx.Response(500)
+
+    def client_with_recording_transport(**kwargs: Any) -> httpx.Client:
+        kwargs["transport"] = httpx.MockTransport(record)
+        return real_client(**kwargs)
+
+    monkeypatch.setattr(conformance.httpx, "Client", client_with_recording_transport)
+
+    with pytest.raises(SystemExit) as exit_info:
         conformance.main(["--base-url", "http://sandbox", "--timeout-seconds", "0"])
+
+    assert exit_info.value.code != 0
+    assert seen == []
 
 
 def test_main_reports_and_exits_nonzero_on_a_broken_backend(
@@ -284,6 +303,9 @@ def test_main_reports_and_exits_nonzero_on_a_broken_backend(
     exit_code = conformance.main(["--base-url", "http://sandbox/", "--auth-token", "secret"])
 
     assert exit_code == 1
-    output = capsys.readouterr().out
-    assert "does not conform to code-execution contract version 1" in output
-    assert "secret" not in output
+    # Both streams: a credential that leaked into a traceback or a warning would
+    # go to stderr, which an stdout-only assertion would wave through.
+    captured = capsys.readouterr()
+    assert "does not conform to code-execution contract version 1" in captured.out
+    assert "secret" not in captured.out
+    assert "secret" not in captured.err

--- a/tests/unit/test_code_execution_conformance_script.py
+++ b/tests/unit/test_code_execution_conformance_script.py
@@ -51,14 +51,22 @@ class FakeBackend:
     serve_files: bool = True
     confine_paths: bool = True
     refuse_unknown_tool: bool = True
+    unknown_tool_status: int = 400
+    escape_status: int = 403
+    # Drops the session the moment the file operations are reached, which is the
+    # other thing a 404 on a file route can mean.
+    lose_session_at_files: bool = False
     reported_idle_timeout: int = 300
     download_body: bytes = _FILE_BODY
     calls: list[tuple[str, str]] = field(default_factory=list)
+    _session_lost: bool = False
 
     def handler(self, request: httpx.Request) -> httpx.Response:
         path = request.url.path
         self.calls.append((request.method, path))
 
+        if self._session_lost and _SESSION_ID in path:
+            return httpx.Response(404, json={"detail": "no such session"})
         if request.method == "POST" and path == "/sessions":
             return httpx.Response(
                 201,
@@ -84,7 +92,7 @@ class FakeBackend:
         tool = body["tool"]
         if tool not in ("code_execution", "bash_code_execution", "text_editor_code_execution"):
             if self.refuse_unknown_tool:
-                return httpx.Response(400, json={"detail": f"unknown tool: {tool}"})
+                return httpx.Response(self.unknown_tool_status, json={"detail": f"unknown tool: {tool}"})
             return httpx.Response(200, json=self._envelope(body, "ran it anyway"))
         # A text-editor `create` reports the write; every other call the script
         # makes echoes the marker, which is how it knows code actually ran.
@@ -114,6 +122,9 @@ class FakeBackend:
         return {"tool_use_id": tool_use_id, "execution_time_ms": 12, "result_block": block}
 
     def _upload(self) -> httpx.Response:
+        if self.lose_session_at_files:
+            self._session_lost = True
+            return httpx.Response(404, json={"detail": "no such session"})
         if not self.serve_files:
             return httpx.Response(404, json={"detail": "not implemented"})
         return httpx.Response(201, json={"path": "conformance.txt", "size_bytes": len(_FILE_BODY)})
@@ -140,7 +151,7 @@ class FakeBackend:
             return httpx.Response(404, json={"detail": "not implemented"})
         escaping = ".." in (request.url.params.get("path") or "")
         if escaping and self.confine_paths:
-            return httpx.Response(403, json={"detail": "path escapes the workspace"})
+            return httpx.Response(self.escape_status, json={"detail": "path escapes the workspace"})
         return httpx.Response(200, content=self.download_body)
 
 
@@ -191,6 +202,28 @@ def test_serving_a_path_outside_the_workspace_fails() -> None:
 def test_running_an_unknown_tool_kind_fails() -> None:
     failures = _failures(_run(FakeBackend(refuse_unknown_tool=False)))
     assert "Execute refuses an unknown tool kind" in failures
+
+
+def test_falling_over_on_an_unknown_tool_kind_is_not_a_refusal() -> None:
+    """A 500 means the backend broke on input it was supposed to reject."""
+    failures = _failures(_run(FakeBackend(unknown_tool_status=500)))
+    assert "Execute refuses an unknown tool kind" in failures
+
+
+def test_falling_over_on_a_traversal_attempt_fails() -> None:
+    failures = _failures(_run(FakeBackend(escape_status=500)))
+    assert "GetFile confines access to the session workspace" in failures
+
+
+def test_a_lost_session_is_not_reported_as_absent_file_operations() -> None:
+    """A 404 on a file route means one of two things, and only one is a skip.
+
+    A backend that dropped the session mid-run would otherwise pass as one that
+    simply does not implement the optional operations.
+    """
+    checks = _run(FakeBackend(lose_session_at_files=True))
+    assert "the session was gone" in _failures(checks)["File operations"]
+    assert conformance.SKIP not in set(_statuses(checks).values())
 
 
 def test_lifetime_hint_reported_above_the_request_fails() -> None:

--- a/tests/unit/test_code_execution_conformance_script.py
+++ b/tests/unit/test_code_execution_conformance_script.py
@@ -1,0 +1,246 @@
+"""Unit tests for the code-execution conformance script.
+
+The script is what a third-party backend runs to show it implements contract
+version 1, so its own failure modes matter as much as its happy path: a checker
+that passes a non-conforming backend is worse than no checker. Each test here
+serves one deliberately broken backend and asserts the script catches it.
+
+The backends are `httpx.MockTransport` handlers rather than a live container, so
+these run in the unit suite with no Docker.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import httpx
+import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_code_execution_conformance.py"
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_code_execution_conformance", _SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+conformance = _load()
+
+_MARKER = conformance._MARKER
+_FILE_BODY = f"{_MARKER}\n".encode()
+_SESSION_ID = "3f6c1a9e8b2d4c7f"
+_EXEC_PATH = re.compile(rf"^/sessions/{_SESSION_ID}/exec$")
+
+
+@dataclass
+class FakeBackend:
+    """A conforming backend, with a knob per way of being wrong."""
+
+    envelope: bool = True
+    serve_files: bool = True
+    confine_paths: bool = True
+    refuse_unknown_tool: bool = True
+    reported_idle_timeout: int = 300
+    download_body: bytes = _FILE_BODY
+    calls: list[tuple[str, str]] = field(default_factory=list)
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        self.calls.append((request.method, path))
+
+        if request.method == "POST" and path == "/sessions":
+            return httpx.Response(
+                201,
+                json={
+                    "session_id": _SESSION_ID,
+                    "created_at": 1786000000.0,
+                    "last_activity_at": 1786000000.0,
+                    "idle_timeout_seconds": self.reported_idle_timeout,
+                    "max_lifetime_seconds": 3600,
+                },
+            )
+        if request.method == "DELETE" and path == f"/sessions/{_SESSION_ID}":
+            return httpx.Response(204)
+        if request.method == "POST" and _EXEC_PATH.match(path):
+            return self._exec(json.loads(request.content))
+        if path == f"/sessions/{_SESSION_ID}/files/list":
+            return self._list_files()
+        if path == f"/sessions/{_SESSION_ID}/files":
+            return self._upload() if request.method == "POST" else self._download(request)
+        return httpx.Response(404, json={"detail": f"no route for {request.method} {path}"})
+
+    def _exec(self, body: dict[str, Any]) -> httpx.Response:
+        tool = body["tool"]
+        if tool not in ("code_execution", "bash_code_execution", "text_editor_code_execution"):
+            if self.refuse_unknown_tool:
+                return httpx.Response(400, json={"detail": f"unknown tool: {tool}"})
+            return httpx.Response(200, json=self._envelope(body, "ran it anyway"))
+        # A text-editor `create` reports the write; every other call the script
+        # makes echoes the marker, which is how it knows code actually ran.
+        creating = tool == "text_editor_code_execution" and body["input"]["command"] == "create"
+        stdout = "File created successfully" if creating else f"{_MARKER}\n"
+        return httpx.Response(200, json=self._envelope(body, stdout))
+
+    def _envelope(self, request_body: dict[str, Any], stdout: str) -> dict[str, Any]:
+        # Echoed when the request carried one, generated otherwise, as the
+        # contract has it.
+        tool_use_id = request_body.get("tool_use_id") or "srvtoolu_generated"
+        block = {
+            "type": "code_execution_tool_result",
+            "tool_use_id": tool_use_id,
+            "content": {
+                "type": "code_execution_result",
+                "stdout": stdout,
+                "stderr": "",
+                "return_code": 0,
+                "content": [],
+            },
+        }
+        if not self.envelope:
+            # The mistake the typed client was written to catch: the result block
+            # returned bare, at the top level, instead of under `result_block`.
+            return block
+        return {"tool_use_id": tool_use_id, "execution_time_ms": 12, "result_block": block}
+
+    def _upload(self) -> httpx.Response:
+        if not self.serve_files:
+            return httpx.Response(404, json={"detail": "not implemented"})
+        return httpx.Response(201, json={"path": "conformance.txt", "size_bytes": len(_FILE_BODY)})
+
+    def _list_files(self) -> httpx.Response:
+        if not self.serve_files:
+            return httpx.Response(404, json={"detail": "not implemented"})
+        return httpx.Response(
+            200,
+            json={
+                "files": [
+                    {
+                        "path": "conformance.txt",
+                        "size_bytes": len(_FILE_BODY),
+                        "mime_type": "text/plain",
+                        "modified_at": 1786000000.0,
+                    }
+                ]
+            },
+        )
+
+    def _download(self, request: httpx.Request) -> httpx.Response:
+        if not self.serve_files:
+            return httpx.Response(404, json={"detail": "not implemented"})
+        escaping = ".." in (request.url.params.get("path") or "")
+        if escaping and self.confine_paths:
+            return httpx.Response(403, json={"detail": "path escapes the workspace"})
+        return httpx.Response(200, content=self.download_body)
+
+
+def _run(backend: FakeBackend) -> list[Any]:
+    spec = conformance.load_spec()
+    with httpx.Client(base_url="http://sandbox", transport=httpx.MockTransport(backend.handler)) as client:
+        checks: list[Any] = conformance.run_checks(client, spec, timeout_seconds=5)
+    return checks
+
+
+def _failures(checks: list[Any]) -> dict[str, str]:
+    return {check.name: check.detail for check in checks if check.status == conformance.FAIL}
+
+
+def _statuses(checks: list[Any]) -> dict[str, str]:
+    return {check.name: check.status for check in checks}
+
+
+def test_conforming_backend_passes() -> None:
+    checks = _run(FakeBackend())
+    assert not _failures(checks)
+    assert conformance.report(checks) == 0
+    # Every operation the contract requires was actually exercised.
+    assert {"CreateSession", "DestroySession", "PutFile", "ListFiles", "GetFile"} <= set(_statuses(checks))
+    assert sum(1 for check in checks if check.name.startswith("Execute ")) == 5
+
+
+def test_bare_result_block_fails_execute() -> None:
+    """The latent break the typed client closed, now caught at the source."""
+    failures = _failures(_run(FakeBackend(envelope=False)))
+    assert "Execute code_execution" in failures
+    assert "does not match ExecResponse" in failures["Execute code_execution"]
+
+
+def test_missing_file_operations_are_skipped_not_failed() -> None:
+    checks = _run(FakeBackend(serve_files=False))
+    statuses = _statuses(checks)
+    assert [statuses[name] for name in ("PutFile", "ListFiles", "GetFile")] == [conformance.SKIP] * 3
+    assert not _failures(checks)
+    assert conformance.report(checks) == 0
+
+
+def test_serving_a_path_outside_the_workspace_fails() -> None:
+    failures = _failures(_run(FakeBackend(confine_paths=False)))
+    assert "GetFile confines access to the session workspace" in failures
+
+
+def test_running_an_unknown_tool_kind_fails() -> None:
+    failures = _failures(_run(FakeBackend(refuse_unknown_tool=False)))
+    assert "Execute refuses an unknown tool kind" in failures
+
+
+def test_lifetime_hint_reported_above_the_request_fails() -> None:
+    """A backend may clamp a lifetime hint downward, never upward.
+
+    Upward is what breaks a client: the handle is its only statement of how long
+    the session lives.
+    """
+    failures = _failures(_run(FakeBackend(reported_idle_timeout=99_999)))
+    assert "CreateSession honours lifetime hints" in failures
+
+
+def test_downloaded_bytes_must_match_what_was_written() -> None:
+    failures = _failures(_run(FakeBackend(download_body=b"something else")))
+    assert "GetFile" in failures
+
+
+def test_session_is_released_even_when_a_check_fails() -> None:
+    """A checker that leaks sessions cannot be run against a live backend twice."""
+    backend = FakeBackend(envelope=False)
+    checks = _run(backend)
+    assert _failures(checks)
+    assert ("DELETE", f"/sessions/{_SESSION_ID}") in backend.calls
+
+
+def test_unreachable_backend_reports_a_failure_rather_than_raising() -> None:
+    def refuse(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    spec = conformance.load_spec()
+    with httpx.Client(base_url="http://sandbox", transport=httpx.MockTransport(refuse)) as client:
+        checks = conformance.run_checks(client, spec, timeout_seconds=5)
+    assert list(_failures(checks)) == ["CreateSession"]
+    assert conformance.report(checks) == 1
+
+
+def test_main_reports_and_exits_nonzero_on_a_broken_backend(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    backend = FakeBackend(envelope=False)
+    real_client = httpx.Client
+
+    def client_with_fake_transport(**kwargs: Any) -> httpx.Client:
+        kwargs["transport"] = httpx.MockTransport(backend.handler)
+        return real_client(**kwargs)
+
+    monkeypatch.setattr(conformance.httpx, "Client", client_with_fake_transport)
+    exit_code = conformance.main(["--base-url", "http://sandbox/", "--auth-token", "secret"])
+
+    assert exit_code == 1
+    output = capsys.readouterr().out
+    assert "does not conform to code-execution contract version 1" in output
+    assert "secret" not in output

--- a/tests/unit/test_code_execution_contract.py
+++ b/tests/unit/test_code_execution_contract.py
@@ -1,0 +1,246 @@
+"""Keep the code-execution contract's three faces in agreement.
+
+The contract is published in three places, each load-bearing for a different
+reader: `docs/code-execution-protocol.md` is prose for someone building a
+backend, `docs/public/code-execution-openapi.yaml` is the IDL they generate from,
+and `gateway.types.code_execution` is what this gateway actually parses. Nothing
+but a test stops those drifting apart, and drift is exactly what publishing the
+contract was meant to end.
+
+So: every operation, path, status code, and example in the doc has to be in the
+spec too, the spec's examples have to validate against its own schemas, and the
+gateway's client models have to parse them.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from jsonschema import Draft202012Validator
+
+from gateway.types.code_execution import ExecResponse, SessionHandle
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DOC_PATH = _REPO_ROOT / "docs" / "code-execution-protocol.md"
+_SPEC_PATH = _REPO_ROOT / "docs" / "public" / "code-execution-openapi.yaml"
+
+_CORE_OPERATIONS = {"CreateSession", "Execute", "DestroySession"}
+_FILE_OPERATIONS = {"ListFiles", "GetFile", "PutFile"}
+
+_HTTP_METHODS = ("get", "put", "post", "delete", "patch", "head", "options", "trace")
+
+_CODE_SPAN = re.compile(r"`([^`]+)`")
+_TABLE_ROW = re.compile(r"^\|(?P<cells>.+)\|\s*$")
+
+
+@pytest.fixture(scope="module")
+def doc() -> str:
+    return _DOC_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def spec() -> dict[str, Any]:
+    with _SPEC_PATH.open(encoding="utf-8") as handle:
+        loaded: dict[str, Any] = yaml.safe_load(handle)
+    return loaded
+
+
+def _table_rows(doc: str, *, after: str) -> list[list[str]]:
+    """The rows of the first markdown table following a heading or line."""
+    body = doc.split(after, 1)[1]
+    rows: list[list[str]] = []
+    for line in body.splitlines():
+        match = _TABLE_ROW.match(line)
+        if match is None:
+            if rows:
+                break
+            continue
+        cells = [cell.strip() for cell in match.group("cells").split("|")]
+        if all(set(cell) <= {"-", ":"} for cell in cells):  # the header separator
+            continue
+        rows.append(cells)
+    assert rows, f"no table found after {after!r} in {_DOC_PATH.name}"
+    return rows[1:]  # drop the header
+
+
+def _operations(spec: dict[str, Any]) -> dict[str, tuple[str, str]]:
+    """operationId -> (METHOD, path), for every operation in the spec."""
+    found: dict[str, tuple[str, str]] = {}
+    for path, item in spec["paths"].items():
+        for method in _HTTP_METHODS:
+            operation = item.get(method)
+            if operation is None:
+                continue
+            found[operation["operationId"]] = (method.upper(), path)
+    return found
+
+
+def _validator(spec: dict[str, Any], schema_name: str) -> Draft202012Validator:
+    return Draft202012Validator({"$ref": f"#/components/schemas/{schema_name}", "components": spec["components"]})
+
+
+def _walk(node: Any) -> Iterator[Any]:
+    """Every mapping and sequence in the document, depth first."""
+    yield node
+    if isinstance(node, dict):
+        for value in node.values():
+            yield from _walk(value)
+    elif isinstance(node, list):
+        for value in node:
+            yield from _walk(value)
+
+
+def test_spec_is_openapi_31(spec: dict[str, Any]) -> None:
+    # 3.1 and not 3.0 for a concrete reason: its schemas are JSON Schema
+    # 2020-12, which is what lets this file's other tests, and the conformance
+    # script, validate payloads with a plain JSON Schema validator.
+    assert spec["openapi"] == "3.1.0"
+    assert spec["components"]["schemas"], "the spec declares no schemas"
+
+
+def test_spec_version_is_the_contract_version(doc: str, spec: dict[str, Any]) -> None:
+    """`info.version` is the contract version, not a release number."""
+    match = re.search(r"\*\*Contract version: (\d+)\.\*\*", doc)
+    assert match is not None, "the doc no longer states a contract version"
+    assert spec["info"]["version"] == match.group(1)
+
+
+def test_documented_operations_are_the_spec_operations(doc: str, spec: dict[str, Any]) -> None:
+    documented = {
+        span.group(1) for row in _table_rows(doc, after="## Operations") if (span := _CODE_SPAN.search(row[0]))
+    }
+    assert documented == _CORE_OPERATIONS | _FILE_OPERATIONS
+    assert set(_operations(spec)) == documented
+
+
+def test_documented_binding_matches_the_spec_paths(doc: str, spec: dict[str, Any]) -> None:
+    """The doc's binding table and the spec must name the same method and path.
+
+    Parsing the doc is the point: a path edited in one place and not the other is
+    the drift that leaves an implementer building against a URL nothing serves.
+    """
+    operations = _operations(spec)
+    for row in _table_rows(doc, after="## HTTP/JSON binding"):
+        operation = _CODE_SPAN.search(row[0])
+        binding = _CODE_SPAN.search(row[1])
+        assert operation is not None and binding is not None, f"unparsable binding row: {row}"
+        method, _, path = binding.group(1).partition(" ")
+        # The doc annotates two cells with a query string and a note; the spec
+        # carries those as parameters and a request body.
+        assert operations[operation.group(1)] == (method, path.split("?", 1)[0])
+
+
+def test_file_operations_are_marked_optional_in_the_spec(spec: dict[str, Any]) -> None:
+    """A backend implementing only the three session operations still conforms.
+
+    The conformance script reads this marker to decide whether a missing
+    operation is a skip or a failure, so it is contract data, not a comment.
+    """
+    optional = set()
+    for path, item in spec["paths"].items():
+        for method in _HTTP_METHODS:
+            operation = item.get(method)
+            if operation is not None and operation.get("x-otari-optional"):
+                optional.add(operation["operationId"])
+                assert "Optional." in operation["description"], (
+                    f"{path} {method} is marked optional but does not say so"
+                )
+    assert optional == _FILE_OPERATIONS
+
+
+def test_documented_status_codes_are_the_spec_status_codes(doc: str, spec: dict[str, Any]) -> None:
+    documented = {
+        code for row in _table_rows(doc, after="Status codes:") for code in re.findall(r"\b(\d{3})\b", row[1])
+    }
+    declared = {
+        status
+        for path_item in spec["paths"].values()
+        for method in _HTTP_METHODS
+        if (operation := path_item.get(method)) is not None
+        for status in operation["responses"]
+    }
+    assert documented == declared
+
+
+def test_documented_example_is_the_spec_example(doc: str, spec: dict[str, Any]) -> None:
+    """The doc's worked example and the spec's `ExecResponse` example are one payload.
+
+    Two examples that disagree are worse than one: an implementer copies
+    whichever they read first.
+    """
+    block = re.search(r"```json\n(.*?)```", doc, re.DOTALL)
+    assert block is not None, "the doc no longer carries a worked example"
+    assert json.loads(block.group(1)) == spec["components"]["schemas"]["ExecResponse"]["examples"][0]
+
+
+@pytest.mark.parametrize("schema_name", ["SessionHandle", "ExecResponse", "CodeExecutionRequest"])
+def test_spec_examples_validate_against_their_schemas(spec: dict[str, Any], schema_name: str) -> None:
+    validator = _validator(spec, schema_name)
+    examples = spec["components"]["schemas"][schema_name]["examples"]
+    assert examples, f"{schema_name} carries no example"
+    for example in examples:
+        assert not list(validator.iter_errors(example)), f"{schema_name} example violates its own schema: {example}"
+
+
+def test_gateway_client_parses_the_spec_examples(spec: dict[str, Any]) -> None:
+    """The client this gateway ships must accept what the spec advertises."""
+    schemas = spec["components"]["schemas"]
+    assert SessionHandle.model_validate(schemas["SessionHandle"]["examples"][0]).session_id
+
+    parsed = ExecResponse.model_validate(schemas["ExecResponse"]["examples"][0])
+    assert parsed.result_block.type == "code_execution_tool_result"
+    assert [ref.filename for ref in parsed.result_block.content.content] == ["chart.png"]
+
+
+def test_result_block_type_is_not_a_closed_enum(spec: dict[str, Any]) -> None:
+    """A tool kind added later must not make an older client reject the response.
+
+    The client keeps `type` an opaque string for this reason; an enum here would
+    hand a generated client the opposite rule.
+    """
+    block_type = spec["components"]["schemas"]["ResultBlock"]["properties"]["type"]
+    assert "enum" not in block_type and "const" not in block_type
+    assert len(block_type["examples"]) == 3
+
+
+def test_response_schemas_tolerate_unknown_fields(spec: dict[str, Any]) -> None:
+    """The extension policy, spelled out where a generator can read it."""
+    offenders = [
+        name
+        for name, schema in spec["components"]["schemas"].items()
+        if schema.get("type") == "object" and schema.get("additionalProperties") is not True
+    ]
+    assert not offenders, f"schemas that would reject an additive field: {offenders}"
+
+
+def test_every_ref_resolves(spec: dict[str, Any]) -> None:
+    broken = []
+    for node in _walk(spec):
+        if not isinstance(node, dict) or "$ref" not in node:
+            continue
+        ref = node["$ref"]
+        assert ref.startswith("#/"), f"the spec must stay self-contained, found {ref}"
+        target: Any = spec
+        for part in ref.removeprefix("#/").split("/"):
+            if not isinstance(target, dict) or part not in target:
+                broken.append(ref)
+                break
+            target = target[part]
+    assert not broken, f"unresolvable reference(s): {broken}"
+
+
+def test_no_orphan_schemas(spec: dict[str, Any]) -> None:
+    """Every schema is reachable from an operation, so none is dead spec."""
+    referenced = {
+        node["$ref"].removeprefix("#/components/schemas/")
+        for node in _walk(spec)
+        if isinstance(node, dict) and str(node.get("$ref", "")).startswith("#/components/schemas/")
+    }
+    orphans = set(spec["components"]["schemas"]) - referenced
+    assert not orphans, f"schema(s) nothing references: {orphans}"

--- a/tests/unit/test_code_execution_contract.py
+++ b/tests/unit/test_code_execution_contract.py
@@ -35,6 +35,8 @@ _FILE_OPERATIONS = {"ListFiles", "GetFile", "PutFile"}
 
 _HTTP_METHODS = ("get", "put", "post", "delete", "patch", "head", "options", "trace")
 
+_SCHEMA_PREFIX = "#/components/schemas/"
+
 _CODE_SPAN = re.compile(r"`([^`]+)`")
 _TABLE_ROW = re.compile(r"^\|(?P<cells>.+)\|\s*$")
 
@@ -95,6 +97,21 @@ def _walk(node: Any) -> Iterator[Any]:
     elif isinstance(node, list):
         for value in node:
             yield from _walk(value)
+
+
+def _refs_in(node: Any) -> set[str]:
+    """Every `$ref` value at or below `node`."""
+    return {found["$ref"] for found in _walk(node) if isinstance(found, dict) and isinstance(found.get("$ref"), str)}
+
+
+def _resolve_ref(spec: dict[str, Any], ref: str) -> Any:
+    """What a local JSON pointer points at, or None when it points nowhere."""
+    target: Any = spec
+    for part in ref.removeprefix("#/").split("/"):
+        if not isinstance(target, dict) or part not in target:
+            return None
+        target = target[part]
+    return target
 
 
 def test_spec_is_openapi_31(spec: dict[str, Any]) -> None:
@@ -238,26 +255,35 @@ def test_response_schemas_tolerate_unknown_fields(spec: dict[str, Any]) -> None:
 
 def test_every_ref_resolves(spec: dict[str, Any]) -> None:
     broken = []
-    for node in _walk(spec):
-        if not isinstance(node, dict) or "$ref" not in node:
-            continue
-        ref = node["$ref"]
+    for ref in _refs_in(spec):
         assert ref.startswith("#/"), f"the spec must stay self-contained, found {ref}"
-        target: Any = spec
-        for part in ref.removeprefix("#/").split("/"):
-            if not isinstance(target, dict) or part not in target:
-                broken.append(ref)
-                break
-            target = target[part]
+        if _resolve_ref(spec, ref) is None:
+            broken.append(ref)
     assert not broken, f"unresolvable reference(s): {broken}"
 
 
 def test_no_orphan_schemas(spec: dict[str, Any]) -> None:
-    """Every schema is reachable from an operation, so none is dead spec."""
-    referenced = {
-        node["$ref"].removeprefix("#/components/schemas/")
-        for node in _walk(spec)
-        if isinstance(node, dict) and str(node.get("$ref", "")).startswith("#/components/schemas/")
-    }
-    orphans = set(spec["components"]["schemas"]) - referenced
-    assert not orphans, f"schema(s) nothing references: {orphans}"
+    """Every schema is reachable from an operation, so none is dead spec.
+
+    Reachability is traced outward from `paths`, not read off the set of `$ref`
+    values anywhere in the document: a schema that references itself, or an
+    unused pair that reference each other, would otherwise vouch for itself and
+    a dead branch of the contract would keep passing as live.
+    """
+    frontier = _refs_in(spec["paths"])
+    reached: set[str] = set()
+    while frontier:
+        ref = frontier.pop()
+        if ref in reached:
+            continue
+        reached.add(ref)
+        target = _resolve_ref(spec, ref)
+        # An unresolvable ref is test_every_ref_resolves' business, not this one.
+        if target is not None:
+            frontier |= _refs_in(target)
+
+    reachable = {ref.removeprefix(_SCHEMA_PREFIX) for ref in reached if ref.startswith(_SCHEMA_PREFIX)}
+    # A traversal that reaches nothing would pass this test for the wrong reason.
+    assert reachable, "no schema is reachable from paths; the traversal, not the spec, is broken"
+    orphans = set(spec["components"]["schemas"]) - reachable
+    assert not orphans, f"schema(s) no operation reaches: {orphans}"

--- a/tests/unit/test_code_execution_contract.py
+++ b/tests/unit/test_code_execution_contract.py
@@ -53,6 +53,7 @@ def spec() -> dict[str, Any]:
 
 def _table_rows(doc: str, *, after: str) -> list[list[str]]:
     """The rows of the first markdown table following a heading or line."""
+    assert after in doc, f"{_DOC_PATH.name} no longer contains {after!r}, so its table cannot be checked"
     body = doc.split(after, 1)[1]
     rows: list[list[str]] = []
     for line in body.splitlines():
@@ -166,6 +167,22 @@ def test_documented_status_codes_are_the_spec_status_codes(doc: str, spec: dict[
         for status in operation["responses"]
     }
     assert documented == declared
+
+
+def test_every_operation_declares_the_unauthorized_response(spec: dict[str, Any]) -> None:
+    """The credential is a deployment property, so any operation can answer 401.
+
+    Declaring it on one operation only would leave a generated client treating
+    the same answer elsewhere as an unrecognised failure.
+    """
+    missing = [
+        operation["operationId"]
+        for path_item in spec["paths"].values()
+        for method in _HTTP_METHODS
+        if (operation := path_item.get(method)) is not None
+        and operation["responses"].get("401", {}).get("$ref") != "#/components/responses/Unauthorized"
+    ]
+    assert not missing, f"operation(s) with no 401 declared: {missing}"
 
 
 def test_documented_example_is_the_spec_example(doc: str, spec: dict[str, Any]) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3,8 +3,8 @@ revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'linux'",
-    "python_full_version < '3.14' and sys_platform == 'linux'",
     "python_full_version >= '3.14' and sys_platform == 'darwin'",
+    "python_full_version < '3.14' and sys_platform == 'linux'",
     "python_full_version < '3.14' and sys_platform == 'darwin'",
 ]
 supported-markers = [
@@ -936,6 +936,7 @@ s3 = [
 [package.dev-dependencies]
 dev = [
     { name = "boto3-stubs", extra = ["s3"] },
+    { name = "jsonschema" },
     { name = "moto", extra = ["s3"] },
     { name = "mypy" },
     { name = "pytest" },
@@ -946,6 +947,7 @@ dev = [
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "testcontainers" },
+    { name = "types-jsonschema" },
 ]
 
 [package.metadata]
@@ -982,6 +984,7 @@ provides-extras = ["ocr", "s3"]
 [package.metadata.requires-dev]
 dev = [
     { name = "boto3-stubs", extras = ["s3"] },
+    { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "moto", extras = ["s3"], specifier = ">=5.0.0" },
     { name = "mypy" },
     { name = "pytest", specifier = ">=9.0.3,<10" },
@@ -992,6 +995,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "ruff", specifier = ">=0.15.9" },
     { name = "testcontainers", extras = ["postgres"], specifier = ">=4.0.0" },
+    { name = "types-jsonschema" },
 ]
 
 [[package]]
@@ -3588,6 +3592,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3e/59/44409a8fc06b444ab1a6f71dcb29d49a6e17e02424345eb51b051bebb345/types_awscrt-0.34.1.tar.gz", hash = "sha256:559aa04250f6a419a617dfb788f3e10903aaf74700ef23e521b64a411b83b803", size = 19062, upload-time = "2026-06-05T04:40:10.689Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/b1/214b12162b452ed6acd230065e6c587cde6b96871e3ce6d653f40888f8df/types_awscrt-0.34.1-py3-none-any.whl", hash = "sha256:20c752b6031544d8f694803c35174aee129f1be5ddf886ae46d22f7ffd9b7d75", size = 45688, upload-time = "2026-06-05T04:40:09.198Z" },
+]
+
+[[package]]
+name = "types-jsonschema"
+version = "4.26.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/46/73b6a5d61a61015c4248030a8cb07e5bdddb4041430fae9e585a68692578/types_jsonschema-4.26.0.20260518.tar.gz", hash = "sha256:e1dd53dc97a64f5eccdd6fa9839666e09bb500a8ebba2db6fdaf1789faea81a6", size = 16638, upload-time = "2026-05-18T06:06:44.106Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/d5/134f8a147dcecda10db7f60cfc6af0578a25a5c53c87b3907a64385e0184/types_jsonschema-4.26.0.20260518-py3-none-any.whl", hash = "sha256:30b30a518c7fe335df85c919fcbcc631b69c03d4a4b5b632fa916bea03065307", size = 16072, upload-time = "2026-05-18T06:06:43.264Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

[#544](https://github.com/mozilla-ai/otari/pull/544) published the code-execution wire contract as prose while its transport was still open, so the doc marked the HTTP/JSON binding provisional. That is settled ([otari-ai#1601](https://github.com/mozilla-ai/otari-ai/issues/1601)): OpenAPI is the IDL, HTTP/JSON is the committed binding, proto sits behind two recorded revisit triggers (first non-HTTP backend, first bidirectional interactive workload).

So this publishes the IDL itself, `docs/public/code-execution-openapi.yaml`, which a backend implementer generates a stub or a client from instead of transcribing tables. Hand-maintained, unlike the generated artifacts beside it: it specifies a backend Otari calls, so nothing here serves those paths. The prose doc stays normative for what a schema cannot carry (session statefulness, failure reported in the payload, the extension policy) and drops the provisional marker.

Two published faces of one contract drift, and a doc nobody executes drifts silently, so both are now executable:

- `tests/unit/test_code_execution_contract.py` parses the doc's own tables and fails when an operation, path, status code, or the worked example disagrees with the spec, then parses the spec's examples through the gateway's client models.
- `scripts/check_code_execution_conformance.py` drives a live backend through the contract: every tool kind, an unknown kind refused, workspace confinement, session release. It validates requests on the way out as well as responses on the way in, and reports the optional file operations as skipped rather than failed. `mzdotai/otari-sandbox-container` passes all 13 checks.

Three clauses the spec forced into the open, each read off the reference implementation: session timestamps are POSIX seconds, a file reference carries both `file_id` and `filename`, and a backend may cap `timeout_seconds` by refusing rather than clamping (the reference one refuses above 120). A `401` row joins the status table, since a deployment may require a credential the contract itself does not define.

`jsonschema` becomes a dev dependency (tests and that script). Nothing at runtime uses it: the gateway parses this contract with its own Pydantic models.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Addresses the publish half of [otari-ai#1448](https://github.com/mozilla-ai/otari-ai/issues/1448), now unblocked by [otari-ai#1601](https://github.com/mozilla-ai/otari-ai/issues/1601). Not closing it: the entitlement gate on the capability is platform-side work, so it lands in `otari-ai` rather than here.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).
- [x] If this PR adds or changes a persistent table, a control-plane contract the otari.ai platform consumes or serves, a capability the platform also has, or a mode-specific surface, I appended an entry to the M4 reconciliation ledger ([otari-ai#1587](https://github.com/mozilla-ai/otari-ai/issues/1587)). See [.github/instructions/reconciliation-ledger.instructions.md](.github/instructions/reconciliation-ledger.instructions.md).

No route or schema changes here, so `openapi-check` and `postman-check` are unaffected; both pass. The 1674-test unit suite passes, and the conformance script was run against the reference container.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

The spec was read off `otari-sandbox-container`'s `sandbox/models.py` and `sandbox/exec_server.py`, then checked against the running container rather than trusted from the source read. Three deviations from the prose surfaced that way, and are in the diff.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added the canonical OpenAPI contract for the code-execution backend.
- Updated protocol documentation to define HTTP/JSON, sessions, timestamps, errors, timeouts, and extensions.
- Added links to the machine-readable contract.
- Added contract tests and live conformance checks.
- Added `jsonschema` development dependencies.

These changes provide one validated backend contract without changing runtime code or routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
