### PR TITLE
feat(search): serve POST /v1/search from a SearXNG backend

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -107,9 +107,9 @@ providers:
 
 # Search tools (optional): what POST /v1/search can run against, keyed by the
 # name callers pass as `search_tool_name` (or in the /v1/search/{tool} path).
-# `provider` defaults to the tool name and must be one of: exa. `options` holds
-# provider-native request defaults for knobs the request body has no field for;
-# the caller's query always wins. Standalone-mode only.
+# `provider` defaults to the tool name and must be one of: exa, searxng.
+# `options` holds provider-native request defaults for knobs the request body has
+# no field for; the caller's query always wins. Standalone-mode only.
 # search_tools:
 #   exa-search:
 #     provider: exa
@@ -118,6 +118,14 @@ providers:
 #     # timeout: 30                      # optional, seconds
 #     options:
 #       type: fast
+#   # A SearXNG-shaped backend (the bundled container, or a Brave/Tavily
+#   # adapter) needs no api_key, and inherits web_search_url when it declares
+#   # no api_base, so the in-loop web_search backend is served here too.
+#   local:
+#     provider: searxng
+#     # api_base: "http://searxng:8080"  # optional; defaults to web_search_url
+#     options:
+#       engines: duckduckgo,mojeek
 
 # Model aliases (optional): expose a friendly display name that maps to a real
 # selector, hiding the underlying provider/model. Format: name -> target

--- a/config.example.yml
+++ b/config.example.yml
@@ -119,13 +119,14 @@ providers:
 #     options:
 #       type: fast
 #   # A SearXNG-shaped backend (the bundled container, or a Brave/Tavily
-#   # adapter) needs no api_key, and inherits web_search_url when it declares
-#   # no api_base, so the in-loop web_search backend is served here too.
+#   # adapter) needs no api_key, and inherits web_search_url and
+#   # web_search_engines when it declares neither, so the in-loop web_search
+#   # backend is served here too.
 #   local:
 #     provider: searxng
 #     # api_base: "http://searxng:8080"  # optional; defaults to web_search_url
-#     options:
-#       engines: duckduckgo,mojeek
+#     # options:
+#     #   engines: duckduckgo,mojeek     # optional; defaults to web_search_engines
 
 # Model aliases (optional): expose a friendly display name that maps to a real
 # selector, hiding the underlying provider/model. Format: name -> target

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -168,6 +168,12 @@ rejected, so check that your client does not depend on one. Provider-native
 knobs with no request field, such as Exa's `type` or `category`, belong in the
 tool's `options`.
 
