### PR TITLE
feat(tenancy): add the nullable credential columns to `user`

### DIFF
--- a/alembic/versions/f2a4c6d8b0e3_add_user_credential_columns.py
+++ b/alembic/versions/f2a4c6d8b0e3_add_user_credential_columns.py
@@ -1,0 +1,81 @@
+"""Add the nullable credential columns to ``user``.
+
+``hashed_password``, ``terms_accepted_at``, ``oauth_provider``,
+``email_verification_token`` and ``email_verified_at``, all nullable, all
+unread. They exist in the platform's production ``user`` table and in no table
+here, and the overlay contributes no tables, so landing them now gives the
+re-parenting migration (otari-ai#1644) one target schema instead of one per
+edition. otari-ai#1716 settled the flow they belong to: the master key stays the
+API credential and sessions become the dashboard login, so a standalone row with
+all five null is the normal state rather than an unmigrated one. No
+authentication behavior changes here.
+
+``email`` is deliberately untouched: it stays nullable and uniquely indexed,
+because a standalone operator identity is a label rather than a sign-in address.
+
+Three things this revision settles, all of them stated in ``models/tenancy.py``
+next to the columns:
+
+- **No table rebuild.** Five ``ADD COLUMN`` statements and one
+  ``CREATE UNIQUE INDEX``, which both engines take as plain DDL.
+  ``batch_alter_table`` is what a constraint would have cost, and rebuilding
+  ``user`` on SQLite would mean recreating the table four other tables hold
+  foreign keys into, plus the half of the ``organization`` cycle that points at
+  it. ``email_verification_token`` is therefore unique through an index rather
+  than a constraint, which is what the platform does too, and the index is
+  dropped before the column in ``downgrade`` because SQLite refuses
+  ``DROP COLUMN`` on an indexed column.
+- **``oauth_provider`` is a VARCHAR, not the platform's native ``oauthprovider``
+  enum.** ``op.add_column`` does not create a PostgreSQL enum type for you, and
+  the same type renders as VARCHAR plus a CHECK on SQLite, which the OSS edition
+  ships by default. The vocabulary belongs to the OAuth flow that has not
+  rehomed; the tenancy tables already store their own vocabularies as strings.
+- **The two timestamps are timezone-aware**, unlike the platform's naive
+  ``DateTime``, matching the departure the tenancy revision already applied to
+  every ``created_at`` and ``updated_at`` in this schema.
+
+Revision ID: f2a4c6d8b0e3
+Revises: a3c7e1b9d5f2
+Create Date: 2026-08-19
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f2a4c6d8b0e3"
+down_revision: str | Sequence[str] | None = "a3c7e1b9d5f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_VERIFICATION_TOKEN_INDEX = "ix_user_email_verification_token"
+
+
+def upgrade() -> None:
+    # Unbounded, as the platform has it: a hash carries its own algorithm and
+    # cost parameters, so a ceiling here would be a bet on which one the session
+    # flow picks.
+    op.add_column("user", sa.Column("hashed_password", sa.String(), nullable=True))
+    op.add_column("user", sa.Column("terms_accepted_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("user", sa.Column("oauth_provider", sa.String(length=50), nullable=True))
+    op.add_column("user", sa.Column("email_verification_token", sa.String(), nullable=True))
+    op.add_column("user", sa.Column("email_verified_at", sa.DateTime(timezone=True), nullable=True))
+    # Unique so two identities cannot hold one token, and repeated NULLs stay
+    # legal on both engines, which is what every existing row will have.
+    op.create_index(
+        op.f(_VERIFICATION_TOKEN_INDEX),
+        "user",
+        ["email_verification_token"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    # Before the column: SQLite refuses ``DROP COLUMN`` while an index covers it.
+    op.drop_index(op.f(_VERIFICATION_TOKEN_INDEX), table_name="user")
+    op.drop_column("user", "email_verified_at")
+    op.drop_column("user", "email_verification_token")
+    op.drop_column("user", "oauth_provider")
+    op.drop_column("user", "terms_accepted_at")
+    op.drop_column("user", "hashed_password")

--- a/alembic/versions/f2a4c6d8b0e3_add_user_credential_columns.py
+++ b/alembic/versions/f2a4c6d8b0e3_add_user_credential_columns.py
@@ -13,26 +13,21 @@ authentication behavior changes here.
 ``email`` is deliberately untouched: it stays nullable and uniquely indexed,
 because a standalone operator identity is a label rather than a sign-in address.
 
-Three things this revision settles, all of them stated in ``models/tenancy.py``
-next to the columns:
+**No table rebuild**, which is the one thing here that belongs to the revision
+rather than to the columns. Five ``ADD COLUMN`` statements and one
+``CREATE UNIQUE INDEX``, which both engines take as plain DDL;
+``batch_alter_table`` is what a constraint would have cost, and rebuilding
+``user`` on SQLite would mean recreating the table four other tables hold
+foreign keys into, plus the half of the ``organization`` cycle that points at it.
+``email_verification_token`` is therefore unique through an index rather than a
+constraint, as it is on the platform, and ``downgrade`` drops that index before
+the column because SQLite refuses ``DROP COLUMN`` while one covers it.
 
-- **No table rebuild.** Five ``ADD COLUMN`` statements and one
-  ``CREATE UNIQUE INDEX``, which both engines take as plain DDL.
-  ``batch_alter_table`` is what a constraint would have cost, and rebuilding
-  ``user`` on SQLite would mean recreating the table four other tables hold
-  foreign keys into, plus the half of the ``organization`` cycle that points at
-  it. ``email_verification_token`` is therefore unique through an index rather
-  than a constraint, which is what the platform does too, and the index is
-  dropped before the column in ``downgrade`` because SQLite refuses
-  ``DROP COLUMN`` on an indexed column.
-- **``oauth_provider`` is a VARCHAR, not the platform's native ``oauthprovider``
-  enum.** ``op.add_column`` does not create a PostgreSQL enum type for you, and
-  the same type renders as VARCHAR plus a CHECK on SQLite, which the OSS edition
-  ships by default. The vocabulary belongs to the OAuth flow that has not
-  rehomed; the tenancy tables already store their own vocabularies as strings.
-- **The two timestamps are timezone-aware**, unlike the platform's naive
-  ``DateTime``, matching the departure the tenancy revision already applied to
-  every ``created_at`` and ``updated_at`` in this schema.
+Two departures from the platform's production DDL travel with the columns, so
+their reasoning lives beside them in ``models/tenancy.py`` and is not repeated
+here: ``oauth_provider`` is a VARCHAR rather than a native ``oauthprovider``
+enum, and the two timestamps are timezone-aware rather than naive. Everything
+else is DDL-identical to the platform's ``3c08d06718ce``.
 
 Revision ID: f2a4c6d8b0e3
 Revises: a3c7e1b9d5f2

--- a/src/gateway/models/tenancy.py
+++ b/src/gateway/models/tenancy.py
@@ -39,10 +39,13 @@ Three deliberate departures from the platform's models, applied on arrival:
   never tables), so a column the hosted edition needs has to live here or
   nowhere. ``workspace.activation_classification`` and
   ``user.default_organization_id`` therefore stay, neither of them read by
-  anything in this edition. The columns
-  that do *not* come are the ones gated on the still-open identity decision
-  (otari-ai#1716): password hashes, OAuth provider, verification tokens. They
-  arrive with the flow that reads them, rather than being invented ahead of it.
+  anything in this edition. The identity columns
+  (``hashed_password``, ``oauth_provider``, ``email_verification_token``,
+  ``email_verified_at``, ``terms_accepted_at``) were held back while
+  otari-ai#1716 was open and now join them: that issue settled that the master
+  key stays the API credential while sessions become the dashboard login, so the
+  columns land here ahead of the flow that reads them, which gives otari-ai#1644
+  one target schema instead of two. Nothing in this edition reads them yet.
   Purely hosted CRM and onboarding columns are the third case and are simply
   not part of the reconciled schema.
 
@@ -241,6 +244,29 @@ class User(UserBase, PrimaryKeyMixin, CreatedAtMixin, UpdatedAtMixin, table=True
     __tablename__ = "user"
 
     email: str | None = Field(default=None, unique=True, index=True, max_length=255)
+    # The credential columns, in the platform's own order. All nullable, none
+    # read anywhere in this tree: they land ahead of the session flow
+    # (otari-ai#1716) so the re-parenting migration (otari-ai#1644) has one
+    # target schema rather than one per edition. A row with every one of them
+    # null is the normal standalone state, not an unmigrated one, because the
+    # master key remains the API credential.
+    #
+    # Unbounded, matching the platform's ``AutoString()``: a hash carries its own
+    # algorithm and cost parameters, so a length ceiling here would be a bet on
+    # which hash the session flow picks.
+    hashed_password: str | None = Field(default=None)
+    terms_accepted_at: datetime | None = _timestamp_field(default=None, column_kwargs={})
+    # ``str`` rather than the platform's native ``oauthprovider`` enum. The
+    # vocabulary belongs to the OAuth flow that has not rehomed yet, and a
+    # PostgreSQL enum would have to be created and dropped by hand around
+    # ``add_column`` while rendering as VARCHAR plus a CHECK on SQLite, which the
+    # OSS edition ships by default. This matches how the tenancy tables already
+    # store their own vocabularies (``role``, ``status``).
+    oauth_provider: str | None = Field(default=None, max_length=50)
+    # Unique, like the platform's: two identities holding one verification token
+    # would let either confirm the other's address.
+    email_verification_token: str | None = Field(default=None, unique=True, index=True)
+    email_verified_at: datetime | None = _timestamp_field(default=None, column_kwargs={})
     # NOT NULL: every identity is always looking at exactly one organization,
     # which is what lets the tenancy routes resolve a scope from the caller
     # alone. Provisioning therefore creates the organization first.

--- a/tests/unit/test_tenancy_schema_chain.py
+++ b/tests/unit/test_tenancy_schema_chain.py
@@ -11,23 +11,46 @@ rebuilds the table, which is the step that can silently lose a constraint.
 Every integration run migrates PostgreSQL and nothing migrates SQLite, so this
 is the only coverage of that path. Driven against a real file database rather
 than in-memory because batch mode's rebuild is what is under test.
+
+The later revisions that reshape the same tables are exercised here too, for the
+same reason: the workspace scoping that rebuilds four request-plane tables, and
+the credential columns added to ``user``, whose downgrade depends on SQLite's
+refusal to drop an indexed column.
 """
 
 import json
 import subprocess
 import sys
