### PR TITLE
feat(reprise): per-format normalization hooks for the v0 fingerprint

### DIFF
--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -496,6 +496,39 @@ class FormatAdapter(Protocol, Generic[ResultT, ChunkT]):
         """Prepend tool purpose hints to the format's system/instructions slot."""
         ...
 
+    def client_system_prompt(self, kwargs: dict[str, Any]) -> str:
+        """The caller's own system prompt, normalized, before hint injection.
+
+        Feeds Reprise's ``client_system_hash`` (otari-ai#1647). It lives here
+        rather than in the loop because :meth:`inject_hints` runs at the route
+        layer and every adapter copies before injecting, so this is the last
+        place ``kwargs`` still holds the caller's original text. Each format
+        carries it somewhere else (a top-level ``system``, a leading ``system``
+        or ``developer`` message, ``instructions``) and Anthropic's is a string
+        or a block list, so the accessor normalizes rather than merely reads:
+        see :func:`gateway.core.observation.message_text`. Absent and empty both
+        give ``""``.
+
+        The gateway prepends the hint block for two formats and appends it for
+        the third, so hashing the injected result would never group the same
+        automation across SDKs; the pre-injection text is the only thing they
+        can agree on.
+        """
+        ...
+
+    def first_user_message(self, kwargs: dict[str, Any]) -> str:
+        """The caller's opening turn, normalized. Never a fingerprint input.
+
+        Recorded in the Reprise payload as ``first_user_message_hash``, which
+        #1488 conditions a pile's agreement on, so that a workspace where one
+        automation dominates cannot report the dominant behavior as the pile's.
+        Same per-format problem as :meth:`client_system_prompt`: the opening turn
+        is the first ``user`` message for chat and messages, and ``input`` for
+        responses. The transcript as a whole is deliberately not an input to
+        anything, so a later turn in the same conversation must not move it.
+        """
+        ...
+
     def attempt_kwargs(
         self,
         attempt: ResolvedAttempt,

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -38,6 +38,7 @@ from gateway.api.routes._platform import ResolvedAttempt
 from gateway.api.routes._schema_derive import SESSION_LABEL_DESC, SESSION_LABEL_MAX_LENGTH, derive_request_base
 from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
+from gateway.core.observation import message_text
 from gateway.core.usage import GatewayUsage
 from gateway.log_config import logger
 from gateway.models.guardrails import GuardrailConfig
@@ -231,6 +232,22 @@ class _ChatAdapter:
             **kwargs,
             "messages": inject_purpose_hints(kwargs["messages"], hints, header=header),
         }
+
+    def client_system_prompt(self, kwargs: dict[str, Any]) -> str:
+        # A leading ``developer`` message counts too. ``inject_purpose_hints`` only
+        # merges into ``system`` and otherwise inserts one, so a developer-led
+        # request gets the hint block as a separate message; both roles are the
+        # caller's own prompt as far as the hash is concerned.
+        leading = next(iter(kwargs.get("messages") or []), None)
+        if not isinstance(leading, dict) or leading.get("role") not in {"system", "developer"}:
+            return ""
+        return message_text(leading.get("content"))
+
+    def first_user_message(self, kwargs: dict[str, Any]) -> str:
+        for message in kwargs.get("messages") or []:
+            if isinstance(message, dict) and message.get("role") == "user":
+                return message_text(message.get("content"))
+        return ""
 
     def attempt_kwargs(
         self,

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -44,7 +44,7 @@ from gateway.api.routes._schema_derive import SESSION_LABEL_DESC, SESSION_LABEL_
 from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
 from gateway.core.observation import message_text
-from gateway.core.usage import GatewayUsage
+from gateway.core.usage import GatewayUsage, anthropic_billable_usage, anthropic_cache_write_1h_tokens
 from gateway.log_config import logger
 from gateway.models.guardrails import GuardrailConfig
 from gateway.models.mcp import McpServerConfig
@@ -255,29 +255,9 @@ _ERROR_KIND_TO_ANTHROPIC_TYPE = {
 }
 
 
-def _billable_messages_usage(usage: Any) -> GatewayUsage:
-    """Use per-iteration totals when Anthropic reports compaction sampling."""
-    billable_parts = list(getattr(usage, "iterations", None) or []) or [usage]
-    input_tokens = sum((getattr(part, "input_tokens", None) or 0) for part in billable_parts)
-    output_tokens = sum((getattr(part, "output_tokens", None) or 0) for part in billable_parts)
-    return GatewayUsage(
-        prompt_tokens=input_tokens,
-        completion_tokens=output_tokens,
-        total_tokens=input_tokens + output_tokens,
-        cache_read_tokens=sum(
-            (getattr(part, "cache_read_input_tokens", None) or 0) for part in billable_parts
-        ),
-        cache_write_tokens=sum(
-            (getattr(part, "cache_creation_input_tokens", None) or 0) for part in billable_parts
-        ),
-        cache_write_1h_tokens=sum(_cache_write_1h_tokens(part) for part in billable_parts),
-        cache_tokens_in_prompt=False,
-    )
-
-
 def _messages_stream_usage(event: MessageStreamEvent) -> CompletionUsage | None:
     if isinstance(event, MessageDeltaEvent):
-        return _billable_messages_usage(event.usage)
+        return anthropic_billable_usage(event.usage)
     if isinstance(event, MessageStartEvent):
         usage = event.message.usage
         input_tokens = usage.input_tokens or 0
@@ -290,16 +270,10 @@ def _messages_stream_usage(event: MessageStreamEvent) -> CompletionUsage | None:
                 total_tokens=input_tokens,
                 cache_read_tokens=cache_read,
                 cache_write_tokens=cache_write,
-                cache_write_1h_tokens=_cache_write_1h_tokens(usage),
+                cache_write_1h_tokens=anthropic_cache_write_1h_tokens(usage),
                 cache_tokens_in_prompt=False,
             )
     return None
-
-
-def _cache_write_1h_tokens(usage: Any) -> int:
-    """Read Anthropic's optional 1-hour cache-creation breakdown."""
-    cache_creation = getattr(usage, "cache_creation", None)
-    return getattr(cache_creation, "ephemeral_1h_input_tokens", 0) or 0
 
 
 def _requested_cache_write_ttl(*values: Any) -> Literal["5m", "1h"] | None:
@@ -363,7 +337,7 @@ class _MessagesAdapter:
     def extract_usage(self, result: MessageResponse) -> CompletionUsage | None:
         if not result.usage:
             return None
-        return _billable_messages_usage(result.usage)
+        return anthropic_billable_usage(result.usage)
 
     async def call_provider(self, kwargs: dict[str, Any]) -> MessageResponse:
         return await amessages(**kwargs)  # type: ignore[return-value]

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -43,6 +43,7 @@ from gateway.api.routes._platform import (
 from gateway.api.routes._schema_derive import SESSION_LABEL_DESC, SESSION_LABEL_MAX_LENGTH, derive_request_base
 from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
+from gateway.core.observation import message_text
 from gateway.core.usage import GatewayUsage
 from gateway.log_config import logger
 from gateway.models.guardrails import GuardrailConfig
@@ -419,6 +420,17 @@ class _MessagesAdapter:
         header: str | None,
     ) -> dict[str, Any]:
         return inject_purpose_hints_anthropic({**kwargs}, hints, header=header)
+
+    def client_system_prompt(self, kwargs: dict[str, Any]) -> str:
+        # ``system`` is legally a string or a list of content blocks meaning the
+        # same thing; both flatten to the same text.
+        return message_text(kwargs.get("system"))
+
+    def first_user_message(self, kwargs: dict[str, Any]) -> str:
+        for message in kwargs.get("messages") or []:
+            if isinstance(message, dict) and message.get("role") == "user":
+                return message_text(message.get("content"))
+        return ""
 
     def attempt_kwargs(
         self,

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -9,8 +9,6 @@ from any_llm.types.responses import ResponsesParams, ResponseStreamEvent
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
 from fastapi import Response as FastAPIResponse
 from fastapi.responses import StreamingResponse
-from openai.types.responses import ResponseUsage
-from openresponses_types.types import Usage as OpenResponsesUsage
 from pydantic import ConfigDict, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,7 +37,7 @@ from gateway.api.routes._schema_derive import SESSION_LABEL_DESC, SESSION_LABEL_
 from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
 from gateway.core.observation import message_text
-from gateway.core.usage import GatewayUsage
+from gateway.core.usage import responses_usage
 from gateway.log_config import logger
 from gateway.models.guardrails import GuardrailConfig
 from gateway.models.mcp import McpServerConfig
@@ -218,21 +216,6 @@ def _with_codex_extra_body(fields: dict[str, Any], provider: LLMProvider) -> dic
     return result
 
 
-def _usage_to_completion_usage(
-    usage: ResponseUsage | OpenResponsesUsage | None,
-) -> CompletionUsage | None:
-    if usage is None:
-        return None
-    details = getattr(usage, "input_tokens_details", None)
-    cache_read_tokens = (getattr(details, "cached_tokens", 0) or 0) if details is not None else 0
-    return GatewayUsage(
-        prompt_tokens=getattr(usage, "input_tokens", 0) or 0,
-        completion_tokens=getattr(usage, "output_tokens", 0) or 0,
-        total_tokens=getattr(usage, "total_tokens", 0) or 0,
-        cache_read_tokens=cache_read_tokens,
-    )
-
-
 def _ensure_provider_supports_responses(provider: LLMProvider) -> None:
     provider_class = AnyLLM.get_provider_class(provider)
     if not getattr(provider_class, "SUPPORTS_RESPONSES", False):
@@ -273,11 +256,11 @@ class _ResponsesAdapter:
     def extract_stream_usage(self, chunk: ResponseStreamEvent) -> CompletionUsage | None:
         response_obj = getattr(chunk, "response", None)
         if response_obj and getattr(response_obj, "usage", None):
-            return _usage_to_completion_usage(response_obj.usage)
+            return responses_usage(response_obj.usage)
         return None
 
     def extract_usage(self, result: ResponsesResponse) -> CompletionUsage | None:
-        return _usage_to_completion_usage(getattr(result, "usage", None))
+        return responses_usage(getattr(result, "usage", None))
 
     async def call_provider(self, kwargs: dict[str, Any]) -> ResponsesResponse:
         return await aresponses(**kwargs)  # type: ignore[return-value]

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -38,6 +38,7 @@ from gateway.api.routes._platform import ResolvedAttempt, build_attempt_client_a
 from gateway.api.routes._schema_derive import SESSION_LABEL_DESC, SESSION_LABEL_MAX_LENGTH, derive_request_base
 from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
+from gateway.core.observation import message_text
 from gateway.core.usage import GatewayUsage
 from gateway.log_config import logger
 from gateway.models.guardrails import GuardrailConfig
@@ -334,6 +335,21 @@ class _ResponsesAdapter:
         header: str | None,
     ) -> dict[str, Any]:
         return inject_purpose_hints_responses({**kwargs}, hints, header=header)
