### PR TITLE
fix(auth): move the API key format check off the verify path

### DIFF
--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -117,15 +117,13 @@ def _extract_bearer_token(request: Request, config: GatewayConfig) -> str:
 
 
 async def _verify_and_update_api_key(db: AsyncSession, token: str) -> APIKey:
-    """Verify API key token and update last_used_at."""
-    try:
-        key_hash = hash_key(token)
-    except ValueError as e:
-        record_auth_failure("invalid_format")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"Invalid API key format: {e}",
-        ) from e
+    """Verify API key token and update last_used_at.
+
+    The token's shape is not checked: any presented token is hashed and looked
+    up, so a key minted elsewhere (a migrated platform key) authenticates on its
+    hash and an unrecognized one gets the ordinary "Invalid API key" 401.
+    """
+    key_hash = hash_key(token)
 
     try:
         result = await db.execute(select(APIKey).where(APIKey.key_hash == key_hash))

--- a/src/gateway/auth/models.py
+++ b/src/gateway/auth/models.py
@@ -70,15 +70,16 @@ def validate_api_key_format(api_key: str) -> None:
 def hash_key(api_key: str) -> str:
     """Hash an API key using SHA-256.
 
+    Deliberately does not validate the key's format. Format is a mint-time
+    concern (``generate_api_key`` validates what it generates); on the verify
+    path a shape check only decides which error a wrong key gets, and it would
+    reject a key minted elsewhere whose hash is legitimately on a row.
+
     Args:
         api_key: The API key to hash
 
     Returns:
         Hexadecimal string of the SHA-256 hash
 
-    Raises:
-        ValueError: If the API key format is invalid
-
     """
-    validate_api_key_format(api_key)
     return hashlib.sha256(api_key.encode()).hexdigest()

--- a/src/gateway/services/master_key_service.py
+++ b/src/gateway/services/master_key_service.py
@@ -48,8 +48,8 @@ def is_generated_master_key(token: str) -> bool:
 def hash_master_key(token: str) -> str:
     """SHA-256 hex of a master key.
 
-    Deliberately not ``auth.hash_key``, which validates the ``gw-`` API-key
-    format; a master key has its own shape.
+    Deliberately not ``auth.hash_key``: a master key is a different credential
+    with its own shape and its own storage, so the two hashes stay independent.
     """
     return hashlib.sha256(token.encode()).hexdigest()
 

--- a/tests/integration/test_control_plane_error_contract.py
+++ b/tests/integration/test_control_plane_error_contract.py
@@ -22,9 +22,9 @@ from fastapi.testclient import TestClient
 
 from gateway.core.config import API_KEY_HEADER
 
-# A well-formed but unknown key: it passes ``validate_api_key_format`` so it
-# reaches the hash lookup and misses, the closest inference-path analog to an
-# invalid master key (both are recognized-shape-but-wrong credentials).
+# A well-formed but unknown key: its hash reaches the lookup and misses, the
+# closest inference-path analog to an invalid master key (both are
+# recognized-shape-but-wrong credentials).
 INVALID_API_KEY = "gw-" + "a" * 60
 
 # The inference path guards on ``verify_api_key``; an unknown key yields 401.