+import uuid
 from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 from alembic import command
 from alembic.config import Config
-from sqlalchemy import Engine, create_engine, inspect, text
+from alembic.script import ScriptDirectory
+from sqlalchemy import Connection, Engine, create_engine, inspect, text
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import SQLModel
+
+import gateway.models  # noqa: F401  (registers every table on the shared metadata)
+from gateway.models.tenancy import UtcDateTime
 
 _ALEMBIC_DIR = Path(__file__).resolve().parents[2] / "alembic"
 _TENANCY_REVISION = "c4b6d8e0f2a3"
 _PREVIOUS_REVISION = "b2d4f6a8c0e1"
 _TENANCY_TABLES = {"user", "organization", "organization_member", "workspace", "workspace_member"}
+
+_CREDENTIAL_REVISION = "f2a4c6d8b0e3"
+_BEFORE_CREDENTIALS = "a3c7e1b9d5f2"
+_CREDENTIAL_COLUMNS = {
+    "hashed_password",
+    "terms_accepted_at",
+    "oauth_provider",
+    "email_verification_token",
+    "email_verified_at",
+}
+_TOKEN_INDEX = "ix_user_email_verification_token"
 
 
 def _alembic_config(database_url: str) -> Config:
@@ -211,3 +234,163 @@ def test_workspace_scope_keeps_the_partial_indexes_it_rebuilds_around(
             )
         }
     assert {"uq_model_aliases_global_name", "uq_routing_policies_global_name"} <= partial