+
+    def client_system_prompt(self, kwargs: dict[str, Any]) -> str:
+        return message_text(kwargs.get("instructions"))
+
+    def first_user_message(self, kwargs: dict[str, Any]) -> str:
+        # ``input`` is a bare string or a list of items. A bare string is itself
+        # the opening turn; in a list it is the first ``user`` item, which may be
+        # a plain message or a ``{"type": "message"}`` one carrying input_text parts.
+        input_data = kwargs.get("input_data")
+        if isinstance(input_data, str):
+            return input_data
+        for item in input_data or []:
+            if isinstance(item, dict) and item.get("role") == "user":
+                return message_text(item.get("content"))
+        return ""
 
     def attempt_kwargs(
         self,

--- a/src/gateway/core/observation.py
+++ b/src/gateway/core/observation.py
@@ -58,13 +58,22 @@ def normalized_tool(definition: dict[str, Any], schema_key: str) -> NormalizedTo
 
     ``schema_key`` names where the format keeps the JSON Schema (``parameters``
     for chat completions and Responses, ``input_schema`` for Anthropic Messages).
-    An entry carrying neither a description nor a schema, such as a provider-native
-    server tool the gateway never converts, still contributes its name, which is
-    what :func:`tool_set_hash` counts.
+
+    The name falls back to ``type`` when the entry has none. A provider-native
+    server tool the gateway never converts still has to contribute an identity,
+    which is what :func:`tool_set_hash` counts, and only some of them spell it
+    ``name``: Anthropic's carry one (``{"type": "web_search_20250305", "name":
+    "web_search"}``) while the Responses ones carry none at all (``{"type":
+    "web_search"}``, ``{"type": "file_search", ...}``). Reading ``name`` alone
+    collapses every Responses server tool onto the empty string, so a workspace
+    swapping one for another would fingerprint as an unchanged tool set. What such
+    an entry configures (an ``mcp`` tool's ``server_label``, a ``file_search``
+    tool's vector stores) stays out of both hashes, consistent with a key made of
+    names.
     """
     schema = definition.get(schema_key)
     return NormalizedTool(
-        name=str(definition.get("name") or ""),
+        name=str(definition.get("name") or definition.get("type") or ""),
         description=str(definition.get("description") or ""),
         input_schema=schema if isinstance(schema, dict) else {},
     )

--- a/src/gateway/core/observation.py
+++ b/src/gateway/core/observation.py
@@ -1,0 +1,133 @@
+"""Format-neutral vocabulary for the Reprise loop-round observation.
+
+Reprise groups repeated automation by a fingerprint computed over a handful of
+request properties (otari-ai#1482). The same logical request reaches the gateway
+through three wire formats, and a property read "however this format spells it"
+hashes differently in each, so one nightly automation driven through two SDKs
+would never group and the report would understate its own support. Every value
+feeding the fingerprint is therefore normalized to a format-neutral form before
+it is hashed; this module owns those forms and the hashes over them.
+
+The accessors that produce the values live where the format is known:
+``FormatAdapter`` (``gateway.api.routes._pipeline``) for the request fields only
+the route layer still holds unmodified, ``ToolLoopStrategy`` /
+``StreamToolLoopStrategy`` (``gateway.services._tool_loop``) for what the loop
+sees, and :func:`gateway.services.tool_format.normalize_purpose_hints` for the
+purpose-hint block, which is format-neutral already.
+
+Assembling the fingerprint out of these is otari-ai#1648 and emitting the record
+is otari-ai#1484, so nothing here is called from a request path yet.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Sequence
+from typing import Any, NamedTuple
+
+UNDECLARED_HINT = "<default>"
+"""Stands in for a purpose hint the caller did not declare in the request body.
+
+An undeclared hint resolves to whatever the deployment supplies (dashboard
+override, env, YAML, or a built-in default), so hashing the resolved text would
+let an operator editing a text field, or a gateway release rewording a built-in,
+reset every pile in the deployment with nobody having touched the automation.
+The sentinel records "the caller said nothing here", which is the property that
+stays true across such an edit. What the model actually saw is still recorded,
+unhashed, as ``injected_block_hash`` over the assembled block.
+"""
+
+
+class NormalizedTool(NamedTuple):
+    """One tool in the shape all three wire formats agree on.
+
+    The formats wrap the same JSON Schema object differently (nested
+    ``function.parameters`` for chat completions, ``input_schema`` for Anthropic
+    Messages, flat ``parameters`` for Responses), so each loop strategy unwraps
+    its own shape into this triple.
+    """
+
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+
+
+def message_text(content: Any) -> str:
+    """Flatten a message-content value to the text the model was shown.
+
+    Covers the two legal shapes every format has for a prompt: a plain string,
+    and a list of content blocks (dicts or SDK objects) whose text is joined with
+    a blank line, so ``"foo"`` and ``[{"type": "text", "text": "foo"}]`` agree.
+    A block carrying no text (an image, an unknown block type) contributes
+    nothing, and ``None`` flattens to ``""``, so absent and empty normalize alike.
+
+    ``cache_control`` markers are ignored for free, since only ``text`` is read:
+    they move money rather than meaning, and a caller adding one mid-run must not
+    split its own pile.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list | tuple):
+        return "\n\n".join(text for block in content if (text := _block_text(block)))
+    return ""
+
+
+def _block_text(block: Any) -> str:
+    """The text carried by one content block, or ``""`` when it carries none."""
+    if isinstance(block, str):
+        return block
+    text = block.get("text") if isinstance(block, dict) else getattr(block, "text", None)
+    return text if isinstance(text, str) else ""
+
+
+def text_hash(text: str) -> str:
+    """sha256 of one normalized text value.
+
+    Produces ``client_system_hash`` and ``first_user_message_hash`` from the
+    per-format accessors, and ``injected_block_hash`` from the assembled
+    purpose-hint block exactly as sent. Only the first is a fingerprint input;
+    the other two are payload diagnostics.
+    """
+    return _sha256(text)
+
+
+def hint_hash(hints: Sequence[tuple[str, str]]) -> str:
+    """sha256 over normalized ``(name, hint)`` pairs. A fingerprint input.
+
+    Expects the output of
+    :func:`gateway.services.tool_format.normalize_purpose_hints`: sorted, and with
+    every hint the caller did not declare replaced by :data:`UNDECLARED_HINT`.
+    """
+    return _sha256(_canonical_json([list(pair) for pair in hints]))
+
+
+def tool_set_hash(tools: Sequence[NormalizedTool]) -> str:
+    """sha256 over the sorted tool names. A fingerprint input.
+
+    Names only. Descriptions and schemas drift from a third party, since an MCP
+    server's ``list_tools()`` is refetched on every request (the pool is rebuilt
+    per request), so a server adding one optional schema property, backward
+    compatibly and breaking nothing, would otherwise split every pile in the
+    workspace from that moment on. Those go to :func:`tool_definitions_hash`.
+    """
+    return _sha256(_canonical_json(sorted(tool.name for tool in tools)))
+
+
+def tool_definitions_hash(tools: Sequence[NormalizedTool]) -> str:
+    """sha256 over sorted ``(name, description, schema)`` triples. Payload only.
+
+    The schema is canonicalized (sorted keys, no incidental whitespace) so that
+    re-serializing an unchanged schema does not read as a different tool.
+    """
+    triples = sorted([tool.name, tool.description, _canonical_json(tool.input_schema)] for tool in tools)
+    return _sha256(_canonical_json(triples))
+
+
+def _canonical_json(value: Any) -> str:
+    """JSON with sorted keys and no incidental whitespace."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, default=str)
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()

--- a/src/gateway/core/observation.py
+++ b/src/gateway/core/observation.py
@@ -53,6 +53,23 @@ class NormalizedTool(NamedTuple):
     input_schema: dict[str, Any]
 
 
+def normalized_tool(definition: dict[str, Any], schema_key: str) -> NormalizedTool:
+    """Read one format's tool definition into a :class:`NormalizedTool`.
+
+    ``schema_key`` names where the format keeps the JSON Schema (``parameters``
+    for chat completions and Responses, ``input_schema`` for Anthropic Messages).
+    An entry carrying neither a description nor a schema, such as a provider-native
+    server tool the gateway never converts, still contributes its name, which is
+    what :func:`tool_set_hash` counts.
+    """
+    schema = definition.get(schema_key)
+    return NormalizedTool(
+        name=str(definition.get("name") or ""),
+        description=str(definition.get("description") or ""),
+        input_schema=schema if isinstance(schema, dict) else {},
+    )
+
+
 def message_text(content: Any) -> str:
     """Flatten a message-content value to the text the model was shown.
 

--- a/src/gateway/core/usage.py
+++ b/src/gateway/core/usage.py
@@ -12,7 +12,11 @@ as plain integers (rather than relying on ``prompt_tokens_details``) lets the re
 builder forward them uniformly across providers, including Anthropic cache writes.
 """
 
+from typing import Any
+
 from any_llm.types.completion import CompletionUsage
+from openai.types.responses import ResponseUsage
+from openresponses_types.types import Usage as OpenResponsesUsage
 
 
 class GatewayUsage(CompletionUsage):
@@ -77,6 +81,62 @@ class GatewayUsage(CompletionUsage):
             cache_write_1h_tokens=cache_write_1h_tokens,
             cache_tokens_in_prompt=cache_tokens_in_prompt,
         )
+
+
+def anthropic_cache_write_1h_tokens(usage: Any) -> int:
+    """Read Anthropic's optional 1-hour cache-creation breakdown."""
+    cache_creation = getattr(usage, "cache_creation", None)
+    return getattr(cache_creation, "ephemeral_1h_input_tokens", 0) or 0
+
+
+def anthropic_billable_usage(usage: Any) -> GatewayUsage:
+    """Read an Anthropic usage object, using per-iteration totals when present.
+
+    Anthropic reports compaction sampling as an ``iterations`` list, whose parts
+    sum to what the request is actually billed; the top-level counts describe only
+    the last one. ``cache_tokens_in_prompt`` is ``False`` because ``input_tokens``
+    excludes the cache buckets on this path.
+
+    Lives in ``core`` because both the Messages route (for billing) and the
+    Messages tool-loop strategy (for the Reprise usage snapshot) need it, and a
+    service may not import the API layer.
+    """
+    billable_parts = list(getattr(usage, "iterations", None) or []) or [usage]
+    input_tokens = sum((getattr(part, "input_tokens", None) or 0) for part in billable_parts)
+    output_tokens = sum((getattr(part, "output_tokens", None) or 0) for part in billable_parts)
+    return GatewayUsage(
+        prompt_tokens=input_tokens,
+        completion_tokens=output_tokens,
+        total_tokens=input_tokens + output_tokens,
+        cache_read_tokens=sum((getattr(part, "cache_read_input_tokens", None) or 0) for part in billable_parts),
+        cache_write_tokens=sum(
+            (getattr(part, "cache_creation_input_tokens", None) or 0) for part in billable_parts
+        ),
+        cache_write_1h_tokens=sum(anthropic_cache_write_1h_tokens(part) for part in billable_parts),
+        cache_tokens_in_prompt=False,
+    )
+
+
+def responses_usage(usage: ResponseUsage | OpenResponsesUsage | None) -> GatewayUsage | None:
+    """Read an OpenAI Responses usage object, or ``None`` when there is none.
+
+    OpenAI-shaped, so ``cached_tokens`` is a slice of ``input_tokens`` rather than
+    an additive bucket and ``cache_tokens_in_prompt`` keeps its ``True`` default.
+    The Responses API reports no cache-write charge.
+
+    In ``core`` for the same reason as :func:`anthropic_billable_usage`: both the
+    Responses route and its tool-loop strategy read it, on opposite sides of the
+    service/API boundary.
+    """
+    if usage is None:
+        return None
+    details = getattr(usage, "input_tokens_details", None)
+    return GatewayUsage(
+        prompt_tokens=getattr(usage, "input_tokens", 0) or 0,
+        completion_tokens=getattr(usage, "output_tokens", 0) or 0,
+        total_tokens=getattr(usage, "total_tokens", 0) or 0,
+        cache_read_tokens=(getattr(details, "cached_tokens", 0) or 0) if details is not None else 0,
+    )
 
 
 def cache_read_tokens_of(usage: CompletionUsage) -> int:

--- a/src/gateway/services/_tool_loop.py
+++ b/src/gateway/services/_tool_loop.py
@@ -26,6 +26,7 @@ from enum import Enum, auto
 from typing import Any, Generic, Protocol, TypeVar, cast
 
 from gateway.core.observation import NormalizedTool
+from gateway.core.usage import GatewayUsage
 
 ResultT = TypeVar("ResultT")
 ChunkT = TypeVar("ChunkT")
@@ -81,13 +82,24 @@ class ToolLoopStrategy(Protocol, Generic[ResultT, AccT]):
     checks the stop_reason only after the foreign-tool branch
     (``exit_after_split``); see :func:`run_tool_loop` for the consequences.
 
