### PR TITLE
feat(reprise): ship gateway observations to the platform on a bounded queue

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -247,6 +247,10 @@ These are only relevant when running connected to [otari.ai](https://otari.ai). 
 | `PLATFORM_USAGE_MAX_RETRIES` | `3` | Max retries for transient usage reporting failures |
 | `STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS` | `2000` | Per-attempt timeout waiting for first streamed chunk |
 | `STREAMING_FALLBACK_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS` | `0` | Extra first-chunk grace for the sole/final attempt, added on top of the per-attempt budget. `0` = no grace (unchanged) |
+| `PLATFORM_OBSERVATION_MAX_QUEUE` | `10000` | Bound on queued observation records; a full queue drops the arriving record rather than slowing the request |
+| `PLATFORM_OBSERVATION_MAX_BATCH` | `500` | Max observation records shipped in one batch |
+| `PLATFORM_OBSERVATION_FLUSH_INTERVAL_MS` | `5000` | How often queued observation records are shipped |
+| `PLATFORM_OBSERVATION_TIMEOUT_MS` | `5000` | Timeout for one observation batch |
 
 ## Provider configuration
 

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -18,6 +18,7 @@ Otari calls these endpoints, all rooted at the configured platform base URL:
 | `POST {base}/gateway/usage`                 | Report the outcome of an attempt back to the platform |
 | `POST {base}/gateway/mcp-servers/resolve`   | Swap workspace-scoped MCP server ids for inline server configs (called only when a request references MCP server ids) |
 | `POST {base}/gateway/web-search/resolve`    | Resolve the workspace's web-search policy (called only when a request uses the `otari_web_search` tool) |
+| `POST {base}/gateway/loop-observations`     | Report a batch of observation records (optional for a peer; see [Observation ingest](#observation-ingest)) |
 
 `{base}` means Otari platform `base_url` setting. Otari concatenates literally. The peer service is responsible for including any API-version prefix it exposes its own routes under. For the reference otari deployment that prefix is `/api/v1`, so the base URL is `http://backend:8000/api/v1` and Otari ends up POSTing to `http://backend:8000/api/v1/gateway/provider-keys/resolve`.
 
@@ -27,8 +28,11 @@ Every endpoint requires `X-Gateway-Token: <gw_...>` in the request headers. This
 proves the caller is an Otari instance configured against this platform
 deployment. The three resolve endpoints additionally require `X-User-Token:
 <tk_...>`, which is the workspace API token forwarded opaquely from the end
-user's `Authorization: Bearer ...` header. The usage endpoint sends only the
-gateway token.
+user's `Authorization: Bearer ...` header. The usage and observation endpoints
+send only the gateway token. Usage reports carry a `correlation_id` the platform
+issued at resolve time, which already identifies the caller, and an observation
+batch is not sent on behalf of any one caller: it mixes records from every
+request that was in flight when the flush timer fired.
 
 ## Extension policy
 
@@ -414,6 +418,73 @@ retries on transient failures (timeout, network error, 5xx) up to
 (`0.25s`, `0.5s`, `1s`). It does **not** retry on `401`, `404`, `409`, `422`;
 those are treated as terminal client errors.
 
+## Observation ingest
+
+Otari can report *observation records*, a measurement stream describing what
+its tool loop did, so the peer can count how often a request recurs and how
+predictable a loop's rounds are. A hybrid-mode gateway has no local database, so
+there is nowhere on the box to keep them.
+
+```http
+POST /gateway/loop-observations
+X-Gateway-Token: gw_...
+Content-Type: application/json
+
+{
+  "records": [
+    { "kind": "loop_round", ... },
+    { "kind": "request_counter", ... }
+  ]
+}
+```
+
+`records` is whatever a flush timer had collected, so it is an arbitrary
+grouping rather than a unit of meaning: one batch mixes both record kinds,
+discriminated by `kind`, and carries records from many concurrent requests.
+A peer should therefore treat a malformed record as a per-record problem and
+write the rest of the batch, rather than rejecting the batch.
+
+The record shapes themselves are **not** part of this contract yet. Otari does
+not inspect a record beyond queueing it, and the peer is the only side that
+reads the fields.
+
+Any `2xx` means the batch was accepted. A response body, if any, is ignored.
+
+### Fail-open contract
+
+This endpoint is **optional for a peer**. Every failure mode ends the same way,
+with records lost and the request completing exactly as it would have:
+
+| What happens | What Otari does |
+|---|---|
+| Timeout, connection error, unreachable peer | Drops the batch, counts it |
+| `5xx` | Drops the batch, counts it |
+| `404` (peer does not implement this endpoint) | Drops the batch, counts it |
+| `401` (peer rejects the gateway token) | Drops the batch, counts it |
+
+Nothing is retried. Observation records are disposable, unlike usage reports,
+and a retry would compete for the connection pool with the very traffic being
+measured. This is also why the records do not travel on the usage report, which
+already fires once per request and would carry them happily: coupling them would
+mean either retrying billing data because measurement data failed, or dropping
+billing data because the payload grew.
+
+Records queue in memory, bounded, and are flushed by a background task. Emitting
+a record is an in-memory put and nothing more, so nothing on the request path
+waits for a flush. When the queue is full the arriving record is dropped rather
+than the producer being made to wait, and the process's final flush ships what
+is queued within a bounded budget.
+
+The loss is counted, because a lossy stream whose loss rate is unknown cannot
+support a measurement conclusion. On Otari's `/metrics`:
+
+| Metric | Meaning |
+|---|---|
+| `gateway_observation_queue_depth` | Records waiting to be shipped |
+| `gateway_observation_records_total{result="queued"}` | Accepted into the queue |
+| `gateway_observation_records_total{result="shipped"}` | Accepted by the peer |
+| `gateway_observation_records_total{result=~"dropped.*"}` | Lost, split by cause: `dropped_queue_full`, `dropped_flush_failed`, `dropped_shutdown` |
+
 ## Streaming
 
 Streaming requests (`stream: true`) iterate `attempts` just like non-streaming
@@ -467,3 +538,7 @@ flag.
 | `PLATFORM_USAGE_MAX_RETRIES` | `3` | Max retries for transient usage-report failures. |
 | `STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS` | `2000` | Per-attempt budget for the streaming first-chunk gate. |
 | `STREAMING_FALLBACK_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS` | `0` | Extra first-chunk grace for the sole/final attempt, on top of the budget. `0` = unchanged. |
+| `PLATFORM_OBSERVATION_MAX_QUEUE` | `10000` | Bound on queued observation records. A full queue drops the arriving record. |
+| `PLATFORM_OBSERVATION_MAX_BATCH` | `500` | Max records in one observation batch. |
+| `PLATFORM_OBSERVATION_FLUSH_INTERVAL_MS` | `5000` | How often the observation queue is flushed. |
+| `PLATFORM_OBSERVATION_TIMEOUT_MS` | `5000` | Per-batch timeout for observation ingest. |

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -163,6 +163,21 @@ def _get_platform_token_from_env() -> str | None:
     return token or None
 
 
+def _as_platform_number(key: str, value: Any) -> float:
+    """Read a numeric `platform:` setting, naming the key when it is not a number.
+
+    `platform` is an untyped dict, so a value arrives however YAML parsed it. A
+    bare `float(value)` raises TypeError on the None that an empty YAML value
+    (`observation_timeout_ms:` with nothing after the colon) parses to, and
+    pydantic converts only ValueError and AssertionError into a ValidationError,
+    so that TypeError would escape config load as a traceback naming no field.
+    """
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{key} must be a number, got {value!r}") from None
+
+
 def provider_credential_env_names(provider_type: str) -> tuple[str, ...] | None:
     """Environment variables any-llm reads for a provider's credential.
 
@@ -1225,22 +1240,44 @@ class GatewayConfig(BaseSettings):
 
     @field_validator("platform")
     @classmethod
-    def _validate_platform_streaming_timeouts(cls, platform: dict[str, Any]) -> dict[str, Any]:
-        """Reject non-sensical streaming first-chunk timeout settings at load time.
+    def _validate_platform_numeric_settings(cls, platform: dict[str, Any]) -> dict[str, Any]:
+        """Reject non-sensical streaming and observation settings at load time.
 
-        The per-attempt first-chunk budgets must be positive: a zero or negative
-        wait would treat every attempt as instantly hung. The terminal-attempt
-        extra grace must be non-negative, since it is added on top of the budget.
+        The streaming per-attempt first-chunk budgets must be positive: a zero or
+        negative wait would treat every attempt as instantly hung. The
+        terminal-attempt extra grace must be non-negative, since it is added on
+        top of the budget.
+
+        The observation settings size the bounded queue the observation shipper
+        flushes from, and every one of them has to be positive too: a zero bound
+        rejects every record, a zero batch flushes nothing, and a non-positive
+        interval or timeout either spins or abandons each flush. All four failure
+        modes leave the stream silently empty, which reads downstream as "nothing
+        was observable" rather than as a misconfiguration.
+
+        The two record counts are additionally required to be whole numbers,
+        because the shipper sizes a queue and a batch with them: a fraction below
+        1 truncates to 0, and ``asyncio.Queue(maxsize=0)`` is *unbounded*, so the
+        bound the setting exists to impose would silently disappear.
         """
-        positive_ms_keys = (
+        whole_positive_keys = ("observation_max_queue", "observation_max_batch")
+        positive_keys = (
             "streaming_first_chunk_timeout_ms",
             "streaming_first_chunk_timeout_ms_tool_loop",
+            "observation_flush_interval_ms",
+            "observation_timeout_ms",
+            *whole_positive_keys,
         )
-        for key in positive_ms_keys:
-            if key in platform and float(platform[key]) <= 0:
+        for key in positive_keys:
+            if key not in platform:
+                continue
+            value = _as_platform_number(key, platform[key])
+            if value <= 0:
                 raise ValueError(f"{key} must be > 0, got {platform[key]}")
+            if key in whole_positive_keys and value != int(value):
+                raise ValueError(f"{key} must be a whole number of records, got {platform[key]}")
         extra_key = "streaming_final_attempt_extra_first_chunk_timeout_ms"
-        if extra_key in platform and float(platform[extra_key]) < 0:
+        if extra_key in platform and _as_platform_number(extra_key, platform[extra_key]) < 0:
             raise ValueError(f"{extra_key} must be >= 0, got {platform[extra_key]}")
         return platform
 
@@ -1464,6 +1501,15 @@ def _apply_platform_env_overrides(config: dict[str, Any]) -> None:
             "streaming_final_attempt_extra_first_chunk_timeout_ms",
             int,
         ),
+        # Observation transport (hybrid mode). The queue bound is a capacity
+        # decision rather than a correctness one: records are fixed-size, so a
+        # deployment can trade memory for how large a production burst it absorbs
+        # between two flushes. It buys nothing during a platform outage, where a
+        # failed batch is dropped rather than requeued.
+        "PLATFORM_OBSERVATION_MAX_QUEUE": ("observation_max_queue", int),
+        "PLATFORM_OBSERVATION_MAX_BATCH": ("observation_max_batch", int),
+        "PLATFORM_OBSERVATION_FLUSH_INTERVAL_MS": ("observation_flush_interval_ms", int),
+        "PLATFORM_OBSERVATION_TIMEOUT_MS": ("observation_timeout_ms", int),
     }
 
     for env_name, (field_name, caster) in env_mappings.items():

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -33,6 +33,7 @@ from gateway.services.model_discovery_service import (
     reset_discovery_cache,
     run_discovery_refresher,
 )
+from gateway.services.observation_shipper import create_observation_shipper
 from gateway.services.policy_store import (
     load_policies_at_startup,
     reset_policy_cache,
@@ -301,13 +302,23 @@ def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
             # Same shape for the models.dev catalog, whose fetch is bounded at 15s.
             catalog_refresher = asyncio.create_task(run_catalog_refresher(config))
 
-        # Start the writer inside the try so a failure here still runs the cleanup
-        # below; the refresher tasks are already created and would otherwise leak.
+        # Hybrid mode reports observation records to the platform; standalone has
+        # nowhere to ship them, and gets a null shipper so producers can emit
+        # unconditionally. Building one contacts nothing.
+        observation_shipper = create_observation_shipper(config)
+
+        # Start the writer and the shipper inside the try so a failure in either
+        # still runs the cleanup below; the refresher tasks are already created
+        # and would otherwise leak.
         log_writer_started = False
+        observation_shipper_started = False
         try:
             await log_writer.start()
             log_writer_started = True
             app.state.log_writer = log_writer
+            await observation_shipper.start()
+            observation_shipper_started = True
+            app.state.observation_shipper = observation_shipper
             yield
         finally:
             refreshers = [
@@ -336,6 +347,11 @@ def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
             # nothing to stop, but the refreshers above still needed cancelling.
             if log_writer_started:
                 await log_writer.stop()
+            # The shipper holds queued observation records in memory, so stopping
+            # it is what flushes the tail. Bounded on its own side, so a hung
+            # platform cannot hold the lifespan open here.
+            if observation_shipper_started:
+                await observation_shipper.stop()
             # POST /v1/search dispatches on one pooled client for the process, so
             # shutdown owns closing it. A no-op when no search was ever served.
             await close_search_client()

--- a/src/gateway/metrics.py
+++ b/src/gateway/metrics.py
@@ -114,6 +114,43 @@ LOG_WRITER_ROWS = Counter(
     registry=REGISTRY,
 )
 
+OBSERVATION_QUEUE_DEPTH = Gauge(
+    "gateway_observation_queue_depth",
+    "Number of observation records waiting to be shipped to the platform",
+    registry=REGISTRY,
+)
+
+# Record counts, not seconds, so the default latency buckets do not apply: their
+# largest finite bound is 10, and a batch runs to max_batch (500 by default), so
+# every real batch would land in +Inf and the distribution would be unreadable.
+# Batches pinned at the cap are the signal that the flusher is falling behind.
+OBSERVATION_BATCH_SIZE = Histogram(
+    "gateway_observation_batch_size",
+    "Number of observation records per flush batch",
+    buckets=(1, 5, 10, 25, 50, 100, 250, 500, 1000),
+    registry=REGISTRY,
+)
+
+OBSERVATION_FLUSH_DURATION = Histogram(
+    "gateway_observation_flush_duration_seconds",
+    "Time spent flushing observation batches to the platform",
+    ["result"],
+    registry=REGISTRY,
+)
+
+# The observation queue is bounded and drops on overflow, so the loss rate is
+# part of the signal rather than an incident: a measurement drawn from a lossy
+# stream is only as trustworthy as the known loss. ``result`` separates the
+# causes, since they call for different responses: dropped_queue_full is
+# capacity, dropped_flush_failed is the platform, dropped_shutdown is a backlog
+# abandoned when the process stopped. ``result=~"dropped.*"`` totals them.
+OBSERVATION_RECORDS = Counter(
+    "gateway_observation_records",
+    "Total observation records by outcome",
+    ["result"],
+    registry=REGISTRY,
+)
+
 
 _PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
 

--- a/src/gateway/services/observation_shipper.py
+++ b/src/gateway/services/observation_shipper.py
@@ -1,0 +1,389 @@
+"""Transport for the observation records the gateway reports to the platform.
+
+A gateway in hybrid mode has no local database by design, so observation
+records have nowhere on the box to go, and they are produced *mid-request*: the
+tool loop records a round and immediately calls the model again. Emitting one
+over HTTP inline would put that network I/O on the request path, competing for
+the same event loop and connection pool as the request it is measuring. An
+observability stream that can degrade the request path is worse than no stream.
+
+So the shape is a bounded in-memory queue plus a periodic background flush,
+batching records to the platform's ingest endpoint. Three properties hold:
+
+- **Bounded, drop on overflow.** ``emit`` is a plain function whose whole body
+  is an in-memory put, so a producer physically cannot await a flush. When the
+  queue is full the arriving record is discarded and counted; the loop is never
+  made to wait on a measurement.
+- **Batched, not per request.** One POST per flush interval for the whole
+  process, however many requests are in flight, plus extra POSTs only while a
+  backlog is clearing in full batches. The per-request counter runs unsampled so
+  recurrence counts are trustworthy, which would otherwise double the gateway's
+  outbound request rate to the platform at every level of load.
+- **Any error loses records, never a request.** A timeout, a 5xx, a peer that
+  does not implement the endpoint, an unreachable platform: all of them mean
+  records vanish, counted, and the request completes exactly as it does today.
+
+Deliberately not folded into the existing ``/gateway/usage`` report, which
+already fires once per request and would carry these happily: usage reports are
+billing-relevant and retried, observations are disposable. Coupling them means
+either retrying billing data because measurement data failed, or dropping
+billing data because the payload grew.
+
+Modeled on ``BatchLogWriter`` in :mod:`gateway.services.log_writer` for the
+queue-plus-flush-task shape, with one deliberate difference: that queue is
+unbounded, and this one must not be.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any, Protocol
+
+import httpx
+
+from gateway.log_config import logger
+from gateway.metrics import (
+    OBSERVATION_BATCH_SIZE,
+    OBSERVATION_FLUSH_DURATION,
+    OBSERVATION_QUEUE_DEPTH,
+    OBSERVATION_RECORDS,
+)
+
+if TYPE_CHECKING:
+    from gateway.core.config import GatewayConfig
+
+ObservationRecord = dict[str, Any]
+"""One record as the producer built it. The transport never inspects it: both
+kinds travel in the same batch, discriminated for the platform by ``kind``."""
+
+OBSERVATION_INGEST_PATH = "/gateway/loop-observations"
+
+# Records are fixed-size now that arguments are recorded as shape plus per-value
+# hashes, so the queue bound is a capacity decision rather than a source of bias:
+# 10k records is a bounded amount of memory and absorbs a large production burst
+# between two flushes. It does not buy outage tolerance, since a batch that fails
+# to POST is dropped rather than requeued. All four are operator-tunable through
+# the platform config block.
+DEFAULT_MAX_QUEUE = 10_000
+DEFAULT_MAX_BATCH = 500
+DEFAULT_FLUSH_INTERVAL_MS = 5_000
+DEFAULT_TIMEOUT_MS = 5_000
+
+# Floor for the shutdown drain's total budget, across however many batches it
+# takes. Unbounded, the drain is worst-case (queue / batch) POSTs long, each
+# waiting out its own timeout, which outlasts any container stop grace: uvicorn's
+# lifespan would then block on an observability stream. Whatever is still queued
+# when the budget runs out is dropped, and counted as such. The effective budget
+# is this floor or one worst-case batch, whichever is larger, so an operator who
+# widens ``observation_timeout_ms`` past it does not thereby make the final flush
+# unable to complete a single batch.
+_SHUTDOWN_DRAIN_TIMEOUT_SECONDS = 5.0
+
+# How long to wait for the flusher to acknowledge a cancellation once the drain
+# budget is spent. Short because nothing is left to ship by then.
+_TASK_CANCEL_TIMEOUT_SECONDS = 1.0
+
+
+class ObservationShipper(Protocol):
+    """What a producer needs: emit and forget."""
+
+    def emit(self, record: ObservationRecord) -> None: ...
+
+    async def start(self) -> None: ...
+
+    async def stop(self) -> None: ...
+
+
+class NullObservationShipper:
+    """Discards every record.
+
+    Bound in standalone mode, where there is no platform to ship to, so
+    producers can emit unconditionally instead of testing the mode themselves.
+    """
+
+    def emit(self, record: ObservationRecord) -> None:
+        return None
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+
+class PlatformObservationShipper:
+    """Queue observation records and flush them to the platform in batches.
+
+    ``transport`` is httpx's own injection point and exists for tests; leaving
+    it unset uses the default network transport.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        gateway_token: str,
+        max_queue: int = DEFAULT_MAX_QUEUE,
+        max_batch: int = DEFAULT_MAX_BATCH,
+        flush_interval_seconds: float = DEFAULT_FLUSH_INTERVAL_MS / 1000,
+        timeout_seconds: float = DEFAULT_TIMEOUT_MS / 1000,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._url = f"{base_url.rstrip('/')}{OBSERVATION_INGEST_PATH}"
+        # The same machine identity the usage report and the resolve endpoints
+        # carry. A second header for one identity is worse than one shared one.
+        self._headers = {"X-Gateway-Token": gateway_token}
+        self._queue: asyncio.Queue[ObservationRecord] = asyncio.Queue(maxsize=max_queue)
+        self._max_queue = max_queue
+        self._max_batch = max_batch
+        self._flush_interval_seconds = flush_interval_seconds
+        self._timeout_seconds = timeout_seconds
+        # A budget below one batch's timeout could not ship even one worst-case
+        # batch, so a widened per-batch timeout widens the drain with it.
+        self._shutdown_drain_seconds = max(_SHUTDOWN_DRAIN_TIMEOUT_SECONDS, timeout_seconds)
+        self._transport = transport
+        self._task: asyncio.Task[None] | None = None
+        self._client: httpx.AsyncClient | None = None
+        # Set to ask the flusher to finish its current flush and exit, so a POST
+        # in flight at shutdown is delivered rather than cancelled.
+        self._stopping = asyncio.Event()
+        # Records this stop() lost inside a flush that was cancelled mid-POST.
+        # They are already off the queue, so the queue's remainder alone would
+        # under-report the loss in the warning below.
+        self._dropped_in_flight = 0
+
+    @property
+    def queue_depth(self) -> int:
+        return self._queue.qsize()
+
+    @property
+    def max_queue(self) -> int:
+        return self._max_queue
+
+    @property
+    def max_batch(self) -> int:
+        return self._max_batch
+
+    @property
+    def flush_interval_seconds(self) -> float:
+        return self._flush_interval_seconds
+
+    @property
+    def timeout_seconds(self) -> float:
+        return self._timeout_seconds
+
+    def emit(self, record: ObservationRecord) -> None:
+        """Hand a record to the queue, or drop it. Never blocks, never raises.
+
+        Synchronous on purpose: a coroutine here would invite an ``await`` that
+        reaches the network, and the whole point is that the producer's next
+        statement runs regardless of what the platform is doing.
+        """
+        try:
+            self._queue.put_nowait(record)
+        except asyncio.QueueFull:
+            OBSERVATION_RECORDS.labels(result="dropped_queue_full").inc()
+            return
+        OBSERVATION_RECORDS.labels(result="queued").inc()
+        OBSERVATION_QUEUE_DEPTH.set(self._queue.qsize())
+
+    async def start(self) -> None:
+        if self._task is None:
+            self._stopping.clear()
+            self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        """Stop flushing, then ship what is queued within a bounded budget.
+
+        The flusher is asked to stop rather than cancelled outright: cancelling it
+        would abort a POST already in flight and discard that whole batch, even
+        against a healthy platform with the budget untouched. It is cancelled only
+        if the budget runs out, which is the case the accounting below is for.
+        """
+        task, self._task = self._task, None
+        self._dropped_in_flight = 0
+        self._stopping.set()
+        deadline = time.monotonic() + self._shutdown_drain_seconds
+        try:
+            if task is not None:
+                # ``asyncio.wait`` rather than ``await task``: awaiting a task
+                # directly hands a timeout's cancellation to that task, and the
+                # flusher handles CancelledError, so it would complete normally,
+                # the timeout would be spent without ever raising, and whatever
+                # came next would run with a deadline that can no longer fire.
+                # ``wait`` leaves the flusher's in-flight POST alone and just
+                # reports whether it finished in time.
+                done, _ = await asyncio.wait([task], timeout=self._shutdown_drain_seconds)
+                if not done:
+                    raise TimeoutError
+            # Anything a producer queued while that ran. Emptied rather than
+            # stopped at the first partial batch: there is no next interval to
+            # leave a remainder for. Bounded by what is left of the budget, so
+            # the two steps together cannot outlast it.
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError
+            async with asyncio.timeout(remaining):
+                await self._drain(until_empty=True)
+        except TimeoutError:
+            await self._abandon(task)
+        finally:
+            await self._close_client()
+
+    async def _abandon(self, task: asyncio.Task[None] | None) -> None:
+        """Give up on the drain: stop the flusher and account for what is lost."""
+        if task is not None and not task.done():
+            task.cancel()
+            # Bounded, like the refresher shutdown in ``gateway.main``: an
+            # httpx timeout is an anyio cancel scope, and one that absorbs this
+            # cancellation would leave an unbounded ``await task`` hanging the
+            # lifespan on an observability stream.
+            await asyncio.wait([task], timeout=_TASK_CANCEL_TIMEOUT_SECONDS)
+        abandoned = self._queue.qsize()
+        if abandoned:
+            self._take(abandoned)
+            OBSERVATION_RECORDS.labels(result="dropped_shutdown").inc(abandoned)
+        logger.warning(
+            "Observation shipper gave up draining at shutdown after %.1fs; %d record(s) dropped",
+            self._shutdown_drain_seconds,
+            abandoned + self._dropped_in_flight,
+        )
+
+    async def _run(self) -> None:
+        while not self._stopping.is_set():
+            try:
+                # Woken early by stop(), so a shutdown does not wait out the
+                # interval before the tail is shipped.
+                with suppress(TimeoutError):
+                    await asyncio.wait_for(self._stopping.wait(), self._flush_interval_seconds)
+                await self._drain()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:  # pragma: no cover - defensive: the loop outlives any flush
+                logger.error("Observation shipper loop error: %s", e)
+
+    async def _drain(self, *, until_empty: bool = False) -> None:
+        """Ship what is queued, in batches of at most ``max_batch``.
+
+        Keeps going while batches come back full, so a backlog clears at the
+        platform's pace instead of at one batch per interval, and stops at the
+        first partial batch. Draining until the queue is empty instead would never
+        finish under a steady trickle: a producer only has to queue one record per
+        round trip to keep the next batch non-empty, and the flusher would then
+        POST tiny batches back to back and never sleep again, which is the
+        opposite of batching. ``until_empty`` is for the shutdown drain, which has
+        no next interval to leave a remainder for.
+        """
+        while batch := self._take(self._max_batch):
+            await self._flush(batch)
+            if len(batch) < self._max_batch and not until_empty:
+                break
+
+    def _take(self, limit: int) -> list[ObservationRecord]:
+        batch: list[ObservationRecord] = []
+        while len(batch) < limit:
+            try:
+                batch.append(self._queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+        if batch:
+            OBSERVATION_QUEUE_DEPTH.set(self._queue.qsize())
+        return batch
+
+    async def _flush(self, batch: list[ObservationRecord]) -> None:
+        """POST one batch. Every outcome except success is a counted loss."""
+        started = time.monotonic()
+        OBSERVATION_BATCH_SIZE.observe(len(batch))
+        try:
+            response = await self._post(batch)
+        except asyncio.CancelledError:
+            # The shutdown budget ran out mid-POST. These records are already off
+            # the queue, so they are counted here or they vanish from the ledger,
+            # and tallied separately so the warning can report them too.
+            OBSERVATION_RECORDS.labels(result="dropped_shutdown").inc(len(batch))
+            self._dropped_in_flight += len(batch)
+            raise
+        except Exception as e:
+            self._record_failed_flush(batch, started, f"{type(e).__name__}: {e}")
+            return
+
+        if response.is_success:
+            OBSERVATION_RECORDS.labels(result="shipped").inc(len(batch))
+            OBSERVATION_FLUSH_DURATION.labels(result="ok").observe(time.monotonic() - started)
+            return
+        # Includes the peer that does not implement the endpoint at all (404):
+        # observations are optional, so an older platform costs records, not
+        # requests. Nothing is retried, since the records are disposable and a
+        # retry would compete with the very traffic being measured.
+        self._record_failed_flush(batch, started, f"HTTP {response.status_code}")
+
+    def _record_failed_flush(self, batch: list[ObservationRecord], started: float, reason: str) -> None:
+        logger.warning("Observation flush failed, dropping %d record(s): %s", len(batch), reason)
+        OBSERVATION_RECORDS.labels(result="dropped_flush_failed").inc(len(batch))
+        OBSERVATION_FLUSH_DURATION.labels(result="error").observe(time.monotonic() - started)
+
+    async def _post(self, batch: list[ObservationRecord]) -> httpx.Response:
+        client = self._ensure_client()
+        return await client.post(
+            self._url,
+            headers=self._headers,
+            json={"records": batch},
+            timeout=self._timeout_seconds,
+        )
+
+    def _ensure_client(self) -> httpx.AsyncClient:
+        """The pooled client flushes share.
+
+        Built on first flush rather than at start, so a gateway that never emits
+        an observation never holds one. A client per flush would pay a fresh TCP
+        and TLS handshake every interval and pool nothing.
+
+        The limits are sized for what this client actually does: one sequential
+        POST per interval to one host. httpx's default ``keepalive_expiry`` of 5s
+        equals the default flush interval, so the pooled connection would be
+        evicted as idle between every flush and each POST would pay the handshake
+        this client exists to avoid; the expiry has to outlast an idle interval.
+        """
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                transport=self._transport,
+                limits=httpx.Limits(
+                    max_connections=1,
+                    max_keepalive_connections=1,
+                    keepalive_expiry=self._flush_interval_seconds * 2,
+                ),
+            )
+        return self._client
+
+    async def _close_client(self) -> None:
+        client, self._client = self._client, None
+        if client is not None and not client.is_closed:
+            await client.aclose()
+
+
+def create_observation_shipper(config: GatewayConfig) -> ObservationShipper:
+    """Build the shipper for this deployment, or a null one if there is nowhere to ship."""
+    if not config.is_hybrid_mode:
+        return NullObservationShipper()
+
+    base_url = config.platform.get("base_url")
+    gateway_token = config.platform_token
+    if not base_url or not gateway_token:
+        logger.warning("Observations are not being shipped: hybrid mode without a platform base URL and token")
+        return NullObservationShipper()
+
+    # Via float, since a setting arrives as whatever YAML parsed it to and a bare
+    # ``int()`` rejects the numeric strings the validator accepts. The validator
+    # has already established that both are whole and positive, so nothing
+    # truncates here.
+    return PlatformObservationShipper(
+        base_url=str(base_url),
+        gateway_token=gateway_token,
+        max_queue=int(float(config.platform.get("observation_max_queue", DEFAULT_MAX_QUEUE))),
+        max_batch=int(float(config.platform.get("observation_max_batch", DEFAULT_MAX_BATCH))),
+        flush_interval_seconds=float(config.platform.get("observation_flush_interval_ms", DEFAULT_FLUSH_INTERVAL_MS))
+        / 1000,
+        timeout_seconds=float(config.platform.get("observation_timeout_ms", DEFAULT_TIMEOUT_MS)) / 1000,
+    )

--- a/tests/integration/test_config_env_loading.py
+++ b/tests/integration/test_config_env_loading.py
@@ -409,6 +409,25 @@ def test_load_config_platform_env_overrides(tmp_path: Path, monkeypatch: pytest.
     assert config.platform["usage_max_retries"] == 7
 
 
+def test_load_config_platform_observation_env_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The observation queue's bound is a capacity decision, so it is tunable per deployment."""
+    config_file = tmp_path / "gateway.yml"
+    config_file.write_text("mode: hybrid\n", encoding="utf-8")
+
+    monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
+    monkeypatch.setenv("PLATFORM_OBSERVATION_MAX_QUEUE", "25000")
+    monkeypatch.setenv("PLATFORM_OBSERVATION_MAX_BATCH", "750")
+    monkeypatch.setenv("PLATFORM_OBSERVATION_FLUSH_INTERVAL_MS", "3000")
+    monkeypatch.setenv("PLATFORM_OBSERVATION_TIMEOUT_MS", "4000")
+
+    config = load_config(str(config_file))
+
+    assert config.platform["observation_max_queue"] == 25000
+    assert config.platform["observation_max_batch"] == 750
+    assert config.platform["observation_flush_interval_ms"] == 3000
+    assert config.platform["observation_timeout_ms"] == 4000
+
+
 def test_load_config_sets_default_platform_base_url_when_token_is_set(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_gateway_metrics.py
+++ b/tests/unit/test_gateway_metrics.py
@@ -9,6 +9,10 @@ from prometheus_client import generate_latest
 
 from gateway.core.config import GatewayConfig
 from gateway.metrics import (
+    OBSERVATION_BATCH_SIZE,
+    OBSERVATION_FLUSH_DURATION,
+    OBSERVATION_QUEUE_DEPTH,
+    OBSERVATION_RECORDS,
     REGISTRY,
     MetricsMiddleware,
     metrics_endpoint,
@@ -107,6 +111,71 @@ def test_record_abandoned_attempt_labels_by_reason_and_position() -> None:
 
     assert _sample("gateway_abandoned_attempts_total", build_labels) - before_build == 1.0
     assert _sample("gateway_abandoned_attempts_total", upstream_labels) - before_upstream == 1.0
+
+
+def test_observation_queue_depth_is_exposed_like_the_usage_log_gauge() -> None:
+    """The observation queue is bounded and lossy, so its depth has to be readable.
+
+    Sits next to ``gateway_usage_log_queue_depth`` deliberately: an operator
+    reading one queue's saturation reads the other the same way.
+    """
+    body = generate_latest(REGISTRY).decode()
+
+    assert "gateway_observation_queue_depth" in body
+    assert "gateway_usage_log_queue_depth" in body
+
+
+def test_observation_queue_depth_tracks_the_set_value() -> None:
+    OBSERVATION_QUEUE_DEPTH.set(7)
+
+    assert _sample("gateway_observation_queue_depth") == 7.0
+
+    OBSERVATION_QUEUE_DEPTH.set(0)
+
+
+@pytest.mark.parametrize(
+    "result",
+    ["queued", "shipped", "dropped_queue_full", "dropped_flush_failed", "dropped_shutdown"],
+)
+def test_observation_records_counts_each_outcome_separately(result: str) -> None:
+    """A lossy stream whose loss rate is unknown cannot support a conclusion.
+
+    Each outcome is its own series so overflow (a capacity problem), a failed
+    flush (a platform problem), and a backlog abandoned at shutdown stay
+    distinguishable, and ``result=~"dropped.*"`` still totals the loss.
+    """
+    labels = {"result": result}
+    before = _sample("gateway_observation_records_total", labels)
+
+    OBSERVATION_RECORDS.labels(result=result).inc()
+
+    assert _sample("gateway_observation_records_total", labels) - before == 1.0
+
+
+def test_observation_batch_size_buckets_span_a_full_batch() -> None:
+    """The histogram counts records, not seconds.
+
+    With prometheus_client's default latency buckets (largest finite bound 10),
+    every batch above 10 records lands in +Inf, so a quantile could not tell a
+    batch of 15 from one pinned at max_batch, which is the saturation signal.
+    """
+    before = _sample("gateway_observation_batch_size_bucket", {"le": "500.0"})
+
+    OBSERVATION_BATCH_SIZE.observe(500)
+
+    assert _sample("gateway_observation_batch_size_bucket", {"le": "500.0"}) - before == 1.0
+
+
+def test_observation_flush_metrics_record_size_and_duration() -> None:
+    before_batches = _sample("gateway_observation_batch_size_count")
+    before_flushes = _sample("gateway_observation_flush_duration_seconds_count", {"result": "ok"})
+
+    OBSERVATION_BATCH_SIZE.observe(12)
+    OBSERVATION_FLUSH_DURATION.labels(result="ok").observe(0.25)
+
+    assert _sample("gateway_observation_batch_size_count") - before_batches == 1.0
+    assert _sample("gateway_observation_batch_size_sum") >= 12.0
+    assert _sample("gateway_observation_flush_duration_seconds_count", {"result": "ok"}) - before_flushes == 1.0
 
 
 def test_config_enable_metrics_defaults_to_false() -> None:

--- a/tests/unit/test_lifespan_observation_shipper.py
+++ b/tests/unit/test_lifespan_observation_shipper.py
@@ -1,0 +1,105 @@
+"""The lifespan owns the observation shipper's background flush task.
+
+Producers reach the shipper through ``app.state``, so nothing observes anything
+unless the lifespan builds one, starts its flusher, and publishes it. Shutdown
+matters as much: the shipper is the only thing holding queued records, and its
+final flush is the difference between a clean stop and a lost tail.
+"""
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+
+from gateway.core.config import GatewayConfig
+from gateway.main import _create_lifespan
+from gateway.services.observation_shipper import (
+    NullObservationShipper,
+    ObservationRecord,
+    PlatformObservationShipper,
+)
+
+
+class _RecordingShipper:
+    """An ObservationShipper that logs its own lifecycle."""
+
+    def __init__(self, *, fail_to_start: bool = False) -> None:
+        self.fail_to_start = fail_to_start
+        self.starts = 0
+        self.stops = 0
+
+    def emit(self, record: ObservationRecord) -> None:
+        return None
+
+    async def start(self) -> None:
+        self.starts += 1
+        if self.fail_to_start:
+            raise RuntimeError("flusher would not start")
+
+    async def stop(self) -> None:
+        self.stops += 1
+
+
+def _standalone_config(tmp_path: Path) -> GatewayConfig:
+    return GatewayConfig(
+        database_url=f"sqlite:///{tmp_path / 'lifespan.db'}",
+        master_key="sk-test-master",
+    )
+
+
+@pytest.mark.asyncio
+async def test_lifespan_starts_publishes_and_stops_the_shipper(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shipper = _RecordingShipper()
+    monkeypatch.setattr("gateway.main.create_observation_shipper", lambda _config: shipper)
+    app = FastAPI()
+
+    async with _create_lifespan(_standalone_config(tmp_path))(app):
+        assert shipper.starts == 1
+        assert shipper.stops == 0
+        assert app.state.observation_shipper is shipper
+
+    assert shipper.stops == 1
+
+
+@pytest.mark.asyncio
+async def test_a_shipper_that_fails_to_start_is_not_stopped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mirrors the log writer's guard: there is nothing to stop, and the rest of
+    the shutdown still has to run."""
+    shipper = _RecordingShipper(fail_to_start=True)
+    monkeypatch.setattr("gateway.main.create_observation_shipper", lambda _config: shipper)
+
+    with pytest.raises(RuntimeError, match="flusher would not start"):
+        async with _create_lifespan(_standalone_config(tmp_path))(FastAPI()):
+            pytest.fail("the lifespan should not have yielded")  # pragma: no cover
+
+    assert shipper.starts == 1
+    assert shipper.stops == 0
+
+
+@pytest.mark.asyncio
+async def test_standalone_mode_gets_the_null_shipper(tmp_path: Path) -> None:
+    """No platform to ship to, but producers still emit unconditionally."""
+    app = FastAPI()
+
+    async with _create_lifespan(_standalone_config(tmp_path))(app):
+        assert isinstance(app.state.observation_shipper, NullObservationShipper)
+
+
+@pytest.mark.asyncio
+async def test_hybrid_mode_gets_the_platform_shipper(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
+    config = GatewayConfig(mode="hybrid", platform={"base_url": "http://platform.test/api/v1"})
+    app = FastAPI()
+
+    # Nothing is emitted, so the flusher's first tick finds an empty queue and
+    # the shutdown drain posts nothing: no platform is contacted here.
+    async with _create_lifespan(config)(app):
+        shipper = app.state.observation_shipper
+        assert isinstance(shipper, PlatformObservationShipper)
+        assert shipper.queue_depth == 0

--- a/tests/unit/test_observation_shipper.py
+++ b/tests/unit/test_observation_shipper.py
@@ -1,0 +1,656 @@
+"""The observation shipper's contract: it may lose records, never a request.
+
+A gateway in hybrid mode has no local database, and observation records are
+produced mid-request (the tool loop records a round and immediately calls the
+model again). So the transport is a bounded in-memory queue with a periodic
+background flush, and every one of its failure modes has to end in a lost
+record rather than in a slower or failed request. The tests below pin exactly
+that: emitting never awaits network I/O, an overflowing queue drops instead of
+applying backpressure, any flush failure is swallowed, and the loss is counted.
+
+HTTP is stubbed with ``httpx.MockTransport``, so nothing here needs a platform.
+"""
+
+import asyncio
+import inspect
+import json
+import logging
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger as gateway_logger
+from gateway.metrics import REGISTRY
+from gateway.services import observation_shipper as shipper_module
+from gateway.services.observation_shipper import (
+    OBSERVATION_INGEST_PATH,
+    NullObservationShipper,
+    PlatformObservationShipper,
+    create_observation_shipper,
+)
+
+_BASE_URL = "http://platform.test/api/v1"
+_TOKEN = "gw_test_token"
+
+
+class _Ingest:
+    """A stand-in platform ingest endpoint that records what it was sent."""
+
+    def __init__(self, *, status_code: int = 204, error: Exception | None = None) -> None:
+        self.status_code = status_code
+        self.error = error
+        self.requests: list[httpx.Request] = []
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        if self.error is not None:
+            raise self.error
+        return httpx.Response(self.status_code)
+
+    @property
+    def batches(self) -> list[list[dict[str, object]]]:
+        payloads = [json.loads(request.content.decode()) for request in self.requests]
+        return [payload["records"] for payload in payloads]
+
+    @property
+    def records(self) -> list[dict[str, object]]:
+        return [record for batch in self.batches for record in batch]
+
+
+def _make_shipper(
+    ingest: _Ingest,
+    *,
+    max_queue: int = 1000,
+    max_batch: int = 100,
+    flush_interval_seconds: float = 0.01,
+) -> PlatformObservationShipper:
+    """Build a shipper wired to ``ingest``, flushing fast enough for a test."""
+    return PlatformObservationShipper(
+        base_url=_BASE_URL,
+        gateway_token=_TOKEN,
+        max_queue=max_queue,
+        max_batch=max_batch,
+        flush_interval_seconds=flush_interval_seconds,
+        transport=httpx.MockTransport(ingest),
+    )
+
+
+def _round_record(index: int = 0) -> dict[str, object]:
+    """A loop-round record. Only ``kind`` matters to the transport."""
+    return {"kind": "loop_round", "round_index": index, "fingerprint": f"9f2ac{index}"}
+
+
+def _counter_record() -> dict[str, object]:
+    return {"kind": "request_counter", "request_hash": "1bd0f", "entered_loop": True}
+
+
+def _count(result: str) -> float:
+    return REGISTRY.get_sample_value("gateway_observation_records_total", {"result": result}) or 0.0
+
+
+async def _wait_until(predicate: Callable[[], bool], *, timeout: float = 5.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        if loop.time() >= deadline:
+            raise AssertionError("condition was not met within the timeout")
+        await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_emit_awaits_nothing() -> None:
+    """The strongest form of "nothing on the request path awaits a flush".
+
+    ``emit`` is a plain function, so a producer physically cannot await network
+    I/O through it, whatever the platform is doing.
+    """
+    assert not inspect.iscoroutinefunction(PlatformObservationShipper.emit)
+
+    ingest = _Ingest(error=AssertionError("emit must not post"))
+    shipper = _make_shipper(ingest, flush_interval_seconds=60.0)
+
+    shipper.emit(_round_record())
+
+    assert shipper.queue_depth == 1
+    assert ingest.requests == []
+
+
+@pytest.mark.asyncio
+async def test_a_full_queue_drops_the_new_record_and_counts_it() -> None:
+    ingest = _Ingest()
+    shipper = _make_shipper(ingest, max_queue=2, flush_interval_seconds=60.0)
+    before_dropped = _count("dropped_queue_full")
+    before_queued = _count("queued")
+
+    shipper.emit(_round_record(0))
+    shipper.emit(_round_record(1))
+    shipper.emit(_round_record(2))
+
+    assert shipper.queue_depth == 2
+    assert _count("dropped_queue_full") - before_dropped == 1.0
+    assert _count("queued") - before_queued == 2.0
+
+    # The queue drops the arriving record, keeping the ones already accepted.
+    await shipper.stop()
+    assert [record["round_index"] for record in ingest.records] == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_overflow_never_raises_at_the_producer() -> None:
+    """Backpressure would reach the tool loop as either a block or a raise.
+
+    A queue this small overflows on all but the first record, so an
+    implementation that awaited ``put`` would hang here and one that let
+    ``QueueFull`` escape would fail the loop's round instead of losing a record.
+    """
+    shipper = _make_shipper(_Ingest(), max_queue=1, flush_interval_seconds=60.0)
+
+    async with asyncio.timeout(2):
+        for index in range(500):
+            shipper.emit(_round_record(index))
+
+    assert shipper.queue_depth == 1
+
+
+@pytest.mark.asyncio
+async def test_records_ship_to_the_ingest_endpoint_with_the_gateway_token() -> None:
+    ingest = _Ingest()
+    shipper = _make_shipper(ingest)
+    before_shipped = _count("shipped")
+
+    await shipper.start()
+    try:
+        shipper.emit(_round_record())
+        await _wait_until(lambda: _count("shipped") - before_shipped == 1.0)
+    finally:
+        await shipper.stop()
+
+    request = ingest.requests[0]
+    assert str(request.url) == f"{_BASE_URL}{OBSERVATION_INGEST_PATH}"
+    assert request.method == "POST"
+    assert request.headers["X-Gateway-Token"] == _TOKEN
+    assert request.headers["content-type"] == "application/json"
+    assert json.loads(request.content.decode()) == {"records": [_round_record()]}
+
+
+@pytest.mark.asyncio
+async def test_a_trailing_slash_on_the_base_url_does_not_double_up() -> None:
+    ingest = _Ingest()
+    shipper = PlatformObservationShipper(
+        base_url=f"{_BASE_URL}/",
+        gateway_token=_TOKEN,
+        flush_interval_seconds=0.01,
+        transport=httpx.MockTransport(ingest),
+    )
+
+    await shipper.start()
+    try:
+        shipper.emit(_round_record())
+        await _wait_until(lambda: len(ingest.requests) == 1)
+    finally:
+        await shipper.stop()
+
+    assert str(ingest.requests[0].url) == f"{_BASE_URL}{OBSERVATION_INGEST_PATH}"
+
+
+@pytest.mark.asyncio
+async def test_both_record_kinds_travel_in_one_batch() -> None:
+    """A round record and a request-counter record share the queue and the batch.
+
+    The transport is deliberately blind to the shapes: ``kind`` discriminates
+    them for the platform, not here.
+    """
+    ingest = _Ingest()
+    shipper = _make_shipper(ingest)
+
+    await shipper.start()
+    try:
+        shipper.emit(_round_record(0))
+        shipper.emit(_counter_record())
+        await _wait_until(lambda: len(ingest.records) == 2)
+    finally:
+        await shipper.stop()
+
+    assert [record["kind"] for record in ingest.batches[0]] == ["loop_round", "request_counter"]
+
+
+@pytest.mark.asyncio
+async def test_a_batch_is_capped_at_max_batch() -> None:
+    ingest = _Ingest()
+    shipper = _make_shipper(ingest, max_batch=2)
+
+    await shipper.start()
+    try:
+        for index in range(5):
+            shipper.emit(_round_record(index))
+        await _wait_until(lambda: len(ingest.records) == 5)
+    finally:
+        await shipper.stop()
+
+    assert [len(batch) for batch in ingest.batches] == [2, 2, 1]
+    assert [record["round_index"] for record in ingest.records] == [0, 1, 2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_a_steady_trickle_does_not_turn_the_flusher_into_a_post_loop() -> None:
+    """The drain stops at a partial batch instead of chasing the queue empty.
+
+    A producer only has to queue one record per round trip to keep the next batch
+    non-empty, so a drain that ran until the queue was empty would never return:
+    the flusher would stop sleeping altogether and POST tiny batches back to back,
+    multiplying the request rate to the platform that batching exists to hold down.
+    """
+    ingest = _Ingest()
+
+    async def _slow(request: httpx.Request) -> httpx.Response:
+        await asyncio.sleep(0.02)  # a platform that answers, just not instantly
+        return ingest(request)
+
+    shipper = PlatformObservationShipper(
+        base_url=_BASE_URL,
+        gateway_token=_TOKEN,
+        max_batch=500,
+        flush_interval_seconds=0.1,
+        transport=httpx.MockTransport(_slow),
+    )
+
+    await shipper.start()
+    try:
+        # ~10x more records than there are flush intervals, all well under one batch.
+        for _ in range(50):
+            shipper.emit(_round_record())
+            await asyncio.sleep(0.01)
+    finally:
+        await shipper.stop()
+
+    # 0.5s of production over a 0.1s interval is ~5 ticks; a POST per round trip
+    # would instead be ~25. The bound is loose on purpose: the point is that the
+    # rate tracks the interval, not the record count.
+    assert len(ingest.requests) <= 10, [len(batch) for batch in ingest.batches]
+    assert len(ingest.records) == 50
+
+
+@pytest.mark.parametrize(
+    ("status_code", "error"),
+    [
+        (204, httpx.ReadTimeout("platform too slow")),
+        (204, httpx.ConnectError("platform unreachable")),
+        (500, None),
+        (404, None),
+        (401, None),
+        (204, RuntimeError("something unforeseen")),
+    ],
+    ids=["timeout", "unreachable", "http_500", "http_404", "http_401", "unexpected_error"],
+)
+@pytest.mark.asyncio
+async def test_a_failed_flush_loses_records_and_keeps_shipping(status_code: int, error: Exception | None) -> None:
+    """Every flush failure is swallowed, counted, and survivable.
+
+    The second half is what makes this more than "no exception escaped": the
+    background flusher has to still be running afterwards, or one unreachable
+    platform would end observation shipping for the life of the process.
+    """
+    ingest = _Ingest(status_code=status_code, error=error)
+    shipper = _make_shipper(ingest)
+    before = _count("dropped_flush_failed")
+
+    await shipper.start()
+    try:
+        shipper.emit(_round_record(0))
+        await _wait_until(lambda: _count("dropped_flush_failed") - before == 1.0)
+
+        # The platform recovers; the flusher is still alive to notice.
+        ingest.error = None
+        ingest.status_code = 204
+        shipper.emit(_round_record(1))
+        await _wait_until(lambda: any(record["round_index"] == 1 for record in ingest.records))
+    finally:
+        await shipper.stop()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_flushes_what_is_queued() -> None:
+    """Nothing has flushed yet: the interval is far longer than the test."""
+    ingest = _Ingest()
+    shipper = _make_shipper(ingest, flush_interval_seconds=60.0)
+    before_shipped = _count("shipped")
+
+    await shipper.start()
+    for index in range(3):
+        shipper.emit(_round_record(index))
+    assert ingest.requests == []
+
+    await shipper.stop()
+
+    assert [record["round_index"] for record in ingest.records] == [0, 1, 2]
+    assert _count("shipped") - before_shipped == 3.0
+    assert shipper.queue_depth == 0
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drains_in_batches() -> None:
+    ingest = _Ingest()
+    shipper = _make_shipper(ingest, max_batch=2, flush_interval_seconds=60.0)
+
+    await shipper.start()
+    for index in range(5):
+        shipper.emit(_round_record(index))
+    await shipper.stop()
+
+    assert [len(batch) for batch in ingest.batches] == [2, 2, 1]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_is_safe_without_a_start() -> None:
+    """Startup can fail between constructing the shipper and starting it."""
+    ingest = _Ingest()
+    shipper = _make_shipper(ingest, flush_interval_seconds=60.0)
+    shipper.emit(_round_record())
+
+    await shipper.stop()
+
+    assert len(ingest.records) == 1
+
+
+@pytest.mark.asyncio
+async def test_shutdown_is_bounded_when_the_backlog_outlasts_the_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A slow platform and a deep queue must not hold the process open.
+
+    The budget covers the whole drain, not one batch: without it the drain is
+    worst-case (queue / batch) POSTs long, each waiting out its own timeout, which
+    outlasts any container stop grace and blocks the lifespan behind an
+    observability stream. Every POST here succeeds well inside its own timeout, so
+    only the total is what gives up.
+    """
+    posts = 0
+
+    async def _slow(request: httpx.Request) -> httpx.Response:
+        nonlocal posts
+        posts += 1
+        await asyncio.sleep(0.03)
+        return httpx.Response(204)
+
+    monkeypatch.setattr(shipper_module, "_SHUTDOWN_DRAIN_TIMEOUT_SECONDS", 0.1)
+    shipper = PlatformObservationShipper(
+        base_url=_BASE_URL,
+        gateway_token=_TOKEN,
+        max_batch=1,  # 20 records is 20 POSTs, ~0.6s of work against a 0.1s budget
+        flush_interval_seconds=60.0,
+        timeout_seconds=0.05,
+        transport=httpx.MockTransport(_slow),
+    )
+    before_dropped = _count("dropped_shutdown")
+    before_shipped = _count("shipped")
+
+    await shipper.start()
+    for index in range(20):
+        shipper.emit(_round_record(index))
+
+    async with asyncio.timeout(5):
+        await shipper.stop()
+
+    shipped = _count("shipped") - before_shipped
+    dropped = _count("dropped_shutdown") - before_dropped
+    assert posts > 0, "the drain should have shipped what it had time for"
+    assert dropped > 0, "and given up on the rest rather than run to completion"
+    assert shipped + dropped == 20, "every record is either shipped or counted as lost"
+    assert shipper.queue_depth == 0
+
+
+@pytest.mark.asyncio
+async def test_shutdown_is_bounded_when_the_platform_hangs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hung platform must not hold the process open.
+
+    The budget is the floor or one batch's timeout, whichever is larger, so a
+    per-batch timeout below the floor leaves the floor in charge.
+    """
+    hang_started = asyncio.Event()
+
+    async def _hang(request: httpx.Request) -> httpx.Response:
+        hang_started.set()
+        await asyncio.sleep(30)
+        return httpx.Response(204)  # pragma: no cover - the drain gives up first
+
+    monkeypatch.setattr(shipper_module, "_SHUTDOWN_DRAIN_TIMEOUT_SECONDS", 0.1)
+    shipper = PlatformObservationShipper(
+        base_url=_BASE_URL,
+        gateway_token=_TOKEN,
+        flush_interval_seconds=60.0,
+        timeout_seconds=0.05,
+        transport=httpx.MockTransport(_hang),
+    )
+    before = _count("dropped_shutdown")
+
+    await shipper.start()
+    shipper.emit(_round_record(0))
+    shipper.emit(_round_record(1))
+
+    async with asyncio.timeout(5):
+        await shipper.stop()
+
+    assert hang_started.is_set()
+    assert _count("dropped_shutdown") - before == 2.0
+    assert shipper.queue_depth == 0
+
+
+def test_the_drain_budget_covers_at_least_one_batch_timeout() -> None:
+    """An operator widening the per-batch timeout widens the drain with it.
+
+    Otherwise a legal ``observation_timeout_ms`` above the budget would make the
+    final flush structurally unable to complete even one batch, and the whole
+    queue would be abandoned on every shutdown.
+    """
+    generous = PlatformObservationShipper(
+        base_url=_BASE_URL, gateway_token=_TOKEN, timeout_seconds=30.0
+    )
+    assert generous._shutdown_drain_seconds == 30.0
+
+    modest = PlatformObservationShipper(base_url=_BASE_URL, gateway_token=_TOKEN, timeout_seconds=1.0)
+    assert modest._shutdown_drain_seconds == shipper_module._SHUTDOWN_DRAIN_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_a_flush_in_flight_at_shutdown_is_delivered_not_cancelled() -> None:
+    """Cancelling the flusher first would throw away a batch it was mid-way through.
+
+    The platform is healthy and the drain budget untouched, so those records have
+    somewhere to go; a shutdown that discards them loses up to ``max_batch``
+    records on every graceful restart of a busy replica.
+    """
+    in_flight = asyncio.Event()
+    release = asyncio.Event()
+    ingest = _Ingest()
+
+    async def _slow(request: httpx.Request) -> httpx.Response:
+        in_flight.set()
+        await release.wait()
+        return ingest(request)
+
+    shipper = PlatformObservationShipper(
+        base_url=_BASE_URL,
+        gateway_token=_TOKEN,
+        flush_interval_seconds=0.01,
+        transport=httpx.MockTransport(_slow),
+    )
+    before_shipped = _count("shipped")
+    before_dropped = _count("dropped_shutdown")
+
+    await shipper.start()
+    for index in range(3):
+        shipper.emit(_round_record(index))
+    await asyncio.wait_for(in_flight.wait(), timeout=5)
+
+    stop = asyncio.create_task(shipper.stop())
+    await asyncio.sleep(0.05)  # stop() lands while the POST is still open
+    release.set()
+    async with asyncio.timeout(5):
+        await stop
+
+    assert _count("shipped") - before_shipped == 3.0
+    assert _count("dropped_shutdown") - before_dropped == 0.0
+    assert [record["round_index"] for record in ingest.records] == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_the_shutdown_warning_counts_the_records_lost_in_flight(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The queue's remainder alone under-reports the loss.
+
+    A batch cancelled mid-POST is already off the queue, so a warning counting
+    only what is left behind reads ``0 record(s) dropped`` on the common path,
+    while the counter records the real loss.
+    """
+
+    async def _hang(request: httpx.Request) -> httpx.Response:
+        await asyncio.sleep(30)
+        return httpx.Response(204)  # pragma: no cover - the drain gives up first
+
+    monkeypatch.setattr(shipper_module, "_SHUTDOWN_DRAIN_TIMEOUT_SECONDS", 0.1)
+    shipper = PlatformObservationShipper(
+        base_url=_BASE_URL,
+        gateway_token=_TOKEN,
+        max_batch=4,
+        flush_interval_seconds=60.0,
+        timeout_seconds=0.1,
+        transport=httpx.MockTransport(_hang),
+    )
+    before = _count("dropped_shutdown")
+
+    await shipper.start()
+    for index in range(4):
+        shipper.emit(_round_record(index))
+
+    # The ``gateway`` logger does not propagate (log_config sets propagate=False),
+    # so caplog's handler goes on it directly rather than on root.
+    gateway_logger.addHandler(caplog.handler)
+    caplog.set_level(logging.WARNING, logger=gateway_logger.name)
+    try:
+        async with asyncio.timeout(5):
+            await shipper.stop()
+    finally:
+        gateway_logger.removeHandler(caplog.handler)
+
+    assert _count("dropped_shutdown") - before == 4.0
+    gave_up = [record.getMessage() for record in caplog.records if "gave up draining" in record.getMessage()]
+    assert gave_up and "4 record(s) dropped" in gave_up[0], gave_up
+
+
+@pytest.mark.asyncio
+async def test_shutdown_stays_bounded_when_records_outlive_the_in_flight_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The budget has to cover both halves of the shutdown, not just the first.
+
+    Waiting on the flusher with a bare ``await task`` hands the budget's
+    cancellation to the flusher, which handles CancelledError and so completes
+    normally: the timeout is spent without ever raising, and the drain that
+    follows runs with a deadline that can no longer fire. That only shows up when
+    records are still queued behind the in-flight batch, since an empty queue
+    makes the second drain a no-op and hides it.
+    """
+    hang = asyncio.Event()
+
+    async def _hang_forever(request: httpx.Request) -> httpx.Response:
+        hang.set()
+        await asyncio.sleep(30)
+        return httpx.Response(204)  # pragma: no cover - the drain gives up first
+
+    monkeypatch.setattr(shipper_module, "_SHUTDOWN_DRAIN_TIMEOUT_SECONDS", 0.3)
+    shipper = PlatformObservationShipper(
+        base_url=_BASE_URL,
+        gateway_token=_TOKEN,
+        max_batch=5,
+        flush_interval_seconds=0.05,
+        timeout_seconds=0.1,
+        transport=httpx.MockTransport(_hang_forever),
+    )
+    before = _count("dropped_shutdown")
+
+    await shipper.start()
+    for index in range(5):
+        shipper.emit(_round_record(index))
+    await asyncio.wait_for(hang.wait(), timeout=5)  # that batch is now in flight
+    for index in range(5, 15):
+        shipper.emit(_round_record(index))  # and these are queued behind it
+
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    await shipper.stop()
+    elapsed = loop.time() - started
+
+    assert elapsed < 3.0, f"stop() ran {elapsed:.1f}s against a {shipper._shutdown_drain_seconds}s budget"
+    assert _count("dropped_shutdown") - before == 15.0
+    assert shipper.queue_depth == 0
+
+
+@pytest.mark.asyncio
+async def test_stop_is_idempotent() -> None:
+    shipper = _make_shipper(_Ingest())
+
+    await shipper.start()
+    await shipper.stop()
+    await shipper.stop()
+
+
+@pytest.mark.asyncio
+async def test_the_null_shipper_discards_everything() -> None:
+    """Producers emit unconditionally, so standalone mode needs a silent sink."""
+    shipper = NullObservationShipper()
+
+    await shipper.start()
+    shipper.emit(_round_record())
+    await shipper.stop()
+
+
+def test_create_observation_shipper_is_null_in_standalone_mode() -> None:
+    config = GatewayConfig(mode="standalone")
+
+    assert isinstance(create_observation_shipper(config), NullObservationShipper)
+
+
+def test_create_observation_shipper_is_null_without_a_platform_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Defensive: ``load_config`` fills the base URL in, a hand-built config may not."""
+    monkeypatch.setenv("OTARI_AI_TOKEN", _TOKEN)
+    config = GatewayConfig(mode="hybrid", platform={})
+
+    assert config.is_hybrid_mode
+    assert isinstance(create_observation_shipper(config), NullObservationShipper)
+
+
+def test_create_observation_shipper_reads_the_platform_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTARI_AI_TOKEN", _TOKEN)
+    config = GatewayConfig(
+        mode="hybrid",
+        platform={
+            "base_url": _BASE_URL,
+            "observation_max_queue": 42,
+            "observation_max_batch": 7,
+            "observation_flush_interval_ms": 1500,
+            "observation_timeout_ms": 2500,
+        },
+    )
+
+    shipper = create_observation_shipper(config)
+
+    assert isinstance(shipper, PlatformObservationShipper)
+    assert shipper.max_queue == 42
+    assert shipper.max_batch == 7
+    assert shipper.flush_interval_seconds == 1.5
+    assert shipper.timeout_seconds == 2.5
+
+
+def test_create_observation_shipper_defaults_the_unset_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTARI_AI_TOKEN", _TOKEN)
+    config = GatewayConfig(mode="hybrid", platform={"base_url": _BASE_URL})
+
+    shipper = create_observation_shipper(config)
+
+    assert isinstance(shipper, PlatformObservationShipper)
+    assert shipper.max_queue == shipper_module.DEFAULT_MAX_QUEUE
+    assert shipper.max_batch == shipper_module.DEFAULT_MAX_BATCH

--- a/tests/unit/test_platform_observation_config.py
+++ b/tests/unit/test_platform_observation_config.py
@@ -1,0 +1,91 @@
+"""Validation of the observation transport settings in ``GatewayConfig``.
+
+The four knobs size the bounded queue the observation shipper flushes from.
+Each has to be positive: a zero or negative bound would make the queue reject
+every record, a zero batch would flush nothing forever, and a non-positive
+interval or timeout would spin or abandon every flush. Rejecting them at
+config-load time keeps a typo from turning the stream silently empty, which is
+indistinguishable from "nothing was observable" in the report the stream feeds.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from gateway.core.config import GatewayConfig
+
+
+def test_valid_observation_settings_are_accepted() -> None:
+    config = GatewayConfig(
+        platform={
+            "observation_max_queue": 20000,
+            "observation_max_batch": 250,
+            "observation_flush_interval_ms": 2000,
+            "observation_timeout_ms": 3000,
+        }
+    )
+
+    assert config.platform["observation_max_queue"] == 20000
+    assert config.platform["observation_max_batch"] == 250
+    assert config.platform["observation_flush_interval_ms"] == 2000
+    assert config.platform["observation_timeout_ms"] == 3000
+
+
+def test_absent_observation_settings_are_accepted() -> None:
+    """Unset is the normal case: the shipper owns the defaults."""
+    config = GatewayConfig(platform={"base_url": "http://platform/api/v1"})
+
+    assert "observation_max_queue" not in config.platform
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "observation_max_queue",
+        "observation_max_batch",
+        "observation_flush_interval_ms",
+        "observation_timeout_ms",
+    ],
+)
+@pytest.mark.parametrize("bad_value", [0, -1, -5000])
+def test_non_positive_observation_setting_is_rejected(key: str, bad_value: int) -> None:
+    with pytest.raises(ValidationError, match=f"{key} must be > 0"):
+        GatewayConfig(platform={key: bad_value})
+
+
+@pytest.mark.parametrize("key", ["observation_max_queue", "observation_max_batch"])
+@pytest.mark.parametrize("bad_value", [0.5, 0.9, 250.5])
+def test_a_fractional_record_count_is_rejected(key: str, bad_value: float) -> None:
+    """The shipper sizes a queue and a batch with these, via ``int()``.
+
+    A fraction below 1 truncates to 0, and ``asyncio.Queue(maxsize=0)`` is
+    unbounded, so a bound of 0.5 would accept records without limit: the one
+    property the transport is built around, inverted by a typo.
+    """
+    with pytest.raises(ValidationError, match=f"{key} must be a whole number of records"):
+        GatewayConfig(platform={key: bad_value})
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "observation_max_queue",
+        "observation_max_batch",
+        "observation_flush_interval_ms",
+        "observation_timeout_ms",
+    ],
+)
+def test_an_empty_observation_setting_is_rejected_by_key(key: str) -> None:
+    """An empty YAML value (``observation_timeout_ms:``) parses to None.
+
+    ``float(None)`` raises TypeError, which pydantic does not convert into a
+    ValidationError, so this used to escape config load as a bare traceback that
+    named no field.
+    """
+    with pytest.raises(ValidationError, match=f"{key} must be a number"):
+        GatewayConfig(platform={key: None})
+
+
+def test_a_bad_observation_setting_does_not_mask_a_streaming_one() -> None:
+    """One validator covers both key sets, so neither shadows the other."""
+    with pytest.raises(ValidationError, match="streaming_first_chunk_timeout_ms must be > 0"):
+        GatewayConfig(platform={"streaming_first_chunk_timeout_ms": 0, "observation_max_batch": 100})


### PR DESCRIPTION
## Description

Adds the transport for Reprise v0 observation records (one per tool-loop round, one per request). A hybrid-mode gateway has no local database, so there is nowhere on the box to keep them, and they are produced mid-request: an inline POST would compete for the event loop and connection pool with the request it is measuring.

So: a bounded in-memory queue plus a periodic background flush, batching to `POST {platform}/gateway/loop-observations` (served by mozilla-ai/otari-ai#1487). Neither existing mechanism fits. `BatchLogWriter` has the right shape but an unbounded queue; `_report_platform_usage` retries per request, which is right for billing data and wrong for disposable measurement data.

Nothing is wired to it yet. The producers land in mozilla-ai/otari-ai#1484 and mozilla-ai/otari-ai#1485, so this is transport plus `/metrics` only.

- **`emit` is a plain function, not a coroutine**, so a producer physically cannot reach the network through it. Its body is a `put_nowait`; a full queue drops the arriving record and counts it rather than applying backpressure.
- **Every failure loses records, never a request.** Timeout, 5xx, 404 from a peer without the endpoint, 401: each drops the batch, counts it, and leaves the flusher alive. Nothing is retried, since a retry would compete with the traffic being measured.
- **The drain empties the queue in `max_batch` chunks per tick**, so a backlog clears at the platform's pace, not one batch per interval.
- **Shutdown drains under a 5s total budget.** Unbounded it is worst-case `(queue / batch)` POSTs long, outlasting any stop grace and blocking uvicorn's lifespan behind an observability stream. The remainder is counted `dropped_shutdown`.
- **Loss is counted per cause**, since an unknown loss rate cannot support a measurement conclusion: `gateway_observation_queue_depth`, plus `gateway_observation_records_total{result=...}` over `queued` / `shipped` / `dropped_queue_full` / `dropped_flush_failed` / `dropped_shutdown`, and batch-size and flush-duration histograms.
- **`NullObservationShipper` in standalone mode**, so producers emit unconditionally; the lifespan owns one shipper per worker on `app.state`.
- The shipper builds its own platform URL and pooled client instead of reusing `_platform_url` / `_post_platform`, which live in the API layer that `check_architecture.py` forbids a service to import. That duplicates a two-token expression; the tidy-up would move the helper into `core/`.

Four knobs size the queue (10000 records / 500 per batch / 5s interval / 5s timeout), validated positive at load: every zero-value leaves the stream silently empty, which reads as "nothing was observable" rather than as a misconfiguration.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Closes mozilla-ai/otari-ai#1483. Issues are fully qualified throughout: a bare `#1483` here would resolve to an unrelated issue in this repo.

Follow-ups: mozilla-ai/otari-ai#1711 (the M4 ledger row, see below) and mozilla-ai/otari-ai#1712 (an operator off switch; the `PLATFORM_OBSERVATION_*` knobs only size the queue, and #1483 was scoped to transport).

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec. No route changed; `make openapi-check` and `make postman-check` confirm no drift.
- [ ] If this PR adds or changes a persistent table, a control-plane contract the otari.ai platform consumes or serves, a capability the platform also has, or a mode-specific surface, I appended an entry to the M4 reconciliation ledger ([otari-ai#1587](https://github.com/mozilla-ai/otari-ai/issues/1587)).

**Unchecked deliberately:** this does add a control-plane contract, so the row is owed. The append is a comment on an existing issue, which the session that wrote this branch could not make, so it is tracked as mozilla-ai/otari-ai#1711 rather than silently skipped.

## Verification

On this exact tree: unit suite 1817 passed / 7 skipped; `make lint`, `make typecheck` (`mypy --strict`), `make openapi-check`, `make postman-check`, and the OSS-edition smoke gate all pass. Pre-rebase: integration suite 1199 passed against real PostgreSQL, and a wheel build. The rebase pulled in only dashboard and CI commits with no file overlap, so CI is the confirmation for those two.

Beyond tests, the app ran in hybrid mode against a stub platform on a real socket: emits queue with nothing posted and `/metrics` showing the depth; the flush posts one batch carrying `X-Gateway-Token`; the bound drops exactly the records past it and the backlog drains in batches of at most `max_batch`; shutdown flushes the tail; against a dead platform records count as `dropped_flush_failed` while `/health` still answers 200.

No browser verification applies: gateway-internal transport plus `/metrics`, no dashboard code touched.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

Verified against a real gateway process and a stub platform, not on test output alone. The five commits are split so each is independently green on lint, typecheck, and tests.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds hybrid-mode transport for gateway observation records.

- Queues records in memory and sends them in bounded batches.
- Handles queue overflow and transport failures without affecting requests.
- Drains queued records during shutdown within a five-second limit.
- Adds observation metrics for queue depth, outcomes, batch size, and flush duration.
- Adds configuration validation and environment-variable support.
- Uses `NullObservationShipper` in standalone mode.
- Documents the ingest endpoint, payloads, failure behavior, and configuration.
- Adds comprehensive unit and integration tests.

Observation producers are not included in this change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->