### PR TITLE
fix(e2e): wait for the provider form to close, not for a button to be relabeled

### DIFF
--- a/web/e2e/parity.management.spec.ts
+++ b/web/e2e/parity.management.spec.ts
@@ -68,7 +68,12 @@ test.describe("standalone provider setup", () => {
     await provider.getByRole("button", { name: "Edit" }).click();
     await page.getByLabel("API base").fill("http://127.0.0.1:9/v2");
     await page.getByRole("button", { name: "Save changes" }).click();
-    await expect(page.getByRole("button", { name: "Save changes" })).toBeHidden();
+    // Wait on Cancel, not on the button that was just pressed: that one reads
+    // "Saving…" while the request is in flight, so asserting "Save changes" is
+    // hidden passes the instant it is pressed, and the reload below then aborts
+    // the PATCH and loses the edit. Cancel is present for as long as the form is,
+    // and the form closes only in the mutation's onSuccess.
+    await expect(page.getByRole("button", { name: "Cancel" })).toBeHidden();
 
     // Reopening is what proves the edit was persisted rather than only echoed
     // back into a form that never closed. Reload first: the form seeds its fields


### PR DESCRIPTION
## Description

`parity.management.spec.ts` fails intermittently on `main`, twice in six runs here. It is not the unreachable endpoint the test aims at, and not a timeout.

The save button renders `{update.isPending ? "Saving…" : "Save changes"}`. So `expect(getByRole("button", {name: "Save changes"})).toBeHidden()` passes the instant the button is pressed, while the PATCH is still in flight. The test then reloads, the reload aborts the request (`status: -1` in the trace that caught it), the server never stores the new `api_base`, and the reopened form correctly shows the old one. The failure reads as "the edit did not persist" and the edit really did not, but the dashboard behaved properly throughout: it showed a pending state and closes the form only in the mutation's `onSuccess`.

Wait on Cancel instead. It is present for exactly as long as the form is, its label never changes, and the form closes only on success, so its disappearance is the event the assertion meant to wait for. One line plus the comment explaining why not the obvious button.

## PR Type

- [x] Bug Fix

## Relevant issues

None. Found while running the suite for #611.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).
- [ ] If this PR adds or changes a persistent table, a control-plane contract the otari.ai platform consumes or serves, a capability the platform also has, or a mode-specific surface, I appended an entry to the M4 reconciliation ledger ([otari-ai#1587](https://github.com/mozilla-ai/otari-ai/issues/1587)). See [.github/instructions/reconciliation-ledger.instructions.md](.github/instructions/reconciliation-ledger.instructions.md).

The change is to a test, so the test box refers to the test itself. Nothing here touches Python, a route, a table, or a contract.

**Verification.** Four consecutive full Playwright runs, 32 passing each. The assertion this replaces cannot be made to fail on demand without slowing the network, which is the other reason it survived this long: it is green on any run where the PATCH happens to beat the reload.

**Ordering.** #611 reformats this file, so whichever lands second needs a trivial conflict resolution. This one is a line; that one is 800. Easier if this goes first.

## AI Usage

- [x] AI was used for drafting/refactoring.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

Diagnosed from the retained Playwright trace (the aborted PATCH) rather than from the failure message, which points at the wrong thing. Written by the model through back-and-forth with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the provider edit test to wait for the `Cancel` button to disappear after saving.
- This confirms that the form closed after the update completed.
- The change prevents reloads from interrupting the save request and improves test reliability.

## Validation

- Four consecutive full Playwright runs passed.
- Each run passed all 32 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->