### PR TITLE
feat(hybrid): initialize a local database and a shadow caller identity

### DIFF
--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -360,7 +360,19 @@ async def verify_api_key_or_master_key(
 async def get_db_if_needed(
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> AsyncGenerator[AsyncSession | None, None]:
-    """Get a database session in standalone mode, otherwise return None."""
+    """Get a database session in standalone mode, otherwise return None.
+
+    Deliberately still keyed on ``is_hybrid_mode`` rather than whether a
+    database is initialized: hybrid mode does initialize one now (#1643's
+    gateway survivals need it for a shadow identity, see
+    ``platform_identity.ensure_local_user``), but a couple dozen call sites
+    across ``_pipeline.py`` use ``ctx.db is None`` as their own implicit "are
+    we in hybrid mode" gate (budget reservation, usage logging, tool-pricing
+    enforcement). Widening what this yields would silently reactivate every
+    one of them for hybrid traffic. Code that needs the hybrid-mode database
+    opens its own session with ``create_session()`` instead of going through
+    this dependency.
+    """
     if config.is_hybrid_mode:
         yield None
         return

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -93,6 +93,7 @@ from gateway.api.routes._tools import (
     declares_native_web_search,
 )
 from gateway.core.config import GatewayConfig
+from gateway.core.database import create_session
 from gateway.core.env import otari_env
 from gateway.core.usage import cache_read_tokens_of, cache_write_1h_tokens_of, cache_write_tokens_of
 from gateway.inflight import track_request
@@ -122,6 +123,7 @@ from gateway.services.mcp_loop import (
 )
 from gateway.services.metered_pricing import calculate_metered_cost
 from gateway.services.model_access import is_model_allowed, model_not_allowed_detail, resolve_request_allowlist
+from gateway.services.platform_identity import ensure_local_user
 from gateway.services.policy_store import resolve_effective_policy
 from gateway.services.pricing_service import (
     GATEWAY_TOOL_PRICING_PROVIDER,
@@ -975,7 +977,9 @@ async def resolve_request_context(
     """Run the shared handler preamble up to (and including) budget pre-debit.
 
     Hybrid mode: extract the caller's bearer token and resolve the routing
-    plan against the platform; no local DB state is touched.
+    plan against the platform. The only local DB write is best-effort:
+    ensuring a shadow ``User`` row exists for the platform's caller identity,
+    when the resolve response carries one (see ``ensure_local_user``).
 
     Standalone mode: validate the API key, resolve the billed user, check the
     rate limit, then reserve the estimated cost. The reservation is taken
@@ -1042,6 +1046,29 @@ async def resolve_request_context(
             route.fallback_enabled,
             resolve_latency_ms,
         )
+        # The resolve response is the only place hybrid mode learns a caller
+        # identity (docs/hybrid-mode-protocol.md's optional user_id). A local
+        # shadow row makes that identity usable by this gateway's own
+        # survival tables (aliases, routing memory, files, batches), which
+        # all FK to users.user_id.
+        #
+        # Deliberately opens its own session via create_session() rather than
+        # using this function's `db` parameter (which stays None in hybrid
+        # mode, unchanged): a couple dozen call sites below key off `ctx.db
+        # is None` as their own implicit "are we in hybrid mode" gate (budget
+        # reservation, usage logging, tool-pricing enforcement), and handing
+        # them a real session here would silently reactivate every one of
+        # them for hybrid traffic. This write is isolated on purpose.
+        #
+        # A peer that omits the field, or a failure creating the shadow row,
+        # both degrade to user_id=None (today's behavior) rather than failing
+        # an otherwise-servable request.
+        if route.user_id is not None:
+            try:
+                async with create_session() as identity_db:
+                    user_id = await ensure_local_user(identity_db, route.user_id)
+            except SQLAlchemyError:
+                logger.warning("Failed to ensure local shadow user for platform identity", exc_info=True)
     else:
         if db is None:
             raise adapter.error(500, DB_UNAVAILABLE_DETAIL, ErrorKind.API)

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -233,10 +233,20 @@ def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
         price_refresher: asyncio.Task[None] | None = None
         discovery_refresher: asyncio.Task[None] | None = None
         catalog_refresher: asyncio.Task[None] | None = None
+        # Every mode initializes a database as of #1643's gateway survivals:
+        # aliases, routing memory, router preferences, files, and batches all
+        # need one in hybrid mode too, not just standalone. Hybrid mode's
+        # init is deliberately request-plane-only: it runs migrations against
+        # the same linear Alembic chain (unused management tables stay
+        # empty), but skips every startup step below that belongs to a local
+        # management API hybrid mode does not have (master key, dashboard
+        # sessions, provider/pricing overlays, discovery, alias/policy
+        # loading). Alias loading joins this branch in a later phase, once
+        # hybrid mode actually resolves aliases (see _pipeline.py).
+        init_db(config)
         if config.is_hybrid_mode:
             log_writer = NoopLogWriter()
         else:
-            init_db(config)
             async with create_session() as session:
                 # Persisted dashboard overrides win over config/env; apply them
                 # before pricing init so default-pricing behavior is consistent.

--- a/src/gateway/services/platform_identity.py
+++ b/src/gateway/services/platform_identity.py
@@ -1,0 +1,68 @@
+"""Bridge a platform-supplied caller identity onto a local shadow ``User`` row.
+
+Hybrid mode has no local user directory; the platform is the identity
+authority there. But this gateway's own survival tables (``model_aliases``,
+``routing_policies``, ``routing_memory``, ``router_preferences``,
+``file_objects``, ``batches``) all carry a foreign key to ``users.user_id``,
+four of them ``NOT NULL``, so keying anything on a hybrid caller's identity
+needs a local row for that key to point at. This module creates that row on
+first sight of a platform ``user_id`` and never touches it again: a shadow row
+is deliberately not synchronized with the platform user's alias, blocked
+status, or anything else the platform owns.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.models.entities import User
+
+# Provenance marker distinguishing a platform-originated shadow row from one
+# an operator created directly (standalone /v1/users), so a future
+# re-parenting pass (see otari-ai#1643's fan-out) can tell them apart.
+SHADOW_USER_ORIGIN = "platform"
+
+# In-process cache of platform user ids already known to have a local row.
+# A write-through set, not a TTL cache like alias_service's: a shadow row is
+# created once and never edited or deleted, so there is nothing to
+# invalidate and no refresher to converge sibling workers on.
+_known_user_ids: set[str] = set()
+
+
+async def ensure_local_user(db: AsyncSession, platform_user_id: str) -> str:
+    """Idempotently ensure a local ``User`` row exists for a platform identity.
+
+    Returns ``platform_user_id`` unchanged; the point of this call is the
+    side effect, and the return value only saves the caller a redundant
+    variable. Race-safe under concurrent first requests for the same
+    identity: the write is a dialect-native "insert, do nothing on conflict"
+    rather than a check-then-insert, so two workers racing to create the same
+    row never raise a duplicate-key error into a request path.
+    """
+    if platform_user_id in _known_user_ids:
+        return platform_user_id
+
+    dialect_name = db.bind.dialect.name if db.bind is not None else ""
+    insert_stmt = pg_insert if dialect_name == "postgresql" else sqlite_insert
+    stmt = (
+        insert_stmt(User)
+        .values(
+            user_id=platform_user_id,
+            budget_id=None,
+            blocked=False,
+            allowed_models=None,
+            metadata_={"origin": SHADOW_USER_ORIGIN},
+        )
+        .on_conflict_do_nothing(index_elements=[User.user_id])
+    )
+    await db.execute(stmt)
+    await db.commit()
+    _known_user_ids.add(platform_user_id)
+    return platform_user_id
+
+
+def reset_known_user_cache() -> None:
+    """Clear the in-process cache. Test-only; nothing in production needs this."""
+    _known_user_ids.clear()

--- a/tests/integration/test_agent_telemetry_read.py
+++ b/tests/integration/test_agent_telemetry_read.py
@@ -8,6 +8,7 @@ normally fills those tables.
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -433,9 +434,15 @@ def test_read_endpoints_require_the_master_key(client: TestClient, path: str) ->
 
 
 @pytest.mark.parametrize("path", [SUMMARY_PATH, COUNT_PATH, SERIES_PATH])
-def test_read_endpoints_are_absent_in_hybrid_mode(monkeypatch: pytest.MonkeyPatch, path: str) -> None:
+def test_read_endpoints_are_absent_in_hybrid_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, path: str
+) -> None:
     monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
-    config = GatewayConfig(mode="hybrid", platform={"base_url": "http://localhost:8100/api/v1"})
+    config = GatewayConfig(
+        mode="hybrid",
+        database_url=f"sqlite:///{tmp_path / 'hybrid-telemetry.db'}",
+        platform={"base_url": "http://localhost:8100/api/v1"},
+    )
     app = create_app(config)
 
     with TestClient(app) as hybrid_client:

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -1,4 +1,5 @@
 from collections.abc import Generator
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -19,11 +20,16 @@ from gateway.main import create_app
 
 
 @pytest.fixture
-def platform_client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient]:
+def platform_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient]:
     monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
     app = create_app(
         GatewayConfig(
             mode="hybrid",
+            # Hybrid mode initializes a database now (see #1643's gateway
+            # survivals); an isolated per-test file keeps every test in this
+            # module from sharing state through a default ./otari.db in the
+            # working directory.
+            database_url=f"sqlite:///{tmp_path / 'hybrid.db'}",
             platform={"base_url": "http://platform.test/api/v1"},
         )
     )