+The supported providers are `exa` and `searxng`, the latter being the same
+SearXNG-shaped backend the `otari_web_search` tool uses, so a deployment that
+already runs one can serve this endpoint from it without a commercial key. Which
+request fields a `searxng` tool honors differs slightly; see
+[serving the web-search backend you already run](configuration.md#serving-the-web-search-backend-you-already-run).
+
 Search bills per request rather than per token, so a usage
 row carries zero tokens and a cost taken from the provider's own reported charge
 when it reports one (Exa does); otherwise it uses the flat per-request rate

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -336,21 +336,28 @@ Set `api_base` to point a tool at a different backend than the in-loop tool
 uses, and `api_key` only when the backend authenticates the gateway (it is sent
 as `X-Gateway-Token`, the header the in-loop backend already sends); a
 self-hosted SearXNG ignores it. `options` become extra `/search` query params,
-so backend-native knobs (`engines`, `language`, `time_range`) go there, and
-`q` / `format` stay the gateway's.
+so backend-native knobs (`language`, `time_range`) go there, and `q`, `format`
+and `max_results` stay the gateway's. A tool that pins no `engines` option
+inherits `web_search_engines`, so both surfaces query the same engines on the
+same backend.
 
-Three request fields behave differently on this provider, because SearXNG has no
-equivalent param: `max_results` and `search_domain_filter` are applied by the
-gateway to the returned hits rather than upstream, `country` is forwarded as a
-query param that a fronting adapter can honor and a plain SearXNG ignores, and
-`max_tokens_per_page` does not apply, since each result carries the engine's
-snippet rather than fetched page content. SearXNG reports no cost either, so a
-search is billed at the flat rate configured for the tool (below).
+Two request fields are honored by the gateway rather than upstream, because
+SearXNG has no equivalent param: `search_domain_filter` and
+`max_tokens_per_page` are applied to the returned hits. A plain SearXNG hit
+carries the engine's short snippet, so the per-page cap usually does not bite; an
+adapter that returns whole extracted pages (the bundled Tavily one does) is where
+it does. `max_results` and `country` are forwarded, for a backend that reads them
+(Tavily's adapter caps its page at 5 without the former), and a plain SearXNG
+ignores an unknown param. SearXNG reports no cost either, so a search is billed at
+the flat rate configured for the tool (below).
 
-Every entry is validated at startup, so an unsupported provider, a missing
-`api_key`, or a `searxng` tool with no backend URL fails before the first
-request. Search tools are standalone mode only: in hybrid mode, search is the
-platform's to configure.
+Every entry is validated at startup, so an unsupported provider or a missing
+`api_key` fails before the first request. A `searxng` tool with no backend URL
+anywhere is a startup warning instead of a failure, since the web-search URL can
+also come from the dashboard's Tools page, which is read after the config loads;
+until one is set, `POST /v1/search` refuses that tool with a 400 and the rest of
+the gateway serves. Search tools are standalone mode only: in hybrid mode, search
+is the platform's to configure.
 
 To price search, add a flat per-request rate under the model key
 `<provider>:<tool>` (for example `exa:exa-search`), following the same

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -288,9 +288,9 @@ search_tools:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `provider` | string | the tool name | Search provider to dispatch to. Supported: `exa`. |
-| `api_key` | string | required | Credential for the provider. |
-| `api_base` | string | provider default | Override the provider's base URL. |
+| `provider` | string | the tool name | Search provider to dispatch to. Supported: `exa`, `searxng`. |
+| `api_key` | string | required for `exa` | Credential for the provider. A `searxng` backend is normally keyless; see below. |
+| `api_base` | string | provider default | Override the provider's base URL. Required for `searxng` unless `web_search_url` is set. |
 | `timeout` | number | `30` | Request timeout in seconds; must be greater than 0. |
 | `options` | dict | `{}` | Provider-native request fields used as defaults. |
 
@@ -316,9 +316,41 @@ search_tools:
 The opt-out is the operator's, so it holds even for a request that carries
 `max_tokens_per_page`.
 
-Every entry is validated at startup, so an unsupported provider or a missing
-`api_key` fails before the first request. Search tools are standalone mode only:
-in hybrid mode, search is the platform's to configure.
+### Serving the web-search backend you already run
+
+The `searxng` provider speaks the same
+`GET {api_base}/search?format=json` contract as the
+[`otari_web_search`](tools.md#web-search) tool's backend, so the bundled SearXNG
+container and the Brave and Tavily fronting adapters are reachable from
+`POST /v1/search` too, with no commercial key:
+
+```yaml
+web_search_url: "http://searxng:8080"
+
+search_tools:
+  local:
+    provider: searxng   # api_base defaults to web_search_url
+```
+
+Set `api_base` to point a tool at a different backend than the in-loop tool
+uses, and `api_key` only when the backend authenticates the gateway (it is sent
+as `X-Gateway-Token`, the header the in-loop backend already sends); a
+self-hosted SearXNG ignores it. `options` become extra `/search` query params,
+so backend-native knobs (`engines`, `language`, `time_range`) go there, and
+`q` / `format` stay the gateway's.
+
+Three request fields behave differently on this provider, because SearXNG has no
+equivalent param: `max_results` and `search_domain_filter` are applied by the
+gateway to the returned hits rather than upstream, `country` is forwarded as a
+query param that a fronting adapter can honor and a plain SearXNG ignores, and
+`max_tokens_per_page` does not apply, since each result carries the engine's
+snippet rather than fetched page content. SearXNG reports no cost either, so a
+search is billed at the flat rate configured for the tool (below).
+
+Every entry is validated at startup, so an unsupported provider, a missing
+`api_key`, or a `searxng` tool with no backend URL fails before the first
+request. Search tools are standalone mode only: in hybrid mode, search is the
+platform's to configure.
 
 To price search, add a flat per-request rate under the model key
 `<provider>:<tool>` (for example `exa:exa-search`), following the same

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -187,4 +187,6 @@ To search directly rather than as part of a completion, use
 same way, but the caller supplies the query instead of the model, it is
 configured separately under
 [`search_tools`](configuration.md#search-tools), and it is priced under its own
-key (see [Pricing a gateway-run tool](#pricing-a-gateway-run-tool)).
+key (see [Pricing a gateway-run tool](#pricing-a-gateway-run-tool)). A tool with
+`provider: searxng` runs against this same backend, so the endpoint needs no
+commercial search key when `OTARI_WEB_SEARCH_URL` is already set.

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -89,7 +89,17 @@ ROUTER_GRANULARITIES = ("trace_sticky", "step")
 # Declared here rather than in the adapter module so startup validation can
 # reject an unknown ``search_tools.<name>.provider`` without the config layer
 # importing the service layer.
-SEARCH_PROVIDERS = ("exa",)
+SEARCH_PROVIDERS = ("exa", "searxng")
+# Providers that authenticate with an API key, so a tool declaring one of them
+# without a key is a misconfiguration. A SearXNG-shaped backend is normally
+# keyless (the bundled container, a self-hosted adapter), which is why the key
+# is per-provider rather than universally required.
+SEARCH_PROVIDERS_REQUIRING_API_KEY = ("exa",)
+# Providers with no endpoint of their own to default to, so the tool has to say
+# where the backend is. The only one today is ``searxng``, which speaks the same
+# wire contract as the in-loop otari_web_search backend and therefore inherits
+# ``web_search_url`` when the tool declares no ``api_base``.
+SEARCH_PROVIDERS_REQUIRING_API_BASE = ("searxng",)
 
 
 class _NonScalarField(Exception):
@@ -384,9 +394,10 @@ class GatewayConfig(BaseSettings):
         default_factory=dict,
         description=(
             "Search tools served by POST /v1/search, keyed by the name callers pass as "
-            "'search_tool_name' (or in the /v1/search/{tool} path). Each entry needs an "
-            "'api_key' and may declare a 'provider' (one of: exa; defaults to the tool "
-            "name), an 'api_base', a 'timeout' in seconds, and an 'options' mapping of "
+            "'search_tool_name' (or in the /v1/search/{tool} path). Each entry may declare a "
+            "'provider' (one of: exa, searxng; defaults to the tool name), an 'api_key' "
+            "(required for exa), an 'api_base' (required for searxng unless web_search_url is "
+            "set, which it then inherits), a 'timeout' in seconds, and an 'options' mapping of "
             "provider-native defaults. Standalone-mode only."
         ),
     )
@@ -1102,9 +1113,12 @@ class GatewayConfig(BaseSettings):
     def validate_search_tools(self) -> None:
         """Validate the ``search_tools`` map at startup so misconfig fails fast.
 
-        Every supported provider authenticates with an API key, so a tool
-        without one is rejected here rather than at request time as an opaque
-        upstream 401. The tool name doubles as a ``/v1/search/{tool}`` path
+        A tool on a provider that authenticates with an API key is rejected here
+        without one, rather than at request time as an opaque upstream 401; a
+        keyless provider (a self-hosted SearXNG or an adapter fronting one) is
+        allowed to declare none. A provider with no default endpoint needs an
+        ``api_base``, which a ``searxng`` tool may inherit from
+        ``web_search_url``. The tool name doubles as a ``/v1/search/{tool}`` path
         segment, so it must not contain a slash.
         """
         for name, entry in self.search_tools.items():
@@ -1124,8 +1138,18 @@ class GatewayConfig(BaseSettings):
                     f"(one of: {', '.join(SEARCH_PROVIDERS)})."
                 )
                 raise ValueError(msg)
-            if not entry.get("api_key"):
-                msg = f"search_tools.{name}.api_key is required."
+            if provider in SEARCH_PROVIDERS_REQUIRING_API_KEY and not entry.get("api_key"):
+                msg = f"search_tools.{name}.api_key is required for provider '{provider}'."
+                raise ValueError(msg)
+            if (
+                provider in SEARCH_PROVIDERS_REQUIRING_API_BASE
+                and not entry.get("api_base")
+                and not self.web_search_url
+            ):
+                msg = (
+                    f"search_tools.{name}.api_base is required for provider '{provider}' "
+                    "(or set web_search_url, which the tool then inherits)."
+                )
                 raise ValueError(msg)
             timeout = entry.get("timeout")
             if timeout is not None:

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -1110,16 +1110,38 @@ class GatewayConfig(BaseSettings):
         """
         return {str(entry.get("provider") or name) for name, entry in self.search_tools.items()}
 
+    def search_tools_without_backend_url(self) -> list[str]:
+        """Search tools whose provider needs an ``api_base`` and has none to inherit.
+
+        Reported as a startup warning rather than raised by
+        :meth:`validate_search_tools`, because ``web_search_url`` (which a
+        ``searxng`` tool inherits) can also come from a dashboard-stored
+        override, and those are applied to the config after it loads. Failing at
+        load time would refuse to boot a gateway the operator has in fact
+        configured. Enforcement is per request instead: ``resolve_search_tool``
+        refuses such a tool with a 400, and the rest of the gateway serves.
+        """
+        if self.web_search_url:
+            return []
+        return [
+            name
+            for name, entry in self.search_tools.items()
+            if isinstance(entry, dict)
+            and str(entry.get("provider") or name) in SEARCH_PROVIDERS_REQUIRING_API_BASE
+            and not entry.get("api_base")
+        ]
+
     def validate_search_tools(self) -> None:
         """Validate the ``search_tools`` map at startup so misconfig fails fast.
 
         A tool on a provider that authenticates with an API key is rejected here
         without one, rather than at request time as an opaque upstream 401; a
         keyless provider (a self-hosted SearXNG or an adapter fronting one) is
-        allowed to declare none. A provider with no default endpoint needs an
-        ``api_base``, which a ``searxng`` tool may inherit from
-        ``web_search_url``. The tool name doubles as a ``/v1/search/{tool}`` path
-        segment, so it must not contain a slash.
+        allowed to declare none. The tool name doubles as a
+        ``/v1/search/{tool}`` path segment, so it must not contain a slash.
+
+        A missing backend URL is deliberately not fatal here; see
+        :meth:`search_tools_without_backend_url`.
         """
         for name, entry in self.search_tools.items():
             if not name:
@@ -1140,16 +1162,6 @@ class GatewayConfig(BaseSettings):
                 raise ValueError(msg)
             if provider in SEARCH_PROVIDERS_REQUIRING_API_KEY and not entry.get("api_key"):
                 msg = f"search_tools.{name}.api_key is required for provider '{provider}'."
-                raise ValueError(msg)
-            if (
-                provider in SEARCH_PROVIDERS_REQUIRING_API_BASE
-                and not entry.get("api_base")
-                and not self.web_search_url
-            ):
-                msg = (
-                    f"search_tools.{name}.api_base is required for provider '{provider}' "
-                    "(or set web_search_url, which the tool then inherits)."
-                )
                 raise ValueError(msg)
             timeout = entry.get("timeout")
             if timeout is not None:

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -217,6 +217,17 @@ def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
                 # knobs) win over config/env too; apply them so the running worker
                 # reflects a dashboard change made in a prior run.
                 await apply_tool_overrides_from_db(config, session)
+                # After the overrides, not at config load: the web-search URL a
+                # searxng search tool inherits can be the dashboard-stored one
+                # applied just above, and that tool is only broken if nothing
+                # supplied it at all.
+                if missing_backend_url := config.search_tools_without_backend_url():
+                    logger.warning(
+                        "No backend URL for search tool(s): %s. POST /v1/search refuses them with a 400 until "
+                        "each declares an 'api_base' or a web-search URL is set (web_search_url, "
+                        "OTARI_WEB_SEARCH_URL, or the dashboard's Tools page).",
+                        ", ".join(sorted(missing_backend_url)),
+                    )
                 # Generate + persist a master key on first run when none is set,
                 # so the dashboard is reachable without hand-editing config, and
                 # the management API is never left unauthenticated.

--- a/src/gateway/services/search_backend.py
+++ b/src/gateway/services/search_backend.py
@@ -23,6 +23,17 @@ the caller. Every entry is validated at startup by
 ``GatewayConfig.validate_search_tools``, so an unsupported provider or a
 missing API key fails before the first request.
 
+The other provider is ``searxng``, which speaks the SearXNG-shaped
+``GET {api_base}/search?format=json`` contract that
+:mod:`gateway.services.web_search_backend` already dispatches the in-loop tool
+to. It needs no API key, so the bundled SearXNG container and the Brave and
+Tavily fronting adapters are reachable from this endpoint too, and a tool that
+declares no ``api_base`` inherits ``web_search_url``::
+
+    search_tools:
+      local:
+        provider: searxng   # api_base defaults to web_search_url
+
 Provider calls go through one pooled ``httpx.AsyncClient`` for the process
 (:func:`get_search_client`), closed on shutdown by :func:`close_search_client`.
 A search is a single request, so a client per call would pay a fresh TCP and TLS
@@ -38,15 +49,21 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
-from gateway.core.config import SEARCH_PROVIDERS, GatewayConfig
+from gateway.core.config import SEARCH_PROVIDERS, SEARCH_PROVIDERS_REQUIRING_API_KEY, GatewayConfig
 
 EXA_PROVIDER = "exa"
+SEARXNG_PROVIDER = "searxng"
 
 _DEFAULT_API_BASE = {EXA_PROVIDER: "https://api.exa.ai"}
 _DEFAULT_TIMEOUT_S = 30.0
+
+# Query params the gateway owns on a SearXNG request, so a tool's ``options``
+# cannot displace the caller's query or ask for a non-JSON response.
+_RESERVED_SEARXNG_PARAMS = frozenset({"q", "format"})
 
 # Result-count defaults and the ceiling the route also enforces on the request
 # field. Applied again here because a tool's ``options`` can carry its own
@@ -106,9 +123,10 @@ class SearchTool:
 
     name: str
     provider: str
-    api_key: str
     api_base: str
     timeout_s: float
+    # None for a keyless backend, which is the usual self-hosted SearXNG case.
+    api_key: str | None = None
     options: dict[str, Any] = field(default_factory=dict)
 
 
@@ -176,29 +194,46 @@ def resolve_search_tool(config: GatewayConfig, name: str | None) -> SearchTool:
 
     provider = str(entry.get("provider") or name)
     api_key = entry.get("api_key")
-    # Defense in depth: startup validation already guarantees both, so this only
-    # fires for a config built in-process. Refusing here beats calling an unknown
-    # provider or calling a known one unauthenticated.
-    if provider not in SEARCH_PROVIDERS or not api_key:
+    api_base = str(entry.get("api_base") or _default_api_base(config, provider) or "").strip().rstrip("/")
+    # Defense in depth: startup validation already guarantees all three, so this
+    # only fires for a config built in-process. Refusing here beats calling an
+    # unknown provider, calling a keyed one unauthenticated, or calling a backend
+    # whose address nothing supplied.
+    missing_key = provider in SEARCH_PROVIDERS_REQUIRING_API_KEY and not api_key
+    if provider not in SEARCH_PROVIDERS or missing_key or not api_base:
         msg = f"Search tool '{name}' is not configured correctly."
         raise SearchToolError(msg)
 
-    api_base = str(entry.get("api_base") or _DEFAULT_API_BASE[provider]).rstrip("/")
     options = entry.get("options")
     return SearchTool(
         name=name,
         provider=provider,
-        api_key=str(api_key),
+        api_key=str(api_key) if api_key else None,
         api_base=api_base,
         timeout_s=float(entry.get("timeout") or _DEFAULT_TIMEOUT_S),
         options=dict(options) if isinstance(options, dict) else {},
     )
 
 
+def _default_api_base(config: GatewayConfig, provider: str) -> str | None:
+    """The base URL a tool inherits when it declares no ``api_base``.
+
+    A ``searxng`` tool falls back to ``web_search_url``, the backend the in-loop
+    ``otari_web_search`` tool already speaks to over the same contract, so a
+    deployment that runs one exposes it on ``POST /v1/search`` with a single
+    ``provider: searxng`` line.
+    """
+    if provider == SEARXNG_PROVIDER:
+        return (config.web_search_url or "").strip() or None
+    return _DEFAULT_API_BASE.get(provider)
+
+
 async def run_search(tool: SearchTool, query: SearchQuery) -> SearchOutcome:
     """Dispatch one search against the tool's provider."""
     if tool.provider == EXA_PROVIDER:
         return await _search_exa(tool, query)
+    if tool.provider == SEARXNG_PROVIDER:
+        return await _search_searxng(tool, query)
     # Unreachable via config: startup validation rejects unknown providers.
     msg = f"Unsupported search provider '{tool.provider}'."
     raise SearchProviderError(msg)
@@ -268,6 +303,12 @@ def build_exa_payload(tool: SearchTool, query: SearchQuery) -> dict[str, Any]:
 
 
 async def _search_exa(tool: SearchTool, query: SearchQuery) -> SearchOutcome:
+    if not tool.api_key:
+        # Unreachable via config: exa is in SEARCH_PROVIDERS_REQUIRING_API_KEY, so
+        # both startup validation and tool resolution refuse a keyless entry.
+        msg = "exa search requires an api_key"
+        raise SearchProviderError(msg)
+
     payload = build_exa_payload(tool, query)
     client = get_search_client()
     try:
@@ -281,19 +322,7 @@ async def _search_exa(tool: SearchTool, query: SearchQuery) -> SearchOutcome:
         msg = f"exa search request failed: {exc}"
         raise SearchProviderError(msg) from exc
 
-    if response.status_code >= 400:
-        msg = f"exa search returned HTTP {response.status_code}: {response.text[:_ERROR_BODY_CHARS]}"
-        raise SearchProviderError(msg)
-
-    try:
-        body = response.json()
-    except ValueError as exc:
-        msg = "exa search returned a body that is not JSON"
-        raise SearchProviderError(msg) from exc
-    if not isinstance(body, dict):
-        msg = f"exa search returned a {type(body).__name__} body, expected an object"
-        raise SearchProviderError(msg)
-
+    body = _json_object(EXA_PROVIDER, response)
     return SearchOutcome(results=_exa_hits(body), cost_usd=_exa_cost(body))
 
 
@@ -331,6 +360,158 @@ def _exa_cost(body: dict[str, Any]) -> float | None:
     if isinstance(total, bool) or not isinstance(total, (int, float)):
         return None
     return max(float(total), 0.0)
+
+
+# --------------------------------------------------------------------------- #
+# SearXNG
+# --------------------------------------------------------------------------- #
+
+
+def build_searxng_params(tool: SearchTool, query: SearchQuery) -> dict[str, str | int | float]:
+    """Build the SearXNG ``GET /search`` query params from the neutral request.
+
+    The tool's ``options`` are the base, so an operator can pin backend-native
+    knobs (``engines``, ``language``, ``time_range``, or whatever a commercial
+    API's fronting adapter reads) the same way ``provider_options`` does on the
+    in-loop path. These ride in a query string, so only scalars are forwarded
+    (bools as lowercase ``true`` / ``false``); ``q`` and ``format`` are the
+    gateway's, so no option can displace the caller's query.
+
+    ``country`` is forwarded for an adapter that can localize; a plain SearXNG
+    ignores an unknown param. The remaining request fields have no SearXNG
+    equivalent and are honored after the response instead: ``max_results`` and
+    ``search_domain_filter`` are applied to the hits, and
+    ``max_tokens_per_page`` does not apply because a SearXNG result carries the
+    engine's snippet rather than fetched page content.
+    """
+    params: dict[str, str | int | float] = {}
+    for key, value in tool.options.items():
+        if key in _RESERVED_SEARXNG_PARAMS or value is None:
+            continue
+        if isinstance(value, bool):
+            params[key] = "true" if value else "false"
+        elif isinstance(value, (str, int, float)):
+            params[key] = value
+
+    if query.country:
+        params["country"] = query.country
+
+    params["q"] = query.query
+    params["format"] = "json"
+    return params
+
+
+async def _search_searxng(tool: SearchTool, query: SearchQuery) -> SearchOutcome:
+    client = get_search_client()
+    # A self-hosted SearXNG needs no credential and ignores the header. A tool
+    # that does carry an api_key is fronting something that authenticates the
+    # gateway, and gets the header the in-loop backend already sends.
+    headers = {"X-Gateway-Token": tool.api_key} if tool.api_key else None
+    try:
+        response = await client.get(
+            f"{tool.api_base}/search",
+            params=build_searxng_params(tool, query),
+            headers=headers,
+            timeout=tool.timeout_s,
+        )
+    except httpx.HTTPError as exc:
+        msg = f"searxng search request failed: {exc}"
+        raise SearchProviderError(msg) from exc
+
+    body = _json_object(SEARXNG_PROVIDER, response)
+    hits = _apply_domain_filter(_searxng_hits(body), query.domain_filter)
+    limit = max(1, min(query.max_results or DEFAULT_MAX_RESULTS, MAX_RESULTS_CAP))
+    # SearXNG reports no cost, so the tool's configured flat rate is what bills.
+    return SearchOutcome(results=hits[:limit], cost_usd=None)
+
+
+def _searxng_hits(body: dict[str, Any]) -> list[SearchHit]:
+    raw = body.get("results")
+    if not isinstance(raw, list):
+        msg = "searxng search response has no 'results' list"
+        raise SearchProviderError(msg)
+
+    hits: list[SearchHit] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        url = item.get("url")
+        if not isinstance(url, str) or not url:
+            continue
+        hits.append(
+            SearchHit(
+                url=url,
+                title=_text_or_none(item.get("title")),
+                # ``extracted_content`` is the page text an adapter already had,
+                # the same optional field the in-loop backend prefers; otherwise
+                # the engine's own snippet.
+                snippet=_text_or_none(item.get("extracted_content")) or _text_or_none(item.get("content")),
+                # ``published_date`` is the adapter convention (the Brave one
+                # sets it); ``publishedDate`` is what SearXNG's own news engines
+                # return.
+                date=_text_or_none(item.get("published_date")) or _text_or_none(item.get("publishedDate")),
+            )
+        )
+    return hits
+
+
+def _apply_domain_filter(hits: list[SearchHit], domain_filter: tuple[str, ...]) -> list[SearchHit]:
+    """Filter hits by host for a provider whose API has no domain filter.
+
+    Exa takes include and exclude lists in the request, so its adapter passes
+    them upstream; SearXNG has no equivalent, and dropping the filter would
+    silently widen the search the caller asked for. Perplexity's convention
+    holds either way: a leading '-' excludes rather than restricts.
+    """
+    include = tuple(d for d in (_normalize_domain(d) for d in domain_filter if not d.startswith("-")) if d)
+    exclude = tuple(d for d in (_normalize_domain(d[1:]) for d in domain_filter if d.startswith("-")) if d)
+    if not include and not exclude:
+        return hits
+
+    kept: list[SearchHit] = []
+    for hit in hits:
+        host = (urlparse(hit.url).hostname or "").lower()
+        if exclude and _host_matches(host, exclude):
+            continue
+        if include and not _host_matches(host, include):
+            continue
+        kept.append(hit)
+    return kept
+
+
+def _normalize_domain(domain: str) -> str:
+    return domain.strip().lower().lstrip(".")
+
+
+def _host_matches(host: str, domains: tuple[str, ...]) -> bool:
+    """Whether ``host`` is one of ``domains`` or a subdomain of one."""
+    return any(host == domain or host.endswith(f".{domain}") for domain in domains)
+
+
+# --------------------------------------------------------------------------- #
+# Shared
+# --------------------------------------------------------------------------- #
+
+
+def _json_object(provider: str, response: httpx.Response) -> dict[str, Any]:
+    """The provider's JSON body, or a :class:`SearchProviderError` explaining why not.
+
+    The upstream status and body stay in the message, which reaches the usage log
+    and the gateway log; the route never puts it in the response.
+    """
+    if response.status_code >= 400:
+        msg = f"{provider} search returned HTTP {response.status_code}: {response.text[:_ERROR_BODY_CHARS]}"
+        raise SearchProviderError(msg)
+
+    try:
+        body = response.json()
+    except ValueError as exc:
+        msg = f"{provider} search returned a body that is not JSON"
+        raise SearchProviderError(msg) from exc
+    if not isinstance(body, dict):
+        msg = f"{provider} search returned a {type(body).__name__} body, expected an object"
+        raise SearchProviderError(msg)
+    return body
 
 
 def _text_or_none(value: Any) -> str | None:

--- a/src/gateway/services/search_backend.py
+++ b/src/gateway/services/search_backend.py
@@ -28,7 +28,9 @@ The other provider is ``searxng``, which speaks the SearXNG-shaped
 :mod:`gateway.services.web_search_backend` already dispatches the in-loop tool
 to. It needs no API key, so the bundled SearXNG container and the Brave and
 Tavily fronting adapters are reachable from this endpoint too, and a tool that
-declares no ``api_base`` inherits ``web_search_url``::
+declares no ``api_base`` inherits ``web_search_url`` (and, with no ``engines``
+option of its own, ``web_search_engines``), so the two surfaces query the same
+backend the same way::
 
     search_tools:
       local:
@@ -62,8 +64,9 @@ _DEFAULT_API_BASE = {EXA_PROVIDER: "https://api.exa.ai"}
 _DEFAULT_TIMEOUT_S = 30.0
 
 # Query params the gateway owns on a SearXNG request, so a tool's ``options``
-# cannot displace the caller's query or ask for a non-JSON response.
-_RESERVED_SEARXNG_PARAMS = frozenset({"q", "format"})
+# cannot displace the caller's query, ask for a non-JSON response, or widen the
+# result count past what the request asked for and the route caps.
+_RESERVED_SEARXNG_PARAMS = frozenset({"q", "format", "max_results"})
 
 # Result-count defaults and the ceiling the route also enforces on the request
 # field. Applied again here because a tool's ``options`` can carry its own
@@ -204,14 +207,21 @@ def resolve_search_tool(config: GatewayConfig, name: str | None) -> SearchTool:
         msg = f"Search tool '{name}' is not configured correctly."
         raise SearchToolError(msg)
 
-    options = entry.get("options")
+    raw_options = entry.get("options")
+    options = dict(raw_options) if isinstance(raw_options, dict) else {}
+    # A searxng tool that pins no engines takes the operator's configured set, so
+    # the two search surfaces query the same engines on the same backend instead
+    # of this one silently falling back to whatever the instance defaults to.
+    if provider == SEARXNG_PROVIDER and "engines" not in options and config.web_search_engines:
+        options["engines"] = config.web_search_engines
+
     return SearchTool(
         name=name,
         provider=provider,
         api_key=str(api_key) if api_key else None,
         api_base=api_base,
         timeout_s=float(entry.get("timeout") or _DEFAULT_TIMEOUT_S),
-        options=dict(options) if isinstance(options, dict) else {},
+        options=options,
     )
 
 
@@ -377,12 +387,14 @@ def build_searxng_params(tool: SearchTool, query: SearchQuery) -> dict[str, str 
     (bools as lowercase ``true`` / ``false``); ``q`` and ``format`` are the
     gateway's, so no option can displace the caller's query.
 
-    ``country`` is forwarded for an adapter that can localize; a plain SearXNG
-    ignores an unknown param. The remaining request fields have no SearXNG
-    equivalent and are honored after the response instead: ``max_results`` and
-    ``search_domain_filter`` are applied to the hits, and
-    ``max_tokens_per_page`` does not apply because a SearXNG result carries the
-    engine's snippet rather than fetched page content.
+    ``max_results`` and ``country`` are forwarded for a backend that reads them
+    (the bundled Tavily adapter honors ``max_results``, and would otherwise cap
+    the page at its own default of 5 whatever the caller asked for); a plain
+    SearXNG ignores an unknown param. ``search_domain_filter`` has no equivalent
+    on either, so it is applied to the hits after the response, as is
+    ``max_tokens_per_page``, since an adapter fronting a commercial API can
+    return a whole page in ``extracted_content`` rather than the engine's short
+    snippet.
     """
     params: dict[str, str | int | float] = {}
     for key, value in tool.options.items():
@@ -393,12 +405,20 @@ def build_searxng_params(tool: SearchTool, query: SearchQuery) -> dict[str, str 
         elif isinstance(value, (str, int, float)):
             params[key] = value
 
+    # The same bound the hits are sliced to, so a backend that reads it is asked
+    # for what the caller will actually be given and no more.
+    params["max_results"] = _result_limit(query)
     if query.country:
         params["country"] = query.country
 
     params["q"] = query.query
     params["format"] = "json"
     return params
+
+
+def _result_limit(query: SearchQuery) -> int:
+    """How many hits a search returns, under the ceiling the route also enforces."""
+    return max(1, min(query.max_results or DEFAULT_MAX_RESULTS, MAX_RESULTS_CAP))
 
 
 async def _search_searxng(tool: SearchTool, query: SearchQuery) -> SearchOutcome:
@@ -419,13 +439,19 @@ async def _search_searxng(tool: SearchTool, query: SearchQuery) -> SearchOutcome
         raise SearchProviderError(msg) from exc
 
     body = _json_object(SEARXNG_PROVIDER, response)
-    hits = _apply_domain_filter(_searxng_hits(body), query.domain_filter)
-    limit = max(1, min(query.max_results or DEFAULT_MAX_RESULTS, MAX_RESULTS_CAP))
+    # A backend that fronts a commercial API can put a whole extracted page in
+    # ``extracted_content`` (the bundled Tavily adapter always does), so the
+    # caller's per-page cap is applied here rather than dropped. Same conversion
+    # the Exa path hands upstream as ``contents.text.maxCharacters``.
+    max_chars = max(1, (query.max_tokens_per_page or DEFAULT_MAX_TOKENS_PER_PAGE) * _CHARS_PER_TOKEN)
+    hits = _apply_domain_filter(_searxng_hits(body, max_chars), query.domain_filter)
+    # Sliced again on this side: a plain SearXNG ignores the count param, and the
+    # domain filter above can only have been applied here.
     # SearXNG reports no cost, so the tool's configured flat rate is what bills.
-    return SearchOutcome(results=hits[:limit], cost_usd=None)
+    return SearchOutcome(results=hits[: _result_limit(query)], cost_usd=None)
 
 
-def _searxng_hits(body: dict[str, Any]) -> list[SearchHit]:
+def _searxng_hits(body: dict[str, Any], max_chars: int) -> list[SearchHit]:
     raw = body.get("results")
     if not isinstance(raw, list):
         msg = "searxng search response has no 'results' list"
@@ -438,14 +464,16 @@ def _searxng_hits(body: dict[str, Any]) -> list[SearchHit]:
         url = item.get("url")
         if not isinstance(url, str) or not url:
             continue
+        # ``extracted_content`` is the page text an adapter already had, the same
+        # optional field the in-loop backend prefers; otherwise the engine's own
+        # snippet. Bounded by the caller's per-page budget, because the former can
+        # be a whole page and nothing upstream applied the cap.
+        snippet = _text_or_none(item.get("extracted_content")) or _text_or_none(item.get("content"))
         hits.append(
             SearchHit(
                 url=url,
                 title=_text_or_none(item.get("title")),
-                # ``extracted_content`` is the page text an adapter already had,
-                # the same optional field the in-loop backend prefers; otherwise
-                # the engine's own snippet.
-                snippet=_text_or_none(item.get("extracted_content")) or _text_or_none(item.get("content")),
+                snippet=snippet[:max_chars] if snippet else None,
                 # ``published_date`` is the adapter convention (the Brave one
                 # sets it); ``publishedDate`` is what SearXNG's own news engines
                 # return.

--- a/tests/unit/test_search_backend.py
+++ b/tests/unit/test_search_backend.py
@@ -18,6 +18,7 @@ import pytest_asyncio
 
 from gateway.core.config import GatewayConfig
 from gateway.services.search_backend import (
+    DEFAULT_MAX_TOKENS_PER_PAGE,
     SearchProviderError,
     SearchQuery,
     SearchTool,
@@ -130,6 +131,33 @@ def test_searxng_tool_api_base_wins_over_the_web_search_url() -> None:
         web_search_url="http://searxng:8080",
     )
     assert resolve_search_tool(config, "local").api_base == "http://adapter:9000"
+
+
+def test_searxng_tool_inherits_the_configured_engines() -> None:
+    """Both surfaces query the same engines on the same backend."""
+    config = GatewayConfig(
+        search_tools={"local": {"provider": "searxng"}},
+        web_search_url="http://searxng:8080",
+        web_search_engines="duckduckgo,mojeek",
+    )
+    assert resolve_search_tool(config, "local").options["engines"] == "duckduckgo,mojeek"
+
+
+def test_searxng_tool_engines_option_wins_over_the_configured_engines() -> None:
+    config = GatewayConfig(
+        search_tools={"local": {"provider": "searxng", "options": {"engines": "wikipedia"}}},
+        web_search_url="http://searxng:8080",
+        web_search_engines="duckduckgo,mojeek",
+    )
+    assert resolve_search_tool(config, "local").options["engines"] == "wikipedia"
+
+
+def test_configured_engines_do_not_leak_into_an_exa_tool() -> None:
+    config = GatewayConfig(
+        search_tools={"exa": {"api_key": "k"}},
+        web_search_engines="duckduckgo,mojeek",
+    )
+    assert "engines" not in resolve_search_tool(config, "exa").options
 
 
 def test_searxng_tool_without_any_base_url_is_a_tool_error() -> None:
@@ -331,7 +359,7 @@ async def test_run_search_raises_when_the_provider_is_unreachable(monkeypatch: p
 
 def test_searxng_params_defaults() -> None:
     params = build_searxng_params(_SEARXNG_TOOL, SearchQuery(query="otari gateway"))
-    assert params == {"q": "otari gateway", "format": "json"}
+    assert params == {"q": "otari gateway", "format": "json", "max_results": 10}
 
 
 def test_searxng_params_forward_scalar_tool_options() -> None:
@@ -357,6 +385,18 @@ def test_searxng_params_never_let_options_displace_the_query() -> None:
 def test_searxng_params_forward_the_country() -> None:
     params = build_searxng_params(_SEARXNG_TOOL, SearchQuery(query="q", country="US"))
     assert params["country"] == "US"
+
+
+def test_searxng_params_forward_the_result_count() -> None:
+    """An adapter that reads it would otherwise cap the page at its own default."""
+    assert build_searxng_params(_SEARXNG_TOOL, SearchQuery(query="q", max_results=7))["max_results"] == 7
+    assert build_searxng_params(_SEARXNG_TOOL, SearchQuery(query="q"))["max_results"] == 10
+
+
+def test_searxng_params_result_count_is_not_overridable_by_options() -> None:
+    """The count is the gateway's: an option cannot ask upstream for more."""
+    tool = replace(_SEARXNG_TOOL, options={"max_results": 500})
+    assert build_searxng_params(tool, SearchQuery(query="q", max_results=5))["max_results"] == 5
 
 
 # --------------------------------------------------------------------------- #
@@ -397,7 +437,7 @@ async def test_searxng_search_normalizes_results(monkeypatch: pytest.MonkeyPatch
     _patch_transport(monkeypatch, handler)
     outcome = await run_search(_SEARXNG_TOOL, SearchQuery(query="otari"))
 
-    assert seen["url"] == "http://searxng:8080/search?q=otari&format=json"
+    assert seen["url"] == "http://searxng:8080/search?max_results=10&q=otari&format=json"
     # A self-hosted SearXNG has no credential to send.
     assert seen["token"] is None
     # SearXNG reports no charge, so the tool's configured flat rate bills.
@@ -442,6 +482,19 @@ async def test_searxng_search_caps_the_result_count(monkeypatch: pytest.MonkeyPa
     # With no max_results the module default applies rather than the whole page.
     defaulted = await run_search(_SEARXNG_TOOL, SearchQuery(query="q"))
     assert len(defaulted.results) == 10
+
+
+@pytest.mark.asyncio
+async def test_searxng_search_caps_extracted_page_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An adapter can return a whole page, so the caller's per-page cap applies."""
+    body = {"results": [{"url": "https://example.com/1", "extracted_content": "x" * 50_000}]}
+    _patch_transport(monkeypatch, lambda _r: httpx.Response(200, json=body))
+
+    requested = await run_search(_SEARXNG_TOOL, SearchQuery(query="q", max_tokens_per_page=100))
+    assert requested.results[0].snippet == "x" * 400
+    # With no request field the module default bounds it rather than nothing at all.
+    defaulted = await run_search(_SEARXNG_TOOL, SearchQuery(query="q"))
+    assert len(defaulted.results[0].snippet or "") == DEFAULT_MAX_TOKENS_PER_PAGE * 4
 
 
 @pytest.mark.asyncio
@@ -534,7 +587,9 @@ async def test_closing_the_pooled_client_lets_the_next_search_rebuild_it(monkeyp
         ({"exa": {}}, "api_key is required for provider 'exa'"),
         ({"searxng": {"api_base": "http://searxng:8080"}}, None),
         ({"local": {"provider": "searxng", "api_base": "http://searxng:8080"}}, None),
-        ({"searxng": {}}, "api_base is required for provider 'searxng'"),
+        # A missing backend URL is reported as a startup warning, not raised: see
+        # the search_tools_without_backend_url tests below.
+        ({"searxng": {}}, None),
         ({"exa": {"api_key": "k", "options": "nope"}}, "options must be a mapping"),
         ({"exa": {"api_key": "k", "timeout": "soon"}}, "timeout must be a number"),
         ({"exa": {"api_key": "k", "timeout": 0}}, "timeout must be greater than 0"),
@@ -559,3 +614,15 @@ def test_validate_accepts_a_searxng_tool_that_inherits_the_web_search_url() -> N
         web_search_url="http://searxng:8080",
     )
     config.validate_search_tools()
+    assert config.search_tools_without_backend_url() == []
+
+
+def test_a_searxng_tool_with_no_backend_url_anywhere_is_reported() -> None:
+    """Startup warns instead of failing: a dashboard-stored URL lands after load."""
+    config = GatewayConfig(search_tools={"local": {"provider": "searxng"}, "exa": {"api_key": "k"}})
+    assert config.search_tools_without_backend_url() == ["local"]
+
+
+def test_a_searxng_tool_with_its_own_api_base_is_not_reported() -> None:
+    config = GatewayConfig(search_tools={"local": {"provider": "searxng", "api_base": "http://adapter:9000"}})
+    assert config.search_tools_without_backend_url() == []

--- a/tests/unit/test_search_backend.py
+++ b/tests/unit/test_search_backend.py
@@ -1,9 +1,9 @@
 """Unit tests for the ``POST /v1/search`` backend.
 
-Covers tool resolution against ``config.search_tools`` and the Exa adapter:
-request translation from the LiteLLM-shaped request to Exa's native body, and
-response translation back. The provider is stubbed with an
-``httpx.MockTransport`` so no network call is made.
+Covers tool resolution against ``config.search_tools`` and the Exa and SearXNG
+adapters: request translation from the LiteLLM-shaped request to each
+provider's native shape, and response translation back. The provider is stubbed
+with an ``httpx.MockTransport`` so no network call is made.
 """
 
 from __future__ import annotations
@@ -23,6 +23,7 @@ from gateway.services.search_backend import (
     SearchTool,
     SearchToolError,
     build_exa_payload,
+    build_searxng_params,
     close_search_client,
     get_search_client,
     resolve_search_tool,
@@ -34,6 +35,14 @@ _EXA_TOOL = SearchTool(
     provider="exa",
     api_key="exa-secret",
     api_base="https://api.exa.ai",
+    timeout_s=30.0,
+    options={},
+)
+
+_SEARXNG_TOOL = SearchTool(
+    name="local",
+    provider="searxng",
+    api_base="http://searxng:8080",
     timeout_s=30.0,
     options={},
 )
@@ -96,6 +105,43 @@ def test_no_configured_tools_is_a_tool_error() -> None:
 def test_unknown_tool_name_is_a_tool_error() -> None:
     with pytest.raises(SearchToolError, match="Unknown search tool 'nope'"):
         resolve_search_tool(_config(exa={"api_key": "k"}), "nope")
+
+
+def test_searxng_tool_resolves_without_an_api_key() -> None:
+    """A self-hosted SearXNG authenticates with nothing, so no key is required."""
+    tool = resolve_search_tool(_config(local={"provider": "searxng", "api_base": "http://searxng:8080/"}), "local")
+    assert tool.provider == "searxng"
+    assert tool.api_key is None
+    assert tool.api_base == "http://searxng:8080"
+
+
+def test_searxng_tool_inherits_the_web_search_url() -> None:
+    """The in-loop backend's URL is the default, so one config line is enough."""
+    config = GatewayConfig(
+        search_tools={"local": {"provider": "searxng"}},
+        web_search_url="http://searxng:8080/",
+    )
+    assert resolve_search_tool(config, "local").api_base == "http://searxng:8080"
+
+
+def test_searxng_tool_api_base_wins_over_the_web_search_url() -> None:
+    config = GatewayConfig(
+        search_tools={"local": {"provider": "searxng", "api_base": "http://adapter:9000"}},
+        web_search_url="http://searxng:8080",
+    )
+    assert resolve_search_tool(config, "local").api_base == "http://adapter:9000"
+
+
+def test_searxng_tool_without_any_base_url_is_a_tool_error() -> None:
+    """Nothing says where the backend is, so refuse rather than call nowhere."""
+    with pytest.raises(SearchToolError, match="not configured correctly"):
+        resolve_search_tool(_config(local={"provider": "searxng"}), "local")
+
+
+def test_exa_tool_without_an_api_key_is_a_tool_error() -> None:
+    """Exa still authenticates with a key: keyless is per-provider, not universal."""
+    with pytest.raises(SearchToolError, match="not configured correctly"):
+        resolve_search_tool(_config(exa={}), "exa")
 
 
 def test_omitted_name_with_several_tools_is_a_tool_error() -> None:
@@ -279,6 +325,165 @@ async def test_run_search_raises_when_the_provider_is_unreachable(monkeypatch: p
 
 
 # --------------------------------------------------------------------------- #
+# SearXNG request translation
+# --------------------------------------------------------------------------- #
+
+
+def test_searxng_params_defaults() -> None:
+    params = build_searxng_params(_SEARXNG_TOOL, SearchQuery(query="otari gateway"))
+    assert params == {"q": "otari gateway", "format": "json"}
+
+
+def test_searxng_params_forward_scalar_tool_options() -> None:
+    tool = replace(
+        _SEARXNG_TOOL,
+        options={"engines": "duckduckgo,mojeek", "safesearch": 1, "image_proxy": True, "extra": {"nope": 1}},
+    )
+    params = build_searxng_params(tool, SearchQuery(query="q"))
+    assert params["engines"] == "duckduckgo,mojeek"
+    assert params["safesearch"] == 1
+    assert params["image_proxy"] == "true"
+    # Complex values cannot ride in a query string, so they are dropped.
+    assert "extra" not in params
+
+
+def test_searxng_params_never_let_options_displace_the_query() -> None:
+    tool = replace(_SEARXNG_TOOL, options={"q": "operator-injected", "format": "html"})
+    params = build_searxng_params(tool, SearchQuery(query="caller wins"))
+    assert params["q"] == "caller wins"
+    assert params["format"] == "json"
+
+
+def test_searxng_params_forward_the_country() -> None:
+    params = build_searxng_params(_SEARXNG_TOOL, SearchQuery(query="q", country="US"))
+    assert params["country"] == "US"
+
+
+# --------------------------------------------------------------------------- #
+# SearXNG response translation
+# --------------------------------------------------------------------------- #
+
+
+_SEARXNG_BODY: dict[str, Any] = {
+    "query": "otari",
+    "results": [
+        {
+            "url": "https://example.com/otari",
+            "title": "Otari",
+            "content": "An OpenAI-compatible LLM gateway.",
+            "publishedDate": "2026-01-02T00:00:00.000Z",
+        },
+        {"title": "No URL", "content": "dropped"},
+        {
+            "url": "https://docs.example.com/guide",
+            "title": "Guide",
+            "content": "snippet",
+            "extracted_content": "full page text",
+            "published_date": "2026-02-03",
+        },
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_searxng_search_normalizes_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["token"] = request.headers.get("x-gateway-token")
+        return httpx.Response(200, json=_SEARXNG_BODY)
+
+    _patch_transport(monkeypatch, handler)
+    outcome = await run_search(_SEARXNG_TOOL, SearchQuery(query="otari"))
+
+    assert seen["url"] == "http://searxng:8080/search?q=otari&format=json"
+    # A self-hosted SearXNG has no credential to send.
+    assert seen["token"] is None
+    # SearXNG reports no charge, so the tool's configured flat rate bills.
+    assert outcome.cost_usd is None
+    # The result without a URL is dropped: it cannot be cited or followed.
+    assert [hit.url for hit in outcome.results] == [
+        "https://example.com/otari",
+        "https://docs.example.com/guide",
+    ]
+    assert outcome.results[0].title == "Otari"
+    assert outcome.results[0].snippet == "An OpenAI-compatible LLM gateway."
+    assert outcome.results[0].date == "2026-01-02T00:00:00.000Z"
+    # An adapter that already had the page text wins over the engine snippet.
+    assert outcome.results[1].snippet == "full page text"
+    assert outcome.results[1].date == "2026-02-03"
+
+
+@pytest.mark.asyncio
+async def test_searxng_search_forwards_a_configured_key_as_the_gateway_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tool with a key fronts something that authenticates the gateway."""
+    seen: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["token"] = request.headers.get("x-gateway-token")
+        return httpx.Response(200, json={"results": []})
+
+    _patch_transport(monkeypatch, handler)
+    await run_search(replace(_SEARXNG_TOOL, api_key="adapter-secret"), SearchQuery(query="otari"))
+    assert seen["token"] == "adapter-secret"
+
+
+@pytest.mark.asyncio
+async def test_searxng_search_caps_the_result_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SearXNG has no result-count param, so max_results is applied to the hits."""
+    body = {"results": [{"url": f"https://example.com/{i}"} for i in range(12)]}
+    _patch_transport(monkeypatch, lambda _r: httpx.Response(200, json=body))
+
+    capped = await run_search(_SEARXNG_TOOL, SearchQuery(query="q", max_results=3))
+    assert len(capped.results) == 3
+    # With no max_results the module default applies rather than the whole page.
+    defaulted = await run_search(_SEARXNG_TOOL, SearchQuery(query="q"))
+    assert len(defaulted.results) == 10
+
+
+@pytest.mark.asyncio
+async def test_searxng_search_applies_the_domain_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No SearXNG-side filter exists, so dropping it would widen the search."""
+    body = {
+        "results": [
+            {"url": "https://arxiv.org/abs/1"},
+            {"url": "https://export.arxiv.org/abs/2"},
+            {"url": "https://spam.example/3"},
+        ]
+    }
+    _patch_transport(monkeypatch, lambda _r: httpx.Response(200, json=body))
+
+    restricted = await run_search(_SEARXNG_TOOL, SearchQuery(query="q", domain_filter=("arxiv.org",)))
+    assert [hit.url for hit in restricted.results] == [
+        "https://arxiv.org/abs/1",
+        "https://export.arxiv.org/abs/2",
+    ]
+
+    excluded = await run_search(_SEARXNG_TOOL, SearchQuery(query="q", domain_filter=("-spam.example",)))
+    assert [hit.url for hit in excluded.results] == [
+        "https://arxiv.org/abs/1",
+        "https://export.arxiv.org/abs/2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_searxng_search_raises_on_upstream_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_transport(monkeypatch, lambda _r: httpx.Response(429, text="too many requests"))
+    with pytest.raises(SearchProviderError, match="searxng search returned HTTP 429"):
+        await run_search(_SEARXNG_TOOL, SearchQuery(query="otari"))
+
+
+@pytest.mark.asyncio
+async def test_searxng_search_raises_on_malformed_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_transport(monkeypatch, lambda _r: httpx.Response(200, json={"unexpected": True}))
+    with pytest.raises(SearchProviderError, match="no 'results' list"):
+        await run_search(_SEARXNG_TOOL, SearchQuery(query="otari"))
+
+
+# --------------------------------------------------------------------------- #
 # Pooled client
 # --------------------------------------------------------------------------- #
 
@@ -326,7 +531,10 @@ async def test_closing_the_pooled_client_lets_the_next_search_rebuild_it(monkeyp
         ({"exa": {"api_key": "k"}}, None),
         ({"web": {"provider": "exa", "api_key": "k"}}, None),
         ({"web": {"api_key": "k"}}, "is not a supported search provider"),
-        ({"exa": {}}, "api_key is required"),
+        ({"exa": {}}, "api_key is required for provider 'exa'"),
+        ({"searxng": {"api_base": "http://searxng:8080"}}, None),
+        ({"local": {"provider": "searxng", "api_base": "http://searxng:8080"}}, None),
+        ({"searxng": {}}, "api_base is required for provider 'searxng'"),
         ({"exa": {"api_key": "k", "options": "nope"}}, "options must be a mapping"),
         ({"exa": {"api_key": "k", "timeout": "soon"}}, "timeout must be a number"),
         ({"exa": {"api_key": "k", "timeout": 0}}, "timeout must be greater than 0"),
@@ -342,3 +550,12 @@ def test_validate_search_tools(search_tools: dict[str, Any], expected: str | Non
         return
     with pytest.raises(ValueError, match=expected):
         config.validate_search_tools()
+
+
+def test_validate_accepts_a_searxng_tool_that_inherits_the_web_search_url() -> None:
+    """The api_base a searxng tool omits is the one the in-loop tool already uses."""
+    config = GatewayConfig(
+        search_tools={"local": {"provider": "searxng"}},
+        web_search_url="http://searxng:8080",
+    )
+    config.validate_search_tools()


### PR DESCRIPTION
## Description

`POST /v1/search` could only dispatch to Exa, and every `search_tools` entry had to carry an `api_key`, so a deployment already running a web-search backend could not use the endpoint without buying a commercial key.

Adds a `searxng` provider that speaks the same `GET {api_base}/search?format=json` contract `web_search_backend` already uses for the in-loop `otari_web_search` tool, so the bundled container and the Brave and Tavily fronting adapters are reachable from the endpoint too. `api_key` is now required per provider rather than universally, `api_base` is required for a provider with no default endpoint, and a `searxng` tool that declares none inherits `web_search_url`, making the common case one line:

```yaml
search_tools:
  local:
    provider: searxng   # api_base defaults to web_search_url
```

On this provider, `options` become extra `/search` query params (`q`, `format` and `max_results` stay the gateway's), and an `api_key`, when set, is sent as `X-Gateway-Token`, the header the in-loop backend already sends. A tool that pins no `engines` option inherits `web_search_engines`. `search_domain_filter` and `max_tokens_per_page` are applied by the gateway to the returned hits, since SearXNG has no equivalent param and an adapter fronting a commercial API can return a whole extracted page per hit; `max_results` and `country` are forwarded for a backend that reads them (the bundled Tavily adapter caps its page at 5 without the former). No cost is reported upstream, so the tool's configured flat rate bills. A `searxng` tool with no backend URL anywhere is a startup warning rather than a boot failure, because the web-search URL can come from the dashboard's Tools page, which is read after the config loads.

The status and JSON-body checks the Exa adapter had are now a shared `_json_object` helper, with the messages unchanged.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #593

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). No route schema or docstring changed; `make openapi-check` and `make postman-check` both report up to date.
- [x] If this PR adds or changes a persistent table, a control-plane contract the otari.ai platform consumes or serves, a capability the platform also has, or a mode-specific surface, I appended an entry to the M4 reconciliation ledger ([otari-ai#1587](https://github.com/mozilla-ai/otari-ai/issues/1587)). No entry: this extends the existing standalone-only `search_tools` surface, adding no table, no cross-repo contract, and no new mode-specific surface. Happy to add one if a reviewer disagrees.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via the Claude Code CLI.

**Any additional AI details you'd like to share:**

Implemented from the issue by @njbrake driving Claude Code: the design decisions (reuse the SearXNG contract, per-provider key requirement, `web_search_url` as the default `api_base`) are his; the code and prose are the model's.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
