### PR TITLE
feat(reprise): retain the resolved workspace and organization ids

### DIFF
--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -38,11 +38,12 @@ Otari ignores any it does not recognize. Consumers of this contract MUST do the
 same (ignore unknown fields) so the platform can add fields without breaking
 older gateways.
 
-For example, the otari.ai resolve response also carries `workspace_id`,
-`organization_id`, `provider_key_id`, and `allowed_models`. Otari does not read
-these today, so they are intentionally absent from the shapes documented here.
-`user_id` (below) is the one exception: Otari reads it when present, but a
-peer omitting it is exactly as valid as any other unrecognized field.
+For example, the otari.ai resolve response also carries `provider_key_id` and
+`allowed_models`. Otari does not read these today, so they are intentionally
+absent from the shapes documented here. `user_id`, `workspace_id`, and
+`organization_id` (all below) are the exceptions: Otari reads each when
+present, but a peer omitting any of them is exactly as valid as a peer sending
+an unrecognized field.
 
 When the operator points Otari's web-search backend at the platform
 (`OTARI_WEB_SEARCH_URL` under `base_url`), Otari also sends `X-Gateway-Token`
@@ -74,6 +75,8 @@ Content-Type: application/json
   "request_id": "01HXY...",
   "fallback_enabled": true,
   "user_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "workspace_id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d",