--- a/tests/integration/test_hybrid_mode_messages.py
+++ b/tests/integration/test_hybrid_mode_messages.py
@@ -13,6 +13,7 @@ the chat suite.
 from __future__ import annotations
 
 from collections.abc import Generator
+from pathlib import Path
 from typing import Any, cast
 
 import httpx
@@ -31,11 +32,15 @@ from gateway.main import create_app
 
 
 @pytest.fixture
-def platform_client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient]:
+def platform_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient]:
     monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
     app = create_app(
         GatewayConfig(
             mode="hybrid",
+            # Hybrid mode initializes a database now (see #1643's gateway
+            # survivals); an isolated per-test file keeps every test in this
+            # module from sharing state through a default ./otari.db.
+            database_url=f"sqlite:///{tmp_path / 'hybrid.db'}",
             platform={"base_url": "http://platform.test/api/v1"},
         )
     )

--- a/tests/integration/test_hybrid_mode_responses.py
+++ b/tests/integration/test_hybrid_mode_responses.py
@@ -9,6 +9,7 @@ single-attempt collapsed form; pre-lock-in fallback for tool-loop is gated on
 from __future__ import annotations
 
 from collections.abc import Generator
+from pathlib import Path
 from typing import Any, cast
 
 import httpx
@@ -25,11 +26,15 @@ from gateway.main import create_app
 
 
 @pytest.fixture
