### PR TITLE
feat(hybrid): read the platform's optional caller-identity field

### DIFF
--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -41,6 +41,8 @@ older gateways.
 For example, the otari.ai resolve response also carries `workspace_id`,
 `organization_id`, `provider_key_id`, and `allowed_models`. Otari does not read
 these today, so they are intentionally absent from the shapes documented here.
+`user_id` (below) is the one exception: Otari reads it when present, but a
+peer omitting it is exactly as valid as any other unrecognized field.
 
 When the operator points Otari's web-search backend at the platform
 (`OTARI_WEB_SEARCH_URL` under `base_url`), Otari also sends `X-Gateway-Token`
@@ -71,6 +73,7 @@ Content-Type: application/json
 {
   "request_id": "01HXY...",
   "fallback_enabled": true,
+  "user_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "attempts": [
     {
       "attempt_id": "01HX1...",
@@ -161,6 +164,14 @@ own behavior.
 `attempts` MUST contain at least one entry. An empty list is treated as a
 platform bug and surfaced as `502 Bad Gateway`.
 
+`user_id` (optional) identifies the platform identity that owns the
+`X-User-Token` presented for this call, i.e. the token's creator. It is a
+stable, opaque string; Otari does not assume any particular format and never
+tries to parse it. Absent on older peers, which is exactly as valid as a peer
+omitting any other unrecognized field: nothing that reads this field may
+require it. When present, it is Otari's only way to key its own per-caller
+gateway-side state (aliases, routing memory, files, batches) in hybrid mode.
+
 ### Response: single-attempt shape
 
 Otari also accepts a flat payload:
@@ -179,7 +190,9 @@ Otari also accepts a flat payload:
 Otari maps this onto a single-attempt route (`attempts = [{...}]`,
 `fallback_enabled = false`) and behaves as it always has: no retry loop, errors
 propagate to the client. New platform implementations should prefer the
-multi-attempt shape.
+multi-attempt shape. `user_id` has no legacy mirror here, the same treatment
+as `extra_params`: a peer old enough to still emit this shape predates the
+field entirely.
 
 ### Failure
 

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -127,7 +127,7 @@ class ResolvedRoute(BaseModel):
     # opaque string, never parsed; absent for peers that predate the field or
     # simply don't send it. This is the only per-caller identity hybrid mode
     # has, so it is what gateway-side survivals (aliases, routing memory,
-    # files, batches) key their own state on there.
+    # files, batches) can key their state on in a later hybrid-mode phase.
     user_id: str | None = None
 
 

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -122,6 +122,13 @@ class ResolvedRoute(BaseModel):
     request_id: str
     fallback_enabled: bool
     attempts: list[ResolvedAttempt]
+    # The platform identity that owns the presented X-User-Token, when the peer
+    # supplies one (see docs/hybrid-mode-protocol.md's Extension policy). An
+    # opaque string, never parsed; absent for peers that predate the field or
+    # simply don't send it. This is the only per-caller identity hybrid mode
+    # has, so it is what gateway-side survivals (aliases, routing memory,
+    # files, batches) key their own state on there.
+    user_id: str | None = None
 
 
 class _AttemptFailure(NamedTuple):
@@ -564,12 +571,16 @@ def _parse_resolve_payload(payload: dict[str, Any]) -> ResolvedRoute:
             )
             for att in attempts_payload
         ]
+        raw_user_id = payload.get("user_id")
         return ResolvedRoute(
             request_id=str(payload["request_id"]),
             fallback_enabled=bool(payload.get("fallback_enabled", False)),
             attempts=attempts,
+            user_id=str(raw_user_id) if raw_user_id is not None else None,
         )
 