+
+
+def _insert_identity(connection: Connection, *, email: str | None = None, token: str | None = None) -> str:
+    """Store one organization-scoped identity, returning its id.
+
+    Raw SQL rather than the models, because what is under test is the migrated
+    table: going through SQLModel would assert against the metadata that
+    produced the revision instead of against what the revision built. UUIDs are
+    CHAR(32) hex on SQLite, so the literals are written that way.
+    """
+    organization_id = uuid.uuid4().hex
+    user_id = uuid.uuid4().hex
+    connection.execute(
+        text(
+            "INSERT INTO organization (id, name, slug, created_at) "
+            "VALUES (:id, :name, :slug, CURRENT_TIMESTAMP)"
+        ),
+        {"id": organization_id, "name": f"Org {organization_id[:6]}", "slug": organization_id[:6]},
+    )
+    connection.execute(
+        text(
+            'INSERT INTO "user" '
+            "(id, email, is_active, is_superuser, full_name, active_organization_id, created_at) "
+            "VALUES (:id, :email, 1, 0, 'Ada', :org, CURRENT_TIMESTAMP)"
+        ),
+        {"id": user_id, "email": email, "org": organization_id},
+    )
+    if token is not None:
+        connection.execute(
+            text('UPDATE "user" SET email_verification_token = :token WHERE id = :id'),
+            {"token": token, "id": user_id},
+        )
+    return user_id
+
+
+def test_the_credential_columns_arrive_nullable(sqlite_at_head: tuple[Config, Engine]) -> None:
+    """All five, and every one of them optional.
+
+    Nothing reads them yet, and the master key remains the API credential, so a
+    standalone row with all five null is the normal state. A NOT NULL here would
+    make the session flow's arrival a data migration rather than a code change.
+    """
+    _, engine = sqlite_at_head
+    columns = {column["name"]: column for column in inspect(engine).get_columns("user")}
+
+    assert _CREDENTIAL_COLUMNS <= set(columns)
+    assert [columns[name]["nullable"] for name in sorted(_CREDENTIAL_COLUMNS)] == [True] * 5
+
+
+def test_the_verification_token_is_uniquely_indexed(sqlite_at_head: tuple[Config, Engine]) -> None:
+    """Unique like the platform's, because a shared token confirms the wrong address."""
+    _, engine = sqlite_at_head
+    indexes = [
+        index
+        for index in inspect(engine).get_indexes("user")
+        if index["column_names"] == ["email_verification_token"]
+    ]
+
+    assert [index["name"] for index in indexes] == [_TOKEN_INDEX]
+    assert [index["unique"] for index in indexes] == [True]
+
+
+def test_two_identities_cannot_share_a_verification_token(sqlite_at_head: tuple[Config, Engine]) -> None:
+    """The error path the unique index exists for."""
+    _, engine = sqlite_at_head
+
+    with engine.begin() as connection:
+        _insert_identity(connection, email="ada@example.com", token="tok-1")
+
+    with pytest.raises(IntegrityError), engine.begin() as connection:
+        _insert_identity(connection, email="grace@example.com", token="tok-1")
+
+
+def test_identities_without_a_token_coexist_under_that_index(sqlite_at_head: tuple[Config, Engine]) -> None:
+    """Which is every existing row: both engines allow repeated NULLs in a unique index."""
+    _, engine = sqlite_at_head
+
+    with engine.begin() as connection:
+        _insert_identity(connection)
+        _insert_identity(connection)
+        stored = connection.execute(
+            text('SELECT COUNT(*) FROM "user" WHERE email_verification_token IS NULL')
+        ).scalar_one()
+
+    assert stored == 2
+
+
+def test_an_existing_database_upgrades_with_its_rows_untouched(tmp_path: Path) -> None:
+    """The upgrade an operator on v0.x runs: additive, and null everywhere it lands."""
+    url = f"sqlite:///{tmp_path / 'credentials.db'}"
+    config = _alembic_config(url)
+    command.upgrade(config, _BEFORE_CREDENTIALS)
+    engine = create_engine(url)
+
+    with engine.begin() as connection:
+        user_id = _insert_identity(connection, email="ada@example.com")
+
+    command.upgrade(config, _CREDENTIAL_REVISION)
+
+    with engine.begin() as connection:
+        row = connection.execute(
+            text(
+                "SELECT email, full_name, is_active, hashed_password, terms_accepted_at, oauth_provider, "
+                'email_verification_token, email_verified_at FROM "user" WHERE id = :id'
+            ),
+            {"id": user_id},
+        ).mappings().one()
+
+    assert (row["email"], row["full_name"], row["is_active"]) == ("ada@example.com", "Ada", 1)
+    assert all(row[column] is None for column in _CREDENTIAL_COLUMNS)
+    engine.dispose()
+
+
+def test_the_credential_revision_round_trips(sqlite_at_head: tuple[Config, Engine]) -> None:
+    """Down drops the five columns and the index; up puts them back.
+
+    The downgrade drops the index first on purpose: SQLite refuses
+    ``DROP COLUMN`` while an index covers the column, and this is the only
+    coverage of that ordering, since nothing else migrates SQLite.
+    """
+    config, engine = sqlite_at_head
+
+    command.downgrade(config, _BEFORE_CREDENTIALS)
+
+    inspector = inspect(engine)
+    assert not (_CREDENTIAL_COLUMNS & {column["name"] for column in inspector.get_columns("user")})
+    assert _TOKEN_INDEX not in {index["name"] for index in inspector.get_indexes("user")}
+
+    command.upgrade(config, _CREDENTIAL_REVISION)
+
+    assert _CREDENTIAL_COLUMNS <= {column["name"] for column in inspect(engine).get_columns("user")}
+
+
+def test_the_migrated_columns_match_the_model(sqlite_at_head: tuple[Config, Engine]) -> None:
+    """Hand-written revision, so nothing else would notice the two drifting apart.
+
+    The timestamps are the half worth pinning: the platform stores them naive,
+    and this schema's departure is that every tenancy timestamp reads back
+    UTC-aware on both engines, which ``UtcDateTime`` is what delivers.
+    """
+    _, engine = sqlite_at_head
+
+    declared = SQLModel.metadata.tables["user"]
+    migrated = {column["name"] for column in inspect(engine).get_columns("user")}
+
+    assert migrated == set(declared.columns.keys())
+    for name in ("terms_accepted_at", "email_verified_at"):
+        assert isinstance(declared.columns[name].type, UtcDateTime)
+
+
+def test_the_revision_chain_has_one_head() -> None:
+    """A second head is not a merge conflict, so nothing else fails when one appears.
+
+    Several migrations land in parallel during the M5 rehome, and Alembic accepts
+    two revisions naming the same ``down_revision`` without complaint until
+    ``upgrade head`` refuses to choose between them.
+    """
+    heads = ScriptDirectory.from_config(_alembic_config("sqlite://")).get_heads()
+
+    assert len(heads) == 1, heads