-def platform_client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient]:
+def platform_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient]:
     monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
     app = create_app(
         GatewayConfig(
             mode="hybrid",
+            # Hybrid mode initializes a database now (see #1643's gateway
+            # survivals); an isolated per-test file keeps every test in this
+            # module from sharing state through a default ./otari.db.
+            database_url=f"sqlite:///{tmp_path / 'hybrid.db'}",
             platform={"base_url": "http://platform.test/api/v1"},
         )
     )

--- a/tests/integration/test_hybrid_mode_surface.py
+++ b/tests/integration/test_hybrid_mode_surface.py
@@ -1,5 +1,8 @@
+from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import OperationalError
 
 from gateway.api.deps import reset_config
 from gateway.core.config import GatewayConfig
@@ -7,12 +10,32 @@ from gateway.core.database import reset_db
 from gateway.main import create_app
 
 
-def test_hybrid_mode_starts_without_database(monkeypatch: pytest.MonkeyPatch) -> None:
+def _hybrid_database_url(tmp_path: Path) -> str:
+    """An isolated, real SQLite file per test.
+
+    Hybrid mode initializes a database and runs migrations against it now
+    (see #1643); every test in this file needs its own so they don't share
+    state through a default ``./otari.db`` in the working directory.
+    """
+    return f"sqlite:///{tmp_path / 'hybrid.db'}"
+
+
+def test_hybrid_mode_starts_with_a_working_database(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hybrid mode initializes its own local database and runs migrations against it.
+
+    This is the reversal of what this test used to pin (hybrid boots even
+    with an unreachable database): #1643's gateway survivals (aliases,
+    routing memory, router preferences, files, batches) need a shadow
+    identity row to key on, so hybrid mode is no longer database-less. See
+    test_hybrid_mode_fails_to_start_with_an_unreachable_database for the
+    other half of this reversal: a real, working database is now required,
+    the same as standalone.
+    """
     monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
 
     config = GatewayConfig(
         mode="hybrid",
-        database_url="postgresql://127.0.0.1:1/does-not-exist",
+        database_url=_hybrid_database_url(tmp_path),
         platform={"base_url": "http://localhost:8100/api/v1"},
     )
     app = create_app(config)
@@ -30,11 +53,38 @@ def test_hybrid_mode_starts_without_database(monkeypatch: pytest.MonkeyPatch) ->
     reset_db()
 
 
-def test_hybrid_mode_disables_local_management_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_hybrid_mode_fails_to_start_with_an_unreachable_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The other half of the reversal above: hybrid mode now needs a real database.
+
+    Deliberately does not clean up config/db state on the failure path (there
+    is nothing to clean up: init_db never got far enough to set the module
+    globals reset_db() clears), matching how a standalone boot against a bad
+    database_url already fails today.
+    """
     monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
 
     config = GatewayConfig(
         mode="hybrid",
+        database_url="postgresql://127.0.0.1:1/does-not-exist",
+        platform={"base_url": "http://localhost:8100/api/v1"},
+    )
+    app = create_app(config)
+
+    # init_db (and, with auto_migrate on by default, the migration run) fires
+    # on ASGI startup, i.e. when the TestClient context is entered, not at
+    # create_app() itself.
+    with pytest.raises(OperationalError), TestClient(app):
+        pass
+
+    reset_config()
+
+
+def test_hybrid_mode_disables_local_management_endpoints(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
+
+    config = GatewayConfig(
+        mode="hybrid",
+        database_url=_hybrid_database_url(tmp_path),
         platform={"base_url": "http://localhost:8100/api/v1"},
     )
     app = create_app(config)
@@ -59,13 +109,14 @@ def test_hybrid_mode_disables_local_management_endpoints(monkeypatch: pytest.Mon
     reset_db()
 
 
-def test_hybrid_mode_disables_dashboard_management_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_hybrid_mode_disables_dashboard_management_endpoints(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # The admin-dashboard management surface is standalone-only; in hybrid mode
     # it must be unavailable (owned by the platform), with the same helpful hint.
     monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
 
     config = GatewayConfig(
         mode="hybrid",
+        database_url=_hybrid_database_url(tmp_path),
         platform={"base_url": "http://localhost:8100/api/v1"},
     )
     app = create_app(config)
@@ -91,7 +142,7 @@ def test_hybrid_mode_disables_dashboard_management_endpoints(monkeypatch: pytest
     reset_db()
 
 
-def test_hybrid_mode_omits_model_management_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_hybrid_mode_omits_model_management_endpoints(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # models.router is standalone-only (register_routers returns early in hybrid),
     # so the dashboard's model-management reads have no route at all. Guards
     # against re-mounting models.router in hybrid, which would expose them.
@@ -99,6 +150,7 @@ def test_hybrid_mode_omits_model_management_endpoints(monkeypatch: pytest.Monkey
 
     config = GatewayConfig(
         mode="hybrid",
+        database_url=_hybrid_database_url(tmp_path),
         platform={"base_url": "http://localhost:8100/api/v1"},
     )
     app = create_app(config)
@@ -111,7 +163,9 @@ def test_hybrid_mode_omits_model_management_endpoints(monkeypatch: pytest.Monkey
     reset_db()
 
 
-def test_hybrid_mode_root_falls_back_to_tutorial_without_a_bundle(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_hybrid_mode_root_falls_back_to_tutorial_without_a_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     # Hybrid serves the same dashboard bundle as standalone (it renders the
     # data-plane landing page there), so an unbuilt checkout degrades the same
     # way: the get-started tutorial at the root. Pinned with the bundle absent so
@@ -121,6 +175,7 @@ def test_hybrid_mode_root_falls_back_to_tutorial_without_a_bundle(monkeypatch: p
 
     config = GatewayConfig(
         mode="hybrid",
+        database_url=_hybrid_database_url(tmp_path),
         platform={"base_url": "http://localhost:8100/api/v1"},
     )
     app = create_app(config)
@@ -136,7 +191,7 @@ def test_hybrid_mode_root_falls_back_to_tutorial_without_a_bundle(monkeypatch: p
     reset_db()
 
 
-def test_hybrid_mode_health_reports_reachability(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_hybrid_mode_health_reports_reachability(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
 
     async def _reachable(_: GatewayConfig) -> bool:
@@ -146,6 +201,7 @@ def test_hybrid_mode_health_reports_reachability(monkeypatch: pytest.MonkeyPatch
 
     config = GatewayConfig(
         mode="hybrid",
+        database_url=_hybrid_database_url(tmp_path),
         platform={"base_url": "http://localhost:8100/api/v1"},
     )
     app = create_app(config)
@@ -163,7 +219,9 @@ def test_hybrid_mode_health_reports_reachability(monkeypatch: pytest.MonkeyPatch
     reset_db()
 
 
-def test_hybrid_mode_readiness_fails_when_platform_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_hybrid_mode_readiness_fails_when_platform_unreachable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
 
     async def _unreachable(_: GatewayConfig) -> bool:
@@ -173,6 +231,7 @@ def test_hybrid_mode_readiness_fails_when_platform_unreachable(monkeypatch: pyte
 
     config = GatewayConfig(
         mode="hybrid",
+        database_url=_hybrid_database_url(tmp_path),
         platform={"base_url": "http://localhost:8100/api/v1"},
     )
     app = create_app(config)

--- a/tests/integration/test_routing_learned.py
+++ b/tests/integration/test_routing_learned.py
@@ -12,6 +12,7 @@ API, the routing-memory table, the compiler, the attempt walker, and settlement.
 """
 
 from collections.abc import Generator
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -878,13 +879,14 @@ def test_explain_says_the_router_decides_at_request_time(client: TestClient) -> 
     assert body["is_dynamic"] is True
 
 
-def test_a_learned_policy_is_refused_in_hybrid_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_a_learned_policy_is_refused_in_hybrid_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Hybrid mode resolves models upstream, so a local policy name is not a model
     # the platform knows. Guarded here because the router is the newest reason
     # someone might reach for a policy.
     monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
     config = GatewayConfig(
         mode="hybrid",
+        database_url=f"sqlite:///{tmp_path / 'hybrid-learned-policy.db'}",
         platform={"base_url": "http://platform.test/api/v1"},
         routing=RoutingConfig.model_validate(
             {

--- a/tests/integration/test_search_endpoint.py
+++ b/tests/integration/test_search_endpoint.py
@@ -6,6 +6,7 @@ row that makes a search visible in the Activity and Usage views.
 """
 
 import logging
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -464,10 +465,16 @@ def test_search_is_budget_enforced(
     assert resp.status_code == 403
 
 
-def test_search_is_not_registered_in_hybrid_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_search_is_not_registered_in_hybrid_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Search is a standalone-mode surface: hybrid has no local search config."""
     monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
-    app = create_app(GatewayConfig(mode="hybrid", platform={"base_url": "http://localhost:8100/api/v1"}))
+    app = create_app(
+        GatewayConfig(
+            mode="hybrid",
+            database_url=f"sqlite:///{tmp_path / 'hybrid-search.db'}",
+            platform={"base_url": "http://localhost:8100/api/v1"},
+        )
+    )
     try:
         with TestClient(app) as hybrid_client:
             resp = hybrid_client.post("/v1/search/exa-search", json=SEARCH_PAYLOAD)

--- a/tests/unit/test_deployment_bootstrap.py
+++ b/tests/unit/test_deployment_bootstrap.py
@@ -3,7 +3,8 @@
 The shell fetches this before it renders anything, so it decides whether a
 sign-in screen, a management dashboard, or a data-plane landing page is the
 right thing to show. Unit rather than integration because the route reads
-configuration and nothing else: no database, so no PostgreSQL to stand up.
+configuration and nothing else, and the local SQLite database both modes now
+initialize needs no PostgreSQL to stand up.
 """
 
 from pathlib import Path
@@ -28,9 +29,10 @@ def _standalone(tmp_path: Path) -> GatewayConfig:
     )
 
 
-def _hybrid(**platform: str) -> GatewayConfig:
+def _hybrid(tmp_path: Path, **platform: str) -> GatewayConfig:
     return GatewayConfig(
         mode="hybrid",
+        database_url=f"sqlite:///{tmp_path / 'bootstrap-hybrid.db'}",
         platform={"base_url": "http://localhost:8100/api/v1", **platform},
     )
 
@@ -82,9 +84,11 @@ def test_every_surface_names_a_route_the_gateway_mounts(tmp_path: Path) -> None:
         )
 
 
-def test_hybrid_reports_no_session_no_surfaces_and_the_hosted_url(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_hybrid_reports_no_session_no_surfaces_and_the_hosted_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("OTARI_AI_TOKEN", PLATFORM_TOKEN)
-    app = create_app(_hybrid())
+    app = create_app(_hybrid(tmp_path))
 
     with TestClient(app) as client:
         response = client.get("/v1/bootstrap")
@@ -101,10 +105,10 @@ def test_hybrid_reports_no_session_no_surfaces_and_the_hosted_url(monkeypatch: p
     reset_db()
 
 
-def test_hybrid_bootstrap_leaks_no_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_hybrid_bootstrap_leaks_no_secret(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The one route a hybrid gateway serves to an unauthenticated browser."""
     monkeypatch.setenv("OTARI_AI_TOKEN", PLATFORM_TOKEN)
-    app = create_app(_hybrid())
+    app = create_app(_hybrid(tmp_path))
 
     with TestClient(app) as client:
         body = client.get("/v1/bootstrap").text
@@ -115,10 +119,10 @@ def test_hybrid_bootstrap_leaks_no_secret(monkeypatch: pytest.MonkeyPatch) -> No
     reset_db()
 
 
-def test_management_url_is_configurable(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_management_url_is_configurable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """An operator on a staging platform links at that platform, not otari.ai."""
     monkeypatch.setenv("OTARI_AI_TOKEN", PLATFORM_TOKEN)
-    app = create_app(_hybrid(management_url="https://staging.otari.example/"))
+    app = create_app(_hybrid(tmp_path, management_url="https://staging.otari.example/"))
 
     with TestClient(app) as client:
         response = client.get("/v1/bootstrap")
@@ -131,7 +135,7 @@ def test_management_url_is_configurable(monkeypatch: pytest.MonkeyPatch) -> None
 
 @pytest.mark.parametrize("configured", ["javascript:alert(1)", "otari.ai", ""])
 def test_a_management_url_that_is_not_an_http_link_fails_at_startup(
-    monkeypatch: pytest.MonkeyPatch, configured: str
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, configured: str
 ) -> None:
     """The browser turns this into an anchor, so a bad scheme is a startup error.
 
@@ -142,9 +146,9 @@ def test_a_management_url_that_is_not_an_http_link_fails_at_startup(
 
     if configured:
         with pytest.raises(ValueError, match="management_url"):
-            create_app(_hybrid(management_url=configured))
+            create_app(_hybrid(tmp_path, management_url=configured))
     else:
-        app = create_app(_hybrid(management_url=configured))
+        app = create_app(_hybrid(tmp_path, management_url=configured))
         with TestClient(app) as client:
             assert client.get("/v1/bootstrap").json()["management_url"] == "https://otari.ai"
 

--- a/tests/unit/test_platform_identity.py
+++ b/tests/unit/test_platform_identity.py
@@ -1,0 +1,151 @@
+"""Unit tests for platform_identity.ensure_local_user.
+
+Real SQLite engine per test, mirroring test_runtime_settings_service.py's
+pattern: this touches the users table's unique constraint (the PK), which an
+in-memory mock session cannot exercise honestly. Engine creation, use, and
+disposal all happen inside one asyncio.run() per test, so aiosqlite's
+background connection thread is torn down before that call's event loop
+closes (disposing it after would leak the thread into whatever test runs
+next, surfacing as an unrelated "Event loop is closed" warning there).
+"""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
+
+from gateway.models.entities import Base, User
+from gateway.services.platform_identity import (
+    SHADOW_USER_ORIGIN,
+    ensure_local_user,
+    reset_known_user_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache() -> None:
+    reset_known_user_cache()
+
+
+async def _make_engine(tmp_path: Path) -> AsyncEngine:
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'identity.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine
+
+
+def test_ensure_local_user_creates_a_shadow_row(tmp_path: Path) -> None:
+    async def _run() -> User | None:
+        engine = await _make_engine(tmp_path)
+        try:
+            factory = async_sessionmaker(engine, expire_on_commit=False)
+            async with factory() as session:
+                returned_id = await ensure_local_user(session, "plat-user-1")
+                assert returned_id == "plat-user-1"
+            async with factory() as session:
+                found: User | None = await session.scalar(select(User).where(User.user_id == "plat-user-1"))
+                return found
+        finally:
+            await engine.dispose()
+
+    user = asyncio.run(_run())
+    assert user is not None
+    assert user.blocked is False
+    assert user.budget_id is None
+    assert user.allowed_models is None
+    assert user.metadata_ == {"origin": SHADOW_USER_ORIGIN}
+
+
+def test_ensure_local_user_is_idempotent(tmp_path: Path) -> None:
+    """Re-running for the same identity is a no-op, not a duplicate-key error."""
+
+    async def _run() -> int:
+        engine = await _make_engine(tmp_path)
+        try:
+            factory = async_sessionmaker(engine, expire_on_commit=False)
+            async with factory() as session:
+                await ensure_local_user(session, "plat-user-2")
+            reset_known_user_cache()  # force past the in-process cache, onto the DB path
+            async with factory() as session:
+                await ensure_local_user(session, "plat-user-2")
+            async with factory() as session:
+                rows = (await session.scalars(select(User).where(User.user_id == "plat-user-2"))).all()
+                return len(rows)
+        finally:
+            await engine.dispose()
+
+    assert asyncio.run(_run()) == 1
+
+
+def test_ensure_local_user_concurrent_first_use_does_not_raise(tmp_path: Path) -> None:
+    """Two requests racing to create the same identity's shadow row must not
+    surface a duplicate-key error into either request; on_conflict_do_nothing
+    is what makes this safe rather than a check-then-insert."""
+
+    async def _run() -> int:
+        engine = await _make_engine(tmp_path)
+        try:
+            factory = async_sessionmaker(engine, expire_on_commit=False)
+
+            async def _ensure() -> None:
+                async with factory() as session:
+                    await ensure_local_user(session, "plat-user-race")
+
+            await asyncio.gather(_ensure(), _ensure())
+            async with factory() as session:
+                rows = (await session.scalars(select(User).where(User.user_id == "plat-user-race"))).all()
+                return len(rows)
+        finally:
+            await engine.dispose()
+
+    assert asyncio.run(_run()) == 1
+
+
+def test_ensure_local_user_does_not_touch_an_existing_operator_created_row(tmp_path: Path) -> None:
+    """A platform identity that happens to collide with an operator-created
+    user (e.g. a standalone user_id an operator later re-parents through the
+    bridge) must not be overwritten: on_conflict_do_nothing leaves it alone."""
+
+    async def _run() -> User | None:
+        engine = await _make_engine(tmp_path)
+        try:
+            factory = async_sessionmaker(engine, expire_on_commit=False)
+            async with factory() as session:
+                session.add(User(user_id="shared-id", alias="operator's user", blocked=True))
+                await session.commit()
+            async with factory() as session:
+                await ensure_local_user(session, "shared-id")
+            async with factory() as session:
+                found: User | None = await session.scalar(select(User).where(User.user_id == "shared-id"))
+                return found
+        finally:
+            await engine.dispose()
+
+    user = asyncio.run(_run())
+    assert user is not None
+    assert user.alias == "operator's user"
+    assert user.blocked is True
+    assert user.metadata_ == {}
+
+
+def test_ensure_local_user_second_call_hits_the_in_process_cache(tmp_path: Path) -> None:
+    """A second call for an already-known identity, within the same process,
+    does no DB work at all: the session is never touched."""
+
+    async def _run() -> None:
+        engine = await _make_engine(tmp_path)
+        try:
+            factory = async_sessionmaker(engine, expire_on_commit=False)
+            async with factory() as session:
+                await ensure_local_user(session, "plat-user-cached")
+            # A closed session would raise if ensure_local_user tried to use
+            # it; reaching the cached branch must never do that.
+            async with factory() as session:
+                await session.close()
+                await ensure_local_user(session, "plat-user-cached")
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_run())

--- a/tests/unit/test_tool_settings_endpoint.py
+++ b/tests/unit/test_tool_settings_endpoint.py
@@ -174,6 +174,7 @@ def _hybrid_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 def test_tool_settings_not_mounted_in_hybrid_mode(tmp_path: Path, _hybrid_env: None) -> None:
     config = GatewayConfig(
         mode="hybrid",
+        database_url=f"sqlite:///{tmp_path / 'hybrid-tool-settings.db'}",
         master_key="sk-test-master",
         platform={"base_url": "https://otari.ai"},
     )

--- a/tests/unit/test_tools_endpoint.py
+++ b/tests/unit/test_tools_endpoint.py
@@ -118,26 +118,23 @@ def test_available_reflects_the_env_url_for_a_pure_env_deployment(
     assert tools["otari_web_search"]["available"] is True
 
 
-def _hybrid_client(monkeypatch: pytest.MonkeyPatch, **overrides: Any) -> TestClient:
-    """A hybrid-mode app: no ``init_db``, so nothing here may touch the local DB."""
+def _hybrid_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, **overrides: Any) -> TestClient:
     monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
     config = GatewayConfig(
         mode="hybrid",
+        database_url=f"sqlite:///{tmp_path / 'hybrid-tools.db'}",
         platform={"base_url": "http://platform.test/api/v1"},
         **overrides,
     )
     return TestClient(create_app(config))
 
 
-def test_not_registered_in_hybrid_mode(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Standalone-only, and a 404 rather than a 500.
-
-    Hybrid mode never initializes the local database, so a route whose auth
-    dependency opens a session would 500 before the handler ran. It is also the
-    wrong answer to give there: the platform owns the per-workspace tool policy, so
-    this gateway's own configuration does not decide what the caller can call.
+def test_not_registered_in_hybrid_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Standalone-only: ``tools.router`` is one of the routers ``register_routers``
+    never mounts in hybrid mode. The platform owns the per-workspace tool policy,
+    so this gateway's own configuration does not decide what the caller can call.
     """
-    with _hybrid_client(monkeypatch, web_search_url="http://searxng:8080") as client:
+    with _hybrid_client(tmp_path, monkeypatch, web_search_url="http://searxng:8080") as client:
         response = client.get("/v1/tools", headers={"Authorization": "Bearer platform-user-token"})
 
     assert response.status_code == 404, response.text


### PR DESCRIPTION
## Description

Hybrid mode now calls `init_db()` (migrations included) the same as standalone, but request-plane-only: it skips every startup step that belongs to a local management API hybrid mode does not have (master key, dashboard sessions, provider/pricing overlays, discovery, alias/policy loading, which joins in a later phase). This is what #1643's gateway survivals (aliases, routing memory, router preferences, files, batches) need: a shadow `platform_identity.ensure_local_user` row keyed on the caller identity the platform's resolve response now carries (mozilla-ai/otari#615 / mozilla-ai/otari-ai#1710), satisfying the `NOT NULL` FK four of those six tables have onto `users.user_id`.

**Deliberately narrow.** `get_db_if_needed` still yields `None` in hybrid mode, unchanged. A first pass wired the shadow-identity write through that shared dependency and it silently broke tool-pricing enforcement (a couple dozen call sites in `_pipeline.py` use `ctx.db is None` as their own implicit "are we in hybrid mode" gate: budget reservation, usage logging, tool-pricing enforcement). Widening what that dependency yields reactivated every one of them for hybrid traffic, turning expected `502`s into `402`s on the sandbox/web-search unreachable-backend tests. The shadow row is written through its own `create_session()` instead, fully isolated from that shared dependency, so nothing else in the request pipeline changes behavior.

**Reverses a previously tested invariant.** `test_hybrid_mode_surface.py` pinned that hybrid mode boots even with an unreachable database. It now requires a real, working one, the same as standalone; the complementary test (`test_hybrid_mode_fails_to_start_with_an_unreachable_database`) is added to pin that reversal explicitly rather than let it happen as a side effect.

**Test hygiene fallout.** Every other test file that boots a hybrid `GatewayConfig` without an explicit `database_url` picked up an isolated `tmp_path` one instead of silently sharing a default `./otari.db` in the working directory across test runs (confirmed one was actually being created and left behind before this fix).

**Nothing observable changes for any caller yet.** Aliases stay inert in hybrid (that's the next phase, #1643) and no new endpoint is reachable.

Rides on the Phase 0 decision request in otari-ai#1717 (proposing this narrowed exception to the M4 spec's "hybrid gateway has no local management state" line). Per direction, proceeding with implementation in parallel with that review.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Refs mozilla-ai/otari-ai#1643

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary (`docs/modes.md` is deliberately **not** touched here: nothing user-observable changes until aliases actually start resolving in hybrid mode next phase; updating it now would describe a future state as present fact).
- [x] If the API contract changed, I regenerated the OpenAPI spec (N/A, no route/schema change).
- [x] If this PR adds or changes a persistent table, a control-plane contract the otari.ai platform consumes or serves, a capability the platform also has, or a mode-specific surface, I appended an entry to the M4 reconciliation ledger ([otari-ai#1587](https://github.com/mozilla-ai/otari-ai/issues/1587), [comment](https://github.com/mozilla-ai/otari-ai/issues/1587#issuecomment-5324920794)). See [.github/instructions/reconciliation-ledger.instructions.md](.github/instructions/reconciliation-ledger.instructions.md).

Local results: ruff, mypy, `check_architecture.py`, `openapi --check`, `postman --check` all clean. Full `tests/unit` (1787 passed) and `tests/integration` (1200 passed) suites pass, plus the OSS-edition smoke script.

## AI Usage

- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Sonnet 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added hybrid-mode database initialization and migrations.
- Created a local shadow user from the platform caller identity.
- Kept hybrid mode limited to request-plane features.
- Preserved existing downstream behavior by keeping `get_db_if_needed` session-free in hybrid mode.
- Added startup validation for unreachable databases.
- Updated tests to use isolated temporary databases and verify shadow-user behavior.

## Benefits

Hybrid mode now has a reliable local identity and database foundation without enabling management features or changing caller-visible endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->