-    ``normalize_tools`` is the odd one out: nothing in the loop calls it. It
-    unwraps the format-shaped list :func:`_prepare` merges (nested
-    ``function.parameters`` for chat, ``input_schema`` for messages, flat
-    ``parameters`` for responses) into the format-neutral triples Reprise hashes
-    as ``tool_set_hash`` and ``tool_definitions_hash`` (otari-ai#1647). It sits on
-    the Protocol, and on its streaming twin, because that merged list is built
-    here and because ``mypy --strict`` then names any format that forgot one.
+    ``normalize_tools`` and ``usage_snapshot`` are the odd ones out: nothing in
+    the loop calls either. They exist so Reprise can read a round without
+    reimplementing three wire vocabularies (otari-ai#1647), and they sit on the
+    Protocol, and on its streaming twin, because that is where the format is
+    known and because ``mypy --strict`` then names a format that forgot one.
+
+    ``normalize_tools`` unwraps the format-shaped list :func:`_prepare` merges
+    (nested ``function.parameters`` for chat, ``input_schema`` for messages, flat
+    ``parameters`` for responses) into the format-neutral triples behind
+    ``tool_set_hash`` and ``tool_definitions_hash``.
+
+    ``usage_snapshot`` reads one round's usage off the provider's own result as a
+    :class:`~gateway.core.usage.GatewayUsage`, cache reads and cache writes
+    included, and its streaming twin ``stream_usage_snapshot`` reads the same
+    figures off the events of one upstream stream. Both return ``None`` when the
+    provider reported no usage at all, because zero and unknown are different
+    answers. Neither touches the usage accumulators, which exist to fold totals
+    into the client's response and must keep doing exactly that.
     """
 
     transcript_key: str
@@ -105,6 +117,8 @@ class ToolLoopStrategy(Protocol, Generic[ResultT, AccT]):
     def accumulate_usage(self, acc: AccT, result: ResultT) -> None: ...
 
     def fold_usage(self, result: ResultT, acc: AccT) -> None: ...
+
+    def usage_snapshot(self, result: ResultT) -> GatewayUsage | None: ...
 
     def exit_before_split(self, result: ResultT) -> bool: ...
 
@@ -161,6 +175,8 @@ class StreamToolLoopStrategy(Protocol, Generic[ChunkT, StateT, AccT]):
     def terminal_events(self, state: StateT, acc: AccT) -> list[ChunkT]: ...
 
     def accumulate_stream_usage(self, acc: AccT, state: StateT) -> None: ...
+
+    def stream_usage_snapshot(self, state: StateT) -> GatewayUsage | None: ...
 
     async def advance_stream_transcript(
         self,

--- a/src/gateway/services/_tool_loop.py
+++ b/src/gateway/services/_tool_loop.py
@@ -25,6 +25,8 @@ from contextlib import AbstractAsyncContextManager, aclosing, nullcontext
 from enum import Enum, auto
 from typing import Any, Generic, Protocol, TypeVar, cast
 
+from gateway.core.observation import NormalizedTool
+
 ResultT = TypeVar("ResultT")
 ChunkT = TypeVar("ChunkT")
 StateT = TypeVar("StateT")
@@ -78,6 +80,14 @@ class ToolLoopStrategy(Protocol, Generic[ResultT, AccT]):
     finish_reason before splitting (``exit_before_split``), while messages
     checks the stop_reason only after the foreign-tool branch
     (``exit_after_split``); see :func:`run_tool_loop` for the consequences.
+
+    ``normalize_tools`` is the odd one out: nothing in the loop calls it. It
+    unwraps the format-shaped list :func:`_prepare` merges (nested
+    ``function.parameters`` for chat, ``input_schema`` for messages, flat
+    ``parameters`` for responses) into the format-neutral triples Reprise hashes
+    as ``tool_set_hash`` and ``tool_definitions_hash`` (otari-ai#1647). It sits on
+    the Protocol, and on its streaming twin, because that merged list is built
+    here and because ``mypy --strict`` then names any format that forgot one.
     """
 
     transcript_key: str
@@ -85,6 +95,8 @@ class ToolLoopStrategy(Protocol, Generic[ResultT, AccT]):
     def coerce_transcript(self, value: Any) -> list[Any]: ...
 
     def convert_pool_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]: ...
+
+    def normalize_tools(self, tools: list[dict[str, Any]]) -> list[NormalizedTool]: ...
 
     async def call(self, kwargs: dict[str, Any]) -> ResultT: ...
 
@@ -131,6 +143,8 @@ class StreamToolLoopStrategy(Protocol, Generic[ChunkT, StateT, AccT]):
     def coerce_transcript(self, value: Any) -> list[Any]: ...
 
     def convert_pool_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]: ...
+
+    def normalize_tools(self, tools: list[dict[str, Any]]) -> list[NormalizedTool]: ...
 
     async def open_stream(self, kwargs: dict[str, Any]) -> AsyncIterator[ChunkT]: ...
 

--- a/src/gateway/services/mcp_loop.py
+++ b/src/gateway/services/mcp_loop.py
@@ -24,10 +24,11 @@ from contextlib import aclosing
 from typing import TYPE_CHECKING, Any
 
 from any_llm import acompletion
-from any_llm.types.completion import PromptTokensDetails
+from any_llm.types.completion import CompletionUsage, PromptTokensDetails
 
 from gateway.core.env import otari_env
 from gateway.core.observation import NormalizedTool, normalized_tool
+from gateway.core.usage import GatewayUsage
 from gateway.log_config import logger
 from gateway.services._tool_loop import (
     MaxToolIterationsExceeded,
@@ -234,6 +235,11 @@ class _ChatStreamState:
         # official OpenAI client raise IndexError.
         self.visible_tool_index: dict[int, int] = {}
         self.next_visible_tool_index = 0
+        # This round's provider-reported usage, for the Reprise usage snapshot
+        # (otari-ai#1647). Recorded only: the chunk carrying it is forwarded
+        # untouched, and the client-facing usage accounting still happens
+        # downstream in ``streaming_generator``.
+        self.usage: CompletionUsage | None = None
 
 
 class _ChatToolLoopStrategy:
@@ -275,6 +281,14 @@ class _ChatToolLoopStrategy:
 
     def fold_usage(self, result: ChatCompletion, acc: dict[str, int]) -> None:
         _fold_usage(result, acc["prompt"], acc["completion"], acc["cache_read"])
+
+    def usage_snapshot(self, result: ChatCompletion) -> GatewayUsage | None:
+        # OpenAI-shaped: cached tokens are a slice of prompt_tokens rather than an
+        # additive bucket, which ``from_completion_usage`` records by leaving
+        # ``cache_tokens_in_prompt`` at its True default.
+        if result.usage is None:
+            return None
+        return GatewayUsage.from_completion_usage(result.usage)
 
     def exit_before_split(self, result: ChatCompletion) -> bool:
         return not result.choices or result.choices[0].finish_reason != "tool_calls"
@@ -359,6 +373,11 @@ class _ChatToolLoopStrategy:
         pool: ToolBackend,
         acc: None,
     ) -> tuple[StreamAction, ChatCompletionChunk]:
+        if event.usage is not None:
+            # Usually a trailing choices-less chunk, but a provider any-llm
+            # synthesizes streaming for may attach it to the terminal chunk
+            # instead; last one wins, since the counts are cumulative.
+            state.usage = event.usage
         chunk_is_terminal = False
         hide = False
         visible = event
@@ -461,6 +480,15 @@ class _ChatToolLoopStrategy:
 
     def accumulate_stream_usage(self, acc: None, state: _ChatStreamState) -> None:
         return None
+
+    def stream_usage_snapshot(self, state: _ChatStreamState) -> GatewayUsage | None:
+        # ``None`` rather than a zero-filled snapshot when the caller set
+        # ``include_usage: False`` and the provider therefore sent nothing: this is
+        # the one format where a round's usage can be genuinely unknown, and
+        # unknown must not read as zero.
+        if state.usage is None:
+            return None
+        return GatewayUsage.from_completion_usage(state.usage)
 
     def synthetic_events(self, state: _ChatStreamState, acc: None) -> list[Any]:
         # This format has no native vocabulary for a server-side tool call, so the

--- a/src/gateway/services/mcp_loop.py
+++ b/src/gateway/services/mcp_loop.py
@@ -27,6 +27,7 @@ from any_llm import acompletion
 from any_llm.types.completion import PromptTokensDetails
 
 from gateway.core.env import otari_env
