### PR TITLE
feat(tenancy): add nullable credential columns to user

### DIFF
--- a/alembic/versions/4fa31cc2307a_add_user_credential_columns.py
+++ b/alembic/versions/4fa31cc2307a_add_user_credential_columns.py
@@ -1,0 +1,48 @@
+"""Add nullable credential columns to user.
+
+Revision ID: 4fa31cc2307a
+Revises: a3c7e1b9d5f2
+Create Date: 2026-08-19 21:27:29.965175
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4fa31cc2307a"
+down_revision: str | Sequence[str] | None = "a3c7e1b9d5f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # All nullable, no server_default: existing identities stay NULL on every
+    # one of these, which is what "unread by anything yet" (otari#645) means
+    # in the schema. oauth_provider is a plain string rather than a DB-level
+    # enum so the chain stays dialect-neutral for SQLite.
+    op.add_column("user", sa.Column("hashed_password", sa.String(), nullable=True))
+    op.add_column("user", sa.Column("oauth_provider", sa.String(length=50), nullable=True))
+    op.add_column("user", sa.Column("email_verification_token", sa.String(), nullable=True))
+    op.add_column("user", sa.Column("email_verified_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("user", sa.Column("terms_accepted_at", sa.DateTime(timezone=True), nullable=True))
+    # Unique like user.email: nullable so most rows carry no pending
+    # verification, unique so the verification flow can look an identity up
+    # by the token it was issued.
+    op.create_index(op.f("ix_user_email_verification_token"), "user", ["email_verification_token"], unique=True)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_user_email_verification_token"), table_name="user")
+    # Batch mode: SQLite has no ALTER TABLE ... DROP COLUMN, so dropping any of
+    # these on that engine requires the table-rebuild path.
+    with op.batch_alter_table("user") as batch_op:
+        batch_op.drop_column("terms_accepted_at")
+        batch_op.drop_column("email_verified_at")
+        batch_op.drop_column("email_verification_token")
+        batch_op.drop_column("oauth_provider")
+        batch_op.drop_column("hashed_password")

--- a/src/gateway/models/tenancy.py
+++ b/src/gateway/models/tenancy.py
@@ -39,12 +39,17 @@ Three deliberate departures from the platform's models, applied on arrival:
   never tables), so a column the hosted edition needs has to live here or
   nowhere. ``workspace.activation_classification`` and
   ``user.default_organization_id`` therefore stay, neither of them read by
-  anything in this edition. The columns
-  that do *not* come are the ones gated on the still-open identity decision
-  (otari-ai#1716): password hashes, OAuth provider, verification tokens. They
-  arrive with the flow that reads them, rather than being invented ahead of it.
-  Purely hosted CRM and onboarding columns are the third case and are simply
-  not part of the reconciled schema.
+  anything in this edition. Purely hosted CRM and onboarding columns are the
+  other case and are simply not part of the reconciled schema.
+- **Credential columns are nullable and unread, ahead of the flow that fills
+  them.** ``hashed_password``, ``oauth_provider``, ``email_verification_token``,
+  ``email_verified_at`` and ``terms_accepted_at`` (otari#645) exist so the
+  schema is ready for the authentication track; no route or service reads or
+  writes them yet. That inverts the usual rule for this file (a column arrives
+  with the flow that reads it), because the still-open identity decision
+  (otari-ai#1716) is about *how* those flows populate the columns, not whether
+  the columns exist. ``hashed_password`` is deliberately absent from
+  ``UserBase``/``UserCreate``: it must never round-trip through a wire schema.
 
 No ORM ``relationship()`` is declared on purpose. Lazy loading on an
 ``AsyncSession`` raises ``MissingGreenlet`` at the point of attribute access
@@ -263,6 +268,20 @@ class User(UserBase, PrimaryKeyMixin, CreatedAtMixin, UpdatedAtMixin, table=True
         ondelete="SET NULL",
         index=True,
     )
+    # Nullable and unread by anything in this edition, see the module
+    # docstring: the schema is ready ahead of the authentication track, not a
+    # sign that these flows exist yet.
+    hashed_password: str | None = Field(default=None)
+    # A plain string, not a DB-level enum: the chain must stay dialect-neutral
+    # for SQLite, and there is no reader yet to justify committing to a
+    # closed set of values at the schema level.
+    oauth_provider: str | None = Field(default=None, max_length=50)
+    # Unique like ``email``: nullable so most rows carry no pending
+    # verification, unique so the verification flow can look an identity up
+    # by the token it was issued.
+    email_verification_token: str | None = Field(default=None, unique=True, index=True)
+    email_verified_at: datetime | None = _timestamp_field(default=None, column_kwargs={})
+    terms_accepted_at: datetime | None = _timestamp_field(default=None, column_kwargs={})
 
 
 # =============================================================================

--- a/tests/unit/test_user_credential_columns_migration.py
+++ b/tests/unit/test_user_credential_columns_migration.py
@@ -1,0 +1,145 @@
+"""The user-credential-columns revision's Alembic chain, exercised on SQLite.
+
+otari#645 adds five nullable columns to ``user`` ahead of the authentication
+track. Driven against a real file database, like
+``test_tenancy_schema_chain.py``, because the downgrade's column drops go
+through SQLite's batch-mode table rebuild, and that rebuild is what could
+silently lose the unique index on ``email_verification_token``.
+"""
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import Engine, create_engine, inspect, text
+
+_ALEMBIC_DIR = Path(__file__).resolve().parents[2] / "alembic"
+_REVISION = "4fa31cc2307a"
+_PREVIOUS_REVISION = "a3c7e1b9d5f2"
+_NEW_COLUMNS = {
+    "hashed_password",
+    "oauth_provider",
+    "email_verification_token",
+    "email_verified_at",
+    "terms_accepted_at",
+}
+
+
+def _alembic_config(database_url: str) -> Config:
+    config = Config()
+    config.set_main_option("script_location", str(_ALEMBIC_DIR))
+    config.set_main_option("sqlalchemy.url", database_url)
+    config.attributes["configure_logger"] = False
+    return config
+
+
+@pytest.fixture
+def sqlite_at_head(tmp_path: Path) -> Iterator[tuple[Config, Engine]]:
+    """A SQLite database migrated to head, with its config for further steps."""
+    database_url = f"sqlite:///{tmp_path / 'user_credentials.db'}"
+    config = _alembic_config(database_url)
+    command.upgrade(config, "head")
+    engine = create_engine(database_url)
+    try:
+        yield config, engine
+    finally:
+        engine.dispose()
+
+
+def test_alembic_chain_has_a_single_head() -> None:
+    """otari#645's DoD: the chain must not fork."""
+    script = ScriptDirectory.from_config(_alembic_config("sqlite:///:memory:"))
+    assert script.get_heads() == [_REVISION]
+
+
+def test_upgrade_adds_all_five_columns_nullable(sqlite_at_head: tuple[Config, Engine]) -> None:
+    _, engine = sqlite_at_head
+    columns = {column["name"]: column for column in inspect(engine).get_columns("user")}
+
+    assert _NEW_COLUMNS <= columns.keys()
+    assert all(columns[name]["nullable"] is True for name in _NEW_COLUMNS)
+
+
+def test_email_verification_token_is_uniquely_indexed(sqlite_at_head: tuple[Config, Engine]) -> None:
+    """Nullable and unique, matching ``user.email``'s existing shape."""
+    _, engine = sqlite_at_head
+    indexes = [
+        index
+        for index in inspect(engine).get_indexes("user")
+        if index["column_names"] == ["email_verification_token"]
+    ]
+    assert [index["unique"] for index in indexes] == [True]
+
+
+def test_existing_rows_survive_the_upgrade_with_new_columns_null(tmp_path: Path) -> None:
+    """A v0.x database's rows must come through intact, per the issue's DoD."""
+    url = f"sqlite:///{tmp_path / 'existing.db'}"
+    config = _alembic_config(url)
+
+    command.upgrade(config, _PREVIOUS_REVISION)
+    engine = create_engine(url)
+    try:
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    "INSERT INTO organization (id, slug, name, created_at) "
+                    "VALUES ('11111111-1111-1111-1111-111111111111', 'ada-org', 'Ada Org', CURRENT_TIMESTAMP)"
+                )
+            )
+            connection.execute(
+                text(
+                    "INSERT INTO user (id, email, is_active, is_superuser, full_name, "
+                    "active_organization_id, created_at) "
+                    "VALUES ('22222222-2222-2222-2222-222222222222', 'ada@example.com', 1, 0, 'Ada', "
+                    "'11111111-1111-1111-1111-111111111111', CURRENT_TIMESTAMP)"
+                )
+            )
+
+        command.upgrade(config, "head")
+
+        with engine.begin() as connection:
+            row = connection.execute(
+                text(
+                    "SELECT email, hashed_password, oauth_provider, email_verification_token, "
+                    "email_verified_at, terms_accepted_at FROM user "
+                    "WHERE id = '22222222-2222-2222-2222-222222222222'"
+                )
+            ).one()
+            assert row.email == "ada@example.com"
+            assert row.hashed_password is None
+            assert row.oauth_provider is None
+            assert row.email_verification_token is None
+            assert row.email_verified_at is None
+            assert row.terms_accepted_at is None
+    finally:
+        engine.dispose()
+
+
+def test_upgrade_downgrade_upgrade_round_trips(sqlite_at_head: tuple[Config, Engine]) -> None:
+    """A downgrade leaves nothing behind for the next upgrade to collide with."""
+    config, engine = sqlite_at_head
+
+    command.downgrade(config, _PREVIOUS_REVISION)
+    columns = {column["name"] for column in inspect(engine).get_columns("user")}
+    assert not (_NEW_COLUMNS & columns)
+
+    command.upgrade(config, _REVISION)
+    columns = {column["name"] for column in inspect(engine).get_columns("user")}
+    assert _NEW_COLUMNS <= columns
+
+
+def test_downgrade_leaves_the_rest_of_user_untouched(sqlite_at_head: tuple[Config, Engine]) -> None:
+    """The batch-mode rebuild on downgrade must not lose pre-existing columns or the email index."""
+    config, engine = sqlite_at_head
+
+    command.downgrade(config, _PREVIOUS_REVISION)
+
+    inspector = inspect(engine)
+    columns = {column["name"] for column in inspector.get_columns("user")}
+    assert {"id", "email", "is_active", "is_superuser", "full_name", "active_organization_id"} <= columns
+
+    email_indexes = [index for index in inspector.get_indexes("user") if index["column_names"] == ["email"]]
+    assert [index["unique"] for index in email_indexes] == [True]