+  "organization_id": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
   "attempts": [
     {
       "attempt_id": "01HX1...",
@@ -172,6 +175,16 @@ omitting any other unrecognized field: nothing that reads this field may
 require it. When present, it is Otari's only way to key its own per-caller
 gateway-side state (aliases, routing memory, files, batches) in hybrid mode.
 
+`workspace_id` and `organization_id` (both optional) identify the tenant that
+owns this resolution: the workspace the presented `X-User-Token` belongs to,
+and the organization above it. Both are stable, opaque strings that Otari never
+parses. They are the only tenant Otari sees, because `X-Gateway-Token`
+authenticates the calling gateway and carries no tenant of its own, so nothing
+downstream can recover them after the fact. Both are optional in the same
+fail-open sense as `user_id`: a peer that omits them costs whatever record
+needed a tenant, never the request. Otari records them and does not route on
+them, so neither value can reach a provider call.
+
 ### Response: single-attempt shape
 
 Otari also accepts a flat payload:
@@ -192,7 +205,9 @@ Otari maps this onto a single-attempt route (`attempts = [{...}]`,
 propagate to the client. New platform implementations should prefer the
 multi-attempt shape. `user_id` has no legacy mirror here, the same treatment
 as `extra_params`: a peer old enough to still emit this shape predates the
-field entirely.
+field entirely. `workspace_id` and `organization_id` are read here too, from
+the same top level, since a peer that still answers flat may nonetheless know
+its own tenant.
 
 ### Failure
 

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -129,6 +129,17 @@ class ResolvedRoute(BaseModel):
     # has, so it is what gateway-side survivals (aliases, routing memory,
     # files, batches) can key their state on in a later hybrid-mode phase.
     user_id: str | None = None
+    # The tenant that owns this resolution: the workspace the presented
+    # X-User-Token belongs to, and the organization above it. Both opaque
+    # strings, never parsed. The platform has carried them on its resolve
+    # response all along (see docs/hybrid-mode-protocol.md); keeping them here
+    # is the only way anything downstream can attribute a record to a tenant,
+    # because the gateway token that authenticates the call to the platform
+    # carries no tenant of its own. Absent on a peer that does not send them,
+    # in which case a record that needs them is dropped rather than pooled
+    # into some other tenant's.
+    workspace_id: str | None = None
+    organization_id: str | None = None
 
 
 class _AttemptFailure(NamedTuple):
@@ -546,6 +557,22 @@ async def _resolve_platform_credentials(
     return _parse_resolve_payload(payload)
 
 
+def _tenant_ids(payload: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Read the optional ``(workspace_id, organization_id)`` pair off a resolve
+    payload, tolerating absence.
+
+    Shared by both payload shapes, since the fields sit at the top level in
+    each. A peer that omits them yields ``None`` rather than an error, so
+    resolution is never blocked on a field only recording needs.
+    """
+    workspace_id = payload.get("workspace_id")
+    organization_id = payload.get("organization_id")
+    return (
+        str(workspace_id) if workspace_id is not None else None,
+        str(organization_id) if organization_id is not None else None,
+    )
+
+
 def _parse_resolve_payload(payload: dict[str, Any]) -> ResolvedRoute:
     """Build a ResolvedRoute from either the new attempts-list shape or the
     legacy single-attempt shape.
@@ -572,19 +599,27 @@ def _parse_resolve_payload(payload: dict[str, Any]) -> ResolvedRoute:
             for att in attempts_payload
         ]
         raw_user_id = payload.get("user_id")
+        workspace_id, organization_id = _tenant_ids(payload)
         return ResolvedRoute(
             request_id=str(payload["request_id"]),
             fallback_enabled=bool(payload.get("fallback_enabled", False)),
             attempts=attempts,
             user_id=str(raw_user_id) if raw_user_id is not None else None,
+            workspace_id=workspace_id,
+            organization_id=organization_id,
         )
 
     # Legacy single-attempt shape predates user_id entirely, same treatment as
     # extra_params (see the class docstring above): no legacy mirror to read.
+    # The tenant ids are the exception: they sit at the top level in both
+    # shapes, so a flat-answering peer that knows its tenant still gets read.
     correlation_id = str(payload["correlation_id"])
+    workspace_id, organization_id = _tenant_ids(payload)
     return ResolvedRoute(
         request_id=correlation_id,
         fallback_enabled=False,
+        workspace_id=workspace_id,
+        organization_id=organization_id,
         attempts=[
             ResolvedAttempt(
                 attempt_id=correlation_id,

--- a/tests/unit/test_platform_resolve_payload.py
+++ b/tests/unit/test_platform_resolve_payload.py
@@ -1,14 +1,19 @@
-"""Unit tests for ``_parse_resolve_payload``'s handling of the platform's
-optional caller-identity field (``user_id``).
+"""Unit tests for ``_parse_resolve_payload``'s handling of the optional
+identity fields a peer sends alongside the routing plan: the caller identity
+(``user_id``) and the tenancy pair (``workspace_id``, ``organization_id``).
 
-Covers the three shapes a peer can send: the modern attempts-list shape with
-the field present, the same shape with it absent (an older or non-otari.ai
-peer), and the legacy single-attempt shape, which never carries it.
+Covers the shapes a peer can send: the modern attempts-list shape with the
+fields present, the same shape with them absent (an older or non-otari.ai
+peer), and the legacy single-attempt shape, which carries no ``user_id`` but
+does mirror the tenancy pair. A last test pins the tenancy values as
+recording-only: they must not reach the provider call.
 """
 
 from __future__ import annotations
 
-from gateway.api.routes._platform import _parse_resolve_payload
+from typing import Any
+
+from gateway.api.routes._platform import ResolvedAttempt, _parse_resolve_payload, default_attempt_kwargs
 
 
 def test_parse_resolve_payload_reads_user_id_from_attempts_shape() -> None:
@@ -72,3 +77,122 @@ def test_parse_resolve_payload_legacy_shape_has_no_user_id() -> None:
     route = _parse_resolve_payload(payload)
 
     assert route.user_id is None
+
+
+def test_parse_resolve_payload_reads_tenant_ids_from_attempts_shape() -> None:
+    """The attempts-list shape carries the tenancy pair at the top level, next to request_id."""
+    payload = {
+        "request_id": "req-3",
+        "fallback_enabled": False,
+        "workspace_id": "ws-42",
+        "organization_id": "org-7",
+        "attempts": [
+            {
+                "attempt_id": "a0",
+                "position": 0,
+                "provider": "openai",
+                "model": "gpt-4o",
+                "api_key": "sk-...",
+                "managed": False,
+            }
+        ],
+    }
+
+    route = _parse_resolve_payload(payload)
+
+    assert route.workspace_id == "ws-42"
+    assert route.organization_id == "org-7"
+
+
+def test_parse_resolve_payload_reads_tenant_ids_from_legacy_shape() -> None:
+    """Unlike user_id, the tenancy pair is read off the legacy single-attempt shape too.
+
+    A peer old enough to still answer flat may nonetheless know its own tenant,
+    and a record that ships untenanted is a record the miner throws away.
+    """
+    payload = {
+        "provider": "openai",
+        "model": "gpt-4o-mini",
+        "api_key": "sk-...",
+        "managed": False,
+        "correlation_id": "corr-2",
+        "workspace_id": "ws-42",
+        "organization_id": "org-7",
+    }
+
+    route = _parse_resolve_payload(payload)
+
+    assert route.workspace_id == "ws-42"
+    assert route.organization_id == "org-7"
+
+
+def test_parse_resolve_payload_tolerates_missing_tenant_ids() -> None:
+    """Both shapes must resolve without the pair: no error, both fields None.
+
+    This is the fail-open rule the observation stream runs under. An older peer
+    that omits them costs the record, never the request.
+    """
+    attempts_payload = {
+        "request_id": "req-4",
+        "fallback_enabled": False,
+        "attempts": [
+            {
+                "attempt_id": "a0",
+                "position": 0,
+                "provider": "openai",
+                "model": "gpt-4o",
+                "api_key": "sk-...",
+                "managed": False,
+            }
+        ],
+    }
+    legacy_payload = {
+        "provider": "openai",
+        "model": "gpt-4o-mini",
+        "api_key": "sk-...",
+        "managed": False,
+        "correlation_id": "corr-3",
+    }
+
+    for payload in (attempts_payload, legacy_payload):
+        route = _parse_resolve_payload(payload)
+        assert route.workspace_id is None
+        assert route.organization_id is None
+
+
+def test_tenant_ids_do_not_reach_the_provider_call() -> None:
+    """The tenancy pair is recording-only: it cannot alter an upstream request.
+
+    That holds structurally, because the pair lives on the route and only a
+    ResolvedAttempt feeds the provider kwargs. This pins it, so moving either
+    field onto the attempt (where extra_params is forwarded to the provider
+    client verbatim) fails here instead of silently leaking a tenant id
+    upstream.
+    """
+    payload = {
+        "request_id": "req-5",
+        "fallback_enabled": False,
+        "workspace_id": "ws-42",
+        "organization_id": "org-7",
+        "attempts": [
+            {
+                "attempt_id": "a0",
+                "position": 0,
+                "provider": "openai",
+                "model": "gpt-4o",
+                "api_key": "sk-...",
+                "managed": False,
+            }
+        ],
+    }
+
+    route = _parse_resolve_payload(payload)
+    assert "workspace_id" not in ResolvedAttempt.model_fields
+    assert "organization_id" not in ResolvedAttempt.model_fields
+
+    kwargs = default_attempt_kwargs(route.attempts[0], {"messages": [{"role": "user", "content": "hi"}]})
+    flattened: dict[str, Any] = {**kwargs, **(kwargs.get("client_args") or {})}
+    assert "workspace_id" not in flattened
+    assert "organization_id" not in flattened
+    assert "ws-42" not in str(kwargs)
+    assert "org-7" not in str(kwargs)


### PR DESCRIPTION
## Description

The platform's resolve response has always carried `workspace_id` and `organization_id`, and the gateway read past both: `_parse_resolve_payload` built a `ResolvedRoute` holding only `request_id`, `fallback_enabled`, `attempts`, and (as of #615) `user_id`. This keeps the two it already receives.

- `workspace_id: str | None` and `organization_id: str | None` on `ResolvedRoute`.
- Read off the top level of both payload shapes, the attempts-list one and the legacy flat one. Unlike `user_id`, the tenancy pair does get a legacy mirror: a peer that still answers flat may nonetheless know its own tenant, and a record that ships untenanted is a record the miner discards.
- Absence is tolerated. Both stay `None`, no error, no request impact. That is the fail-open rule the observation stream runs under.

**Why it matters.** Nothing downstream can recover these after the fact. `X-Gateway-Token` authenticates the calling gateway and carries no tenant of its own, and the platform's default gateway token serves every org. Observations carry tool arguments, so pooling every org's together would be a tenancy problem rather than only a measurement one.

**Not a protocol change.** The values already cross the wire. `docs/hybrid-mode-protocol.md` only moves them out of its "fields Otari does not read" list and documents the fail-open semantics; `provider_key_id` and `allowed_models` stay in that list.

They are recording-only, and structurally so: the pair lives on the route, never on a `ResolvedAttempt`, so it cannot reach a provider call. Nothing consumes it yet; the fingerprint that does is mozilla-ai/otari-ai#1648 and the recorder that stamps it is mozilla-ai/otari-ai#1484.

**Tests** (`tests/unit/test_platform_resolve_payload.py`):

- both ids read from the attempts-list shape
- both ids read from the legacy single-attempt shape
- both shapes resolve with the pair omitted: both `None`, no error
- neither id reaches the provider call, pinned against a future move onto `ResolvedAttempt`, whose `extra_params` is forwarded to the provider client verbatim

## PR Type
<!-- Check all that apply -->

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Refs mozilla-ai/otari-ai#1646. That issue lives in the platform repo by design, and its code lands here.

Follow-ups that consume these fields, neither of them in this PR: mozilla-ai/otari-ai#1648 (fingerprint) and mozilla-ai/otari-ai#1484 (recorder).

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). Four unit tests in `tests/unit/test_platform_resolve_payload.py`, one per acceptance criterion on the issue. No integration test: the change is confined to parsing a payload the existing hybrid-mode integration tests already cover end to end.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). `make lint` (architecture check plus Ruff), `make typecheck` (`mypy --strict`, 357 files) and `make openapi-check` are clean. On tests: the full `tests/unit` suite (1786 passed, 9 skipped) and the three hybrid-mode integration suites (66 passed) are green locally; the combined `make test` run over `tests/unit` plus all of `tests/integration` was still finishing when this description was written, so treat the CI `test` job on this head as the authority for it.
- [x] Documentation was updated where necessary. `docs/hybrid-mode-protocol.md`: both fields move out of the "fields Otari does not read" list into the documented resolve shapes, with the fail-open semantics and the legacy-shape mirror spelled out.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). Not applicable, no public route or schema changed; confirmed with `make openapi-check`.
- [x] If this PR adds or changes a persistent table, a control-plane contract the otari.ai platform consumes or serves, a capability the platform also has, or a mode-specific surface, I appended an entry to the M4 reconciliation ledger ([otari-ai#1587](https://github.com/mozilla-ai/otari-ai/issues/1587)). See [.github/instructions/reconciliation-ledger.instructions.md](https://github.com/mozilla-ai/otari/blob/main/.github/instructions/reconciliation-ledger.instructions.md). Entry: https://github.com/mozilla-ai/otari-ai/issues/1587#issuecomment-5326037967, under the "Tenancy and access" row, confirming the existing target rather than changing it.

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5, via Claude Code.

**Any additional AI details you'd like to share:**

Written from the issue's proposed change and acceptance criteria, test-first: the three parsing tests were written and observed failing before the fields existed. The agent also ran `make lint`, `make typecheck`, `make test`, and `make openapi-check` locally, and posted the ledger entry.

Two judgment calls a reviewer may want to weigh in on:

1. The legacy single-attempt shape reads the tenancy pair, which differs from how the immediately preceding `user_id` change (#615) deliberately left that branch alone. The issue asks for both shapes, so that is what this does, with a comment at the branch explaining why the pair is the exception. Dropping the legacy read is a two-line change if you prefer consistency with `user_id`.
2. An earlier draft passed the pair as `**_tenant_ids(payload)` at both call sites. That type-checks, but pydantic ignores an unexpected keyword, so a typo'd key would silently leave the field `None`. It now unpacks a tuple into named keyword arguments so mypy checks each field.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