+from gateway.core.observation import NormalizedTool, normalized_tool
 from gateway.log_config import logger
 from gateway.services._tool_loop import (
     MaxToolIterationsExceeded,
@@ -92,6 +93,12 @@ def inject_purpose_hints(
     else:
         out.insert(0, {"role": "system", "content": block})
     return out
+
+
+def _definition_of(tool: dict[str, Any]) -> dict[str, Any]:
+    """The chat-completions tool definition, unwrapped from its ``function`` nesting."""
+    fn = tool.get("function")
+    return fn if isinstance(fn, dict) else tool
 
 
 def _accumulate_tool_call_deltas(slots: dict[int, dict[str, Any]], deltas: list[Any]) -> None:
@@ -243,6 +250,11 @@ class _ChatToolLoopStrategy:
 
     def convert_pool_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
         return tools
+
+    def normalize_tools(self, tools: list[dict[str, Any]]) -> list[NormalizedTool]:
+        # Chat nests the definition under ``function``; an entry that is not a
+        # function tool is read flat, so a provider-native tool still counts by name.
+        return [normalized_tool(_definition_of(tool), "parameters") for tool in tools]
 
     # ---- non-streaming hooks ----
 

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -636,11 +636,22 @@ class _MessagesToolLoopStrategy:
     def stream_usage_snapshot(self, state: _MessagesStreamState) -> GatewayUsage | None:
         """One round's usage, reassembled from where Anthropic splits it.
 
-        The input side (input tokens, cache reads, cache writes) arrives on
-        ``message_start`` and the final cumulative output count on the last
-        ``message_delta``, so the snapshot takes each from its own event and agrees
-        with what the non-streaming round reports. Both events reach ``observe``
-        even on a continuing round, where they are deferred rather than dropped.
+        The input side (input tokens, cache reads, cache writes) ordinarily arrives
+        on ``message_start`` and the cumulative output on the last ``message_delta``,
+        but the split is not clean enough to take either source wholesale. When the
+        round sampled compaction, only the delta carries the ``iterations`` list
+        whose parts sum to what the round is billed, ``message_start`` having been
+        emitted before the compaction pass happened; newer API versions repeat the
+        input fields on the delta too. Picking ``message_start`` for the whole input
+        side would then report a compaction round's output summed over every
+        iteration and its input from only the first, understating the cache re-read
+        the estimate is mostly made of, and disagreeing with what the same stream is
+        billed.
+
+        So the two are reconciled per field, last non-zero winning, which is the
+        convention ``gateway.streaming._merge_usage`` already applies to this stream
+        for the client-facing totals. Both events reach ``observe`` even on a
+        continuing round, where they are deferred rather than dropped.
         """
         delta_usage = next(
             (
@@ -651,24 +662,20 @@ class _MessagesToolLoopStrategy:
             ),
             None,
         )
-        start = anthropic_billable_usage(state.start_usage) if state.start_usage is not None else None
-        delta = anthropic_billable_usage(delta_usage) if delta_usage is not None else None
-        # A ``message_start`` that reported no input at all is no better a source
-        # than the delta, which newer API versions also populate.
-        reported_input = start is not None and bool(
-            start.prompt_tokens or start.cache_read_tokens or start.cache_write_tokens
-        )
-        input_side = start if reported_input else delta
-        if input_side is None:
+        if state.start_usage is None and delta_usage is None:
             return None
-        completion_tokens = delta.completion_tokens if delta is not None else input_side.completion_tokens
+        empty = GatewayUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+        start = anthropic_billable_usage(state.start_usage) if state.start_usage is not None else empty
+        delta = anthropic_billable_usage(delta_usage) if delta_usage is not None else empty
+        prompt_tokens = delta.prompt_tokens or start.prompt_tokens
+        completion_tokens = delta.completion_tokens or start.completion_tokens
         return GatewayUsage(
-            prompt_tokens=input_side.prompt_tokens,
+            prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
-            total_tokens=input_side.prompt_tokens + completion_tokens,
-            cache_read_tokens=input_side.cache_read_tokens,
-            cache_write_tokens=input_side.cache_write_tokens,
-            cache_write_1h_tokens=input_side.cache_write_1h_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+            cache_read_tokens=delta.cache_read_tokens or start.cache_read_tokens,
+            cache_write_tokens=delta.cache_write_tokens or start.cache_write_tokens,
+            cache_write_1h_tokens=delta.cache_write_1h_tokens or start.cache_write_1h_tokens,
             cache_tokens_in_prompt=False,
         )
 

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -29,6 +29,7 @@ from any_llm.types.messages import (
 )
 
 from gateway.core.observation import NormalizedTool, normalized_tool
+from gateway.core.usage import GatewayUsage, anthropic_billable_usage
 from gateway.log_config import logger
 from gateway.services._tool_loop import StreamAction, run_tool_loop, run_tool_loop_stream
 from gateway.services.mcp_loop import (
@@ -330,6 +331,11 @@ class _MessagesStreamState:
         # ``synthetic_events`` into content_block start/stop pairs.
         self.native_blocks: list[Any] = []
         self.stop_reason: str | None = None
+        # This round's ``message_start`` usage, which is where Anthropic reports the
+        # input side (input, cache reads, cache writes). Recorded for the Reprise
+        # usage snapshot (otari-ai#1647); the event itself is forwarded or deferred
+        # exactly as before.
+        self.start_usage: Any = None
         self.deferred_terminal: list[MessageStreamEvent] = []
         self.owned_specs: list[dict[str, Any]] = []
         # Blocks the gateway runs itself. Their events are swallowed rather than
@@ -398,6 +404,11 @@ class _MessagesToolLoopStrategy:
                 result.content = [*acc["native_blocks"], *(result.content or [])]
             except (AttributeError, TypeError):
                 logger.warning("Could not add native web-search blocks to the response content")
+
+    def usage_snapshot(self, result: MessageResponse) -> GatewayUsage | None:
+        if result.usage is None:
+            return None
+        return anthropic_billable_usage(result.usage)
 
     def exit_before_split(self, result: MessageResponse) -> bool:
         return False
@@ -493,6 +504,7 @@ class _MessagesToolLoopStrategy:
         event_type = getattr(event, "type", None)
 
         if event_type == "message_start":
+            state.start_usage = getattr(getattr(event, "message", None), "usage", None)
             # One envelope per response, no matter how many upstream messages the
             # tool loop consumed to produce it.
             if acc["started"]:
@@ -620,6 +632,45 @@ class _MessagesToolLoopStrategy:
             context_management = getattr(term, "context_management", None)
             if context_management is not None:
                 acc["applied_edits"].extend(getattr(context_management, "applied_edits", None) or [])
+
+    def stream_usage_snapshot(self, state: _MessagesStreamState) -> GatewayUsage | None:
+        """One round's usage, reassembled from where Anthropic splits it.
+
+        The input side (input tokens, cache reads, cache writes) arrives on
+        ``message_start`` and the final cumulative output count on the last
+        ``message_delta``, so the snapshot takes each from its own event and agrees
+        with what the non-streaming round reports. Both events reach ``observe``
+        even on a continuing round, where they are deferred rather than dropped.
+        """
+        delta_usage = next(
+            (
+                usage
+                for term in reversed(state.deferred_terminal)
+                if getattr(term, "type", None) == "message_delta"
+                and (usage := getattr(term, "usage", None)) is not None
+            ),
+            None,
+        )
+        start = anthropic_billable_usage(state.start_usage) if state.start_usage is not None else None
+        delta = anthropic_billable_usage(delta_usage) if delta_usage is not None else None
+        # A ``message_start`` that reported no input at all is no better a source
+        # than the delta, which newer API versions also populate.
+        reported_input = start is not None and bool(
+            start.prompt_tokens or start.cache_read_tokens or start.cache_write_tokens
+        )
+        input_side = start if reported_input else delta
+        if input_side is None:
+            return None
+        completion_tokens = delta.completion_tokens if delta is not None else input_side.completion_tokens
+        return GatewayUsage(
+            prompt_tokens=input_side.prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=input_side.prompt_tokens + completion_tokens,
+            cache_read_tokens=input_side.cache_read_tokens,
+            cache_write_tokens=input_side.cache_write_tokens,
+            cache_write_1h_tokens=input_side.cache_write_1h_tokens,
+            cache_tokens_in_prompt=False,
+        )
 
     @staticmethod
     def _native_block_events(blocks: list[Any], acc: _MessagesStreamAccumulator) -> list[Any]:

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -28,6 +28,7 @@ from any_llm.types.messages import (
     ContentBlockStopEvent,
 )
 
+from gateway.core.observation import NormalizedTool, normalized_tool
 from gateway.log_config import logger
 from gateway.services._tool_loop import StreamAction, run_tool_loop, run_tool_loop_stream
 from gateway.services.mcp_loop import (
@@ -366,6 +367,9 @@ class _MessagesToolLoopStrategy:
 
     def convert_pool_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
         return openai_to_anthropic_tools(tools)
+
+    def normalize_tools(self, tools: list[dict[str, Any]]) -> list[NormalizedTool]:
+        return [normalized_tool(tool, "input_schema") for tool in tools]
 
     # ---- non-streaming hooks ----
 

--- a/src/gateway/services/mcp_loop_responses.py
+++ b/src/gateway/services/mcp_loop_responses.py
@@ -308,6 +308,13 @@ class _ResponsesStreamState:
         self.function_calls: dict[int, dict[str, Any]] = {}
         self.compaction_items: dict[int, Any] = {}
         self.deferred_completed: ResponseStreamEvent | None = None
+        # This round's provider-reported usage, for the Reprise usage snapshot
+        # (otari-ai#1647). Taken from any event that carries one rather than from
+        # ``deferred_completed`` alone, because a round truncated by
+        # ``max_output_tokens`` or a content filter ends on ``response.incomplete``,
+        # which the gateway bills and which would otherwise read as unknown usage.
+        # Recorded only: no event's handling changes.
+        self.usage: Any = None
         self.owned_specs: list[dict[str, Any]] = []
         # Output items the gateway runs itself. Their events are swallowed: the
         # client can never be sent a ``function_call_output`` for a call the
@@ -465,6 +472,9 @@ class _ResponsesToolLoopStrategy:
         acc: dict[str, Any],
     ) -> tuple[StreamAction, ResponseStreamEvent]:
         etype = getattr(event, "type", None)
+        usage = getattr(getattr(event, "response", None), "usage", None)
+        if usage is not None:
+            state.usage = usage
 
         if etype == "response.created":
             if acc["started"]:
@@ -601,10 +611,10 @@ class _ResponsesToolLoopStrategy:
         acc["compactions"].extend(state.compaction_items[index] for index in sorted(state.compaction_items))
 
     def stream_usage_snapshot(self, state: _ResponsesStreamState) -> GatewayUsage | None:
-        # One round's whole usage object rides on ``response.completed``, which the
-        # strategy already keeps on the state whether the round exits or continues.
-        response = getattr(state.deferred_completed, "response", None)
-        return responses_usage(getattr(response, "usage", None))
+        # One round's whole usage object rides on its terminal event, recorded by
+        # ``observe`` whichever terminal it was. Matches what the route's
+        # ``extract_stream_usage`` bills off the same stream.
+        return responses_usage(state.usage)
 
     def synthetic_events(
         self, state: _ResponsesStreamState, acc: dict[str, Any]

--- a/src/gateway/services/mcp_loop_responses.py
+++ b/src/gateway/services/mcp_loop_responses.py
@@ -33,6 +33,7 @@ from openai.types.responses.response_function_web_search import ActionSearch
 from openai.types.responses.response_output_item_added_event import ResponseOutputItemAddedEvent
 from openai.types.responses.response_output_item_done_event import ResponseOutputItemDoneEvent
 
+from gateway.core.observation import NormalizedTool, normalized_tool
 from gateway.log_config import logger
 from gateway.services._tool_loop import StreamAction, run_tool_loop, run_tool_loop_stream
 from gateway.services.mcp_loop import (
@@ -331,6 +332,9 @@ class _ResponsesToolLoopStrategy:
 
     def convert_pool_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
         return openai_to_responses_tools(tools)
+
+    def normalize_tools(self, tools: list[dict[str, Any]]) -> list[NormalizedTool]:
+        return [normalized_tool(tool, "parameters") for tool in tools]
 
     # ---- non-streaming hooks ----
 

--- a/src/gateway/services/mcp_loop_responses.py
+++ b/src/gateway/services/mcp_loop_responses.py
@@ -34,6 +34,7 @@ from openai.types.responses.response_output_item_added_event import ResponseOutp
 from openai.types.responses.response_output_item_done_event import ResponseOutputItemDoneEvent
 
 from gateway.core.observation import NormalizedTool, normalized_tool
+from gateway.core.usage import GatewayUsage, responses_usage
 from gateway.log_config import logger
 from gateway.services._tool_loop import StreamAction, run_tool_loop, run_tool_loop_stream
 from gateway.services.mcp_loop import (
@@ -354,6 +355,9 @@ class _ResponsesToolLoopStrategy:
             acc["output"] += result.usage.output_tokens or 0
             acc["total"] += result.usage.total_tokens or 0
 
+    def usage_snapshot(self, result: Response) -> GatewayUsage | None:
+        return responses_usage(getattr(result, "usage", None))
+
     def fold_usage(self, result: Response, acc: dict[str, Any]) -> None:
         _fold_usage(result, acc["input"], acc["output"], acc["total"])
         # Prepend a native ``web_search_call`` item per gateway-run search. The
@@ -595,6 +599,12 @@ class _ResponsesToolLoopStrategy:
             if iter_usage is not None:
                 acc["output_tokens"] += getattr(iter_usage, "output_tokens", 0) or 0
         acc["compactions"].extend(state.compaction_items[index] for index in sorted(state.compaction_items))
+
+    def stream_usage_snapshot(self, state: _ResponsesStreamState) -> GatewayUsage | None:
+        # One round's whole usage object rides on ``response.completed``, which the
+        # strategy already keeps on the state whether the round exits or continues.
+        response = getattr(state.deferred_completed, "response", None)
+        return responses_usage(getattr(response, "usage", None))
 
     def synthetic_events(
         self, state: _ResponsesStreamState, acc: dict[str, Any]

--- a/src/gateway/services/tool_format.py
+++ b/src/gateway/services/tool_format.py
@@ -19,9 +19,11 @@ separate top-level field, so they get their own per-format helpers here.
 
 from __future__ import annotations
 
+from collections.abc import Container, Sequence
 from typing import Any
 
 from gateway.core.env import otari_env
+from gateway.core.observation import UNDECLARED_HINT
 from gateway.services.mcp_loop import PURPOSE_HINT_HEADER
 
 
@@ -67,11 +69,45 @@ def _resolve_header(header: str | None) -> str:
     return header or otari_env("TOOLS_HEADER") or PURPOSE_HINT_HEADER
 
 
-def _build_hint_block(hints: list[tuple[str, str]], header: str | None) -> str:
+def build_hint_block(hints: Sequence[tuple[str, str]], header: str | None = None) -> str:
+    """Assemble the purpose-hint preamble, in the caller's declaration order.
+
+    Public because the block is what the model actually saw, which Reprise records
+    as ``injected_block_hash`` (:func:`gateway.core.observation.text_hash`). It is a
+    pure function of ``(hints, header)`` for all three wire formats: chat
+    completions assembles an identical block inline in
+    :func:`gateway.services.mcp_loop.inject_purpose_hints`, and
+    ``test_purpose_hint_normalization`` pins the two together.
+    """
     lines = [_resolve_header(header)]
     for name, hint in hints:
         lines.append(f"- {name}: {hint}")
     return "\n".join(lines)
+
+
+def normalize_purpose_hints(
+    hints: Sequence[tuple[str, str]],
+    *,
+    caller_declared: Container[str],
+) -> list[tuple[str, str]]:
+    """Normalize purpose hints for :func:`gateway.core.observation.hint_hash`.
+
+    Sorted, because the pairs come out in the order the request body listed the
+    servers (``MCPClientPool.purpose_hints``), so the same two servers listed the
+    other way round would otherwise hash differently. The injected block keeps the
+    caller's order, since that is what the model sees; only the hash sorts.
+
+    A name absent from ``caller_declared`` hashes as
+    :data:`~gateway.core.observation.UNDECLARED_HINT` rather than as its resolved
+    text, so ``caller_declared`` is the set of names the *request body* carried a
+    ``purpose_hint`` for, not the set that ended up with one.
+
+    The pairs arrive per server for MCP and per tool for the sandbox
+    (``SandboxBackend.purpose_hints``); this does not care which produced them.
+    The deployment's header is not an input: ``OTARI_TOOLS_HEADER`` is an operator
+    knob rather than customer content, so it never reaches the key.
+    """
+    return sorted((name, hint if name in caller_declared else UNDECLARED_HINT) for name, hint in hints)
 
 
 def inject_purpose_hints_anthropic(
@@ -92,7 +128,7 @@ def inject_purpose_hints_anthropic(
     if not hints:
         return call_kwargs
 
-    block = _build_hint_block(hints, header)
+    block = build_hint_block(hints, header)
     existing = call_kwargs.get("system")
 
     if existing is None:
@@ -150,7 +186,7 @@ def inject_purpose_hints_responses(
     if not hints:
         return call_kwargs
 
-    block = _build_hint_block(hints, header)
+    block = build_hint_block(hints, header)
     existing = call_kwargs.get("instructions")
 
     if not existing:

--- a/tests/unit/test_observation_request_accessors.py
+++ b/tests/unit/test_observation_request_accessors.py
@@ -1,0 +1,216 @@
+"""Per-format request accessors for the Reprise v0 fingerprint (otari-ai#1647).
+
+``client_system_hash`` is a fingerprint input and ``first_user_message_hash`` is
+a payload field #1488 conditions a pile's agreement on. Both come off the
+caller's request before the gateway rewrites it, and all three wire formats
+carry them somewhere else, so the accessors have to agree on one normalized
+string: one nightly automation driven through two SDKs must land in one pile,
+not two half-sized ones.
+"""
+
+from typing import Any
+
+import pytest
+
+from gateway.api.routes import chat, messages, responses
+from gateway.api.routes._pipeline import FormatAdapter
+from gateway.core.observation import text_hash
+
+_SYSTEM = "You are a release-notes bot."
+_OPENING = "Summarize yesterday's merged PRs."
+_LATER = "Now group them by area."
+
+
+def _chat_kwargs(**overrides: Any) -> dict[str, Any]:
+    return {
+        "messages": [
+            {"role": "system", "content": _SYSTEM},
+            {"role": "user", "content": _OPENING},
+        ],
+        **overrides,
+    }
+
+
+def _messages_kwargs(**overrides: Any) -> dict[str, Any]:
+    return {
+        "system": _SYSTEM,
+        "messages": [{"role": "user", "content": _OPENING}],
+        **overrides,
+    }
+
+
+def _responses_kwargs(**overrides: Any) -> dict[str, Any]:
+    return {
+        "instructions": _SYSTEM,
+        "input_data": [{"role": "user", "content": _OPENING}],
+        **overrides,
+    }
+
+
+_ADAPTERS: list[tuple[FormatAdapter[Any, Any], dict[str, Any]]] = [
+    (chat._ADAPTER, _chat_kwargs()),
+    (messages._ADAPTER, _messages_kwargs()),
+    (responses._ADAPTER, _responses_kwargs()),
+]
+
+
+def test_one_client_system_hash_across_the_three_formats() -> None:
+    hashes = {text_hash(adapter.client_system_prompt(kwargs)) for adapter, kwargs in _ADAPTERS}
+
+    assert len(hashes) == 1
+
+
+def test_one_first_user_message_hash_across_the_three_formats() -> None:
+    hashes = {text_hash(adapter.first_user_message(kwargs)) for adapter, kwargs in _ADAPTERS}
+
+    assert len(hashes) == 1
+
+
+@pytest.mark.parametrize(
+    ("adapter", "kwargs"),
+    [
+        pytest.param(chat._ADAPTER, _chat_kwargs(), id="chat"),
+        pytest.param(messages._ADAPTER, _messages_kwargs(), id="messages"),
+        pytest.param(responses._ADAPTER, _responses_kwargs(), id="responses"),
+    ],
+)
+def test_absent_system_prompt_normalizes_like_an_empty_one(
+    adapter: FormatAdapter[Any, Any], kwargs: dict[str, Any]
+) -> None:
+    without = {k: v for k, v in kwargs.items() if k not in {"system", "instructions"}}
+    if "messages" in without:
+        without["messages"] = [m for m in without["messages"] if m["role"] != "system"]
+
+    assert adapter.client_system_prompt(without) == ""
+
+
+def test_system_string_and_single_text_block_agree() -> None:
+    as_string = messages._ADAPTER.client_system_prompt(_messages_kwargs())
+    as_blocks = messages._ADAPTER.client_system_prompt(
+        _messages_kwargs(system=[{"type": "text", "text": _SYSTEM}])
+    )
+
+    assert as_string == as_blocks
+
+
+def test_developer_led_chat_request_agrees_with_a_system_led_one() -> None:
+    """Both roles carry the caller's own prompt, so both feed the same hash."""
+    as_system = chat._ADAPTER.client_system_prompt(_chat_kwargs())
+    as_developer = chat._ADAPTER.client_system_prompt(
+        _chat_kwargs(
+            messages=[
+                {"role": "developer", "content": _SYSTEM},
+                {"role": "user", "content": _OPENING},
+            ]
+        )
+    )
+
+    assert as_system == as_developer
+
+
+def test_cache_control_markers_do_not_change_the_system_hash() -> None:
+    """A cache marker moves money, not meaning, so it must not split a pile."""
+    plain = messages._ADAPTER.client_system_prompt(
+        _messages_kwargs(system=[{"type": "text", "text": _SYSTEM}])
+    )
+    marked = messages._ADAPTER.client_system_prompt(
+        _messages_kwargs(
+            system=[{"type": "text", "text": _SYSTEM, "cache_control": {"type": "ephemeral"}}]
+        )
+    )
+
+    assert plain == marked
+
+
+def test_multi_block_system_prompt_joins_on_a_blank_line() -> None:
+    prompt = messages._ADAPTER.client_system_prompt(
+        _messages_kwargs(
+            system=[
+                {"type": "text", "text": "You are a release-notes bot."},
+                {"type": "text", "text": "Answer in bullet points.", "cache_control": {"type": "ephemeral"}},
+            ]
+        )
+    )
+
+    assert prompt == "You are a release-notes bot.\n\nAnswer in bullet points."
+
+
+@pytest.mark.parametrize(
+    ("adapter", "with_later_turn"),
+    [
+        pytest.param(
+            chat._ADAPTER,
+            _chat_kwargs(
+                messages=[
+                    {"role": "system", "content": _SYSTEM},
+                    {"role": "user", "content": _OPENING},
+                    {"role": "assistant", "content": "Here they are."},
+                    {"role": "user", "content": _LATER},
+                ]
+            ),
+            id="chat",
+        ),
+        pytest.param(
+            messages._ADAPTER,
+            _messages_kwargs(
+                messages=[
+                    {"role": "user", "content": _OPENING},
+                    {"role": "assistant", "content": "Here they are."},
+                    {"role": "user", "content": _LATER},
+                ]
+            ),
+            id="messages",
+        ),
+        pytest.param(
+            responses._ADAPTER,
+            _responses_kwargs(
+                input_data=[
+                    {"role": "user", "content": _OPENING},
+                    {"role": "assistant", "content": "Here they are."},
+                    {"role": "user", "content": _LATER},
+                ]
+            ),
+            id="responses",
+        ),
+    ],
+)
+def test_a_later_turn_does_not_change_the_first_user_message(
+    adapter: FormatAdapter[Any, Any], with_later_turn: dict[str, Any]
+) -> None:
+    assert adapter.first_user_message(with_later_turn) == _OPENING
+
+
+def test_responses_accepts_a_bare_string_input() -> None:
+    """The Responses ``input`` is a string or a list of items; both are the opening turn."""
+    assert responses._ADAPTER.first_user_message(_responses_kwargs(input_data=_OPENING)) == _OPENING
+
+
+def test_responses_flattens_input_text_parts() -> None:
+    assert (
+        responses._ADAPTER.first_user_message(
+            _responses_kwargs(
+                input_data=[
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": _OPENING}],
+                    }
+                ]
+            )
+        )
+        == _OPENING
+    )
+
+
+@pytest.mark.parametrize(
+    ("adapter", "kwargs"),
+    [
+        pytest.param(chat._ADAPTER, _chat_kwargs(messages=[]), id="chat"),
+        pytest.param(messages._ADAPTER, _messages_kwargs(messages=[]), id="messages"),
+        pytest.param(responses._ADAPTER, _responses_kwargs(input_data=[]), id="responses"),
+    ],
+)
+def test_a_request_with_no_user_turn_normalizes_to_empty(
+    adapter: FormatAdapter[Any, Any], kwargs: dict[str, Any]
+) -> None:
+    assert adapter.first_user_message(kwargs) == ""

--- a/tests/unit/test_observation_tool_set.py
+++ b/tests/unit/test_observation_tool_set.py
@@ -178,6 +178,34 @@ def test_removing_a_tool_moves_both_hashes() -> None:
     assert tool_definitions_hash(before) != tool_definitions_hash(after)
 
 
+def test_responses_native_tools_stay_distinct_without_a_name_key() -> None:
+    """A Responses server tool carries its identity in ``type``, with no ``name`` at all.
+
+    Reading ``name`` alone collapses every one of them to the empty string, so a
+    workspace swapping web search for file search is fingerprinted as an unchanged
+    tool set and the two automations land in one pile.
+    """
+    native: list[dict[str, Any]] = [
+        {"type": "web_search"},
+        {"type": "file_search", "vector_store_ids": ["vs_1"]},
+        {"type": "mcp", "server_label": "github", "server_url": "https://example.invalid"},
+    ]
+
+    normalized = _RESPONSES_STRATEGY.normalize_tools(native)
+
+    assert [tool.name for tool in normalized] == ["web_search", "file_search", "mcp"]
+    assert len({tool_set_hash([tool]) for tool in normalized}) == 3
+
+
+def test_a_named_tool_is_not_renamed_by_its_type() -> None:
+    """``name`` wins wherever a format supplies both; only its absence falls back."""
+    assert _RESPONSES_STRATEGY.normalize_tools(_responses_tools())[0].name == "list_issues"
+    assert _CHAT_STRATEGY.normalize_tools(_chat_tools())[0].name == "list_issues"
+    assert _MESSAGES_STRATEGY.normalize_tools(
+        [{"type": "web_search_20250305", "name": "web_search"}]
+    ) == [NormalizedTool("web_search", "", {})]
+
+
 def test_a_provider_native_tool_still_counts_by_name() -> None:
     """A server-side tool the gateway never converts is still part of the set."""
     native = [*_messages_tools(), {"type": "web_search_20250305", "name": "web_search"}]

--- a/tests/unit/test_observation_tool_set.py
+++ b/tests/unit/test_observation_tool_set.py
@@ -1,0 +1,188 @@
+"""Per-format tool-set normalization for the Reprise v0 fingerprint (otari-ai#1647).
+
+The loop merges the caller's tools with the gateway's converted ones and the
+merged list is format-shaped, so hashing it as built never groups across
+formats. The normalizer unwraps each shape into one triple, which then feeds two
+different values: ``tool_set_hash`` (names only, a fingerprint input) and
+``tool_definitions_hash`` (names, descriptions, schemas; payload only). They are
+separate because they change for unrelated reasons. A tool's description and
+schema arrive in the same live ``list_tools()`` response and the pool is rebuilt
+per request, so an upstream server adding one optional property, backward
+compatibly and breaking nothing, would split every pile in the workspace if the
+key covered them.
+"""
+
+from typing import Any
+
+import pytest
+
+from gateway.core.observation import NormalizedTool, tool_definitions_hash, tool_set_hash
+from gateway.services._tool_loop import ToolLoopStrategy
+from gateway.services.mcp_loop import _CHAT_STRATEGY
+from gateway.services.mcp_loop_messages import _MESSAGES_STRATEGY
+from gateway.services.mcp_loop_responses import _RESPONSES_STRATEGY
+
+_LIST_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"repo": {"type": "string"}},
+    "required": ["repo"],
+}
+_GET_SCHEMA: dict[str, Any] = {"type": "object", "properties": {"number": {"type": "integer"}}}
+
+_LIST_DESCRIPTION = "List open issues."
+_GET_DESCRIPTION = "Fetch one issue."
+
+
+def _chat_tools() -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "list_issues",
+                "description": _LIST_DESCRIPTION,
+                "parameters": _LIST_SCHEMA,
+            },
+        },
+        {
+            "type": "function",
+            "function": {"name": "get_issue", "description": _GET_DESCRIPTION, "parameters": _GET_SCHEMA},
+        },
+    ]
+
+
+def _messages_tools() -> list[dict[str, Any]]:
+    return [
+        {"name": "list_issues", "description": _LIST_DESCRIPTION, "input_schema": _LIST_SCHEMA},
+        {"name": "get_issue", "description": _GET_DESCRIPTION, "input_schema": _GET_SCHEMA},
+    ]
+
+
+def _responses_tools() -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "function",
+            "name": "list_issues",
+            "description": _LIST_DESCRIPTION,
+            "parameters": _LIST_SCHEMA,
+        },
+        {"type": "function", "name": "get_issue", "description": _GET_DESCRIPTION, "parameters": _GET_SCHEMA},
+    ]
+
+
+_FORMATS: list[tuple[ToolLoopStrategy[Any, Any], list[dict[str, Any]]]] = [
+    (_CHAT_STRATEGY, _chat_tools()),
+    (_MESSAGES_STRATEGY, _messages_tools()),
+    (_RESPONSES_STRATEGY, _responses_tools()),
+]
+
+
+def test_one_tool_set_hash_across_the_three_formats() -> None:
+    hashes = {tool_set_hash(strategy.normalize_tools(tools)) for strategy, tools in _FORMATS}
+
+    assert len(hashes) == 1
+
+
+def test_one_tool_definitions_hash_across_the_three_formats() -> None:
+    """The three converters only rewrap the same JSON Schema object."""
+    hashes = {tool_definitions_hash(strategy.normalize_tools(tools)) for strategy, tools in _FORMATS}
+
+    assert len(hashes) == 1
+
+
+@pytest.mark.parametrize(
+    ("strategy", "tools"),
+    [
+        pytest.param(_CHAT_STRATEGY, _chat_tools(), id="chat"),
+        pytest.param(_MESSAGES_STRATEGY, _messages_tools(), id="messages"),
+        pytest.param(_RESPONSES_STRATEGY, _responses_tools(), id="responses"),
+    ],
+)
+def test_normalizer_recovers_the_same_triple_from_every_shape(
+    strategy: ToolLoopStrategy[Any, Any], tools: list[dict[str, Any]]
+) -> None:
+    assert strategy.normalize_tools(tools) == [
+        NormalizedTool("list_issues", _LIST_DESCRIPTION, _LIST_SCHEMA),
+        NormalizedTool("get_issue", _GET_DESCRIPTION, _GET_SCHEMA),
+    ]
+
+
+def test_reordering_the_tools_changes_neither_hash() -> None:
+    forward = _CHAT_STRATEGY.normalize_tools(_chat_tools())
+    reverse = _CHAT_STRATEGY.normalize_tools(list(reversed(_chat_tools())))
+
+    assert tool_set_hash(forward) == tool_set_hash(reverse)
+    assert tool_definitions_hash(forward) == tool_definitions_hash(reverse)
+
+
+def test_an_added_optional_schema_property_moves_only_the_definitions_hash() -> None:
+    """The upstream server broke nothing, so the workspace's piles must survive it."""
+    widened = _chat_tools()
+    widened[0]["function"]["parameters"] = {
+        **_LIST_SCHEMA,
+        "properties": {**_LIST_SCHEMA["properties"], "state": {"type": "string"}},
+    }
+
+    before = _CHAT_STRATEGY.normalize_tools(_chat_tools())
+    after = _CHAT_STRATEGY.normalize_tools(widened)
+
+    assert tool_set_hash(before) == tool_set_hash(after)
+    assert tool_definitions_hash(before) != tool_definitions_hash(after)
+
+
+def test_a_reworded_description_moves_only_the_definitions_hash() -> None:
+    reworded = _chat_tools()
+    reworded[0]["function"]["description"] = "List the issues that are still open."
+
+    before = _CHAT_STRATEGY.normalize_tools(_chat_tools())
+    after = _CHAT_STRATEGY.normalize_tools(reworded)
+
+    assert tool_set_hash(before) == tool_set_hash(after)
+    assert tool_definitions_hash(before) != tool_definitions_hash(after)
+
+
+def test_reserializing_an_unchanged_schema_reads_as_the_same_tool() -> None:
+    """Canonical JSON, so key order and whitespace are not a tool change."""
+    reordered = _chat_tools()
+    reordered[0]["function"]["parameters"] = {
+        "required": ["repo"],
+        "properties": {"repo": {"type": "string"}},
+        "type": "object",
+    }
+
+    assert tool_definitions_hash(_CHAT_STRATEGY.normalize_tools(_chat_tools())) == tool_definitions_hash(
+        _CHAT_STRATEGY.normalize_tools(reordered)
+    )
+
+
+def test_adding_a_tool_moves_both_hashes() -> None:
+    extended = [
+        *_chat_tools(),
+        {
+            "type": "function",
+            "function": {"name": "close_issue", "description": "Close it.", "parameters": _GET_SCHEMA},
+        },
+    ]
+
+    before = _CHAT_STRATEGY.normalize_tools(_chat_tools())
+    after = _CHAT_STRATEGY.normalize_tools(extended)
+
+    assert tool_set_hash(before) != tool_set_hash(after)
+    assert tool_definitions_hash(before) != tool_definitions_hash(after)
+
+
+def test_removing_a_tool_moves_both_hashes() -> None:
+    before = _CHAT_STRATEGY.normalize_tools(_chat_tools())
+    after = _CHAT_STRATEGY.normalize_tools(_chat_tools()[:1])
+
+    assert tool_set_hash(before) != tool_set_hash(after)
+    assert tool_definitions_hash(before) != tool_definitions_hash(after)
+
+
+def test_a_provider_native_tool_still_counts_by_name() -> None:
+    """A server-side tool the gateway never converts is still part of the set."""
+    native = [*_messages_tools(), {"type": "web_search_20250305", "name": "web_search"}]
+
+    normalized = _MESSAGES_STRATEGY.normalize_tools(native)
+
+    assert normalized[-1] == NormalizedTool("web_search", "", {})
+    assert tool_set_hash(normalized) != tool_set_hash(_MESSAGES_STRATEGY.normalize_tools(_messages_tools()))

--- a/tests/unit/test_observation_usage_snapshot.py
+++ b/tests/unit/test_observation_usage_snapshot.py
@@ -1,0 +1,361 @@
+"""Per-round usage snapshots for the Reprise v0 fingerprint (otari-ai#1647).
+
+The saving estimate v0 exists to produce is mostly the cache re-read, so a
+snapshot that records "whatever this provider calls input" understates the
+number in the direction that cancels the project. The hooks therefore return a
+``GatewayUsage``, which already carries cache reads, cache writes, the 1-hour
+write subset, and the ``cache_tokens_in_prompt`` flag that reconciles OpenAI's
+"cached tokens are a slice of the prompt" with Anthropic's additive buckets.
+
+Zero and unknown stay distinguishable: a provider that reported nothing yields
+``None``, not a zero-filled snapshot.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+from any_llm.types.completion import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    ChatCompletionMessage,
+    Choice,
+    CompletionUsage,
+    PromptTokensDetails,
+)
+from any_llm.types.messages import (
+    MessageDeltaEvent,
+    MessageResponse,
+    MessageStartEvent,
+    MessageStreamEvent,
+    MessageUsage,
+)
+from any_llm.types.responses import Response
+from openai.types.responses import ResponseCompletedEvent, ResponseUsage
+from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+
+from gateway.core.usage import GatewayUsage
+from gateway.services._tool_loop import ToolBackend
+from gateway.services.mcp_loop import _CHAT_STRATEGY
+from gateway.services.mcp_loop_messages import _MESSAGES_STRATEGY
+from gateway.services.mcp_loop_responses import _RESPONSES_STRATEGY
+
+
+class _NoTools:
+    """Minimal :class:`ToolBackend` for driving ``observe`` over raw events."""
+
+    @property
+    def openai_tools(self) -> list[dict[str, Any]]:
+        return []
+
+    def owns_tool(self, name: str) -> bool:
+        return False
+
+    def purpose_hints(self) -> list[tuple[str, str]]:
+        return []
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:  # pragma: no cover
+        raise AssertionError("no tools in these fixtures")
+
+
+_POOL: ToolBackend = _NoTools()
+
+
+def _effective_prompt_tokens(usage: GatewayUsage) -> int:
+    """The real input the request paid for, with ``cache_tokens_in_prompt`` applied."""
+    if usage.cache_tokens_in_prompt:
+        return usage.prompt_tokens
+    return usage.prompt_tokens + usage.cache_read_tokens + usage.cache_write_tokens
+
+
+# ---------- fixtures per format ----------
+
+
+def _chat_completion(usage: CompletionUsage | None) -> ChatCompletion:
+    return ChatCompletion(
+        id="cmpl-1",
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content="done"),
+            )
+        ],
+        created=0,
+        model="fake",
+        object="chat.completion",
+        usage=usage,
+    )
+
+
+def _chat_usage_chunk(usage: CompletionUsage) -> ChatCompletionChunk:
+    return ChatCompletionChunk(
+        id="cmpl-1",
+        choices=[],
+        created=0,
+        model="fake",
+        object="chat.completion.chunk",
+        usage=usage,
+    )
+
+
+def _chat_terminal_chunk() -> ChatCompletionChunk:
+    return ChatCompletionChunk.model_validate(
+        {
+            "id": "cmpl-1",
+            "choices": [{"index": 0, "delta": {"content": "done"}, "finish_reason": "stop"}],
+            "created": 0,
+            "model": "fake",
+            "object": "chat.completion.chunk",
+        }
+    )
+
+
+def _message_usage(
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read: int | None = None,
+    cache_write: int | None = None,
+    cache_write_1h: int | None = None,
+) -> MessageUsage:
+    return MessageUsage.model_validate(
+        {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cache_read_input_tokens": cache_read,
+            "cache_creation_input_tokens": cache_write,
+            "cache_creation": (
+                {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": cache_write_1h}
+                if cache_write_1h is not None
+                else None
+            ),
+        }
+    )
+
+
+def _message_response(usage: MessageUsage | None) -> MessageResponse:
+    if usage is None:
+        # The SDK model requires ``usage``; a provider adapter that hands one back
+        # without it is exactly the "reported nothing" case worth covering.
+        return MessageResponse.model_construct(usage=None)
+    return MessageResponse(
+        id="msg_1",
+        type="message",
+        role="assistant",
+        model="fake",
+        content=[],
+        stop_reason=cast(Any, "end_turn"),
+        stop_sequence=None,
+        usage=cast(Any, usage),
+        container=None,
+    )
+
+
+def _message_start(usage: MessageUsage) -> MessageStartEvent:
+    return MessageStartEvent(type="message_start", message=cast(Any, _message_response(usage)))
+
+
+def _message_delta(output_tokens: int) -> MessageDeltaEvent:
+    return MessageDeltaEvent.model_validate(
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"input_tokens": None, "output_tokens": output_tokens},
+        }
+    )
+
+
+def _responses_usage(*, input_tokens: int, output_tokens: int, cached: int = 0) -> ResponseUsage:
+    return ResponseUsage(
+        input_tokens=input_tokens,
+        input_tokens_details=InputTokensDetails(cached_tokens=cached),
+        output_tokens=output_tokens,
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+        total_tokens=input_tokens + output_tokens,
+    )
+
+
+def _response(usage: ResponseUsage | None) -> Response:
+    return Response(
+        id="resp_1",
+        created_at=0.0,
+        model="fake",
+        object="response",
+        status=cast(Any, "completed"),
+        output=[],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+        usage=usage,
+    )
+
+
+# ---------- the cross-provider reconciliation ----------
+
+
+def test_openai_and_anthropic_agree_on_identical_real_token_counts() -> None:
+    """1000 in, 800 of it a cache read, 50 out, expressed in each provider's own fields."""
+    openai = _CHAT_STRATEGY.usage_snapshot(
+        _chat_completion(
+            CompletionUsage(
+                prompt_tokens=1000,
+                completion_tokens=50,
+                total_tokens=1050,
+                prompt_tokens_details=PromptTokensDetails(cached_tokens=800),
+            )
+        )
+    )
+    anthropic = _MESSAGES_STRATEGY.usage_snapshot(
+        _message_response(_message_usage(input_tokens=200, output_tokens=50, cache_read=800))
+    )
+
+    assert openai is not None
+    assert anthropic is not None
+    assert openai.cache_tokens_in_prompt is True
+    assert anthropic.cache_tokens_in_prompt is False
+    assert _effective_prompt_tokens(openai) == _effective_prompt_tokens(anthropic) == 1000
+    assert openai.completion_tokens == anthropic.completion_tokens == 50
+    assert openai.cache_read_tokens == anthropic.cache_read_tokens == 800
+    assert openai.cache_write_tokens == anthropic.cache_write_tokens == 0
+
+
+def test_anthropic_cache_writes_and_the_1h_breakdown_survive() -> None:
+    """Cache writes are the priciest input class, so a snapshot that drops them lies."""
+    snapshot = _MESSAGES_STRATEGY.usage_snapshot(
+        _message_response(
+            _message_usage(
+                input_tokens=100,
+                output_tokens=20,
+                cache_read=40,
+                cache_write=15,
+                cache_write_1h=10,
+            )
+        )
+    )
+
+    assert snapshot is not None
+    assert snapshot.cache_write_tokens == 15
+    assert snapshot.cache_write_1h_tokens == 10
+    assert _effective_prompt_tokens(snapshot) == 155
+
+
+# ---------- streaming agrees with non-streaming ----------
+
+
+def test_chat_streamed_round_matches_the_non_streamed_round() -> None:
+    usage = CompletionUsage(
+        prompt_tokens=1000,
+        completion_tokens=50,
+        total_tokens=1050,
+        prompt_tokens_details=PromptTokensDetails(cached_tokens=800),
+    )
+    state = _CHAT_STRATEGY.new_stream_state()
+    acc: None = None  # chat's stream accumulator is None by design
+    for event in (_chat_terminal_chunk(), _chat_usage_chunk(usage)):
+        _CHAT_STRATEGY.observe(state, event, _POOL, acc)
+
+    assert _CHAT_STRATEGY.stream_usage_snapshot(state) == _CHAT_STRATEGY.usage_snapshot(
+        _chat_completion(usage)
+    )
+
+
+def test_messages_streamed_round_matches_the_non_streamed_round() -> None:
+    """Anthropic splits one round's usage over message_start and message_delta."""
+    state = _MESSAGES_STRATEGY.new_stream_state()
+    acc = _MESSAGES_STRATEGY.new_stream_accumulator()
+    events: list[MessageStreamEvent] = [
+        _message_start(
+            _message_usage(
+                input_tokens=100, output_tokens=0, cache_read=40, cache_write=15, cache_write_1h=10
+            )
+        ),
+        _message_delta(output_tokens=20),
+    ]
+    for event in events:
+        _MESSAGES_STRATEGY.observe(state, event, _POOL, acc)
+
+    assert _MESSAGES_STRATEGY.stream_usage_snapshot(state) == _MESSAGES_STRATEGY.usage_snapshot(
+        _message_response(
+            _message_usage(
+                input_tokens=100, output_tokens=20, cache_read=40, cache_write=15, cache_write_1h=10
+            )
+        )
+    )
+
+
+def test_responses_streamed_round_matches_the_non_streamed_round() -> None:
+    usage = _responses_usage(input_tokens=1000, output_tokens=50, cached=800)
+    state = _RESPONSES_STRATEGY.new_stream_state()
+    acc = _RESPONSES_STRATEGY.new_stream_accumulator()
+    _RESPONSES_STRATEGY.observe(
+        state,
+        ResponseCompletedEvent(type="response.completed", response=_response(usage), sequence_number=0),
+        _POOL,
+        acc,
+    )
+
+    assert _RESPONSES_STRATEGY.stream_usage_snapshot(state) == _RESPONSES_STRATEGY.usage_snapshot(
+        _response(usage)
+    )
+
+
+# ---------- unknown is not zero ----------
+
+
+def test_chat_stream_without_include_usage_yields_none() -> None:
+    """A caller that set ``include_usage: False`` gets no usage, which is not zero usage."""
+    state = _CHAT_STRATEGY.new_stream_state()
+    acc: None = None  # chat's stream accumulator is None by design
+    _CHAT_STRATEGY.observe(state, _chat_terminal_chunk(), _POOL, acc)
+
+    assert _CHAT_STRATEGY.stream_usage_snapshot(state) is None
+
+
+@pytest.mark.parametrize(
+    ("snapshot", "result"),
+    [
+        pytest.param(_CHAT_STRATEGY.usage_snapshot, _chat_completion(None), id="chat"),
+        pytest.param(_MESSAGES_STRATEGY.usage_snapshot, _message_response(None), id="messages"),
+        pytest.param(_RESPONSES_STRATEGY.usage_snapshot, _response(None), id="responses"),
+    ],
+)
+def test_a_result_without_usage_yields_none(snapshot: Any, result: Any) -> None:
+    assert snapshot(result) is None
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        pytest.param(_MESSAGES_STRATEGY, id="messages"),
+        pytest.param(_RESPONSES_STRATEGY, id="responses"),
+    ],
+)
+def test_a_stream_that_reported_nothing_yields_none(strategy: Any) -> None:
+    assert strategy.stream_usage_snapshot(strategy.new_stream_state()) is None
+
+
+# ---------- the loop's own accounting is untouched ----------
+
+
+def test_snapshot_reads_the_round_while_the_loop_still_folds_the_total() -> None:
+    """The snapshot reads the provider's own fields and leaves the accumulators alone.
+
+    The loop's usage accounting exists to fold every round's totals into the one
+    response the client sees, and it must keep doing exactly that.
+    """
+    rounds = [
+        _chat_completion(CompletionUsage(prompt_tokens=10, completion_tokens=3, total_tokens=13)),
+        _chat_completion(CompletionUsage(prompt_tokens=20, completion_tokens=5, total_tokens=25)),
+    ]
+    snapshots = [_CHAT_STRATEGY.usage_snapshot(result) for result in rounds]
+
+    acc = _CHAT_STRATEGY.new_usage_accumulator()
+    for result in rounds:
+        _CHAT_STRATEGY.accumulate_usage(acc, result)
+    _CHAT_STRATEGY.fold_usage(rounds[-1], acc)
+
+    assert [(s.prompt_tokens, s.completion_tokens) for s in snapshots if s is not None] == [(10, 3), (20, 5)]
+    assert rounds[-1].usage is not None
+    assert (rounds[-1].usage.prompt_tokens, rounds[-1].usage.completion_tokens) == (30, 8)