### PR DESCRIPTION
## Summary

Adds five nullable columns to the reconciled control plane's `user` table (`src/gateway/models/tenancy.py`), ahead of the authentication track described in the issue (master-key bootstrapping evolving into dashboard login credentials):

- `hashed_password`
- `oauth_provider`
- `email_verification_token` (unique + indexed, like `email`)
- `email_verified_at`
- `terms_accepted_at`

None of these are read or written by any route/service yet — this is schema-only groundwork, matching the pattern otari-ai used for the same columns. `hashed_password` is deliberately kept out of `UserBase`/`UserCreate` so it can never round-trip through a wire schema. Timestamp columns go through the file's existing `UtcDateTime`-backed `_timestamp_field()` helper rather than a bare `datetime`, to avoid the naive-timestamp bug that helper was built to prevent. `oauth_provider` is a plain string rather than a DB-level enum, keeping the chain dialect-neutral for SQLite.

Migration `4fa31cc2307a` chains onto the previous single head (`a3c7e1b9d5f2`).

## Definition of Done (from the issue)

- [x] Migration appends to the Alembic chain linearly
- [x] Successful roundtrip migrations on SQLite and PostgreSQL
- [x] `alembic heads` maintains single head state
- [x] Existing databases upgrade with all rows intact and new columns null

## Testing

- New `tests/unit/test_user_credential_columns_migration.py`: single-head assertion, column nullability, unique index on `email_verification_token`, existing-row survival across the upgrade, upgrade/downgrade/upgrade roundtrip, and that the downgrade's SQLite batch rebuild doesn't disturb the rest of `user`.
- `tests/unit/test_tenancy_schema_chain.py` (pre-existing) still passes.
- Manually verified the same upgrade/downgrade/upgrade roundtrip against a real PostgreSQL 17 container.
- `uv run --frozen --no-dev python scripts/oss_edition_smoke.py` passes (fresh SQLite, full chain from empty).
- `make lint` and `make typecheck` pass.

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds five nullable credential fields to the `user` table. Existing users remain unchanged, with the new fields set to `NULL`.

The change also adds migration tests for upgrades, downgrades, data preservation, indexing, and Alembic chain integrity. Authentication behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->