+    # Legacy single-attempt shape predates user_id entirely, same treatment as
+    # extra_params (see the class docstring above): no legacy mirror to read.
     correlation_id = str(payload["correlation_id"])
     return ResolvedRoute(
         request_id=correlation_id,

--- a/tests/unit/test_platform_resolve_payload.py
+++ b/tests/unit/test_platform_resolve_payload.py
@@ -12,6 +12,7 @@ from gateway.api.routes._platform import _parse_resolve_payload
 
 
 def test_parse_resolve_payload_reads_user_id_from_attempts_shape() -> None:
+    """The modern attempts-list shape carries user_id at the top level, alongside request_id."""
     payload = {
         "request_id": "req-1",
         "fallback_enabled": False,

--- a/tests/unit/test_platform_resolve_payload.py
+++ b/tests/unit/test_platform_resolve_payload.py
@@ -1,0 +1,73 @@
+"""Unit tests for ``_parse_resolve_payload``'s handling of the platform's
+optional caller-identity field (``user_id``).
+
+Covers the three shapes a peer can send: the modern attempts-list shape with
+the field present, the same shape with it absent (an older or non-otari.ai
+peer), and the legacy single-attempt shape, which never carries it.
+"""
+
+from __future__ import annotations
+
+from gateway.api.routes._platform import _parse_resolve_payload
+
+
+def test_parse_resolve_payload_reads_user_id_from_attempts_shape() -> None:
+    payload = {
+        "request_id": "req-1",
+        "fallback_enabled": False,
+        "user_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "attempts": [
+            {
+                "attempt_id": "a0",
+                "position": 0,
+                "provider": "openai",
+                "model": "gpt-4o",
+                "api_key": "sk-...",
+                "managed": False,
+            }
+        ],
+    }
+
+    route = _parse_resolve_payload(payload)
+
+    assert route.user_id == "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+
+
+def test_parse_resolve_payload_tolerates_missing_user_id() -> None:
+    """A peer that predates the field, or simply omits it, must not break resolution."""
+    payload = {
+        "request_id": "req-2",
+        "fallback_enabled": False,
+        "attempts": [
+            {
+                "attempt_id": "a0",
+                "position": 0,
+                "provider": "openai",
+                "model": "gpt-4o",
+                "api_key": "sk-...",
+                "managed": False,
+            }
+        ],
+    }
+
+    route = _parse_resolve_payload(payload)
+
+    assert route.user_id is None
+
+
+def test_parse_resolve_payload_legacy_shape_has_no_user_id() -> None:
+    """The legacy single-attempt shape predates user_id entirely; no legacy mirror exists."""
+    payload = {
+        "provider": "openai",
+        "model": "gpt-4o-mini",
+        "api_key": "sk-...",
+        "managed": False,
+        "correlation_id": "corr-1",
+        # A hypothetical peer stapling user_id onto the legacy shape is still
+        # ignored: only the attempts-list branch reads it.
+        "user_id": "ignored-on-legacy-shape",
+    }
+
+    route = _parse_resolve_payload(payload)
+
+    assert route.user_id is None


### PR DESCRIPTION
## Description

The resolve response can now carry `user_id`: the platform identity that owns the presented `X-User-Token`. This documents it in `docs/hybrid-mode-protocol.md` as a field Otari reads (moved out of the "fields Otari does not read" list), parses it into `ResolvedRoute` in the modern attempts-list branch, and leaves the legacy single-attempt branch untouched (predates the field, same treatment as `extra_params`).

Nothing observable changes yet: `ResolvedRoute.user_id` is parsed but unused until a later phase threads it into the request context as the hybrid-mode caller identity (giving hybrid mode a per-caller identity for aliases, routing memory, files, and batches). That later phase reverses a currently-documented, tested invariant (hybrid mode has no local database/management state) and needs its own sign-off before landing; this PR is purely the additive, backward-compatible wire-contract seam, safe to ship standalone.

Paired with mozilla-ai/otari-ai#1710 (the platform side that populates the field).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Refs mozilla-ai/otari-ai#1643

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).
- [x] If this PR adds or changes a persistent table, a control-plane contract the otari.ai platform consumes or serves, a capability the platform also has, or a mode-specific surface, I appended an entry to the M4 reconciliation ledger ([otari-ai#1587](https://github.com/mozilla-ai/otari-ai/issues/1587)). See [.github/instructions/reconciliation-ledger.instructions.md](.github/instructions/reconciliation-ledger.instructions.md).

Local results: ruff, mypy, `check_architecture.py`, and `openapi --check` all clean. `tests/unit/test_platform_resolve_payload.py` plus the existing platform/hybrid-mode suites (65 tests total across the touched files) pass.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Sonnet 5 via Claude Code.

**Any additional AI details you'd like to share:**

Prose and code written by Claude working from mozilla-ai/otari-ai#1643; reviewed and directed by the repo owner via Claude Code.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Documented optional `user_id` support for modern hybrid-mode resolve responses.
- Parsed `user_id` into `ResolvedRoute` when present.
- Preserved legacy response behavior.
- Added tests for present, missing, and legacy `user_id` values.

This enables future per-caller state while keeping current behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->