--- a/tests/unit/test_observation_usage_snapshot.py
+++ b/tests/unit/test_observation_usage_snapshot.py
@@ -32,7 +32,7 @@ from any_llm.types.messages import (
     MessageUsage,
 )
 from any_llm.types.responses import Response
-from openai.types.responses import ResponseCompletedEvent, ResponseUsage
+from openai.types.responses import ResponseCompletedEvent, ResponseIncompleteEvent, ResponseUsage
 from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
 
 from gateway.core.usage import GatewayUsage
@@ -167,6 +167,26 @@ def _message_delta(output_tokens: int) -> MessageDeltaEvent:
     )
 
 
+def _message_delta_with_iterations(iterations: list[dict[str, Any]]) -> MessageDeltaEvent:
+    """A ``message_delta`` whose ``iterations`` sum to what the round is billed.
+
+    The shape ``tests/integration/test_messages_streaming_usage.py`` pins: Anthropic
+    reports compaction sampling here and not on ``message_start``, which only ever
+    saw the first pass.
+    """
+    return MessageDeltaEvent.model_validate(
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {
+                "input_tokens": iterations[-1]["input_tokens"],
+                "output_tokens": iterations[-1]["output_tokens"],
+                "iterations": iterations,
+            },
+        }
+    )
+
+
 def _responses_usage(*, input_tokens: int, output_tokens: int, cached: int = 0) -> ResponseUsage:
     return ResponseUsage(
         input_tokens=input_tokens,
@@ -177,13 +197,13 @@ def _responses_usage(*, input_tokens: int, output_tokens: int, cached: int = 0) 
     )
 
 
