### PR TITLE
feat(budgets): report the migration decisions budgets cannot make on their own

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -90,7 +90,7 @@ Assign a budget to a user by setting `budget_id` on the user (at create time or 
 
 ### Preflight before the reconciled budget engine
 
-Otari's budget model is converging onto the one otari.ai runs, whose reset cadence is a fixed period (daily, weekly, or monthly) aligned to the calendar. Two things in your data have no single right answer under that model, so `otari budgets migration-report` lists them before you upgrade:
+Otari's budget model is converging onto the one otari.ai runs, whose reset cadence is a fixed period (daily, weekly, or monthly) aligned to the calendar. Three things in your data have no single right answer under that model, so `otari budgets migration-report` lists them before you upgrade:
 
 ```bash
 otari budgets migration-report --database-url postgresql://... # add --json for a machine readable form
@@ -99,7 +99,9 @@ otari budgets migration-report --database-url postgresql://... # add --json for 
 - **Durations that have to round.** A `budget_duration_sec` with no exact counterpart rounds to the nearest period, which changes how fast a capped user may spend. The report gives each one a rate factor: above `1.00` the cap gets looser, below it the cap gets tighter.
 - **Budgets more than one user shares.** Because `max_budget` is already a per-user ceiling, each attached user becomes their own budget and nothing about enforcement changes. The report lists these so you can instead pool them under one workspace budget, which is a real change in behavior rather than a migration artifact.
 
-Budgets with no `budget_duration_sec` are listed too, since a cap that never resets has to be given a period. The command only reads, so it is safe to run against a live deployment, and it runs no migration itself.
+- **Budgets with no `budget_duration_sec`.** A cap that never resets has to be given a period, since the reconciled model requires one.
+
+The command only reads, so it is safe to run against a live deployment, and it runs no migration itself.
 
 The enforcement strategy is configurable with `OTARI_BUDGET_STRATEGY` (`for_update` row-lock, `cas` compare-and-swap, or `disabled`); see [Configuration](configuration.md).
 

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -88,6 +88,19 @@ curl -X POST http://localhost:8000/v1/budgets \
 
 Assign a budget to a user by setting `budget_id` on the user (at create time or via `PATCH /v1/users/{user_id}`). Manage budgets with `GET /v1/budgets`, `GET /v1/budgets/{budget_id}`, `PATCH /v1/budgets/{budget_id}`, and `DELETE /v1/budgets/{budget_id}`. A budget's response rolls up the users assigned to it: `user_count`, `total_spend`, and `total_reserved`. `GET /v1/budgets/{budget_id}/reset-logs` returns the per-user reset history.
 
+### Preflight before the reconciled budget engine
+
+Otari's budget model is converging onto the one otari.ai runs, whose reset cadence is a fixed period (daily, weekly, or monthly) aligned to the calendar. Two things in your data have no single right answer under that model, so `otari budgets migration-report` lists them before you upgrade:
+
+```bash
+otari budgets migration-report --database-url postgresql://... # add --json for a machine readable form
+```
+
+- **Durations that have to round.** A `budget_duration_sec` with no exact counterpart rounds to the nearest period, which changes how fast a capped user may spend. The report gives each one a rate factor: above `1.00` the cap gets looser, below it the cap gets tighter.
+- **Budgets more than one user shares.** Because `max_budget` is already a per-user ceiling, each attached user becomes their own budget and nothing about enforcement changes. The report lists these so you can instead pool them under one workspace budget, which is a real change in behavior rather than a migration artifact.
+
+Budgets with no `budget_duration_sec` are listed too, since a cap that never resets has to be given a period. The command only reads, so it is safe to run against a live deployment, and it runs no migration itself.
+
 The enforcement strategy is configurable with `OTARI_BUDGET_STRATEGY` (`for_update` row-lock, `cas` compare-and-swap, or `disabled`); see [Configuration](configuration.md).
 
 ## See also

--- a/src/gateway/cli.py
+++ b/src/gateway/cli.py
@@ -1,3 +1,5 @@
+import asyncio
+import json
 import logging
 import os
 import re
@@ -384,6 +386,63 @@ def routing_explain(
             "/v1/chat/completions, /v1/messages and /v1/responses; on the other model-taking endpoints "
             "(embeddings, images, moderations, rerank, batches) it is not a resolvable model name."
         )
+
+
+@cli.group()
+def budgets() -> None:
+    """Inspect budgets."""
+
+
+@budgets.command(name="migration-report")
+@click.option(
+    "--config",
+    "-c",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to config YAML file",
+    default=None,
+)
+@click.option("--database-url", envvar="DATABASE_URL", help="Database connection URL")
+@click.option("--json", "as_json", is_flag=True, help="Emit the report as JSON instead of text")
+def budgets_migration_report(config: str | None, database_url: str | None, as_json: bool) -> None:
+    """Report what the budget migration cannot decide on its own.
+
+    Reads this gateway's budgets and the users attached to them, then lists every
+    duration that has to round onto one of the reconciled engine's periods, every
+    budget with no duration at all, and every budget more than one user shares.
+
+    Read only. Nothing is written and no migration runs, so this is safe to run
+    against a production database before an upgrade.
+    """
+    from sqlalchemy.exc import SQLAlchemyError
+
+    from gateway.db import create_session
+    from gateway.db import init_db as db_init
+    from gateway.services.budget_migration_report import build_migration_report, render_text
+
+    gateway_config = load_config(config)
+
+    if database_url:
+        gateway_config.database_url = database_url
+    # A preflight must not change the database it reports on, so the startup
+    # migration is off here whatever the config says.
+    gateway_config.auto_migrate = False
+
+    db_init(gateway_config)
+
+    async def _build() -> str:
+        async with create_session() as session:
+            report = await build_migration_report(session)
+        return json.dumps(report.to_dict(), indent=2) if as_json else render_text(report)
+
+    try:
+        click.echo(asyncio.run(_build()))
+    except SQLAlchemyError as exc:
+        raise click.ClickException(
+            # The driver's own message ("no such table: budgets") is the useful
+            # half; str(exc) appends the whole statement, which buries it.
+            f"Could not read budgets from {gateway_config.database_url}: {getattr(exc, 'orig', exc)}. "
+            "If this database predates the budgets table, run `otari migrate` first."
+        ) from exc
 
 
 def main() -> None:

--- a/src/gateway/cli.py
+++ b/src/gateway/cli.py
@@ -413,6 +413,7 @@ def budgets_migration_report(config: str | None, database_url: str | None, as_js
     Read only. Nothing is written and no migration runs, so this is safe to run
     against a production database before an upgrade.
     """
+    from sqlalchemy.engine import make_url
     from sqlalchemy.exc import SQLAlchemyError
 
     from gateway.db import create_session
@@ -436,11 +437,19 @@ def budgets_migration_report(config: str | None, database_url: str | None, as_js
 
     try:
         click.echo(asyncio.run(_build()))
-    except SQLAlchemyError as exc:
+    # A refused connection or an unreachable host surfaces as a bare OSError from
+    # the driver's transport, never reaching SQLAlchemy's exception wrapping, and
+    # pointing this at the wrong host is the likeliest way to get it wrong. Both
+    # arms have to be caught or that case exits on a traceback.
+    except (SQLAlchemyError, OSError) as exc:
+        # Naming the database is what makes the failure actionable, but a
+        # PostgreSQL URL carries a password, and this message reaches terminal
+        # history and CI logs. Render it with the password masked.
+        safe_url = make_url(gateway_config.database_url).render_as_string(hide_password=True)
         raise click.ClickException(
             # The driver's own message ("no such table: budgets") is the useful
             # half; str(exc) appends the whole statement, which buries it.
-            f"Could not read budgets from {gateway_config.database_url}: {getattr(exc, 'orig', exc)}. "
+            f"Could not read budgets from {safe_url}: {getattr(exc, 'orig', exc)}. "
             "If this database predates the budgets table, run `otari migrate` first."
         ) from exc
 

--- a/src/gateway/services/budget_migration_report.py
+++ b/src/gateway/services/budget_migration_report.py
@@ -301,7 +301,7 @@ def render_text(report: BudgetMigrationReport) -> str:
     lines += [
         f"{len(report.budgets)} budget(s) in this gateway.",
         f"{report.member_budgets_to_create} member budget(s) would be created in the default workspace.",
-        f"{report.reset_log_count} budget_reset_logs row(s) archive with the legacy tables, unmapped.",
+        f"{report.reset_log_count} row(s) in budget_reset_logs are archived with the legacy tables, not mapped.",
     ]
     if report.deleted_attachments:
         lines.append(

--- a/src/gateway/services/budget_migration_report.py
+++ b/src/gateway/services/budget_migration_report.py
@@ -1,0 +1,359 @@
+"""Preflight report for the budget half of the reconciled control plane.
+
+The reconciled engine keeps one budget model, whose reset cadence is one of the
+platform's three ``BudgetPeriod`` values. This gateway's ``budgets`` table does
+not line up with it in three ways, none of which a migration can decide on an
+operator's behalf:
+
+* ``budget_duration_sec`` is an arbitrary second count, so a duration with no
+  exact counterpart has to round to the nearest period, changing how much a
+  capped user may spend per unit of time.
+* Gateway periods roll from each user's ``budget_started_at``; the reconciled
+  periods are calendar aligned (midnight UTC, Monday, the 1st). Every budget is
+  re-anchored, including the ones whose duration maps exactly.
+* One ``budgets`` row may be attached to several users. Enforcement is per user
+  (``users.spend + users.reserved`` against that row's ``max_budget``), so the
+  row is a shared limit rather than a shared pot of money, and the default
+  mapping materializes one member budget per attached user.
+
+This module enumerates all three before an operator crosses the migration,
+rather than leaving them to be discovered afterwards from a changed bill. It is
+strictly read only: nothing here writes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Final
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.models.entities import Budget, BudgetResetLog, User
+
+__all__ = [
+    "PERIOD_SECONDS",
+    "AttachedUser",
+    "BudgetMigrationReport",
+    "BudgetPlan",
+    "DurationMapping",
+    "build_migration_report",
+    "map_duration",
+    "render_text",
+]
+
+# Seconds the reconciled engine's three periods nominally span. Its windows are
+# calendar aligned, so a real month runs 28 to 31 days; 30 is the nominal length
+# rounding compares against, and the drift it reports is nominal for that reason.
+PERIOD_SECONDS: Final[dict[str, int]] = {
+    "daily": 86_400,
+    "weekly": 604_800,
+    "monthly": 2_592_000,
+}
+
+
+@dataclass(frozen=True)
+class DurationMapping:
+    """Which reconciled period a gateway duration lands on, and what that costs."""
+
+    duration_sec: int
+    period: str
+    is_exact: bool
+
+    @property
+    def drift_sec(self) -> int:
+        """Signed gap from the gateway duration to the period it maps onto.
+
+        Positive means the new period is longer than the old duration.
+        """
+        return PERIOD_SECONDS[self.period] - self.duration_sec
+
+    @property
+    def rate_factor(self) -> float:
+        """Multiplier on how fast a capped user may spend after the migration.
+
+        The same ``max_budget`` applied over a shorter window is more money per
+        unit of time, so a factor above 1.0 loosens the cap and one below 1.0
+        tightens it. This is the number that decides whether a rounded duration
+        needs an operator to intervene.
+        """
+        return self.duration_sec / PERIOD_SECONDS[self.period]
+
+
+def map_duration(duration_sec: int) -> DurationMapping:
+    """Map a gateway ``budget_duration_sec`` onto the nearest reconciled period.
+
+    Nearest is measured in seconds. An exact tie (four days sits exactly between
+    daily and weekly) resolves to the longer period, which is the direction that
+    cannot let a user outspend what the gateway allowed them.
+    """
+    period, seconds = min(
+        PERIOD_SECONDS.items(),
+        key=lambda item: (abs(item[1] - duration_sec), -item[1]),
+    )
+    return DurationMapping(duration_sec=duration_sec, period=period, is_exact=seconds == duration_sec)
+
+
+@dataclass(frozen=True)
+class AttachedUser:
+    """A gateway user pointed at a budget, and the counters that carry over."""
+
+    user_id: str
+    spend: float
+    reserved: float
+    is_deleted: bool
+
+
+@dataclass(frozen=True)
+class BudgetPlan:
+    """One gateway budget row and what the migration makes of it."""
+
+    budget_id: str
+    name: str | None
+    max_budget: float | None
+    duration_sec: int | None
+    attached: list[AttachedUser] = field(default_factory=list)
+
+    @property
+    def live_attached(self) -> list[AttachedUser]:
+        """Attachments that materialize as member budgets.
+
+        Soft deleted users migrate as deactivated identities, so their budget is
+        history rather than a live cap and is counted separately.
+        """
+        return [user for user in self.attached if not user.is_deleted]
+
+    @property
+    def is_shared_pool(self) -> bool:
+        return len(self.live_attached) > 1
+
+    @property
+    def mapping(self) -> DurationMapping | None:
+        """``None`` when the budget has no duration, so it never resets today."""
+        return None if self.duration_sec is None else map_duration(self.duration_sec)
+
+
+@dataclass(frozen=True)
+class BudgetMigrationReport:
+    """Everything an operator has to decide before the budget migration runs."""
+
+    budgets: list[BudgetPlan]
+    reset_log_count: int
+
+    @property
+    def unattached(self) -> list[BudgetPlan]:
+        return [plan for plan in self.budgets if not plan.live_attached]
+
+    @property
+    def member_budgets_to_create(self) -> int:
+        return sum(len(plan.live_attached) for plan in self.budgets)
+
+    @property
+    def deleted_attachments(self) -> int:
+        return sum(len(plan.attached) - len(plan.live_attached) for plan in self.budgets)
+
+    @property
+    def rounded(self) -> list[BudgetPlan]:
+        return [plan for plan in self.budgets if plan.mapping is not None and not plan.mapping.is_exact]
+
+    @property
+    def exact(self) -> list[BudgetPlan]:
+        return [plan for plan in self.budgets if plan.mapping is not None and plan.mapping.is_exact]
+
+    @property
+    def periodless(self) -> list[BudgetPlan]:
+        return [plan for plan in self.budgets if plan.duration_sec is None]
+
+    @property
+    def shared_pools(self) -> list[BudgetPlan]:
+        return [plan for plan in self.budgets if plan.is_shared_pool]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Machine readable form, for diffing a report across dry runs."""
+        return {
+            "summary": {
+                "budgets": len(self.budgets),
+                "unattached_budgets": len(self.unattached),
+                "member_budgets_to_create": self.member_budgets_to_create,
+                "deleted_attachments": self.deleted_attachments,
+                "rounded_durations": len(self.rounded),
+                "exact_durations": len(self.exact),
+                "budgets_without_a_duration": len(self.periodless),
+                "shared_pools": len(self.shared_pools),
+                "reset_logs_archived": self.reset_log_count,
+            },
+            "rounded_durations": [_plan_json(plan) for plan in self.rounded],
+            "budgets_without_a_duration": [_plan_json(plan) for plan in self.periodless],
+            "shared_pools": [_plan_json(plan) for plan in self.shared_pools],
+            "unattached_budgets": [plan.budget_id for plan in self.unattached],
+        }
+
+
+def _plan_json(plan: BudgetPlan) -> dict[str, Any]:
+    mapping = plan.mapping
+    return {
+        "budget_id": plan.budget_id,
+        "name": plan.name,
+        "max_budget": plan.max_budget,
+        "duration_sec": plan.duration_sec,
+        "period": mapping.period if mapping else None,
+        "is_exact": mapping.is_exact if mapping else None,
+        "drift_sec": mapping.drift_sec if mapping else None,
+        "rate_factor": round(mapping.rate_factor, 4) if mapping else None,
+        "attached_users": [
+            {
+                "user_id": user.user_id,
+                "spend": user.spend,
+                "reserved": user.reserved,
+                "deleted": user.is_deleted,
+            }
+            for user in plan.attached
+        ],
+    }
+
+
+async def build_migration_report(db: AsyncSession) -> BudgetMigrationReport:
+    """Read every budget and its attachments, in two queries and no writes."""
+    rows = (
+        await db.execute(
+            select(
+                Budget.budget_id,
+                Budget.name,
+                Budget.max_budget,
+                Budget.budget_duration_sec,
+                User.user_id,
+                User.spend,
+                User.reserved,
+                User.deleted_at,
+            )
+            # Outer join so a budget nothing points at still appears: it is a row
+            # the migration creates nothing for, which is worth seeing.
+            .outerjoin(User, User.budget_id == Budget.budget_id)
+            .order_by(Budget.budget_id, User.user_id)
+        )
+    ).all()
+
+    # The join repeats a budget once per attached user, so the rows are folded
+    # back into one plan each before any plan is constructed: BudgetPlan is
+    # frozen, and a frozen row whose list is filled in afterwards is only
+    # nominally immutable.
+    columns: dict[str, tuple[str | None, float | None, int | None]] = {}
+    attachments: dict[str, list[AttachedUser]] = {}
+    for budget_id, name, max_budget, duration_sec, user_id, spend, reserved, deleted_at in rows:
+        columns.setdefault(budget_id, (name, max_budget, duration_sec))
+        attached = attachments.setdefault(budget_id, [])
+        if user_id is not None:
+            attached.append(
+                AttachedUser(
+                    user_id=user_id,
+                    spend=spend or 0.0,
+                    reserved=reserved or 0.0,
+                    is_deleted=deleted_at is not None,
+                )
+            )
+
+    reset_log_count = (await db.execute(select(func.count()).select_from(BudgetResetLog))).scalar_one()
+
+    return BudgetMigrationReport(
+        budgets=[
+            BudgetPlan(
+                budget_id=budget_id,
+                name=name,
+                max_budget=max_budget,
+                duration_sec=duration_sec,
+                attached=attachments[budget_id],
+            )
+            for budget_id, (name, max_budget, duration_sec) in columns.items()
+        ],
+        reset_log_count=reset_log_count,
+    )
+
+
+def _format_duration(seconds: int) -> str:
+    """Render a second count the way an operator wrote it, e.g. ``3d 12h``."""
+    days, remainder = divmod(seconds, 86_400)
+    hours, remainder = divmod(remainder, 3_600)
+    minutes, secs = divmod(remainder, 60)
+    parts = [f"{value}{unit}" for value, unit in ((days, "d"), (hours, "h"), (minutes, "m"), (secs, "s")) if value]
+    return " ".join(parts) or "0s"
+
+
+def _label(plan: BudgetPlan) -> str:
+    name = f'"{plan.name}" ' if plan.name else ""
+    return f"{name}({plan.budget_id})"
+
+
+def render_text(report: BudgetMigrationReport) -> str:
+    """Render the report for a terminal, one section per decision to make."""
+    lines: list[str] = ["Budget migration preflight", "=" * 26, ""]
+
+    lines += [
+        f"{len(report.budgets)} budget(s) in this gateway.",
+        f"{report.member_budgets_to_create} member budget(s) would be created in the default workspace.",
+        f"{report.reset_log_count} budget_reset_logs row(s) archive with the legacy tables, unmapped.",
+    ]
+    if report.deleted_attachments:
+        lines.append(
+            f"{report.deleted_attachments} attachment(s) belong to soft deleted users, which migrate as "
+            "deactivated identities and get no live cap."
+        )
+    lines.append("")
+
+    lines += [
+        "Every budget is re-anchored, not only the rounded ones: gateway periods roll from each",
+        "user's budget_started_at, the reconciled periods align to the calendar (midnight UTC,",
+        "Monday, the 1st). The first period after the migration is therefore short.",
+        "",
+    ]
+
+    lines.append(f"Rounded durations ({len(report.rounded)})")
+    lines.append("-" * 40)
+    if not report.rounded:
+        lines.append("  None. Every duration maps onto a period exactly.")
+    else:
+        lines.append("  rate is the change in how fast a capped user may spend: above 1.00 loosens the cap.")
+        for plan in sorted(report.rounded, key=lambda item: item.duration_sec or 0):
+            mapping = plan.mapping
+            if mapping is None:  # pragma: no cover - report.rounded excludes these
+                continue
+            direction = "LOOSER" if mapping.rate_factor > 1 else "TIGHTER"
+            lines.append(
+                f"  {_format_duration(mapping.duration_sec)} -> {mapping.period}"
+                f"  (drift {mapping.drift_sec:+d}s, rate {mapping.rate_factor:.2f}x {direction})"
+                f"  {_label(plan)}, {len(plan.live_attached)} user(s)"
+            )
+    lines.append("")
+
+    lines.append(f"Budgets with no duration ({len(report.periodless)})")
+    lines.append("-" * 40)
+    if not report.periodless:
+        lines.append("  None.")
+    else:
+        lines.append("  These never reset today. The reconciled model requires a period, so each needs one chosen.")
+        for plan in report.periodless:
+            lines.append(f"  {_label(plan)}, {len(plan.live_attached)} user(s), max_budget {plan.max_budget}")
+    lines.append("")
+
+    lines.append(f"Shared budgets ({len(report.shared_pools)})")
+    lines.append("-" * 40)
+    if not report.shared_pools:
+        lines.append("  None. Every attached budget has exactly one user.")
+    else:
+        lines.append("  Enforcement is already per user against this row's max_budget, so materializing one")
+        lines.append("  member budget per user preserves today's behavior. Consolidating to a workspace budget")
+        lines.append("  instead would pool the money and tighten the cap, so it is an opt in, not the default.")
+        for plan in report.shared_pools:
+            lines.append(f"  {_label(plan)}  max_budget {plan.max_budget}, {len(plan.live_attached)} user(s)")
+            for user in plan.live_attached:
+                lines.append(f"      {user.user_id}: spend {user.spend}, reserved {user.reserved}")
+    lines.append("")
+
+    if report.unattached:
+        lines.append(f"Unattached budgets ({len(report.unattached)})")
+        lines.append("-" * 40)
+        lines.append("  No live user points at these, so the migration creates nothing for them.")
+        for plan in report.unattached:
+            lines.append(f"  {_label(plan)}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip()

--- a/src/gateway/services/budget_migration_report.py
+++ b/src/gateway/services/budget_migration_report.py
@@ -45,6 +45,12 @@ __all__ = [
 # Seconds the reconciled engine's three periods nominally span. Its windows are
 # calendar aligned, so a real month runs 28 to 31 days; 30 is the nominal length
 # rounding compares against, and the drift it reports is nominal for that reason.
+# Members listed per shared budget before the text report says how many it held
+# back. A pool with thousands of users is exactly the case worth reporting, and
+# exactly the case a full listing makes unreadable; --json always carries all of
+# them.
+_MAX_LISTED_MEMBERS = 10
+
 PERIOD_SECONDS: Final[dict[str, int]] = {
     "daily": 86_400,
     "weekly": 604_800,
@@ -142,6 +148,11 @@ class BudgetMigrationReport:
 
     @property
     def unattached(self) -> list[BudgetPlan]:
+        """Budgets no live user points at, so the migration creates nothing for them.
+
+        This includes a budget whose only users are soft deleted, not just one
+        nothing ever pointed at.
+        """
         return [plan for plan in self.budgets if not plan.live_attached]
 
     @property
@@ -196,10 +207,10 @@ def _plan_json(plan: BudgetPlan) -> dict[str, Any]:
         "name": plan.name,
         "max_budget": plan.max_budget,
         "duration_sec": plan.duration_sec,
-        "period": mapping.period if mapping else None,
-        "is_exact": mapping.is_exact if mapping else None,
-        "drift_sec": mapping.drift_sec if mapping else None,
-        "rate_factor": round(mapping.rate_factor, 4) if mapping else None,
+        "period": mapping.period if mapping is not None else None,
+        "is_exact": mapping.is_exact if mapping is not None else None,
+        "drift_sec": mapping.drift_sec if mapping is not None else None,
+        "rate_factor": round(mapping.rate_factor, 4) if mapping is not None else None,
         "attached_users": [
             {
                 "user_id": user.user_id,
@@ -246,8 +257,8 @@ async def build_migration_report(db: AsyncSession) -> BudgetMigrationReport:
             attached.append(
                 AttachedUser(
                     user_id=user_id,
-                    spend=spend or 0.0,
-                    reserved=reserved or 0.0,
+                    spend=spend,
+                    reserved=reserved,
                     is_deleted=deleted_at is not None,
                 )
             )
@@ -344,8 +355,11 @@ def render_text(report: BudgetMigrationReport) -> str:
         lines.append("  instead would pool the money and tighten the cap, so it is an opt in, not the default.")
         for plan in report.shared_pools:
             lines.append(f"  {_label(plan)}  max_budget {plan.max_budget}, {len(plan.live_attached)} user(s)")
-            for user in plan.live_attached:
+            for user in plan.live_attached[:_MAX_LISTED_MEMBERS]:
                 lines.append(f"      {user.user_id}: spend {user.spend}, reserved {user.reserved}")
+            held_back = len(plan.live_attached) - _MAX_LISTED_MEMBERS
+            if held_back > 0:
+                lines.append(f"      ... and {held_back} more, listed in full by --json")
     lines.append("")
 
     if report.unattached:

--- a/tests/integration/test_budget_migration_report.py
+++ b/tests/integration/test_budget_migration_report.py
@@ -61,6 +61,17 @@ async def seeded(async_db: AsyncSession) -> AsyncSession:
 
 
 @pytest.fixture
+def released_engine() -> Generator[None]:
+    """Dispose the process-wide engine a CLI command leaves behind.
+
+    ``init_db`` installs a global session factory, which would otherwise point
+    the next test at this test's database.
+    """
+    yield
+    reset_db()
+
+
+@pytest.fixture
 def seeded_url(postgres_url: str) -> Generator[str]:
     """Seed the same rows for the CLI, which drives its own synchronous session.
 
@@ -139,6 +150,20 @@ def test_cli_json_output_is_machine_readable(seeded_url: str) -> None:
     payload = json.loads(result.output)
     assert payload["summary"]["shared_pools"] == 1
     assert payload["summary"]["member_budgets_to_create"] == 3
+
+
+def test_cli_does_not_print_the_database_password(released_engine: None) -> None:
+    # Port 1 refuses immediately, so this fails at connect without a live server.
+    result = CliRunner().invoke(
+        gateway_cli.budgets_migration_report,
+        ["--database-url", "postgresql://otari:hunter2@127.0.0.1:1/otari"],
+    )
+
+    assert result.exit_code != 0
+    assert "hunter2" not in result.output
+    # The host is still named, because a failure that does not say which database
+    # it tried is not actionable.
+    assert "127.0.0.1:1/otari" in result.output
 
 
 def test_cli_reports_a_database_it_cannot_read(tmp_path: object) -> None:

--- a/tests/integration/test_budget_migration_report.py
+++ b/tests/integration/test_budget_migration_report.py
@@ -1,0 +1,155 @@
+"""The budget migration preflight against a real schema.
+
+The rounding and partitioning logic is unit tested; what needs a database is the
+join that pairs budgets with the users attached to them, and the CLI command
+that opens the database read only.
+"""
+
+import json
+from collections.abc import Generator
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+from click.testing import CliRunner
+from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import sessionmaker
+
+import gateway.cli as gateway_cli
+from gateway.db import Base, Budget, BudgetResetLog, User, reset_db
+from gateway.services.budget_migration_report import build_migration_report
+
+_DAY = 86_400
+
+
+def _budgets() -> list[Budget]:
+    """One budget of each kind the report has to tell apart."""
+    return [
+        Budget(budget_id="b-daily", name="Daily", max_budget=100.0, budget_duration_sec=_DAY),
+        Budget(budget_id="b-sprint", name="Sprint", max_budget=250.0, budget_duration_sec=3 * _DAY),
+        Budget(budget_id="b-forever", name="No reset", max_budget=50.0, budget_duration_sec=None),
+        Budget(budget_id="b-orphan", name="Orphan", max_budget=10.0, budget_duration_sec=7 * _DAY),
+    ]
+
+
+def _users(now: datetime) -> list[User]:
+    return [
+        User(user_id="alice", spend=12.5, reserved=1.0, budget_id="b-daily"),
+        User(user_id="bob", spend=40.0, reserved=0.0, budget_id="b-sprint"),
+        User(user_id="carol", spend=7.25, reserved=0.5, budget_id="b-sprint"),
+        # Soft deleted: migrates as a deactivated identity, so no live cap.
+        User(user_id="dave", spend=3.0, reserved=0.0, budget_id="b-forever", deleted_at=now),
+        # No budget attached at all.
+        User(user_id="erin", spend=0.0, reserved=0.0, budget_id=None),
+    ]
+
+
+def _reset_log(now: datetime) -> BudgetResetLog:
+    return BudgetResetLog(user_id="alice", budget_id="b-daily", previous_spend=5.0, reset_at=now)
+
+
+@pytest_asyncio.fixture
+async def seeded(async_db: AsyncSession) -> AsyncSession:
+    now = datetime.now(UTC)
+    async_db.add_all(_budgets())
+    await async_db.flush()
+    async_db.add_all(_users(now))
+    async_db.add(_reset_log(now))
+    await async_db.commit()
+    return async_db
+
+
+@pytest.fixture
+def seeded_url(postgres_url: str) -> Generator[str]:
+    """Seed the same rows for the CLI, which drives its own synchronous session.
+
+    The command calls ``asyncio.run``, so its tests cannot be async, and an async
+    fixture would leave them without a running loop to seed from. Alembic is not
+    needed here: the report reads three tables the models already describe.
+    """
+    engine = create_engine(postgres_url, pool_pre_ping=True)
+    Base.metadata.create_all(bind=engine)
+    now = datetime.now(UTC)
+    with sessionmaker(bind=engine)() as session:
+        session.add_all(_budgets())
+        session.flush()
+        session.add_all(_users(now))
+        session.add(_reset_log(now))
+        session.commit()
+    try:
+        yield postgres_url
+    finally:
+        # The command leaves a process-wide engine behind, which would otherwise
+        # point the next test at this database.
+        reset_db()
+        Base.metadata.drop_all(bind=engine)
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_report_pairs_budgets_with_their_attached_users(seeded: AsyncSession) -> None:
+    report = await build_migration_report(seeded)
+
+    assert {plan.budget_id for plan in report.budgets} == {"b-daily", "b-sprint", "b-forever", "b-orphan"}
+    assert [plan.budget_id for plan in report.shared_pools] == ["b-sprint"]
+    (shared,) = report.shared_pools
+    assert [(user.user_id, user.spend, user.reserved) for user in shared.live_attached] == [
+        ("bob", 40.0, 0.0),
+        ("carol", 7.25, 0.5),
+    ]
+    # alice, bob and carol; dave is soft deleted and erin has no budget.
+    assert report.member_budgets_to_create == 3
+    assert report.deleted_attachments == 1
+    assert report.reset_log_count == 1
+
+
+@pytest.mark.asyncio
+async def test_report_partitions_durations_and_orphans(seeded: AsyncSession) -> None:
+    report = await build_migration_report(seeded)
+
+    assert [plan.budget_id for plan in report.rounded] == ["b-sprint"]
+    assert [plan.budget_id for plan in report.periodless] == ["b-forever"]
+    # b-forever's only user is soft deleted, so nothing live points at it either.
+    assert {plan.budget_id for plan in report.unattached} == {"b-forever", "b-orphan"}
+
+
+@pytest.mark.asyncio
+async def test_report_is_empty_on_a_gateway_with_no_budgets(async_db: AsyncSession) -> None:
+    report = await build_migration_report(async_db)
+
+    assert report.budgets == []
+    assert report.member_budgets_to_create == 0
+
+
+def test_cli_prints_the_report(seeded_url: str) -> None:
+    result = CliRunner().invoke(gateway_cli.budgets_migration_report, ["--database-url", seeded_url])
+
+    assert result.exit_code == 0, result.output
+    assert "4 budget(s) in this gateway." in result.output
+    assert "3 member budget(s)" in result.output
+    assert "3d -> daily" in result.output
+    assert '"Sprint" (b-sprint)' in result.output
+
+
+def test_cli_json_output_is_machine_readable(seeded_url: str) -> None:
+    result = CliRunner().invoke(gateway_cli.budgets_migration_report, ["--database-url", seeded_url, "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["summary"]["shared_pools"] == 1
+    assert payload["summary"]["member_budgets_to_create"] == 3
+
+
+def test_cli_reports_a_database_it_cannot_read(tmp_path: object) -> None:
+    try:
+        result = CliRunner().invoke(
+            gateway_cli.budgets_migration_report,
+            ["--database-url", f"sqlite:///{tmp_path}/absent.db"],
+        )
+    finally:
+        reset_db()
+
+    assert result.exit_code != 0
+    assert "Could not read budgets" in result.output
+    assert "otari migrate" in result.output

--- a/tests/unit/test_budget_migration_report.py
+++ b/tests/unit/test_budget_migration_report.py
@@ -148,7 +148,7 @@ def test_render_text_names_every_budget_needing_a_decision() -> None:
     assert "Budgets with no duration (1)" in text
     assert "Shared budgets (1)" in text
     assert "bob: spend 0.0" in text
-    assert "12 budget_reset_logs row(s)" in text
+    assert "12 row(s) in budget_reset_logs are archived" in text
     # Calendar re-anchoring hits every budget, not only the rounded ones, so it is
     # stated even when nothing rounds.
     assert "re-anchored" in text

--- a/tests/unit/test_budget_migration_report.py
+++ b/tests/unit/test_budget_migration_report.py
@@ -1,0 +1,162 @@
+"""Unit tests for the budget migration preflight's pure half.
+
+Duration rounding and the shape of the report are decided without a database, so
+they are tested without one. `tests/integration/test_budget_migration_report.py`
+covers the query and the CLI command against a real schema.
+"""
+
+import json
+
+import pytest
+
+from gateway.services.budget_migration_report import (
+    PERIOD_SECONDS,
+    AttachedUser,
+    BudgetMigrationReport,
+    BudgetPlan,
+    map_duration,
+    render_text,
+)
+
+_DAY = 86_400
+
+
+def _user(user_id: str, *, spend: float = 0.0, reserved: float = 0.0, deleted: bool = False) -> AttachedUser:
+    return AttachedUser(user_id=user_id, spend=spend, reserved=reserved, is_deleted=deleted)
+
+
+@pytest.mark.parametrize(
+    ("duration_sec", "period"),
+    [(_DAY, "daily"), (7 * _DAY, "weekly"), (30 * _DAY, "monthly")],
+)
+def test_exact_durations_map_without_drift(duration_sec: int, period: str) -> None:
+    mapping = map_duration(duration_sec)
+
+    assert mapping.period == period
+    assert mapping.is_exact
+    assert mapping.drift_sec == 0
+    assert mapping.rate_factor == 1.0
+
+
+@pytest.mark.parametrize(
+    ("duration_sec", "period"),
+    [
+        (3_600, "daily"),
+        (3 * _DAY, "daily"),
+        (5 * _DAY, "weekly"),
+        (14 * _DAY, "weekly"),
+        (60 * _DAY, "monthly"),
+    ],
+)
+def test_inexact_durations_round_to_the_nearest_period(duration_sec: int, period: str) -> None:
+    mapping = map_duration(duration_sec)
+
+    assert mapping.period == period
+    assert not mapping.is_exact
+    assert mapping.drift_sec == PERIOD_SECONDS[period] - duration_sec
+
+
+def test_an_exact_tie_rounds_to_the_longer_period() -> None:
+    # Four days sits exactly between daily and weekly. The longer period is the
+    # one that cannot let a user outspend what the gateway allowed them.
+    mapping = map_duration(4 * _DAY)
+
+    assert mapping.period == "weekly"
+    assert mapping.rate_factor < 1.0
+
+
+def test_rate_factor_reports_the_direction_of_the_change() -> None:
+    # A three-day cap becoming daily lets the same money be spent three times as fast.
+    assert map_duration(3 * _DAY).rate_factor == pytest.approx(3.0)
+    # A five-day cap becoming weekly stretches the same money over longer.
+    assert map_duration(5 * _DAY).rate_factor == pytest.approx(5 / 7)
+
+
+def test_shared_budget_counts_only_live_users() -> None:
+    plan = BudgetPlan(
+        budget_id="b-shared",
+        name="Team",
+        max_budget=100.0,
+        duration_sec=_DAY,
+        attached=[_user("alice"), _user("bob", deleted=True)],
+    )
+
+    # A soft deleted user migrates as a deactivated identity with no live cap, so
+    # one live user plus one deleted user is not a shared budget.
+    assert not plan.is_shared_pool
+    assert [user.user_id for user in plan.live_attached] == ["alice"]
+
+
+def test_a_budget_without_a_duration_has_no_mapping() -> None:
+    plan = BudgetPlan(budget_id="b", name=None, max_budget=10.0, duration_sec=None, attached=[_user("alice")])
+
+    assert plan.mapping is None
+
+
+def _report() -> BudgetMigrationReport:
+    return BudgetMigrationReport(
+        budgets=[
+            BudgetPlan("b-daily", "Daily", 100.0, _DAY, [_user("alice", spend=1.0)]),
+            BudgetPlan("b-sprint", "Sprint", 250.0, 3 * _DAY, [_user("bob"), _user("carol", reserved=2.0)]),
+            BudgetPlan("b-forever", None, 50.0, None, [_user("dave", deleted=True)]),
+            BudgetPlan("b-orphan", "Orphan", 10.0, 7 * _DAY, []),
+        ],
+        reset_log_count=12,
+    )
+
+
+def test_report_partitions_every_budget() -> None:
+    report = _report()
+
+    assert [plan.budget_id for plan in report.rounded] == ["b-sprint"]
+    assert [plan.budget_id for plan in report.exact] == ["b-daily", "b-orphan"]
+    assert [plan.budget_id for plan in report.periodless] == ["b-forever"]
+    assert [plan.budget_id for plan in report.shared_pools] == ["b-sprint"]
+    # b-forever's only user is soft deleted, so nothing live points at it either.
+    assert [plan.budget_id for plan in report.unattached] == ["b-forever", "b-orphan"]
+    assert report.member_budgets_to_create == 3
+    assert report.deleted_attachments == 1
+
+
+def test_report_json_is_serializable_and_carries_the_decisions() -> None:
+    payload = json.loads(json.dumps(_report().to_dict()))
+
+    assert payload["summary"] == {
+        "budgets": 4,
+        "unattached_budgets": 2,
+        "member_budgets_to_create": 3,
+        "deleted_attachments": 1,
+        "rounded_durations": 1,
+        "exact_durations": 2,
+        "budgets_without_a_duration": 1,
+        "shared_pools": 1,
+        "reset_logs_archived": 12,
+    }
+    (rounded,) = payload["rounded_durations"]
+    assert rounded["period"] == "daily"
+    assert rounded["rate_factor"] == 3.0
+    (shared,) = payload["shared_pools"]
+    assert [user["user_id"] for user in shared["attached_users"]] == ["bob", "carol"]
+
+
+def test_render_text_names_every_budget_needing_a_decision() -> None:
+    text = render_text(_report())
+
+    assert "Rounded durations (1)" in text
+    assert "3d -> daily" in text
+    assert "rate 3.00x LOOSER" in text
+    assert "Budgets with no duration (1)" in text
+    assert "Shared budgets (1)" in text
+    assert "bob: spend 0.0" in text
+    assert "12 budget_reset_logs row(s)" in text
+    # Calendar re-anchoring hits every budget, not only the rounded ones, so it is
+    # stated even when nothing rounds.
+    assert "re-anchored" in text
+
+
+def test_render_text_says_so_when_there_is_nothing_to_decide() -> None:
+    text = render_text(BudgetMigrationReport(budgets=[], reset_log_count=0))
+
+    assert "Every duration maps onto a period exactly." in text
+    assert "Every attached budget has exactly one user." in text
+    assert "Unattached budgets" not in text

--- a/tests/unit/test_budget_migration_report.py
+++ b/tests/unit/test_budget_migration_report.py
@@ -160,3 +160,18 @@ def test_render_text_says_so_when_there_is_nothing_to_decide() -> None:
     assert "Every duration maps onto a period exactly." in text
     assert "Every attached budget has exactly one user." in text
     assert "Unattached budgets" not in text
+
+
+def test_render_text_holds_back_the_tail_of_a_very_large_pool() -> None:
+    report = BudgetMigrationReport(
+        budgets=[BudgetPlan("b-big", "Everyone", 5.0, _DAY, [_user(f"u{index}") for index in range(25)])],
+        reset_log_count=0,
+    )
+
+    text = render_text(report)
+
+    assert "u0: spend 0.0" in text
+    assert "u9: spend 0.0" in text
+    assert "u10: spend 0.0" not in text
+    # The count is stated rather than the listing silently ending.
+    assert "... and 15 more, listed in full by --json" in text


### PR DESCRIPTION
## Description

`otari budgets migration-report` lists what an operator has to decide before this gateway's budgets move onto the reconciled engine, whose reset cadence is a fixed, calendar-aligned period:

- **Durations that round.** Each gets a rate factor, since the number that matters is how much faster the same `max_budget` may be spent afterwards. An exact tie (four days) rounds to the longer period, which cannot let a user outspend what the gateway allowed.
- **Budgets with no duration**, which have to be given a period.
- **Budgets several users share.** Enforcement here is already per user (`users.spend + users.reserved` against that row's `max_budget`), so per-member materialization is behavior-preserving and pooling into a workspace budget is the change. The report surfaces pools as an opt in rather than performing either.

Read only, two queries, and the startup migration is forced off whatever the config says, so it is safe against a live deployment. `--json` for a diffable form.

**Scope.** mozilla-ai/otari-ai#1657 also asks for the gateway's `budget_service` to be retired, which needs the reconciled engine rehomed here first (#624 / #625 are the first phase of that and are still draft). This is the part that stands alone: it reads only tables that exist today, and it is the artifact operators need before the cutover either way.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Part of mozilla-ai/otari-ai#1657 (the migration report half; see Scope above).

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). No HTTP route changed, so the spec is untouched.
- [x] If this PR adds or changes a persistent table, a control-plane contract the otari.ai platform consumes or serves, a capability the platform also has, or a mode-specific surface, I appended an entry to the M4 reconciliation ledger ([otari-ai#1587](https://github.com/mozilla-ai/otari-ai/issues/1587)). No table or contract changes; the budgets row is confirmed, not moved, in a ledger comment.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code (Opus 4.8)

**Any additional AI details you'd like to share:**

Scope, the rounding tie-break, and the per-member default were decided with the author; the code, tests, and docs were written by the agent.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds `otari budgets migration-report` as a read-only preflight check for gateway budget migration.

- Reports duration rounding, missing periods, shared budgets, deleted users, and reset-log handling.
- Supports readable terminal output and diffable `--json` output.
- Disables automatic migration and writes no data, so operators can run it safely on live deployments.
- Adds documentation and unit and integration test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->