### PR TITLE
feat(pricing/usage): track and persist reasoning/thinking tokens (#430)

### DIFF
--- a/alembic/versions/6163c9f0d2ef_add_reasoning_tokens_to_usage_logs.py
+++ b/alembic/versions/6163c9f0d2ef_add_reasoning_tokens_to_usage_logs.py
@@ -1,0 +1,29 @@
+"""add reasoning_tokens to usage_logs
+
+Revision ID: 6163c9f0d2ef
+Revises: b2d4f6a8c0e1
+Create Date: 2026-08-19 00:11:17.393968
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '6163c9f0d2ef'
+down_revision: Union[str, Sequence[str], None] = 'b2d4f6a8c0e1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("usage_logs", sa.Column("reasoning_tokens", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("usage_logs", "reasoning_tokens")
+

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -2801,6 +2801,13 @@
             "title": "Provider",
             "type": "string"
           },
+          "reasoning_tokens": {
+            "default": 0,
+            "maximum": 2147483647.0,
+            "minimum": 0.0,
+            "title": "Reasoning Tokens",
+            "type": "integer"
+          },
           "session_label": {
             "anyOf": [
               {

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -94,7 +94,12 @@ from gateway.api.routes._tools import (
 )
 from gateway.core.config import GatewayConfig
 from gateway.core.env import otari_env
-from gateway.core.usage import cache_read_tokens_of, cache_write_1h_tokens_of, cache_write_tokens_of
+from gateway.core.usage import (
+    cache_read_tokens_of,
+    cache_write_1h_tokens_of,
+    cache_write_tokens_of,
+    reasoning_tokens_of,
+)
 from gateway.inflight import track_request
 from gateway.log_config import logger
 from gateway.metrics import record_abandoned_attempt, record_cost, record_tokens
@@ -1865,6 +1870,7 @@ async def log_usage(
         usage_log.cache_read_tokens = cache_read_tokens_of(usage_data)
         usage_log.cache_write_tokens = cache_write_tokens_of(usage_data)
         usage_log.cache_write_1h_tokens = cache_write_1h_tokens_of(usage_data)
+        usage_log.reasoning_tokens = reasoning_tokens_of(usage_data)
 
         record_tokens(
             str(provider or ""),

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -158,12 +158,16 @@ class _ChatAdapter:
         if not chunk.usage:
             return None
         details = chunk.usage.prompt_tokens_details
+        completion_details = chunk.usage.completion_tokens_details
+        reasoning_tokens = (completion_details.reasoning_tokens or 0) if completion_details is not None else 0
         return GatewayUsage(
             prompt_tokens=chunk.usage.prompt_tokens or 0,
             completion_tokens=chunk.usage.completion_tokens or 0,
             total_tokens=chunk.usage.total_tokens or 0,
             prompt_tokens_details=details,
+            completion_tokens_details=completion_details,
             cache_read_tokens=(details.cached_tokens or 0) if details is not None else 0,
+            reasoning_tokens=reasoning_tokens,
         )
 
     def extract_usage(self, result: ChatCompletion) -> CompletionUsage | None:

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -254,13 +254,23 @@ _ERROR_KIND_TO_ANTHROPIC_TYPE = {
 }
 
 
+def _reasoning_tokens_of_anthropic(part: Any) -> int:
+    thinking = getattr(part, "thinking_tokens", None)
+    if thinking is not None:
+        return int(thinking)
+    reasoning = getattr(part, "reasoning_tokens", None)
+    if reasoning is not None:
+        return int(reasoning)
+    return 0
+
+
 def _billable_messages_usage(usage: Any) -> GatewayUsage:
     """Use per-iteration totals when Anthropic reports compaction sampling."""
     billable_parts = list(getattr(usage, "iterations", None) or []) or [usage]
     input_tokens = sum((getattr(part, "input_tokens", None) or 0) for part in billable_parts)
     output_tokens = sum((getattr(part, "output_tokens", None) or 0) for part in billable_parts)
     reasoning_tokens = sum(
-        (getattr(part, "thinking_tokens", None) or getattr(part, "reasoning_tokens", None) or 0)
+        _reasoning_tokens_of_anthropic(part)
         for part in billable_parts
     )
     return GatewayUsage(
@@ -287,8 +297,12 @@ def _messages_stream_usage(event: MessageStreamEvent) -> CompletionUsage | None:
         input_tokens = usage.input_tokens or 0
         cache_read = usage.cache_read_input_tokens or 0
         cache_write = usage.cache_creation_input_tokens or 0
-        reasoning_tokens = getattr(usage, "thinking_tokens", None) or getattr(usage, "reasoning_tokens", None) or 0
-        if input_tokens or cache_read or cache_write or reasoning_tokens:
+        reasoning_tokens = _reasoning_tokens_of_anthropic(usage)
+        has_reasoning = (
+            getattr(usage, "thinking_tokens", None) is not None
+            or getattr(usage, "reasoning_tokens", None) is not None
+        )
+        if input_tokens or cache_read or cache_write or has_reasoning:
             return GatewayUsage(
                 prompt_tokens=input_tokens,
                 completion_tokens=0,

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -259,6 +259,10 @@ def _billable_messages_usage(usage: Any) -> GatewayUsage:
     billable_parts = list(getattr(usage, "iterations", None) or []) or [usage]
     input_tokens = sum((getattr(part, "input_tokens", None) or 0) for part in billable_parts)
     output_tokens = sum((getattr(part, "output_tokens", None) or 0) for part in billable_parts)
+    reasoning_tokens = sum(
+        (getattr(part, "thinking_tokens", None) or getattr(part, "reasoning_tokens", None) or 0)
+        for part in billable_parts
+    )
     return GatewayUsage(
         prompt_tokens=input_tokens,
         completion_tokens=output_tokens,
@@ -271,6 +275,7 @@ def _billable_messages_usage(usage: Any) -> GatewayUsage:
         ),
         cache_write_1h_tokens=sum(_cache_write_1h_tokens(part) for part in billable_parts),
         cache_tokens_in_prompt=False,
+        reasoning_tokens=reasoning_tokens,
     )
 
 
@@ -282,7 +287,8 @@ def _messages_stream_usage(event: MessageStreamEvent) -> CompletionUsage | None:
         input_tokens = usage.input_tokens or 0
         cache_read = usage.cache_read_input_tokens or 0
         cache_write = usage.cache_creation_input_tokens or 0
-        if input_tokens or cache_read or cache_write:
+        reasoning_tokens = getattr(usage, "thinking_tokens", None) or getattr(usage, "reasoning_tokens", None) or 0
+        if input_tokens or cache_read or cache_write or reasoning_tokens:
             return GatewayUsage(
                 prompt_tokens=input_tokens,
                 completion_tokens=0,
@@ -291,6 +297,7 @@ def _messages_stream_usage(event: MessageStreamEvent) -> CompletionUsage | None:
                 cache_write_tokens=cache_write,
                 cache_write_1h_tokens=_cache_write_1h_tokens(usage),
                 cache_tokens_in_prompt=False,
+                reasoning_tokens=reasoning_tokens,
             )
     return None
 

--- a/src/gateway/api/routes/otlp.py
+++ b/src/gateway/api/routes/otlp.py
@@ -184,6 +184,14 @@ def _int(value: Any) -> int:
         return 0
 
 
+def _first_presence(attrs: dict[str, Any], keys: list[str]) -> Any:
+    for key in keys:
+        val = attrs.get(key)
+        if val is not None:
+            return val
+    return None
+
+
 def _nanos_to_dt(nanos: int) -> datetime | None:
     if not nanos:
         return None
@@ -277,9 +285,10 @@ def _build_event(
         cache_read = _int(attrs.get("cache_read_tokens"))
         cache_write = _int(attrs.get("cache_creation_tokens"))
         reasoning = _int(
-            attrs.get("reasoning_tokens")
-            or attrs.get("thinking_tokens")
-            or attrs.get("reasoning_token_count")
+            _first_presence(
+                attrs,
+                ["reasoning_tokens", "thinking_tokens", "reasoning_token_count"],
+            )
         )
         session = attrs.get("session.id")
         duration = attrs.get("duration_ms", duration_ms)
@@ -298,9 +307,10 @@ def _build_event(
             output_tokens = _int(attrs.get("output_token_count"))
             cache_read = _int(attrs.get("cached_token_count"))
             reasoning = _int(
-                attrs.get("reasoning_token_count")
-                or attrs.get("reasoning_tokens")
-                or attrs.get("thinking_tokens")
+                _first_presence(
+                    attrs,
+                    ["reasoning_token_count", "reasoning_tokens", "thinking_tokens"],
+                )
             )
             event_id = _codex_event_id(attrs, None)
             duration = duration_ms
@@ -309,10 +319,15 @@ def _build_event(
             output_tokens = _int(attrs.get("gen_ai.usage.output_tokens"))
             cache_read = _int(attrs.get("gen_ai.usage.cache_read.input_tokens"))
             reasoning = _int(
-                attrs.get("gen_ai.usage.reasoning_tokens")
-                or attrs.get("gen_ai.usage.reasoning.output_tokens")
-                or attrs.get("reasoning_tokens")
-                or attrs.get("reasoning_token_count")
+                _first_presence(
+                    attrs,
+                    [
+                        "gen_ai.usage.reasoning_tokens",
+                        "gen_ai.usage.reasoning.output_tokens",
+                        "reasoning_tokens",
+                        "reasoning_token_count",
+                    ],
+                )
             )
             event_id = _codex_event_id(attrs, attrs.get("gen_ai.response.id"))
             duration = attrs.get("duration_ms", duration_ms)
@@ -332,10 +347,15 @@ def _build_event(
         )
         cache_write = _int(attrs.get("gen_ai.usage.cache_write_tokens"))
         reasoning = _int(
-            attrs.get("gen_ai.usage.reasoning_tokens")
-            or attrs.get("gen_ai.usage.reasoning.output_tokens")
-            or attrs.get("reasoning_tokens")
-            or attrs.get("reasoning_token_count")
+            _first_presence(
+                attrs,
+                [
+                    "gen_ai.usage.reasoning_tokens",
+                    "gen_ai.usage.reasoning.output_tokens",
+                    "reasoning_tokens",
+                    "reasoning_token_count",
+                ],
+            )
         )
         client = attrs.get("otari.client_name")
         source = _sanitize_source(str(client)) if client else _DEFAULT_SOURCE

--- a/src/gateway/api/routes/otlp.py
+++ b/src/gateway/api/routes/otlp.py
@@ -276,6 +276,11 @@ def _build_event(
         output_tokens = _int(attrs.get("output_tokens"))
         cache_read = _int(attrs.get("cache_read_tokens"))
         cache_write = _int(attrs.get("cache_creation_tokens"))
+        reasoning = _int(
+            attrs.get("reasoning_tokens")
+            or attrs.get("thinking_tokens")
+            or attrs.get("reasoning_token_count")
+        )
         session = attrs.get("session.id")
         duration = attrs.get("duration_ms", duration_ms)
         cache_tokens_in_prompt = False
@@ -292,12 +297,23 @@ def _build_event(
             input_tokens = _int(attrs.get("input_token_count"))
             output_tokens = _int(attrs.get("output_token_count"))
             cache_read = _int(attrs.get("cached_token_count"))
+            reasoning = _int(
+                attrs.get("reasoning_token_count")
+                or attrs.get("reasoning_tokens")
+                or attrs.get("thinking_tokens")
+            )
             event_id = _codex_event_id(attrs, None)
             duration = duration_ms
         else:  # codex.api_request (HTTP /models path)
             input_tokens = _int(attrs.get("gen_ai.usage.input_tokens"))
             output_tokens = _int(attrs.get("gen_ai.usage.output_tokens"))
             cache_read = _int(attrs.get("gen_ai.usage.cache_read.input_tokens"))
+            reasoning = _int(
+                attrs.get("gen_ai.usage.reasoning_tokens")
+                or attrs.get("gen_ai.usage.reasoning.output_tokens")
+                or attrs.get("reasoning_tokens")
+                or attrs.get("reasoning_token_count")
+            )
             event_id = _codex_event_id(attrs, attrs.get("gen_ai.response.id"))
             duration = attrs.get("duration_ms", duration_ms)
         cache_write = 0
@@ -315,6 +331,12 @@ def _build_event(
             or attrs.get("gen_ai.usage.cached_tokens")
         )
         cache_write = _int(attrs.get("gen_ai.usage.cache_write_tokens"))
+        reasoning = _int(
+            attrs.get("gen_ai.usage.reasoning_tokens")
+            or attrs.get("gen_ai.usage.reasoning.output_tokens")
+            or attrs.get("reasoning_tokens")
+            or attrs.get("reasoning_token_count")
+        )
         client = attrs.get("otari.client_name")
         source = _sanitize_source(str(client)) if client else _DEFAULT_SOURCE
         session = attrs.get("otari.user_session_label") or attrs.get("otari.session_label")
@@ -324,7 +346,7 @@ def _build_event(
     timestamp = _resolve_timestamp(attrs, default_timestamp)
     if not (event_id and model and provider and timestamp):
         return None
-    if not (input_tokens or output_tokens or cache_read or cache_write):
+    if not (input_tokens or output_tokens or cache_read or cache_write or reasoning):
         return None  # not an LLM call worth recording
     try:
         event = ExternalUsageEvent(
@@ -338,6 +360,7 @@ def _build_event(
             cache_read_tokens=cache_read,
             cache_write_tokens=cache_write,
             cache_write_1h_tokens=cache_write_1h,
+            reasoning_tokens=reasoning,
             cache_tokens_in_prompt=cache_tokens_in_prompt,
             duration_ms=int(duration) if duration is not None else None,
             session_label=str(session) if session else None,

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -224,11 +224,14 @@ def _usage_to_completion_usage(
         return None
     details = getattr(usage, "input_tokens_details", None)
     cache_read_tokens = (getattr(details, "cached_tokens", 0) or 0) if details is not None else 0
+    output_details = getattr(usage, "output_tokens_details", None)
+    reasoning_tokens = (getattr(output_details, "reasoning_tokens", 0) or 0) if output_details is not None else 0
     return GatewayUsage(
         prompt_tokens=getattr(usage, "input_tokens", 0) or 0,
         completion_tokens=getattr(usage, "output_tokens", 0) or 0,
         total_tokens=getattr(usage, "total_tokens", 0) or 0,
         cache_read_tokens=cache_read_tokens,
+        reasoning_tokens=reasoning_tokens,
     )
 
 

--- a/src/gateway/core/usage.py
+++ b/src/gateway/core/usage.py
@@ -26,6 +26,7 @@ class GatewayUsage(CompletionUsage):
     cache_write_tokens: int = 0
     cache_write_1h_tokens: int = 0
     cache_tokens_in_prompt: bool = True
+    reasoning_tokens: int = 0
     """Whether ``cache_read_tokens`` / ``cache_write_tokens`` are already counted
     within ``prompt_tokens``.
 
@@ -47,6 +48,7 @@ class GatewayUsage(CompletionUsage):
         cache_write_tokens: int | None = None,
         cache_write_1h_tokens: int | None = None,
         cache_tokens_in_prompt: bool | None = None,
+        reasoning_tokens: int | None = None,
     ) -> "GatewayUsage":
         """Build a ``GatewayUsage`` from a base ``CompletionUsage`` plus cache counts.
 
@@ -66,6 +68,8 @@ class GatewayUsage(CompletionUsage):
             cache_write_1h_tokens = cache_write_1h_tokens_of(usage)
         if cache_tokens_in_prompt is None:
             cache_tokens_in_prompt = cache_tokens_in_prompt_of(usage)
+        if reasoning_tokens is None:
+            reasoning_tokens = reasoning_tokens_of(usage)
         return cls(
             prompt_tokens=usage.prompt_tokens,
             completion_tokens=usage.completion_tokens,
@@ -76,6 +80,7 @@ class GatewayUsage(CompletionUsage):
             cache_write_tokens=cache_write_tokens,
             cache_write_1h_tokens=cache_write_1h_tokens,
             cache_tokens_in_prompt=cache_tokens_in_prompt,
+            reasoning_tokens=reasoning_tokens,
         )
 
 
@@ -116,3 +121,13 @@ def cache_tokens_in_prompt_of(usage: CompletionUsage) -> bool:
     if isinstance(usage, GatewayUsage):
         return usage.cache_tokens_in_prompt
     return True
+
+
+def reasoning_tokens_of(usage: CompletionUsage) -> int:
+    """Return the reasoning/thinking token count carried by ``usage``."""
+    if isinstance(usage, GatewayUsage):
+        return usage.reasoning_tokens
+    if getattr(usage, "completion_tokens_details", None) is not None:
+        return getattr(usage.completion_tokens_details, "reasoning_tokens", 0) or 0
+    return 0
+

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -513,6 +513,7 @@ class UsageLog(Base):
     cache_read_tokens: Mapped[int | None] = mapped_column()
     cache_write_tokens: Mapped[int | None] = mapped_column()
     cache_write_1h_tokens: Mapped[int | None] = mapped_column()
+    reasoning_tokens: Mapped[int | None] = mapped_column()
     billing_meters: Mapped[dict[str, Any] | None] = mapped_column(JSON)
     pricing_breakdown: Mapped[list[dict[str, Any]] | None] = mapped_column(JSON)
     cost: Mapped[float | None] = mapped_column()
@@ -579,6 +580,7 @@ class UsageLog(Base):
             "cache_read_tokens": self.cache_read_tokens,
             "cache_write_tokens": self.cache_write_tokens,
             "cache_write_1h_tokens": self.cache_write_1h_tokens,
+            "reasoning_tokens": self.reasoning_tokens,
             "billing_meters": self.billing_meters,
             "pricing_breakdown": self.pricing_breakdown,
             "cost": self.cost,

--- a/src/gateway/services/external_usage_service.py
+++ b/src/gateway/services/external_usage_service.py
@@ -79,6 +79,7 @@ class ExternalUsageEvent(BaseModel):
     cache_read_tokens: int = Field(default=0, ge=0, le=_MAX_TOKENS)
     cache_write_tokens: int = Field(default=0, ge=0, le=_MAX_TOKENS)
     cache_write_1h_tokens: int = Field(default=0, ge=0, le=_MAX_TOKENS)
+    reasoning_tokens: int = Field(default=0, ge=0, le=_MAX_TOKENS)
     # Whether ``input_tokens`` already includes the cache counts (OpenAI shape,
     # where ``cached_tokens`` is a subset of ``prompt_tokens``) or excludes them
     # (Anthropic / Claude Code shape, where the cache buckets are additive). The
@@ -274,6 +275,7 @@ def _build_usage(event: ExternalUsageEvent) -> GatewayUsage:
         cache_write_tokens=event.cache_write_tokens,
         cache_write_1h_tokens=event.cache_write_1h_tokens,
         cache_tokens_in_prompt=event.cache_tokens_in_prompt,
+        reasoning_tokens=event.reasoning_tokens,
     )
 
 
@@ -306,6 +308,7 @@ def _build_row(
         cache_read_tokens=event.cache_read_tokens,
         cache_write_tokens=event.cache_write_tokens,
         cache_write_1h_tokens=event.cache_write_1h_tokens,
+        reasoning_tokens=event.reasoning_tokens,
         billing_meters=meters,
         pricing_breakdown=breakdown,
         cost=cost,

--- a/src/gateway/services/metered_pricing.py
+++ b/src/gateway/services/metered_pricing.py
@@ -8,6 +8,7 @@ from gateway.core.usage import (
     cache_tokens_in_prompt_of,
     cache_write_1h_tokens_of,
     cache_write_tokens_of,
+    reasoning_tokens_of,
 )
 from gateway.models.entities import ModelPricing
 
@@ -29,6 +30,7 @@ class BillableUsage:
     cache_read_tokens: int
     cache_write_tokens: int
     cache_write_1h_tokens: int
+    reasoning_tokens: int
 
     @property
     def cache_write_base_tokens(self) -> int:
@@ -42,6 +44,7 @@ def billable_usage(usage: Any) -> BillableUsage:
     cache_read = max(cache_read_tokens_of(usage), 0)
     cache_write = max(cache_write_tokens_of(usage), 0)
     cache_write_1h = min(max(cache_write_1h_tokens_of(usage), 0), cache_write)
+    reasoning = min(max(reasoning_tokens_of(usage), 0), completion_tokens)
 
     if cache_tokens_in_prompt_of(usage):
         cache_read = min(cache_read, prompt_tokens)
@@ -57,6 +60,7 @@ def billable_usage(usage: Any) -> BillableUsage:
         cache_read_tokens=cache_read,
         cache_write_tokens=cache_write,
         cache_write_1h_tokens=cache_write_1h,
+        reasoning_tokens=reasoning,
     )
 
 
@@ -151,6 +155,7 @@ def calculate_metered_cost(
         "cache_write_tokens": billable.cache_write_tokens,
         "cache_write_1h_tokens": billable.cache_write_1h_tokens,
         "completion_tokens": billable.completion_tokens,
+        "reasoning_tokens": billable.reasoning_tokens,
     }
     lines: list[dict[str, float | int | str]] = []
 

--- a/tests/unit/test_usage_reasoning_tokens.py
+++ b/tests/unit/test_usage_reasoning_tokens.py
@@ -1,0 +1,181 @@
+"""Unit tests for reasoning/thinking token capture in the usage carrier, parse sites, and pricing."""
+
+import pytest
+from any_llm.types.completion import (
+    ChatCompletionChunk,
+    CompletionUsage,
+)
+from openai.types.completion_usage import CompletionTokensDetails
+
+from gateway.api.routes.chat import _ChatAdapter
+from gateway.api.routes.messages import _messages_stream_usage, _MessagesAdapter
+from gateway.api.routes.responses import _usage_to_completion_usage
+from gateway.core.usage import GatewayUsage, reasoning_tokens_of
+from gateway.models.entities import ModelPricing
+from gateway.services.metered_pricing import calculate_metered_cost
+
+
+def test_gateway_usage_reasoning_tokens_defaults_to_zero() -> None:
+    usage = GatewayUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    assert usage.reasoning_tokens == 0
+
+
+def test_from_completion_usage_reads_reasoning_tokens_fallback() -> None:
+    base = CompletionUsage(
+        prompt_tokens=100,
+        completion_tokens=20,
+        total_tokens=120,
+        completion_tokens_details=CompletionTokensDetails(reasoning_tokens=12),
+    )
+    usage = GatewayUsage.from_completion_usage(base)
+    assert usage.reasoning_tokens == 12
+
+
+def test_from_completion_usage_explicit_overrides_fallback() -> None:
+    base = CompletionUsage(
+        prompt_tokens=100,
+        completion_tokens=20,
+        total_tokens=120,
+        completion_tokens_details=CompletionTokensDetails(reasoning_tokens=12),
+    )
+    usage = GatewayUsage.from_completion_usage(base, reasoning_tokens=5)
+    assert usage.reasoning_tokens == 5
+
+
+def test_from_completion_usage_honors_explicit_zero() -> None:
+    base = CompletionUsage(
+        prompt_tokens=100,
+        completion_tokens=20,
+        total_tokens=120,
+        completion_tokens_details=CompletionTokensDetails(reasoning_tokens=12),
+    )
+    usage = GatewayUsage.from_completion_usage(base, reasoning_tokens=0)
+    assert usage.reasoning_tokens == 0
+
+
+def test_reasoning_tokens_of_helper_on_plain_completion_usage() -> None:
+    plain = CompletionUsage(
+        prompt_tokens=100,
+        completion_tokens=20,
+        total_tokens=120,
+        completion_tokens_details=CompletionTokensDetails(reasoning_tokens=8),
+    )
+    assert reasoning_tokens_of(plain) == 8
+
+
+def test_reasoning_tokens_of_helper_without_details() -> None:
+    plain = CompletionUsage(prompt_tokens=10, completion_tokens=2, total_tokens=12)
+    assert reasoning_tokens_of(plain) == 0
+
+
+def test_chat_stream_captures_reasoning_tokens() -> None:
+    chunk = ChatCompletionChunk.model_construct(
+        usage=CompletionUsage(
+            prompt_tokens=100,
+            completion_tokens=20,
+            total_tokens=120,
+            completion_tokens_details=CompletionTokensDetails(reasoning_tokens=15),
+        ),
+    )
+    usage = _ChatAdapter().extract_stream_usage(chunk)
+    assert isinstance(usage, GatewayUsage)
+    assert usage.reasoning_tokens == 15
+
+
+def test_responses_captures_reasoning_tokens() -> None:
+    from openai.types.responses import ResponseUsage
+    from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+
+    usage_in = ResponseUsage(
+        input_tokens=100,
+        output_tokens=20,
+        total_tokens=120,
+        input_tokens_details=InputTokensDetails(cached_tokens=33),
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=14),
+    )
+    usage = _usage_to_completion_usage(usage_in)
+    assert isinstance(usage, GatewayUsage)
+    assert usage.reasoning_tokens == 14
+    assert usage.cache_read_tokens == 33
+
+
+def test_messages_non_stream_captures_thinking_tokens() -> None:
+    from any_llm.types.messages import MessageResponse, MessageUsage
+
+    # Simulate Anthropic response usage containing thinking_tokens/reasoning_tokens
+    result = MessageResponse.model_construct(
+        usage=MessageUsage.model_validate(
+            {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "thinking_tokens": 30,
+            }
+        )
+    )
+    usage = _MessagesAdapter().extract_usage(result)
+    assert isinstance(usage, GatewayUsage)
+    assert usage.prompt_tokens == 100
+    assert usage.completion_tokens == 50
+    assert usage.reasoning_tokens == 30
+
+
+def test_messages_stream_delta_captures_thinking_tokens() -> None:
+    from anthropic.types.message_delta_usage import MessageDeltaUsage
+    from any_llm.types.messages import MessageDeltaEvent
+
+    event = MessageDeltaEvent.model_construct(
+        usage=MessageDeltaUsage.model_validate(
+            {
+                "input_tokens": 10,
+                "output_tokens": 30,
+                "thinking_tokens": 12,
+            }
+        )
+    )
+    usage = _messages_stream_usage(event)
+    assert isinstance(usage, GatewayUsage)
+    assert usage.completion_tokens == 30
+    assert usage.reasoning_tokens == 12
+
+
+def test_messages_stream_start_captures_thinking_tokens() -> None:
+    from any_llm.types.messages import MessageResponse, MessageStartEvent, MessageUsage
+
+    msg = MessageResponse.model_construct(
+        usage=MessageUsage.model_validate(
+            {
+                "input_tokens": 100,
+                "output_tokens": 0,
+                "thinking_tokens": 25,
+            }
+        )
+    )
+    event = MessageStartEvent.model_construct(message=msg)
+    usage = _messages_stream_usage(event)
+    assert isinstance(usage, GatewayUsage)
+    assert usage.prompt_tokens == 100
+    assert usage.reasoning_tokens == 25
+
+
+def test_metered_pricing_adds_reasoning_tokens_to_meters_but_does_not_double_bill() -> None:
+    pricing = ModelPricing(
+        model_key="openai:gpt-4o",
+        input_price_per_million=5.0,
+        output_price_per_million=15.0,
+    )
+    usage = GatewayUsage(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        total_tokens=1500,
+        reasoning_tokens=200,
+    )
+    cost, meters, breakdown = calculate_metered_cost(pricing, usage)
+
+    # Expected cost should only bill input (1000) and completion (500) tokens.
+    # Reasoning tokens (200) are a subset of completion tokens and do not have their own pricing rate.
+    expected_cost = (1000 / 1_000_000) * 5.0 + (500 / 1_000_000) * 15.0
+    assert cost == pytest.approx(expected_cost)
+
+    assert meters["reasoning_tokens"] == 200
+    assert meters["completion_tokens"] == 500
+    assert meters["total_input_tokens"] == 1000


### PR DESCRIPTION
## Description
This PR implements end-to-end support for tracking and metering "reasoning tokens" (used by OpenAI's reasoning models and Anthropic's extended thinking models) within the Otari gateway. 
Changes include:
* **Database Persistence:** Added a nullable `reasoning_tokens` integer column to the `usage_logs` table via Alembic migration (`6163c9f0d2ef`).
* **Adapters & Ingestion:** Extended the `GatewayUsage` core carrier and updated the endpoint adapters (`chat.py`, `messages.py`, `responses.py`) to extract reasoning/thinking tokens from OpenAI and Anthropic response usage payloads (handling stream chunks and final responses).
* **OTLP / Ingestion:** Updated `ExternalUsageEvent` and the OTLP telemetry parser (`otlp.py`) to support extraction of reasoning tokens from standard semantic attributes.
* **Pricing Engine Integration:** Registered `reasoning_tokens` under `billing_meters` in the pricing engine (`metered_pricing.py`) with non-additive pricing (ensuring correct output token pricing without double-billing).
* **Validation & Specs:** Regenerated and validated the OpenAPI spec (`openapi.json`) and Postman collections.
* **Tests:** Added a complete unit test suite in `tests/unit/test_usage_reasoning_tokens.py` covering adapters, stream aggregation, telemetry, and pricing.


## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
Fixes #430

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).
- [ ] If this PR adds or changes a persistent table, a control-plane contract the otari.ai platform consumes or serves, a capability the platform also has, or a mode-specific surface, I appended an entry to the M4 reconciliation ledger ([otari-ai#1587](https://github.com/mozilla-ai/otari-ai/issues/1587)). See [.github/instructions/reconciliation-ledger.instructions.md](instructions/reconciliation-ledger.instructions.md).

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**
Gemini 3.5 Flash (High) via Antigravity

**Any additional AI details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds end-to-end tracking for reasoning and thinking tokens across provider responses, streaming usage, OTLP events, usage logs, and pricing.

## Benefits

- Records reasoning tokens for reporting and attribution.
- Supports OpenAI and Anthropic usage data.
- Prevents double billing because reasoning tokens remain non-additive.
- Adds coverage for extraction, aggregation, telemetry, and pricing behavior.
- Updates the database schema, OpenAPI specification, and Postman collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->