--- a/tests/integration/test_migrated_key_auth.py
+++ b/tests/integration/test_migrated_key_auth.py
@@ -1,0 +1,45 @@
+"""Route-level auth for a key that does not have the ``gw-`` shape (issue #646).
+
+Otari and otari-ai both store an unsalted SHA-256 hex digest of the whole
+presented key, so a migrated ``tk_`` key's hash lands on an ``api_keys`` row
+unchanged. The format check that used to run inside ``hash_key`` rejected such a
+key with a 401 before the lookup ever happened; auth now depends on the row
+alone, which is what makes a cutover re-issue unnecessary.
+"""
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+from sqlalchemy import update
+from sqlalchemy.orm import Session
+
+from gateway.auth.models import hash_key
+from gateway.core.config import API_KEY_HEADER
+from gateway.models.entities import APIKey
+
+# The shape otari-ai mints: it fails both the ``gw-``/``gw_`` prefix check and the
+# ``gw[-_][A-Za-z0-9_-]+`` charset check the old validator applied.
+MIGRATED_KEY = "tk_live.migrated-platform-key-0123456789abcdefghij"
+
+
+def test_migrated_key_authenticates_when_its_hash_is_on_a_row(
+    client: TestClient,
+    db_session: Session,
+    api_key_obj: dict[str, Any],
+) -> None:
+    """Re-point an existing key row at a migrated key's hash, as the migration would."""
+    db_session.execute(
+        update(APIKey).where(APIKey.id == api_key_obj["id"]).values(key_hash=hash_key(MIGRATED_KEY)),
+    )
+    db_session.commit()
+
+    response = client.get("/v1/models", headers={API_KEY_HEADER: MIGRATED_KEY})
+
+    assert response.status_code == 200
+
+
+def test_unknown_migrated_shape_key_gets_the_ordinary_invalid_key_401(client: TestClient) -> None:
+    response = client.get("/v1/models", headers={API_KEY_HEADER: MIGRATED_KEY})
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid API key"

--- a/tests/integration/test_migrated_key_auth.py
+++ b/tests/integration/test_migrated_key_auth.py
@@ -7,19 +7,29 @@ key with a 401 before the lookup ever happened; auth now depends on the row
 alone, which is what makes a cutover re-issue unnecessary.
 """
 
+import hashlib
 from typing import Any
 
 from fastapi.testclient import TestClient
 from sqlalchemy import update
 from sqlalchemy.orm import Session
 
-from gateway.auth.models import hash_key
 from gateway.core.config import API_KEY_HEADER
 from gateway.models.entities import APIKey
 
 # The shape otari-ai mints: it fails both the ``gw-``/``gw_`` prefix check and the
 # ``gw[-_][A-Za-z0-9_-]+`` charset check the old validator applied.
 MIGRATED_KEY = "tk_live.migrated-platform-key-0123456789abcdefghij"
+
+
+def _platform_digest(api_key: str) -> str:
+    """The digest otari-ai stored for ``api_key``, computed without ``hash_key``.
+
+    Standing in for the other product's hasher is what makes this a migration
+    test rather than a round-trip through our own helper, and it keeps the row
+    buildable on a tree where ``hash_key`` still rejects the key.
+    """
+    return hashlib.sha256(api_key.encode()).hexdigest()
 
 
 def test_migrated_key_authenticates_when_its_hash_is_on_a_row(
@@ -29,7 +39,7 @@ def test_migrated_key_authenticates_when_its_hash_is_on_a_row(
 ) -> None:
     """Re-point an existing key row at a migrated key's hash, as the migration would."""
     db_session.execute(
-        update(APIKey).where(APIKey.id == api_key_obj["id"]).values(key_hash=hash_key(MIGRATED_KEY)),
+        update(APIKey).where(APIKey.id == api_key_obj["id"]).values(key_hash=_platform_digest(MIGRATED_KEY)),
     )
     db_session.commit()
 

--- a/tests/unit/test_auth_models.py
+++ b/tests/unit/test_auth_models.py
@@ -1,6 +1,9 @@
+import hashlib
+from unittest.mock import patch
+
 import pytest
 
