### PR TITLE
feat(scripts): enforce OSS/enterprise boundary in check_architecture.py

### DIFF
--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -6,6 +6,7 @@ Enforces:
 2. API route purity: routes must not use the sync ORM layer (sqlalchemy.orm).
 3. Repository boundaries: repositories must not import services or the API layer.
 4. Naming conventions: repository modules end in _repository.py.
+5. OSS/enterprise boundary: OSS code must not import the enterprise overlay.
 
 Usage:
     uv run python scripts/check_architecture.py
@@ -23,6 +24,7 @@ from typing import TypedDict
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SRC_ROOT = REPO_ROOT / "src"
 GATEWAY_ROOT = SRC_ROOT / "gateway"
+TESTS_ROOT = REPO_ROOT / "tests"
 
 
 class LayerRule(TypedDict):
@@ -40,6 +42,26 @@ class LayerRule(TypedDict):
 # gateway/api/routes answers to a gateway/api entry as well as its own; a nested
 # layer can add restrictions but cannot opt out of an enclosing layer's.
 RULES: dict[str, LayerRule] = {
+    # OSS -> enterprise boundary. Keyed at the gateway root so it covers every
+    # layer, ports and adapters included; nothing legitimately in this tree
+    # matches. The overlay (e.g. otari.ai's enterprise adapters) is imported
+    # as "overlay.*" today; a build that composes it into the gateway
+    # namespace instead would spell it "gateway.overlay.*". Both are
+    # forbidden, so an OSS file that reaches for an enterprise concept fails
+    # the build rather than waiting on review, whichever way the overlay is
+    # composed.
+    "gateway": {
+        "allowed": [],
+        "forbidden": ["gateway.overlay", "overlay"],
+        "description": "OSS base",
+    },
+    # The OSS test suite answers to the same boundary: a test of overlay
+    # behavior belongs in the overlay's own suite, not here.
+    "tests": {
+        "allowed": [],
+        "forbidden": ["gateway.overlay", "overlay"],
+        "description": "OSS test suite",
+    },
     "gateway/services": {
         "allowed": ["gateway.repositories", "gateway.models", "gateway.core", "gateway.auth"],
         "forbidden": ["gateway.api"],
@@ -179,10 +201,13 @@ def check_naming_conventions(src_root: Path) -> list[str]:
 
 
 def main() -> int:
-    """Run the architecture checks over the gateway package."""
-    if not GATEWAY_ROOT.is_dir():
-        print(f"❌ Gateway package not found at {GATEWAY_ROOT}")
-        return 1
+    """Run the architecture checks over the gateway package and the OSS test suite."""
+    # Both must exist: silently skipping either would let its rules (including
+    # the OSS/enterprise boundary) stop enforcing while the check stays green.
+    for required_root in (GATEWAY_ROOT, TESTS_ROOT):
+        if not required_root.is_dir():
+            print(f"❌ Expected directory not found at {required_root}")
+            return 1
 
     import_violations: list[tuple[Path, int, str, str]] = []
     for py_file in sorted(GATEWAY_ROOT.rglob("*.py")):
@@ -190,6 +215,14 @@ def main() -> int:
             continue
         import_violations.extend(
             (py_file, lineno, module, message) for lineno, module, message in check_file(py_file, SRC_ROOT)
+        )
+    # tests/ sits beside src/, not under it, so its relative paths (and the
+    # "tests" rule key above) are rooted at the repo root instead.
+    for py_file in sorted(TESTS_ROOT.rglob("*.py")):
+        if "__pycache__" in py_file.parts:
+            continue
+        import_violations.extend(
+            (py_file, lineno, module, message) for lineno, module, message in check_file(py_file, REPO_ROOT)
         )
 
     naming_violations = check_naming_conventions(SRC_ROOT)

--- a/tests/unit/test_check_architecture.py
+++ b/tests/unit/test_check_architecture.py
@@ -206,5 +206,20 @@ def test_test_suite_importing_the_overlay_is_flagged(tmp_path: Path) -> None:
     ]
 
 
+def test_main_discovers_tests_root_and_fails_on_overlay_import(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Unlike the check_file() tests above, this exercises main() itself: that
+    # it walks TESTS_ROOT (not just GATEWAY_ROOT) and resolves those paths
+    # against REPO_ROOT, using the gateway-composed overlay spelling.
+    _write(tmp_path, "src/gateway/__init__.py", "")
+    _write(tmp_path, "tests/unit/test_thing.py", "from gateway.overlay.billing import charge\n")
+    monkeypatch.setattr(check, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(check, "SRC_ROOT", tmp_path / "src")
+    monkeypatch.setattr(check, "GATEWAY_ROOT", tmp_path / "src" / "gateway")
+    monkeypatch.setattr(check, "TESTS_ROOT", tmp_path / "tests")
+    assert check.main() == 1
+
+
 def test_real_gateway_tree_is_clean() -> None:
     assert check.main() == 0

--- a/tests/unit/test_check_architecture.py
+++ b/tests/unit/test_check_architecture.py
@@ -149,5 +149,62 @@ def test_repository_naming_convention(tmp_path: Path) -> None:
     assert violations == ["Repository file gateway/repositories/helpers.py must end with '_repository.py'"]
 
 
+def test_service_importing_the_overlay_is_flagged(tmp_path: Path) -> None:
+    file_path = _write(tmp_path, "gateway/services/thing.py", "from gateway.overlay.billing import charge\n")
+    assert check.check_file(file_path, tmp_path) == [(1, "gateway.overlay.billing", "Forbidden import in OSS base")]
+
+
+def test_adapter_importing_the_overlay_is_flagged(tmp_path: Path) -> None:
+    # The issue's example: an OSS adapter must not reference an enterprise one.
+    file_path = _write(
+        tmp_path, "gateway/adapters/thing_adapter.py", "from gateway.overlay.adapters import Enterprise\n"
+    )
+    assert check.check_file(file_path, tmp_path) == [(1, "gateway.overlay.adapters", "Forbidden import in OSS base")]
+
+
+def test_file_outside_named_layers_importing_the_overlay_is_flagged(tmp_path: Path) -> None:
+    # The boundary covers the whole gateway tree, not only the named layers.
+    file_path = _write(tmp_path, "gateway/main.py", "from gateway.overlay import register\n")
+    assert check.check_file(file_path, tmp_path) == [(1, "gateway.overlay", "Forbidden import in OSS base")]
+
+
+def test_overlay_boundary_via_from_gateway_import_is_flagged(tmp_path: Path) -> None:
+    # `from gateway import overlay` binds the submodule gateway.overlay, which the resolver flags.
+    file_path = _write(tmp_path, "gateway/services/thing.py", "from gateway import overlay\n")
+    assert check.check_file(file_path, tmp_path) == [(1, "gateway.overlay", "Forbidden import in OSS base")]
+
+
+def test_overlay_prefix_requires_a_module_boundary(tmp_path: Path) -> None:
+    # A sibling module whose name merely starts with "overlay" is not the overlay.
+    file_path = _write(tmp_path, "gateway/services/thing.py", "import gateway.overlaything\n")
+    assert check.check_file(file_path, tmp_path) == []
+
+
+def test_service_importing_the_top_level_overlay_is_flagged(tmp_path: Path) -> None:
+    # The overlay is imported as "overlay.*" today; a build that composes it
+    # into the gateway namespace instead would spell it "gateway.overlay.*".
+    # Both spellings are the boundary.
+    file_path = _write(tmp_path, "gateway/services/thing.py", "from overlay.adapters import Enterprise\n")
+    assert check.check_file(file_path, tmp_path) == [(1, "overlay.adapters", "Forbidden import in OSS base")]
+
+
+def test_top_level_overlay_prefix_requires_a_module_boundary(tmp_path: Path) -> None:
+    # An unrelated module whose name merely starts with "overlay" is not the overlay.
+    file_path = _write(tmp_path, "gateway/services/thing.py", "import overlaything\n")
+    assert check.check_file(file_path, tmp_path) == []
+
+
+def test_test_suite_importing_the_overlay_is_flagged(tmp_path: Path) -> None:
+    # The OSS test suite answers to the same boundary as the gateway package.
+    file_path = _write(
+        tmp_path,
+        "tests/unit/services/test_thing.py",
+        "from overlay.adapters.billing_adapter import WalletBillingAdapter\n",
+    )
+    assert check.check_file(file_path, tmp_path) == [
+        (1, "overlay.adapters.billing_adapter", "Forbidden import in OSS test suite")
+    ]
+
+
 def test_real_gateway_tree_is_clean() -> None:
     assert check.main() == 0


### PR DESCRIPTION
## Description

Populates the ports/adapters boundary scaffolding seeded by #1460 with the real OSS/enterprise boundary rule, mirroring the platform's equivalent check ([`otari-ai` backend/scripts/check_architecture.py](https://github.com/mozilla-ai/otari-ai/blob/main/backend/scripts/check_architecture.py), built for otari-ai#1435).

- Adds a `"gateway"` root-level rule to `RULES` that forbids any file under `src/gateway/` from importing `gateway.overlay.*` or the top-level `overlay.*` (the overlay folder name locked in otari-ai#1431). Keyed at the package root so it covers every layer, including `gateway/ports` and `gateway/adapters`, without touching their existing empty `forbidden` lists — restrictions already accumulate down the tree.
- Adds a matching `"tests"` rule and wires `tests/` into `main()` (it wasn't scanned by the architecture check before), so a test importing overlay behavior fails the same way.
- Both spellings (`overlay.*` and `gateway.overlay.*`) are forbidden since the overlay may be imported as a standalone top-level package today, or composed into the gateway namespace by a superset build later.
- Adds 8 unit tests covering: OSS service/adapter importing the overlay (the issue's explicit example), a file outside the named layers, the `from gateway import overlay` submodule-binding form, module-boundary edge cases (`gateway.overlaything` is not the overlay), the top-level spelling, and the test-suite boundary.

No CI wiring changes needed: `otari-lint.yml` already runs `make lint` → `check-architecture` on every PR touching `scripts/**`.

Verified manually: planted `from gateway.overlay.billing import charge_overage` in `budget_service.py`, confirmed `check_architecture.py` fails with exit 1 and correct attribution, then reverted.

## PR Type
<!-- Check all that apply -->

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#1453

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).
- [ ] If this PR adds or changes a persistent table, a control-plane contract the otari.ai platform consumes or serves, a capability the platform also has, or a mode-specific surface, I appended an entry to the M4 reconciliation ledger ([otari-ai#1587](https://github.com/mozilla-ai/otari-ai/issues/1587)). See [.github/instructions/reconciliation-ledger.instructions.md](instructions/reconciliation-ledger.instructions.md).

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Sonnet 5)

**Any additional AI details you'd like to share:**

Investigated the linked issue and its dependency chain (#1460, #1431, #1438, and the platform's equivalent #1435) directly via `gh`/repo reading, then implemented and self-verified (tests, lint, typecheck, a planted-violation smoke test) before opening this PR.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Enforces the OSS/enterprise boundary for gateway code and tests.
- Blocks imports from `overlay` and `gateway.overlay`.
- Adds architecture checks for the `tests` directory.
- Preserves existing nested rule restrictions.
- Adds tests for blocked imports, valid module names, and complete test-directory scanning.

These checks prevent accidental enterprise dependencies in OSS code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->