### PR TITLE
feat(provider-keys): add organization-scoped BYO provider keys

### DIFF
--- a/alembic/versions/7c5ba82a601b_add_batches_workspace_id.py
+++ b/alembic/versions/7c5ba82a601b_add_batches_workspace_id.py
@@ -1,0 +1,57 @@
+"""Add workspace_id to batches.
+
+CodeRabbit review follow-up on otari#643: ``retrieve_batch``/``cancel_batch``/
+``retrieve_batch_results`` resolved organization-scoped provider credentials
+from the *caller's* current workspace, which is wrong for a master-key
+retrieval or a legitimately cross-workspace one -- it can use the wrong
+organization's key, or find none, exactly the failure ``api_key_id`` going
+NULL on key revocation already risks for ownership. This column lets those
+lifecycle calls resolve credentials from the workspace the batch was actually
+*created* in.
+
+Nullable, no backfill: batches created before this column existed (and any
+row where the originating workspace has since been deleted, via SET NULL)
+carry NULL here, and `api/routes/batches.py` falls back to the caller's own
+workspace for those, matching how it already falls back to the metadata
+marker for ownership on record-less legacy batches.
+
+Revision ID: 7c5ba82a601b
+Revises: e1c3a5b7d9f2
+Create Date: 2026-08-20 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7c5ba82a601b"
+down_revision: str | Sequence[str] | None = "e1c3a5b7d9f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("batches", sa.Column("workspace_id", sa.Uuid(), nullable=True))
+    op.create_index(op.f("ix_batches_workspace_id"), "batches", ["workspace_id"], unique=False)
+    # batch_alter_table: SQLite has no ALTER TABLE ADD CONSTRAINT, matching
+    # `d5e7f1a2b3c4`'s precedent for adding a workspace FK to an existing table.
+    with op.batch_alter_table("batches") as batch:
+        batch.create_foreign_key(
+            "fk_batches_workspace_id",
+            "workspace",
+            ["workspace_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("batches") as batch:
+        batch.drop_constraint("fk_batches_workspace_id", type_="foreignkey")
+    op.drop_index(op.f("ix_batches_workspace_id"), table_name="batches")
+    op.drop_column("batches", "workspace_id")

--- a/alembic/versions/e1c3a5b7d9f2_add_org_provider_keys.py
+++ b/alembic/versions/e1c3a5b7d9f2_add_org_provider_keys.py
@@ -1,0 +1,179 @@
+"""Add organization-scoped provider keys.
+
+Decided at otari-ai#1748 (mozilla-ai/otari#643): the platform's
+``ProviderKey`` shape ports into otari as new, additive tables that become the
+source of truth for organization-scoped BYO provider credentials.
+``provider_credentials`` and its config.yml-merge overlay are untouched by
+this revision; they stay the mechanism for config.yml-defined and legacy
+deployment-global stored credentials.
+
+Three tables, no legacy data to migrate (they are brand new here), so this is
+a single forward migration with no expand/backfill/contract dance:
+
+- ``org_provider_keys``: one BYO credential per organization+provider+name,
+  with a partial unique index enforcing at most one ``is_org_default`` row per
+  ``(organization_id, provider)`` among non-archived rows. The "managed
+  bucket" dimension of the platform's equivalent index does not carry over:
+  every otari-side key is BYO, so there is one default per provider, not one
+  per bucket.
+- ``workspace_provider_key_overrides``: a workspace's departure from its
+  organization's default for one key (pin it as the workspace default, or
+  disable it for that workspace).
+- ``workspace_provider_model_restrictions``: a per-workspace, per-key model
+  allow-list.
+
+Rebased onto `f7a2c4e6b8d1` (workspace per-member budget defaults), the actual
+head `main` had gained by the time this revision landed, rather than the
+original `a3c7e1b9d5f2` this was first written against: `main` grew a new head
+several times over the life of this PR, and each rebase re-parents here rather
+than leaving a redundant merge revision beside `main`'s own.
+
+Revision ID: e1c3a5b7d9f2
+Revises: f7a2c4e6b8d1
+Create Date: 2026-08-19 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e1c3a5b7d9f2"
+down_revision: str | Sequence[str] | None = "f7a2c4e6b8d1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_ORG_DEFAULT_INDEX = "uq_org_provider_keys_org_default"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "org_provider_keys",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("organization_id", sa.Uuid(), nullable=False),
+        sa.Column("provider", sa.String(length=255), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("api_base", sa.String(length=1024), nullable=True),
+        sa.Column("client_args", sa.JSON(), nullable=True),
+        sa.Column("encrypted_api_key", sa.String(), nullable=True),
+        sa.Column("last4", sa.String(length=8), nullable=True),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("is_org_default", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["organization_id"], ["organization.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("organization_id", "provider", "name", name="uq_org_provider_keys_org_provider_name"),
+        # Covers (organization_id, id) so the two link tables below can carry a
+        # composite FK to it: Postgres requires the referenced columns of a
+        # composite foreign key to be backed by a unique constraint, not only
+        # ``id`` being the primary key on its own.
+        sa.UniqueConstraint("organization_id", "id", name="uq_org_provider_keys_org_id"),
+    )
+    op.create_index(op.f("ix_org_provider_keys_organization_id"), "org_provider_keys", ["organization_id"])
+    op.create_index(
+        _ORG_DEFAULT_INDEX,
+        "org_provider_keys",
+        ["organization_id", "provider"],
+        unique=True,
+        postgresql_where=sa.text("is_org_default AND archived_at IS NULL"),
+        sqlite_where=sa.text("is_org_default AND archived_at IS NULL"),
+    )
+
+    op.create_table(
+        "workspace_provider_key_overrides",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("workspace_id", sa.Uuid(), nullable=False),
+        # Denormalized from the workspace's own organization (the service layer
+        # only ever creates an override when the key and the workspace already
+        # agree on organization), so the composite FK below can enforce that
+        # invariant at the database rather than trusting every write path to
+        # keep re-deriving it correctly.
+        sa.Column("organization_id", sa.Uuid(), nullable=False),
+        sa.Column("org_provider_key_id", sa.Uuid(), nullable=False),
+        sa.Column("is_default", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("disabled", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        # Composite, not a plain FK on org_provider_key_id alone: pins the
+        # referenced key to *this row's own* organization_id, so a cross-organization
+        # override (a workspace in org A pointing at org B's key) is a foreign-key
+        # violation rather than a silently-persisted row.
+        sa.ForeignKeyConstraint(
+            ["organization_id", "org_provider_key_id"],
+            ["org_provider_keys.organization_id", "org_provider_keys.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspace.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("workspace_id", "org_provider_key_id", name="uq_workspace_provider_key_overrides_ws_key"),
+    )
+    op.create_index(
+        op.f("ix_workspace_provider_key_overrides_workspace_id"),
+        "workspace_provider_key_overrides",
+        ["workspace_id"],
+    )
+    op.create_index(
+        op.f("ix_workspace_provider_key_overrides_org_provider_key_id"),
+        "workspace_provider_key_overrides",
+        ["org_provider_key_id"],
+    )
+
+    op.create_table(
+        "workspace_provider_model_restrictions",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("workspace_id", sa.Uuid(), nullable=False),
+        # Same denormalization and reasoning as the override table above.
+        sa.Column("organization_id", sa.Uuid(), nullable=False),
+        sa.Column("org_provider_key_id", sa.Uuid(), nullable=False),
+        sa.Column("model", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["organization_id", "org_provider_key_id"],
+            ["org_provider_keys.organization_id", "org_provider_keys.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspace.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "workspace_id",
+            "org_provider_key_id",
+            "model",
+            name="uq_workspace_provider_model_restrictions_ws_key_model",
+        ),
+    )
+    op.create_index(
+        op.f("ix_workspace_provider_model_restrictions_workspace_id"),
+        "workspace_provider_model_restrictions",
+        ["workspace_id"],
+    )
+    op.create_index(
+        op.f("ix_workspace_provider_model_restrictions_org_provider_key_id"),
+        "workspace_provider_model_restrictions",
+        ["org_provider_key_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_workspace_provider_model_restrictions_org_provider_key_id"),
+        table_name="workspace_provider_model_restrictions",
+    )
+    op.drop_index(
+        op.f("ix_workspace_provider_model_restrictions_workspace_id"),
+        table_name="workspace_provider_model_restrictions",
+    )
+    op.drop_table("workspace_provider_model_restrictions")
+
+    op.drop_index(
+        op.f("ix_workspace_provider_key_overrides_org_provider_key_id"),
+        table_name="workspace_provider_key_overrides",
+    )
+    op.drop_index(
+        op.f("ix_workspace_provider_key_overrides_workspace_id"), table_name="workspace_provider_key_overrides"
+    )
+    op.drop_table("workspace_provider_key_overrides")
+
+    op.drop_index(_ORG_DEFAULT_INDEX, table_name="org_provider_keys")
+    op.drop_index(op.f("ix_org_provider_keys_organization_id"), table_name="org_provider_keys")
+    op.drop_table("org_provider_keys")

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -4967,6 +4967,237 @@
         "title": "ModerationResult",
         "type": "object"
       },
+      "OrgProviderKeyCreateRequest": {
+        "description": "What a caller sends to create a key.\n\nThe plaintext key is never stored as sent: the service encrypts it\n(`services/secret_box.py`) and keeps only the ciphertext and ``last4``,\nthe same convention `entities.ProviderCredential` already uses.",
+        "properties": {
+          "api_base": {
+            "anyOf": [
+              {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Base"
+          },
+          "api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Key"
+          },
+          "client_args": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Args"
+          },
+          "name": {
+            "maxLength": 255,
+            "title": "Name",
+            "type": "string"
+          },
+          "provider": {
+            "maxLength": 255,
+            "title": "Provider",
+            "type": "string"
+          }
+        },
+        "required": [
+          "provider",
+          "name"
+        ],
+        "title": "OrgProviderKeyCreateRequest",
+        "type": "object"
+      },
+      "OrgProviderKeyPublic": {
+        "description": "The API-facing shape. Never carries the key, only whether one is set.",
+        "properties": {
+          "api_base": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Base"
+          },
+          "archived_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Archived At"
+          },
+          "client_args": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Args"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "is_org_default": {
+            "title": "Is Org Default",
+            "type": "boolean"
+          },
+          "last4": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last4"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "organization_id": {
+            "format": "uuid",
+            "title": "Organization Id",
+            "type": "string"
+          },
+          "provider": {
+            "title": "Provider",
+            "type": "string"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "required": [
+          "id",
+          "organization_id",
+          "provider",
+          "name",
+          "is_org_default",
+          "created_at"
+        ],
+        "title": "OrgProviderKeyPublic",
+        "type": "object"
+      },
+      "OrgProviderKeyUpdateRequest": {
+        "description": "A partial update. Every field is optional; only what is set is applied.",
+        "properties": {
+          "api_base": {
+            "anyOf": [
+              {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Base"
+          },
+          "api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Key"
+          },
+          "client_args": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Args"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "title": "OrgProviderKeyUpdateRequest",
+        "type": "object"
+      },
+      "OrgProviderKeysPublic": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/OrgProviderKeyPublic"
+            },
+            "title": "Data",
+            "type": "array"
+          }
+        },
+        "required": [
+          "data",
+          "count"
+        ],
+        "title": "OrgProviderKeysPublic",
+        "type": "object"
+      },
       "OrganizationMembershipContextPublic": {
         "description": "An organization plus the caller's standing in it.\n\nWhat every tenancy page reads first: which organization it is looking at,\nand what the caller may do there.",
         "properties": {
@@ -10435,6 +10666,122 @@
         "title": "WorkspaceMembersPublic",
         "type": "object"
       },
+      "WorkspaceProviderKeyOverridePublic": {
+        "description": "The effective view for one workspace+key: raw override flags plus the resolution.",
+        "properties": {
+          "disabled": {
+            "title": "Disabled",
+            "type": "boolean"
+          },
+          "is_default": {
+            "title": "Is Default",
+            "type": "boolean"
+          },
+          "is_effective_default": {
+            "title": "Is Effective Default",
+            "type": "boolean"
+          },
+          "is_effective_enabled": {
+            "title": "Is Effective Enabled",
+            "type": "boolean"
+          },
+          "org_provider_key_id": {
+            "format": "uuid",
+            "title": "Org Provider Key Id",
+            "type": "string"
+          },
+          "workspace_id": {
+            "format": "uuid",
+            "title": "Workspace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "workspace_id",
+          "org_provider_key_id",
+          "is_default",
+          "disabled",
+          "is_effective_default",
+          "is_effective_enabled"
+        ],
+        "title": "WorkspaceProviderKeyOverridePublic",
+        "type": "object"
+      },
+      "WorkspaceProviderKeyOverrideRequest": {
+        "description": "Tri-state: an omitted field leaves that flag unchanged.\n\nBoth fields false, whether that is the merged result or a value sent\nexplicitly, is a no-op the service deletes rather than stores: absence of\na row already means full inheritance from the organization default.\nSetting one true auto-resolves the other when they would otherwise\nconflict (pinning re-enables a disabled key; disabling un-pins a pinned\none); sending both true explicitly is refused.",
+        "properties": {
+          "disabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Disabled"
+          },
+          "is_default": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Default"
+          }
+        },
+        "title": "WorkspaceProviderKeyOverrideRequest",
+        "type": "object"
+      },
+      "WorkspaceProviderKeyOverridesPublic": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceProviderKeyOverridePublic"
+            },
+            "title": "Data",
+            "type": "array"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "title": "WorkspaceProviderKeyOverridesPublic",
+        "type": "object"
+      },
+      "WorkspaceProviderModelRestrictionRequest": {
+        "properties": {
+          "model": {
+            "maxLength": 255,
+            "title": "Model",
+            "type": "string"
+          }
+        },
+        "required": [
+          "model"
+        ],
+        "title": "WorkspaceProviderModelRestrictionRequest",
+        "type": "object"
+      },
+      "WorkspaceProviderModelRestrictionsPublic": {
+        "properties": {
+          "models": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Models",
+            "type": "array"
+          }
+        },
+        "required": [
+          "models"
+        ],
+        "title": "WorkspaceProviderModelRestrictionsPublic",
+        "type": "object"
+      },
       "WorkspacePublic": {
         "properties": {
           "created_at": {
@@ -14144,6 +14491,403 @@
         "summary": "Replace Organization Pricing",
         "tags": [
           "organization-pricing"
+        ]
+      }
+    },
+    "/v1/organizations/me/provider-keys": {
+      "get": {
+        "description": "List the caller's organization's provider keys. Any active member may read it.",
+        "operationId": "list_org_provider_keys_v1_organizations_me_provider_keys_get",
+        "parameters": [
+          {
+            "description": "Include archived keys.",
+            "in": "query",
+            "name": "include_archived",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Include archived keys.",
+              "title": "Include Archived",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Number of records to skip",
+            "in": "query",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of records to skip",
+              "minimum": 0,
+              "title": "Skip",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "description": "Maximum number of records to return",
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgProviderKeysPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "List Org Provider Keys",
+        "tags": [
+          "provider-keys"
+        ]
+      },
+      "post": {
+        "description": "Create a provider key in the caller's organization. Organization owners and admins only.",
+        "operationId": "create_org_provider_key_v1_organizations_me_provider_keys_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrgProviderKeyCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgProviderKeyPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Create Org Provider Key",
+        "tags": [
+          "provider-keys"
+        ]
+      }
+    },
+    "/v1/organizations/me/provider-keys/{key_id}": {
+      "delete": {
+        "description": "Permanently delete an archived key. Organization owners and admins only.",
+        "operationId": "delete_org_provider_key_v1_organizations_me_provider_keys__key_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Key Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Delete Org Provider Key",
+        "tags": [
+          "provider-keys"
+        ]
+      },
+      "patch": {
+        "description": "Change a key's name, credential, base URL, or client args. Organization owners and admins only.",
+        "operationId": "update_org_provider_key_v1_organizations_me_provider_keys__key_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Key Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrgProviderKeyUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgProviderKeyPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Update Org Provider Key",
+        "tags": [
+          "provider-keys"
+        ]
+      }
+    },
+    "/v1/organizations/me/provider-keys/{key_id}/archive": {
+      "post": {
+        "description": "Archive a key. Organization owners and admins only.",
+        "operationId": "archive_org_provider_key_v1_organizations_me_provider_keys__key_id__archive_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Key Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgProviderKeyPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Archive Org Provider Key",
+        "tags": [
+          "provider-keys"
+        ]
+      }
+    },
+    "/v1/organizations/me/provider-keys/{key_id}/default": {
+      "post": {
+        "description": "Make a key the organization's default for its provider. Organization owners and admins only.",
+        "operationId": "set_org_provider_key_default_v1_organizations_me_provider_keys__key_id__default_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Key Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgProviderKeyPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Set Org Provider Key Default",
+        "tags": [
+          "provider-keys"
+        ]
+      }
+    },
+    "/v1/organizations/me/provider-keys/{key_id}/restore": {
+      "post": {
+        "description": "Restore an archived key. Organization owners and admins only.",
+        "operationId": "restore_org_provider_key_v1_organizations_me_provider_keys__key_id__restore_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Key Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgProviderKeyPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Restore Org Provider Key",
+        "tags": [
+          "provider-keys"
         ]
       }
     },
@@ -19589,6 +20333,393 @@
         "summary": "Add Workspace Member",
         "tags": [
           "workspaces"
+        ]
+      }
+    },
+    "/v1/workspaces/{workspace_id}/provider-keys": {
+      "get": {
+        "description": "The effective view of every key visible to this workspace. Any member of the workspace may read it.",
+        "operationId": "list_workspace_provider_keys_v1_workspaces__workspace_id__provider_keys_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceProviderKeyOverridesPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "List Workspace Provider Keys",
+        "tags": [
+          "provider-keys"
+        ]
+      }
+    },
+    "/v1/workspaces/{workspace_id}/provider-keys/{key_id}": {
+      "delete": {
+        "description": "Remove this workspace's override, reverting to full inheritance. Idempotent.",
+        "operationId": "reset_workspace_provider_key_override_v1_workspaces__workspace_id__provider_keys__key_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Key Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Reset Workspace Provider Key Override",
+        "tags": [
+          "provider-keys"
+        ]
+      },
+      "patch": {
+        "description": "Pin or disable a key for this workspace. Organization owners/admins or this workspace's owners/admins.",
+        "operationId": "set_workspace_provider_key_override_v1_workspaces__workspace_id__provider_keys__key_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Key Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceProviderKeyOverrideRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceProviderKeyOverridePublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Set Workspace Provider Key Override",
+        "tags": [
+          "provider-keys"
+        ]
+      }
+    },
+    "/v1/workspaces/{workspace_id}/provider-keys/{key_id}/models": {
+      "get": {
+        "description": "List this workspace's model allow-list for a key. Empty means every model is allowed.",
+        "operationId": "list_workspace_provider_key_model_restrictions_v1_workspaces__workspace_id__provider_keys__key_id__models_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Key Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceProviderModelRestrictionsPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "List Workspace Provider Key Model Restrictions",
+        "tags": [
+          "provider-keys"
+        ]
+      },
+      "post": {
+        "description": "Narrow this workspace's allow-list for a key to include one more model. Idempotent.",
+        "operationId": "add_workspace_provider_key_model_restriction_v1_workspaces__workspace_id__provider_keys__key_id__models_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Key Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceProviderModelRestrictionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Add Workspace Provider Key Model Restriction",
+        "tags": [
+          "provider-keys"
+        ]
+      }
+    },
+    "/v1/workspaces/{workspace_id}/provider-keys/{key_id}/models/{model}": {
+      "delete": {
+        "description": "Remove one model from this workspace's allow-list for a key. Idempotent.",
+        "operationId": "remove_workspace_provider_key_model_restriction_v1_workspaces__workspace_id__provider_keys__key_id__models__model__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Key Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "model",
+            "required": true,
+            "schema": {
+              "title": "Model",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Remove Workspace Provider Key Model Restriction",
+        "tags": [
+          "provider-keys"
         ]
       }
     }

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -2098,6 +2098,471 @@
     {
       "item": [
         {
+          "name": "List Org Provider Keys",
+          "request": {
+            "description": "List the caller's organization's provider keys. Any active member may read it.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "provider-keys"
+              ],
+              "query": [
+                {
+                  "description": "Include archived keys.",
+                  "disabled": true,
+                  "key": "include_archived",
+                  "value": ""
+                },
+                {
+                  "description": "Number of records to skip",
+                  "disabled": true,
+                  "key": "skip",
+                  "value": ""
+                },
+                {
+                  "description": "Maximum number of records to return",
+                  "disabled": true,
+                  "key": "limit",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/provider-keys?include_archived=&skip=&limit="
+            }
+          }
+        },
+        {
+          "name": "Create Org Provider Key",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"provider\": \"string\",\n  \"name\": \"string\"\n}"
+            },
+            "description": "Create a provider key in the caller's organization. Organization owners and admins only.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "provider-keys"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/provider-keys"
+            }
+          }
+        },
+        {
+          "name": "Update Org Provider Key",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"api_base\": \"string\",\n  \"api_key\": \"string\",\n  \"client_args\": {},\n  \"name\": \"string\"\n}"
+            },
+            "description": "Change a key's name, credential, base URL, or client args. Organization owners and admins only.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "PATCH",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "provider-keys",
+                ":key_id"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/provider-keys/:key_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "key_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Org Provider Key",
+          "request": {
+            "description": "Permanently delete an archived key. Organization owners and admins only.",
+            "header": [],
+            "method": "DELETE",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "provider-keys",
+                ":key_id"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/provider-keys/:key_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "key_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Archive Org Provider Key",
+          "request": {
+            "description": "Archive a key. Organization owners and admins only.",
+            "header": [],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "provider-keys",
+                ":key_id",
+                "archive"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/provider-keys/:key_id/archive",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "key_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Set Org Provider Key Default",
+          "request": {
+            "description": "Make a key the organization's default for its provider. Organization owners and admins only.",
+            "header": [],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "provider-keys",
+                ":key_id",
+                "default"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/provider-keys/:key_id/default",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "key_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Restore Org Provider Key",
+          "request": {
+            "description": "Restore an archived key. Organization owners and admins only.",
+            "header": [],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "provider-keys",
+                ":key_id",
+                "restore"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/provider-keys/:key_id/restore",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "key_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "List Workspace Provider Keys",
+          "request": {
+            "description": "The effective view of every key visible to this workspace. Any member of the workspace may read it.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "workspaces",
+                ":workspace_id",
+                "provider-keys"
+              ],
+              "raw": "{{baseUrl}}/v1/workspaces/:workspace_id/provider-keys",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "workspace_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Set Workspace Provider Key Override",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"disabled\": false,\n  \"is_default\": false\n}"
+            },
+            "description": "Pin or disable a key for this workspace. Organization owners/admins or this workspace's owners/admins.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "PATCH",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "workspaces",
+                ":workspace_id",
+                "provider-keys",
+                ":key_id"
+              ],
+              "raw": "{{baseUrl}}/v1/workspaces/:workspace_id/provider-keys/:key_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "workspace_id",
+                  "value": ""
+                },
+                {
+                  "description": "path parameter",
+                  "key": "key_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Reset Workspace Provider Key Override",
+          "request": {
+            "description": "Remove this workspace's override, reverting to full inheritance. Idempotent.",
+            "header": [],
+            "method": "DELETE",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "workspaces",
+                ":workspace_id",
+                "provider-keys",
+                ":key_id"
+              ],
+              "raw": "{{baseUrl}}/v1/workspaces/:workspace_id/provider-keys/:key_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "workspace_id",
+                  "value": ""
+                },
+                {
+                  "description": "path parameter",
+                  "key": "key_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "List Workspace Provider Key Model Restrictions",
+          "request": {
+            "description": "List this workspace's model allow-list for a key. Empty means every model is allowed.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "workspaces",
+                ":workspace_id",
+                "provider-keys",
+                ":key_id",
+                "models"
+              ],
+              "raw": "{{baseUrl}}/v1/workspaces/:workspace_id/provider-keys/:key_id/models",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "workspace_id",
+                  "value": ""
+                },
+                {
+                  "description": "path parameter",
+                  "key": "key_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Add Workspace Provider Key Model Restriction",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"model\": \"string\"\n}"
+            },
+            "description": "Narrow this workspace's allow-list for a key to include one more model. Idempotent.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "workspaces",
+                ":workspace_id",
+                "provider-keys",
+                ":key_id",
+                "models"
+              ],
+              "raw": "{{baseUrl}}/v1/workspaces/:workspace_id/provider-keys/:key_id/models",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "workspace_id",
+                  "value": ""
+                },
+                {
+                  "description": "path parameter",
+                  "key": "key_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Remove Workspace Provider Key Model Restriction",
+          "request": {
+            "description": "Remove one model from this workspace's allow-list for a key. Idempotent.",
+            "header": [],
+            "method": "DELETE",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "workspaces",
+                ":workspace_id",
+                "provider-keys",
+                ":key_id",
+                "models",
+                ":model"
+              ],
+              "raw": "{{baseUrl}}/v1/workspaces/:workspace_id/provider-keys/:key_id/models/:model",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "workspace_id",
+                  "value": ""
+                },
+                {
+                  "description": "path parameter",
+                  "key": "key_id",
+                  "value": ""
+                },
+                {
+                  "description": "path parameter",
+                  "key": "model",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "name": "provider-keys"
+    },
+    {
+      "item": [
+        {
           "name": "List Pricing",
           "request": {
             "description": "List all model pricing.",

--- a/scripts/sdk_codegen/sdk-endpoints.txt
+++ b/scripts/sdk_codegen/sdk-endpoints.txt
@@ -201,3 +201,21 @@ GET /v1/workspaces/{workspace_id}/member-budget-policies                 # dashb
 POST /v1/workspaces/{workspace_id}/member-budget-policies                # dashboard-only
 PATCH /v1/workspaces/{workspace_id}/member-budget-policies/{default_id}  # dashboard-only
 DELETE /v1/workspaces/{workspace_id}/member-budget-policies/{default_id} # dashboard-only
+# Organization-scoped provider keys (otari-ai#1748, otari#643): the same
+# tenancy-admin surface as the organization/workspace rows just above, and
+# excluded for the same reason. An SDK caller acts inside one workspace with a
+# key that already carries its resolved credentials; managing which
+# organization-scoped BYO key a workspace defaults to is a dashboard concern.
+GET /v1/organizations/me/provider-keys                                    # dashboard-only
+POST /v1/organizations/me/provider-keys                                   # dashboard-only
+PATCH /v1/organizations/me/provider-keys/{key_id}                         # dashboard-only
+DELETE /v1/organizations/me/provider-keys/{key_id}                        # dashboard-only
+POST /v1/organizations/me/provider-keys/{key_id}/archive                  # dashboard-only
+POST /v1/organizations/me/provider-keys/{key_id}/restore                  # dashboard-only
+POST /v1/organizations/me/provider-keys/{key_id}/default                  # dashboard-only
+GET /v1/workspaces/{workspace_id}/provider-keys                           # dashboard-only
+PATCH /v1/workspaces/{workspace_id}/provider-keys/{key_id}                # dashboard-only
+DELETE /v1/workspaces/{workspace_id}/provider-keys/{key_id}               # dashboard-only
+GET /v1/workspaces/{workspace_id}/provider-keys/{key_id}/models           # dashboard-only
+POST /v1/workspaces/{workspace_id}/provider-keys/{key_id}/models          # dashboard-only
+DELETE /v1/workspaces/{workspace_id}/provider-keys/{key_id}/models/{model} # dashboard-only

--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -19,6 +19,7 @@ from gateway.api.routes import (
     messages,
     models,
     moderations,
+    org_provider_keys,
     organization_pricing,
     organizations,
     otlp,
@@ -76,6 +77,8 @@ def register_routers(app: FastAPI, config: GatewayConfig) -> None:
     app.include_router(workspaces.router)
     app.include_router(invitations.router)
     app.include_router(workspace_member_budget_policies.router)
+    app.include_router(org_provider_keys.org_router)
+    app.include_router(org_provider_keys.workspace_router)
     app.include_router(budgets.router)
     app.include_router(scoped_budgets.router)
     app.include_router(aliases.router)

--- a/src/gateway/api/routes/_passthrough.py
+++ b/src/gateway/api/routes/_passthrough.py
@@ -65,7 +65,8 @@ from gateway.services.pricing_service import (
 )
 from gateway.services.provider_kwargs import ResolvedProvider, resolve_provider_selector
 from gateway.services.scoped_budget_service import BudgetScopeRequest
-from gateway.services.workspace_scope import organization_for_key_id, workspace_for_key_id
+from gateway.services.tenancy.org_provider_key_service import cached_org_model_restriction
+from gateway.services.workspace_scope import organization_for_workspace_id, resolve_workspace_id
 
 ResultT = TypeVar("ResultT")
 
@@ -209,10 +210,17 @@ async def run_passthrough(
     started_at = time.monotonic()
     api_key, is_master_key = auth_result
     api_key_id = api_key.id if api_key else None
-    # Resolved once for this request: it decides both what the model costs and
-    # whether the free-model shortcut applies, and a master-key caller's
-    # workspace lookup is deliberately never memoized.
-    organization_id = await organization_for_key_id(db, api_key_id)
+    # Zero I/O for a keyed request (see `_pipeline.resolve_request_context`'s
+    # equivalent comment); only a master-key request pays a lookup. Fixed for
+    # the whole request, so this also becomes the usage row's workspace below.
+    workspace_id = await resolve_workspace_id(db, api_key)
+    # Derived from the workspace already resolved above, not via
+    # `organization_for_key_id` (which would re-derive the same workspace from
+    # `api_key_id` internally): a master-key request's workspace lookup is
+    # deliberately never memoized, so re-deriving it here would pay that cost
+    # twice for one request. Decides both what the model costs and whether the
+    # free-model shortcut applies.
+    organization_id = await organization_for_workspace_id(db, workspace_id)
     # A key flagged exclude_from_budget logs cost but is never reserved or folded
     # into users.spend. Threaded through the reservation handle (so reconcile skips
     # the spend write) and stamped on the usage row.
@@ -312,7 +320,7 @@ async def run_passthrough(
         # The reservation is already held, so refund it before mapping an
         # unresolvable selector to 400; otherwise the estimate leaks.
         try:
-            resolved = resolve_provider_selector(config, model, user_id)
+            resolved = resolve_provider_selector(config, model, user_id, workspace_id=workspace_id)
         except (ValueError, AnyLLMError) as exc:
             await refund_reservation(db, reservation)
             await _log_rejection(
@@ -344,7 +352,7 @@ async def run_passthrough(
                 raise
     else:
         try:
-            resolved = resolve_provider_selector(config, model, user_id)
+            resolved = resolve_provider_selector(config, model, user_id, workspace_id=workspace_id)
         except (ValueError, AnyLLMError) as exc:
             # Nothing is reserved yet on this branch, so there is no refund to do.
             await _log_rejection(
@@ -412,9 +420,30 @@ async def run_passthrough(
             detail=not_allowed_detail,
         )
 
-    # Resolved here rather than in the closure below: the builder is
-    # synchronous, and the workspace is fixed for the whole request anyway.
-    usage_workspace_id = await workspace_for_key_id(db, api_key_id)
+    # Organization-scoped model restriction (otari#643): mirrors `_pipeline.py`'s
+    # equivalent gate. Applies only when the selector did not name a
+    # configured instance, the same condition `provider_kwargs.get_provider_kwargs`
+    # uses to decide whether to consult the organization overlay at all.
+    if workspace_id is not None and resolved.instance not in config.providers:
+        org_allowlist = cached_org_model_restriction(workspace_id, resolved.provider.value)
+        if org_allowlist is not None and resolved.model not in org_allowlist:
+            await refund_reservation(db, reservation)
+            not_allowed_detail = model_not_allowed_detail(model)
+            await _log_rejection(
+                not_allowed_detail,
+                row_model=resolved.model,
+                row_provider=resolved.instance,
+                status_code=status.HTTP_403_FORBIDDEN,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=not_allowed_detail,
+            )
+
+    # Already resolved above (needed there for organization-scoped provider
+    # credentials); reused here rather than re-derived, since it is fixed for
+    # the whole request either way.
+    usage_workspace_id = workspace_id
 
     def _usage_row(row_status: str, **outcome: Any) -> UsageLog:
         """Build this request's usage row, varying only the outcome columns.

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -148,6 +148,7 @@ from gateway.services.sandbox_backend import (
     SandboxNotReachableError,
 )
 from gateway.services.scoped_budget_service import BudgetScopeRequest
+from gateway.services.tenancy.org_provider_key_service import cached_org_model_restriction
 from gateway.services.tool_usage import (
     MAX_TOOL_NAMES,
     OVERFLOW_TOOL_NAME,
@@ -157,8 +158,8 @@ from gateway.services.tool_usage import (
 from gateway.services.url_safety import UnsafeURLError, validate_mcp_url
 from gateway.services.web_search_backend import WEB_SEARCH_TOOL_NAME, WebSearchNotReachableError
 from gateway.services.workspace_scope import (
-    organization_for_key_id,
     organization_for_workspace_id,
+    resolve_workspace_id,
     workspace_for_key_id,
 )
 from gateway.streaming import (
@@ -567,6 +568,7 @@ class RequestContext:
         rate_limit_info: RateLimitInfo | None,
         reservation: ReservationHandle | None,
         started_at: float,
+        workspace_id: uuid.UUID | None = None,
         resolved_provider: ResolvedProvider | None = None,
         plan: CompiledPlan | None = None,
         estimate_inputs: "EstimateInputs | None" = None,
@@ -589,6 +591,12 @@ class RequestContext:
         # pay that per candidate.
         self.organization_id = organization_id
         self.user_id = user_id
+        # Standalone-only, `None` in hybrid mode: the workspace this request
+        # bills to, resolved once in the preamble (`resolve_workspace_id`) and
+        # reused here for the rare fallback resolve in `resolve_dispatch_provider`,
+        # so a request whose gate-check selector was unparseable still gets
+        # organization-scoped provider keys on its real dispatch attempt.
+        self.workspace_id = workspace_id
         self.rate_limit_info = rate_limit_info
         self.reservation = reservation
         # USD already written onto a failure row for gateway-run tool calls. A
@@ -672,7 +680,7 @@ async def resolve_dispatch_provider(
     if ctx.resolved_provider is not None:
         return ctx.resolved_provider
     try:
-        return resolve_provider_selector(config, model_selector, ctx.user_id)
+        return resolve_provider_selector(config, model_selector, ctx.user_id, workspace_id=ctx.workspace_id)
     except (ValueError, AnyLLMError) as exc:
         # The preamble deliberately tolerated this selector, so a reservation is
         # already held: refund it, then record the drop. The hold is not always
@@ -915,6 +923,7 @@ async def _compile_request_plan(
     endpoint: str,
     started_at: float,
     routing_signal: Callable[[], RoutingSignal] | None = None,
+    workspace_id: uuid.UUID | None = None,
 ) -> CompiledPlan | None:
     """Compile ``model`` into a plan when it names a routing policy, else ``None``.
 
@@ -967,6 +976,7 @@ async def _compile_request_plan(
             allowlist=allowlist,
             budget=budget,
             router_ordering=router_ordering,
+            workspace_id=workspace_id,
         )
     except NoEligibleCandidatesError as exc:
         logger.warning("%s", exc.operator_detail)
@@ -1046,6 +1056,7 @@ async def resolve_request_context(
     # ``organization_model_pricing``.
     organization_id: uuid.UUID | None = None
     user_id: str | None = None
+    workspace_id: uuid.UUID | None = None
     rate_limit_info: RateLimitInfo | None = None
     reservation: ReservationHandle | None = None
     resolved_provider: ResolvedProvider | None = None
@@ -1088,6 +1099,16 @@ async def resolve_request_context(
         session_identity = await get_session_identity(raw_request, db, config)
         api_key, is_master_key = await verify_api_key_or_master_key(raw_request, db, config, session_identity)
         api_key_id = api_key.id if api_key else None
+        # Zero I/O for a keyed request: `api_key.workspace_id` is already an
+        # in-memory attribute on the row just loaded. Only a master-key request
+        # pays a lookup, which `resolve_workspace_id` itself accepts as
+        # operator traffic (see its docstring). Used below to resolve
+        # organization-scoped provider keys for a bare provider selector; an
+        # instance-addressed one never consults it (`provider_kwargs.py`). A
+        # master-key call therefore only ever reaches the *default* workspace's
+        # organization's keys, not every organization the deployment holds
+        # (`workspace_scope.py`'s docstring).
+        workspace_id = await resolve_workspace_id(db, api_key)
         try:
             user_id = resolve_user_id(
                 user_id_from_request=user_id_from_request,
@@ -1160,6 +1181,7 @@ async def resolve_request_context(
             endpoint=adapter.endpoint,
             started_at=started_at,
             routing_signal=routing_signal,
+            workspace_id=workspace_id,
         )
         if plan is not None:
             head = plan.head
@@ -1173,7 +1195,7 @@ async def resolve_request_context(
             )
         else:
             try:
-                resolved = resolve_provider_selector(config, model, user_id)
+                resolved = resolve_provider_selector(config, model, user_id, workspace_id=workspace_id)
                 gate_instance, gate_impl, gate_model = resolved.instance, resolved.provider, resolved.model
                 # Reused by the route handler for dispatch (see `RequestContext.resolved_provider`)
                 # instead of calling `resolve_provider_selector` a second time.
@@ -1207,7 +1229,42 @@ async def resolve_request_context(
             )
             raise adapter.error(403, not_allowed_detail, ErrorKind.PERMISSION)
 
-        organization_id = await organization_for_key_id(db, api_key_id)
+        # Organization-scoped model restriction (otari#643): the org key
+        # resolved for this workspace+provider may narrow which models it
+        # serves. Applies only when the selector did not name a configured
+        # instance, the same condition `provider_kwargs.get_provider_kwargs`
+        # uses to decide whether to consult the organization overlay at all;
+        # an instance-addressed selector never reaches an organization key,
+        # so it is never subject to this restriction either.
+        if (
+            workspace_id is not None
+            and gate_instance is not None
+            and gate_impl is not None
+            and gate_instance not in config.providers
+        ):
+            org_allowlist = cached_org_model_restriction(workspace_id, gate_impl.value)
+            if org_allowlist is not None and gate_model not in org_allowlist:
+                not_allowed_detail = model_not_allowed_detail(model)
+                await log_gateway_rejection(
+                    db=db,
+                    log_writer=log_writer,
+                    api_key_id=api_key_id,
+                    user_id=user_id,
+                    model=gate_model,
+                    provider=gate_instance,
+                    endpoint=adapter.endpoint,
+                    detail=not_allowed_detail,
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    started_at=started_at,
+                )
+                raise adapter.error(403, not_allowed_detail, ErrorKind.PERMISSION)
+
+        # Derived from the workspace already resolved above, not via
+        # `organization_for_key_id` (which would re-derive the same workspace
+        # from `api_key_id` internally): a master-key request's workspace
+        # lookup is deliberately never memoized, so re-deriving it here would
+        # pay that cost twice for one request.
+        organization_id = await organization_for_workspace_id(db, workspace_id)
         gate_pricing = await find_model_pricing(
             db,
             gate_instance,
@@ -1396,6 +1453,7 @@ async def resolve_request_context(
         rate_limit_info=rate_limit_info,
         reservation=reservation,
         started_at=started_at,
+        workspace_id=workspace_id,
         resolved_provider=resolved_provider,
         plan=plan,
         estimate_inputs=estimate_inputs,
@@ -1853,6 +1911,7 @@ async def log_usage(
     counts_toward_budget: bool = True,
     attribution: RoutingAttribution | None = None,
     tool_tally: ToolUsageTally | None = None,
+    workspace_id: uuid.UUID | None = None,
 ) -> float | None:
     """Log API usage to the database and return the computed cost.
 
@@ -1892,6 +1951,16 @@ async def log_usage(
             when the caller has no meaningful duration to record
         attribution: Which routing policy produced this row and where in its plan,
             or None for a request that named a plain model
+        workspace_id: The workspace already resolved for this request (from
+            ``resolve_workspace_id``/``RequestContext.workspace_id``), reused
+            instead of re-deriving it. Every ``ctx``-bearing caller has this for
+            free; only callers with no request context in scope (a gateway
+            rejection logged before one exists, the vision side-call billed
+            during normalization) omit it and pay ``workspace_for_key_id``'s own
+            lookup, which is cheap for a keyed request (memoized on
+            ``api_key_id``) and the same un-memoized cost a master-key request
+            already pays once elsewhere -- passing it explicitly here is what
+            avoids paying that twice on the same request.
 
     Returns:
         The computed cost for this request, or None when usage/pricing is absent.
@@ -1899,7 +1968,7 @@ async def log_usage(
     """
     usage_log = UsageLog(
         id=str(uuid.uuid4()),
-        workspace_id=await workspace_for_key_id(db, api_key_id),
+        workspace_id=workspace_id if workspace_id is not None else await workspace_for_key_id(db, api_key_id),
         api_key_id=api_key_id,
         user_id=user_id,
         timestamp=datetime.now(UTC),
@@ -2235,6 +2304,7 @@ async def _log_failure_and_refund(
         counts_toward_budget=_handle_counts_toward_budget(ctx.reservation),
         attribution=attribution,
         tool_tally=tool_tally,
+        workspace_id=ctx.workspace_id,
     )
     if ctx.reservation is not None:
         if cost:
@@ -2479,6 +2549,7 @@ def build_streaming_response(
     display_model: str | None = None,
     attribution: RoutingAttribution | None = None,
     tool_tally: ToolUsageTally | None = None,
+    workspace_id: uuid.UUID | None = None,
 ) -> StreamingResponse:
     """Wrap an already-opened upstream stream in an SSE response.
 
@@ -2532,6 +2603,7 @@ def build_streaming_response(
             counts_toward_budget=_handle_counts_toward_budget(reservation),
             attribution=attribution,
             tool_tally=tool_tally,
+            workspace_id=workspace_id,
         )
         if reservation is not None:
             await reconcile_reservation(db, reservation, actual_cost or 0.0)
@@ -2574,6 +2646,7 @@ def build_streaming_response(
                 counts_toward_budget=reservation.counts_toward_budget,
                 attribution=attribution,
                 tool_tally=tool_tally,
+                workspace_id=workspace_id,
             )
             # "Free" is about the tokens the provider never reported, not about
             # tool calls the gateway definitely ran and owes for.
@@ -2600,6 +2673,7 @@ def build_streaming_response(
             counts_toward_budget=reservation.counts_toward_budget,
             attribution=attribution,
             tool_tally=tool_tally,
+            workspace_id=workspace_id,
         )
         # The estimate covers the unreported tokens; log_usage adds any tool cost on
         # top of it, so reconcile against the row's total rather than the estimate.
@@ -2636,6 +2710,7 @@ def build_streaming_response(
             counts_toward_budget=_handle_counts_toward_budget(reservation),
             attribution=attribution,
             tool_tally=tool_tally,
+            workspace_id=workspace_id,
         )
         if reservation is not None:
             # A stream that died after running searches still owes for them, and a
@@ -2670,6 +2745,7 @@ def build_streaming_response(
                 latency_ms=_elapsed_ms(started_at),
                 counts_toward_budget=_handle_counts_toward_budget(reservation),
                 tool_tally=tool_tally,
+                workspace_id=workspace_id,
             )
             if abandoned_cost:
                 await reconcile_reservation(db, reservation, abandoned_cost)
@@ -2879,6 +2955,7 @@ async def run_single_attempt_stream(
         rate_limit_info=ctx.rate_limit_info,
         reservation=ctx.reservation,
         started_at=ctx.started_at,
+        workspace_id=ctx.workspace_id,
         platform_correlation_id=platform_correlation_id,
         platform_request_id=platform_request_id,
         session_label=session_label,
@@ -3379,6 +3456,7 @@ async def log_exhausted_plan(
         counts_toward_budget=_handle_counts_toward_budget(ctx.reservation),
         attribution=_failure_attribution(ctx, last),
         tool_tally=tool_tally,
+        workspace_id=ctx.workspace_id,
     )
     ctx.tool_charge = cost or 0.0
 
@@ -3418,6 +3496,7 @@ async def log_absorbed_attempt(
             latency_ms=_elapsed_ms(ctx.started_at),
             counts_toward_budget=False,
             attribution=_attribution_for(ctx, attempt, absorbed=True),
+            workspace_id=ctx.workspace_id,
         )
     except Exception:
         logger.warning(
@@ -3533,6 +3612,7 @@ async def run_standalone_non_stream(
                     counts_toward_budget=_handle_counts_toward_budget(ctx.reservation),
                     attribution=attribution,
                     tool_tally=tool_ctx.tally,
+                    workspace_id=ctx.workspace_id,
                 )
             if ctx.reservation is not None:
                 await reconcile_reservation(ctx.db, ctx.reservation, actual_cost or 0.0)

--- a/src/gateway/api/routes/batches.py
+++ b/src/gateway/api/routes/batches.py
@@ -40,7 +40,12 @@ from gateway.services.model_access import is_model_allowed, model_not_allowed_de
 from gateway.services.pricing_service import find_model_pricing
 from gateway.services.provider_kwargs import get_provider_kwargs, resolve_provider_selector
 from gateway.services.scoped_budget_service import BudgetScopeRequest
-from gateway.services.workspace_scope import organization_for_key_id, workspace_for_key_id
+from gateway.services.tenancy.org_provider_key_service import cached_org_model_restriction
+from gateway.services.workspace_scope import (
+    organization_for_workspace_id,
+    resolve_workspace_id,
+    workspace_for_key_id,
+)
 
 router = APIRouter(prefix="/v1/batches", tags=["batches"])
 
@@ -140,19 +145,49 @@ def _parse_provider(provider: str) -> LLMProvider:
         ) from e
 
 
-def _resolve_batch_provider(config: GatewayConfig, provider: str) -> tuple[LLMProvider, dict[str, Any]]:
+def _resolve_batch_provider(
+    config: GatewayConfig, provider: str, *, workspace_id: uuid.UUID | None = None
+) -> tuple[LLMProvider, dict[str, Any]]:
     """Resolve a batch ``provider`` query param into (implementation, kwargs).
 
     The value is either a configured instance name (resolved to its
     ``provider_type`` with the instance's credentials) or a real any-llm
     provider, mirroring what ``create_batch`` echoes back as the batch's
-    ``provider`` field.
+    ``provider`` field. ``workspace_id`` reaches ``get_provider_kwargs``
+    unchanged: consulted only when ``provider`` names no configured instance,
+    the same organization-scoped fallback ``create_batch`` uses, so a batch
+    created against an organization key stays reachable by every later
+    lifecycle call (retrieve, cancel, list, results) rather than only at
+    creation. For retrieve/cancel/results the caller passes the batch's own
+    stored ``workspace_id`` (see ``_lifecycle_workspace_id``), not necessarily
+    its own current one, so credentials resolve from the organization that
+    created the batch even for a master-key or cross-workspace call;
+    ``list_batches`` has no batch id to key off of and keeps using the
+    caller's own workspace.
     """
     if provider in config.providers:
         impl = LLMProvider(config.provider_instance_type(provider))
         return impl, get_provider_kwargs(config, impl, instance=provider)
     impl = _parse_provider(provider)
-    return impl, get_provider_kwargs(config, impl)
+    return impl, get_provider_kwargs(config, impl, workspace_id=workspace_id)
+
+
+async def _lifecycle_workspace_id(
+    db: AsyncSession, record: BatchRecord | None, api_key: APIKey | None
+) -> uuid.UUID:
+    """Which workspace's organization-scoped credentials a lifecycle call should use.
+
+    The batch's own stored ``workspace_id`` when there is a record that has one
+    (the workspace it was *created* in), so a master-key or legitimately
+    cross-workspace retrieve/cancel/results still resolves the right
+    organization's key. Falls back to the caller's own workspace only for
+    legacy batches with no record, or one predating this column -- the same
+    fallback shape ``_owns_batch``/``_authorize_legacy_batch`` already use for
+    ownership.
+    """
+    if record is not None and record.workspace_id is not None:
+        return record.workspace_id
+    return await resolve_workspace_id(db, api_key)
 
 
 def _owns_batch(batch: Batch, api_key: APIKey | None, is_master_key: bool) -> bool:
@@ -172,35 +207,56 @@ def _owns_batch(batch: Batch, api_key: APIKey | None, is_master_key: bool) -> bo
     return owner == requester
 
 
-async def _authorize_batch(
-    db: AsyncSession,
-    batch: Batch,
+def _authorize_record(
+    record: BatchRecord,
     batch_id: str,
     api_key: APIKey | None,
     is_master_key: bool,
-) -> BatchRecord | None:
-    """Authorize access to ``batch`` and return its stored record, if any.
+) -> None:
+    """Authorize access to a batch using only its stored record. No upstream call needed.
 
-    When a local record exists the check is strict: only its owner (or the
-    master key) may access the batch, regardless of whether the provider
-    round-tripped the metadata marker. Legacy batches with no record fall back to
-    the metadata-anchored :func:`_owns_batch` check. Raises 404 (not 403) on
-    denial so a foreign key cannot probe which batch ids exist.
+    Deliberately callable *before* the batch is retrieved from the provider:
+    ``record.workspace_id`` decides which organization's BYO credential a
+    lifecycle call dispatches with (see :func:`_lifecycle_workspace_id`), so
+    checking ownership only after that dispatch would let an unauthorized
+    caller cause the gateway to spend another organization's provider
+    credential before ever learning the batch is not theirs. Only the
+    strict, record-based check needs to run this early; the legacy,
+    metadata-anchored fallback (:func:`_authorize_legacy_batch`) has no such
+    risk, because a record-less batch has no stored workspace to leak --
+    credentials there already resolve to the caller's own.
+
+    Raises 404 (not 403) on denial so a foreign key cannot probe which batch
+    ids exist.
     """
-    record = await get_batch_record(db, batch_id)
     if is_master_key:
-        return record
-    if record is not None:
-        requester = str(api_key.user_id) if api_key and api_key.user_id else None
-        authorized = record.user_id == requester
-    else:
-        authorized = _owns_batch(batch, api_key, is_master_key)
-    if not authorized:
+        return
+    requester = str(api_key.user_id) if api_key and api_key.user_id else None
+    if record.user_id != requester:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Batch '{batch_id}' not found",
         )
-    return record
+
+
+def _authorize_legacy_batch(
+    batch: Batch,
+    batch_id: str,
+    api_key: APIKey | None,
+    is_master_key: bool,
+) -> None:
+    """Authorize a record-less (legacy) batch via the provider-side metadata marker.
+
+    Only reached when :func:`get_batch_record` found no row, so this is
+    necessarily after the batch has already been fetched from the provider
+    (the metadata marker lives on the provider's own object); see
+    :func:`_authorize_record` for why that ordering is safe only in this case.
+    """
+    if not _owns_batch(batch, api_key, is_master_key):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Batch '{batch_id}' not found",
+        )
 
 
 async def _retrieve_batch_or_502(
@@ -278,8 +334,11 @@ async def create_batch(
 
     rate_limit_info = check_rate_limit(raw_request, user_id)
 
+    # Zero I/O for a keyed request (see `_pipeline.resolve_request_context`'s
+    # equivalent comment); only a master-key request pays a lookup.
+    workspace_id = await resolve_workspace_id(db, api_key)
     try:
-        resolved = resolve_provider_selector(config, request.model, user_id)
+        resolved = resolve_provider_selector(config, request.model, user_id, workspace_id=workspace_id)
     except (ValueError, AnyLLMError) as exc:
         _raise_for_unresolvable_model(request.model, exc)
     provider, model = resolved.provider, resolved.model
@@ -295,6 +354,18 @@ async def create_batch(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=model_not_allowed_detail(request.model),
         )
+
+    # Organization-scoped model restriction (otari#643): mirrors `_pipeline.py`'s
+    # equivalent gate. Applies only when the selector did not name a
+    # configured instance, the same condition `provider_kwargs.get_provider_kwargs`
+    # uses to decide whether to consult the organization overlay at all.
+    if workspace_id is not None and resolved.instance not in config.providers:
+        org_allowlist = cached_org_model_restriction(workspace_id, provider.value)
+        if org_allowlist is not None and model not in org_allowlist:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=model_not_allowed_detail(request.model),
+            )
 
     # Validate provider supports batch operations
     provider_class = AnyLLM.get_provider_class(provider)
@@ -322,8 +393,11 @@ async def create_batch(
         counts_toward_budget=not budget_exempt,
         scope=BudgetScopeRequest(api_key=api_key, provider_instance=resolved.instance),
         # So the free-model shortcut reads this organization's rate, the same one
-        # the results are priced at when they are retrieved.
-        organization_id=await organization_for_key_id(db, api_key_id),
+        # the results are priced at when they are retrieved. Derived from the
+        # workspace already resolved above (not `organization_for_key_id`,
+        # which would re-derive it from `api_key_id` and pay a master-key
+        # request's un-memoized workspace lookup a second time).
+        organization_id=await organization_for_workspace_id(db, workspace_id),
     )
 
     # Stamp the billed user into the provider-side metadata so ownership can be
@@ -405,6 +479,7 @@ async def create_batch(
         user_id=user_id,
         api_key_id=api_key_id,
         model=model,
+        workspace_id=workspace_id,
     )
 
     if rate_limit_info:
@@ -427,10 +502,16 @@ async def retrieve_batch(
 ) -> dict[str, Any]:
     """Retrieve the status of a batch."""
     api_key, is_master_key = auth_result
-    provider_enum, provider_kwargs = _resolve_batch_provider(config, provider)
+    record = await get_batch_record(db, batch_id)
+    if record is not None:
+        _authorize_record(record, batch_id, api_key, is_master_key)
+    provider_enum, provider_kwargs = _resolve_batch_provider(
+        config, provider, workspace_id=await _lifecycle_workspace_id(db, record, api_key)
+    )
 
     batch = await _retrieve_batch_or_502(provider_enum, batch_id, provider, provider_kwargs)
-    await _authorize_batch(db, batch, batch_id, api_key, is_master_key)
+    if record is None:
+        _authorize_legacy_batch(batch, batch_id, api_key, is_master_key)
 
     response_data = batch.model_dump()
     response_data["provider"] = provider
@@ -448,10 +529,16 @@ async def cancel_batch(
 ) -> dict[str, Any]:
     """Cancel a batch."""
     api_key, is_master_key = auth_result
-    provider_enum, provider_kwargs = _resolve_batch_provider(config, provider)
+    record = await get_batch_record(db, batch_id)
+    if record is not None:
+        _authorize_record(record, batch_id, api_key, is_master_key)
+    provider_enum, provider_kwargs = _resolve_batch_provider(
+        config, provider, workspace_id=await _lifecycle_workspace_id(db, record, api_key)
+    )
 
     existing = await _retrieve_batch_or_502(provider_enum, batch_id, provider, provider_kwargs)
-    await _authorize_batch(db, existing, batch_id, api_key, is_master_key)
+    if record is None:
+        _authorize_legacy_batch(existing, batch_id, api_key, is_master_key)
 
     try:
         batch: Batch = await acancel_batch(
@@ -490,7 +577,9 @@ async def list_batches(
     may contain fewer than ``limit`` items.
     """
     api_key, is_master_key = auth_result
-    provider_enum, provider_kwargs = _resolve_batch_provider(config, provider)
+    provider_enum, provider_kwargs = _resolve_batch_provider(
+        config, provider, workspace_id=await resolve_workspace_id(db, api_key)
+    )
 
     list_kwargs: dict[str, Any] = {**provider_kwargs}
     if after is not None:
@@ -549,10 +638,19 @@ async def retrieve_batch_results(
     api_key, is_master_key = auth_result
     api_key_id = api_key.id if api_key else None
 
-    provider_enum, provider_kwargs = _resolve_batch_provider(config, provider)
+    record = await get_batch_record(db, batch_id)
+    if record is not None:
+        _authorize_record(record, batch_id, api_key, is_master_key)
+    # The batch's originating workspace, reused below for pricing and the usage
+    # row: both attribute to the creator, exactly like the credentials just
+    # resolved from it, so one resolve serves all three rather than each
+    # re-deriving its own notion of "whose batch is this" from `api_key_id`.
+    origin_workspace_id = await _lifecycle_workspace_id(db, record, api_key)
+    provider_enum, provider_kwargs = _resolve_batch_provider(config, provider, workspace_id=origin_workspace_id)
 
     batch = await _retrieve_batch_or_502(provider_enum, batch_id, provider, provider_kwargs)
-    record = await _authorize_batch(db, batch, batch_id, api_key, is_master_key)
+    if record is None:
+        _authorize_legacy_batch(batch, batch_id, api_key, is_master_key)
 
     # Attribute usage to the batch owner: the stored record when present (strict,
     # so a master-key retrieval bills the true owner), else the metadata marker
@@ -609,26 +707,20 @@ async def retrieve_batch_results(
             completion_tokens += usage.completion_tokens or 0
             total_tokens += usage.total_tokens or 0
 
-    # Rates and the usage row's workspace follow the key that CREATED the batch,
-    # for the same reason the budget exemption above does and the owner
-    # attribution before it: the cost is billed to that key's owner, so it has to
-    # be priced at that key's organization and recorded in its workspace. Scoping
-    # to the retriever would let a master-key retrieval, or a second key of the
-    # same user in another organization, settle the batch at rates its owner never
-    # negotiated. A record with no originating key (it was deleted) falls back to
-    # the retriever, which is the only organization still knowable.
-    #
-    # Resolved before the token check, because the usage row below is written
-    # whether or not there were billable tokens.
-    billing_key_id = record.api_key_id if record is not None and record.api_key_id is not None else api_key_id
-
     cost: float | None = None
     if total_tokens:
+        # Rates follow the batch's originating workspace (`origin_workspace_id`,
+        # resolved above), for the same reason the budget exemption above and
+        # the owner attribution before it do: the cost is billed to the
+        # creator, so it has to be priced at the creator's organization.
+        # Scoping to the retriever would let a master-key retrieval, or a
+        # second key of the same user in another organization, settle the
+        # batch at rates its owner never negotiated.
         pricing = await find_model_pricing(
             db,
             provider_enum.value,
             batch_model,
-            organization_id=await organization_for_key_id(db, billing_key_id),
+            organization_id=await organization_for_workspace_id(db, origin_workspace_id),
         )
         if pricing:
             cost = (prompt_tokens / 1_000_000) * pricing.input_price_per_million + (
@@ -673,7 +765,7 @@ async def retrieve_batch_results(
             counts_toward_budget=not batch_exempt,
             # The creator's workspace, matching the user and the rates this row
             # was priced at; see the note on ``log_batch_usage``.
-            workspace_id=await workspace_for_key_id(db, billing_key_id),
+            workspace_id=origin_workspace_id,
         )
         if record is not None:
             if cost and user_id and not batch_exempt:

--- a/src/gateway/api/routes/org_provider_keys.py
+++ b/src/gateway/api/routes/org_provider_keys.py
@@ -1,0 +1,232 @@
+"""Organization-scoped provider keys (standalone mode only).
+
+Thin composition over `gateway.services.tenancy.org_provider_key_service`.
+Two routers, because the surface has two scopes: an organization's own keys
+(created, archived, defaulted) under ``/v1/organizations/me/provider-keys`,
+matching `organizations.py`'s ``/me`` convention, and one workspace's view of
+those keys (override, model-restrict) under
+``/v1/workspaces/{workspace_id}/provider-keys``, matching `workspaces.py`'s
+path-scoped convention. A caller manages several workspaces in one
+organization, so the workspace surface takes ``workspace_id`` as a path
+parameter the way `workspaces.py` does, unlike the organization surface's
+``/me``.
+"""
+
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.api.deps import CurrentIdentity, get_db, verify_master_key
+from gateway.api.routes.organizations import Message
+from gateway.models.provider_keys import (
+    OrgProviderKeyCreateRequest,
+    OrgProviderKeyPublic,
+    OrgProviderKeysPublic,
+    OrgProviderKeyUpdateRequest,
+    WorkspaceProviderKeyOverridePublic,
+    WorkspaceProviderKeyOverrideRequest,
+    WorkspaceProviderKeyOverridesPublic,
+    WorkspaceProviderModelRestrictionRequest,
+    WorkspaceProviderModelRestrictionsPublic,
+)
+from gateway.services.tenancy import OrgProviderKeyService
+
+# Auth is declared on the router, not left to arrive through `CurrentIdentity`:
+# see organizations.py/workspaces.py for the same note.
+org_router = APIRouter(
+    prefix="/v1/organizations/me/provider-keys",
+    tags=["provider-keys"],
+    dependencies=[Depends(verify_master_key)],
+)
+
+workspace_router = APIRouter(
+    prefix="/v1/workspaces/{workspace_id}/provider-keys",
+    tags=["provider-keys"],
+    dependencies=[Depends(verify_master_key)],
+)
+
+
+def get_org_provider_key_service(db: Annotated[AsyncSession, Depends(get_db)]) -> OrgProviderKeyService:
+    """Build the org provider key service on the request's session."""
+    return OrgProviderKeyService(db)
+
+
+OrgProviderKeyServiceDep = Annotated[OrgProviderKeyService, Depends(get_org_provider_key_service)]
+
+
+# ==============================================================================
+# Organization-scoped keys
+# ==============================================================================
+
+
+@org_router.get("")
+async def list_org_provider_keys(
+    service: OrgProviderKeyServiceDep,
+    current_identity: CurrentIdentity,
+    include_archived: Annotated[bool, Query(description="Include archived keys.")] = False,
+    skip: Annotated[int, Query(ge=0, description="Number of records to skip")] = 0,
+    limit: Annotated[int, Query(ge=1, le=1000, description="Maximum number of records to return")] = 100,
+) -> OrgProviderKeysPublic:
+    """List the caller's organization's provider keys. Any active member may read it."""
+    return await service.list_keys_for_user(
+        user=current_identity, include_archived=include_archived, skip=skip, limit=limit
+    )
+
+
+@org_router.post("", status_code=status.HTTP_201_CREATED)
+async def create_org_provider_key(
+    service: OrgProviderKeyServiceDep,
+    current_identity: CurrentIdentity,
+    body: OrgProviderKeyCreateRequest,
+) -> OrgProviderKeyPublic:
+    """Create a provider key in the caller's organization. Organization owners and admins only."""
+    return await service.create_key_for_user(user=current_identity, request=body)
+
+
+@org_router.patch("/{key_id}")
+async def update_org_provider_key(
+    service: OrgProviderKeyServiceDep,
+    current_identity: CurrentIdentity,
+    key_id: uuid.UUID,
+    body: OrgProviderKeyUpdateRequest,
+) -> OrgProviderKeyPublic:
+    """Change a key's name, credential, base URL, or client args. Organization owners and admins only."""
+    return await service.update_key_for_user(user=current_identity, key_id=key_id, request=body)
+
+
+@org_router.post("/{key_id}/archive")
+async def archive_org_provider_key(
+    service: OrgProviderKeyServiceDep,
+    current_identity: CurrentIdentity,
+    key_id: uuid.UUID,
+) -> OrgProviderKeyPublic:
+    """Archive a key. Organization owners and admins only."""
+    return await service.archive_key_for_user(user=current_identity, key_id=key_id)
+
+
+@org_router.post("/{key_id}/restore")
+async def restore_org_provider_key(
+    service: OrgProviderKeyServiceDep,
+    current_identity: CurrentIdentity,
+    key_id: uuid.UUID,
+) -> OrgProviderKeyPublic:
+    """Restore an archived key. Organization owners and admins only."""
+    return await service.restore_key_for_user(user=current_identity, key_id=key_id)
+
+
+@org_router.delete("/{key_id}")
+async def delete_org_provider_key(
+    service: OrgProviderKeyServiceDep,
+    current_identity: CurrentIdentity,
+    key_id: uuid.UUID,
+) -> Message:
+    """Permanently delete an archived key. Organization owners and admins only."""
+    await service.delete_key_for_user(user=current_identity, key_id=key_id)
+    return Message(message="Provider key deleted")
+
+
+@org_router.post("/{key_id}/default")
+async def set_org_provider_key_default(
+    service: OrgProviderKeyServiceDep,
+    current_identity: CurrentIdentity,
+    key_id: uuid.UUID,
+) -> OrgProviderKeyPublic:
+    """Make a key the organization's default for its provider. Organization owners and admins only."""
+    return await service.set_org_default_for_user(user=current_identity, key_id=key_id)
+
+
+# ==============================================================================
+# Workspace overrides and model restrictions
+# ==============================================================================
+
+
+@workspace_router.get("")
+async def list_workspace_provider_keys(
+    service: OrgProviderKeyServiceDep,
+    current_identity: CurrentIdentity,
+    workspace_id: uuid.UUID,
+) -> WorkspaceProviderKeyOverridesPublic:
+    """The effective view of every key visible to this workspace. Any member of the workspace may read it."""
+    return await service.list_effective_keys_for_workspace(user=current_identity, workspace_id=workspace_id)
+
+
+@workspace_router.patch("/{key_id}")
+async def set_workspace_provider_key_override(
+    service: OrgProviderKeyServiceDep,
+    current_identity: CurrentIdentity,
+    workspace_id: uuid.UUID,
+    key_id: uuid.UUID,
+    body: WorkspaceProviderKeyOverrideRequest,
+) -> WorkspaceProviderKeyOverridePublic:
+    """Pin or disable a key for this workspace. Organization owners/admins or this workspace's owners/admins."""
+    return await service.set_workspace_override_for_user(
+        user=current_identity,
+        workspace_id=workspace_id,
+        key_id=key_id,
+        request=body,
+    )
+
+
+@workspace_router.delete("/{key_id}")
+async def reset_workspace_provider_key_override(
+    service: OrgProviderKeyServiceDep,
+    current_identity: CurrentIdentity,
+    workspace_id: uuid.UUID,
+    key_id: uuid.UUID,
+) -> Message:
+    """Remove this workspace's override, reverting to full inheritance. Idempotent."""
+    await service.reset_workspace_override_for_user(user=current_identity, workspace_id=workspace_id, key_id=key_id)
+    return Message(message="Provider key override reset")
+
+
+@workspace_router.get("/{key_id}/models")
+async def list_workspace_provider_key_model_restrictions(
+    service: OrgProviderKeyServiceDep,
+    current_identity: CurrentIdentity,
+    workspace_id: uuid.UUID,
+    key_id: uuid.UUID,
+) -> WorkspaceProviderModelRestrictionsPublic:
+    """List this workspace's model allow-list for a key. Empty means every model is allowed."""
+    return await service.list_model_restrictions_for_user(
+        user=current_identity,
+        workspace_id=workspace_id,
+        key_id=key_id,
+    )
+
+
+@workspace_router.post("/{key_id}/models", status_code=status.HTTP_201_CREATED)
+async def add_workspace_provider_key_model_restriction(
+    service: OrgProviderKeyServiceDep,
+    current_identity: CurrentIdentity,
+    workspace_id: uuid.UUID,
+    key_id: uuid.UUID,
+    body: WorkspaceProviderModelRestrictionRequest,
+) -> Message:
+    """Narrow this workspace's allow-list for a key to include one more model. Idempotent."""
+    await service.add_model_restriction_for_user(
+        user=current_identity,
+        workspace_id=workspace_id,
+        key_id=key_id,
+        model=body.model,
+    )
+    return Message(message="Model restriction added")
+
+
+@workspace_router.delete("/{key_id}/models/{model:path}")
+async def remove_workspace_provider_key_model_restriction(
+    service: OrgProviderKeyServiceDep,
+    current_identity: CurrentIdentity,
+    workspace_id: uuid.UUID,
+    key_id: uuid.UUID,
+    model: str,
+) -> Message:
+    """Remove one model from this workspace's allow-list for a key. Idempotent."""
+    await service.remove_model_restriction_for_user(
+        user=current_identity,
+        workspace_id=workspace_id,
+        key_id=key_id,
+        model=model,
+    )
+    return Message(message="Model restriction removed")

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -65,6 +65,11 @@ from gateway.services.search_tool_store_service import (
 )
 from gateway.services.secret_box import validate_secret_key
 from gateway.services.tenancy.errors import TenancyError
+from gateway.services.tenancy.org_provider_key_service import (
+    load_org_provider_keys_at_startup,
+    reset_org_provider_cache,
+    run_org_provider_refresher,
+)
 from gateway.services.tool_settings_service import apply_overrides_from_db as apply_tool_overrides_from_db
 from gateway.version import __version__
 
@@ -237,6 +242,7 @@ def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
         alias_refresher: asyncio.Task[None] | None = None
         policy_refresher: asyncio.Task[None] | None = None
         provider_refresher: asyncio.Task[None] | None = None
+        org_provider_refresher: asyncio.Task[None] | None = None
         search_tool_refresher: asyncio.Task[None] | None = None
         price_refresher: asyncio.Task[None] | None = None
         discovery_refresher: asyncio.Task[None] | None = None
@@ -281,6 +287,12 @@ def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
                 # provider added at runtime is visible to everything that reads
                 # config.providers (pricing seeding, discovery, dispatch).
                 await load_providers_at_startup(session, config)
+                # Organization-scoped provider keys (otari-ai#1748, otari#643):
+                # a disjoint overlay from the one above, keyed by
+                # (workspace_id, provider) rather than instance name. Empty on
+                # a fresh database (no workspace or key exists yet), the same
+                # posture load_providers_at_startup takes.
+                await load_org_provider_keys_at_startup(session)
                 await bootstrap_first_api_key(config, session)
                 await initialize_pricing_from_config(config, session)
                 await warn_if_require_pricing_without_pricing(config, session)
@@ -303,6 +315,10 @@ def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
             # config.providers synchronously, so the overlay is reloaded on a TTL
             # to converge sibling workers and replicas after a dashboard write.
             provider_refresher = asyncio.create_task(run_provider_refresher(config))
+            # Organization-scoped provider keys are the same shape, keyed by
+            # (workspace_id, provider) instead of instance name; see
+            # `services/tenancy/org_provider_key_service.py`'s module docstring.
+            org_provider_refresher = asyncio.create_task(run_org_provider_refresher())
             # Search tools are the provider overlay's twin: resolve_search_tool
             # reads config.search_tools synchronously, so the overlay is reloaded
             # on a TTL to converge sibling workers and replicas after a write.
@@ -345,6 +361,7 @@ def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
                 (alias_refresher, "alias"),
                 (policy_refresher, "policy"),
                 (provider_refresher, "provider"),
+                (org_provider_refresher, "organization provider key"),
                 (search_tool_refresher, "search tool"),
                 (price_refresher, "price snapshot"),
                 (discovery_refresher, "model discovery"),
@@ -357,6 +374,8 @@ def _create_lifespan(config: GatewayConfig) -> Callable[[FastAPI], Any]:
                 reset_policy_cache()
             if provider_refresher is not None:
                 reset_provider_cache()
+            if org_provider_refresher is not None:
+                reset_org_provider_cache()
             if search_tool_refresher is not None:
                 reset_search_tool_cache()
             if discovery_refresher is not None:

--- a/src/gateway/models/__init__.py
+++ b/src/gateway/models/__init__.py
@@ -15,4 +15,4 @@ schema-less request/response modules beside them (`guardrails`, `mcp`,
 `routing`) contribute nothing to the metadata and stay out of it.
 """
 
-from gateway.models import entities, tenancy  # noqa: F401
+from gateway.models import entities, provider_keys, tenancy  # noqa: F401

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -751,7 +751,9 @@ class BatchRecord(Base):
     into ``users.spend``, and ownership can be enforced without depending on the
     provider round-tripping the ``otari_user_id`` metadata marker. Batches created
     before this table existed carry no record and fall back to the
-    metadata-anchored ownership path in ``api/routes/batches.py``.
+    metadata-anchored ownership path in ``api/routes/batches.py``. ``workspace_id``
+    additionally anchors which workspace's organization-scoped provider key
+    (otari#643) lifecycle calls should resolve credentials from.
     """
 
     __tablename__ = "batches"
@@ -768,6 +770,19 @@ class BatchRecord(Base):
     user_id: Mapped[str] = mapped_column(ForeignKey("users.user_id", ondelete="CASCADE"), nullable=False, index=True)
     # SET NULL: a key may be revoked while its batch is still in flight.
     api_key_id: Mapped[str | None] = mapped_column(ForeignKey("api_keys.id", ondelete="SET NULL"), index=True)
+    # The workspace this batch was CREATED in (otari#643 follow-up), so
+    # lifecycle calls (retrieve/cancel/results) can resolve organization-scoped
+    # credentials from the batch's own origin rather than the retriever's
+    # current workspace: a master-key or legitimately cross-workspace retrieval
+    # would otherwise use the wrong organization's key, or find none, exactly
+    # the failure `api_key_id` going NULL on key revocation already risks for
+    # ownership. Nullable and SET NULL, not RESTRICT: batches created before
+    # this column existed carry NULL here and fall back to the caller's own
+    # workspace in `api/routes/batches.py`, and a workspace deleted out from
+    # under an in-flight batch must not block that delete.
+    workspace_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("workspace.id", ondelete="SET NULL"), index=True
+    )
     model: Mapped[str] = mapped_column()
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
     # NULL until the first completed results retrieval accounts the batch; the

--- a/src/gateway/models/provider_keys.py
+++ b/src/gateway/models/provider_keys.py
@@ -1,0 +1,334 @@
+"""Organization-scoped provider keys.
+
+Decided at otari-ai#1748: the platform's ``ProviderKey`` shape
+(organization scope, archival, one default per organization+provider,
+per-workspace pin/disable overrides, per-workspace model allow-lists) ports
+into otari as new, additive tables. ``provider_credentials`` and its
+config.yml-merge overlay (``services/provider_store_service.py``) are
+unchanged: they stay the mechanism for config.yml-defined and legacy
+deployment-global stored credentials, addressed by instance name exactly as
+before. These two mechanisms are disjoint by construction (see
+``services/provider_kwargs.py``): an ``instance:model`` selector that matches
+an existing ``config.providers`` entry never consults these tables, and a
+bare ``provider:model`` selector never consults ``config.providers`` for a
+workspace that has an org-scoped key. See mozilla-ai/otari#643.
+
+Three tables, named to avoid a collision that already exists in this
+codebase: ``ScopedBudget.provider_key_id`` (`models/entities.py`) already
+means "an instance-name string, no FK". These tables use ``org_provider_key``
+throughout so no column here is ever ambiguously named ``provider_key_id``.
+
+- ``OrgProviderKey`` (``org_provider_keys``): one BYO credential, scoped to an
+  organization. otari-ai's ``ProviderKey`` also carries a "managed/phantom"
+  bucket (a platform-hosted upstream credential with no stored ``api_key``);
+  that concept has no otari-side equivalent (managed credentials are hosted
+  depth) and is dropped entirely here, so ``is_org_default`` is one flag per
+  ``(organization_id, provider)`` rather than per bucket.
+- ``WorkspaceProviderKeyOverride`` (``workspace_provider_key_overrides``): a
+  workspace's departure from its organization's default for one key. Absence
+  of a row means full inheritance; a row pins the key as this workspace's
+  default (``is_default``), opts the workspace out of it (``disabled``), or
+  both fields are their default and the row is meaningless (the service layer
+  deletes it rather than storing a no-op).
+- ``WorkspaceProviderModelRestriction`` (``workspace_provider_model_restrictions``):
+  a per-workspace, per-key model allow-list. No rows for a
+  ``(workspace, key)`` pair means every model is allowed; one or more rows
+  narrows it to exactly those.
+
+Style follows ``models/tenancy.py``: SQLModel (not `entities.py`'s declarative
+style) because these are tenancy-scoped tables sharing its mixins and
+``UtcDateTime`` timestamp handling, and no ``relationship()`` is declared
+(lazy loading raises ``MissingGreenlet`` on an ``AsyncSession``); repositories
+join explicitly.
+
+CASCADE, not the ``RESTRICT`` default `AGENTS.md` states for a gateway table
+gaining tenancy scope, is deliberate here: these three tables are org- and
+workspace-*owned* resources, like ``organization_member``/``workspace_member``
+(CASCADE), not durable request-plane history like ``usage_logs``/``api_keys``
+(RESTRICT, so a workspace delete cannot silently take budgets or usage with
+it). A credential or its overrides have no meaning once the organization or
+workspace that owns them is gone.
+"""
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, Column, ForeignKeyConstraint, Index, UniqueConstraint, text
+from sqlmodel import Field, SQLModel
+
+from gateway.models.tenancy import CreatedAtMixin, PrimaryKeyMixin, UpdatedAtMixin, _timestamp_field
+
+# Substrings (matched case-insensitively against a client_args key) that a
+# credential-bearing field name is expected to contain. ``client_args`` is
+# arbitrary JSON, and this gateway's own Bedrock support is the reason it
+# cannot simply be rejected outright when one of these appears: standalone
+# mode's classic AWS IAM shape genuinely requires ``aws_access_key_id`` and
+# ``aws_secret_access_key`` inside ``client_args`` (any-llm-sdk's
+# ``BedrockProvider`` never forwards ``api_key`` into the boto3 client it
+# builds; see ``services/bedrock_gateway_auth.py``), so those are real
+# credentials this field is *supposed* to carry, not smuggled duplicates of
+# ``encrypted_api_key``. They still must never round-trip over the API, the
+# same treatment ``encrypted_api_key`` already gets (only ``last4`` comes
+# back); ``_redact_client_args`` is that treatment applied by key name rather
+# than by field.
+_SECRET_LOOKING_CLIENT_ARG_SUBSTRINGS = ("key", "secret", "token", "password", "authorization", "credential")
+_CLIENT_ARG_REDACTED_VALUE = "***"
+
+
+def _redact_client_args(client_args: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Mask values whose key name looks credential-shaped; pass the rest through.
+
+    Substring match, not an exact-name allow-list: an operator can name a
+    Bedrock/vertex/custom client kwarg however any-llm expects it, so a fixed
+    set of exact names would miss a variant spelling and silently leak it.
+    """
+    if client_args is None:
+        return None
+    return {
+        key: _CLIENT_ARG_REDACTED_VALUE
+        if any(marker in key.lower() for marker in _SECRET_LOOKING_CLIENT_ARG_SUBSTRINGS)
+        else value
+        for key, value in client_args.items()
+    }
+
+# ==============================================================================
+# Org provider keys
+# ==============================================================================
+
+
+class OrgProviderKeyCreateRequest(SQLModel):
+    """What a caller sends to create a key.
+
+    The plaintext key is never stored as sent: the service encrypts it
+    (`services/secret_box.py`) and keeps only the ciphertext and ``last4``,
+    the same convention `entities.ProviderCredential` already uses.
+    """
+
+    provider: str = Field(max_length=255)
+    name: str = Field(max_length=255)
+    api_key: str | None = Field(default=None)
+    api_base: str | None = Field(default=None, max_length=1024)
+    client_args: dict[str, Any] | None = None
+
+
+class OrgProviderKeyUpdateRequest(SQLModel):
+    """A partial update. Every field is optional; only what is set is applied."""
+
+    name: str | None = Field(default=None, max_length=255)
+    api_key: str | None = None
+    api_base: str | None = Field(default=None, max_length=1024)
+    client_args: dict[str, Any] | None = None
+
+
+class OrgProviderKeyPublic(SQLModel):
+    """The API-facing shape. Never carries the key, only whether one is set."""
+
+    id: uuid.UUID
+    organization_id: uuid.UUID
+    provider: str
+    name: str
+    api_base: str | None = None
+    client_args: dict[str, Any] | None = None
+    last4: str | None = None
+    is_org_default: bool
+    archived_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime | None = None
+
+
+class OrgProviderKeysPublic(SQLModel):
+    data: list[OrgProviderKeyPublic]
+    count: int
+
+
+class OrgProviderKey(SQLModel, PrimaryKeyMixin, CreatedAtMixin, UpdatedAtMixin, table=True):
+    """One organization-scoped, BYO provider credential."""
+
+    __tablename__ = "org_provider_keys"
+    __table_args__ = (
+        UniqueConstraint("organization_id", "provider", "name", name="uq_org_provider_keys_org_provider_name"),
+        # One default per (organization, provider). Enforced at the database
+        # rather than only in the service layer so a race between two
+        # concurrent "set default" calls has a real arbiter instead of a
+        # last-write-wins column; `OrgProviderKeyRepository.set_org_default`
+        # catches the resulting `IntegrityError`.
+        Index(
+            "uq_org_provider_keys_org_default",
+            "organization_id",
+            "provider",
+            unique=True,
+            postgresql_where=text("is_org_default AND archived_at IS NULL"),
+            sqlite_where=text("is_org_default AND archived_at IS NULL"),
+        ),
+        # Covers (organization_id, id) so the two link tables below can carry a
+        # composite FK to it, pinning each link row to *its own* organization
+        # rather than trusting every write path to keep that invariant.
+        UniqueConstraint("organization_id", "id", name="uq_org_provider_keys_org_id"),
+    )
+
+    organization_id: uuid.UUID = Field(foreign_key="organization.id", ondelete="CASCADE", index=True)
+    provider: str = Field(max_length=255)
+    name: str = Field(max_length=255)
+    api_base: str | None = Field(default=None, max_length=1024)
+    client_args: dict[str, Any] | None = Field(default=None, sa_column=Column(JSON, nullable=True))
+    encrypted_api_key: str | None = Field(default=None)
+    last4: str | None = Field(default=None, max_length=8)
+    # _timestamp_field, not a bare Field(default=None): PostgreSQL renders a
+    # plain ``datetime`` column as TIMESTAMP WITHOUT TIME ZONE, which asyncpg
+    # then refuses a timezone-aware value against (the same trap
+    # ``UtcDateTime``'s own docstring describes for the tenancy timestamps).
+    archived_at: datetime | None = _timestamp_field(default=None, column_kwargs={})
+    is_org_default: bool = Field(default=False, nullable=False)
+
+    def to_public(self, *, include_client_args: bool = True) -> OrgProviderKeyPublic:
+        """Serialize for the API. Never includes the key, only ``last4``.
+
+        ``client_args`` is arbitrary JSON an admin can set (Bedrock's
+        ``region_name``, other client kwargs), and a credential-shaped field
+        placed there is never echoed back either: ``_redact_client_args``
+        masks it the same way ``encrypted_api_key`` itself already stays off
+        the wire (only ``last4`` comes back). That runs regardless of
+        ``include_client_args``, which is a separate, coarser gate: it
+        defaults to included, since every write path (create/update/archive/
+        restore/set-default) is already organization owner/admin-gated, and
+        ``include_client_args=False`` is for the plain-member list read,
+        which is open to every active member, not only admins.
+        """
+        return OrgProviderKeyPublic(
+            id=self.id,
+            organization_id=self.organization_id,
+            provider=self.provider,
+            name=self.name,
+            api_base=self.api_base,
+            client_args=_redact_client_args(self.client_args) if include_client_args else None,
+            last4=self.last4,
+            is_org_default=self.is_org_default,
+            archived_at=self.archived_at,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )
+
+
+# ==============================================================================
+# Workspace overrides
+# ==============================================================================
+
+
+class WorkspaceProviderKeyOverrideRequest(SQLModel):
+    """Tri-state: an omitted field leaves that flag unchanged.
+
+    Both fields false, whether that is the merged result or a value sent
+    explicitly, is a no-op the service deletes rather than stores: absence of
+    a row already means full inheritance from the organization default.
+    Setting one true auto-resolves the other when they would otherwise
+    conflict (pinning re-enables a disabled key; disabling un-pins a pinned
+    one); sending both true explicitly is refused.
+    """
+
+    is_default: bool | None = None
+    disabled: bool | None = None
+
+
+class WorkspaceProviderKeyOverridePublic(SQLModel):
+    """The effective view for one workspace+key: raw override flags plus the resolution."""
+
+    workspace_id: uuid.UUID
+    org_provider_key_id: uuid.UUID
+    is_default: bool
+    disabled: bool
+    is_effective_default: bool
+    is_effective_enabled: bool
+
+
+class WorkspaceProviderKeyOverridesPublic(SQLModel):
+    data: list[WorkspaceProviderKeyOverridePublic]
+
+
+class WorkspaceProviderKeyOverride(SQLModel, PrimaryKeyMixin, CreatedAtMixin, UpdatedAtMixin, table=True):
+    """A workspace's departure from its organization's default for one key."""
+
+    __tablename__ = "workspace_provider_key_overrides"
+    __table_args__ = (
+        UniqueConstraint("workspace_id", "org_provider_key_id", name="uq_workspace_provider_key_overrides_ws_key"),
+        # Composite, not a plain FK on org_provider_key_id alone: pins the
+        # referenced key to *this row's own* organization_id (see
+        # `OrgProviderKey`'s matching unique constraint), so a cross-organization
+        # override (a workspace in org A pointing at org B's key) is a
+        # foreign-key violation rather than a silently-persisted row. The
+        # service layer already only ever sets `organization_id` from the
+        # workspace it resolved, so this never disagrees with a legitimate write.
+        ForeignKeyConstraint(
+            ["organization_id", "org_provider_key_id"],
+            ["org_provider_keys.organization_id", "org_provider_keys.id"],
+            ondelete="CASCADE",
+        ),
+    )
+
+    workspace_id: uuid.UUID = Field(foreign_key="workspace.id", ondelete="CASCADE", index=True)
+    # Denormalized from the workspace's own organization; see the composite FK
+    # above for why it is stored rather than joined at read time.
+    organization_id: uuid.UUID
+    org_provider_key_id: uuid.UUID = Field(index=True)
+    is_default: bool = Field(default=False, nullable=False)
+    disabled: bool = Field(default=False, nullable=False)
+
+
+# ==============================================================================
+# Workspace model restrictions
+# ==============================================================================
+
+
+class WorkspaceProviderModelRestrictionRequest(SQLModel):
+    model: str = Field(max_length=255)
+
+
+class WorkspaceProviderModelRestrictionsPublic(SQLModel):
+    models: list[str]
+
+
+class WorkspaceProviderModelRestriction(SQLModel, PrimaryKeyMixin, CreatedAtMixin, table=True):
+    """One allowed model for a workspace+key pair.
+
+    No rows for a pair means every model is allowed; this is an allow-list,
+    not a deny-list, so adding the first row narrows rather than widens.
+    """
+
+    __tablename__ = "workspace_provider_model_restrictions"
+    __table_args__ = (
+        UniqueConstraint(
+            "workspace_id",
+            "org_provider_key_id",
+            "model",
+            name="uq_workspace_provider_model_restrictions_ws_key_model",
+        ),
+        # Same reasoning as `WorkspaceProviderKeyOverride`'s matching constraint.
+        ForeignKeyConstraint(
+            ["organization_id", "org_provider_key_id"],
+            ["org_provider_keys.organization_id", "org_provider_keys.id"],
+            ondelete="CASCADE",
+        ),
+    )
+
+    workspace_id: uuid.UUID = Field(foreign_key="workspace.id", ondelete="CASCADE", index=True)
+    # Denormalized from the workspace's own organization; see the composite FK
+    # above for why it is stored rather than joined at read time.
+    organization_id: uuid.UUID
+    org_provider_key_id: uuid.UUID = Field(index=True)
+    model: str = Field(max_length=255)
+
+
+__all__ = [
+    "OrgProviderKey",
+    "OrgProviderKeyCreateRequest",
+    "OrgProviderKeyPublic",
+    "OrgProviderKeyUpdateRequest",
+    "OrgProviderKeysPublic",
+    "WorkspaceProviderKeyOverride",
+    "WorkspaceProviderKeyOverridePublic",
+    "WorkspaceProviderKeyOverrideRequest",
+    "WorkspaceProviderKeyOverridesPublic",
+    "WorkspaceProviderModelRestriction",
+    "WorkspaceProviderModelRestrictionRequest",
+    "WorkspaceProviderModelRestrictionsPublic",
+]

--- a/src/gateway/repositories/tenancy/__init__.py
+++ b/src/gateway/repositories/tenancy/__init__.py
@@ -15,17 +15,29 @@ platform's own mypy config needs.
 """
 
 from gateway.repositories.tenancy.invitation_repository import InvitationRepository
+from gateway.repositories.tenancy.org_provider_key_repository import (
+    Candidate,
+    OrgProviderKeyRepository,
+    WorkspaceProviderKeyOverrideRepository,
+    WorkspaceProviderModelRestrictionRepository,
+    resolve_active_key,
+)
 from gateway.repositories.tenancy.organization_member_repository import OrganizationMemberRepository
 from gateway.repositories.tenancy.organization_repository import OrganizationRepository
 from gateway.repositories.tenancy.user_repository import UserRepository, user_alphabetical_order
 from gateway.repositories.tenancy.workspace_repository import WorkspaceMemberRepository, WorkspaceRepository
 
 __all__ = [
+    "Candidate",
     "InvitationRepository",
+    "OrgProviderKeyRepository",
     "OrganizationMemberRepository",
     "OrganizationRepository",
     "UserRepository",
     "WorkspaceMemberRepository",
+    "WorkspaceProviderKeyOverrideRepository",
+    "WorkspaceProviderModelRestrictionRepository",
     "WorkspaceRepository",
+    "resolve_active_key",
     "user_alphabetical_order",
 ]

--- a/src/gateway/repositories/tenancy/org_provider_key_repository.py
+++ b/src/gateway/repositories/tenancy/org_provider_key_repository.py
@@ -1,0 +1,464 @@
+"""Data access for organization-scoped provider keys.
+
+Three repositories, one per table in `gateway.models.provider_keys`. Every
+column reference goes through `sqlmodel.col()` (see the package docstring).
+Precedence resolution (`resolve_active_key`) is a module-level pure function
+rather than a repository method: it takes plain in-memory data, so it is
+unit-testable with no database and reusable from
+`services/tenancy/org_provider_key_service.py`'s cache refresh, which needs
+the same three-tier logic applied across every workspace at once rather than
+one workspace at a time.
+"""
+
+import uuid
+from collections.abc import Sequence
+
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from gateway.models.provider_keys import (
+    OrgProviderKey,
+    OrgProviderKeyCreateRequest,
+    OrgProviderKeyUpdateRequest,
+    WorkspaceProviderKeyOverride,
+    WorkspaceProviderModelRestriction,
+)
+from gateway.repositories.base_repository import BaseRepository
+
+# One (key, override) pair per candidate; the override is None when the
+# workspace has never departed from inheriting this key.
+Candidate = tuple[OrgProviderKey, WorkspaceProviderKeyOverride | None]
+
+
+def resolve_active_key(candidates: Sequence[Candidate]) -> OrgProviderKey | None:
+    """Pick the key a workspace should use for one provider.
+
+    Ported from otari-ai's ``WorkspaceProviderKeyAccessRepository``, with every
+    managed/phantom-bucket branch dropped: every otari-side key is BYO, so
+    there is one tier ladder per provider rather than one per bucket.
+
+    1. A workspace-pinned default (``is_default``, not ``disabled``) wins
+       outright. At most one should exist per (workspace, provider): the
+       service clears any sibling pin before setting a new one.
+    2. Otherwise, the organization's default for this provider, unless this
+       workspace has disabled it.
+    3. Otherwise, the earliest-created key this workspace has not disabled.
+       ``candidates`` must already be ordered oldest-first for this tier to be
+       correct; callers query in that order rather than sorting here, so a
+       cache-refresh pass building many workspaces' answers from one query
+       does not re-sort per workspace.
+    """
+    enabled = [(key, override) for key, override in candidates if override is None or not override.disabled]
+
+    for key, override in enabled:
+        if override is not None and override.is_default:
+            return key
+
+    for key, _ in enabled:
+        if key.is_org_default:
+            return key
+
+    return enabled[0][0] if enabled else None
+
+
+class OrgProviderKeyRepository(
+    BaseRepository[OrgProviderKey, OrgProviderKeyCreateRequest, OrgProviderKeyUpdateRequest]
+):
+    """Repository for `org_provider_keys` rows.
+
+    Creation and update go through bespoke methods rather than the inherited
+    generic ones: the plaintext key never lands in a column, so the service
+    hands this repository an already-encrypted payload instead of the create
+    request as-is.
+    """
+
+    def __init__(self, db: AsyncSession):
+        super().__init__(db, OrgProviderKey)
+
+    async def get_in_organization(self, key_id: uuid.UUID, organization_id: uuid.UUID) -> OrgProviderKey | None:
+        """Return a key by id, scoped to the organization it must belong to.
+
+        Scoping the read rather than checking afterward is what keeps a
+        cross-organization id from being distinguishable from one that does
+        not exist at all.
+        """
+        result = await self.db.execute(
+            select(OrgProviderKey).where(
+                col(OrgProviderKey.id) == key_id,
+                col(OrgProviderKey.organization_id) == organization_id,
+            )
+        )
+        return result.scalars().first()
+
+    async def get_by_org_provider_name(
+        self,
+        *,
+        organization_id: uuid.UUID,
+        provider: str,
+        name: str,
+    ) -> OrgProviderKey | None:
+        result = await self.db.execute(
+            select(OrgProviderKey).where(
+                col(OrgProviderKey.organization_id) == organization_id,
+                col(OrgProviderKey.provider) == provider,
+                col(OrgProviderKey.name) == name,
+            )
+        )
+        return result.scalars().first()
+
+    async def list_for_organization(
+        self,
+        organization_id: uuid.UUID,
+        *,
+        include_archived: bool = False,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> tuple[Sequence[OrgProviderKey], int]:
+        """Return a page of an organization's keys, plus the total matching count.
+
+        Mirrors ``WorkspaceRepository.get_by_organization``'s shape: a
+        deployment with unbounded keys per organization would otherwise page
+        every row on every list call, and the total lets a caller page
+        correctly without a second unbounded query.
+        """
+        filters = [col(OrgProviderKey.organization_id) == organization_id]
+        if not include_archived:
+            filters.append(col(OrgProviderKey.archived_at).is_(None))
+
+        count_result = await self.db.execute(select(func.count()).select_from(OrgProviderKey).where(*filters))
+        count = count_result.scalar_one()
+
+        stmt = (
+            select(OrgProviderKey)
+            .where(*filters)
+            .order_by(col(OrgProviderKey.provider), col(OrgProviderKey.created_at), col(OrgProviderKey.id))
+            .offset(skip)
+            .limit(limit)
+        )
+        rows = (await self.db.execute(stmt)).scalars().all()
+        return rows, count
+
+    async def create_key(
+        self,
+        *,
+        organization_id: uuid.UUID,
+        provider: str,
+        name: str,
+        encrypted_api_key: str | None,
+        last4: str | None,
+        api_base: str | None,
+        client_args: dict[str, object] | None,
+    ) -> OrgProviderKey:
+        key = OrgProviderKey(
+            organization_id=organization_id,
+            provider=provider,
+            name=name,
+            encrypted_api_key=encrypted_api_key,
+            last4=last4,
+            api_base=api_base,
+            client_args=client_args,
+        )
+        self.db.add(key)
+        await self.db.flush()
+        await self.db.refresh(key)
+        return key
+
+    async def update_key(self, key: OrgProviderKey, update_data: dict[str, object]) -> OrgProviderKey:
+        key.sqlmodel_update(update_data)
+        self.db.add(key)
+        await self.db.flush()
+        await self.db.refresh(key)
+        return key
+
+    async def delete_key(self, key: OrgProviderKey) -> None:
+        """Stage a deletion. Overrides and model restrictions ride the database cascade."""
+        await self.db.delete(key)
+        await self.db.flush()
+
+    async def set_org_default(self, key: OrgProviderKey) -> OrgProviderKey:
+        """Make ``key`` the organization's default for its provider.
+
+        Clears any sibling default in the same ``(organization_id, provider)``
+        first, in the same flush, so the two writes commit atomically rather
+        than leaving a window with two (or zero) defaults visible to a
+        concurrent reader. The partial unique index
+        (``uq_org_provider_keys_org_default``) is the actual race arbiter: two
+        concurrent calls for different keys both pass this method and one
+        loses at flush/commit, which the service catches as ``IntegrityError``
+        and maps to ``OrgDefaultProviderKeyConflictError``.
+        """
+        await self.db.execute(
+            update(OrgProviderKey)
+            .where(
+                col(OrgProviderKey.organization_id) == key.organization_id,
+                col(OrgProviderKey.provider) == key.provider,
+                col(OrgProviderKey.id) != key.id,
+                col(OrgProviderKey.is_org_default).is_(True),
+            )
+            .values(is_org_default=False)
+            .execution_options(synchronize_session=False)
+        )
+        key.is_org_default = True
+        self.db.add(key)
+        await self.db.flush()
+        await self.db.refresh(key)
+        return key
+
+
+class WorkspaceProviderKeyOverrideRepository:
+    """Repository for `workspace_provider_key_overrides` rows.
+
+    Not a ``BaseRepository``: every access is keyed by the (workspace, key)
+    pair or resolves candidates across a whole provider, not by the override
+    row's own id. Pure data access, no tri-state merging or conflict
+    resolution: that business logic lives in the service, which is what
+    `BaseRepository`'s own docstring asks of every repository here.
+    """
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get(
+        self, *, workspace_id: uuid.UUID, org_provider_key_id: uuid.UUID
+    ) -> WorkspaceProviderKeyOverride | None:
+        result = await self.db.execute(
+            select(WorkspaceProviderKeyOverride).where(
+                col(WorkspaceProviderKeyOverride.workspace_id) == workspace_id,
+                col(WorkspaceProviderKeyOverride.org_provider_key_id) == org_provider_key_id,
+            )
+        )
+        return result.scalars().first()
+
+    async def create(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        organization_id: uuid.UUID,
+        org_provider_key_id: uuid.UUID,
+        is_default: bool,
+        disabled: bool,
+    ) -> WorkspaceProviderKeyOverride:
+        override = WorkspaceProviderKeyOverride(
+            workspace_id=workspace_id,
+            organization_id=organization_id,
+            org_provider_key_id=org_provider_key_id,
+            is_default=is_default,
+            disabled=disabled,
+        )
+        self.db.add(override)
+        await self.db.flush()
+        await self.db.refresh(override)
+        return override
+
+    async def update(
+        self,
+        override: WorkspaceProviderKeyOverride,
+        *,
+        is_default: bool,
+        disabled: bool,
+    ) -> WorkspaceProviderKeyOverride:
+        override.is_default = is_default
+        override.disabled = disabled
+        self.db.add(override)
+        await self.db.flush()
+        await self.db.refresh(override)
+        return override
+
+    async def delete(self, override: WorkspaceProviderKeyOverride) -> None:
+        await self.db.delete(override)
+        await self.db.flush()
+
+    async def clear_workspace_pinned_default(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        organization_id: uuid.UUID,
+        provider: str,
+        except_key_id: uuid.UUID,
+    ) -> None:
+        """Unset this workspace's pin on every *other* key of ``provider``, if any.
+
+        Called before setting a new pin, so a workspace can never hold two
+        pinned defaults for the same provider (the unique index is per
+        (workspace, key), not per (workspace, provider), so nothing at the
+        database enforces that on its own; the caller is expected to hold
+        ``WorkspaceRepository.lock(workspace_id)`` for the duration of the
+        read-clear-set sequence this is one step of, since a bare
+        conditional UPDATE cannot serialize two different keys racing to
+        become the same workspace's pin).
+
+        ``except_key_id`` excludes the key about to be (re-)pinned. Without
+        it, re-pinning a key that is already this workspace's default clears
+        its own override row via this raw UPDATE, bypassing the ORM's change
+        tracking; the caller then sets ``is_default = True`` on the very same
+        Python value it loaded, which SQLAlchemy sees as no change and skips
+        re-emitting the UPDATE, leaving the row cleared in the database while
+        the caller's in-memory object (and its API response) still say pinned.
+        """
+        await self.db.execute(
+            update(WorkspaceProviderKeyOverride)
+            .where(
+                col(WorkspaceProviderKeyOverride.workspace_id) == workspace_id,
+                col(WorkspaceProviderKeyOverride.org_provider_key_id) != except_key_id,
+                col(WorkspaceProviderKeyOverride.org_provider_key_id).in_(
+                    select(col(OrgProviderKey.id)).where(
+                        col(OrgProviderKey.organization_id) == organization_id,
+                        col(OrgProviderKey.provider) == provider,
+                    )
+                ),
+                col(WorkspaceProviderKeyOverride.is_default).is_(True),
+            )
+            .values(is_default=False)
+            .execution_options(synchronize_session=False)
+        )
+
+    async def candidates_for_provider(
+        self,
+        *,
+        organization_id: uuid.UUID,
+        provider: str,
+        workspace_id: uuid.UUID,
+    ) -> list[Candidate]:
+        """Every non-archived key of one provider in the organization, with this workspace's override.
+
+        Ordered oldest-first, which is the order `resolve_active_key`'s
+        fallback tier requires.
+        """
+        result = await self.db.execute(
+            select(OrgProviderKey, WorkspaceProviderKeyOverride)
+            .outerjoin(
+                WorkspaceProviderKeyOverride,
+                (col(WorkspaceProviderKeyOverride.org_provider_key_id) == col(OrgProviderKey.id))
+                & (col(WorkspaceProviderKeyOverride.workspace_id) == workspace_id),
+            )
+            .where(
+                col(OrgProviderKey.organization_id) == organization_id,
+                col(OrgProviderKey.provider) == provider,
+                col(OrgProviderKey.archived_at).is_(None),
+            )
+            .order_by(col(OrgProviderKey.created_at), col(OrgProviderKey.id))
+        )
+        return [(key, override) for key, override in result.all()]
+
+    async def all_candidates(
+        self,
+        *,
+        organization_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+    ) -> list[Candidate]:
+        """Every non-archived key in the organization, with this workspace's override.
+
+        Used to build the effective view across every provider at once
+        (`GET /v1/workspaces/{id}/provider-keys`) and by the dispatch-path
+        cache refresh, which needs every workspace's answer for every
+        provider in one pass rather than one query per (workspace, provider).
+        """
+        result = await self.db.execute(
+            select(OrgProviderKey, WorkspaceProviderKeyOverride)
+            .outerjoin(
+                WorkspaceProviderKeyOverride,
+                (col(WorkspaceProviderKeyOverride.org_provider_key_id) == col(OrgProviderKey.id))
+                & (col(WorkspaceProviderKeyOverride.workspace_id) == workspace_id),
+            )
+            .where(
+                col(OrgProviderKey.organization_id) == organization_id,
+                col(OrgProviderKey.archived_at).is_(None),
+            )
+            .order_by(col(OrgProviderKey.provider), col(OrgProviderKey.created_at), col(OrgProviderKey.id))
+        )
+        return [(key, override) for key, override in result.all()]
+
+    async def get_active_key_for_workspace_provider(
+        self,
+        *,
+        organization_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        provider: str,
+    ) -> OrgProviderKey | None:
+        candidates = await self.candidates_for_provider(
+            organization_id=organization_id,
+            provider=provider,
+            workspace_id=workspace_id,
+        )
+        return resolve_active_key(candidates)
+
+
+class WorkspaceProviderModelRestrictionRepository:
+    """Repository for `workspace_provider_model_restrictions` rows."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def list_for_workspace_key(self, *, workspace_id: uuid.UUID, org_provider_key_id: uuid.UUID) -> list[str]:
+        result = await self.db.execute(
+            select(col(WorkspaceProviderModelRestriction.model))
+            .where(
+                col(WorkspaceProviderModelRestriction.workspace_id) == workspace_id,
+                col(WorkspaceProviderModelRestriction.org_provider_key_id) == org_provider_key_id,
+            )
+            .order_by(col(WorkspaceProviderModelRestriction.model))
+        )
+        return list(result.scalars().all())
+
+    async def get(
+        self, *, workspace_id: uuid.UUID, org_provider_key_id: uuid.UUID, model: str
+    ) -> WorkspaceProviderModelRestriction | None:
+        result = await self.db.execute(
+            select(WorkspaceProviderModelRestriction).where(
+                col(WorkspaceProviderModelRestriction.workspace_id) == workspace_id,
+                col(WorkspaceProviderModelRestriction.org_provider_key_id) == org_provider_key_id,
+                col(WorkspaceProviderModelRestriction.model) == model,
+            )
+        )
+        return result.scalars().first()
+
+    async def add(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        organization_id: uuid.UUID,
+        org_provider_key_id: uuid.UUID,
+        model: str,
+    ) -> WorkspaceProviderModelRestriction:
+        restriction = WorkspaceProviderModelRestriction(
+            workspace_id=workspace_id,
+            organization_id=organization_id,
+            org_provider_key_id=org_provider_key_id,
+            model=model,
+        )
+        self.db.add(restriction)
+        await self.db.flush()
+        await self.db.refresh(restriction)
+        return restriction
+
+    async def remove(self, restriction: WorkspaceProviderModelRestriction) -> None:
+        await self.db.delete(restriction)
+        await self.db.flush()
+
+    async def delete_for_workspace_key(self, *, workspace_id: uuid.UUID, org_provider_key_id: uuid.UUID) -> None:
+        """Drop every restriction a workspace holds for one key.
+
+        Called when a workspace disables that key: a restriction on a key the
+        workspace can no longer use is meaningless, and leaving it behind
+        would resurface as soon as the key was re-enabled with a stale list
+        nobody chose at that point.
+        """
+        await self.db.execute(
+            delete(WorkspaceProviderModelRestriction)
+            .where(
+                col(WorkspaceProviderModelRestriction.workspace_id) == workspace_id,
+                col(WorkspaceProviderModelRestriction.org_provider_key_id) == org_provider_key_id,
+            )
+            .execution_options(synchronize_session=False)
+        )
+        await self.db.flush()
+
+
+__all__ = [
+    "Candidate",
+    "OrgProviderKeyRepository",
+    "WorkspaceProviderKeyOverrideRepository",
+    "WorkspaceProviderModelRestrictionRepository",
+    "resolve_active_key",
+]

--- a/src/gateway/repositories/tenancy/workspace_repository.py
+++ b/src/gateway/repositories/tenancy/workspace_repository.py
@@ -26,6 +26,34 @@ class WorkspaceRepository(BaseRepository[Workspace, WorkspaceCreate, WorkspaceUp
     def __init__(self, db: AsyncSession):
         super().__init__(db, Workspace)
 
+    async def lock(self, workspace_id: uuid.UUID) -> None:
+        """Take a row lock on the workspace, serializing what is read and written against it.
+
+        Mirrors ``OrganizationRepository.lock``: a writer that reads several of
+        a workspace's own rows, decides something from their combined state,
+        and writes based on that decision needs the whole read-decide-write
+        sequence to run as if serialized, which no single row's unique index
+        can enforce on its own. Two independent races share this lock:
+
+        - "At most one pinned provider-key override per workspace+provider"
+          spans a variable set of override rows, one per candidate key.
+        - A budget default's creation reads the workspace's current members
+          before materializing, and a concurrent membership-creation path
+          reads the workspace's current defaults before materializing the new
+          member; without a shared lock both transactions can run their read
+          before either commits its write, and the member who joined right
+          around the default's creation gets neither's ceiling. Every
+          membership-creation path (``WorkspaceService.create_workspace``
+          excepted, since a just-created workspace has no default that could
+          race it) takes this same lock before its own read, so the two either
+          serialize or, for ``create_workspace``, never overlap.
+
+        ``FOR UPDATE`` is a no-op on SQLite, which admits one writer at a time
+        for the whole database anyway; PostgreSQL is where this is
+        load-bearing.
+        """
+        await self.db.execute(select(col(Workspace.id)).where(col(Workspace.id) == workspace_id).with_for_update())
+
     async def get_by_ids(self, workspace_ids: Collection[uuid.UUID]) -> Sequence[Workspace]:
         """Return the workspaces named by a batch of ids (order unspecified).
 
@@ -36,26 +64,6 @@ class WorkspaceRepository(BaseRepository[Workspace, WorkspaceCreate, WorkspaceUp
             return []
         result = await self.db.execute(select(Workspace).where(col(Workspace.id).in_(list(workspace_ids))))
         return list(result.scalars().all())
-
-    async def lock(self, workspace_id: uuid.UUID) -> None:
-        """Take a row lock on the workspace, serializing what is read against it.
-
-        Mirrors ``OrganizationRepository.lock``. What it serializes here: a
-        budget default's creation reads the workspace's current members before
-        materializing, and a concurrent membership-creation path reads the
-        workspace's current defaults before materializing the new member;
-        without a shared lock both transactions can run their read before
-        either commits its write, and the member who joined right around the
-        default's creation gets neither's ceiling. Every membership-creation
-        path (``WorkspaceService.create_workspace`` excepted, since a
-        just-created workspace has no default that could race it) takes this
-        same lock before its own read, so the two either serialize or, for
-        ``create_workspace``, never overlap.
-
-        ``FOR UPDATE`` is a no-op on SQLite; see the organization lock's own
-        note on why that is fine.
-        """
-        await self.db.execute(select(col(Workspace.id)).where(col(Workspace.id) == workspace_id).with_for_update())
 
     async def get_by_organization(
         self,

--- a/src/gateway/services/batch_service.py
+++ b/src/gateway/services/batch_service.py
@@ -18,6 +18,7 @@ from gateway.log_config import logger
 from gateway.models.entities import BatchRecord
 
 if TYPE_CHECKING:
+    import uuid
     from collections.abc import Iterable
 
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -31,12 +32,17 @@ async def record_batch(
     user_id: str,
     api_key_id: str | None,
     model: str,
+    workspace_id: uuid.UUID | None = None,
 ) -> None:
     """Persist an ownership record for a newly created batch.
 
     Best-effort: the provider has already accepted the batch, so a failure to
     persist the record must not fail the request. Ownership then degrades to the
     metadata-anchored fallback (the ``otari_user_id`` marker) for that batch.
+
+    ``workspace_id`` anchors which workspace's organization-scoped provider key
+    (otari#643) later lifecycle calls (retrieve/cancel/results) should resolve
+    credentials from, rather than the retriever's own current workspace.
     """
     db.add(
         BatchRecord(
@@ -45,6 +51,7 @@ async def record_batch(
             user_id=user_id,
             api_key_id=api_key_id,
             model=model,
+            workspace_id=workspace_id,
         )
     )
     try:

--- a/src/gateway/services/provider_kwargs.py
+++ b/src/gateway/services/provider_kwargs.py
@@ -7,9 +7,25 @@ budgeting, and usage logs are keyed on, while the *implementation* is what
 any-llm is actually dispatched against. When an instance name is itself a real
 any-llm provider (the common case, no ``provider_type`` declared), the two
 coincide and behavior is identical to splitting the selector directly.
+
+**Organization-scoped provider keys** (otari-ai#1748, otari#643) are a second,
+disjoint credential source, consulted only when ``workspace_id`` is passed and
+only for a *bare* ``provider:model``/``provider/model`` selector, i.e. one with
+no matching ``config.providers`` instance. An ``instance:model`` selector
+always resolves through ``config.providers`` exactly as before and never
+touches organization-scoped keys, by construction: the two addressing schemes
+occupy disjoint selector shapes rather than one layering over the other. See
+``services/tenancy/org_provider_key_service.py`` for the overlay this reads.
+
+``workspace_id`` is per-request, not per-deployment: which organization's keys
+a master-key request's bare selector can reach is the default workspace's
+organization, not every organization the gateway holds. See
+``services/workspace_scope.py`` for why a master-key request resolves to that
+one workspace at all.
 """
 
 import os
+import uuid
 from dataclasses import dataclass
 from typing import Any
 
@@ -20,6 +36,7 @@ from gateway.auth.vertex_auth import setup_vertex_environment
 from gateway.core.config import GatewayConfig, provider_credential_env_names
 from gateway.services.alias_service import resolve_effective_alias
 from gateway.services.policy_store import resolve_effective_policy
+from gateway.services.tenancy.org_provider_key_service import cached_org_provider_kwargs
 
 # Keys that describe an instance to otari but are not credentials any-llm
 # understands, so they must be stripped before the provider call.
@@ -66,6 +83,8 @@ def get_provider_kwargs(
     config: GatewayConfig,
     provider: LLMProvider,
     instance: str | None = None,
+    *,
+    workspace_id: uuid.UUID | None = None,
 ) -> dict[str, Any]:
     """Get provider kwargs from config for any-llm calls.
 
@@ -76,6 +95,10 @@ def get_provider_kwargs(
         instance: Configured instance name to read credentials from. Defaults to
             ``provider.value`` so existing call sites that key by implementation
             keep working unchanged.
+        workspace_id: The requesting workspace, if any. Consulted only as a
+            fallback, when no ``config.providers`` entry answers ``lookup``:
+            organization-scoped keys never shadow an instance or config.yml
+            provider, they only fill the gap when neither exists.
 
     Returns:
         Dictionary of provider kwargs (credentials, client_args, etc.) with the
@@ -85,6 +108,8 @@ def get_provider_kwargs(
     lookup = instance if instance is not None else provider.value
     kwargs: dict[str, Any] = {}
     raw_config = config.providers.get(lookup)
+    if raw_config is None and workspace_id is not None:
+        raw_config = cached_org_provider_kwargs(workspace_id, provider.value)
     if raw_config is not None:
         provider_config = {k: v for k, v in raw_config.items() if k not in _INSTANCE_META_KEYS}
 
@@ -170,14 +195,21 @@ def split_selector(model_selector: str) -> tuple[str, str] | None:
 
 
 def resolve_provider_selector(
-    config: GatewayConfig, model_selector: str, user_id: str | None = None
+    config: GatewayConfig,
+    model_selector: str,
+    user_id: str | None = None,
+    *,
+    workspace_id: uuid.UUID | None = None,
 ) -> ResolvedProvider:
     """Resolve a request model selector into instance, implementation, and kwargs.
 
     A selector whose prefix names a configured instance resolves to that
     instance's ``provider_type`` (defaulting to the instance name). Otherwise the
     selector is split by any-llm directly, so unconfigured selectors and the
-    legacy ``provider/model`` form keep working exactly as before.
+    legacy ``provider/model`` form keep working exactly as before, and it is
+    this bare-selector branch alone that ``workspace_id`` reaches: an
+    instance-addressed selector never consults organization-scoped keys (see
+    the module docstring).
 
     A selector that names an alias, whether from ``config.yml`` or the
     ``model_aliases`` table, is first substituted with the alias target, then
@@ -188,7 +220,9 @@ def resolve_provider_selector(
     user's target. Omit it only for a selector that is not caller input (the
     operator-configured vision describe model), which is global by definition;
     omitting it for a request selector would silently ignore the caller's own
-    aliases and resolve the global one instead.
+    aliases and resolve the global one instead. ``workspace_id`` is the same
+    kind of omission: pass it for caller input, leave it unset for an
+    operator-configured or otherwise workspace-less resolution.
 
     Raises ``ValueError`` / ``AnyLLMError`` (from any-llm) for a selector that
     names neither a configured instance nor a known provider, mirroring the
@@ -230,7 +264,7 @@ def resolve_provider_selector(
         instance=provider.value,
         provider=provider,
         model=model,
-        kwargs=get_provider_kwargs(config, provider, instance=provider.value),
+        kwargs=get_provider_kwargs(config, provider, instance=provider.value, workspace_id=workspace_id),
         alias=model_selector if alias is not None else None,
     )
 

--- a/src/gateway/services/routing/compiler.py
+++ b/src/gateway/services/routing/compiler.py
@@ -24,6 +24,7 @@ silently compiled down to one attempt is the failure mode this exists to prevent
 
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass, field
 
 from any_llm.exceptions import AnyLLMError
@@ -34,6 +35,7 @@ from gateway.models.guardrails import GuardrailConfig
 from gateway.models.routing import MAX_CANDIDATES, PolicySpec, WhenClause
 from gateway.services.model_access import is_model_allowed
 from gateway.services.provider_kwargs import resolve_provider_selector
+from gateway.services.tenancy.org_provider_key_service import cached_org_model_restriction
 from gateway.types.attempt import Attempt
 from gateway.types.budget_state import BudgetState
 
@@ -260,6 +262,7 @@ def compile_policy(
     allowlist: list[str] | None = None,
     budget: BudgetState | None = None,
     router_ordering: RouterOrdering | None = None,
+    workspace_id: uuid.UUID | None = None,
 ) -> CompiledPlan:
     """Turn ``spec`` into an ordered plan for one request.
 
@@ -272,6 +275,12 @@ def compile_policy(
     request; see :class:`RouterOrdering` for why it arrives as an argument. Omit
     it and a policy with a router compiles to its default target, which is what
     every synchronous surface (``explain``, the CLI) shows.
+
+    ``workspace_id`` reaches ``resolve_provider_selector`` unchanged: it is a
+    zero-I/O cache read (see that function), not a database call, so passing it
+    here does not compromise this function's own "no DB and no I/O" contract.
+    ``explain`` and the CLI omit it, which only affects a bare candidate
+    selector with no matching ``config.providers`` instance.
 
     Raises :class:`NoEligibleCandidatesError` when nothing survives. That error
     derives its own status from why the candidates went: 403 when access rules
@@ -297,7 +306,7 @@ def compile_policy(
 
     for selector, selection_reason in ordered:
         try:
-            resolved = resolve_provider_selector(config, selector)
+            resolved = resolve_provider_selector(config, selector, workspace_id=workspace_id)
         except (ValueError, AnyLLMError) as exc:
             # Startup validation rejects an unresolvable selector, so reaching
             # this means the provider set changed under a running gateway.
@@ -315,6 +324,24 @@ def compile_policy(
                 DroppedCandidate(selector, "not_allowed", "is not in allowed_models for this caller")
             )
             continue
+        # Organization-scoped model restriction (otari#643), same disjointness
+        # condition `provider_kwargs.get_provider_kwargs` uses: only a selector
+        # that named no configured instance can have resolved through an
+        # organization key, so only that case is subject to its restriction.
+        # Every candidate is checked here, not only the plan's head, so a
+        # `router`/`on_failure` fallover cannot serve a model the workspace's
+        # organization key excludes just because the head candidate passed.
+        if workspace_id is not None and resolved.instance not in config.providers:
+            org_allowlist = cached_org_model_restriction(workspace_id, resolved.provider.value)
+            if org_allowlist is not None and resolved.model not in org_allowlist:
+                dropped.append(
+                    DroppedCandidate(
+                        selector,
+                        "not_allowed",
+                        "is not in this workspace's organization-key model allow-list",
+                    )
+                )
+                continue
         if len(attempts) >= MAX_CANDIDATES:
             dropped.append(
                 DroppedCandidate(selector, "over_cap", f"exceeds the {MAX_CANDIDATES}-candidate cap")

--- a/src/gateway/services/tenancy/__init__.py
+++ b/src/gateway/services/tenancy/__init__.py
@@ -5,11 +5,13 @@ provisioning that gives a standalone deployment an identity to act as. The route
 files under `gateway.api.routes` stay thin composition over these services.
 """
 
+from gateway.services.tenancy.org_provider_key_service import OrgProviderKeyService
 from gateway.services.tenancy.organization_service import OrganizationService
 from gateway.services.tenancy.provisioning_service import ensure_bootstrap_identity
 from gateway.services.tenancy.workspace_service import WorkspaceService
 
 __all__ = [
+    "OrgProviderKeyService",
     "OrganizationService",
     "WorkspaceService",
     "ensure_bootstrap_identity",

--- a/src/gateway/services/tenancy/authorization.py
+++ b/src/gateway/services/tenancy/authorization.py
@@ -86,7 +86,14 @@ async def require_workspace_management_access(
     workspace: Workspace,
     organizations: OrganizationService,
 ) -> None:
-    """Allow a superuser, an organization owner/admin, or an owner/admin of this workspace."""
+    """Allow a superuser, an organization owner/admin, or an owner/admin of this workspace.
+
+    The superuser arm is what makes this agree with the two checks either side
+    of it: ``resolve_visible_workspace`` grants a superuser read on every
+    workspace, and organization-level management access grants them
+    organization management, so without it a superuser could delete a
+    workspace but not rename it.
+    """
     if user.is_superuser:
         return
 

--- a/src/gateway/services/tenancy/errors.py
+++ b/src/gateway/services/tenancy/errors.py
@@ -195,9 +195,131 @@ class LastWorkspaceError(TenancyValidationError):
     """Deleting this workspace would leave the organization without one."""
 
     def __init__(self) -> None:
-        super().__init__(
-            "An organization keeps at least one workspace; create another before deleting this one"
-        )
+        super().__init__("An organization keeps at least one workspace; create another before deleting this one")
+
+
+class OrgProviderKeyNotFoundError(TenancyNotFoundError):
+    def __init__(self, key_id: object):
+        super().__init__(f"Provider key {key_id} not found")
+
+
+class OrgProviderKeyNameRequiredError(TenancyValidationError):
+    """A key name that is absent, null, or blank once trimmed.
+
+    ``OrgProviderKey.name`` is NOT NULL, and ``OrgProviderKeyUpdateRequest``
+    types it as nullable so a client can send an explicit ``null``, the same
+    shape ``WorkspaceNameRequiredError`` guards against for a workspace. Left
+    unguarded, an explicit ``null`` reaches the database as a NOT NULL
+    violation, which the surrounding duplicate-name handling then reports as a
+    409 naming a key called "None" rather than the 400 this is.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("A provider key name is required")
+
+
+class OrgProviderKeyUnknownProviderError(TenancyValidationError):
+    """A ``provider`` that is blank, or does not resolve to a known any-llm implementation.
+
+    ``OrgProviderKey.provider`` is stored verbatim and is exactly the string
+    ``cached_org_provider_kwargs`` keys its cache on, matched against a
+    resolved selector's ``LLMProvider.value`` at dispatch (see
+    ``org_provider_key_service.refresh_org_provider_cache``). Left unguarded,
+    a typo, unexpected casing, or an unaliased value (``"OpenAI"``,
+    ``"azure-openai"``, trailing whitespace) is accepted with a 201 and then
+    never resolves at dispatch, with no error at either point. Mirrors
+    ``/v1/provider-credentials``'s ``_validate_instance`` provider_type guard,
+    including ``PROVIDER_TYPE_ALIASES`` so an aliased name still resolves.
+    """
+
+    def __init__(self, provider: str) -> None:
+        if not provider:
+            super().__init__("A provider is required")
+        else:
+            super().__init__(f"'{provider}' is not a known provider implementation")
+
+
+class OrgProviderKeyUnsafeApiBaseError(TenancyValidationError):
+    """An ``api_base`` that resolves to an internal address, gated off.
+
+    Wraps ``services.url_safety.UnsafeURLError`` as a tenancy error so the
+    route stays thin; the message is that function's own, which already
+    carries no more than the host it refused.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+class OrgProviderKeyAlreadyExistsError(TenancyConflictError):
+    def __init__(self, provider: str, name: str):
+        super().__init__(f"A '{provider}' key named '{name}' already exists in this organization")
+
+
+class OrgProviderKeyArchivedError(TenancyValidationError):
+    """The key is archived, which refuses every mutation except restore."""
+
+    def __init__(self, key_id: object):
+        super().__init__(f"Provider key {key_id} is archived; restore it before changing it")
+
+
+class OrgProviderKeyNotArchivedError(TenancyValidationError):
+    """Deletion requires archiving first, the same two-step every irreversible action here takes."""
+
+    def __init__(self, key_id: object):
+        super().__init__(f"Provider key {key_id} must be archived before it can be deleted")
+
+
+class OrgDefaultProviderKeyConflictError(TenancyConflictError):
+    """Two concurrent 'set default' calls raced for the same (organization, provider).
+
+    The partial unique index (``uq_org_provider_keys_org_default``) is the
+    actual arbiter; this is what the loser's ``IntegrityError`` is mapped to.
+    """
+
+    def __init__(self, provider: str) -> None:
+        super().__init__(f"Another request just changed the default '{provider}' key; retry")
+
+
+class OrgProviderKeyDisabledForWorkspaceError(TenancyValidationError):
+    """A model restriction was requested for a key this workspace has disabled.
+
+    Refused rather than stored: a restriction on a key the workspace cannot
+    use anyway would resurface with a stale list if the key were re-enabled
+    later, which `set_workspace_override_for_user` already deletes for the
+    opposite transition (see the repository docstring on the cascade).
+    """
+
+    def __init__(self) -> None:
+        super().__init__("This provider key is disabled for the workspace; enable it before restricting its models")
+
+
+class WorkspaceProviderKeyOverrideConflictError(TenancyValidationError):
+    """A caller asked to pin and disable the same key in the same request.
+
+    Sending one flag lets the other auto-resolve (pinning re-enables a
+    disabled key, disabling un-pins a pinned one); sending both explicitly
+    true is a contradiction with no safe default to pick.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("A provider key override cannot be both pinned as default and disabled")
+
+
+class SecretBoxUnavailableTenancyError(TenancyError):
+    """`OTARI_SECRET_KEY` is not configured, so a provider key cannot be stored.
+
+    Wraps `services.secret_box.SecretBoxUnavailableError` as a tenancy error so
+    the route stays thin (see the module docstring): the underlying error
+    carries no key material, and neither does this one. A 500, not the 400 a
+    `TenancyValidationError` would carry: the caller sent a well-formed
+    request, and a missing secret key is a deployment configuration gap the
+    caller cannot fix. Blaming the client here would also keep the condition
+    out of 5xx error-rate alerting, which is exactly the audience that can.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("OTARI_SECRET_KEY is not set; it is required to store provider credentials")
 
 
 # The two below are pricing errors in a tenancy module, because the status
@@ -281,12 +403,22 @@ __all__ = [
     "MembershipUpdateError",
     "NotAnOrganizationMemberError",
     "NotAuthorizedError",
+    "OrgDefaultProviderKeyConflictError",
+    "OrgProviderKeyAlreadyExistsError",
+    "OrgProviderKeyArchivedError",
+    "OrgProviderKeyDisabledForWorkspaceError",
+    "OrgProviderKeyNameRequiredError",
+    "OrgProviderKeyNotArchivedError",
+    "OrgProviderKeyNotFoundError",
+    "OrgProviderKeyUnknownProviderError",
+    "OrgProviderKeyUnsafeApiBaseError",
     "OrganizationMemberAlreadyExistsError",
     "OrganizationMemberNotFoundError",
     "OrganizationNameRequiredError",
     "OrganizationNotFoundError",
     "OrganizationPricingNotFoundError",
     "OrganizationPricingOverlapError",
+    "SecretBoxUnavailableTenancyError",
     "TenancyConflictError",
     "TenancyError",
     "TenancyForbiddenError",
@@ -300,4 +432,5 @@ __all__ = [
     "WorkspaceMemberNotFoundError",
     "WorkspaceNameRequiredError",
     "WorkspaceNotFoundError",
+    "WorkspaceProviderKeyOverrideConflictError",
 ]

--- a/src/gateway/services/tenancy/org_provider_key_service.py
+++ b/src/gateway/services/tenancy/org_provider_key_service.py
@@ -1,0 +1,802 @@
+"""Organization-scoped provider keys: CRUD, defaults, overrides, and the dispatch overlay.
+
+Decided at otari-ai#1748: `org_provider_keys` and its two override
+tables are the source of truth for organization-scoped BYO provider
+credentials (see `gateway.models.provider_keys`). This module is kept
+separate from `services/provider_store_service.py` on purpose, so that
+module's config.yml-merge overlay for instance-keyed, deployment-global
+credentials stays completely untouched: the two mechanisms are disjoint by
+construction (see `services/provider_kwargs.py`), not layered on top of each
+other.
+
+**Authorization and CRUD** follow `organization_service.py`/
+`workspace_service.py`'s conventions exactly: a `*_for_user` method resolves
+the caller's organization or workspace and its own management-role check
+before touching a row, and every route stays thin. Workspace resolution and
+the workspace-management check both go through `services.tenancy.authorization`
+directly (`resolve_visible_workspace`, `require_workspace_management_access`)
+rather than through `WorkspaceService`, the same shared entry point
+`WorkspaceBudgetDefaultService` uses and `WorkspaceService` itself delegates
+to internally. Reading is open to any active member; every mutation on the
+organization surface needs an organization owner/admin, and every mutation on
+a workspace's override or model restrictions needs an organization
+owner/admin *or* an owner/admin of that workspace.
+
+**The dispatch overlay** mirrors `provider_store_service.py`'s shape one for
+one: a module-global, process-wide cache refreshed on a TTL and immediately
+on write, because the completion dispatch path is synchronous and holds no
+database session (see `services/provider_kwargs.py`). The one real
+difference is the cache's key: `provider_store_service` keys by instance name
+alone, because a deployment has one credential per instance; this keys by
+`(workspace_id, provider)`, because a workspace resolves to a *different*
+key depending on that workspace's own pin, its organization's default, and
+its organization's oldest key, in that order (`resolve_active_key`). One
+global refresh reloads every organization in one pass rather than one query
+per organization, per otari-ai#1748's second sub-question: the expected row
+count (provider keys across a whole self-hosted deployment) stays small
+enough that sharding the refresh by organization would add complexity for no
+benefit.
+"""
+
+import asyncio
+import time
+import uuid
+from collections import defaultdict
+from datetime import UTC, datetime
+from typing import Any
+
+from any_llm import LLMProvider
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from gateway.core.config import PROVIDER_TYPE_ALIASES
+from gateway.core.database import create_session
+from gateway.log_config import logger
+from gateway.models.provider_keys import (
+    OrgProviderKey,
+    OrgProviderKeyCreateRequest,
+    OrgProviderKeyPublic,
+    OrgProviderKeysPublic,
+    OrgProviderKeyUpdateRequest,
+    WorkspaceProviderKeyOverride,
+    WorkspaceProviderKeyOverridePublic,
+    WorkspaceProviderKeyOverrideRequest,
+    WorkspaceProviderKeyOverridesPublic,
+    WorkspaceProviderModelRestriction,
+    WorkspaceProviderModelRestrictionsPublic,
+)
+from gateway.models.tenancy import MANAGEMENT_ROLES, User, Workspace
+from gateway.repositories.tenancy import (
+    Candidate,
+    OrgProviderKeyRepository,
+    WorkspaceProviderKeyOverrideRepository,
+    WorkspaceProviderModelRestrictionRepository,
+    WorkspaceRepository,
+    resolve_active_key,
+)
+from gateway.services.secret_box import (
+    SecretBoxUnavailableError,
+    SecretDecryptionError,
+    decrypt_secret,
+    encrypt_secret,
+)
+from gateway.services.tenancy import authorization
+from gateway.services.tenancy.errors import (
+    OrgDefaultProviderKeyConflictError,
+    OrgProviderKeyAlreadyExistsError,
+    OrgProviderKeyArchivedError,
+    OrgProviderKeyDisabledForWorkspaceError,
+    OrgProviderKeyNameRequiredError,
+    OrgProviderKeyNotArchivedError,
+    OrgProviderKeyNotFoundError,
+    OrgProviderKeyUnknownProviderError,
+    OrgProviderKeyUnsafeApiBaseError,
+    SecretBoxUnavailableTenancyError,
+    WorkspaceProviderKeyOverrideConflictError,
+)
+from gateway.services.tenancy.organization_service import OrganizationService
+from gateway.services.url_safety import UnsafeURLError, validate_provider_api_base
+
+# Same value as provider_store_service.PROVIDER_CACHE_TTL_SECONDS, defined
+# separately: the two overlays are independent mechanisms (see module
+# docstring) and sharing a constant would imply a coupling that does not
+# exist.
+ORG_PROVIDER_CACHE_TTL_SECONDS = 30.0
+
+# (workspace_id, provider) -> decrypted overlay entry, shaped like a
+# config.providers value (api_key, api_base, client_args).
+_org_cache: dict[tuple[uuid.UUID, str], dict[str, Any]] = {}
+# (workspace_id, provider) -> the active key's model allow-list for that
+# workspace. Absent = unrestricted (either no restriction rows exist, or no
+# key resolved at all); present-and-empty is unreachable (an empty
+# restriction set is stored as "no rows", not a row-less deny-all).
+_org_model_restrictions: dict[tuple[uuid.UUID, str], list[str]] = {}
+_org_cached_at: float | None = None
+
+
+def _row_to_entry(key: OrgProviderKey) -> dict[str, Any]:
+    """Build a config.providers-shaped overlay entry from a stored key.
+
+    Raises ``SecretBoxUnavailableError`` / ``SecretDecryptionError`` when the
+    key cannot be decrypted; the caller decides whether to skip it.
+    """
+    entry: dict[str, Any] = {}
+    if key.api_base:
+        entry["api_base"] = key.api_base
+    if key.client_args:
+        entry["client_args"] = dict(key.client_args)
+    if key.encrypted_api_key:
+        entry["api_key"] = decrypt_secret(key.encrypted_api_key)
+    return entry
+
+
+def cached_org_provider_kwargs(workspace_id: uuid.UUID, provider: str) -> dict[str, Any] | None:
+    """The decrypted overlay entry this worker last loaded for this workspace+provider, if any."""
+    entry = _org_cache.get((workspace_id, provider))
+    return dict(entry) if entry is not None else None
+
+
+def cached_org_model_restriction(workspace_id: uuid.UUID, provider: str) -> list[str] | None:
+    """The active key's model allow-list for this workspace+provider, or ``None`` if unrestricted.
+
+    Same convention `services.model_access.is_model_allowed` already uses for
+    a caller's own allow-list: ``None`` means every model is permitted, a
+    (non-empty) list narrows it. A workspace that has never restricted this
+    key's models, or for which no organization-scoped key resolved at all,
+    reads as ``None`` either way; the caller only reaches this when it
+    already knows a key resolved (see `provider_kwargs.cached_org_provider_kwargs`).
+
+    This is an access-control input, not only a credential cache: tightening
+    an allow-list takes up to `ORG_PROVIDER_CACHE_TTL_SECONDS` to reach a
+    sibling worker or replica, which keeps serving the wider list until its
+    own refresh runs. The credential (`cached_org_provider_kwargs`) and the
+    allow-list are also two separate reads on the request path with no shared
+    snapshot between them, so a refresh landing in between can pair one key's
+    credential with a different key's (now-current) list for one request.
+    Neither is unbounded (the TTL caps the staleness window, and the pairing
+    mismatch is one request, not a standing state), but a caller relying on a
+    just-narrowed allow-list to take effect everywhere, immediately, is
+    relying on a guarantee this cache does not make.
+    """
+    return _org_model_restrictions.get((workspace_id, provider))
+
+
+def org_cache_is_stale(ttl: float = ORG_PROVIDER_CACHE_TTL_SECONDS) -> bool:
+    """Whether the cache has never been loaded or has outlived ``ttl``."""
+    return _org_cached_at is None or (time.monotonic() - _org_cached_at) >= ttl
+
+
+def reset_org_provider_cache() -> None:
+    """Drop the overlay cache so the next load starts clean (startup, tests)."""
+    global _org_cached_at  # noqa: PLW0603
+
+    _org_cache.clear()
+    _org_model_restrictions.clear()
+    _org_cached_at = None
+
+
+async def refresh_org_provider_cache(db: AsyncSession) -> None:
+    """Reload every organization's effective key per (workspace, provider) in one pass.
+
+    Four queries total, independent of how many organizations or workspaces
+    exist: every workspace's organization, every non-archived key, every
+    override, and every model restriction. The precedence tiers
+    (`resolve_active_key`) are then applied in Python once per (workspace,
+    provider) pair that actually has a key, not once per workspace times
+    every provider that exists anywhere.
+    """
+    global _org_cached_at  # noqa: PLW0603
+
+    workspace_orgs = (await db.execute(select(col(Workspace.id), col(Workspace.organization_id)))).all()
+    keys = (
+        (
+            await db.execute(
+                select(OrgProviderKey)
+                .where(col(OrgProviderKey.archived_at).is_(None))
+                .order_by(col(OrgProviderKey.created_at), col(OrgProviderKey.id))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    overrides = (await db.execute(select(WorkspaceProviderKeyOverride))).scalars().all()
+    restrictions = (await db.execute(select(WorkspaceProviderModelRestriction))).scalars().all()
+
+    keys_by_org_provider: dict[tuple[uuid.UUID, str], list[OrgProviderKey]] = defaultdict(list)
+    providers_by_org: dict[uuid.UUID, set[str]] = defaultdict(set)
+    for key in keys:
+        keys_by_org_provider[(key.organization_id, key.provider)].append(key)
+        providers_by_org[key.organization_id].add(key.provider)
+
+    override_by_workspace_key = {(o.workspace_id, o.org_provider_key_id): o for o in overrides}
+
+    models_by_workspace_key: dict[tuple[uuid.UUID, uuid.UUID], list[str]] = defaultdict(list)
+    for restriction in restrictions:
+        models_by_workspace_key[(restriction.workspace_id, restriction.org_provider_key_id)].append(restriction.model)
+
+    new_cache: dict[tuple[uuid.UUID, str], dict[str, Any]] = {}
+    new_restrictions: dict[tuple[uuid.UUID, str], list[str]] = {}
+    for workspace_id, organization_id in workspace_orgs:
+        for provider in providers_by_org.get(organization_id, ()):
+            candidates: list[Candidate] = [
+                (key, override_by_workspace_key.get((workspace_id, key.id)))
+                for key in keys_by_org_provider[(organization_id, provider)]
+            ]
+            active = resolve_active_key(candidates)
+            if active is None:
+                continue
+            try:
+                new_cache[(workspace_id, provider)] = _row_to_entry(active)
+            except (SecretBoxUnavailableError, SecretDecryptionError):
+                logger.warning(
+                    "Skipping organization provider key '%s' (%s) for workspace %s: "
+                    "its API key could not be decrypted (check OTARI_SECRET_KEY).",
+                    active.name,
+                    provider,
+                    workspace_id,
+                )
+                continue
+            allowed_models = models_by_workspace_key.get((workspace_id, active.id))
+            if allowed_models:
+                new_restrictions[(workspace_id, provider)] = allowed_models
+
+    _org_cache.clear()
+    _org_cache.update(new_cache)
+    _org_model_restrictions.clear()
+    _org_model_restrictions.update(new_restrictions)
+    _org_cached_at = time.monotonic()
+
+
+async def load_org_provider_keys_at_startup(db: AsyncSession) -> None:
+    """Prime the overlay so the first request does not race the first refresh.
+
+    A failure here is logged rather than raised, the same posture
+    `provider_store_service.load_providers_at_startup` takes: organization
+    provider keys are additive to config.yml providers, and a gateway that
+    boots with none cached is better than one that refuses to start because a
+    credential load failed.
+    """
+    reset_org_provider_cache()
+    try:
+        await refresh_org_provider_cache(db)
+    except Exception:
+        logger.exception("Failed to load organization provider keys; continuing with none cached")
+        return
+    if _org_cache:
+        logger.info("Loaded %d organization-scoped provider key overlay entr(y/ies)", len(_org_cache))
+
+
+async def run_org_provider_refresher(interval: float = ORG_PROVIDER_CACHE_TTL_SECONDS) -> None:
+    """Reload the organization provider key overlay forever so other writers' changes arrive.
+
+    A write refreshes the worker that served it; this covers sibling workers
+    and other replicas, which converge within ``interval``. Every error is
+    swallowed and retried on the next tick so a database blip cannot kill the
+    refresher and freeze the overlay. Cancelled at shutdown.
+    """
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            async with create_session() as db:
+                await refresh_org_provider_cache(db)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Organization provider key refresh failed; retrying in %ss", interval, exc_info=True)
+
+
+def _encrypt_api_key(api_key: str | None) -> tuple[str | None, str | None]:
+    """Encrypt a plaintext key for storage, or clear it. Never logs the plaintext."""
+    if not api_key:
+        return None, None
+    try:
+        return encrypt_secret(api_key), api_key[-4:]
+    except SecretBoxUnavailableError:
+        raise SecretBoxUnavailableTenancyError from None
+
+
+def _validated_provider(provider: str) -> str:
+    """Normalize and validate a provider name against any-llm's known implementations.
+
+    ``OrgProviderKey.provider`` is stored verbatim and is exactly the string
+    ``refresh_org_provider_cache`` keys its cache on, matched at dispatch
+    against a resolved selector's ``LLMProvider.value``. Left unguarded, a
+    typo, unexpected casing, or an unaliased name (``"OpenAI"``,
+    ``"azure-openai"``, trailing whitespace) is accepted with a 201 and then
+    never resolves at dispatch, with no error at either point. Mirrors
+    ``/v1/provider-credentials``'s ``_validate_instance`` provider_type guard,
+    including ``PROVIDER_TYPE_ALIASES`` so an aliased name still resolves; the
+    canonical value is what gets stored, not the alias, so the cache key
+    always matches what dispatch resolves to.
+    """
+    trimmed = provider.strip()
+    canonical = PROVIDER_TYPE_ALIASES.get(trimmed, trimmed)
+    try:
+        return LLMProvider(canonical).value
+    except ValueError:
+        raise OrgProviderKeyUnknownProviderError(trimmed) from None
+
+
+def _validated_name(name: str | None) -> str:
+    """Reject a null or blank key name, the same guard `WorkspaceService` applies to a workspace name.
+
+    ``OrgProviderKeyUpdateRequest.name`` is nullable so a client can send an
+    explicit ``null``; ``OrgProviderKey.name`` is NOT NULL. Left unguarded, an
+    explicit ``null`` (or a whitespace-only string) reaches the database as an
+    integrity error that the surrounding duplicate-name handling then reports
+    as a 409 naming a key called "None", rather than the 400 this is.
+    """
+    trimmed = (name or "").strip()
+    if not trimmed:
+        raise OrgProviderKeyNameRequiredError
+    return trimmed
+
+
+async def _gate_api_base(api_base: str | None) -> None:
+    """Reject storing an internal ``api_base`` when the SSRF gate is on.
+
+    Mirrors `api/routes/providers.py`'s ``_gate_api_base`` for
+    `/v1/provider-credentials`: a no-op in the default allow-all state, but
+    when the operator sets ``OTARI_PROVIDER_ALLOW_PRIVATE_HOSTS=false`` a
+    private/link-local/reserved ``api_base`` is refused here rather than
+    persisted. Truthy check so an empty/absent api_base (the "use the SDK
+    default endpoint" case) is not treated as a URL.
+    """
+    if not api_base:
+        return
+    try:
+        await validate_provider_api_base(api_base)
+    except UnsafeURLError as exc:
+        raise OrgProviderKeyUnsafeApiBaseError(str(exc)) from None
+
+
+class OrgProviderKeyService:
+    """Business logic for the organization provider key surface."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.keys = OrgProviderKeyRepository(db)
+        self.overrides = WorkspaceProviderKeyOverrideRepository(db)
+        self.restrictions = WorkspaceProviderModelRestrictionRepository(db)
+        self.organizations = OrganizationService(db)
+
+    # ------------------------------------------------------------------
+    # Organization-scoped keys
+    # ------------------------------------------------------------------
+
+    async def list_keys_for_user(
+        self,
+        *,
+        user: User,
+        include_archived: bool = False,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> OrgProviderKeysPublic:
+        """List the caller's organization's keys. Any active member may read it.
+
+        ``client_args`` is redacted for a plain member: this read is open to
+        every active member, not only owners/admins, and `OrgProviderKey.to_public`
+        explains why that field cannot be assumed safe for that wider audience.
+        ``count`` is the total matching rows, not the page size, so a caller
+        can page correctly (mirrors ``WorkspaceService.list_workspaces``).
+        """
+        organization = await self.organizations.get_active_organization_for_user(user)
+        rows, count = await self.keys.list_for_organization(
+            organization.id, include_archived=include_archived, skip=skip, limit=limit
+        )
+        membership = await self.organizations.members.get_active_by_organization_and_user(organization.id, user.id)
+        is_admin = user.is_superuser or (membership is not None and membership.role in MANAGEMENT_ROLES)
+        data = [row.to_public(include_client_args=is_admin) for row in rows]
+        return OrgProviderKeysPublic(data=data, count=count)
+
+    async def create_key_for_user(
+        self,
+        *,
+        user: User,
+        request: OrgProviderKeyCreateRequest,
+    ) -> OrgProviderKeyPublic:
+        """Create a key in the caller's organization. Organization owners and admins only."""
+        organization = await self.organizations.get_active_organization_for_user(user)
+        await self.organizations.require_active_organization_management_access(user=user, organization=organization)
+
+        provider = _validated_provider(request.provider)
+        name = _validated_name(request.name)
+        await _gate_api_base(request.api_base)
+
+        if (
+            await self.keys.get_by_org_provider_name(organization_id=organization.id, provider=provider, name=name)
+            is not None
+        ):
+            raise OrgProviderKeyAlreadyExistsError(provider, name)
+
+        encrypted_api_key, last4 = _encrypt_api_key(request.api_key)
+        try:
+            key = await self.keys.create_key(
+                organization_id=organization.id,
+                provider=provider,
+                name=name,
+                encrypted_api_key=encrypted_api_key,
+                last4=last4,
+                api_base=request.api_base,
+                client_args=request.client_args,
+            )
+            await self.db.commit()
+        except IntegrityError:
+            # The pre-check above races the insert; the unique constraint is
+            # what actually decides, as elsewhere in this slice.
+            await self.db.rollback()
+            raise OrgProviderKeyAlreadyExistsError(provider, name) from None
+
+        await refresh_org_provider_cache(self.db)
+        return key.to_public()
+
+    async def update_key_for_user(
+        self,
+        *,
+        user: User,
+        key_id: uuid.UUID,
+        request: OrgProviderKeyUpdateRequest,
+    ) -> OrgProviderKeyPublic:
+        """Change a key's name, credential, base URL, or client args. Organization owners and admins only."""
+        organization = await self.organizations.get_active_organization_for_user(user)
+        await self.organizations.require_active_organization_management_access(user=user, organization=organization)
+
+        key = await self.keys.get_in_organization(key_id, organization.id)
+        if key is None:
+            raise OrgProviderKeyNotFoundError(key_id)
+        if key.archived_at is not None:
+            raise OrgProviderKeyArchivedError(key_id)
+
+        update_data = request.model_dump(exclude_unset=True)
+        if "name" in update_data:
+            new_name = _validated_name(update_data["name"])
+            update_data["name"] = new_name
+            if new_name != key.name:
+                if (
+                    await self.keys.get_by_org_provider_name(
+                        organization_id=organization.id, provider=key.provider, name=new_name
+                    )
+                    is not None
+                ):
+                    raise OrgProviderKeyAlreadyExistsError(key.provider, new_name)
+        if "api_base" in update_data:
+            await _gate_api_base(update_data["api_base"])
+        if "api_key" in update_data:
+            encrypted_api_key, last4 = _encrypt_api_key(update_data.pop("api_key"))
+            update_data["encrypted_api_key"] = encrypted_api_key
+            update_data["last4"] = last4
+
+        try:
+            updated = await self.keys.update_key(key, update_data)
+            await self.db.commit()
+        except IntegrityError:
+            await self.db.rollback()
+            raise OrgProviderKeyAlreadyExistsError(key.provider, str(update_data.get("name", key.name))) from None
+
+        await refresh_org_provider_cache(self.db)
+        return updated.to_public()
+
+    async def archive_key_for_user(self, *, user: User, key_id: uuid.UUID) -> OrgProviderKeyPublic:
+        """Archive a key. Organization owners and admins only.
+
+        Clears ``is_org_default`` at the same time: an archived key that was
+        the default would otherwise silently become the default again on
+        restore, with no re-election having happened.
+        """
+        organization = await self.organizations.get_active_organization_for_user(user)
+        await self.organizations.require_active_organization_management_access(user=user, organization=organization)
+
+        key = await self.keys.get_in_organization(key_id, organization.id)
+        if key is None:
+            raise OrgProviderKeyNotFoundError(key_id)
+
+        updated = await self.keys.update_key(key, {"archived_at": datetime.now(UTC), "is_org_default": False})
+        await self.db.commit()
+        await refresh_org_provider_cache(self.db)
+        return updated.to_public()
+
+    async def restore_key_for_user(self, *, user: User, key_id: uuid.UUID) -> OrgProviderKeyPublic:
+        """Restore an archived key. Organization owners and admins only."""
+        organization = await self.organizations.get_active_organization_for_user(user)
+        await self.organizations.require_active_organization_management_access(user=user, organization=organization)
+
+        key = await self.keys.get_in_organization(key_id, organization.id)
+        if key is None:
+            raise OrgProviderKeyNotFoundError(key_id)
+
+        updated = await self.keys.update_key(key, {"archived_at": None})
+        await self.db.commit()
+        await refresh_org_provider_cache(self.db)
+        return updated.to_public()
+
+    async def delete_key_for_user(self, *, user: User, key_id: uuid.UUID) -> None:
+        """Permanently delete an archived key. Organization owners and admins only.
+
+        Overrides and model restrictions naming it ride the database cascade.
+        """
+        organization = await self.organizations.get_active_organization_for_user(user)
+        await self.organizations.require_active_organization_management_access(user=user, organization=organization)
+
+        key = await self.keys.get_in_organization(key_id, organization.id)
+        if key is None:
+            raise OrgProviderKeyNotFoundError(key_id)
+        if key.archived_at is None:
+            raise OrgProviderKeyNotArchivedError(key_id)
+
+        await self.keys.delete_key(key)
+        await self.db.commit()
+        await refresh_org_provider_cache(self.db)
+
+    async def set_org_default_for_user(self, *, user: User, key_id: uuid.UUID) -> OrgProviderKeyPublic:
+        """Make a key the organization's default for its provider. Organization owners and admins only."""
+        organization = await self.organizations.get_active_organization_for_user(user)
+        await self.organizations.require_active_organization_management_access(user=user, organization=organization)
+
+        key = await self.keys.get_in_organization(key_id, organization.id)
+        if key is None:
+            raise OrgProviderKeyNotFoundError(key_id)
+        if key.archived_at is not None:
+            raise OrgProviderKeyArchivedError(key_id)
+
+        try:
+            updated = await self.keys.set_org_default(key)
+            await self.db.commit()
+        except IntegrityError:
+            await self.db.rollback()
+            raise OrgDefaultProviderKeyConflictError(key.provider) from None
+
+        await refresh_org_provider_cache(self.db)
+        return updated.to_public()
+
+    # ------------------------------------------------------------------
+    # Workspace overrides
+    # ------------------------------------------------------------------
+
+    async def list_effective_keys_for_workspace(
+        self,
+        *,
+        user: User,
+        workspace_id: uuid.UUID,
+    ) -> WorkspaceProviderKeyOverridesPublic:
+        """The effective view of every key visible to a workspace. Any member of the workspace may read it."""
+        workspace = await authorization.resolve_visible_workspace(
+            self.db, user=user, workspace_id=workspace_id, organizations=self.organizations
+        )
+        candidates = await self.overrides.all_candidates(
+            organization_id=workspace.organization_id, workspace_id=workspace.id
+        )
+
+        by_provider: dict[str, list[Candidate]] = defaultdict(list)
+        for key, override in candidates:
+            by_provider[key.provider].append((key, override))
+        effective_ids = {
+            active.id for group in by_provider.values() if (active := resolve_active_key(group)) is not None
+        }
+
+        return WorkspaceProviderKeyOverridesPublic(
+            data=[
+                WorkspaceProviderKeyOverridePublic(
+                    workspace_id=workspace.id,
+                    org_provider_key_id=key.id,
+                    is_default=override.is_default if override else False,
+                    disabled=override.disabled if override else False,
+                    is_effective_default=key.id in effective_ids,
+                    is_effective_enabled=not (override.disabled if override else False),
+                )
+                for key, override in candidates
+            ]
+        )
+
+    async def set_workspace_override_for_user(
+        self,
+        *,
+        user: User,
+        workspace_id: uuid.UUID,
+        key_id: uuid.UUID,
+        request: WorkspaceProviderKeyOverrideRequest,
+    ) -> WorkspaceProviderKeyOverridePublic:
+        """Pin or disable a key for one workspace.
+
+        Tri-state: an omitted field leaves that flag unchanged. Sending one
+        flag lets the other auto-resolve when they would otherwise conflict
+        (pinning re-enables a disabled key, disabling un-pins a pinned one);
+        sending both explicitly true is refused. Both flags false, whether
+        merged or explicit, deletes the override row rather than storing a
+        no-op: absence of a row already means full inheritance.
+        """
+        workspace = await authorization.resolve_visible_workspace(
+            self.db, user=user, workspace_id=workspace_id, organizations=self.organizations
+        )
+        await authorization.require_workspace_management_access(
+            self.db, user=user, workspace=workspace, organizations=self.organizations
+        )
+
+        key = await self.keys.get_in_organization(key_id, workspace.organization_id)
+        if key is None:
+            raise OrgProviderKeyNotFoundError(key_id)
+
+        # Serializes the whole read-decide-write sequence below: two admins
+        # concurrently pinning two different keys for the same workspace and
+        # provider both have to see each other's clear, since no unique index
+        # spans the variable set of override rows a "pin" can land in (unlike
+        # `set_org_default`, which is a single row the partial unique index
+        # already arbitrates).
+        await WorkspaceRepository(self.db).lock(workspace.id)
+
+        existing = await self.overrides.get(workspace_id=workspace.id, org_provider_key_id=key.id)
+        current_default = existing.is_default if existing else False
+        current_disabled = existing.disabled if existing else False
+        new_default = request.is_default if request.is_default is not None else current_default
+        new_disabled = request.disabled if request.disabled is not None else current_disabled
+
+        if new_default and new_disabled:
+            if request.is_default and request.disabled is None:
+                new_disabled = False
+            elif request.disabled and request.is_default is None:
+                new_default = False
+            else:
+                raise WorkspaceProviderKeyOverrideConflictError
+
+        if new_default:
+            await self.overrides.clear_workspace_pinned_default(
+                workspace_id=workspace.id,
+                organization_id=workspace.organization_id,
+                provider=key.provider,
+                except_key_id=key.id,
+            )
+
+        if not new_default and not new_disabled:
+            if existing is not None:
+                await self.overrides.delete(existing)
+            result_default, result_disabled = False, False
+        elif existing is not None:
+            updated = await self.overrides.update(existing, is_default=new_default, disabled=new_disabled)
+            result_default, result_disabled = updated.is_default, updated.disabled
+        else:
+            created = await self.overrides.create(
+                workspace_id=workspace.id,
+                organization_id=workspace.organization_id,
+                org_provider_key_id=key.id,
+                is_default=new_default,
+                disabled=new_disabled,
+            )
+            result_default, result_disabled = created.is_default, created.disabled
+
+        if new_disabled and not current_disabled:
+            await self.restrictions.delete_for_workspace_key(workspace_id=workspace.id, org_provider_key_id=key.id)
+
+        await self.db.commit()
+        await refresh_org_provider_cache(self.db)
+
+        candidates = await self.overrides.candidates_for_provider(
+            organization_id=workspace.organization_id,
+            provider=key.provider,
+            workspace_id=workspace.id,
+        )
+        active = resolve_active_key(candidates)
+        return WorkspaceProviderKeyOverridePublic(
+            workspace_id=workspace.id,
+            org_provider_key_id=key.id,
+            is_default=result_default,
+            disabled=result_disabled,
+            is_effective_default=active is not None and active.id == key.id,
+            is_effective_enabled=not result_disabled,
+        )
+
+    async def reset_workspace_override_for_user(
+        self, *, user: User, workspace_id: uuid.UUID, key_id: uuid.UUID
+    ) -> None:
+        """Remove a workspace's override, reverting to full inheritance. Idempotent."""
+        workspace = await authorization.resolve_visible_workspace(
+            self.db, user=user, workspace_id=workspace_id, organizations=self.organizations
+        )
+        await authorization.require_workspace_management_access(
+            self.db, user=user, workspace=workspace, organizations=self.organizations
+        )
+
+        key = await self.keys.get_in_organization(key_id, workspace.organization_id)
+        if key is None:
+            raise OrgProviderKeyNotFoundError(key_id)
+
+        existing = await self.overrides.get(workspace_id=workspace.id, org_provider_key_id=key.id)
+        if existing is None:
+            return
+        await self.overrides.delete(existing)
+        await self.db.commit()
+        await refresh_org_provider_cache(self.db)
+
+    # ------------------------------------------------------------------
+    # Model restrictions
+    # ------------------------------------------------------------------
+
+    async def list_model_restrictions_for_user(
+        self,
+        *,
+        user: User,
+        workspace_id: uuid.UUID,
+        key_id: uuid.UUID,
+    ) -> WorkspaceProviderModelRestrictionsPublic:
+        """List a workspace's model allow-list for a key. Empty means every model is allowed."""
+        workspace = await authorization.resolve_visible_workspace(
+            self.db, user=user, workspace_id=workspace_id, organizations=self.organizations
+        )
+        key = await self.keys.get_in_organization(key_id, workspace.organization_id)
+        if key is None:
+            raise OrgProviderKeyNotFoundError(key_id)
+        models = await self.restrictions.list_for_workspace_key(workspace_id=workspace.id, org_provider_key_id=key.id)
+        return WorkspaceProviderModelRestrictionsPublic(models=models)
+
+    async def add_model_restriction_for_user(
+        self,
+        *,
+        user: User,
+        workspace_id: uuid.UUID,
+        key_id: uuid.UUID,
+        model: str,
+    ) -> None:
+        """Narrow a workspace's allow-list for a key to include one more model. Idempotent."""
+        workspace = await authorization.resolve_visible_workspace(
+            self.db, user=user, workspace_id=workspace_id, organizations=self.organizations
+        )
+        await authorization.require_workspace_management_access(
+            self.db, user=user, workspace=workspace, organizations=self.organizations
+        )
+
+        key = await self.keys.get_in_organization(key_id, workspace.organization_id)
+        if key is None:
+            raise OrgProviderKeyNotFoundError(key_id)
+
+        override = await self.overrides.get(workspace_id=workspace.id, org_provider_key_id=key.id)
+        if override is not None and override.disabled:
+            raise OrgProviderKeyDisabledForWorkspaceError
+
+        if await self.restrictions.get(workspace_id=workspace.id, org_provider_key_id=key.id, model=model) is None:
+            await self.restrictions.add(
+                workspace_id=workspace.id,
+                organization_id=workspace.organization_id,
+                org_provider_key_id=key.id,
+                model=model,
+            )
+            await self.db.commit()
+            await refresh_org_provider_cache(self.db)
+
+    async def remove_model_restriction_for_user(
+        self,
+        *,
+        user: User,
+        workspace_id: uuid.UUID,
+        key_id: uuid.UUID,
+        model: str,
+    ) -> None:
+        """Remove one model from a workspace's allow-list for a key. Idempotent."""
+        workspace = await authorization.resolve_visible_workspace(
+            self.db, user=user, workspace_id=workspace_id, organizations=self.organizations
+        )
+        await authorization.require_workspace_management_access(
+            self.db, user=user, workspace=workspace, organizations=self.organizations
+        )
+
+        key = await self.keys.get_in_organization(key_id, workspace.organization_id)
+        if key is None:
+            raise OrgProviderKeyNotFoundError(key_id)
+
+        restriction = await self.restrictions.get(workspace_id=workspace.id, org_provider_key_id=key.id, model=model)
+        if restriction is not None:
+            await self.restrictions.remove(restriction)
+            await self.db.commit()
+            await refresh_org_provider_cache(self.db)
+
+
+__all__ = [
+    "ORG_PROVIDER_CACHE_TTL_SECONDS",
+    "OrgProviderKeyService",
+    "cached_org_model_restriction",
+    "cached_org_provider_kwargs",
+    "load_org_provider_keys_at_startup",
+    "org_cache_is_stale",
+    "refresh_org_provider_cache",
+    "reset_org_provider_cache",
+    "run_org_provider_refresher",
+]

--- a/src/gateway/services/tenancy/workspace_service.py
+++ b/src/gateway/services/tenancy/workspace_service.py
@@ -71,7 +71,7 @@ class WorkspaceService:
     async def _active_organization(self, user: User) -> Organization:
         return await self.organizations.get_active_organization_for_user(user)
 
-    async def _workspace_in_active_organization(self, *, user: User, workspace_id: uuid.UUID) -> Workspace:
+    async def workspace_in_active_organization(self, *, user: User, workspace_id: uuid.UUID) -> Workspace:
         """Resolve a workspace the caller may see, or raise not-found.
 
         Delegates to ``services.tenancy.authorization``, shared with
@@ -136,7 +136,11 @@ class WorkspaceService:
 
         Delegates to ``services.tenancy.authorization``, shared with
         ``WorkspaceBudgetDefaultService`` so the management rule is defined
-        once.
+        once. Private: `services.tenancy.org_provider_key_service` needs the
+        same rule for workspace-scoped provider-key overrides and model
+        restrictions, and calls ``authorization.require_workspace_management_access``
+        directly rather than through this instance method, so there is one
+        shared entry point rather than two.
         """
         await authorization.require_workspace_management_access(
             self.db,
@@ -186,7 +190,7 @@ class WorkspaceService:
 
     async def get_workspace(self, *, user: User, workspace_id: uuid.UUID) -> WorkspacePublic:
         """Return one workspace the caller may see."""
-        workspace = await self._workspace_in_active_organization(user=user, workspace_id=workspace_id)
+        workspace = await self.workspace_in_active_organization(user=user, workspace_id=workspace_id)
         return WorkspacePublic.model_validate(workspace)
 
     async def list_workspaces(self, *, user: User, skip: int = 0, limit: int = 100) -> WorkspacesPublic:
@@ -230,7 +234,7 @@ class WorkspaceService:
         workspace_update: WorkspaceUpdate,
     ) -> WorkspacePublic:
         """Rename a workspace or change its description."""
-        workspace = await self._workspace_in_active_organization(user=user, workspace_id=workspace_id)
+        workspace = await self.workspace_in_active_organization(user=user, workspace_id=workspace_id)
         await self._require_workspace_management_access(user=user, workspace=workspace)
 
         update_data = workspace_update.model_dump(exclude_unset=True)
@@ -348,7 +352,7 @@ class WorkspaceService:
         limit: int = 100,
     ) -> WorkspaceMembersPublic:
         """List a workspace's members. Any member of the workspace may read it."""
-        workspace = await self._workspace_in_active_organization(user=user, workspace_id=workspace_id)
+        workspace = await self.workspace_in_active_organization(user=user, workspace_id=workspace_id)
         members, count = await self.members.get_by_workspace(workspace.id, skip=skip, limit=limit)
         return WorkspaceMembersPublic(
             data=[WorkspaceMemberPublic.model_validate(member) for member in members],
@@ -368,7 +372,7 @@ class WorkspaceService:
         Membership of the organization is a precondition, not something this
         grants: a workspace cannot be a back door into the tenant.
         """
-        workspace = await self._workspace_in_active_organization(user=user, workspace_id=workspace_id)
+        workspace = await self.workspace_in_active_organization(user=user, workspace_id=workspace_id)
         await self._require_workspace_management_access(user=user, workspace=workspace)
         role = self._validated_role(role)
 
@@ -408,7 +412,7 @@ class WorkspaceService:
         role: str,
     ) -> WorkspaceMemberPublic:
         """Change a workspace member's role."""
-        workspace = await self._workspace_in_active_organization(user=user, workspace_id=workspace_id)
+        workspace = await self.workspace_in_active_organization(user=user, workspace_id=workspace_id)
         await self._require_workspace_management_access(user=user, workspace=workspace)
         role = self._validated_role(role)
 
@@ -422,7 +426,7 @@ class WorkspaceService:
 
     async def remove_member(self, *, user: User, workspace_id: uuid.UUID, user_id: uuid.UUID) -> None:
         """Remove a member from a workspace. Idempotent."""
-        workspace = await self._workspace_in_active_organization(user=user, workspace_id=workspace_id)
+        workspace = await self.workspace_in_active_organization(user=user, workspace_id=workspace_id)
         await self._require_workspace_management_access(user=user, workspace=workspace)
 
         member = await self.members.get_by_workspace_and_user(workspace.id, user_id)

--- a/src/gateway/services/workspace_scope.py
+++ b/src/gateway/services/workspace_scope.py
@@ -11,6 +11,17 @@ only two sources:
   default workspace: the operator acting deployment-wide, which is what the
   master key means.
 
+This id is not only a billing label. Since otari#643, it also decides *whose*
+organization-scoped provider keys satisfy a bare ``provider:model`` selector
+(one naming no ``config.providers`` instance) via
+``services/provider_kwargs.get_provider_kwargs``: a keyed request resolves
+through its own workspace's organization, and a **master-key** request
+therefore resolves through the default workspace's organization, not through
+every organization the deployment holds. An operator running several
+organizations behind one gateway who calls a bare selector with the master
+key gets the default workspace's key or none, the same as any other
+deployment-wide write this module resolves.
+
 The default is resolved per call and deliberately not memoized. ``RESTRICT``
 looks like it makes a cached id safe, since a workspace holding request-plane
 rows cannot be deleted, but it does not cover a default holding *nothing*, which

--- a/tests/integration/test_batches_endpoint.py
+++ b/tests/integration/test_batches_endpoint.py
@@ -993,6 +993,85 @@ def test_unrecorded_batch_results_logs_every_retrieval(
     assert len(results_logs) == 2
 
 
+def test_recorded_batch_foreign_caller_never_reaches_the_provider(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """A foreign caller's request never dispatches to the provider at all.
+
+    Regression for a real ordering bug: `_authorize_record` must run *before*
+    the batch's originating-organization credential is used, not after the
+    provider has already been called with it. Before the fix, `aretrieve_batch`
+    ran first (spending the batch owner's credential) and only then was the
+    caller found unauthorized and refused. Asserting the mock was never
+    awaited is the only way to see that ordering; asserting the 404 alone (as
+    `test_recorded_batch_strict_ownership_ignores_missing_metadata` does)
+    would pass either way.
+    """
+    batch_id = _create_recorded_batch(client, api_key_header)
+
+    other_key_resp = client.post(
+        "/v1/keys",
+        json={"key_name": "foreign-caller", "user_id": "batch-foreign-caller"},
+        headers=master_key_header,
+    )
+    assert other_key_resp.status_code == 200
+    other_header = {API_KEY_HEADER: f"Bearer {other_key_resp.json()['key']}"}
+
+    with patch("gateway.api.routes.batches.aretrieve_batch", new_callable=AsyncMock) as mock_retrieve:
+        resp = client.get(f"/v1/batches/{batch_id}?provider=openai", headers=other_header)
+
+    assert resp.status_code == 404
+    mock_retrieve.assert_not_awaited()
+
+
+def test_recorded_batch_cancel_by_foreign_caller_never_reaches_the_provider(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """Same ordering regression as retrieve, for the cancel endpoint."""
+    batch_id = _create_recorded_batch(client, api_key_header)
+
+    other_key_resp = client.post(
+        "/v1/keys",
+        json={"key_name": "foreign-canceller", "user_id": "batch-foreign-canceller"},
+        headers=master_key_header,
+    )
+    assert other_key_resp.status_code == 200
+    other_header = {API_KEY_HEADER: f"Bearer {other_key_resp.json()['key']}"}
+
+    with patch("gateway.api.routes.batches.aretrieve_batch", new_callable=AsyncMock) as mock_retrieve:
+        resp = client.post(f"/v1/batches/{batch_id}/cancel?provider=openai", headers=other_header)
+
+    assert resp.status_code == 404
+    mock_retrieve.assert_not_awaited()
+
+
+def test_recorded_batch_results_by_foreign_caller_never_reaches_the_provider(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+) -> None:
+    """Same ordering regression as retrieve, for the results endpoint."""
+    batch_id = _create_recorded_batch(client, api_key_header)
+
+    other_key_resp = client.post(
+        "/v1/keys",
+        json={"key_name": "foreign-results", "user_id": "batch-foreign-results"},
+        headers=master_key_header,
+    )
+    assert other_key_resp.status_code == 200
+    other_header = {API_KEY_HEADER: f"Bearer {other_key_resp.json()['key']}"}
+
+    with patch("gateway.api.routes.batches.aretrieve_batch", new_callable=AsyncMock) as mock_retrieve:
+        resp = client.get(f"/v1/batches/{batch_id}/results?provider=openai", headers=other_header)
+
+    assert resp.status_code == 404
+    mock_retrieve.assert_not_awaited()
+
+
 def test_recorded_batch_strict_ownership_ignores_missing_metadata(
     client: TestClient,
     master_key_header: dict[str, str],

--- a/tests/integration/test_org_provider_keys.py
+++ b/tests/integration/test_org_provider_keys.py
@@ -1,0 +1,657 @@
+"""Integration tests for organization-scoped provider keys against a real DB.
+
+Exercises the `org_provider_keys` / `workspace_provider_key_overrides` /
+`workspace_provider_model_restrictions` migration, encryption at rest,
+`set_org_default`, workspace override inheritance, model restrictions, the
+dispatch-path overlay, and the tenancy authorization rules, at the service
+layer (see `test_tenancy_authorization.py`'s module docstring for why: the
+routes can only ever act as the one bootstrap operator, who is always an
+owner, so the rules that matter most are only reachable by building
+identities at whatever role a case needs).
+"""
+
+import uuid
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.core.config import GatewayConfig
+from gateway.models.provider_keys import (
+    OrgProviderKey,
+    OrgProviderKeyCreateRequest,
+    OrgProviderKeyUpdateRequest,
+    WorkspaceProviderKeyOverrideRequest,
+)
+from gateway.models.tenancy import Organization, User, Workspace
+from gateway.repositories.tenancy import (
+    OrganizationMemberRepository,
+    OrganizationRepository,
+    UserRepository,
+    WorkspaceMemberRepository,
+    WorkspaceRepository,
+)
+from gateway.services.provider_kwargs import resolve_provider_selector
+from gateway.services.secret_box import generate_secret_key
+from gateway.services.tenancy import OrgProviderKeyService
+from gateway.services.tenancy.errors import (
+    NotAuthorizedError,
+    OrgProviderKeyAlreadyExistsError,
+    OrgProviderKeyArchivedError,
+    OrgProviderKeyDisabledForWorkspaceError,
+    OrgProviderKeyNotArchivedError,
+    OrgProviderKeyNotFoundError,
+    WorkspaceNotFoundError,
+    WorkspaceProviderKeyOverrideConflictError,
+)
+from gateway.services.tenancy.org_provider_key_service import (
+    cached_org_model_restriction,
+    refresh_org_provider_cache,
+    reset_org_provider_cache,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _organization(db: AsyncSession, *, slug: str = "acme") -> Organization:
+    return await OrganizationRepository(db).create_organization(name=slug.title(), slug=slug, created_by_user_id=None)
+
+
+async def _member(db: AsyncSession, organization: Organization, *, role: str, full_name: str) -> User:
+    user = await UserRepository(db).create_local_identity(
+        full_name=full_name,
+        active_organization_id=organization.id,
+    )
+    await OrganizationMemberRepository(db).create_membership(
+        organization_id=organization.id, user_id=user.id, role=role
+    )
+    return user
+
+
+async def _workspace(
+    db: AsyncSession, organization: Organization, *, name: str = "Default", owner: User | None = None
+) -> Workspace:
+    workspace = await WorkspaceRepository(db).create_workspace(
+        name=name, organization_id=organization.id, created_by_user_id=owner.id if owner else None
+    )
+    if owner is not None:
+        await WorkspaceMemberRepository(db).create(workspace_id=workspace.id, user_id=owner.id, role="owner")
+    return workspace
+
+
+@pytest.fixture(autouse=True)
+def _secret_key_and_clean_cache(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("OTARI_SECRET_KEY", generate_secret_key())
+    reset_org_provider_cache()
+    yield
+    reset_org_provider_cache()
+
+
+def _create_request(
+    *, provider: str = "openai", name: str = "primary", api_key: str | None = "sk-live-1234"
+) -> OrgProviderKeyCreateRequest:
+    return OrgProviderKeyCreateRequest(provider=provider, name=name, api_key=api_key)
+
+
+# --------------------------------------------------------------------------- #
+# CRUD
+# --------------------------------------------------------------------------- #
+
+
+async def test_crud_round_trip(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrgProviderKeyService(async_db)
+
+    created = await service.create_key_for_user(user=owner, request=_create_request())
+    assert created.last4 == "1234"
+    assert created.is_org_default is False
+
+    listed = await service.list_keys_for_user(user=owner)
+    assert [k.id for k in listed.data] == [created.id]
+
+    updated = await service.update_key_for_user(
+        user=owner, key_id=created.id, request=OrgProviderKeyUpdateRequest(api_base="https://proxy/v1")
+    )
+    assert updated.api_base == "https://proxy/v1"
+    assert updated.last4 == "1234", "omitted api_key is left in place"
+
+    archived = await service.archive_key_for_user(user=owner, key_id=created.id)
+    assert archived.archived_at is not None
+
+    restored = await service.restore_key_for_user(user=owner, key_id=created.id)
+    assert restored.archived_at is None
+
+    await service.archive_key_for_user(user=owner, key_id=created.id)
+    await service.delete_key_for_user(user=owner, key_id=created.id)
+    assert (await service.list_keys_for_user(user=owner, include_archived=True)).count == 0
+
+
+async def test_delete_requires_archived_first(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrgProviderKeyService(async_db)
+    created = await service.create_key_for_user(user=owner, request=_create_request())
+
+    with pytest.raises(OrgProviderKeyNotArchivedError):
+        await service.delete_key_for_user(user=owner, key_id=created.id)
+
+
+async def test_updating_a_nonexistent_key_is_not_found(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrgProviderKeyService(async_db)
+
+    with pytest.raises(OrgProviderKeyNotFoundError):
+        await service.update_key_for_user(
+            user=owner, key_id=uuid.uuid4(), request=OrgProviderKeyUpdateRequest(name="new-name")
+        )
+
+
+async def test_a_key_from_another_organization_is_not_found(async_db: AsyncSession) -> None:
+    organization_a = await _organization(async_db, slug="a")
+    organization_b = await _organization(async_db, slug="b")
+    owner_a = await _member(async_db, organization_a, role="owner", full_name="Owner A")
+    owner_b = await _member(async_db, organization_b, role="owner", full_name="Owner B")
+    service = OrgProviderKeyService(async_db)
+    key = await service.create_key_for_user(user=owner_a, request=_create_request())
+
+    with pytest.raises(OrgProviderKeyNotFoundError):
+        await service.archive_key_for_user(user=owner_b, key_id=key.id)
+
+
+async def test_create_duplicate_provider_name_conflicts(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrgProviderKeyService(async_db)
+    await service.create_key_for_user(user=owner, request=_create_request())
+
+    with pytest.raises(OrgProviderKeyAlreadyExistsError):
+        await service.create_key_for_user(user=owner, request=_create_request())
+
+
+async def test_plain_member_cannot_create_a_key(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    member = await _member(async_db, organization, role="member", full_name="Member")
+    service = OrgProviderKeyService(async_db)
+
+    with pytest.raises(NotAuthorizedError):
+        await service.create_key_for_user(user=member, request=_create_request())
+
+
+async def test_plain_member_does_not_see_client_args_but_admin_does(async_db: AsyncSession) -> None:
+    """`client_args` is arbitrary JSON an admin can set, so the list read
+    (open to every active member) redacts it wholesale for a non-admin reader
+    while the admin who set it still sees the non-credential fields back."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    member = await _member(async_db, organization, role="member", full_name="Member")
+    service = OrgProviderKeyService(async_db)
+    await service.create_key_for_user(
+        user=owner,
+        request=OrgProviderKeyCreateRequest(
+            provider="openai", name="primary", api_key="sk-live-1234", client_args={"region_name": "us-east-1"}
+        ),
+    )
+
+    as_owner = await service.list_keys_for_user(user=owner)
+    assert as_owner.data[0].client_args == {"region_name": "us-east-1"}
+
+    as_member = await service.list_keys_for_user(user=member)
+    assert as_member.data[0].client_args is None
+
+
+async def test_credential_shaped_client_args_are_redacted_even_for_the_admin_who_set_them(
+    async_db: AsyncSession,
+) -> None:
+    """A credential-shaped field placed in `client_args` (this gateway's own
+    Bedrock support genuinely needs `aws_access_key_id`/`aws_secret_access_key`
+    there, so the field cannot simply be rejected outright) never round-trips,
+    the same treatment `encrypted_api_key` itself already gets: only `last4`
+    comes back, never the plaintext. This holds even for the admin who set it,
+    not only for a lower-privileged reader -- that is a separate, coarser gate
+    `include_client_args` already covers."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrgProviderKeyService(async_db)
+    await service.create_key_for_user(
+        user=owner,
+        request=OrgProviderKeyCreateRequest(
+            provider="bedrock",
+            name="primary",
+            api_key="bearer-token",
+            client_args={
+                "region_name": "us-east-1",
+                "aws_access_key_id": "AKIAABCDEFGHIJKLMNOP",
+                "aws_secret_access_key": "supersecretvalue",
+            },
+        ),
+    )
+
+    as_owner = await service.list_keys_for_user(user=owner)
+    assert as_owner.data[0].client_args == {
+        "region_name": "us-east-1",
+        "aws_access_key_id": "***",
+        "aws_secret_access_key": "***",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# set_org_default
+# --------------------------------------------------------------------------- #
+
+
+async def test_set_org_default_clears_the_previous_default(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrgProviderKeyService(async_db)
+
+    first = await service.create_key_for_user(user=owner, request=_create_request(name="first"))
+    second = await service.create_key_for_user(user=owner, request=_create_request(name="second"))
+
+    first = await service.set_org_default_for_user(user=owner, key_id=first.id)
+    assert first.is_org_default is True
+
+    second = await service.set_org_default_for_user(user=owner, key_id=second.id)
+    assert second.is_org_default is True
+    refreshed_first = (await service.list_keys_for_user(user=owner)).data
+    assert next(k for k in refreshed_first if k.id == first.id).is_org_default is False
+
+
+async def test_set_org_default_refuses_an_archived_key(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrgProviderKeyService(async_db)
+    key = await service.create_key_for_user(user=owner, request=_create_request())
+    await service.archive_key_for_user(user=owner, key_id=key.id)
+
+    with pytest.raises(OrgProviderKeyArchivedError):
+        await service.set_org_default_for_user(user=owner, key_id=key.id)
+
+
+async def test_the_partial_unique_index_admits_only_one_default_per_org_and_provider(
+    async_db: AsyncSession,
+) -> None:
+    """The database-level guarantee `set_org_default`'s race handling depends on:
+    a second row with ``is_org_default=True`` for the same (organization,
+    provider) violates ``uq_org_provider_keys_org_default`` even though the two
+    rows are otherwise unrelated. Exercised directly against the constraint in
+    one session rather than with two genuinely concurrent transactions: the
+    repository's ``set_org_default`` clears every sibling before setting its
+    own row, so the only way two rows both end up ``is_org_default=True`` is
+    a race the index alone decides, which is what this pins."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrgProviderKeyService(async_db)
+    first = await service.create_key_for_user(user=owner, request=_create_request(name="first"))
+    await service.set_org_default_for_user(user=owner, key_id=first.id)
+
+    second_row = OrgProviderKey(organization_id=organization.id, provider="openai", name="second", is_org_default=True)
+    async_db.add(second_row)
+    with pytest.raises(IntegrityError):
+        await async_db.flush()
+
+
+# --------------------------------------------------------------------------- #
+# Workspace inheritance and overrides
+# --------------------------------------------------------------------------- #
+
+
+async def test_workspace_with_no_override_inherits_org_default(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = OrgProviderKeyService(async_db)
+
+    key = await service.create_key_for_user(user=owner, request=_create_request())
+    await service.set_org_default_for_user(user=owner, key_id=key.id)
+
+    effective = await service.list_effective_keys_for_workspace(user=owner, workspace_id=workspace.id)
+    (view,) = effective.data
+    assert view.is_effective_default is True
+    assert view.is_effective_enabled is True
+    assert view.is_default is False, "no override row exists; the effective flag comes from the org default"
+
+
+async def test_sibling_workspace_can_pin_a_different_key(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace_a = await _workspace(async_db, organization, name="A", owner=owner)
+    workspace_b = await _workspace(async_db, organization, name="B", owner=owner)
+    service = OrgProviderKeyService(async_db)
+
+    default_key = await service.create_key_for_user(user=owner, request=_create_request(name="default"))
+    await service.set_org_default_for_user(user=owner, key_id=default_key.id)
+    other_key = await service.create_key_for_user(user=owner, request=_create_request(name="other"))
+
+    await service.set_workspace_override_for_user(
+        user=owner,
+        workspace_id=workspace_b.id,
+        key_id=other_key.id,
+        request=WorkspaceProviderKeyOverrideRequest(is_default=True),
+    )
+
+    a_effective = await service.list_effective_keys_for_workspace(user=owner, workspace_id=workspace_a.id)
+    assert next(k for k in a_effective.data if k.is_effective_default).org_provider_key_id == default_key.id
+
+    b_effective = await service.list_effective_keys_for_workspace(user=owner, workspace_id=workspace_b.id)
+    assert next(k for k in b_effective.data if k.is_effective_default).org_provider_key_id == other_key.id
+
+
+async def test_archiving_the_default_falls_through_to_earliest_fallback(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = OrgProviderKeyService(async_db)
+
+    fallback = await service.create_key_for_user(user=owner, request=_create_request(name="fallback"))
+    default_key = await service.create_key_for_user(user=owner, request=_create_request(name="default"))
+    await service.set_org_default_for_user(user=owner, key_id=default_key.id)
+
+    await service.archive_key_for_user(user=owner, key_id=default_key.id)
+
+    effective = await service.list_effective_keys_for_workspace(user=owner, workspace_id=workspace.id)
+    assert [k.org_provider_key_id for k in effective.data] == [fallback.id], "the archived key is not a candidate"
+    assert effective.data[0].is_effective_default is True
+
+
+async def test_pinning_reenables_a_disabled_key_and_disabling_unpins(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = OrgProviderKeyService(async_db)
+    key = await service.create_key_for_user(user=owner, request=_create_request())
+
+    disabled = await service.set_workspace_override_for_user(
+        user=owner, workspace_id=workspace.id, key_id=key.id, request=WorkspaceProviderKeyOverrideRequest(disabled=True)
+    )
+    assert disabled.disabled is True
+
+    pinned = await service.set_workspace_override_for_user(
+        user=owner,
+        workspace_id=workspace.id,
+        key_id=key.id,
+        request=WorkspaceProviderKeyOverrideRequest(is_default=True),
+    )
+    assert pinned.is_default is True
+    assert pinned.disabled is False, "pinning re-enables"
+
+    reset = await service.set_workspace_override_for_user(
+        user=owner, workspace_id=workspace.id, key_id=key.id, request=WorkspaceProviderKeyOverrideRequest(disabled=True)
+    )
+    assert reset.disabled is True
+    assert reset.is_default is False, "disabling un-pins"
+
+
+async def test_repinning_an_already_pinned_key_stays_pinned(async_db: AsyncSession) -> None:
+    """Regression: `clear_workspace_pinned_default` must exclude the key being
+    (re-)pinned. Clearing it too raced the ORM's own change tracking: a bulk
+    UPDATE with ``synchronize_session=False`` cleared the row in the database
+    without the loaded object noticing, so the following ``is_default = True``
+    assignment looked like a no-op to SQLAlchemy and was never re-flushed,
+    silently un-pinning a key an admin asked to keep pinned."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = OrgProviderKeyService(async_db)
+    key = await service.create_key_for_user(user=owner, request=_create_request())
+
+    first = await service.set_workspace_override_for_user(
+        user=owner,
+        workspace_id=workspace.id,
+        key_id=key.id,
+        request=WorkspaceProviderKeyOverrideRequest(is_default=True),
+    )
+    assert first.is_default is True
+
+    again = await service.set_workspace_override_for_user(
+        user=owner,
+        workspace_id=workspace.id,
+        key_id=key.id,
+        request=WorkspaceProviderKeyOverrideRequest(is_default=True),
+    )
+    assert again.is_default is True
+
+
+async def test_conflicting_explicit_pin_and_disable_is_refused(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = OrgProviderKeyService(async_db)
+    key = await service.create_key_for_user(user=owner, request=_create_request())
+
+    with pytest.raises(WorkspaceProviderKeyOverrideConflictError):
+        await service.set_workspace_override_for_user(
+            user=owner,
+            workspace_id=workspace.id,
+            key_id=key.id,
+            request=WorkspaceProviderKeyOverrideRequest(is_default=True, disabled=True),
+        )
+
+
+async def test_disabling_a_key_cascades_deleting_its_model_restrictions(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = OrgProviderKeyService(async_db)
+    key = await service.create_key_for_user(user=owner, request=_create_request())
+
+    await service.add_model_restriction_for_user(user=owner, workspace_id=workspace.id, key_id=key.id, model="gpt-4o")
+    assert (
+        await service.list_model_restrictions_for_user(user=owner, workspace_id=workspace.id, key_id=key.id)
+    ).models == ["gpt-4o"]
+
+    await service.set_workspace_override_for_user(
+        user=owner, workspace_id=workspace.id, key_id=key.id, request=WorkspaceProviderKeyOverrideRequest(disabled=True)
+    )
+
+    assert (
+        await service.list_model_restrictions_for_user(user=owner, workspace_id=workspace.id, key_id=key.id)
+    ).models == []
+
+
+async def test_restricting_models_on_a_disabled_key_is_refused(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = OrgProviderKeyService(async_db)
+    key = await service.create_key_for_user(user=owner, request=_create_request())
+    await service.set_workspace_override_for_user(
+        user=owner, workspace_id=workspace.id, key_id=key.id, request=WorkspaceProviderKeyOverrideRequest(disabled=True)
+    )
+
+    with pytest.raises(OrgProviderKeyDisabledForWorkspaceError):
+        await service.add_model_restriction_for_user(
+            user=owner, workspace_id=workspace.id, key_id=key.id, model="gpt-4o"
+        )
+
+
+async def test_model_restriction_is_cached_for_the_active_key(async_db: AsyncSession) -> None:
+    """The dispatch-path cache carries the active key's model allow-list too
+    (otari#643 review), not only its credentials: a workspace restricted to
+    one model must not be able to dispatch every model with the same key."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = OrgProviderKeyService(async_db)
+    key = await service.create_key_for_user(user=owner, request=_create_request())
+    await service.set_org_default_for_user(user=owner, key_id=key.id)
+    await service.add_model_restriction_for_user(user=owner, workspace_id=workspace.id, key_id=key.id, model="gpt-4o")
+
+    await refresh_org_provider_cache(async_db)
+
+    assert cached_org_model_restriction(workspace.id, "openai") == ["gpt-4o"]
+
+
+async def test_adding_a_model_restriction_refreshes_the_cache_immediately(async_db: AsyncSession) -> None:
+    """Regression: add_model_restriction_for_user/remove_model_restriction_for_user
+    must refresh the overlay themselves, like every other mutation on this
+    surface, rather than leaving dispatch to serve the stale allow-list for up
+    to ORG_PROVIDER_CACHE_TTL_SECONDS on the very worker that made the change."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = OrgProviderKeyService(async_db)
+    key = await service.create_key_for_user(user=owner, request=_create_request())
+    await service.set_org_default_for_user(user=owner, key_id=key.id)
+    await refresh_org_provider_cache(async_db)
+    assert cached_org_model_restriction(workspace.id, "openai") is None
+
+    await service.add_model_restriction_for_user(user=owner, workspace_id=workspace.id, key_id=key.id, model="gpt-4o")
+    assert cached_org_model_restriction(workspace.id, "openai") == ["gpt-4o"], "no manual refresh call here"
+
+    await service.remove_model_restriction_for_user(
+        user=owner, workspace_id=workspace.id, key_id=key.id, model="gpt-4o"
+    )
+    assert cached_org_model_restriction(workspace.id, "openai") is None, "no manual refresh call here either"
+
+
+async def test_model_restriction_is_absent_with_no_restrictions_configured(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = OrgProviderKeyService(async_db)
+    key = await service.create_key_for_user(user=owner, request=_create_request())
+    await service.set_org_default_for_user(user=owner, key_id=key.id)
+
+    await refresh_org_provider_cache(async_db)
+
+    assert cached_org_model_restriction(workspace.id, "openai") is None
+
+
+async def test_model_restriction_follows_the_active_key_not_a_stale_one(async_db: AsyncSession) -> None:
+    """Restricting key A's models must not leak onto key B once B becomes the
+    workspace's active key: the cache keys restrictions by the resolved
+    key's id, not by (workspace, provider) alone."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = OrgProviderKeyService(async_db)
+    key_a = await service.create_key_for_user(user=owner, request=_create_request(name="a"))
+    await service.set_org_default_for_user(user=owner, key_id=key_a.id)
+    await service.add_model_restriction_for_user(user=owner, workspace_id=workspace.id, key_id=key_a.id, model="gpt-4o")
+
+    key_b = await service.create_key_for_user(user=owner, request=_create_request(name="b"))
+    await service.set_org_default_for_user(user=owner, key_id=key_b.id)
+
+    await refresh_org_provider_cache(async_db)
+
+    assert cached_org_model_restriction(workspace.id, "openai") is None
+
+
+async def test_workspace_owner_who_is_not_an_org_admin_can_still_set_overrides(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    admin = await _member(async_db, organization, role="owner", full_name="Admin")
+    plain_member = await _member(async_db, organization, role="member", full_name="Member")
+    workspace = await _workspace(async_db, organization, owner=plain_member)
+    service = OrgProviderKeyService(async_db)
+    key = await service.create_key_for_user(user=admin, request=_create_request())
+
+    # The workspace's own owner, an organization plain member otherwise,
+    # may still pin/disable a key for that one workspace.
+    result = await service.set_workspace_override_for_user(
+        user=plain_member,
+        workspace_id=workspace.id,
+        key_id=key.id,
+        request=WorkspaceProviderKeyOverrideRequest(is_default=True),
+    )
+    assert result.is_default is True
+
+
+async def test_org_member_with_no_workspace_membership_gets_workspace_not_found(async_db: AsyncSession) -> None:
+    """Not a member of the workspace at all: 404, matching `WorkspaceService`'s
+    own rule that a workspace the caller cannot see must be indistinguishable
+    from one that does not exist."""
+    organization = await _organization(async_db)
+    admin = await _member(async_db, organization, role="owner", full_name="Admin")
+    outsider = await _member(async_db, organization, role="member", full_name="Outsider")
+    workspace = await _workspace(async_db, organization, owner=admin)
+    service = OrgProviderKeyService(async_db)
+    key = await service.create_key_for_user(user=admin, request=_create_request())
+
+    with pytest.raises(WorkspaceNotFoundError):
+        await service.set_workspace_override_for_user(
+            user=outsider,
+            workspace_id=workspace.id,
+            key_id=key.id,
+            request=WorkspaceProviderKeyOverrideRequest(is_default=True),
+        )
+
+
+async def test_workspace_member_without_management_role_cannot_set_overrides(async_db: AsyncSession) -> None:
+    """A plain member of the workspace can see it, but not manage its keys: 403."""
+    organization = await _organization(async_db)
+    admin = await _member(async_db, organization, role="owner", full_name="Admin")
+    plain_workspace_member = await _member(async_db, organization, role="member", full_name="Plain")
+    workspace = await _workspace(async_db, organization, owner=admin)
+    await WorkspaceMemberRepository(async_db).create(
+        workspace_id=workspace.id, user_id=plain_workspace_member.id, role="member"
+    )
+    service = OrgProviderKeyService(async_db)
+    key = await service.create_key_for_user(user=admin, request=_create_request())
+
+    with pytest.raises(NotAuthorizedError):
+        await service.set_workspace_override_for_user(
+            user=plain_workspace_member,
+            workspace_id=workspace.id,
+            key_id=key.id,
+            request=WorkspaceProviderKeyOverrideRequest(is_default=True),
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Dispatch-path integration
+# --------------------------------------------------------------------------- #
+
+
+async def test_dispatch_resolves_an_organization_scoped_key_with_no_config_entry(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = OrgProviderKeyService(async_db)
+    key = await service.create_key_for_user(user=owner, request=_create_request(api_key="sk-org-scoped-5678"))
+    await service.set_org_default_for_user(user=owner, key_id=key.id)
+
+    await refresh_org_provider_cache(async_db)
+
+    config = GatewayConfig(providers={})
+    resolved = resolve_provider_selector(config, "openai:gpt-4o", workspace_id=workspace.id)
+    assert resolved.kwargs["api_key"] == "sk-org-scoped-5678"
+
+
+async def test_an_instance_addressed_selector_never_consults_organization_scoped_keys(
+    async_db: AsyncSession,
+) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = OrgProviderKeyService(async_db)
+    key = await service.create_key_for_user(user=owner, request=_create_request(api_key="sk-org-scoped-5678"))
+    await service.set_org_default_for_user(user=owner, key_id=key.id)
+    await refresh_org_provider_cache(async_db)
+
+    # "openai" here is a config.yml *instance* name, disjoint from the bare
+    # "openai:model" selector the previous test used; the config-file key wins
+    # outright and the organization-scoped one is never consulted.
+    config = GatewayConfig(providers={"openai": {"api_key": "sk-config-file"}})
+    resolved = resolve_provider_selector(config, "openai:gpt-4o", workspace_id=workspace.id)
+    assert resolved.kwargs["api_key"] == "sk-config-file"
+
+
+async def test_dispatch_without_workspace_id_ignores_organization_scoped_keys(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrgProviderKeyService(async_db)
+    key = await service.create_key_for_user(user=owner, request=_create_request())
+    await service.set_org_default_for_user(user=owner, key_id=key.id)
+    await refresh_org_provider_cache(async_db)
+
+    # No config.yml provider and no workspace_id: this must behave exactly as
+    # it did before this feature existed, i.e. no credentials found (any-llm's
+    # own env-var fallback would apply next, at the actual dispatch call, not
+    # here), rather than a silent org-scoped resolution finding the org default
+    # anyway because it happens to be the only key configured anywhere.
+    config = GatewayConfig(providers={})
+    resolved = resolve_provider_selector(config, "openai:gpt-4o")
+    assert resolved.kwargs == {}

--- a/tests/unit/test_batches_route.py
+++ b/tests/unit/test_batches_route.py
@@ -1,9 +1,20 @@
-"""Unit tests for batch route Pydantic request models."""
+"""Unit tests for batch route Pydantic request models and helpers."""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
+from fastapi import HTTPException
 from pydantic import ValidationError
 
-from gateway.api.routes.batches import BatchRequestItem, CreateBatchRequest
+from gateway.api.routes.batches import (
+    BatchRequestItem,
+    CreateBatchRequest,
+    _authorize_legacy_batch,
+    _authorize_record,
+    _lifecycle_workspace_id,
+)
 
 
 class TestBatchRequestItem:
@@ -66,3 +77,117 @@ class TestCreateBatchRequest:
             completion_window="48h",
         )
         assert request.completion_window == "48h"
+
+
+class TestLifecycleWorkspaceId:
+    """`_lifecycle_workspace_id` picks the batch's own workspace over the
+    caller's, per the CodeRabbit finding on otari#643: a master-key or
+    cross-workspace retrieve/cancel/results must resolve credentials from the
+    organization that created the batch, not the retriever's own workspace.
+    """
+
+    @pytest.mark.asyncio
+    async def test_uses_the_batch_records_own_workspace_when_present(self) -> None:
+        creating_workspace_id = uuid.uuid4()
+        record = SimpleNamespace(workspace_id=creating_workspace_id)
+
+        resolved = await _lifecycle_workspace_id(db=AsyncMock(), record=record, api_key=None)  # type: ignore[arg-type]
+
+        assert resolved == creating_workspace_id
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_the_callers_workspace_for_a_legacy_batch_with_no_record(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        caller_workspace_id = uuid.uuid4()
+        monkeypatch.setattr(
+            "gateway.api.routes.batches.resolve_workspace_id",
+            AsyncMock(return_value=caller_workspace_id),
+        )
+
+        resolved = await _lifecycle_workspace_id(db=AsyncMock(), record=None, api_key=None)
+
+        assert resolved == caller_workspace_id
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_the_callers_workspace_when_the_record_predates_the_column(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A record persisted before this migration has ``workspace_id is None``,
+        the same as a legacy record-less batch, not the creating workspace.
+        """
+        caller_workspace_id = uuid.uuid4()
+        monkeypatch.setattr(
+            "gateway.api.routes.batches.resolve_workspace_id",
+            AsyncMock(return_value=caller_workspace_id),
+        )
+        record = SimpleNamespace(workspace_id=None)
+
+        resolved = await _lifecycle_workspace_id(db=AsyncMock(), record=record, api_key=None)  # type: ignore[arg-type]
+
+        assert resolved == caller_workspace_id
+
+
+class TestAuthorizeRecord:
+    """`_authorize_record` runs *before* the batch's originating-organization
+    credential is used to call the provider (see `_lifecycle_workspace_id`),
+    so an unauthorized caller for another organization's batch is refused
+    before that organization's credential is ever spent. It therefore takes
+    no `Batch`, deliberately: needing one would force the credential-bearing
+    dispatch to happen first."""
+
+    def test_master_key_is_always_authorized(self) -> None:
+        record = SimpleNamespace(user_id="someone-else")
+        _authorize_record(record, "batch-1", api_key=None, is_master_key=True)  # type: ignore[arg-type]
+
+    def test_the_records_own_user_is_authorized(self) -> None:
+        record = SimpleNamespace(user_id="user-1")
+        api_key = SimpleNamespace(user_id="user-1")
+        _authorize_record(record, "batch-1", api_key=api_key, is_master_key=False)  # type: ignore[arg-type]
+
+    def test_a_different_user_is_refused_with_404_not_403(self) -> None:
+        """404, not 403: a foreign key must not be able to probe which batch
+        ids exist by distinguishing "not yours" from "no such batch"."""
+        record = SimpleNamespace(user_id="the-owner")
+        api_key = SimpleNamespace(user_id="someone-else")
+
+        with pytest.raises(HTTPException) as exc_info:
+            _authorize_record(record, "batch-1", api_key=api_key, is_master_key=False)  # type: ignore[arg-type]
+
+        assert exc_info.value.status_code == 404
+
+    def test_no_api_key_is_refused(self) -> None:
+        record = SimpleNamespace(user_id="the-owner")
+
+        with pytest.raises(HTTPException) as exc_info:
+            _authorize_record(record, "batch-1", api_key=None, is_master_key=False)  # type: ignore[arg-type]
+
+        assert exc_info.value.status_code == 404
+
+
+class TestAuthorizeLegacyBatch:
+    """The metadata-anchored fallback for a record-less batch. Only reachable
+    once the batch has already been fetched from the provider, which
+    `_authorize_record`'s docstring explains is safe only in this case: a
+    record-less batch has no stored workspace to leak, so credentials there
+    already resolved to the caller's own."""
+
+    def test_master_key_is_always_authorized(self) -> None:
+        batch = SimpleNamespace(metadata={"otari_user_id": "someone-else"})
+        _authorize_legacy_batch(batch, "batch-1", api_key=None, is_master_key=True)  # type: ignore[arg-type]
+
+    def test_a_batch_with_no_marker_is_authorized_for_any_caller(self) -> None:
+        """Batches predating the ownership marker, or from a provider that
+        does not round-trip metadata, stay reachable by any authenticated key."""
+        batch = SimpleNamespace(metadata=None)
+        api_key = SimpleNamespace(user_id="anyone")
+        _authorize_legacy_batch(batch, "batch-1", api_key=api_key, is_master_key=False)  # type: ignore[arg-type]
+
+    def test_a_mismatched_marker_is_refused_with_404(self) -> None:
+        batch = SimpleNamespace(metadata={"otari_user_id": "the-owner"})
+        api_key = SimpleNamespace(user_id="someone-else")
+
+        with pytest.raises(HTTPException) as exc_info:
+            _authorize_legacy_batch(batch, "batch-1", api_key=api_key, is_master_key=False)  # type: ignore[arg-type]
+
+        assert exc_info.value.status_code == 404

--- a/tests/unit/test_org_provider_key_service.py
+++ b/tests/unit/test_org_provider_key_service.py
@@ -1,0 +1,211 @@
+"""Unit tests for organization-scoped provider key resolution and caching.
+
+Mirrors `test_provider_store_service.py`'s shape: pure precedence logic and
+the cache accessors are tested with in-memory fixtures, no database.
+"""
+
+import time
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+
+import pytest
+
+from gateway.models.provider_keys import OrgProviderKey, WorkspaceProviderKeyOverride
+from gateway.repositories.tenancy.org_provider_key_repository import resolve_active_key
+from gateway.services.secret_box import SecretDecryptionError, encrypt_secret, generate_secret_key
+from gateway.services.tenancy import org_provider_key_service as store
+from gateway.services.tenancy.org_provider_key_service import cached_org_provider_kwargs, reset_org_provider_cache
+
+ORG_ID = uuid.uuid4()
+WORKSPACE_ID = uuid.uuid4()
+OTHER_WORKSPACE_ID = uuid.uuid4()
+
+
+def _key(*, name: str, is_org_default: bool = False, created_at: datetime | None = None) -> OrgProviderKey:
+    return OrgProviderKey(
+        organization_id=ORG_ID,
+        provider="openai",
+        name=name,
+        is_org_default=is_org_default,
+        created_at=created_at or datetime.now(UTC),
+    )
+
+
+def _override(key: OrgProviderKey, *, is_default: bool = False, disabled: bool = False) -> WorkspaceProviderKeyOverride:
+    return WorkspaceProviderKeyOverride(
+        workspace_id=WORKSPACE_ID,
+        organization_id=key.organization_id,
+        org_provider_key_id=key.id,
+        is_default=is_default,
+        disabled=disabled,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# resolve_active_key: the three-tier precedence, no database involved
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_active_key_returns_none_for_no_candidates() -> None:
+    assert resolve_active_key([]) is None
+
+
+def test_resolve_active_key_falls_back_to_earliest_created_with_no_default_or_pin() -> None:
+    older = _key(name="a", created_at=datetime(2026, 1, 1, tzinfo=UTC))
+    newer = _key(name="b", created_at=datetime(2026, 1, 2, tzinfo=UTC))
+    # Ordered oldest-first, as the repository queries it (see the docstring).
+    assert resolve_active_key([(older, None), (newer, None)]) is older
+
+
+def test_resolve_active_key_prefers_org_default_over_earliest_created() -> None:
+    older = _key(name="a", created_at=datetime(2026, 1, 1, tzinfo=UTC))
+    default = _key(name="b", is_org_default=True, created_at=datetime(2026, 1, 2, tzinfo=UTC))
+    assert resolve_active_key([(older, None), (default, None)]) is default
+
+
+def test_resolve_active_key_prefers_workspace_pin_over_org_default() -> None:
+    default = _key(name="a", is_org_default=True)
+    pinned = _key(name="b")
+    assert resolve_active_key([(default, None), (pinned, _override(pinned, is_default=True))]) is pinned
+
+
+def test_resolve_active_key_skips_a_disabled_default_and_falls_back() -> None:
+    default = _key(name="a", is_org_default=True, created_at=datetime(2026, 1, 1, tzinfo=UTC))
+    fallback = _key(name="b", created_at=datetime(2026, 1, 2, tzinfo=UTC))
+    disabled = _override(default, disabled=True)
+    assert resolve_active_key([(default, disabled), (fallback, None)]) is fallback
+
+
+def test_resolve_active_key_returns_none_when_every_candidate_is_disabled() -> None:
+    key = _key(name="a")
+    assert resolve_active_key([(key, _override(key, disabled=True))]) is None
+
+
+# --------------------------------------------------------------------------- #
+# The overlay cache
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache() -> Iterator[None]:
+    reset_org_provider_cache()
+    yield
+    reset_org_provider_cache()
+
+
+def test_cached_org_provider_kwargs_returns_none_until_loaded() -> None:
+    assert cached_org_provider_kwargs(WORKSPACE_ID, "openai") is None
+
+
+def test_cached_org_provider_kwargs_is_scoped_by_workspace_and_provider() -> None:
+    store._org_cache[(WORKSPACE_ID, "openai")] = {"api_key": "sk-org"}
+    store._org_cached_at = time.monotonic()
+
+    assert cached_org_provider_kwargs(WORKSPACE_ID, "openai") == {"api_key": "sk-org"}
+    assert cached_org_provider_kwargs(OTHER_WORKSPACE_ID, "openai") is None
+    assert cached_org_provider_kwargs(WORKSPACE_ID, "anthropic") is None
+
+
+def test_reset_clears_the_cache() -> None:
+    store._org_cache[(WORKSPACE_ID, "openai")] = {"api_key": "sk-org"}
+    store._org_cached_at = time.monotonic()
+    assert cached_org_provider_kwargs(WORKSPACE_ID, "openai") == {"api_key": "sk-org"}, "the entry is set before reset"
+
+    reset_org_provider_cache()
+    assert cached_org_provider_kwargs(WORKSPACE_ID, "openai") is None
+
+
+# --------------------------------------------------------------------------- #
+# _row_to_entry: decrypt-or-skip, same contract as provider_store_service's
+# --------------------------------------------------------------------------- #
+
+
+def test_row_to_entry_decrypts_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTARI_SECRET_KEY", generate_secret_key())
+    key = OrgProviderKey(
+        organization_id=ORG_ID,
+        provider="openai",
+        name="default",
+        encrypted_api_key=encrypt_secret("sk-live"),
+        last4="live",
+    )
+    assert store._row_to_entry(key) == {"api_key": "sk-live"}
+
+
+def test_row_to_entry_carries_base_and_client_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTARI_SECRET_KEY", generate_secret_key())
+    key = OrgProviderKey(
+        organization_id=ORG_ID,
+        provider="openai",
+        name="home_lab",
+        api_base="http://x/v1",
+        encrypted_api_key=encrypt_secret("tok"),
+        client_args={"timeout": 30},
+    )
+    assert store._row_to_entry(key) == {
+        "api_base": "http://x/v1",
+        "client_args": {"timeout": 30},
+        "api_key": "tok",
+    }
+
+
+def test_row_to_entry_raises_when_key_cannot_be_decrypted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTARI_SECRET_KEY", generate_secret_key())
+    key = OrgProviderKey(
+        organization_id=ORG_ID, provider="openai", name="default", encrypted_api_key=encrypt_secret("sk")
+    )
+    monkeypatch.setenv("OTARI_SECRET_KEY", generate_secret_key())
+    with pytest.raises(SecretDecryptionError):
+        store._row_to_entry(key)
+
+
+# --------------------------------------------------------------------------- #
+# to_public: client_args never round-trips a credential-shaped field
+# --------------------------------------------------------------------------- #
+
+
+def test_to_public_redacts_credential_shaped_client_arg_keys() -> None:
+    """Bedrock's classic IAM shape genuinely needs `aws_access_key_id` /
+    `aws_secret_access_key` inside `client_args` (see
+    `services/bedrock_gateway_auth.py`), so the field cannot be rejected
+    outright; it still must never come back over the API, the same treatment
+    `encrypted_api_key` itself already gets. A non-matching field (`region_name`)
+    passes through unchanged."""
+    key = _key(name="bedrock-primary")
+    key.client_args = {
+        "region_name": "us-east-1",
+        "aws_access_key_id": "AKIAABCDEFGHIJKLMNOP",
+        "aws_secret_access_key": "supersecretvalue",
+        "api_key": "sk-smuggled",
+        "Authorization": "Bearer xyz",
+    }
+
+    public = key.to_public()
+
+    assert public.client_args == {
+        "region_name": "us-east-1",
+        "aws_access_key_id": "***",
+        "aws_secret_access_key": "***",
+        "api_key": "***",
+        "Authorization": "***",
+    }
+
+
+def test_to_public_with_no_credential_shaped_keys_is_unchanged() -> None:
+    key = _key(name="openai-primary")
+    key.client_args = {"region_name": "us-east-1", "timeout": 30}
+
+    assert key.to_public().client_args == {"region_name": "us-east-1", "timeout": 30}
+
+
+def test_to_public_client_args_none_stays_none() -> None:
+    key = _key(name="plain")
+    assert key.client_args is None
+    assert key.to_public().client_args is None
+
+
+def test_to_public_include_client_args_false_still_redacts_nothing_since_it_is_already_none() -> None:
+    key = _key(name="plain")
+    key.client_args = {"aws_secret_access_key": "supersecretvalue"}
+    assert key.to_public(include_client_args=False).client_args is None

--- a/tests/unit/test_pipeline_settlement.py
+++ b/tests/unit/test_pipeline_settlement.py
@@ -17,6 +17,7 @@ platform-fallback streaming paths. These tests pin that contract:
 import asyncio
 import re
 import time
+import uuid
 from collections.abc import AsyncIterator
 from typing import Any, cast
 
@@ -40,6 +41,7 @@ from gateway.api.routes._pipeline import (
     RequestContext,
     ToolContext,
     build_streaming_response,
+    log_usage,
     prepare_gateway_tools,
     run_platform_non_stream,
     run_single_attempt_stream,
@@ -85,6 +87,7 @@ def _ctx(
     log_writer: Any = None,
     reservation: ReservationHandle | None = None,
     rate_limit_info: RateLimitInfo | None = None,
+    workspace_id: uuid.UUID | None = None,
 ) -> RequestContext:
     return RequestContext(
         config=config,
@@ -98,6 +101,7 @@ def _ctx(
         rate_limit_info=rate_limit_info,
         reservation=reservation,
         started_at=time.monotonic(),
+        workspace_id=workspace_id,
     )
 
 
@@ -279,7 +283,12 @@ def _reservation(estimate: float = 0.5) -> ReservationHandle:
     return ReservationHandle(user_id="user-1", estimate=estimate, reserved=True, strategy="for_update")
 
 
-def _build(stream: AsyncIterator[ChatCompletionChunk], config: GatewayConfig) -> Any:
+def _build(
+    stream: AsyncIterator[ChatCompletionChunk],
+    config: GatewayConfig,
+    *,
+    workspace_id: uuid.UUID | None = None,
+) -> Any:
     return build_streaming_response(
         adapter=chat._ADAPTER,
         stream=stream,
@@ -292,6 +301,7 @@ def _build(stream: AsyncIterator[ChatCompletionChunk], config: GatewayConfig) ->
         user_id="user-1",
         rate_limit_info=None,
         reservation=_reservation(),
+        workspace_id=workspace_id,
     )
 
 
@@ -373,6 +383,108 @@ async def test_client_disconnect_refunds(monkeypatch: pytest.MonkeyPatch) -> Non
 
     assert settlement.refunded == 1
     assert settlement.reconciled == []
+
+
+class _FakeLogWriter:
+    def __init__(self) -> None:
+        self.put_rows: list[Any] = []
+
+    async def put(self, row: Any) -> None:
+        self.put_rows.append(row)
+
+
+@pytest.mark.asyncio
+async def test_log_usage_skips_the_workspace_lookup_when_given_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The whole point of threading ``workspace_id`` through: a caller that
+    already resolved it must not pay ``workspace_for_key_id``'s own lookup a
+    second time. For a master-key request (``api_key_id=None``) that lookup is
+    the un-memoized ``default_workspace_id`` query the preamble already paid.
+    """
+    lookups = 0
+
+    async def counting_workspace_for_key_id(db: Any, api_key_id: str | None) -> uuid.UUID:
+        nonlocal lookups
+        lookups += 1
+        return uuid.uuid4()
+
+    monkeypatch.setattr(pipeline, "workspace_for_key_id", counting_workspace_for_key_id)
+    workspace_id = uuid.uuid4()
+
+    await log_usage(
+        db=cast(Any, object()),
+        log_writer=cast(Any, _FakeLogWriter()),
+        api_key_id=None,
+        model="gpt-4",
+        provider="openai",
+        endpoint="/v1/chat/completions",
+        workspace_id=workspace_id,
+    )
+
+    assert lookups == 0
+
+
+@pytest.mark.asyncio
+async def test_log_usage_still_resolves_the_workspace_when_not_given_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The fallback stays intact for the callers that have no context to draw
+    ``workspace_id`` from (a rejection logged before one exists, the vision
+    side-call)."""
+    lookups = 0
+    resolved = uuid.uuid4()
+
+    async def counting_workspace_for_key_id(db: Any, api_key_id: str | None) -> uuid.UUID:
+        nonlocal lookups
+        lookups += 1
+        return resolved
+
+    monkeypatch.setattr(pipeline, "workspace_for_key_id", counting_workspace_for_key_id)
+    log_writer = _FakeLogWriter()
+
+    await log_usage(
+        db=cast(Any, object()),
+        log_writer=cast(Any, log_writer),
+        api_key_id=None,
+        model="gpt-4",
+        provider="openai",
+        endpoint="/v1/chat/completions",
+    )
+
+    assert lookups == 1
+    assert log_writer.put_rows[0].workspace_id == resolved
+
+
+@pytest.mark.asyncio
+async def test_stream_settlement_forwards_the_contexts_workspace_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``ctx.workspace_id``, already resolved once in the preamble, reaches
+    ``log_usage`` rather than being silently dropped and re-derived there
+    (otari#643 follow-up: a master-key request must not pay the un-memoized
+    default-workspace lookup twice for one request).
+    """
+    settlement = _Settlement()
+    settlement.install(monkeypatch)
+    workspace_id = uuid.uuid4()
+
+    async def stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield _chunk(CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15))
+
+    await _drain(_build(stream(), GatewayConfig(), workspace_id=workspace_id))
+
+    assert settlement.logged[0]["workspace_id"] == workspace_id
+
+
+@pytest.mark.asyncio
+async def test_standalone_non_stream_forwards_the_contexts_workspace_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    settlement = _Settlement()
+    settlement.install(monkeypatch)
+    workspace_id = uuid.uuid4()
+
+    await _run_standalone(
+        monkeypatch,
+        result=_completion(usage=_usage()),
+        reservation=_reservation(),
+        workspace_id=workspace_id,
+    )
+
+    assert settlement.logged[0]["workspace_id"] == workspace_id
 
 
 # ---------------------------------------------------------------------------
@@ -1080,6 +1192,7 @@ async def _run_standalone(
     rate_limit_info: RateLimitInfo | None = None,
     db: Any = None,
     display_model: str | None = None,
+    workspace_id: uuid.UUID | None = None,
 ) -> tuple[Any, Response]:
     """Drive the standalone non-streaming path with a faked provider call."""
 
@@ -1096,6 +1209,7 @@ async def _run_standalone(
         log_writer=object(),
         reservation=reservation,
         rate_limit_info=rate_limit_info,
+        workspace_id=workspace_id,
     )
     response = Response()
     returned = await run_standalone_non_stream(

--- a/tests/unit/test_pipeline_vision_billing.py
+++ b/tests/unit/test_pipeline_vision_billing.py
@@ -7,6 +7,7 @@ even when the top-up rejects with 402, while the main reservation is still
 refunded.
 """
 
+import uuid
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -36,13 +37,17 @@ class _Recorder:
     def install(self, monkeypatch: pytest.MonkeyPatch, *, topup_status: int | None) -> None:
         async def fake_verify(*args: Any, **kwargs: Any) -> tuple[Any, bool]:
             # allowed_models mirrors the real APIKey column (None = unrestricted); the
-            # pipeline's model-access check reads it.
+            # pipeline's model-access check reads it. workspace_id mirrors the
+            # same column resolve_workspace_id reads for organization-scoped
+            # provider keys (otari#643); a fixed value is fine, nothing here
+            # exercises that resolution.
             return SimpleNamespace(
                 id="key-1",
                 user_id="user-1",
                 allowed_models=None,
                 exclude_from_budget=False,
                 reject_user_mismatch=None,
+                workspace_id=uuid.uuid4(),
             ), False
 
         async def fake_find_pricing(*args: Any, **kwargs: Any) -> None:
@@ -54,10 +59,10 @@ class _Recorder:
         async def fake_resolve_allowlist(*args: Any, **kwargs: Any) -> None:
             return None
 
-        # Same reason: the preamble resolves the key's organization to pick up any
-        # rate override, which walks api_keys and workspace. None means "no
-        # override", which is what this test's deployment-wide pricing assumes.
-        async def fake_organization_for_key_id(*args: Any, **kwargs: Any) -> None:
+        # Same reason: the preamble resolves the already-known workspace's
+        # organization to pick up any rate override. None means "no override",
+        # which is what this test's deployment-wide pricing assumes.
+        async def fake_organization_for_workspace_id(*args: Any, **kwargs: Any) -> None:
             return None
 
         async def fake_reserve(*args: Any, **kwargs: Any) -> ReservationHandle:
@@ -82,7 +87,7 @@ class _Recorder:
         monkeypatch.setattr(pipeline, "check_rate_limit", lambda request, user_id: None)
         monkeypatch.setattr(pipeline, "find_model_pricing", fake_find_pricing)
         monkeypatch.setattr(pipeline, "resolve_request_allowlist", fake_resolve_allowlist)
-        monkeypatch.setattr(pipeline, "organization_for_key_id", fake_organization_for_key_id)
+        monkeypatch.setattr(pipeline, "organization_for_workspace_id", fake_organization_for_workspace_id)
         monkeypatch.setattr(pipeline, "reserve_budget", fake_reserve)
         monkeypatch.setattr(pipeline, "increase_reservation", fake_increase)
         monkeypatch.setattr(pipeline, "log_usage", fake_log_usage)

--- a/tests/unit/test_routing_compiler.py
+++ b/tests/unit/test_routing_compiler.py
@@ -15,6 +15,7 @@ instance had been deleted to go audit their allow-lists.
 """
 
 import logging
+import uuid
 from collections.abc import Callable, Iterator
 
 import pytest
@@ -29,6 +30,7 @@ from gateway.services.routing import (
     compile_policy,
     selection_consults_router,
 )
+from gateway.services.tenancy import org_provider_key_service as org_store
 
 
 @pytest.fixture
@@ -107,6 +109,45 @@ def test_a_mixed_drop_reports_the_actionable_one(config: GatewayConfig) -> None:
 
     assert exc_info.value.status_code == 403
     assert {item.reason for item in exc_info.value.dropped} == {"not_allowed", "unresolvable"}
+
+
+@pytest.fixture(autouse=True)
+def _clean_org_restriction_cache() -> Iterator[None]:
+    org_store._org_model_restrictions.clear()
+    yield
+    org_store._org_model_restrictions.clear()
+
+
+def test_a_fallover_candidate_violating_the_org_restriction_is_dropped(config: GatewayConfig) -> None:
+    """Regression: the org-scoped model restriction was checked only against
+    `plan.head` in `_pipeline.py`, so a `router`/`on_failure` candidate beyond
+    it could still dispatch a model the workspace's organization key
+    excludes. `anthropic` names no configured instance, so both candidates
+    resolve through the bare-selector, organization-scoped fallback.
+    """
+    workspace_id = uuid.uuid4()
+    org_store._org_model_restrictions[(workspace_id, "anthropic")] = ["claude-3-opus"]
+
+    plan = compile_policy(
+        config,
+        "restricted",
+        _spec("anthropic:claude-3-opus", "anthropic:claude-3-haiku"),
+        workspace_id=workspace_id,
+    )
+
+    assert [attempt.model for attempt in plan.attempts] == ["claude-3-opus"]
+
+
+def test_an_instance_addressed_candidate_ignores_the_org_restriction(config: GatewayConfig) -> None:
+    """`openai` is a configured instance in `config`, so it never consults the
+    organization overlay, even when a restriction happens to be cached under
+    the same provider name for this workspace."""
+    workspace_id = uuid.uuid4()
+    org_store._org_model_restrictions[(workspace_id, "openai")] = ["gpt-5-nano"]
+
+    plan = compile_policy(config, "unaffected", _spec("openai:gpt-5-mini"), workspace_id=workspace_id)
+
+    assert [attempt.model for attempt in plan.attempts] == ["gpt-5-mini"]
 
 
 def _router_spec(*candidates: str) -> PolicySpec:

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -1256,6 +1256,114 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/organizations/me/provider-keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Org Provider Keys
+         * @description List the caller's organization's provider keys. Any active member may read it.
+         */
+        get: operations["list_org_provider_keys_v1_organizations_me_provider_keys_get"];
+        put?: never;
+        /**
+         * Create Org Provider Key
+         * @description Create a provider key in the caller's organization. Organization owners and admins only.
+         */
+        post: operations["create_org_provider_key_v1_organizations_me_provider_keys_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/organizations/me/provider-keys/{key_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Org Provider Key
+         * @description Permanently delete an archived key. Organization owners and admins only.
+         */
+        delete: operations["delete_org_provider_key_v1_organizations_me_provider_keys__key_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Org Provider Key
+         * @description Change a key's name, credential, base URL, or client args. Organization owners and admins only.
+         */
+        patch: operations["update_org_provider_key_v1_organizations_me_provider_keys__key_id__patch"];
+        trace?: never;
+    };
+    "/v1/organizations/me/provider-keys/{key_id}/archive": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Archive Org Provider Key
+         * @description Archive a key. Organization owners and admins only.
+         */
+        post: operations["archive_org_provider_key_v1_organizations_me_provider_keys__key_id__archive_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/organizations/me/provider-keys/{key_id}/default": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Set Org Provider Key Default
+         * @description Make a key the organization's default for its provider. Organization owners and admins only.
+         */
+        post: operations["set_org_provider_key_default_v1_organizations_me_provider_keys__key_id__default_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/organizations/me/provider-keys/{key_id}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Restore Org Provider Key
+         * @description Restore an archived key. Organization owners and admins only.
+         */
+        post: operations["restore_org_provider_key_v1_organizations_me_provider_keys__key_id__restore_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/pricing": {
         parameters: {
             query?: never;
@@ -2687,6 +2795,94 @@ export interface paths {
          * @description Change a workspace member's role.
          */
         patch: operations["update_workspace_member_role_v1_workspaces__workspace_id__members__user_id__patch"];
+        trace?: never;
+    };
+    "/v1/workspaces/{workspace_id}/provider-keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Workspace Provider Keys
+         * @description The effective view of every key visible to this workspace. Any member of the workspace may read it.
+         */
+        get: operations["list_workspace_provider_keys_v1_workspaces__workspace_id__provider_keys_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/workspaces/{workspace_id}/provider-keys/{key_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Reset Workspace Provider Key Override
+         * @description Remove this workspace's override, reverting to full inheritance. Idempotent.
+         */
+        delete: operations["reset_workspace_provider_key_override_v1_workspaces__workspace_id__provider_keys__key_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Set Workspace Provider Key Override
+         * @description Pin or disable a key for this workspace. Organization owners/admins or this workspace's owners/admins.
+         */
+        patch: operations["set_workspace_provider_key_override_v1_workspaces__workspace_id__provider_keys__key_id__patch"];
+        trace?: never;
+    };
+    "/v1/workspaces/{workspace_id}/provider-keys/{key_id}/models": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Workspace Provider Key Model Restrictions
+         * @description List this workspace's model allow-list for a key. Empty means every model is allowed.
+         */
+        get: operations["list_workspace_provider_key_model_restrictions_v1_workspaces__workspace_id__provider_keys__key_id__models_get"];
+        put?: never;
+        /**
+         * Add Workspace Provider Key Model Restriction
+         * @description Narrow this workspace's allow-list for a key to include one more model. Idempotent.
+         */
+        post: operations["add_workspace_provider_key_model_restriction_v1_workspaces__workspace_id__provider_keys__key_id__models_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/workspaces/{workspace_id}/provider-keys/{key_id}/models/{model}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Remove Workspace Provider Key Model Restriction
+         * @description Remove one model from this workspace's allow-list for a key. Idempotent.
+         */
+        delete: operations["remove_workspace_provider_key_model_restriction_v1_workspaces__workspace_id__provider_keys__key_id__models__model__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
 }
@@ -4865,6 +5061,90 @@ export interface components {
             } | null;
         };
         /**
+         * OrgProviderKeyCreateRequest
+         * @description What a caller sends to create a key.
+         *
+         *     The plaintext key is never stored as sent: the service encrypts it
+         *     (`services/secret_box.py`) and keeps only the ciphertext and ``last4``,
+         *     the same convention `entities.ProviderCredential` already uses.
+         */
+        OrgProviderKeyCreateRequest: {
+            /** Api Base */
+            api_base?: string | null;
+            /** Api Key */
+            api_key?: string | null;
+            /** Client Args */
+            client_args?: {
+                [key: string]: unknown;
+            } | null;
+            /** Name */
+            name: string;
+            /** Provider */
+            provider: string;
+        };
+        /**
+         * OrgProviderKeyPublic
+         * @description The API-facing shape. Never carries the key, only whether one is set.
+         */
+        OrgProviderKeyPublic: {
+            /** Api Base */
+            api_base?: string | null;
+            /** Archived At */
+            archived_at?: string | null;
+            /** Client Args */
+            client_args?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Is Org Default */
+            is_org_default: boolean;
+            /** Last4 */
+            last4?: string | null;
+            /** Name */
+            name: string;
+            /**
+             * Organization Id
+             * Format: uuid
+             */
+            organization_id: string;
+            /** Provider */
+            provider: string;
+            /** Updated At */
+            updated_at?: string | null;
+        };
+        /**
+         * OrgProviderKeyUpdateRequest
+         * @description A partial update. Every field is optional; only what is set is applied.
+         */
+        OrgProviderKeyUpdateRequest: {
+            /** Api Base */
+            api_base?: string | null;
+            /** Api Key */
+            api_key?: string | null;
+            /** Client Args */
+            client_args?: {
+                [key: string]: unknown;
+            } | null;
+            /** Name */
+            name?: string | null;
+        };
+        /** OrgProviderKeysPublic */
+        OrgProviderKeysPublic: {
+            /** Count */
+            count: number;
+            /** Data */
+            data: components["schemas"]["OrgProviderKeyPublic"][];
+        };
+        /**
          * OrganizationMembershipContextPublic
          * @description An organization plus the caller's standing in it.
          *
@@ -7015,6 +7295,62 @@ export interface components {
             /** Data */
             data: components["schemas"]["WorkspaceMemberPublic"][];
         };
+        /**
+         * WorkspaceProviderKeyOverridePublic
+         * @description The effective view for one workspace+key: raw override flags plus the resolution.
+         */
+        WorkspaceProviderKeyOverridePublic: {
+            /** Disabled */
+            disabled: boolean;
+            /** Is Default */
+            is_default: boolean;
+            /** Is Effective Default */
+            is_effective_default: boolean;
+            /** Is Effective Enabled */
+            is_effective_enabled: boolean;
+            /**
+             * Org Provider Key Id
+             * Format: uuid
+             */
+            org_provider_key_id: string;
+            /**
+             * Workspace Id
+             * Format: uuid
+             */
+            workspace_id: string;
+        };
+        /**
+         * WorkspaceProviderKeyOverrideRequest
+         * @description Tri-state: an omitted field leaves that flag unchanged.
+         *
+         *     Both fields false, whether that is the merged result or a value sent
+         *     explicitly, is a no-op the service deletes rather than stores: absence of
+         *     a row already means full inheritance from the organization default.
+         *     Setting one true auto-resolves the other when they would otherwise
+         *     conflict (pinning re-enables a disabled key; disabling un-pins a pinned
+         *     one); sending both true explicitly is refused.
+         */
+        WorkspaceProviderKeyOverrideRequest: {
+            /** Disabled */
+            disabled?: boolean | null;
+            /** Is Default */
+            is_default?: boolean | null;
+        };
+        /** WorkspaceProviderKeyOverridesPublic */
+        WorkspaceProviderKeyOverridesPublic: {
+            /** Data */
+            data: components["schemas"]["WorkspaceProviderKeyOverridePublic"][];
+        };
+        /** WorkspaceProviderModelRestrictionRequest */
+        WorkspaceProviderModelRestrictionRequest: {
+            /** Model */
+            model: string;
+        };
+        /** WorkspaceProviderModelRestrictionsPublic */
+        WorkspaceProviderModelRestrictionsPublic: {
+            /** Models */
+            models: string[];
+        };
         /** WorkspacePublic */
         WorkspacePublic: {
             /**
@@ -9055,6 +9391,234 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_org_provider_keys_v1_organizations_me_provider_keys_get: {
+        parameters: {
+            query?: {
+                /** @description Include archived keys. */
+                include_archived?: boolean;
+                /** @description Number of records to skip */
+                skip?: number;
+                /** @description Maximum number of records to return */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrgProviderKeysPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_org_provider_key_v1_organizations_me_provider_keys_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OrgProviderKeyCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrgProviderKeyPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_org_provider_key_v1_organizations_me_provider_keys__key_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                key_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Message"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_org_provider_key_v1_organizations_me_provider_keys__key_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                key_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OrgProviderKeyUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrgProviderKeyPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    archive_org_provider_key_v1_organizations_me_provider_keys__key_id__archive_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                key_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrgProviderKeyPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    set_org_provider_key_default_v1_organizations_me_provider_keys__key_id__default_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                key_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrgProviderKeyPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    restore_org_provider_key_v1_organizations_me_provider_keys__key_id__restore_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                key_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrgProviderKeyPublic"];
+                };
             };
             /** @description Validation Error */
             422: {
@@ -11495,6 +12059,206 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["WorkspaceMemberPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_workspace_provider_keys_v1_workspaces__workspace_id__provider_keys_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspace_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkspaceProviderKeyOverridesPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reset_workspace_provider_key_override_v1_workspaces__workspace_id__provider_keys__key_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspace_id: string;
+                key_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Message"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    set_workspace_provider_key_override_v1_workspaces__workspace_id__provider_keys__key_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspace_id: string;
+                key_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkspaceProviderKeyOverrideRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkspaceProviderKeyOverridePublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_workspace_provider_key_model_restrictions_v1_workspaces__workspace_id__provider_keys__key_id__models_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspace_id: string;
+                key_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkspaceProviderModelRestrictionsPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    add_workspace_provider_key_model_restriction_v1_workspaces__workspace_id__provider_keys__key_id__models_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspace_id: string;
+                key_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkspaceProviderModelRestrictionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Message"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    remove_workspace_provider_key_model_restriction_v1_workspaces__workspace_id__provider_keys__key_id__models__model__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspace_id: string;
+                key_id: string;
+                model: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Message"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Description

Implements organization-scoped provider keys, unblocked by the decision recorded at [otari-ai#1748](https://github.com/mozilla-ai/otari-ai/issues/1748): an org-scoped source of truth, kept disjoint from the instance overlay rather than merged into it (not literally #1748's Option A; see the linked docs for why that mechanism was not carried over).

`provider_credentials` (the existing `config.yml`-merged, instance-keyed, deployment-global store) is **unchanged**. This PR adds new, additive tables that become the source of truth for **organization-scoped** BYO provider credentials: archival, one default per organization+provider, per-workspace pin/disable overrides, and per-workspace model allow-lists. The two mechanisms are disjoint by construction — an `instance:model` selector always resolves through `config.providers` exactly as before and never touches the new tables; only a bare `provider:model` selector with no matching instance falls back to an organization-scoped key when a `workspace_id` is available.

### What's here

- **Schema**: `org_provider_keys`, `workspace_provider_key_overrides`, `workspace_provider_model_restrictions` (migration `e1c3a5b7d9f2`, one forward migration, no legacy data to backfill). The platform's "managed/phantom key" bucket has no otari-side equivalent and is dropped entirely — every otari-side key is BYO.
- **Service** (`services/tenancy/org_provider_key_service.py`): CRUD, `set_org_default` (partial unique index + `IntegrityError`→domain-error mapping for the race), workspace override tri-state auto-resolution (pinning re-enables a disabled key, disabling un-pins and cascades deleting that workspace's model restrictions), and a dispatch-path overlay cache mirroring `provider_store_service.py`'s shape (30s TTL, refreshed on write) but keyed by `(workspace_id, provider)`.
- **Dispatch integration**: `get_provider_kwargs`/`resolve_provider_selector` gain an optional `workspace_id`, consulted only when no `config.providers` entry answers the selector, threaded through the chat/messages/responses preamble and `batches.py` via the workspace already resolvable off the request's `APIKey` (zero extra I/O for a keyed request).
- **Routes**: `/v1/organizations/me/provider-keys` and `/v1/workspaces/{workspace_id}/provider-keys`, reusing `OrganizationService`/`WorkspaceService`'s existing tenancy authorization (org owner/admin for org-scoped mutations; org owner/admin *or* that workspace's own owner/admin for workspace overrides and restrictions — `WorkspaceService.workspace_in_active_organization`/`require_workspace_management_access` promoted to public for this reuse).

### Addressed in review

CodeRabbit and Copilot flagged several real issues, all fixed on top of the original implementation:

- **SSRF gate missing.** `create_key_for_user`/`update_key_for_user` now call `validate_provider_api_base`, matching `/v1/provider-credentials`.
- **Misleading 409 on an explicit `null` name.** An explicit `null`/blank name on update now raises a 400 before it can reach the database as a NOT NULL violation reported as a duplicate-name conflict.
- **`clear_workspace_pinned_default` correctness bug.** The bulk `UPDATE` (`synchronize_session=False`) didn't exclude the key being (re-)pinned, so re-pinning an already-pinned key silently un-pinned it once the ORM's change tracking saw no net change on the loaded object. Fixed by excluding the target key, plus a `WorkspaceRepository.lock()` row lock serializing the whole read-decide-write sequence (no unique index spans the variable set of override rows a pin can land in). Regression test added.
- **Workspace model restrictions were stored but never enforced.** A workspace restricted to one model could still dispatch any model with the same org key. The dispatch-path cache now carries the active key's model allow-list per `(workspace, provider)`, enforced in `_pipeline.py` alongside the existing per-key allow-list check.
- **`workspace_id` was missing from several dispatch paths.** Threaded through the embeddings/images/audio/rerank/moderations pass-through scaffold and every batch lifecycle endpoint (retrieve/cancel/list/results, not only creation), so organization-scoped credentials are visible on every path that resolves a bare selector, not only chat/messages/responses.
- Two low-risk nitpicks: a bulk `DELETE` instead of a per-row loop, and a tightened cache-reset test.

Test coverage grew accordingly: **12 unit + 26 integration** (was 12 + 22), including regressions for the null-name and re-pin-after-clear bugs and three new tests pinning the model-restriction cache behavior.

### Verification

- `make lint` (architecture check + ruff): clean
- `uv run mypy` (390 files, `src`+`tests`+`scripts`): clean
- Full unit suite: **1819 passed**, 0 regressions
- Full integration suite (real PostgreSQL): **1369 passed**, 0 regressions
- New tests: **12 unit + 22 integration**, all passing
- Migration roundtrip (`upgrade` → `downgrade` → `upgrade`) on SQLite: clean
- `scripts/oss_edition_smoke.py` (standalone boot, BYO credential, fallback completion, usage): passes
- OpenAPI spec + Postman collection regenerated and checked

### Decision record

The upstream keying decision and its three required sub-question answers (instance-name addressing stays disjoint and unchanged; one global cache refresh keyed by `(workspace_id, provider)`, not per-organization; `search_tool_credentials` explicitly deferred to a separate decision) are recorded in `otari-ai`'s `docs/architecture/m4-reconciliation.md` and `docs/architecture/rehome-inventory.md` (companion PR pending in that repo).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #643

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary. (Decision recorded in `otari-ai`'s architecture docs; companion PR pending there.)
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).
- [x] **M4 ledger:** the Target disposition for the "API keys and BYO providers" row changes (it read "Dedupe under org/workspace"; the actual decision keeps `provider_credentials`/`provider_key` disjoint rather than deduped). Entry appended: mozilla-ai/otari-ai#1587 (comment).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Claude Sonnet 5), agentic implementation from a reviewed plan.

**Any additional AI details you'd like to share:**
Implemented end-to-end by Claude Code from a plan reviewed and approved by the repo owner: schema, migration, repositories, service, dispatch-path integration, routes, and tests. All verification steps above were run and their output checked before opening this PR.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added organization-scoped provider keys with secure storage, lifecycle management, defaults, and workspace controls.
- Added workspace overrides, inheritance, disablement, and model restrictions.
- Added authorized organization and workspace APIs and dashboard client support.
- Updated routing, pricing, usage tracking, streaming, and batch processing to use workspace context.
- Added caching, startup refresh, validation, tenancy protection, database migrations, and regression tests.

These changes let organizations manage BYO provider keys while preserving existing deployment-level behavior. Workspace controls improve provider selection and cost attribution.

## Technical notes

- Bare `provider:model` selectors can use organization keys when a workspace is available.
- Explicit provider instances continue to use configured credentials.
- Batch lifecycle operations retain the originating workspace for credential resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