-from gateway.auth.models import hash_key, validate_api_key_format
+from gateway.auth.models import generate_api_key, hash_key, validate_api_key_format
 
 
 @pytest.mark.parametrize(
@@ -31,3 +34,24 @@ def test_hash_key_accepts_gw_underscore_prefix() -> None:
     digest = hash_key("gw_" + "a" * 48)
 
     assert len(digest) == 64
+
+
+def test_hash_key_hashes_a_key_that_is_not_gw_shaped() -> None:
+    """``hash_key`` no longer validates format (issue #646).
+
+    A key minted by another product (a migrated ``tk_`` platform key) hashes to
+    the same unsalted SHA-256 digest as any other string, so a migrated row's
+    hash still matches on the verify path.
+    """
+    api_key = "tk_" + "b" * 48
+
+    assert hash_key(api_key) == hashlib.sha256(api_key.encode()).hexdigest()
+
+
+def test_generate_api_key_still_validates_at_mint_time() -> None:
+    """Mint-time validation is unaffected by lifting the check out of ``hash_key``."""
+    with (
+        patch("gateway.auth.models.secrets.token_urlsafe", return_value="short"),
+        pytest.raises(RuntimeError, match="failed validation"),
+    ):
+        generate_api_key()

--- a/tests/unit/test_extract_bearer_token.py
+++ b/tests/unit/test_extract_bearer_token.py
@@ -11,6 +11,7 @@ from starlette.requests import Request
 
 from gateway.api.deps import _extract_bearer_token
 from gateway.core.config import API_KEY_HEADER, X_API_KEY_HEADER, GatewayConfig
+from gateway.metrics import REGISTRY
 
 
 def _make_request(headers: dict[str, str]) -> Request:
@@ -77,12 +78,20 @@ def test_canonical_header_accepts_raw_token(config: GatewayConfig) -> None:
 
 
 def test_malformed_authorization_header_raises_401(config: GatewayConfig) -> None:
+    """A non-Bearer Authorization scheme is the ``invalid_format`` auth-failure trigger.
+
+    It is the only one since the ``gw-`` shape check came off the key-verify path
+    (issue #646), so the metric label is pinned here rather than left to lapse.
+    """
     request = _make_request({"Authorization": "Basic abc123"})
+    before = REGISTRY.get_sample_value("gateway_auth_failures_total", {"reason": "invalid_format"}) or 0.0
 
     with pytest.raises(HTTPException) as exc_info:
         _extract_bearer_token(request, config)
 
     assert exc_info.value.status_code == 401
+    after = REGISTRY.get_sample_value("gateway_auth_failures_total", {"reason": "invalid_format"}) or 0.0
+    assert after - before == 1.0
 
 
 def test_missing_credentials_raises_401(config: GatewayConfig) -> None:

--- a/tests/unit/test_verify_api_key_shape.py
+++ b/tests/unit/test_verify_api_key_shape.py
@@ -8,6 +8,7 @@ same unsalted SHA-256 digest. Verification now hashes whatever was presented and
 decides on the row lookup alone; format stays a mint-time concern.
 """
 
+import hashlib
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
@@ -17,12 +18,22 @@ import pytest
 from fastapi import HTTPException, status
 
 from gateway.api.deps import _verify_and_update_api_key
-from gateway.auth.models import hash_key
 from gateway.metrics import REGISTRY
 
 # A key with the shape otari-ai mints: neither the ``gw-``/``gw_`` prefix nor the
 # ``gw[-_][A-Za-z0-9_-]+`` charset the old check enforced.
 MIGRATED_KEY = "tk_live.migrated-platform-key-0123456789abcdefghij"
+
+
+def _platform_digest(api_key: str) -> str:
+    """The digest otari-ai stored for ``api_key``, computed without ``hash_key``.
+
+    Standing in for the other product's hasher keeps the row independent of the
+    function under test: pre-fix, ``hash_key`` raised on this key, so a fixture
+    built through it would fail during setup instead of on the auth behavior the
+    test is about.
+    """
+    return hashlib.sha256(api_key.encode()).hexdigest()
 
 
 def _sample(labels: dict[str, str]) -> float:
@@ -41,7 +52,7 @@ def _db_returning(api_key: Any) -> Any:
 async def test_migrated_key_authenticates_when_its_hash_is_on_a_row() -> None:
     api_key: Any = SimpleNamespace(
         id="key-migrated",
-        key_hash=hash_key(MIGRATED_KEY),
+        key_hash=_platform_digest(MIGRATED_KEY),
         is_active=True,
         expires_at=None,
         # Recent enough that the throttled ``last_used_at`` bump is skipped, so

--- a/tests/unit/test_verify_api_key_shape.py
+++ b/tests/unit/test_verify_api_key_shape.py
@@ -1,0 +1,69 @@
+"""Unit tests for shape-independent API key verification (issue #646).
+
+``hash_key`` used to validate the ``gw-`` format before hashing, and
+``_verify_and_update_api_key`` turned that ``ValueError`` into a 401. A key
+minted by otari-ai (``tk_...``) failed the prefix and charset checks, so a
+migrated row could never authenticate even though the two products compute the
+same unsalted SHA-256 digest. Verification now hashes whatever was presented and
+decides on the row lookup alone; format stays a mint-time concern.
+"""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException, status
+
+from gateway.api.deps import _verify_and_update_api_key
+from gateway.auth.models import hash_key
+from gateway.metrics import REGISTRY
+
+# A key with the shape otari-ai mints: neither the ``gw-``/``gw_`` prefix nor the
+# ``gw[-_][A-Za-z0-9_-]+`` charset the old check enforced.
+MIGRATED_KEY = "tk_live.migrated-platform-key-0123456789abcdefghij"
+
+
+def _sample(labels: dict[str, str]) -> float:
+    return REGISTRY.get_sample_value("gateway_auth_failures_total", labels) or 0.0
+
+
+def _db_returning(api_key: Any) -> Any:
+    db: Any = AsyncMock()
+    lookup_result = MagicMock()
+    lookup_result.scalar_one_or_none.return_value = api_key
+    db.execute.return_value = lookup_result
+    return db
+
+
+@pytest.mark.asyncio
+async def test_migrated_key_authenticates_when_its_hash_is_on_a_row() -> None:
+    api_key: Any = SimpleNamespace(
+        id="key-migrated",
+        key_hash=hash_key(MIGRATED_KEY),
+        is_active=True,
+        expires_at=None,
+        # Recent enough that the throttled ``last_used_at`` bump is skipped, so
+        # the test never reaches a real session.
+        last_used_at=datetime.now(UTC),
+    )
+
+    verified = await _verify_and_update_api_key(_db_returning(api_key), MIGRATED_KEY)
+
+    assert verified is api_key
+
+
+@pytest.mark.asyncio
+async def test_unknown_migrated_shape_key_gets_the_ordinary_invalid_key_401() -> None:
+    before_invalid_key = _sample({"reason": "invalid_key"})
+    before_invalid_format = _sample({"reason": "invalid_format"})
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _verify_and_update_api_key(_db_returning(None), MIGRATED_KEY)
+
+    assert exc_info.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert exc_info.value.detail == "Invalid API key"
+    assert _sample({"reason": "invalid_key"}) - before_invalid_key == 1.0
+    # The wrong-shape key must not be reported as a format failure any more.
+    assert _sample({"reason": "invalid_format"}) == before_invalid_format


### PR DESCRIPTION
## Description

`hash_key` no longer validates the `gw-` key format, so verification depends on the row lookup alone and a migrated otari-ai key authenticates on its hash.

Both products store an unsalted SHA-256 hex digest of the whole presented key, so a migrated `tk_` key's hash already lands on an `api_keys` row unchanged. That equivalence is confirmed against the platform's source, not assumed: `hash_api_client_token` in otari-ai `backend/app/core/security.py:367` is `hashlib.sha256(token.encode("utf-8")).hexdigest()`, and it is what that repo's verify path uses at `backend/app/api/deps.py:835`. The platform's own migration code states the same equivalence in prose at `backend/app/migration/budget_target.py:268`. No cross-repo question is left open here. What broke it was the format check inside `hash_key`: `_verify_and_update_api_key` turned the resulting `ValueError` into a 401 before the lookup ever ran. Mint-time validation is untouched; `generate_api_key` calls `validate_api_key_format` itself, and the other three `hash_key` callers (`routes/keys.py` twice, `bootstrap_service.py`) all hash a freshly generated key.

Two doc comments that asserted the old behavior are updated in the same commit: `hash_master_key`'s "deliberately not `auth.hash_key`, which validates the `gw-` format" rationale, and a comment in `test_control_plane_error_contract.py` that explained its fixture key through `validate_api_key_format`.

**On the `invalid_format` metric:** it does not lose its only trigger. `_extract_bearer_token` still records it for an `Authorization` header with a non-Bearer scheme, so the label keeps a live home rather than needing retirement. That trigger had no test asserting the metric, so this PR pins it in `test_malformed_authorization_header_raises_401`.

**Adjacent, not fixed here** (flagging rather than touching, since other migration PRs are in flight): after this change `hash_master_key` and `hash_key` are byte-for-byte the same function in two layers. Folding them together is a cross-layer refactor and does not belong in this PR.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #646
Part of mozilla-ai/otari-ai#1452

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). No contract change; `make openapi-check` and `make postman-check` both report the artifacts up to date.
- [x] **M4 ledger:** this PR either needs no entry (an existing row already covers it and its target is unchanged), or the entry is appended to [otari-ai#1587](https://github.com/mozilla-ai/otari-ai/issues/1587). No entry: this changes no table and no cross-repo surface, it removes a check on an existing one whose target disposition is unchanged.

## Tests added

Covering each Definition of Done bullet:

- `tests/unit/test_verify_api_key_shape.py`: a `tk_`-shaped key authenticates when its hash is on a row, and an unknown one gets the ordinary `Invalid API key` 401 while `invalid_format` stays flat.
- `tests/integration/test_migrated_key_auth.py`: the same two cases through the real route stack, re-pointing a key row at a migrated key's hash the way the migration would.
- `tests/unit/test_auth_models.py`: `hash_key` on a non-`gw` key equals the plain SHA-256 digest, and `generate_api_key` still refuses a malformed key at mint time.
- `tests/unit/test_extract_bearer_token.py`: the surviving `invalid_format` trigger now asserts the counter.

Both new files build the stored row with a local `_platform_digest` helper (plain `hashlib.sha256`) rather than with `hash_key`, so the fixture stands in for otari-ai's hasher instead of round-tripping through the function under test. Each of the five new assertions was confirmed to fail with the source change reverted, and the two migration tests fail on the auth result (`401 != 200`) rather than during setup.

## Verified locally

- `make lint` (architecture check + Ruff), `make typecheck` (mypy, 386 files)
- `uv run pytest tests/unit`: 1812 passed, 8 skipped
- `uv run pytest tests/integration` against PostgreSQL: 1349 passed, 9 skipped
- `make openapi-check`, `make postman-check`
- `uv run --frozen --no-dev python scripts/oss_edition_smoke.py`

## Not verified locally

Nothing outstanding. Both caveats from the first version of this description are resolved:

- **PostgreSQL version** is covered by CI. The local runs used a PostgreSQL 18 instance via `TEST_DATABASE_URL` because this sandbox has no Docker, but CI's `test` job runs the full unit and integration suites against the Testcontainers `postgres:17` image under `-n auto`, and it is green on this head.
- **Frontend checks do not apply.** `otari-dashboard.yml` (the `dashboard` vitest job and `screenshots`) is path-filtered to `web/**`, `docs/dashboard.md`, `docs/public/openapi.json`, and its own workflow file; this diff touches none of them, so those jobs are correctly not run rather than unverified. The gateway half of dashboard serving is not skipped: `otari-dashboard-serving.yml` triggers on `src/gateway/**`, so the `serving` job did run on this PR and passed.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via the Claude Code CLI.

**Any additional AI details you'd like to share:**

Implemented and tested by Claude Opus 5 through back-and-forth with @njbrake. The reasoning and decisions are his; the code and prose are the model's.

- [x] I am an AI Agent filling out this form (check box if true)