-def _response(usage: ResponseUsage | None) -> Response:
+def _response(usage: ResponseUsage | None, status: str = "completed") -> Response:
     return Response(
         id="resp_1",
         created_at=0.0,
         model="fake",
         object="response",
-        status=cast(Any, "completed"),
+        status=cast(Any, status),
         output=[],
         parallel_tool_calls=False,
         tool_choice="auto",
@@ -298,6 +318,92 @@ def test_responses_streamed_round_matches_the_non_streamed_round() -> None:
 
     assert _RESPONSES_STRATEGY.stream_usage_snapshot(state) == _RESPONSES_STRATEGY.usage_snapshot(
         _response(usage)
+    )
+
+
+def test_messages_streamed_compaction_round_matches_the_non_streamed_round() -> None:
+    """Only ``message_delta`` carries the iterations, so the input side has to read it.
+
+    Taking the input from ``message_start`` wholesale reports a compaction round's
+    output summed over every iteration and its input from only the first, which
+    understates the cache re-read the estimate is mostly made of, and disagrees with
+    what the same stream is billed.
+    """
+    iterations: list[dict[str, Any]] = [
+        {
+            "type": "compaction",
+            "input_tokens": 100,
+            "output_tokens": 20,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 30,
+        },
+        {
+            "type": "message",
+            "input_tokens": 42,
+            "output_tokens": 7,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 5,
+        },
+    ]
+    state = _MESSAGES_STRATEGY.new_stream_state()
+    acc = _MESSAGES_STRATEGY.new_stream_accumulator()
+    events: list[MessageStreamEvent] = [
+        _message_start(_message_usage(input_tokens=42, output_tokens=0)),
+        _message_delta_with_iterations(iterations),
+    ]
+    for event in events:
+        _MESSAGES_STRATEGY.observe(state, event, _POOL, acc)
+
+    streamed = _MESSAGES_STRATEGY.stream_usage_snapshot(state)
+    non_streamed = _MESSAGES_STRATEGY.usage_snapshot(
+        _message_response(
+            MessageUsage.model_validate(
+                {"input_tokens": 42, "output_tokens": 7, "iterations": iterations}
+            )
+        )
+    )
+
+    assert streamed == non_streamed
+    assert streamed is not None
+    assert (streamed.prompt_tokens, streamed.completion_tokens) == (142, 27)
+    assert streamed.cache_read_tokens == 35
+
+
+def test_messages_stream_keeps_the_start_input_when_the_delta_reports_none() -> None:
+    """The ordinary round: only ``message_start`` knows the input side."""
+    state = _MESSAGES_STRATEGY.new_stream_state()
+    acc = _MESSAGES_STRATEGY.new_stream_accumulator()
+    events: list[MessageStreamEvent] = [
+        _message_start(_message_usage(input_tokens=100, output_tokens=0, cache_read=40)),
+        _message_delta(output_tokens=20),
+    ]
+    for event in events:
+        _MESSAGES_STRATEGY.observe(state, event, _POOL, acc)
+
+    snapshot = _MESSAGES_STRATEGY.stream_usage_snapshot(state)
+
+    assert snapshot is not None
+    assert (snapshot.prompt_tokens, snapshot.cache_read_tokens, snapshot.completion_tokens) == (100, 40, 20)
+
+
+def test_responses_stream_reports_usage_for_a_round_that_ended_incomplete() -> None:
+    """A truncated round was still billed, so it is not an unknown-usage round."""
+    usage = _responses_usage(input_tokens=8000, output_tokens=512)
+    state = _RESPONSES_STRATEGY.new_stream_state()
+    acc = _RESPONSES_STRATEGY.new_stream_accumulator()
+    _RESPONSES_STRATEGY.observe(
+        state,
+        ResponseIncompleteEvent(
+            type="response.incomplete",
+            response=_response(usage, status="incomplete"),
+            sequence_number=0,
+        ),
+        _POOL,
+        acc,
+    )
+
+    assert _RESPONSES_STRATEGY.stream_usage_snapshot(state) == _RESPONSES_STRATEGY.usage_snapshot(
+        _response(usage, status="incomplete")
     )
 
 

--- a/tests/unit/test_purpose_hint_normalization.py
+++ b/tests/unit/test_purpose_hint_normalization.py
@@ -1,0 +1,99 @@
+"""Purpose-hint normalization for the Reprise v0 fingerprint (otari-ai#1647).
+
+``hint_hash`` is a fingerprint input, so anything that moves it regroups every
+observation in the deployment. Three properties keep it stable against changes
+the customer never made: declaration order does not count, the deployment's
+header does not count, and a hint the caller never declared hashes as a sentinel
+instead of as whatever text the deployment resolved for it. The text the model
+actually saw stays visible as ``injected_block_hash``, which is expected to move
+in exactly the cases the key must not.
+"""
+
+import pytest
+
+from gateway.core.observation import UNDECLARED_HINT, hint_hash, text_hash
+from gateway.services.mcp_loop import inject_purpose_hints
+from gateway.services.tool_format import (
+    build_hint_block,
+    inject_purpose_hints_anthropic,
+    inject_purpose_hints_responses,
+    normalize_purpose_hints,
+)
+
+_DECLARED = ("github", "slack")
+
+
+def _hint_hash(hints: list[tuple[str, str]], declared: tuple[str, ...] = _DECLARED) -> str:
+    return hint_hash(normalize_purpose_hints(hints, caller_declared=set(declared)))
+
+
+def test_declaration_order_does_not_change_the_hint_hash() -> None:
+    forward = [("github", "issues and PRs"), ("slack", "team chat")]
+    reversed_order = [("slack", "team chat"), ("github", "issues and PRs")]
+
+    assert _hint_hash(forward) == _hint_hash(reversed_order)
+
+
+def test_injected_block_keeps_the_callers_order() -> None:
+    """Only the hash sorts: the model sees the servers in the declared order."""
+    block = build_hint_block([("slack", "team chat"), ("github", "issues and PRs")])
+
+    assert block.index("- slack:") < block.index("- github:")
+
+
+def test_header_changes_the_block_but_not_the_hint_hash(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``OTARI_TOOLS_HEADER`` is a deployment knob, so it stays out of the key."""
+    hints = [("github", "issues and PRs")]
+
+    monkeypatch.setenv("OTARI_TOOLS_HEADER", "Tools at your disposal:")
+    block_with_env_header = build_hint_block(hints)
+    key_with_env_header = _hint_hash(hints)
+
+    monkeypatch.delenv("OTARI_TOOLS_HEADER")
+    block_with_default_header = build_hint_block(hints)
+    key_with_default_header = _hint_hash(hints)
+
+    assert key_with_env_header == key_with_default_header
+    assert text_hash(block_with_env_header) != text_hash(block_with_default_header)
+
+
+def test_undeclared_hint_normalizes_to_the_sentinel() -> None:
+    normalized = normalize_purpose_hints(
+        [("github", "issues and PRs"), ("otari_code_execution", "run python")],
+        caller_declared={"github"},
+    )
+
+    assert normalized == [("github", "issues and PRs"), ("otari_code_execution", UNDECLARED_HINT)]
+
+
+def test_editing_a_resolved_default_moves_the_block_but_not_the_hint_hash() -> None:
+    """An operator editing the sandbox hint in the dashboard must not reset the piles."""
+    before = [("otari_code_execution", "Run Python in a sandbox.")]
+    after = [("otari_code_execution", "Execute code in an isolated sandbox.")]
+    declared: set[str] = set()
+
+    key_before = hint_hash(normalize_purpose_hints(before, caller_declared=declared))
+    key_after = hint_hash(normalize_purpose_hints(after, caller_declared=declared))
+    assert key_before == key_after
+
+    # ...and the edit is still visible, because the payload records the block as sent.
+    assert text_hash(build_hint_block(before)) != text_hash(build_hint_block(after))
+
+
+def test_declared_hint_text_is_part_of_the_key() -> None:
+    """The sentinel replaces only what the caller left out, not what it wrote."""
+    assert _hint_hash([("github", "issues and PRs")]) != _hint_hash([("github", "code review")])
+
+
+def test_all_three_formats_inject_the_same_block() -> None:
+    """``injected_block_hash`` is format-neutral, so the three assemblies must agree."""
+    hints = [("github", "issues and PRs"), ("slack", "team chat")]
+    block = build_hint_block(hints)
+
+    chat = inject_purpose_hints([{"role": "user", "content": "hi"}], hints)
+    anthropic = inject_purpose_hints_anthropic({}, hints)
+    responses = inject_purpose_hints_responses({}, hints)
+
+    assert chat[0] == {"role": "system", "content": block}
+    assert anthropic["system"] == block
+    assert responses["instructions"] == block

--- a/tests/unit/test_usage_cache_tokens.py
+++ b/tests/unit/test_usage_cache_tokens.py
@@ -9,8 +9,13 @@ from any_llm.types.completion import (
 
 from gateway.api.routes.chat import _ChatAdapter
 from gateway.api.routes.messages import _messages_stream_usage, _MessagesAdapter, _requested_cache_write_ttl
-from gateway.api.routes.responses import _usage_to_completion_usage
-from gateway.core.usage import GatewayUsage, cache_read_tokens_of, cache_write_1h_tokens_of, cache_write_tokens_of
+from gateway.core.usage import (
+    GatewayUsage,
+    cache_read_tokens_of,
+    cache_write_1h_tokens_of,
+    cache_write_tokens_of,
+    responses_usage,
+)
 
 
 def test_gateway_usage_defaults_to_zero() -> None:
@@ -285,7 +290,7 @@ def test_responses_captures_cached_tokens() -> None:
         input_tokens_details=InputTokensDetails(cached_tokens=33),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
     )
-    usage = _usage_to_completion_usage(usage_in)
+    usage = responses_usage(usage_in)
     assert isinstance(usage, GatewayUsage)
     assert usage.cache_read_tokens == 33
     assert usage.cache_write_tokens == 0


### PR DESCRIPTION
## Description

The v0 fingerprint has to group the same automation together whichever wire format it arrived through. Several of its inputs are currently unobtainable in a format-neutral way, and each one silently halves or destroys support if the implementer guesses. This adds the normalization hooks the fingerprint reads from, and nothing else: **nothing calls any of them from a request path yet.** Computing the fingerprint is mozilla-ai/otari-ai#1648; emitting the record is mozilla-ai/otari-ai#1484.

Five commits, each closing one gap.

**Purpose hints have three authors and only one is the customer.** Hints come out in the order the request body listed the servers, the preamble header is a deployment knob (`OTARI_TOOLS_HEADER`), and a hint the caller never supplied resolves to whatever the dashboard, env, or YAML holds. Hashing the block as assembled means an operator editing a text field, or a release rewording a built-in, resets every pile in the deployment mid-measurement with nobody having touched the automation. `normalize_purpose_hints` sorts the pairs, excludes the header, and replaces an undeclared hint with the literal sentinel `"<default>"`. The injected block keeps the caller's order, because that is what the model sees.

**The caller's prompt lives in three places and is rewritten before dispatch.** `client_system_prompt` and `first_user_message` land on `FormatAdapter` because `inject_hints` runs at the route layer and all three adapters copy before injecting, so that is the last point at which `call_kwargs` still holds the caller's original text. Hashing the *injected* result is not available: the gateway prepends the block for two formats and appends it for the third, so the same automation through two SDKs would never group. Both accessors normalize rather than merely read, so a string `system` and an equivalent single text block agree, a `developer`-led chat request agrees with a `system`-led one, and a `cache_control` marker (which moves money, not meaning) changes nothing.

**Tool definitions are format-shaped.** `normalize_tools` unwraps nested `function.parameters`, `input_schema`, and flat `parameters` into one triple, feeding two values that move for unrelated reasons: `tool_set_hash` (sorted names, a fingerprint input) and `tool_definitions_hash` (names, descriptions, canonicalized schemas; payload only). They are split because both description and schema arrive in the same live `list_tools()` response and `MCPClientPool` is rebuilt per request, so an upstream server adding one optional property, backward compatibly and breaking nothing, would otherwise split every pile in the workspace from that moment on.

**Usage field names and semantics differ, and the cache term is captured nowhere.** OpenAI's `prompt_tokens` includes cached tokens; Anthropic's `input_tokens` excludes them; Responses has no cache field at all. Since the saving estimate v0 exists to produce is mostly the cache re-read, recording "whatever this provider calls input" understates the number in the direction that cancels the project. `usage_snapshot` / `stream_usage_snapshot` return a `GatewayUsage` rather than a bespoke triple: the carrier already holds cache reads, cache writes, the 1-hour write subset, and `cache_tokens_in_prompt`, which is the per-format mapping expressed as data rather than as a table. A hand-written triple would drop cache writes, the priciest input class (1.25x base input at 5m, 2x at 1h, against 0.1x for a read), and would need editing for every new any-llm provider.

Streaming returns the same populated snapshot, not a partial one. Anthropic splits a round across `message_start` (input and cache) and `message_delta` (cumulative output), and both reach `observe` even on a continuing round, where the strategy defers rather than drops them. The one genuine gap is a chat caller who explicitly sets `include_usage: False`: there the provider sends nothing and the snapshot is `None` rather than a zero-filled carrier, because zero and unknown are different answers and mozilla-ai/otari-ai#1488 has to tell them apart.

The snapshots read the provider's own fields and do **not** touch the loop's usage accumulators, which exist to fold totals into the client response and keep doing exactly that. A test asserts that.

### Two things worth a reviewer's attention

**The hooks are on the Protocols, not duck-typed**, so `mypy --strict` names any format that forgot one. `normalize_tools` and `usage_snapshot` sit on `ToolLoopStrategy` even though nothing in the loop calls either; the Protocol docstring says so out loud, because the merged tool list is built there and the raw provider result is only in scope there.

**Chat completions still assembles the hint block inline** in `inject_purpose_hints`, duplicating `build_hint_block`. Unifying them means moving code between `mcp_loop` and `tool_format` (the import already runs one way, `tool_format` → `mcp_loop`), and this PR is meant to change no behavior. Instead a test pins all three formats to one string, so a future divergence fails there rather than silently splitting `injected_block_hash` from what chat actually sent.

### One fix, from reviewing the diff

An adversarial review pass over the diff after opening found three defects, each fixed in `f685f47` with a test written failing first:

- **The Anthropic streaming snapshot understated input on a compaction round.** It took the whole input side from `message_start`, which is emitted before the compaction pass, so only the `message_delta` carries the `iterations` list that sums to the billed total. It reported output summed over every iteration and input from only the first: 42 in against the 142 the gateway bills for the exact stream `tests/integration/test_messages_streaming_usage.py` already pins. Now reconciled per field, last non-zero winning, the convention `gateway.streaming._merge_usage` already applies to this stream.
- **Every Responses provider-native tool normalized to an empty name.** Anthropic's native tools carry `name`; the Responses ones carry none, since identity lives in `type`. So `web_search`, `file_search`, and `mcp` shared one `tool_set_hash`. Name now falls back to `type`.
- **A Responses round ending in `response.incomplete` reported unknown usage.** Truncation by `max_output_tokens` or a content filter is billed, but the snapshot read only `response.completed`, so a paid round returned the value reserved to mean "the provider reported nothing".

Two of the three were untested cases rather than mistyped code: the acceptance criterion "streamed round == non-streamed round" passed while being false, because the fixture carried no `iterations`.

### One refactor, separated

`c96fb87` is a pure move: the Anthropic usage readers (`_billable_messages_usage` including the compaction `iterations` sum, `_cache_write_1h_tokens`) and the Responses one (`_usage_to_completion_usage`) go from their route modules into `core/usage.py`. The tool-loop strategies need the same readings and a service may not import the API layer, so `core` is the only place both sides can reach, and it already owns `GatewayUsage`. Same code, same declared types, no behavior change.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Closes mozilla-ai/otari-ai#1647

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). Also `make openapi-check`.
- [x] Documentation was updated where necessary. No user-facing surface changed, so no doc change; the reasoning lives in the module and Protocol docstrings, which is where the next reader of these hooks will be.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). No contract change; `make openapi-check` clean.
- [x] If this PR adds or changes a persistent table, a control-plane contract the otari.ai platform consumes or serves, a capability the platform also has, or a mode-specific surface, I appended an entry to the M4 reconciliation ledger ([otari-ai#1587](https://github.com/mozilla-ai/otari-ai/issues/1587)). Entry to follow on this PR, against the **Usage and observability** row; target disposition unchanged, since these hooks add no second accounting implementation.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

Implementation and tests written by Claude from the issue body, test-first. A multi-agent adversarial review over the diff ran after opening; it raised 12 findings, 6 survived independent refutation, and those were the 3 distinct defects fixed in `f685f47` (the streaming-compaction one was found by four separate lenses). The agent also ran `make lint`, `make typecheck`, the full unit suite, and the integration suite locally.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)
