### PR TITLE
chore: teach git blame to look through the dashboard reformat

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,23 @@
+# Commits that `git blame` should look through. The point is that a line's history
+# leads to whoever last changed what it says, rather than stopping at a commit that
+# only moved it.
+#
+# Enable locally once:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+# GitHub honors this file automatically, with no setup.
+#
+# What belongs here: a commit that is formatting, or so nearly all formatting that
+# skipping it is right for almost every line in it. A squash merge usually cannot be
+# purely mechanical, since the branch it squashes carries its review fixes along, so
+# name what the exceptions are instead of pretending there are none. A commit whose
+# real changes are a meaningful share of its diff does not belong here at all: blame
+# would then credit the wrong author for work someone actually did.
+
+# style(dashboard): adopt otari-ai/frontend's Biome formatter and rule set (#611)
+#
+# Roughly 19,700 of its ~20,600 changed lines are `biome format` output over web/.
+# The remainder is real: a hoisted pure function in UsagePage, a useCallback in
+# DataTable, a badge role in ActivityPage, four small test fixes, and the rule
+# suppressions. Blame skips those too, which is the price of getting the other
+# 19,700 right; `git log -S` or `git show 97bacad7` finds them when it matters.
+97bacad73f4f348abfee8108c550372dd52143d7


### PR DESCRIPTION
## Description

#611 reformatted about 19,700 lines of `web/`, so `git blame` on almost any dashboard line now stops at that commit instead of at whoever wrote what the line says. In `shared/helpers/format.ts` alone, 56 lines point at the reformat; with this file they point back at the July commit that wrote them.

```
$ git blame --no-ignore-revs -L 3,3 web/src/shared/helpers/format.ts
97bacad73 (Nathan Brake 2026-08-17)     return "0"
$ git blame -L 3,3 web/src/shared/helpers/format.ts
fc02390f1 web/src/lib/format.ts (Nathan Brake 2026-07-16)
```

GitHub applies this automatically. Locally it is one opt-in, documented in the file.

**Why the entry names its own exceptions.** The squash merge is not purely mechanical: it carries #611's review fixes along with the reformat (a hoisted pure function, a `useCallback`, a badge role, four test fixes, the suppressions). Blame skips those too. That is the right trade at roughly 19,700 lines to 50, but it is a trade, so the entry says so rather than claiming the commit was formatting-only, and the file's admission rule is written to match what a squash merge can actually deliver.

This is also why it lands separately: the version originally in #611 named that branch's SHA, which a squash merge guaranteed would never exist on `main`, so it would have skipped nothing.

## PR Type

- [x] Infrastructure / CI

## Relevant issues

Follows #611.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).
- [ ] If this PR adds or changes a persistent table, a control-plane contract the otari.ai platform consumes or serves, a capability the platform also has, or a mode-specific surface, I appended an entry to the M4 reconciliation ledger ([otari-ai#1587](https://github.com/mozilla-ai/otari-ai/issues/1587)). See [.github/instructions/reconciliation-ledger.instructions.md](.github/instructions/reconciliation-ledger.instructions.md).

Three boxes need a word. There is no test, because the change is one data file read by `git`; it is verified by the blame output above. Nothing here touches Python, a route, a table, or a contract. The file documents itself, which is the whole of the documentation it needs.

**One caution worth repeating from the file.** `git config blame.ignoreRevsFile` writes to `.git/config`, which every worktree of a clone shares. Setting it from a worktree whose branch does not have the file makes `git blame` fail outright there until the branch catches up.

## AI Usage

- [x] AI was used for drafting/refactoring.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

The need for this, and the fact that the original attempt named a SHA that would not survive a squash merge, came out of review of #611. Written by the model through back-and-forth with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `.git-blame-ignore-revs`.
- Documented local Git configuration and its worktree limitation.
- Configured GitHub and local `git blame` to skip the dashboard reformat commit, preserving original line attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->