--- a/tests/unit/test_tenancy_schema_chain.py
+++ b/tests/unit/test_tenancy_schema_chain.py
@@ -241,8 +241,9 @@ def _insert_identity(connection: Connection, *, email: str | None = None, token:
 
     Raw SQL rather than the models, because what is under test is the migrated
     table: going through SQLModel would assert against the metadata that
-    produced the revision instead of against what the revision built. UUIDs are
-    CHAR(32) hex on SQLite, so the literals are written that way.
+    produced the revision instead of against what the revision built. The
+    literals are shaped for SQLite, which is the engine every test here drives:
+    a UUID is CHAR(32) hex and a boolean is 1 or 0.
     """
     organization_id = uuid.uuid4().hex
     user_id = uuid.uuid4().hex
@@ -308,17 +309,22 @@ def test_two_identities_cannot_share_a_verification_token(sqlite_at_head: tuple[
 
 
 def test_identities_without_a_token_coexist_under_that_index(sqlite_at_head: tuple[Config, Engine]) -> None:
-    """Which is every existing row: both engines allow repeated NULLs in a unique index."""
+    """Which is every existing row: both engines allow repeated NULLs in a unique index.
+
+    Counted as a delta rather than as a total, so the assertion still describes
+    the two rows it inserted if a later revision ever seeds an identity of its
+    own (the workspace-scope revision deliberately seeds none today).
+    """
     _, engine = sqlite_at_head
+    without_a_token = text('SELECT COUNT(*) FROM "user" WHERE email_verification_token IS NULL')
 
     with engine.begin() as connection:
+        before = connection.execute(without_a_token).scalar_one()
         _insert_identity(connection)
         _insert_identity(connection)
-        stored = connection.execute(
-            text('SELECT COUNT(*) FROM "user" WHERE email_verification_token IS NULL')
-        ).scalar_one()
+        after = connection.execute(without_a_token).scalar_one()
 
-    assert stored == 2
+    assert after - before == 2
 
 
 def test_an_existing_database_upgrades_with_its_rows_untouched(tmp_path: Path) -> None:


### PR DESCRIPTION
## Description

`user` carried no credential of any kind, so the session flow settled in mozilla-ai/otari-ai#1716 had nowhere to store one and the re-parenting migration (mozilla-ai/otari-ai#1644) faced one target schema per edition. One additive revision (`f2a4c6d8b0e3`) adds `hashed_password`, `terms_accepted_at`, `oauth_provider`, `email_verification_token` and `email_verified_at`, all nullable, none read anywhere in this tree. `email` is untouched: still nullable, still uniquely indexed, because a standalone operator needs no address. No authentication behavior changes, and `webauthn_credential` stays with the passkey issue.

**No table rebuild.** Five `ADD COLUMN` statements and one `CREATE UNIQUE INDEX`, which both engines take as plain DDL. Rebuilding `user` on SQLite would mean recreating the table four others hold foreign keys into, plus the half of the `organization` cycle that points at it, so `email_verification_token` is unique through an index rather than a constraint (as it is in production), and `downgrade` drops the index before the column because SQLite refuses `DROP COLUMN` while one covers it.

**Two departures from the platform's production shape**, both stated next to the columns and both now settled: they stay, and mozilla-ai/otari-ai#1644 carries the cast rather than this tree carrying production's spelling.

- `oauth_provider` is `VARCHAR(50)`, not production's native `oauthprovider` enum. `op.add_column` does not create a PostgreSQL enum type, the same type renders as VARCHAR plus a CHECK on SQLite, and the enum stores uppercase member *names* rather than the flow's values. The vocabulary belongs to the OAuth flow that has not rehomed; the tenancy tables already keep their own vocabularies as strings (`role`, `status`).
- `terms_accepted_at` and `email_verified_at` are timezone-aware (`UtcDateTime`), unlike production's naive `DateTime`, matching the departure the tenancy revision already applied to every other timestamp in this schema.

Per column, against production's `3c08d06718ce`: `hashed_password` and `email_verification_token` are DDL-identical, unbounded VARCHAR and the same `ix_user_email_verification_token` unique index name. The other three (`oauth_provider`, `terms_accepted_at`, `email_verified_at`) are the two departures above, so three of the five columns diverge from production DDL by design. Both departures are recorded on mozilla-ai/otari-ai#1644 as planned casts, each with the cast it owes: native enum to text needs an explicit `::text`, and naive to aware needs localizing to UTC rather than reinterpreting in the server timezone. `alembic heads` stays single, and a new unit test pins that so a parallel M5 revision cannot quietly fork it.

**Adjacent, not fixed here** (flagged rather than touched, since several migrations are landing in parallel): `docs/access-control.md` and `docs/dashboard.md` still describe standalone as master-key authenticated end to end. Issue #645 carries that correction forward to whoever lands the session work, and it is still unowned.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #645
Part of mozilla-ai/otari-ai#1452, ahead of mozilla-ai/otari-ai#1644 and mozilla-ai/otari-ai#1716.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary (the module docstring that said these columns were deliberately absent; the two docs corrections issue #645 carries are named below and still unowned).
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).
- [ ] **M4 ledger:** this PR either needs no entry (an existing row already covers it and its target is unchanged), or the entry is appended to [otari-ai#1587](https://github.com/mozilla-ai/otari-ai/issues/1587). One entry per *change*, not per PR: a stack delivering one surface change gets one. See [.github/instructions/reconciliation-ledger.instructions.md](https://github.com/mozilla-ai/otari/blob/main/.github/instructions/reconciliation-ledger.instructions.md).

Deliberately unchecked: an entry **is** owed and has not been posted yet. The "Tenancy and access" row's Current scope cell reads "otari's `user` carries no credential columns", which this PR makes false, so the third trigger fires. The target disposition does not move (otari's schema still survives the re-parent). @njbrake to post it.

### Verified locally, and what CI re-verified

- `make lint`, `make typecheck` (mypy over 384 files), `make openapi-check`, `make postman-check`: clean. The spec is unchanged, which is the check that the five columns stayed off the wire (they are on the table class, not on `UserBase`), and `openapi.json`, the Postman collection and `web/src/client/schema.ts` contain none of the five names.
- `uv run pytest tests/unit`: 1816 passed locally, 1817 on CI. The eight new tests are named in the CI log, so they ran there rather than only here.
- Up, down, up on **both** engines, with a pre-existing row inserted at `a3c7e1b9d5f2` first: the row reads back byte-identical, all five columns null, and repeated null tokens coexist under the unique index. `compare_metadata` reports no diff for `user` on either engine, and PostgreSQL `information_schema` confirms the DDL (`character varying` unbounded, `character varying(50)`, `timestamp with time zone`, all nullable).
- The tests were checked for revert-sensitivity rather than assumed to have it. Removing the migration and the model fields fails 7 of the 8; reverting only the model fields fails the parity test and nothing else; making the token index non-unique fails both uniqueness tests; downgrading the two timestamps to naive `DateTime` fails the parity test. The one test that stays green under a full revert is the single-head guard, which is a chain invariant rather than a claim about these columns.
- OSS-edition smoke gate on SQLite and on PostgreSQL: passed.

**CI covers the PostgreSQL upgrade.** `tests/integration/conftest.py` runs `alembic upgrade head` against a Testcontainers `postgres:17`, so the earlier caveat about having used a locally installed PostgreSQL 18 instead of Testcontainers is resolved: CI's `test` job exercised that path on this branch (1347 passed, 9 skipped).

### Not covered by CI

- **The PostgreSQL downgrade.** Nothing in the repo runs `alembic downgrade` against PostgreSQL; the integration fixtures tear down with `DROP TABLE ... CASCADE` instead, and the only downgrade tests are the SQLite ones in `tests/unit/test_tenancy_schema_chain.py`. I ran the PostgreSQL down and up myself and it round-trips, but that is a local result, not a standing guarantee. Adding a permanent PostgreSQL downgrade test would introduce a pattern the repo does not have yet, which felt like the wrong thing to smuggle into a migration PR.
- The dashboard suites were not run: no `web/` file changes, and no generated dashboard artifact moves.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via the Claude Code CLI.

**Any additional AI details you'd like to share:**

Column shapes were read off the platform's `backend/app/models/user.py` and its `3c08d06718ce` init revision rather than guessed, which is where the two documented departures come from. Every check above was run, not inferred.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added five nullable credential and identity fields to the `User` model.
- Added a migration to create and remove these fields without rebuilding the table.
- Added documentation that explains why the fields are present but unused.
- Expanded schema tests for nullability, uniqueness, data preservation, migration round trips, model alignment, and Alembic head integrity.
- Preserved existing authentication behavior and the nullable unique `email` field.

## Technical notes

- `oauth_provider` uses `VARCHAR(50)`.
- Timestamp fields use timezone-aware types.
- The downgrade removes the token index before dropping the token column for SQLite compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
