### PR TITLE
feat(tenancy): workspace per-member budget defaults

### DIFF
--- a/alembic/versions/f7a2c4e6b8d1_add_workspace_budget_defaults.py
+++ b/alembic/versions/f7a2c4e6b8d1_add_workspace_budget_defaults.py
@@ -1,0 +1,77 @@
+"""Add the workspace-member-budget-default template table.
+
+A workspace-level template for a per-member ``scoped_budgets`` ceiling. It
+carries no counters and enforces nothing itself; creating one, or a member
+joining a workspace that has one, materializes a ``scoped_budgets`` row per
+member (see ``services/tenancy/workspace_budget_default_service.py``).
+
+Two partial unique indexes rather than one plain UNIQUE over the pair, for the
+same reason ``scoped_budgets`` has them: PostgreSQL and SQLite both treat NULLs
+as distinct, so an index including the nullable ``provider_key_id`` would
+enforce nothing on the aggregate (NULL-key) rows.
+
+Unlike ``scoped_budgets.scope_id``, ``workspace_id`` here is a real foreign
+key: a template belongs to exactly one workspace and nothing else names it, so
+it rides the workspace's own delete rather than needing separate cleanup.
+
+Revision ID: f7a2c4e6b8d1
+Revises: c8f2a6b4e9d3
+Create Date: 2026-08-20
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f7a2c4e6b8d1"
+down_revision: str | Sequence[str] | None = "c8f2a6b4e9d3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_WITH_KEY = "uq_workspace_budget_defaults_with_key"
+_NO_KEY = "uq_workspace_budget_defaults_no_key"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workspace_budget_defaults",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("workspace_id", sa.Uuid(), nullable=False),
+        sa.Column("provider_key_id", sa.String(), nullable=True),
+        sa.Column("name", sa.String(), nullable=True),
+        sa.Column("max_budget", sa.Float(), nullable=True),
+        sa.Column("budget_duration_sec", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspace.id"], ondelete="CASCADE"),
+    )
+    op.create_index(
+        op.f("ix_workspace_budget_defaults_workspace_id"),
+        "workspace_budget_defaults",
+        ["workspace_id"],
+    )
+    op.create_index(
+        _WITH_KEY,
+        "workspace_budget_defaults",
+        ["workspace_id", "provider_key_id"],
+        unique=True,
+        postgresql_where=sa.text("provider_key_id IS NOT NULL"),
+        sqlite_where=sa.text("provider_key_id IS NOT NULL"),
+    )
+    op.create_index(
+        _NO_KEY,
+        "workspace_budget_defaults",
+        ["workspace_id"],
+        unique=True,
+        postgresql_where=sa.text("provider_key_id IS NULL"),
+        sqlite_where=sa.text("provider_key_id IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_NO_KEY, table_name="workspace_budget_defaults")
+    op.drop_index(_WITH_KEY, table_name="workspace_budget_defaults")
+    op.drop_index(op.f("ix_workspace_budget_defaults_workspace_id"), table_name="workspace_budget_defaults")
+    op.drop_table("workspace_budget_defaults")

--- a/alembic/versions/f7a2c4e6b8d1_add_workspace_budget_defaults.py
+++ b/alembic/versions/f7a2c4e6b8d1_add_workspace_budget_defaults.py
@@ -15,7 +15,7 @@ key: a template belongs to exactly one workspace and nothing else names it, so
 it rides the workspace's own delete rather than needing separate cleanup.
 
 Revision ID: f7a2c4e6b8d1
-Revises: 7ff4e082eb0c
+Revises: b6d8f0a2c4e7
 Create Date: 2026-08-20
 """
 
@@ -25,7 +25,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "f7a2c4e6b8d1"
-down_revision: str | Sequence[str] | None = "7ff4e082eb0c"
+down_revision: str | Sequence[str] | None = "b6d8f0a2c4e7"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/f7a2c4e6b8d1_add_workspace_budget_defaults.py
+++ b/alembic/versions/f7a2c4e6b8d1_add_workspace_budget_defaults.py
@@ -15,7 +15,7 @@ key: a template belongs to exactly one workspace and nothing else names it, so
 it rides the workspace's own delete rather than needing separate cleanup.
 
 Revision ID: f7a2c4e6b8d1
-Revises: c8f2a6b4e9d3
+Revises: 7ff4e082eb0c
 Create Date: 2026-08-20
 """
 
@@ -25,7 +25,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "f7a2c4e6b8d1"
-down_revision: str | Sequence[str] | None = "c8f2a6b4e9d3"
+down_revision: str | Sequence[str] | None = "7ff4e082eb0c"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -10155,6 +10155,209 @@
         "title": "WorkspaceCreate",
         "type": "object"
       },
+      "WorkspaceMemberBudgetPoliciesPublic": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceMemberBudgetPolicyPublic"
+            },
+            "title": "Data",
+            "type": "array"
+          }
+        },
+        "required": [
+          "data",
+          "count"
+        ],
+        "title": "WorkspaceMemberBudgetPoliciesPublic",
+        "type": "object"
+      },
+      "WorkspaceMemberBudgetPolicyCreate": {
+        "description": "Request body for creating a default.",
+        "properties": {
+          "budget_duration_sec": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "maximum": 315360000.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Period length in seconds; null never resets",
+            "title": "Budget Duration Sec"
+          },
+          "max_budget": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Maximum USD spend per member in the period",
+            "title": "Max Budget"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Admin-facing label",
+            "title": "Name"
+          },
+          "provider_key_id": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Narrow the default to one provider instance; null applies to every provider",
+            "title": "Provider Key Id"
+          }
+        },
+        "title": "WorkspaceMemberBudgetPolicyCreate",
+        "type": "object"
+      },
+      "WorkspaceMemberBudgetPolicyPublic": {
+        "description": "One default and its template values.",
+        "properties": {
+          "budget_duration_sec": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Budget Duration Sec"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "max_budget": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Budget"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "provider_key_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider Key Id"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          },
+          "workspace_id": {
+            "format": "uuid",
+            "title": "Workspace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "workspace_id",
+          "provider_key_id",
+          "name",
+          "max_budget",
+          "budget_duration_sec",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "WorkspaceMemberBudgetPolicyPublic",
+        "type": "object"
+      },
+      "WorkspaceMemberBudgetPolicyUpdate": {
+        "description": "Request body for updating a default.\n\nNot retroactive: a member already materialized from this default keeps\nthe value that was in effect when they were materialized. Only a member\nmaterialized after this update sees the new one.",
+        "properties": {
+          "budget_duration_sec": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "maximum": 315360000.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Budget Duration Sec"
+          },
+          "max_budget": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Budget"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "title": "WorkspaceMemberBudgetPolicyUpdate",
+        "type": "object"
+      },
       "WorkspaceMemberPublic": {
         "properties": {
           "created_at": {
@@ -18821,6 +19024,275 @@
         "summary": "Update Workspace",
         "tags": [
           "workspaces"
+        ]
+      }
+    },
+    "/v1/workspaces/{workspace_id}/member-budget-policies": {
+      "get": {
+        "description": "List the budget defaults attached to a workspace. Any member may read it.",
+        "operationId": "list_workspace_budget_defaults_v1_workspaces__workspace_id__member_budget_policies_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of records to skip",
+            "in": "query",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of records to skip",
+              "minimum": 0,
+              "title": "Skip",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "description": "Maximum number of records to return",
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceMemberBudgetPoliciesPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "List Workspace Budget Defaults",
+        "tags": [
+          "workspace-member-budget-policies"
+        ]
+      },
+      "post": {
+        "description": "Create a budget default.\n\nMaterializes it into a per-member ``scoped_budgets`` row for every\nexisting active member of the workspace; a member who joins afterwards is\nmaterialized when they join.",
+        "operationId": "create_workspace_budget_default_v1_workspaces__workspace_id__member_budget_policies_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceMemberBudgetPolicyCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceMemberBudgetPolicyPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Create Workspace Budget Default",
+        "tags": [
+          "workspace-member-budget-policies"
+        ]
+      }
+    },
+    "/v1/workspaces/{workspace_id}/member-budget-policies/{default_id}": {
+      "delete": {
+        "description": "Delete a budget default.\n\nThe per-member ``scoped_budgets`` rows it already materialized are kept;\na member joining afterwards no longer gets one from it.",
+        "operationId": "delete_workspace_budget_default_v1_workspaces__workspace_id__member_budget_policies__default_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "default_id",
+            "required": true,
+            "schema": {
+              "title": "Default Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Delete Workspace Budget Default",
+        "tags": [
+          "workspace-member-budget-policies"
+        ]
+      },
+      "patch": {
+        "description": "Update a budget default's label or limit.\n\nNot retroactive: members already materialized from this default keep\ntheir existing ceiling; only a member materialized afterwards sees the\nnew one.",
+        "operationId": "update_workspace_budget_default_v1_workspaces__workspace_id__member_budget_policies__default_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "default_id",
+            "required": true,
+            "schema": {
+              "title": "Default Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceMemberBudgetPolicyUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceMemberBudgetPolicyPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Update Workspace Budget Default",
+        "tags": [
+          "workspace-member-budget-policies"
         ]
       }
     },

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -4709,6 +4709,173 @@
         }
       ],
       "name": "workspaces"
+    },
+    {
+      "item": [
+        {
+          "name": "List Workspace Budget Defaults",
+          "request": {
+            "description": "List the budget defaults attached to a workspace. Any member may read it.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "workspaces",
+                ":workspace_id",
+                "member-budget-policies"
+              ],
+              "query": [
+                {
+                  "description": "Number of records to skip",
+                  "disabled": true,
+                  "key": "skip",
+                  "value": ""
+                },
+                {
+                  "description": "Maximum number of records to return",
+                  "disabled": true,
+                  "key": "limit",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/workspaces/:workspace_id/member-budget-policies?skip=&limit=",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "workspace_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Create Workspace Budget Default",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"budget_duration_sec\": 0,\n  \"max_budget\": 0,\n  \"name\": \"string\",\n  \"provider_key_id\": \"string\"\n}"
+            },
+            "description": "Create a budget default.\n\nMaterializes it into a per-member ``scoped_budgets`` row for every\nexisting active member of the workspace; a member who joins afterwards is\nmaterialized when they join.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "workspaces",
+                ":workspace_id",
+                "member-budget-policies"
+              ],
+              "raw": "{{baseUrl}}/v1/workspaces/:workspace_id/member-budget-policies",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "workspace_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Update Workspace Budget Default",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"budget_duration_sec\": 0,\n  \"max_budget\": 0,\n  \"name\": \"string\"\n}"
+            },
+            "description": "Update a budget default's label or limit.\n\nNot retroactive: members already materialized from this default keep\ntheir existing ceiling; only a member materialized afterwards sees the\nnew one.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "PATCH",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "workspaces",
+                ":workspace_id",
+                "member-budget-policies",
+                ":default_id"
+              ],
+              "raw": "{{baseUrl}}/v1/workspaces/:workspace_id/member-budget-policies/:default_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "workspace_id",
+                  "value": ""
+                },
+                {
+                  "description": "path parameter",
+                  "key": "default_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Workspace Budget Default",
+          "request": {
+            "description": "Delete a budget default.\n\nThe per-member ``scoped_budgets`` rows it already materialized are kept;\na member joining afterwards no longer gets one from it.",
+            "header": [],
+            "method": "DELETE",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "workspaces",
+                ":workspace_id",
+                "member-budget-policies",
+                ":default_id"
+              ],
+              "raw": "{{baseUrl}}/v1/workspaces/:workspace_id/member-budget-policies/:default_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "workspace_id",
+                  "value": ""
+                },
+                {
+                  "description": "path parameter",
+                  "key": "default_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "name": "workspace-member-budget-policies"
     }
   ],
   "variable": [

--- a/scripts/sdk_codegen/sdk-endpoints.txt
+++ b/scripts/sdk_codegen/sdk-endpoints.txt
@@ -197,3 +197,7 @@ DELETE /v1/organizations/me/member-invitations/{invitation_id} # dashboard-only
 # link, not by an SDK caller acting as a key-holder inside a workspace.
 POST /v1/invitations/validate                               # accept-flow, not an SDK surface
 POST /v1/invitations/accept                                 # accept-flow, not an SDK surface
+GET /v1/workspaces/{workspace_id}/member-budget-policies                 # dashboard-only
+POST /v1/workspaces/{workspace_id}/member-budget-policies                # dashboard-only
+PATCH /v1/workspaces/{workspace_id}/member-budget-policies/{default_id}  # dashboard-only
+DELETE /v1/workspaces/{workspace_id}/member-budget-policies/{default_id} # dashboard-only

--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -36,6 +36,7 @@ from gateway.api.routes import (
     tools,
     usage,
     users,
+    workspace_member_budget_policies,
     workspaces,
 )
 from gateway.core.config import GatewayConfig
@@ -74,6 +75,7 @@ def register_routers(app: FastAPI, config: GatewayConfig) -> None:
     app.include_router(organization_pricing.router)
     app.include_router(workspaces.router)
     app.include_router(invitations.router)
+    app.include_router(workspace_member_budget_policies.router)
     app.include_router(budgets.router)
     app.include_router(scoped_budgets.router)
     app.include_router(aliases.router)

--- a/src/gateway/api/routes/workspace_member_budget_policies.py
+++ b/src/gateway/api/routes/workspace_member_budget_policies.py
@@ -1,0 +1,110 @@
+"""Workspace per-member budget defaults (standalone mode only).
+
+A default is a workspace-level template for the per-member ``scoped_budgets``
+ceiling; the materialized per-member rows live on the existing
+``/v1/scoped-budgets`` surface. Thin composition over
+`gateway.services.tenancy.workspace_budget_default_service`, following
+`routes/workspaces.py`'s own shape (master-key on the router, plus the
+caller's tenancy identity for the per-workspace role checks).
+"""
+
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.api.deps import CurrentIdentity, get_db, verify_master_key
+from gateway.api.routes.organizations import Message
+from gateway.services.tenancy.workspace_budget_default_service import (
+    WorkspaceBudgetDefaultService,
+    WorkspaceMemberBudgetPoliciesPublic,
+    WorkspaceMemberBudgetPolicyCreate,
+    WorkspaceMemberBudgetPolicyPublic,
+    WorkspaceMemberBudgetPolicyUpdate,
+)
+
+# Auth is declared on the router, matching `routes/workspaces.py`: every
+# handler here needs the master key, and a future one that forgot the
+# decorator would be unauthenticated with nothing to notice.
+router = APIRouter(
+    prefix="/v1/workspaces/{workspace_id}/member-budget-policies",
+    tags=["workspace-member-budget-policies"],
+    dependencies=[Depends(verify_master_key)],
+)
+
+
+def get_workspace_budget_default_service(db: Annotated[AsyncSession, Depends(get_db)]) -> WorkspaceBudgetDefaultService:
+    """Build the service on the request's session."""
+    return WorkspaceBudgetDefaultService(db)
+
+
+WorkspaceBudgetDefaultServiceDep = Annotated[
+    WorkspaceBudgetDefaultService, Depends(get_workspace_budget_default_service)
+]
+
+
+@router.get("")
+async def list_workspace_budget_defaults(
+    service: WorkspaceBudgetDefaultServiceDep,
+    current_identity: CurrentIdentity,
+    workspace_id: uuid.UUID,
+    skip: Annotated[int, Query(ge=0, description="Number of records to skip")] = 0,
+    limit: Annotated[int, Query(ge=1, le=1000, description="Maximum number of records to return")] = 100,
+) -> WorkspaceMemberBudgetPoliciesPublic:
+    """List the budget defaults attached to a workspace. Any member may read it."""
+    return await service.list_defaults(user=current_identity, workspace_id=workspace_id, skip=skip, limit=limit)
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create_workspace_budget_default(
+    service: WorkspaceBudgetDefaultServiceDep,
+    current_identity: CurrentIdentity,
+    workspace_id: uuid.UUID,
+    body: WorkspaceMemberBudgetPolicyCreate,
+) -> WorkspaceMemberBudgetPolicyPublic:
+    """Create a budget default.
+
+    Materializes it into a per-member ``scoped_budgets`` row for every
+    existing active member of the workspace; a member who joins afterwards is
+    materialized when they join.
+    """
+    return await service.create_default(user=current_identity, workspace_id=workspace_id, request=body)
+
+
+@router.patch("/{default_id}")
+async def update_workspace_budget_default(
+    service: WorkspaceBudgetDefaultServiceDep,
+    current_identity: CurrentIdentity,
+    workspace_id: uuid.UUID,
+    default_id: str,
+    body: WorkspaceMemberBudgetPolicyUpdate,
+) -> WorkspaceMemberBudgetPolicyPublic:
+    """Update a budget default's label or limit.
+
+    Not retroactive: members already materialized from this default keep
+    their existing ceiling; only a member materialized afterwards sees the
+    new one.
+    """
+    return await service.update_default(
+        user=current_identity,
+        workspace_id=workspace_id,
+        default_id=default_id,
+        request=body,
+    )
+
+
+@router.delete("/{default_id}")
+async def delete_workspace_budget_default(
+    service: WorkspaceBudgetDefaultServiceDep,
+    current_identity: CurrentIdentity,
+    workspace_id: uuid.UUID,
+    default_id: str,
+) -> Message:
+    """Delete a budget default.
+
+    The per-member ``scoped_budgets`` rows it already materialized are kept;
+    a member joining afterwards no longer gets one from it.
+    """
+    await service.delete_default(user=current_identity, workspace_id=workspace_id, default_id=default_id)
+    return Message(message="Workspace budget default deleted")

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -1156,3 +1156,63 @@ class OrganizationModelPricing(Base):
         default=lambda: datetime.now(UTC),
         onupdate=lambda: datetime.now(UTC),
     )
+
+
+class WorkspaceBudgetDefault(Base):
+    """A workspace-level template for a per-member ``ScopedBudget``.
+
+    ``scoped_budgets`` holds concrete ceilings; this table has no counters of
+    its own and enforces nothing directly. It is **materialized**: creating one
+    on a workspace that already has members, or a member joining a workspace
+    that already has one, stages a ``ScopedBudget(scope_type="workspace_member",
+    scope_id=<member id>)`` row for each (see
+    ``services/tenancy/workspace_budget_default_service.py``). A member with an
+    existing ceiling for the same ``provider_key_id`` is left alone; a
+    member-specific override always wins over the template.
+
+    Same two-axis shape as ``ScopedBudget``: ``workspace_id`` is who the
+    template belongs to, ``provider_key_id`` optionally narrows it to one
+    provider instance (NULL applies to all of them). Unlike ``ScopedBudget``,
+    ``workspace_id`` is a real foreign key: a template has exactly one owner
+    and nothing else names it, so it is deleted with the workspace rather than
+    requiring the same explicit cleanup ``ScopedBudget`` needs (see
+    ``WorkspaceService._delete_scoped_budgets_for``).
+    """
+
+    __tablename__ = "workspace_budget_defaults"
+    __table_args__ = (
+        # Same reasoning as ScopedBudget's two partial indexes: PostgreSQL and
+        # SQLite both treat NULLs as distinct in a plain UNIQUE, so a single
+        # index over the pair would enforce nothing on the aggregate (NULL-key)
+        # rows.
+        Index(
+            "uq_workspace_budget_defaults_with_key",
+            "workspace_id",
+            "provider_key_id",
+            unique=True,
+            postgresql_where=text("provider_key_id IS NOT NULL"),
+            sqlite_where=text("provider_key_id IS NOT NULL"),
+        ),
+        Index(
+            "uq_workspace_budget_defaults_no_key",
+            "workspace_id",
+            unique=True,
+            postgresql_where=text("provider_key_id IS NULL"),
+            sqlite_where=text("provider_key_id IS NULL"),
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(primary_key=True, default=lambda: str(uuid.uuid4()))
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("workspace.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    provider_key_id: Mapped[str | None] = mapped_column(default=None)
+    name: Mapped[str | None] = mapped_column(default=None)
+    max_budget: Mapped[float | None] = mapped_column(default=None)
+    budget_duration_sec: Mapped[int | None] = mapped_column(default=None)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -1210,9 +1210,15 @@ class WorkspaceBudgetDefault(Base):
     name: Mapped[str | None] = mapped_column(default=None)
     max_budget: Mapped[float | None] = mapped_column(default=None)
     budget_duration_sec: Mapped[int | None] = mapped_column(default=None)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    # ``UtcDateTime``, not ``DateTime(timezone=True)``: these two are serialized with
+    # ``.isoformat()`` (``WorkspaceMemberBudgetPolicyPublic.from_model``) for the
+    # budget-defaults page, and on SQLite (this repo's default ``database_url``)
+    # a plain ``DateTime(timezone=True)`` round-trips naive, so the wire value
+    # would carry no offset and a browser would read it as local time.
+    # ``UtcDateTime.impl`` is ``DateTime(timezone=True)``, so the DDL is unchanged.
+    created_at: Mapped[datetime] = mapped_column(UtcDateTime(), default=lambda: datetime.now(UTC))
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
+        UtcDateTime(),
         default=lambda: datetime.now(UTC),
         onupdate=lambda: datetime.now(UTC),
     )

--- a/src/gateway/repositories/tenancy/workspace_repository.py
+++ b/src/gateway/repositories/tenancy/workspace_repository.py
@@ -37,6 +37,26 @@ class WorkspaceRepository(BaseRepository[Workspace, WorkspaceCreate, WorkspaceUp
         result = await self.db.execute(select(Workspace).where(col(Workspace.id).in_(list(workspace_ids))))
         return list(result.scalars().all())
 
+    async def lock(self, workspace_id: uuid.UUID) -> None:
+        """Take a row lock on the workspace, serializing what is read against it.
+
+        Mirrors ``OrganizationRepository.lock``. What it serializes here: a
+        budget default's creation reads the workspace's current members before
+        materializing, and a concurrent membership-creation path reads the
+        workspace's current defaults before materializing the new member;
+        without a shared lock both transactions can run their read before
+        either commits its write, and the member who joined right around the
+        default's creation gets neither's ceiling. Every membership-creation
+        path (``WorkspaceService.create_workspace`` excepted, since a
+        just-created workspace has no default that could race it) takes this
+        same lock before its own read, so the two either serialize or, for
+        ``create_workspace``, never overlap.
+
+        ``FOR UPDATE`` is a no-op on SQLite; see the organization lock's own
+        note on why that is fine.
+        """
+        await self.db.execute(select(col(Workspace.id)).where(col(Workspace.id) == workspace_id).with_for_update())
+
     async def get_by_organization(
         self,
         organization_id: uuid.UUID,

--- a/src/gateway/services/tenancy/authorization.py
+++ b/src/gateway/services/tenancy/authorization.py
@@ -1,0 +1,111 @@
+"""Shared workspace-visibility and workspace-management checks.
+
+Extracted from :class:`WorkspaceService`, whose private methods now delegate
+here, so :class:`WorkspaceBudgetDefaultService` enforces the same two rules
+rather than carrying a second, driftable copy of them. A leaf module on
+purpose: it reaches :class:`OrganizationService` (to resolve the caller's
+active organization and organization-level role) but nothing here reaches
+back, which is what lets ``workspace_budget_default_service`` sit between
+``workspace_service`` and ``organization_service`` in the import graph without
+closing a cycle.
+"""
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.models.tenancy import MANAGEMENT_ROLES, Organization, User, Workspace
+from gateway.repositories.tenancy import WorkspaceMemberRepository, WorkspaceRepository
+from gateway.services.tenancy.errors import NotAuthorizedError, WorkspaceNotFoundError
+from gateway.services.tenancy.organization_service import OrganizationService
+
+
+async def resolve_visible_workspace(
+    db: AsyncSession,
+    *,
+    user: User,
+    workspace_id: uuid.UUID,
+    organizations: OrganizationService,
+) -> Workspace:
+    """Resolve a workspace the caller may see, in their active organization, or raise not-found.
+
+    Visible to a superuser, an organization owner/admin (who see every
+    workspace in it), or an active member of the workspace itself. Every "may
+    not see" case answers 404 rather than 403: another organization's
+    workspace, and a workspace in this organization the caller is not a member
+    of, must be indistinguishable from one that does not exist.
+    """
+    organization = await organizations.get_active_organization_for_user(user)
+    return await resolve_workspace_in_organization(
+        db,
+        user=user,
+        workspace_id=workspace_id,
+        organization=organization,
+        organizations=organizations,
+    )
+
+
+async def resolve_workspace_in_organization(
+    db: AsyncSession,
+    *,
+    user: User,
+    workspace_id: uuid.UUID,
+    organization: Organization,
+    organizations: OrganizationService,
+) -> Workspace:
+    """The body of :func:`resolve_visible_workspace`, for an already-resolved organization.
+
+    Split out because a caller that already paid for the organization lookup
+    (``WorkspaceService.delete_workspace``, which needs it for its own checks
+    too) should not pay for it twice.
+    """
+    workspace = await WorkspaceRepository(db).get(workspace_id)
+    if workspace is None or workspace.organization_id != organization.id:
+        raise WorkspaceNotFoundError(workspace_id)
+
+    if user.is_superuser:
+        return workspace
+
+    organization_membership = await organizations.members.get_active_by_organization_and_user(
+        organization.id,
+        user.id,
+    )
+    if organization_membership is not None and organization_membership.role in MANAGEMENT_ROLES:
+        return workspace
+
+    # Active-only: a suspended membership grants nothing.
+    if await WorkspaceMemberRepository(db).get_active_by_workspace_and_user(workspace.id, user.id) is None:
+        raise WorkspaceNotFoundError(workspace_id)
+    return workspace
+
+
+async def require_workspace_management_access(
+    db: AsyncSession,
+    *,
+    user: User,
+    workspace: Workspace,
+    organizations: OrganizationService,
+) -> None:
+    """Allow a superuser, an organization owner/admin, or an owner/admin of this workspace."""
+    if user.is_superuser:
+        return
+
+    organization_membership = await organizations.members.get_active_by_organization_and_user(
+        workspace.organization_id,
+        user.id,
+    )
+    if organization_membership is not None and organization_membership.role in MANAGEMENT_ROLES:
+        return
+
+    membership = await WorkspaceMemberRepository(db).get_by_workspace_and_user(workspace.id, user.id)
+    if membership is not None and membership.status == "active" and membership.role in MANAGEMENT_ROLES:
+        return
+
+    raise NotAuthorizedError
+
+
+__all__ = [
+    "require_workspace_management_access",
+    "resolve_visible_workspace",
+    "resolve_workspace_in_organization",
+]

--- a/src/gateway/services/tenancy/errors.py
+++ b/src/gateway/services/tenancy/errors.py
@@ -258,6 +258,17 @@ class InvitationAlreadyUsedError(TenancyValidationError):
         super().__init__("This invitation has already been used or is no longer valid")
 
 
+class WorkspaceBudgetDefaultNotFoundError(TenancyNotFoundError):
+    def __init__(self, default_id: object):
+        super().__init__(f"Workspace budget default {default_id} not found")
+
+
+class WorkspaceBudgetDefaultAlreadyExistsError(TenancyConflictError):
+    def __init__(self, workspace_id: object, provider_key_id: object):
+        scope = "every provider" if provider_key_id is None else f"provider '{provider_key_id}'"
+        super().__init__(f"Workspace {workspace_id} already has a budget default for {scope}")
+
+
 __all__ = [
     "ForeignTenancyError",
     "InvalidEmailError",
@@ -282,6 +293,8 @@ __all__ = [
     "TenancyNotFoundError",
     "TenancyValidationError",
     "WorkspaceAlreadyExistsError",
+    "WorkspaceBudgetDefaultAlreadyExistsError",
+    "WorkspaceBudgetDefaultNotFoundError",
     "WorkspaceInUseError",
     "WorkspaceMemberAlreadyExistsError",
     "WorkspaceMemberNotFoundError",

--- a/src/gateway/services/tenancy/organization_service.py
+++ b/src/gateway/services/tenancy/organization_service.py
@@ -535,9 +535,28 @@ class OrganizationService:
         An existing membership is updated rather than skipped, as the platform's
         own assignment path does: a suspended row that is left alone would leave
         the member listed in a workspace they were just granted while still
-        being refused everything in it.
+        being refused everything in it. Reviving one is materialized exactly
+        as creating one is: a suspended member could have missed a default
+        created while they were out, and the revive is the only signal that
+        they are back to being covered by the workspace's defaults again.
+
+        Each target workspace is locked (`WorkspaceRepository.lock`) before
+        its create-or-revive-and-materialize step, same as
+        `WorkspaceService.add_member`, and in a stable order (`wanted` is
+        walked sorted by id, not in insertion order) so two requests naming
+        the same workspaces in different orders cannot deadlock each other.
+        Imported locally, not at module top: `WorkspaceBudgetDefaultService`
+        reaches back to `OrganizationService` (for its own authorization
+        checks), and importing it at the top of this module would close that
+        into a real cycle. See `tests/unit/test_service_module_imports.py`.
         """
+        from gateway.services.tenancy.workspace_budget_default_service import (
+            WorkspaceBudgetDefaultService,
+        )
+
         members = WorkspaceMemberRepository(self.db)
+        workspaces = WorkspaceRepository(self.db)
+        budget_defaults = WorkspaceBudgetDefaultService(self.db)
         wanted: dict[uuid.UUID, str] = {}
         for assignment in assignments:
             wanted.setdefault(assignment.workspace_id, assignment.role)
@@ -548,12 +567,18 @@ class OrganizationService:
         existing_by_workspace = {
             member.workspace_id: member for member in await members.get_by_workspaces_and_user(wanted, user_id)
         }
-        for workspace_id, role in wanted.items():
+        for workspace_id, role in sorted(wanted.items(), key=lambda item: str(item[0])):
+            # Serialized against a concurrent `WorkspaceBudgetDefaultService.create_default`
+            # on this workspace; see `WorkspaceService.add_member`'s identical lock
+            # for why.
+            await workspaces.lock(workspace_id)
             existing = existing_by_workspace.get(workspace_id)
             if existing is not None:
-                await members.update(existing, WorkspaceMemberUpdate(role=role, status="active"))
+                revived = await members.update(existing, WorkspaceMemberUpdate(role=role, status="active"))
+                await budget_defaults.materialize_for_member(revived)
                 continue
-            await members.create(workspace_id=workspace_id, user_id=user_id, role=role)
+            member = await members.create(workspace_id=workspace_id, user_id=user_id, role=role)
+            await budget_defaults.materialize_for_member(member)
 
     async def invite_active_organization_member_for_user(
         self,

--- a/src/gateway/services/tenancy/organization_service.py
+++ b/src/gateway/services/tenancy/organization_service.py
@@ -539,6 +539,11 @@ class OrganizationService:
         as creating one is: a suspended member could have missed a default
         created while they were out, and the revive is the only signal that
         they are back to being covered by the workspace's defaults again.
+        Gated on the row actually having been inactive: re-applying the same
+        assignment to an already-active membership (a repeat invitation
+        accept, say) is not a join, and materializing it would resurrect a
+        per-member ceiling an admin deliberately deleted through
+        `/v1/scoped-budgets`.
 
         Each target workspace is locked (`WorkspaceRepository.lock`) before
         its create-or-revive-and-materialize step, same as
@@ -574,8 +579,10 @@ class OrganizationService:
             await workspaces.lock(workspace_id)
             existing = existing_by_workspace.get(workspace_id)
             if existing is not None:
+                was_inactive = existing.status != "active"
                 revived = await members.update(existing, WorkspaceMemberUpdate(role=role, status="active"))
-                await budget_defaults.materialize_for_member(revived)
+                if was_inactive:
+                    await budget_defaults.materialize_for_member(revived)
                 continue
             member = await members.create(workspace_id=workspace_id, user_id=user_id, role=role)
             await budget_defaults.materialize_for_member(member)

--- a/src/gateway/services/tenancy/workspace_budget_default_service.py
+++ b/src/gateway/services/tenancy/workspace_budget_default_service.py
@@ -75,7 +75,7 @@ def _period_window(budget_duration_sec: int | None) -> tuple[datetime | None, da
     of two; worth reconciling further, into one definition shared with
     ``scoped_budgets.py`` itself, wherever that shared home ends up landing.
     """
-    if not budget_duration_sec:
+    if budget_duration_sec is None:
         return None, None
     now = datetime.now(UTC)
     return now, now + timedelta(seconds=budget_duration_sec)
@@ -161,7 +161,14 @@ class WorkspaceBudgetDefaultService:
         """Create a per-member ``ScopedBudget`` for every default on the member's workspace.
 
         Skips any ``provider_key_id`` the member already has a ceiling for; a
-        member-specific override always wins over the template.
+        member-specific override always wins over the template. Never raises
+        ``IntegrityError``: a collision on one default (see
+        :meth:`_insert_member_budgets`) is swallowed there, precisely so this
+        method's callers (``WorkspaceService.add_member``,
+        ``OrganizationService._apply_workspace_assignments``) can keep their
+        own ``except IntegrityError`` narrow to the membership row they
+        actually insert, without a materialization-time collision escaping
+        and being misreported as a duplicate membership.
         """
         defaults = (
             (
@@ -178,7 +185,7 @@ class WorkspaceBudgetDefaultService:
         for default in defaults:
             if await self._existing_member_budget(member.id, default.provider_key_id) is not None:
                 continue
-            created.append(await self._create_member_budget(member.id, default))
+            created.extend(await self._insert_member_budgets([member.id], default))
         return created
 
     async def materialize_for_default(self, default: WorkspaceBudgetDefault) -> list[ScopedBudget]:
@@ -204,28 +211,20 @@ class WorkspaceBudgetDefaultService:
                 break
             active_ids = [member.id for member in members if member.status == "active"]
             if active_ids:
-                created.extend(await self._create_member_budgets(active_ids, default))
+                created.extend(await self._materialize_batch(active_ids, default))
             skip += len(members)
             if skip >= total:
                 break
         return created
 
-    async def _create_member_budgets(
+    async def _materialize_batch(
         self, member_ids: list[uuid.UUID], default: WorkspaceBudgetDefault
     ) -> list[ScopedBudget]:
         """Materialize ``default`` onto every id in ``member_ids`` that does not already have one.
 
-        One query for the whole batch's existing rows, one flush for the whole
-        batch's new ones, in the common case. The existence check and the
-        insert are still two round trips with nothing locking the gap between
-        them, and the one surface that can land in it (a direct
-        ``POST /v1/scoped-budgets`` for one of these members, racing this
-        fan-out) takes no lock on this workspace: `routes/scoped_budgets.py`
-        is a master-key admin surface with no notion of one. A batch that
-        collides falls back to inserting one row at a time, each in its own
-        savepoint, so a single colliding member costs one skipped row rather
-        than failing the whole page, and, one level up, the default's own
-        creation with it (see :meth:`create_default`).
+        One query for the whole batch's existing rows: the insert itself is
+        :meth:`_insert_member_budgets`, which is what actually tolerates a
+        collision on any one id.
         """
         existing_stmt = select(ScopedBudget.scope_id).where(
             ScopedBudget.scope_type == _SCOPE_WORKSPACE_MEMBER,
@@ -240,39 +239,67 @@ class WorkspaceBudgetDefaultService:
         candidates = [member_id for member_id in member_ids if str(member_id) not in already_covered]
         if not candidates:
             return []
+        return await self._insert_member_budgets(candidates, default)
 
-        def build(member_id: uuid.UUID) -> ScopedBudget:
-            period_start, period_end = _period_window(default.budget_duration_sec)
-            return ScopedBudget(
-                scope_type=_SCOPE_WORKSPACE_MEMBER,
-                scope_id=str(member_id),
-                provider_key_id=default.provider_key_id,
-                max_budget=default.max_budget,
-                budget_duration_sec=default.budget_duration_sec,
-                period_start=period_start,
-                period_end=period_end,
-            )
+    async def _insert_member_budgets(
+        self, member_ids: list[uuid.UUID], default: WorkspaceBudgetDefault
+    ) -> list[ScopedBudget]:
+        """Insert a ``ScopedBudget`` for each id in ``member_ids``, tolerating a uniqueness collision on any one.
 
-        budgets = [build(member_id) for member_id in candidates]
-        self.db.add_all(budgets)
+        The existence check the two callers run first is a separate round
+        trip with nothing locking the gap after it, and the one surface that
+        can land there (a direct ``POST /v1/scoped-budgets`` for one of these
+        members, racing this insert) takes no lock on the workspace:
+        `routes/scoped_budgets.py` is a master-key admin surface with no
+        notion of one. One flush for the whole batch in the common case;
+        falls back to one row at a time, each in its own savepoint, on
+        conflict, so a single colliding id costs one skipped row rather than
+        the whole batch.
+
+        Each attempt's ``add()`` happens *inside* its ``begin_nested()``
+        block, not before it: ``AsyncSession.begin_nested()`` unconditionally
+        flushes whatever is already pending before it opens the ``SAVEPOINT``,
+        so an add staged beforehand is flushed *outside* any savepoint, and a
+        conflict there fails the outer transaction rather than just rolling
+        back to the point the savepoint was meant to protect. The same reason
+        rules out an explicit ``expunge`` in the ``except`` branch: a
+        savepoint rollback already expunges the row it was protecting, so a
+        second, manual expunge finds nothing there and raises
+        ``InvalidRequestError`` instead.
+        """
         try:
             async with self.db.begin_nested():
+                budgets = [self._build_member_budget(member_id, default) for member_id in member_ids]
+                self.db.add_all(budgets)
                 await self.db.flush()
             return budgets
         except IntegrityError:
             pass  # fall back below; the savepoint already rolled the batch back
 
         created: list[ScopedBudget] = []
-        for member_id in candidates:
-            budget = build(member_id)
-            self.db.add(budget)
+        for member_id in member_ids:
             try:
                 async with self.db.begin_nested():
+                    budget = self._build_member_budget(member_id, default)
+                    self.db.add(budget)
                     await self.db.flush()
                 created.append(budget)
             except IntegrityError:
-                self.db.expunge(budget)
+                pass  # this id's savepoint rolled back and expunged it; move on
         return created
+
+    @staticmethod
+    def _build_member_budget(member_id: uuid.UUID, default: WorkspaceBudgetDefault) -> ScopedBudget:
+        period_start, period_end = _period_window(default.budget_duration_sec)
+        return ScopedBudget(
+            scope_type=_SCOPE_WORKSPACE_MEMBER,
+            scope_id=str(member_id),
+            provider_key_id=default.provider_key_id,
+            max_budget=default.max_budget,
+            budget_duration_sec=default.budget_duration_sec,
+            period_start=period_start,
+            period_end=period_end,
+        )
 
     async def _existing_member_budget(self, member_id: uuid.UUID, provider_key_id: str | None) -> ScopedBudget | None:
         stmt = select(ScopedBudget).where(
@@ -285,21 +312,6 @@ class WorkspaceBudgetDefaultService:
             else ScopedBudget.provider_key_id.is_(None)
         )
         return (await self.db.execute(stmt)).scalars().first()
-
-    async def _create_member_budget(self, member_id: uuid.UUID, default: WorkspaceBudgetDefault) -> ScopedBudget:
-        period_start, period_end = _period_window(default.budget_duration_sec)
-        budget = ScopedBudget(
-            scope_type=_SCOPE_WORKSPACE_MEMBER,
-            scope_id=str(member_id),
-            provider_key_id=default.provider_key_id,
-            max_budget=default.max_budget,
-            budget_duration_sec=default.budget_duration_sec,
-            period_start=period_start,
-            period_end=period_end,
-        )
-        self.db.add(budget)
-        await self.db.flush()
-        return budget
 
     # ------------------------------------------------------------------
     # CRUD (commit on success)
@@ -385,7 +397,7 @@ class WorkspaceBudgetDefaultService:
         # write `WorkspaceBudgetDefaultAlreadyExistsError`'s message describes
         # (the template's own unique index). `materialize_for_default` handles
         # its own, unrelated `IntegrityError`s internally (see
-        # `_create_member_budgets`) precisely so one never reaches here and
+        # `_insert_member_budgets`) precisely so one never reaches here and
         # gets misreported as "this default already exists", rolling back a
         # template that in fact does not conflict with anything.
         try:

--- a/src/gateway/services/tenancy/workspace_budget_default_service.py
+++ b/src/gateway/services/tenancy/workspace_budget_default_service.py
@@ -1,0 +1,465 @@
+"""Workspace-level templates for per-member ``scoped_budgets`` ceilings.
+
+A default (``WorkspaceBudgetDefault``) is a workspace-level template for a
+per-member spend limit. When a member joins the workspace (or when a default
+is created on a workspace that already has members) it is **eagerly
+materialized** into a per-member :class:`ScopedBudget` row, so the ceiling is
+visible immediately rather than on first spend.
+
+The wire DTOs keep the ``WorkspaceMemberBudgetPolicy*`` names from
+``otari-ai``'s ``budget_policy_service`` (the hosted equivalent this is ported
+from), so the generated client stays recognizable across both trees; the
+stored fields follow this repo's own ``ScopedBudget`` vocabulary
+(``max_budget``, ``budget_duration_sec``) rather than otari-ai's
+(``budget_limit``, ``spend_period``), since OSS budgets are USD/seconds-only
+with no token or request dimension.
+
+Materialization methods (``materialize_for_member``, ``materialize_for_default``)
+are flush-only: they do not commit, so they fold into the enclosing
+transaction at each call site (workspace creation, adding a member,
+organization-member creation with workspace assignments). CRUD methods commit
+on success.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from gateway.models.entities import ScopedBudget, WorkspaceBudgetDefault
+from gateway.models.tenancy import User, Workspace, WorkspaceMember
+from gateway.repositories.tenancy import WorkspaceMemberRepository, WorkspaceRepository
+from gateway.services.tenancy import authorization
+from gateway.services.tenancy.errors import (
+    WorkspaceBudgetDefaultAlreadyExistsError,
+    WorkspaceBudgetDefaultNotFoundError,
+)
+from gateway.services.tenancy.organization_service import OrganizationService
+
+# The scope name is spelled out rather than imported from
+# `scoped_budget_service`: that module imports `workspace_scope`, which imports
+# `tenancy.provisioning_service`, which imports `tenancy/__init__`, which
+# imports `workspace_service`, which imports this module. See
+# `WorkspaceService`'s own docstring on `_delete_scoped_budgets_for` for the
+# same avoidance. `tests/unit/test_service_module_imports.py` pins the graph
+# staying acyclic.
+_SCOPE_WORKSPACE_MEMBER = "workspace_member"
+
+# Page size for fanning a new default out across a workspace's active members,
+# and the ceiling a list read pages at.
+_MATERIALIZE_PAGE_SIZE = 500
+_MAX_LIST_LIMIT = 1000
+
+# An upper bound on a period length, in seconds (roughly ten years). Without
+# one, `_period_window`'s `datetime + timedelta(seconds=...)` overflows on an
+# arbitrarily large value: `timedelta` itself refuses more than
+# `timedelta.max`, so a request near that raises `OverflowError` (a 500)
+# instead of the 422 an out-of-range period should be.
+_MAX_BUDGET_DURATION_SEC = 10 * 365 * 24 * 3600
+
+
+def _period_window(budget_duration_sec: int | None) -> tuple[datetime | None, datetime | None]:
+    """The ``(period_start, period_end)`` a freshly materialized ``ScopedBudget`` opens with.
+
+    A private, local duplicate of the same arithmetic
+    ``routes/scoped_budgets.create_scoped_budget`` does, for the same reason
+    ``_SCOPE_WORKSPACE_MEMBER`` above is a literal rather than an import
+    (importing ``scoped_budget_service`` closes a cycle). Centralized to one
+    definition *here* at least, so the module carries one derivation instead
+    of two; worth reconciling further, into one definition shared with
+    ``scoped_budgets.py`` itself, wherever that shared home ends up landing.
+    """
+    if not budget_duration_sec:
+        return None, None
+    now = datetime.now(UTC)
+    return now, now + timedelta(seconds=budget_duration_sec)
+
+
+class WorkspaceMemberBudgetPolicyCreate(BaseModel):
+    """Request body for creating a default."""
+
+    provider_key_id: str | None = Field(
+        default=None,
+        max_length=255,
+        description="Narrow the default to one provider instance; null applies to every provider",
+    )
+    name: str | None = Field(default=None, max_length=200, description="Admin-facing label")
+    max_budget: float | None = Field(default=None, ge=0, description="Maximum USD spend per member in the period")
+    budget_duration_sec: int | None = Field(
+        default=None,
+        gt=0,
+        le=_MAX_BUDGET_DURATION_SEC,
+        description="Period length in seconds; null never resets",
+    )
+
+
+class WorkspaceMemberBudgetPolicyUpdate(BaseModel):
+    """Request body for updating a default.
+
+    Not retroactive: a member already materialized from this default keeps
+    the value that was in effect when they were materialized. Only a member
+    materialized after this update sees the new one.
+    """
+
+    name: str | None = Field(default=None, max_length=200)
+    max_budget: float | None = Field(default=None, ge=0)
+    budget_duration_sec: int | None = Field(default=None, gt=0, le=_MAX_BUDGET_DURATION_SEC)
+
+
+class WorkspaceMemberBudgetPolicyPublic(BaseModel):
+    """One default and its template values."""
+
+    id: str
+    workspace_id: uuid.UUID
+    provider_key_id: str | None
+    name: str | None
+    max_budget: float | None
+    budget_duration_sec: int | None
+    created_at: str
+    updated_at: str
+
+    @classmethod
+    def from_model(cls, default: WorkspaceBudgetDefault) -> WorkspaceMemberBudgetPolicyPublic:
+        return cls(
+            id=default.id,
+            workspace_id=default.workspace_id,
+            provider_key_id=default.provider_key_id,
+            name=default.name,
+            max_budget=default.max_budget,
+            budget_duration_sec=default.budget_duration_sec,
+            created_at=default.created_at.isoformat(),
+            updated_at=default.updated_at.isoformat(),
+        )
+
+
+class WorkspaceMemberBudgetPoliciesPublic(BaseModel):
+    data: list[WorkspaceMemberBudgetPolicyPublic]
+    count: int
+
+
+class WorkspaceBudgetDefaultService:
+    """Materializer + CRUD for workspace per-member budget defaults."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.organizations = OrganizationService(db)
+        self.workspaces = WorkspaceRepository(db)
+        self.workspace_members = WorkspaceMemberRepository(db)
+
+    # ------------------------------------------------------------------
+    # Materialization (flush-only, no auth: called from within an
+    # already-authorized membership-creation transaction)
+    # ------------------------------------------------------------------
+
+    async def materialize_for_member(self, member: WorkspaceMember) -> list[ScopedBudget]:
+        """Create a per-member ``ScopedBudget`` for every default on the member's workspace.
+
+        Skips any ``provider_key_id`` the member already has a ceiling for; a
+        member-specific override always wins over the template.
+        """
+        defaults = (
+            (
+                await self.db.execute(
+                    select(WorkspaceBudgetDefault).where(
+                        col(WorkspaceBudgetDefault.workspace_id) == member.workspace_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        created: list[ScopedBudget] = []
+        for default in defaults:
+            if await self._existing_member_budget(member.id, default.provider_key_id) is not None:
+                continue
+            created.append(await self._create_member_budget(member.id, default))
+        return created
+
+    async def materialize_for_default(self, default: WorkspaceBudgetDefault) -> list[ScopedBudget]:
+        """Create a per-member ``ScopedBudget`` for every active member of the default's workspace.
+
+        Members who already have a ceiling for this ``provider_key_id`` are
+        left untouched, same precedence rule as :meth:`materialize_for_member`.
+        Pages through members so a large workspace is fully materialized.
+
+        One existence query and one flush per page, not per member: for a
+        page of up to ``_MATERIALIZE_PAGE_SIZE`` members that would otherwise
+        be two round trips each (an existence check, then an insert), which on
+        a workspace with hundreds of members is the difference between one
+        query pair and hundreds of them.
+        """
+        created: list[ScopedBudget] = []
+        skip = 0
+        while True:
+            members, total = await self.workspace_members.get_by_workspace(
+                default.workspace_id, skip=skip, limit=_MATERIALIZE_PAGE_SIZE
+            )
+            if not members:
+                break
+            active_ids = [member.id for member in members if member.status == "active"]
+            if active_ids:
+                created.extend(await self._create_member_budgets(active_ids, default))
+            skip += len(members)
+            if skip >= total:
+                break
+        return created
+
+    async def _create_member_budgets(
+        self, member_ids: list[uuid.UUID], default: WorkspaceBudgetDefault
+    ) -> list[ScopedBudget]:
+        """Materialize ``default`` onto every id in ``member_ids`` that does not already have one.
+
+        One query for the whole batch's existing rows, one flush for the whole
+        batch's new ones, in the common case. The existence check and the
+        insert are still two round trips with nothing locking the gap between
+        them, and the one surface that can land in it (a direct
+        ``POST /v1/scoped-budgets`` for one of these members, racing this
+        fan-out) takes no lock on this workspace: `routes/scoped_budgets.py`
+        is a master-key admin surface with no notion of one. A batch that
+        collides falls back to inserting one row at a time, each in its own
+        savepoint, so a single colliding member costs one skipped row rather
+        than failing the whole page, and, one level up, the default's own
+        creation with it (see :meth:`create_default`).
+        """
+        existing_stmt = select(ScopedBudget.scope_id).where(
+            ScopedBudget.scope_type == _SCOPE_WORKSPACE_MEMBER,
+            col(ScopedBudget.scope_id).in_([str(member_id) for member_id in member_ids]),
+        )
+        existing_stmt = existing_stmt.where(
+            ScopedBudget.provider_key_id == default.provider_key_id
+            if default.provider_key_id is not None
+            else ScopedBudget.provider_key_id.is_(None)
+        )
+        already_covered = {row for row in (await self.db.execute(existing_stmt)).scalars().all()}
+        candidates = [member_id for member_id in member_ids if str(member_id) not in already_covered]
+        if not candidates:
+            return []
+
+        def build(member_id: uuid.UUID) -> ScopedBudget:
+            period_start, period_end = _period_window(default.budget_duration_sec)
+            return ScopedBudget(
+                scope_type=_SCOPE_WORKSPACE_MEMBER,
+                scope_id=str(member_id),
+                provider_key_id=default.provider_key_id,
+                max_budget=default.max_budget,
+                budget_duration_sec=default.budget_duration_sec,
+                period_start=period_start,
+                period_end=period_end,
+            )
+
+        budgets = [build(member_id) for member_id in candidates]
+        self.db.add_all(budgets)
+        try:
+            async with self.db.begin_nested():
+                await self.db.flush()
+            return budgets
+        except IntegrityError:
+            pass  # fall back below; the savepoint already rolled the batch back
+
+        created: list[ScopedBudget] = []
+        for member_id in candidates:
+            budget = build(member_id)
+            self.db.add(budget)
+            try:
+                async with self.db.begin_nested():
+                    await self.db.flush()
+                created.append(budget)
+            except IntegrityError:
+                self.db.expunge(budget)
+        return created
+
+    async def _existing_member_budget(self, member_id: uuid.UUID, provider_key_id: str | None) -> ScopedBudget | None:
+        stmt = select(ScopedBudget).where(
+            ScopedBudget.scope_type == _SCOPE_WORKSPACE_MEMBER,
+            ScopedBudget.scope_id == str(member_id),
+        )
+        stmt = stmt.where(
+            ScopedBudget.provider_key_id == provider_key_id
+            if provider_key_id is not None
+            else ScopedBudget.provider_key_id.is_(None)
+        )
+        return (await self.db.execute(stmt)).scalars().first()
+
+    async def _create_member_budget(self, member_id: uuid.UUID, default: WorkspaceBudgetDefault) -> ScopedBudget:
+        period_start, period_end = _period_window(default.budget_duration_sec)
+        budget = ScopedBudget(
+            scope_type=_SCOPE_WORKSPACE_MEMBER,
+            scope_id=str(member_id),
+            provider_key_id=default.provider_key_id,
+            max_budget=default.max_budget,
+            budget_duration_sec=default.budget_duration_sec,
+            period_start=period_start,
+            period_end=period_end,
+        )
+        self.db.add(budget)
+        await self.db.flush()
+        return budget
+
+    # ------------------------------------------------------------------
+    # CRUD (commit on success)
+    # ------------------------------------------------------------------
+
+    async def _get_or_404(self, workspace: Workspace, default_id: str) -> WorkspaceBudgetDefault:
+        default = await self.db.get(WorkspaceBudgetDefault, default_id)
+        if default is None or default.workspace_id != workspace.id:
+            raise WorkspaceBudgetDefaultNotFoundError(default_id)
+        return default
+
+    async def list_defaults(
+        self,
+        *,
+        user: User,
+        workspace_id: uuid.UUID,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> WorkspaceMemberBudgetPoliciesPublic:
+        """List a page of a workspace's defaults, plus the total. Any member of the workspace may read it."""
+        await authorization.resolve_visible_workspace(
+            self.db, user=user, workspace_id=workspace_id, organizations=self.organizations
+        )
+        limit = min(limit, _MAX_LIST_LIMIT)
+
+        count = (
+            await self.db.execute(
+                select(func.count())
+                .select_from(WorkspaceBudgetDefault)
+                .where(col(WorkspaceBudgetDefault.workspace_id) == workspace_id)
+            )
+        ).scalar_one()
+
+        defaults = (
+            (
+                await self.db.execute(
+                    select(WorkspaceBudgetDefault)
+                    .where(col(WorkspaceBudgetDefault.workspace_id) == workspace_id)
+                    .order_by(col(WorkspaceBudgetDefault.created_at), col(WorkspaceBudgetDefault.id))
+                    .offset(skip)
+                    .limit(limit)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return WorkspaceMemberBudgetPoliciesPublic(
+            data=[WorkspaceMemberBudgetPolicyPublic.from_model(default) for default in defaults],
+            count=count,
+        )
+
+    async def create_default(
+        self,
+        *,
+        user: User,
+        workspace_id: uuid.UUID,
+        request: WorkspaceMemberBudgetPolicyCreate,
+    ) -> WorkspaceMemberBudgetPolicyPublic:
+        """Create a default, materializing it onto every existing active member."""
+        workspace = await authorization.resolve_visible_workspace(
+            self.db, user=user, workspace_id=workspace_id, organizations=self.organizations
+        )
+        await authorization.require_workspace_management_access(
+            self.db, user=user, workspace=workspace, organizations=self.organizations
+        )
+
+        # Serialized against every membership-creation path's own lock on this
+        # row (see `WorkspaceRepository.lock`): without it, a concurrent
+        # `add_member` can read the pre-creation set of defaults, and this call
+        # can read the pre-join set of members, and the new member gets neither
+        # ceiling even though both transactions commit successfully.
+        await self.workspaces.lock(workspace.id)
+
+        default = WorkspaceBudgetDefault(
+            workspace_id=workspace.id,
+            provider_key_id=request.provider_key_id,
+            name=request.name,
+            max_budget=request.max_budget,
+            budget_duration_sec=request.budget_duration_sec,
+        )
+        self.db.add(default)
+        # Narrowed to the default row's own flush on purpose: this is the only
+        # write `WorkspaceBudgetDefaultAlreadyExistsError`'s message describes
+        # (the template's own unique index). `materialize_for_default` handles
+        # its own, unrelated `IntegrityError`s internally (see
+        # `_create_member_budgets`) precisely so one never reaches here and
+        # gets misreported as "this default already exists", rolling back a
+        # template that in fact does not conflict with anything.
+        try:
+            await self.db.flush()
+        except IntegrityError:
+            await self.db.rollback()
+            raise WorkspaceBudgetDefaultAlreadyExistsError(workspace_id, request.provider_key_id) from None
+
+        await self.materialize_for_default(default)
+        await self.db.commit()
+        await self.db.refresh(default)
+        return WorkspaceMemberBudgetPolicyPublic.from_model(default)
+
+    async def update_default(
+        self,
+        *,
+        user: User,
+        workspace_id: uuid.UUID,
+        default_id: str,
+        request: WorkspaceMemberBudgetPolicyUpdate,
+    ) -> WorkspaceMemberBudgetPolicyPublic:
+        """Update a default's label or limit.
+
+        Not retroactive (see :class:`WorkspaceMemberBudgetPolicyUpdate`):
+        members already materialized from this default keep their existing
+        ``ScopedBudget`` row untouched. The scope (``provider_key_id``) is not
+        editable, matching ``routes/scoped_budgets.py``'s own rule for the
+        concrete ceilings this produces: changing it would move the template
+        to a different identity, which is a delete and a create, not an
+        update.
+        """
+        workspace = await authorization.resolve_visible_workspace(
+            self.db, user=user, workspace_id=workspace_id, organizations=self.organizations
+        )
+        await authorization.require_workspace_management_access(
+            self.db, user=user, workspace=workspace, organizations=self.organizations
+        )
+        default = await self._get_or_404(workspace, default_id)
+
+        if "name" in request.model_fields_set:
+            default.name = request.name
+        if "max_budget" in request.model_fields_set:
+            default.max_budget = request.max_budget
+        if "budget_duration_sec" in request.model_fields_set:
+            default.budget_duration_sec = request.budget_duration_sec
+
+        await self.db.commit()
+        await self.db.refresh(default)
+        return WorkspaceMemberBudgetPolicyPublic.from_model(default)
+
+    async def delete_default(self, *, user: User, workspace_id: uuid.UUID, default_id: str) -> None:
+        """Delete a default.
+
+        Only the template row is removed. The ``ScopedBudget`` rows it already
+        materialized (and their spend history) are left exactly as they are;
+        a member joining afterwards no longer gets one from it. Matches
+        ``WorkspaceService.delete_workspace``'s own preference for a stated,
+        intentional non-cascade over a silent one.
+        """
+        workspace = await authorization.resolve_visible_workspace(
+            self.db, user=user, workspace_id=workspace_id, organizations=self.organizations
+        )
+        await authorization.require_workspace_management_access(
+            self.db, user=user, workspace=workspace, organizations=self.organizations
+        )
+        default = await self._get_or_404(workspace, default_id)
+        await self.db.delete(default)
+        await self.db.commit()
+
+
+__all__ = [
+    "WorkspaceBudgetDefaultService",
+    "WorkspaceMemberBudgetPoliciesPublic",
+    "WorkspaceMemberBudgetPolicyCreate",
+    "WorkspaceMemberBudgetPolicyPublic",
+    "WorkspaceMemberBudgetPolicyUpdate",
+]

--- a/src/gateway/services/tenancy/workspace_service.py
+++ b/src/gateway/services/tenancy/workspace_service.py
@@ -39,19 +39,19 @@ from gateway.models.tenancy import (
     WorkspaceUpdate,
 )
 from gateway.repositories.tenancy import WorkspaceMemberRepository, WorkspaceRepository
+from gateway.services.tenancy import authorization
 from gateway.services.tenancy.errors import (
     InvalidRoleError,
     LastWorkspaceError,
     NotAnOrganizationMemberError,
-    NotAuthorizedError,
     WorkspaceAlreadyExistsError,
     WorkspaceInUseError,
     WorkspaceMemberAlreadyExistsError,
     WorkspaceMemberNotFoundError,
     WorkspaceNameRequiredError,
-    WorkspaceNotFoundError,
 )
 from gateway.services.tenancy.organization_service import OrganizationService
+from gateway.services.tenancy.workspace_budget_default_service import WorkspaceBudgetDefaultService
 
 
 class WorkspaceService:
@@ -62,6 +62,7 @@ class WorkspaceService:
         self.workspaces = WorkspaceRepository(db)
         self.members = WorkspaceMemberRepository(db)
         self.organizations = OrganizationService(db)
+        self.budget_defaults = WorkspaceBudgetDefaultService(db)
 
     # ------------------------------------------------------------------
     # Scoping and authorization
@@ -73,16 +74,15 @@ class WorkspaceService:
     async def _workspace_in_active_organization(self, *, user: User, workspace_id: uuid.UUID) -> Workspace:
         """Resolve a workspace the caller may see, or raise not-found.
 
-        Every "may not see" case answers 404 rather than 403 on purpose: another
-        organization's workspace, and a workspace in this organization that the
-        caller is not a member of, must be indistinguishable from one that does
-        not exist.
+        Delegates to ``services.tenancy.authorization``, shared with
+        ``WorkspaceBudgetDefaultService`` so the visibility rule is defined
+        once.
         """
-        organization = await self._active_organization(user)
-        return await self._workspace_in_organization(
+        return await authorization.resolve_visible_workspace(
+            self.db,
             user=user,
             workspace_id=workspace_id,
-            organization=organization,
+            organizations=self.organizations,
         )
 
     async def _workspace_in_organization(
@@ -98,27 +98,13 @@ class WorkspaceService:
         resolving it twice cost an extra round trip plus a second membership read
         on a path that already does several.
         """
-        workspace = await self.workspaces.get(workspace_id)
-        if workspace is None or workspace.organization_id != organization.id:
-            raise WorkspaceNotFoundError(workspace_id)
-
-        if user.is_superuser:
-            return workspace
-
-        organization_membership = await self.organizations.members.get_active_by_organization_and_user(
-            organization.id,
-            user.id,
+        return await authorization.resolve_workspace_in_organization(
+            self.db,
+            user=user,
+            workspace_id=workspace_id,
+            organization=organization,
+            organizations=self.organizations,
         )
-        if organization_membership is not None and organization_membership.role in MANAGEMENT_ROLES:
-            return workspace
-
-        # Active-only: a suspended membership grants nothing, and the management
-        # check below already reads it that way, so a suspended member could
-        # otherwise read a workspace and its roster while being refused every
-        # action in it.
-        if await self.members.get_active_by_workspace_and_user(workspace.id, user.id) is None:
-            raise WorkspaceNotFoundError(workspace_id)
-        return workspace
 
     @staticmethod
     def _validated_role(role: str) -> str:
@@ -148,27 +134,16 @@ class WorkspaceService:
     async def _require_workspace_management_access(self, *, user: User, workspace: Workspace) -> None:
         """Allow a superuser, an organization owner/admin, or an owner/admin of this workspace.
 
-        The superuser arm is what makes this agree with the two checks either
-        side of it: ``_workspace_in_active_organization`` grants a superuser read
-        on every workspace and ``_enforce_management_role`` grants them
-        organization management, so without it a superuser could delete a
-        workspace but not rename it.
+        Delegates to ``services.tenancy.authorization``, shared with
+        ``WorkspaceBudgetDefaultService`` so the management rule is defined
+        once.
         """
-        if user.is_superuser:
-            return
-
-        organization_membership = await self.organizations.members.get_active_by_organization_and_user(
-            workspace.organization_id,
-            user.id,
+        await authorization.require_workspace_management_access(
+            self.db,
+            user=user,
+            workspace=workspace,
+            organizations=self.organizations,
         )
-        if organization_membership is not None and organization_membership.role in MANAGEMENT_ROLES:
-            return
-
-        membership = await self.members.get_by_workspace_and_user(workspace.id, user.id)
-        if membership is not None and membership.status == "active" and membership.role in MANAGEMENT_ROLES:
-            return
-
-        raise NotAuthorizedError
 
     # ------------------------------------------------------------------
     # Workspace lifecycle
@@ -196,7 +171,12 @@ class WorkspaceService:
                 organization_id=organization.id,
                 created_by_user_id=user.id,
             )
-            await self.members.create(workspace_id=workspace.id, user_id=user.id, role="owner")
+            member = await self.members.create(workspace_id=workspace.id, user_id=user.id, role="owner")
+            # No-op today: a workspace this fresh has no defaults of its own yet.
+            # Called anyway so every WorkspaceMember-creating path materializes
+            # the same way, rather than two of three doing it and this one
+            # relying on being first.
+            await self.budget_defaults.materialize_for_member(member)
             await self.db.commit()
         except IntegrityError:
             await self.db.rollback()
@@ -401,10 +381,18 @@ class WorkspaceService:
         if await self.members.get_by_workspace_and_user(workspace.id, user_id) is not None:
             raise WorkspaceMemberAlreadyExistsError(user_id)
 
+        # Serialized against a concurrent `WorkspaceBudgetDefaultService.create_default`
+        # on this workspace, via the same row lock it takes: without it, this
+        # read of the current defaults and that one's read of the current
+        # members can each run before the other's write commits, and the new
+        # member gets neither.
+        await self.workspaces.lock(workspace.id)
+
         # As in create_workspace: the pre-check races the insert, and the unique
         # constraint is what actually decides.
         try:
             member = await self.members.create(workspace_id=workspace.id, user_id=user_id, role=role)
+            await self.budget_defaults.materialize_for_member(member)
             await self.db.commit()
         except IntegrityError:
             await self.db.rollback()

--- a/tests/integration/test_workspace_member_budget_policies.py
+++ b/tests/integration/test_workspace_member_budget_policies.py
@@ -9,8 +9,10 @@ services with identities built at whatever role a case needs.
 
 import asyncio
 import uuid
+from collections.abc import AsyncIterator
 
 import pytest
+import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
@@ -474,12 +476,23 @@ async def test_materialize_batch_recovers_from_a_missed_collision(async_db: Asyn
 # =============================================================================
 
 
-@pytest.fixture
-def sessions(postgres_url: str) -> async_sessionmaker[AsyncSession]:
+@pytest_asyncio.fixture
+async def sessions(postgres_url: str) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    """A session factory on its own engine, disposed after the test.
+
+    Undisposed, each test using this leaves an asyncpg connection pool alive
+    until garbage collection, which tends to surface later as a
+    connection-limit failure or "event loop is closed" noise in an unrelated
+    test rather than as a failure here.
+    """
     url = postgres_url.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
         "postgresql://", "postgresql+asyncpg://"
     )
-    return async_sessionmaker(create_async_engine(url), expire_on_commit=False)
+    engine = create_async_engine(url)
+    try:
+        yield async_sessionmaker(engine, expire_on_commit=False)
+    finally:
+        await engine.dispose()
 
 
 async def test_concurrent_default_create_and_member_add_both_land(

--- a/tests/integration/test_workspace_member_budget_policies.py
+++ b/tests/integration/test_workspace_member_budget_policies.py
@@ -14,7 +14,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from gateway.models.entities import ScopedBudget
+from gateway.models.entities import ScopedBudget, WorkspaceBudgetDefault
 from gateway.models.tenancy import (
     ActiveOrganizationMemberCreateRequest,
     Organization,
@@ -233,6 +233,53 @@ async def test_reviving_a_suspended_workspace_membership_is_materialized(async_d
     assert budget.max_budget == 35.0
 
 
+async def test_reapplying_an_active_assignment_does_not_rematerialize_a_deleted_override(
+    async_db: AsyncSession,
+) -> None:
+    """Re-applying an assignment to an already-active member is not a join.
+
+    `_apply_workspace_assignments`'s revive branch also runs for a membership
+    that was already active (an idempotent re-post, or a second invitation
+    naming the same workspace); only a row that was actually inactive is a
+    real join. Without the status gate, re-applying the assignment would
+    resurrect a per-member ceiling an admin deliberately deleted through
+    `/v1/scoped-budgets`.
+    """
+    org = await _organization(async_db, slug="acme-reapply")
+    owner = await _member(async_db, org, role="owner", full_name="Owner")
+    member_user = await _member(async_db, org, role="member", full_name="Member")
+    workspace = await _workspace(async_db, org, name="Engineering", owner=owner)
+    workspace_member = await WorkspaceMemberRepository(async_db).create(
+        workspace_id=workspace.id, user_id=member_user.id, role="member"
+    )
+    await async_db.commit()
+
+    service = WorkspaceBudgetDefaultService(async_db)
+    await service.create_default(
+        user=owner,
+        workspace_id=workspace.id,
+        request=WorkspaceMemberBudgetPolicyCreate(max_budget=50.0),
+    )
+    budget = await _member_budget(async_db, workspace_member.id)
+    assert budget is not None
+
+    # An admin deletes the member's own ceiling directly.
+    await async_db.delete(budget)
+    await async_db.commit()
+    assert await _member_budget(async_db, workspace_member.id) is None
+
+    organization_service = OrganizationService(async_db)
+    await organization_service._apply_workspace_assignments(  # noqa: SLF001 - exercising the internal gate directly
+        user_id=member_user.id,
+        assignments=[WorkspaceAssignmentRequest(workspace_id=workspace.id, role="member")],
+    )
+    await async_db.commit()
+
+    assert await _member_budget(async_db, workspace_member.id) is None, (
+        "re-applying an already-active assignment must not re-materialize a deleted override"
+    )
+
+
 async def test_update_is_not_retroactive(async_db: AsyncSession) -> None:
     org = await _organization(async_db, slug="acme-update")
     owner = await _member(async_db, org, role="owner", full_name="Owner")
@@ -363,6 +410,63 @@ async def test_foreign_workspace_is_not_found(async_db: AsyncSession) -> None:
     service = WorkspaceBudgetDefaultService(async_db)
     with pytest.raises(WorkspaceNotFoundError):
         await service.list_defaults(user=owner_a, workspace_id=workspace_b.id)
+
+
+# =============================================================================
+# _insert_member_budgets' savepoint fallback, exercised directly: a batch
+# collision must fall back to a per-row retry rather than 500ing the request
+# or leaving the session unusable.
+# =============================================================================
+
+
+async def test_materialize_batch_recovers_from_a_missed_collision(async_db: AsyncSession) -> None:
+    """A batch collision falls back to a per-row retry instead of failing outright.
+
+    Reproduces the shape of the race `_insert_member_budgets` exists to
+    survive: by the time the insert runs, a ceiling already exists for one of
+    the ids in the batch (standing in for a concurrent direct
+    ``POST /v1/scoped-budgets`` for that member, which the batch's own
+    existence check, run a moment earlier, would not yet have seen).
+    Called directly rather than through `materialize_for_default`, which
+    otherwise wraps the same existence check around every id and would just
+    filter the colliding one out before ever attempting to insert it.
+    """
+    org = await _organization(async_db, slug="acme-collision")
+    owner = await _member(async_db, org, role="owner", full_name="Owner")
+    other = await _member(async_db, org, role="member", full_name="Other")
+    workspace = await _workspace(async_db, org, name="Engineering", owner=owner)
+    workspace_members = WorkspaceMemberRepository(async_db)
+    other_member = await workspace_members.create(workspace_id=workspace.id, user_id=other.id, role="member")
+    owner_member = await workspace_members.get_by_workspace_and_user(workspace.id, owner.id)
+    assert owner_member is not None
+
+    default = WorkspaceBudgetDefault(workspace_id=workspace.id, max_budget=40.0)
+    async_db.add(default)
+    await async_db.flush()
+
+    # The row `_insert_member_budgets` will collide with, inserted directly
+    # (not through the check-then-insert path this test bypasses).
+    collision = ScopedBudget(scope_type="workspace_member", scope_id=str(other_member.id), max_budget=999.0)
+    async_db.add(collision)
+    await async_db.flush()
+
+    service = WorkspaceBudgetDefaultService(async_db)
+    created = await service._insert_member_budgets(  # noqa: SLF001 - exercising the fallback directly
+        [owner_member.id, other_member.id], default
+    )
+
+    assert {budget.scope_id for budget in created} == {str(owner_member.id)}
+    owner_budget = await _member_budget(async_db, owner_member.id)
+    assert owner_budget is not None
+    assert owner_budget.max_budget == 40.0
+    other_budget = await _member_budget(async_db, other_member.id)
+    assert other_budget is not None
+    assert other_budget.max_budget == 999.0, "the pre-existing row must survive the collision untouched"
+
+    # The broken version failed exactly here: PendingRollbackError on the next
+    # statement, because the failed batch flush had already dirtied the outer
+    # transaction rather than just the savepoint.
+    await async_db.commit()
 
 
 # =============================================================================

--- a/tests/integration/test_workspace_member_budget_policies.py
+++ b/tests/integration/test_workspace_member_budget_policies.py
@@ -1,0 +1,436 @@
+"""Workspace per-member budget defaults: materialization, CRUD, and authorization.
+
+Exercised at the service layer, matching `test_tenancy_authorization.py`: the
+API can only ever act as the one superuser operator identity a standalone
+deployment has, so the rules that matter most (a non-management member
+refused, a foreign workspace refused) are only reachable by calling the
+services with identities built at whatever role a case needs.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from gateway.models.entities import ScopedBudget
+from gateway.models.tenancy import (
+    ActiveOrganizationMemberCreateRequest,
+    Organization,
+    User,
+    Workspace,
+    WorkspaceAssignmentRequest,
+)
+from gateway.repositories.tenancy import (
+    OrganizationMemberRepository,
+    OrganizationRepository,
+    UserRepository,
+    WorkspaceMemberRepository,
+    WorkspaceRepository,
+)
+from gateway.services.tenancy import OrganizationService, WorkspaceService
+from gateway.services.tenancy.errors import (
+    NotAuthorizedError,
+    WorkspaceBudgetDefaultAlreadyExistsError,
+    WorkspaceBudgetDefaultNotFoundError,
+    WorkspaceNotFoundError,
+)
+from gateway.services.tenancy.workspace_budget_default_service import (
+    WorkspaceBudgetDefaultService,
+    WorkspaceMemberBudgetPolicyCreate,
+    WorkspaceMemberBudgetPolicyUpdate,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _organization(db: AsyncSession, *, slug: str) -> Organization:
+    return await OrganizationRepository(db).create_organization(name=slug.title(), slug=slug, created_by_user_id=None)
+
+
+async def _member(
+    db: AsyncSession,
+    organization: Organization,
+    *,
+    role: str,
+    full_name: str,
+) -> User:
+    user = await UserRepository(db).create_local_identity(
+        full_name=full_name,
+        active_organization_id=organization.id,
+    )
+    await OrganizationMemberRepository(db).create_membership(
+        organization_id=organization.id,
+        user_id=user.id,
+        role=role,
+    )
+    return user
+
+
+async def _workspace(db: AsyncSession, organization: Organization, *, name: str, owner: User) -> Workspace:
+    workspace = await WorkspaceRepository(db).create_workspace(
+        name=name,
+        organization_id=organization.id,
+        created_by_user_id=owner.id,
+    )
+    await WorkspaceMemberRepository(db).create(workspace_id=workspace.id, user_id=owner.id, role="owner")
+    return workspace
+
+
+async def _member_budget(
+    db: AsyncSession, member_id: uuid.UUID, *, provider_key_id: str | None = None
+) -> ScopedBudget | None:
+    stmt = select(ScopedBudget).where(
+        ScopedBudget.scope_type == "workspace_member",
+        ScopedBudget.scope_id == str(member_id),
+    )
+    stmt = stmt.where(
+        ScopedBudget.provider_key_id == provider_key_id
+        if provider_key_id is not None
+        else ScopedBudget.provider_key_id.is_(None)
+    )
+    return (await db.execute(stmt)).scalars().first()
+
+
+async def test_create_materializes_onto_existing_members_but_skips_an_override(async_db: AsyncSession) -> None:
+    org = await _organization(async_db, slug="acme-create")
+    owner = await _member(async_db, org, role="owner", full_name="Owner")
+    other = await _member(async_db, org, role="member", full_name="Other")
+    workspace = await _workspace(async_db, org, name="Engineering", owner=owner)
+    workspace_members = WorkspaceMemberRepository(async_db)
+    other_member = await workspace_members.create(workspace_id=workspace.id, user_id=other.id, role="member")
+
+    # `other` already has a ceiling for this scope; the default must not touch it.
+    override = ScopedBudget(scope_type="workspace_member", scope_id=str(other_member.id), max_budget=999.0)
+    async_db.add(override)
+    await async_db.commit()
+
+    service = WorkspaceBudgetDefaultService(async_db)
+    created = await service.create_default(
+        user=owner,
+        workspace_id=workspace.id,
+        request=WorkspaceMemberBudgetPolicyCreate(name="Default", max_budget=50.0, budget_duration_sec=86400),
+    )
+    assert created.max_budget == 50.0
+
+    owner_member = await workspace_members.get_by_workspace_and_user(workspace.id, owner.id)
+    assert owner_member is not None
+    owner_budget = await _member_budget(async_db, owner_member.id)
+    assert owner_budget is not None
+    assert owner_budget.max_budget == 50.0
+    assert owner_budget.budget_duration_sec == 86400
+
+    other_budget = await _member_budget(async_db, other_member.id)
+    assert other_budget is not None
+    assert other_budget.max_budget == 999.0, "an existing member-specific ceiling must win over the template"
+
+
+async def test_member_added_afterwards_is_materialized_on_join(async_db: AsyncSession) -> None:
+    org = await _organization(async_db, slug="acme-join")
+    owner = await _member(async_db, org, role="owner", full_name="Owner")
+    joiner = await _member(async_db, org, role="member", full_name="Joiner")
+    workspace = await _workspace(async_db, org, name="Engineering", owner=owner)
+
+    service = WorkspaceBudgetDefaultService(async_db)
+    await service.create_default(
+        user=owner,
+        workspace_id=workspace.id,
+        request=WorkspaceMemberBudgetPolicyCreate(max_budget=25.0),
+    )
+
+    workspace_service = WorkspaceService(async_db)
+    added = await workspace_service.add_member(user=owner, workspace_id=workspace.id, user_id=joiner.id)
+
+    budget = await _member_budget(async_db, added.id)
+    assert budget is not None
+    assert budget.max_budget == 25.0
+
+
+async def test_member_added_via_organization_workspace_assignment_is_materialized(async_db: AsyncSession) -> None:
+    org = await _organization(async_db, slug="acme-assign")
+    owner = await _member(async_db, org, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, org, name="Engineering", owner=owner)
+
+    service = WorkspaceBudgetDefaultService(async_db)
+    await service.create_default(
+        user=owner,
+        workspace_id=workspace.id,
+        request=WorkspaceMemberBudgetPolicyCreate(max_budget=15.0),
+    )
+
+    organization_service = OrganizationService(async_db)
+    result = await organization_service.create_active_organization_member_for_user(
+        user=owner,
+        request=ActiveOrganizationMemberCreateRequest(
+            email="new-hire@example.test",
+            role="member",
+            workspace_assignments=[WorkspaceAssignmentRequest(workspace_id=workspace.id, role="member")],
+        ),
+    )
+
+    assert result.user_id is not None
+    workspace_member = await WorkspaceMemberRepository(async_db).get_by_workspace_and_user(
+        workspace.id, result.user_id
+    )
+    assert workspace_member is not None
+    budget = await _member_budget(async_db, workspace_member.id)
+    assert budget is not None
+    assert budget.max_budget == 15.0
+
+
+async def test_reviving_a_suspended_workspace_membership_is_materialized(async_db: AsyncSession) -> None:
+    """A member revived from suspended, not just one freshly created, gets caught up.
+
+    There is no service-level producer of a suspended `WorkspaceMember` row in
+    this edition yet (workspace removal deletes rather than suspends), so the
+    row is built directly through the repository, the way the row itself would
+    look if one arrives (an import, or a future suspend action) and a default
+    was created while it was suspended.
+    """
+    org = await _organization(async_db, slug="acme-revive")
+    owner = await _member(async_db, org, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, org, name="Engineering", owner=owner)
+
+    target = await UserRepository(async_db).create_local_identity(
+        full_name="Revived",
+        email="revived@example.test",
+        active_organization_id=org.id,
+    )
+    suspended_member = await WorkspaceMemberRepository(async_db).create(
+        workspace_id=workspace.id,
+        user_id=target.id,
+        role="member",
+        status="suspended",
+    )
+    await async_db.commit()
+
+    service = WorkspaceBudgetDefaultService(async_db)
+    await service.create_default(
+        user=owner,
+        workspace_id=workspace.id,
+        request=WorkspaceMemberBudgetPolicyCreate(max_budget=35.0),
+    )
+    # The default fans out to active members only; the suspended row gets
+    # nothing from it yet.
+    assert await _member_budget(async_db, suspended_member.id) is None
+
+    organization_service = OrganizationService(async_db)
+    await organization_service.create_active_organization_member_for_user(
+        user=owner,
+        request=ActiveOrganizationMemberCreateRequest(
+            email="revived@example.test",
+            role="member",
+            workspace_assignments=[WorkspaceAssignmentRequest(workspace_id=workspace.id, role="member")],
+        ),
+    )
+
+    revived = await WorkspaceMemberRepository(async_db).get_by_workspace_and_user(workspace.id, target.id)
+    assert revived is not None
+    assert revived.status == "active"
+    budget = await _member_budget(async_db, revived.id)
+    assert budget is not None, "a member revived from suspended must be materialized, not just reactivated"
+    assert budget.max_budget == 35.0
+
+
+async def test_update_is_not_retroactive(async_db: AsyncSession) -> None:
+    org = await _organization(async_db, slug="acme-update")
+    owner = await _member(async_db, org, role="owner", full_name="Owner")
+    later_joiner = await _member(async_db, org, role="member", full_name="Later")
+    workspace = await _workspace(async_db, org, name="Engineering", owner=owner)
+
+    service = WorkspaceBudgetDefaultService(async_db)
+    default = await service.create_default(
+        user=owner,
+        workspace_id=workspace.id,
+        request=WorkspaceMemberBudgetPolicyCreate(max_budget=10.0),
+    )
+    owner_member = await WorkspaceMemberRepository(async_db).get_by_workspace_and_user(workspace.id, owner.id)
+    assert owner_member is not None
+    owner_budget_before = await _member_budget(async_db, owner_member.id)
+    assert owner_budget_before is not None
+    assert owner_budget_before.max_budget == 10.0
+
+    await service.update_default(
+        user=owner,
+        workspace_id=workspace.id,
+        default_id=default.id,
+        request=WorkspaceMemberBudgetPolicyUpdate(max_budget=20.0),
+    )
+
+    owner_budget_after = await _member_budget(async_db, owner_member.id)
+    assert owner_budget_after is not None
+    assert owner_budget_after.max_budget == 10.0, "an already-materialized ceiling must not be rewritten"
+
+    workspace_service = WorkspaceService(async_db)
+    joined = await workspace_service.add_member(user=owner, workspace_id=workspace.id, user_id=later_joiner.id)
+    joiner_budget = await _member_budget(async_db, joined.id)
+    assert joiner_budget is not None
+    assert joiner_budget.max_budget == 20.0, "a member joining after the edit must get the new value"
+
+
+async def test_delete_preserves_materialized_rows_and_stops_future_ones(async_db: AsyncSession) -> None:
+    org = await _organization(async_db, slug="acme-delete")
+    owner = await _member(async_db, org, role="owner", full_name="Owner")
+    later_joiner = await _member(async_db, org, role="member", full_name="Later")
+    workspace = await _workspace(async_db, org, name="Engineering", owner=owner)
+
+    service = WorkspaceBudgetDefaultService(async_db)
+    default = await service.create_default(
+        user=owner,
+        workspace_id=workspace.id,
+        request=WorkspaceMemberBudgetPolicyCreate(max_budget=30.0),
+    )
+    owner_member = await WorkspaceMemberRepository(async_db).get_by_workspace_and_user(workspace.id, owner.id)
+    assert owner_member is not None
+
+    await service.delete_default(user=owner, workspace_id=workspace.id, default_id=default.id)
+
+    owner_budget = await _member_budget(async_db, owner_member.id)
+    assert owner_budget is not None, "spend history on an already-materialized ceiling survives the delete"
+
+    workspace_service = WorkspaceService(async_db)
+    joined = await workspace_service.add_member(user=owner, workspace_id=workspace.id, user_id=later_joiner.id)
+    assert await _member_budget(async_db, joined.id) is None, "a member joining after the delete gets nothing from it"
+
+    with pytest.raises(WorkspaceBudgetDefaultNotFoundError):
+        await service._get_or_404(workspace, default.id)  # noqa: SLF001 - asserting the row is actually gone
+
+
+async def test_duplicate_aggregate_default_conflicts(async_db: AsyncSession) -> None:
+    org = await _organization(async_db, slug="acme-conflict")
+    owner = await _member(async_db, org, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, org, name="Engineering", owner=owner)
+
+    service = WorkspaceBudgetDefaultService(async_db)
+    await service.create_default(
+        user=owner,
+        workspace_id=workspace.id,
+        request=WorkspaceMemberBudgetPolicyCreate(max_budget=10.0),
+    )
+
+    with pytest.raises(WorkspaceBudgetDefaultAlreadyExistsError):
+        await service.create_default(
+            user=owner,
+            workspace_id=workspace.id,
+            request=WorkspaceMemberBudgetPolicyCreate(max_budget=20.0),
+        )
+
+
+async def test_non_management_member_may_list_but_not_write(async_db: AsyncSession) -> None:
+    org = await _organization(async_db, slug="acme-authz")
+    owner = await _member(async_db, org, role="owner", full_name="Owner")
+    plain = await _member(async_db, org, role="member", full_name="Plain")
+    workspace = await _workspace(async_db, org, name="Engineering", owner=owner)
+    await WorkspaceMemberRepository(async_db).create(workspace_id=workspace.id, user_id=plain.id, role="member")
+
+    service = WorkspaceBudgetDefaultService(async_db)
+    default = await service.create_default(
+        user=owner,
+        workspace_id=workspace.id,
+        request=WorkspaceMemberBudgetPolicyCreate(max_budget=10.0),
+    )
+
+    listed = await service.list_defaults(user=plain, workspace_id=workspace.id)
+    assert listed.count == 1
+
+    with pytest.raises(NotAuthorizedError):
+        await service.create_default(
+            user=plain,
+            workspace_id=workspace.id,
+            request=WorkspaceMemberBudgetPolicyCreate(max_budget=99.0),
+        )
+
+    with pytest.raises(NotAuthorizedError):
+        await service.update_default(
+            user=plain,
+            workspace_id=workspace.id,
+            default_id=default.id,
+            request=WorkspaceMemberBudgetPolicyUpdate(max_budget=99.0),
+        )
+
+    with pytest.raises(NotAuthorizedError):
+        await service.delete_default(user=plain, workspace_id=workspace.id, default_id=default.id)
+
+
+async def test_foreign_workspace_is_not_found(async_db: AsyncSession) -> None:
+    org_a = await _organization(async_db, slug="acme-foreign-a")
+    org_b = await _organization(async_db, slug="acme-foreign-b")
+    owner_a = await _member(async_db, org_a, role="owner", full_name="Owner A")
+    owner_b = await _member(async_db, org_b, role="owner", full_name="Owner B")
+    workspace_b = await _workspace(async_db, org_b, name="Elsewhere", owner=owner_b)
+
+    service = WorkspaceBudgetDefaultService(async_db)
+    with pytest.raises(WorkspaceNotFoundError):
+        await service.list_defaults(user=owner_a, workspace_id=workspace_b.id)
+
+
+# =============================================================================
+# The race between creating a default and a member joining, driven concurrently
+# =============================================================================
+
+
+@pytest.fixture
+def sessions(postgres_url: str) -> async_sessionmaker[AsyncSession]:
+    url = postgres_url.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+        "postgresql://", "postgresql+asyncpg://"
+    )
+    return async_sessionmaker(create_async_engine(url), expire_on_commit=False)
+
+
+async def test_concurrent_default_create_and_member_add_both_land(
+    async_db: AsyncSession,
+    sessions: async_sessionmaker[AsyncSession],
+) -> None:
+    """A default created at the same moment a member joins must reach that member either way.
+
+    Without `WorkspaceRepository.lock` serializing the two paths, each can read
+    the other's pre-write state under READ COMMITTED: the create reads the
+    members before the join commits, and the join reads the defaults before the
+    create commits, and both still succeed, leaving the new member with no
+    ceiling from a default that, from the outside, looks like it was already
+    there when they joined.
+    """
+    org = await _organization(async_db, slug="acme-race")
+    owner = await _member(async_db, org, role="owner", full_name="Owner")
+    joiner = await _member(async_db, org, role="member", full_name="Joiner")
+    workspace = await _workspace(async_db, org, name="Engineering", owner=owner)
+    # The racing sessions below are separate connections and must see this
+    # graph committed, not merely flushed on `async_db`.
+    await async_db.commit()
+
+    async def create_default_attempt() -> object:
+        async with sessions() as session:
+            user = await UserRepository(session).get(owner.id)
+            assert user is not None
+            try:
+                return await WorkspaceBudgetDefaultService(session).create_default(
+                    user=user,
+                    workspace_id=workspace.id,
+                    request=WorkspaceMemberBudgetPolicyCreate(max_budget=40.0),
+                )
+            except Exception as exc:  # noqa: BLE001 - the outcome is the assertion
+                return exc
+
+    async def add_member_attempt() -> object:
+        async with sessions() as session:
+            user = await UserRepository(session).get(owner.id)
+            assert user is not None
+            try:
+                return await WorkspaceService(session).add_member(
+                    user=user,
+                    workspace_id=workspace.id,
+                    user_id=joiner.id,
+                )
+            except Exception as exc:  # noqa: BLE001 - the outcome is the assertion
+                return exc
+
+    outcomes = await asyncio.gather(create_default_attempt(), add_member_attempt())
+    for outcome in outcomes:
+        assert not isinstance(outcome, Exception), outcome
+
+    joined_member = await WorkspaceMemberRepository(async_db).get_by_workspace_and_user(workspace.id, joiner.id)
+    assert joined_member is not None
+    budget = await _member_budget(async_db, joined_member.id)
+    assert budget is not None, "the new member must get the default whichever transaction committed first"
+    assert budget.max_budget == 40.0

--- a/tests/unit/test_service_module_imports.py
+++ b/tests/unit/test_service_module_imports.py
@@ -31,6 +31,13 @@ _MODULES = [
     "gateway.services.tenancy.workspace_service",
     "gateway.services.tenancy.organization_service",
     "gateway.services.tenancy.provisioning_service",
+    # workspace_budget_default_service sits between workspace_service and
+    # organization_service (both reach it, it reaches organization_service and
+    # authorization but never workspace_service), and authorization sits
+    # between workspace_service and organization_service the same way. Pinned
+    # here for the same reason as the two above them.
+    "gateway.services.tenancy.workspace_budget_default_service",
+    "gateway.services.tenancy.authorization",
 ]
 
 

--- a/web/e2e/screenshots/authenticated.spec.ts
+++ b/web/e2e/screenshots/authenticated.spec.ts
@@ -21,6 +21,11 @@ const WORKSPACE_ROUTES: ReadonlyArray<{
   { route: "/providers", name: "providers", heading: /provider/i },
   { route: "/keys", name: "keys", heading: /keys/i },
   { route: "/budgets", name: "budgets", heading: /budgets/i },
+  {
+    route: "/budget-defaults",
+    name: "budget-defaults",
+    heading: /budget defaults/i,
+  },
   { route: "/users", name: "users", heading: /users/i },
   { route: "/usage", name: "usage", heading: /usage/i },
   { route: "/activity", name: "activity", heading: /activity/i },

--- a/web/src/app/AppShell.test.tsx
+++ b/web/src/app/AppShell.test.tsx
@@ -399,6 +399,7 @@ describe("AppShell surface gating", () => {
       "API keys",
       "Providers",
       "Members",
+      "Budget defaults",
     ])
     // Routing and Tools nest destinations, so they expand rather than
     // navigate; their children are links once the group is open.

--- a/web/src/app/nav/registry.test.ts
+++ b/web/src/app/nav/registry.test.ts
@@ -58,6 +58,7 @@ describe("nav registry", () => {
       "API keys",
       "Providers",
       "Members",
+      "Budget defaults",
       "Workspaces",
       "Members & roles",
       "Users",

--- a/web/src/app/nav/registry.ts
+++ b/web/src/app/nav/registry.ts
@@ -163,6 +163,15 @@ const BASE_NAV_SECTIONS = [
         surface: "workspaces",
         icon: FiUsers,
       },
+      // Per-member spend templates for the selected workspace. Gated on the
+      // same surface as Members: a default names members of this workspace and
+      // materializes onto the same `workspace_member` rows the roster reads.
+      {
+        to: "/budget-defaults",
+        label: "Budget defaults",
+        surface: "workspaces",
+        icon: BudgetsIcon,
+      },
     ],
   },
 ] as const satisfies readonly NavSection[]

--- a/web/src/app/nav/registry.ts
+++ b/web/src/app/nav/registry.ts
@@ -170,7 +170,7 @@ const BASE_NAV_SECTIONS = [
         to: "/budget-defaults",
         label: "Budget defaults",
         surface: "workspaces",
-        icon: BudgetsIcon,
+        icon: FiDollarSign,
       },
     ],
   },

--- a/web/src/client/index.ts
+++ b/web/src/client/index.ts
@@ -346,4 +346,16 @@ export type InviteOrganizationMemberResult =
 export type InvitationPreview = Schemas["InvitationPreviewPublic"]
 export type AcceptInvitationResult = Schemas["AcceptInvitationResultPublic"]
 
+// A workspace-level template for a per-member `scoped_budgets` ceiling; see
+// `src/gateway/services/tenancy/workspace_budget_default_service.py`. The DTO
+// name is `WorkspaceMemberBudgetPolicy*` on the wire (kept recognizable
+// against otari-ai's own hosted equivalent); the dashboard's own name for the
+// concept is "budget default".
+export type WorkspaceBudgetDefault =
+  Schemas["WorkspaceMemberBudgetPolicyPublic"]
+export type CreateWorkspaceBudgetDefaultRequest =
+  Schemas["WorkspaceMemberBudgetPolicyCreate"]
+export type UpdateWorkspaceBudgetDefaultRequest =
+  Schemas["WorkspaceMemberBudgetPolicyUpdate"]
+
 export type * from "./local"

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -2582,6 +2582,65 @@ export interface paths {
         patch: operations["update_workspace_v1_workspaces__workspace_id__patch"];
         trace?: never;
     };
+    "/v1/workspaces/{workspace_id}/member-budget-policies": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Workspace Budget Defaults
+         * @description List the budget defaults attached to a workspace. Any member may read it.
+         */
+        get: operations["list_workspace_budget_defaults_v1_workspaces__workspace_id__member_budget_policies_get"];
+        put?: never;
+        /**
+         * Create Workspace Budget Default
+         * @description Create a budget default.
+         *
+         *     Materializes it into a per-member ``scoped_budgets`` row for every
+         *     existing active member of the workspace; a member who joins afterwards is
+         *     materialized when they join.
+         */
+        post: operations["create_workspace_budget_default_v1_workspaces__workspace_id__member_budget_policies_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/workspaces/{workspace_id}/member-budget-policies/{default_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Workspace Budget Default
+         * @description Delete a budget default.
+         *
+         *     The per-member ``scoped_budgets`` rows it already materialized are kept;
+         *     a member joining afterwards no longer gets one from it.
+         */
+        delete: operations["delete_workspace_budget_default_v1_workspaces__workspace_id__member_budget_policies__default_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Workspace Budget Default
+         * @description Update a budget default's label or limit.
+         *
+         *     Not retroactive: members already materialized from this default keep
+         *     their existing ceiling; only a member materialized afterwards sees the
+         *     new one.
+         */
+        patch: operations["update_workspace_budget_default_v1_workspaces__workspace_id__member_budget_policies__default_id__patch"];
+        trace?: never;
+    };
     "/v1/workspaces/{workspace_id}/members": {
         parameters: {
             query?: never;
@@ -6840,6 +6899,80 @@ export interface components {
             /** Name */
             name: string;
         };
+        /** WorkspaceMemberBudgetPoliciesPublic */
+        WorkspaceMemberBudgetPoliciesPublic: {
+            /** Count */
+            count: number;
+            /** Data */
+            data: components["schemas"]["WorkspaceMemberBudgetPolicyPublic"][];
+        };
+        /**
+         * WorkspaceMemberBudgetPolicyCreate
+         * @description Request body for creating a default.
+         */
+        WorkspaceMemberBudgetPolicyCreate: {
+            /**
+             * Budget Duration Sec
+             * @description Period length in seconds; null never resets
+             */
+            budget_duration_sec?: number | null;
+            /**
+             * Max Budget
+             * @description Maximum USD spend per member in the period
+             */
+            max_budget?: number | null;
+            /**
+             * Name
+             * @description Admin-facing label
+             */
+            name?: string | null;
+            /**
+             * Provider Key Id
+             * @description Narrow the default to one provider instance; null applies to every provider
+             */
+            provider_key_id?: string | null;
+        };
+        /**
+         * WorkspaceMemberBudgetPolicyPublic
+         * @description One default and its template values.
+         */
+        WorkspaceMemberBudgetPolicyPublic: {
+            /** Budget Duration Sec */
+            budget_duration_sec: number | null;
+            /** Created At */
+            created_at: string;
+            /** Id */
+            id: string;
+            /** Max Budget */
+            max_budget: number | null;
+            /** Name */
+            name: string | null;
+            /** Provider Key Id */
+            provider_key_id: string | null;
+            /** Updated At */
+            updated_at: string;
+            /**
+             * Workspace Id
+             * Format: uuid
+             */
+            workspace_id: string;
+        };
+        /**
+         * WorkspaceMemberBudgetPolicyUpdate
+         * @description Request body for updating a default.
+         *
+         *     Not retroactive: a member already materialized from this default keeps
+         *     the value that was in effect when they were materialized. Only a member
+         *     materialized after this update sees the new one.
+         */
+        WorkspaceMemberBudgetPolicyUpdate: {
+            /** Budget Duration Sec */
+            budget_duration_sec?: number | null;
+            /** Max Budget */
+            max_budget?: number | null;
+            /** Name */
+            name?: string | null;
+        };
         /** WorkspaceMemberPublic */
         WorkspaceMemberPublic: {
             /**
@@ -11085,6 +11218,145 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["WorkspacePublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_workspace_budget_defaults_v1_workspaces__workspace_id__member_budget_policies_get: {
+        parameters: {
+            query?: {
+                /** @description Number of records to skip */
+                skip?: number;
+                /** @description Maximum number of records to return */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                workspace_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkspaceMemberBudgetPoliciesPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_workspace_budget_default_v1_workspaces__workspace_id__member_budget_policies_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspace_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkspaceMemberBudgetPolicyCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkspaceMemberBudgetPolicyPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_workspace_budget_default_v1_workspaces__workspace_id__member_budget_policies__default_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspace_id: string;
+                default_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Message"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_workspace_budget_default_v1_workspaces__workspace_id__member_budget_policies__default_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspace_id: string;
+                default_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkspaceMemberBudgetPolicyUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkspaceMemberBudgetPolicyPublic"];
                 };
             };
             /** @description Validation Error */

--- a/web/src/features/organization/roles.test.ts
+++ b/web/src/features/organization/roles.test.ts
@@ -5,6 +5,7 @@ import {
   asMembershipRole,
   asSettableStatus,
   canManage,
+  canManageWorkspace,
   isOwner,
   MEMBERSHIP_ROLES,
   memberLabel,
@@ -22,6 +23,18 @@ describe("tenancy roles", () => {
     // A context that has not loaded is not a manager: the controls stay off
     // until the server has said what the caller is.
     expect(canManage(undefined)).toBe(false)
+  })
+
+  it("also lets a workspace's own owner or admin manage it, without an organization role", () => {
+    const memberContext = organizationContext({ role: "member" })
+    expect(canManageWorkspace(memberContext, "owner")).toBe(true)
+    expect(canManageWorkspace(memberContext, "admin")).toBe(true)
+    expect(canManageWorkspace(memberContext, "member")).toBe(false)
+    expect(canManageWorkspace(memberContext, undefined)).toBe(false)
+    // The organization arm still applies with no workspace role at all.
+    expect(
+      canManageWorkspace(organizationContext({ role: "owner" }), undefined),
+    ).toBe(true)
   })
 
   it("reserves ownership for the owner role", () => {

--- a/web/src/features/organization/roles.ts
+++ b/web/src/features/organization/roles.ts
@@ -17,14 +17,16 @@
  * organization and of every workspace in it; both become reachable with the
  * per-user sign-in of otari-ai#1716, which is when to revisit them.
  *
- * - **Workspace-level management is invisible here.** `_require_workspace_
+ * - **`canManage` alone is organization-role-only.** `_require_workspace_
  *   management_access` also grants a caller whose *workspace* membership is an
  *   active owner or admin, so an organization member who owns one workspace may
- *   manage it. Answering that client-side needs the caller's own user id, which
- *   the membership context does not carry: it names the membership row, not the
- *   identity behind it. Resolving it through the roster would make every
- *   workspace control wait on a second query to say what the server will say
- *   anyway, so `canManage` reads the organization role alone.
+ *   manage it. `canManage` itself stays narrower on the organization pages,
+ *   which have no selected workspace to ask about: answering there would need
+ *   the caller's own user id resolved through the roster, which is a second
+ *   query to say what the server will say anyway. `canManageWorkspace` below is
+ *   for the workspace-scoped pages, where `CallerWorkspaceMembershipPublic.role`
+ *   (the switcher's own data, already fetched) already names the caller's
+ *   standing in *that* workspace, with nothing more to resolve.
  * - **Superuser is not on the contract.** The server grants organization
  *   management, and deletion, to `user.is_superuser` whatever their role;
  *   `OrganizationMembershipContextPublic` carries no such field, so nothing here
@@ -93,6 +95,24 @@ const MANAGEMENT_ROLES: readonly string[] = ["owner", "admin"]
 /** Whether the caller's standing in their organization lets them manage it. */
 export function canManage(context: OrganizationContext | undefined): boolean {
   return context !== undefined && MANAGEMENT_ROLES.includes(context.role)
+}
+
+/**
+ * Whether the caller may manage a specific workspace: `canManage`'s
+ * organization arm, or an active owner/admin of that workspace itself.
+ *
+ * `workspaceRole` is the caller's own role in the selected workspace (e.g.
+ * `useSelectedWorkspace().selected?.role`), not a roster entry. See the
+ * module docstring for why that is enough on its own, with no extra request.
+ */
+export function canManageWorkspace(
+  context: OrganizationContext | undefined,
+  workspaceRole: string | undefined,
+): boolean {
+  return (
+    canManage(context) ||
+    (workspaceRole !== undefined && MANAGEMENT_ROLES.includes(workspaceRole))
+  )
 }
 
 /** Whether the caller owns their organization, which is what deleting it takes. */

--- a/web/src/features/workspaces/WorkspaceBudgetDefaultsPage.test.tsx
+++ b/web/src/features/workspaces/WorkspaceBudgetDefaultsPage.test.tsx
@@ -1,0 +1,150 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { WorkspaceBudgetDefaultsPage } from "@/features/workspaces/WorkspaceBudgetDefaultsPage"
+import { SelectedWorkspaceProvider } from "@/shared/hooks/SelectedWorkspace"
+import { organizationContext, workspaceBudgetDefault } from "@/tests/fixtures"
+
+const ALPHA = "11111111-1111-1111-1111-111111111111"
+
+function mockApi({
+  memberships = [{ workspace_id: ALPHA, name: "Alpha", role: "admin" }],
+  defaults = [workspaceBudgetDefault()],
+}: {
+  memberships?: { workspace_id: string; name: string; role: string }[]
+  defaults?: ReturnType<typeof workspaceBudgetDefault>[]
+} = {}) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input)
+    if (url.includes("/member-budget-policies")) {
+      return Response.json({ data: defaults, count: defaults.length })
+    }
+    if (url.includes("/v1/provider-credentials")) {
+      return Response.json([])
+    }
+    return Response.json(
+      organizationContext({ workspace_memberships: memberships }),
+    )
+  })
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <SelectedWorkspaceProvider>
+        <WorkspaceBudgetDefaultsPage />
+      </SelectedWorkspaceProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe("WorkspaceBudgetDefaultsPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    window.localStorage.clear()
+  })
+
+  it("shows the budget defaults of the selected workspace, named by the organization", async () => {
+    mockApi()
+    renderPage()
+
+    expect(
+      await screen.findByText("Budget defaults for Alpha"),
+    ).toBeInTheDocument()
+    expect(await screen.findByText("Default member budget")).toBeInTheDocument()
+  })
+
+  it("says so rather than showing an empty list when there is no workspace", async () => {
+    mockApi({ memberships: [] })
+    renderPage()
+
+    expect(await screen.findByText("No workspace selected")).toBeInTheDocument()
+  })
+
+  it("offers management controls to a workspace owner even without an organization role", async () => {
+    // "member" at the organization level, but "owner" of the selected
+    // workspace itself: the server's OR rule
+    // (`require_workspace_management_access`), which the page has to match.
+    mockApi({
+      memberships: [{ workspace_id: ALPHA, name: "Alpha", role: "owner" }],
+    })
+    renderPage()
+
+    await screen.findByText("Budget defaults for Alpha")
+    expect(
+      screen.getByRole("button", { name: "Add default" }),
+    ).toBeInTheDocument()
+  })
+
+  it("preserves a reset period that isn't a whole number of days when the field is left untouched", async () => {
+    // 3,600 seconds (one hour) cannot be shown in a whole-days field; editing
+    // an unrelated part of the form and saving must not read that display gap
+    // as "clear the reset period".
+    const fetchMock = mockApi({
+      defaults: [
+        workspaceBudgetDefault({
+          id: "default-1",
+          name: "Hourly-reset default",
+          budget_duration_sec: 3_600,
+        }),
+      ],
+    })
+    const user = userEvent.setup()
+    renderPage()
+
+    const row = (await screen.findByText("Hourly-reset default")).closest("li")!
+    await user.click(within(row).getByRole("button", { name: "Edit" }))
+
+    const daysField = await screen.findByLabelText(
+      "Reset every N days (optional)",
+    )
+    expect(daysField).toHaveValue("")
+    expect(screen.getByText(/currently set to 3600s/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }))
+
+    const patch = fetchMock.mock.calls.find(
+      ([u, init]) =>
+        String(u).includes("/default-1") && (init?.method ?? "") === "PATCH",
+    )
+    expect(JSON.parse(String(patch?.[1]?.body))).toMatchObject({
+      budget_duration_sec: 3_600,
+    })
+  })
+
+  it("clears the reset period when the days field is explicitly emptied", async () => {
+    const fetchMock = mockApi({
+      defaults: [
+        workspaceBudgetDefault({
+          id: "default-1",
+          name: "Daily-reset default",
+          budget_duration_sec: 86_400,
+        }),
+      ],
+    })
+    const user = userEvent.setup()
+    renderPage()
+
+    const row = (await screen.findByText("Daily-reset default")).closest("li")!
+    await user.click(within(row).getByRole("button", { name: "Edit" }))
+
+    const daysField = await screen.findByLabelText(
+      "Reset every N days (optional)",
+    )
+    expect(daysField).toHaveValue("1")
+    await user.clear(daysField)
+    await user.click(screen.getByRole("button", { name: "Save changes" }))
+
+    const patch = fetchMock.mock.calls.find(
+      ([u, init]) =>
+        String(u).includes("/default-1") && (init?.method ?? "") === "PATCH",
+    )
+    expect(JSON.parse(String(patch?.[1]?.body))).toMatchObject({
+      budget_duration_sec: null,
+    })
+  })
+})

--- a/web/src/features/workspaces/WorkspaceBudgetDefaultsPage.tsx
+++ b/web/src/features/workspaces/WorkspaceBudgetDefaultsPage.tsx
@@ -1,0 +1,51 @@
+import { canManageWorkspace } from "@/features/organization/roles"
+import { WorkspaceBudgetDefaultsPanel } from "@/features/workspaces/WorkspaceBudgetDefaultsPanel"
+import { useOrganizationContext } from "@/shared/api/hooks"
+import { EmptyState, PageHeader } from "@/shared/components/ui"
+import { useSelectedWorkspace } from "@/shared/hooks/SelectedWorkspace"
+
+// The budget-default templates of the workspace the switcher has selected,
+// same scoping as `WorkspaceMembersPage`. A default only ever governs members
+// of the one workspace it belongs to, so there is no organization-wide view.
+export function WorkspaceBudgetDefaultsPage() {
+  const { selected, isLoading } = useSelectedWorkspace()
+  const context = useOrganizationContext()
+
+  // An organization's owners and admins manage every workspace's defaults,
+  // and so does an owner/admin of this workspace specifically, which is the
+  // rule `WorkspaceBudgetDefaultService` enforces server-side.
+  const manages = canManageWorkspace(context.data, selected?.role)
+
+  if (!selected) {
+    return (
+      <div className="flex flex-col gap-6">
+        <PageHeader
+          title="Budget defaults"
+          description="Per-member spend templates for this workspace."
+        />
+        <EmptyState
+          title={isLoading ? "Loading…" : "No workspace selected"}
+          description={
+            isLoading
+              ? "Reading the workspaces you belong to."
+              : "You do not belong to a workspace in this organization yet. An owner or admin can add you to one on the Workspaces page."
+          }
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <PageHeader
+        title="Budget defaults"
+        description={`Per-member spend templates for ${selected.name}. Creating one gives every current member a matching budget immediately; a member who joins later gets one too.`}
+      />
+      <WorkspaceBudgetDefaultsPanel
+        workspaceId={selected.workspace_id}
+        workspaceName={selected.name}
+        canManageWorkspace={manages}
+      />
+    </div>
+  )
+}

--- a/web/src/features/workspaces/WorkspaceBudgetDefaultsPanel.tsx
+++ b/web/src/features/workspaces/WorkspaceBudgetDefaultsPanel.tsx
@@ -1,0 +1,399 @@
+import { Button, Chip } from "@heroui/react"
+import { useState } from "react"
+
+import type {
+  CreateWorkspaceBudgetDefaultRequest,
+  WorkspaceBudgetDefault,
+} from "@/client"
+import {
+  useCreateWorkspaceBudgetDefault,
+  useDeleteWorkspaceBudgetDefault,
+  useStoredProviders,
+  useUpdateWorkspaceBudgetDefault,
+  useWorkspaceBudgetDefaults,
+} from "@/shared/api/hooks"
+import { ConfirmDialog } from "@/shared/components/ConfirmDialog"
+import { Field } from "@/shared/components/Field"
+import { ErrorBanner, FilterSelect, InfoBanner } from "@/shared/components/ui"
+
+// A workspace-level template for the per-member `scoped_budgets` ceiling
+// (`WorkspaceBudgetDefault` on the wire, `WorkspaceMemberBudgetPolicy*` in the
+// generated client). Materialization into a concrete, spend-tracking ceiling
+// happens server-side on creation and on join; this panel only manages the
+// template.
+//
+// Deliberately simpler than the Spend & budgets page's form (no reset-period
+// presets): a workspace default is a template, not something an operator
+// tunes as often as a per-user budget.
+
+const DAY = 86_400
+const HOUR = 3_600
+
+// A non-negative dollar amount, empty for "unlimited". Parsed leniently; the
+// caller decides what an empty or invalid value means.
+function parseLimit(raw: string): { value: number | null; valid: boolean } {
+  const trimmed = raw.trim()
+  if (trimmed === "") return { value: null, valid: true }
+  const n = Number(trimmed)
+  if (!Number.isFinite(n) || n < 0) return { value: null, valid: false }
+  return { value: n, valid: true }
+}
+
+// Whole days, empty for "never resets".
+function parseDays(raw: string): { seconds: number | null; valid: boolean } {
+  const trimmed = raw.trim()
+  if (trimmed === "") return { seconds: null, valid: true }
+  const n = Number(trimmed)
+  if (!Number.isSafeInteger(n) || n <= 0) return { seconds: null, valid: false }
+  return { seconds: n * DAY, valid: true }
+}
+
+function daysString(seconds: number | null): string {
+  return seconds !== null && seconds % DAY === 0 ? String(seconds / DAY) : ""
+}
+
+function providerLabel(providerKeyId: string | null): string {
+  return providerKeyId ?? "All providers"
+}
+
+// The reset period as the row displays it. The API accepts any positive
+// number of seconds, not just whole days (the edit form's own field is
+// days-only, which is why it has to special-case this same value, see
+// `daysTouched` below); dividing by `DAY` unconditionally here would print a
+// fraction for one, e.g. "/ 0.041666666666666664 days" for 3,600.
+function formatDuration(seconds: number): string {
+  if (seconds % DAY === 0) return `${seconds / DAY} days`
+  if (seconds % HOUR === 0) return `${seconds / HOUR} hours`
+  return `${seconds}s`
+}
+
+const usd = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 2,
+})
+
+function DefaultForm({
+  title,
+  submitLabel,
+  initial,
+  providerLocked,
+  providerOptions,
+  error,
+  isPending,
+  onSubmit,
+  onClose,
+}: {
+  title: string
+  submitLabel: string
+  initial: {
+    name: string | null
+    provider_key_id: string | null
+    max_budget: number | null
+    budget_duration_sec: number | null
+  }
+  // The scope is fixed on edit (see `WorkspaceBudgetDefaultService.update_default`):
+  // changing it would move the template to a different identity, which is a
+  // delete and a create, not an update.
+  providerLocked: boolean
+  providerOptions: string[]
+  error: unknown
+  isPending: boolean
+  onSubmit: (body: CreateWorkspaceBudgetDefaultRequest) => void
+  onClose: () => void
+}) {
+  const [name, setName] = useState(initial.name ?? "")
+  const [providerKeyId, setProviderKeyId] = useState(
+    initial.provider_key_id ?? "",
+  )
+  const [limit, setLimit] = useState(
+    initial.max_budget === null ? "" : String(initial.max_budget),
+  )
+  const [days, setDays] = useState(daysString(initial.budget_duration_sec))
+  // Whether the operator has actually edited the days field, as opposed to it
+  // merely rendering empty because the stored value isn't a whole number of
+  // days (the API accepts any positive number of seconds; this field only
+  // offers days). Without this, opening such a default shows an empty field
+  // and saving unrelated changes (the name, say) would read that emptiness as
+  // "clear the reset period" and silently drop the value nothing here ever
+  // touched.
+  const [daysTouched, setDaysTouched] = useState(false)
+
+  const parsedLimit = parseLimit(limit)
+  const parsedDays = parseDays(days)
+  const canSubmit = !isPending && parsedLimit.valid && parsedDays.valid
+
+  return (
+    <div className="flex flex-col gap-4 rounded-lg border border-border bg-surface-alt p-4">
+      <div className="text-sm font-semibold text-foreground">{title}</div>
+      <ErrorBanner error={error} />
+      <Field
+        label="Name (optional)"
+        value={name}
+        onChange={setName}
+        autoFocus
+        placeholder="Default member budget"
+        description="A label to recognize this default later."
+      />
+      <FilterSelect
+        label="Provider"
+        value={providerKeyId}
+        disabled={providerLocked}
+        onChange={setProviderKeyId}
+        options={[
+          { value: "", label: "All providers" },
+          ...providerOptions.map((instance) => ({
+            value: instance,
+            label: instance,
+          })),
+        ]}
+      />
+      <Field
+        label="Spending limit (USD)"
+        value={limit}
+        onChange={setLimit}
+        placeholder="50.00"
+        description={
+          parsedLimit.valid ? (
+            "The most a member gets from this default per period. Leave blank for no limit."
+          ) : (
+            <span className="text-danger">
+              Enter a non-negative number, or leave blank for no limit.
+            </span>
+          )
+        }
+      />
+      <Field
+        label="Reset every N days (optional)"
+        value={days}
+        onChange={(value) => {
+          setDaysTouched(true)
+          setDays(value)
+        }}
+        placeholder="30"
+        description={
+          !daysTouched &&
+          days === "" &&
+          initial.budget_duration_sec !== null ? (
+            <span className="text-warning">
+              Currently set to {initial.budget_duration_sec}s, which isn&rsquo;t
+              a whole number of days and can&rsquo;t be shown here. Left alone,
+              it is kept as-is; enter a day count to replace it.
+            </span>
+          ) : parsedDays.valid ? (
+            "Leave blank for a limit that never resets."
+          ) : (
+            <span className="text-danger">
+              Enter a whole number of days, or leave blank.
+            </span>
+          )
+        }
+      />
+      <div className="flex gap-2">
+        <Button
+          variant="primary"
+          isDisabled={!canSubmit}
+          onPress={() =>
+            onSubmit({
+              name: name.trim() || null,
+              provider_key_id: providerKeyId.trim() || null,
+              max_budget: parsedLimit.value,
+              // Untouched and blank only because the value can't be shown as
+              // days: keep it exactly as it was rather than reading the
+              // display gap as "clear it".
+              budget_duration_sec: daysTouched
+                ? parsedDays.seconds
+                : initial.budget_duration_sec,
+            })
+          }
+        >
+          {isPending ? "Saving…" : submitLabel}
+        </Button>
+        <Button variant="ghost" isDisabled={isPending} onPress={onClose}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export function WorkspaceBudgetDefaultsPanel({
+  workspaceId,
+  workspaceName,
+  canManageWorkspace,
+}: {
+  workspaceId: string
+  workspaceName: string
+  canManageWorkspace: boolean
+}) {
+  const defaults = useWorkspaceBudgetDefaults(workspaceId)
+  const providers = useStoredProviders()
+  const create = useCreateWorkspaceBudgetDefault()
+  const update = useUpdateWorkspaceBudgetDefault()
+  const remove = useDeleteWorkspaceBudgetDefault()
+
+  const [addOpen, setAddOpen] = useState(false)
+  const [editing, setEditing] = useState<string | null>(null)
+  const [deleting, setDeleting] = useState<WorkspaceBudgetDefault | null>(null)
+
+  const rows = defaults.data ?? []
+  const providerOptions = (providers.data ?? []).map((p) => p.instance)
+  const editingDefault = rows.find((d) => d.id === editing) ?? null
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex items-center justify-between">
+        <div className="text-sm font-semibold text-foreground">
+          Budget defaults for {workspaceName}
+        </div>
+        {canManageWorkspace && !addOpen && !editingDefault ? (
+          <Button size="sm" variant="primary" onPress={() => setAddOpen(true)}>
+            Add default
+          </Button>
+        ) : null}
+      </div>
+      <ErrorBanner
+        error={defaults.error ?? create.error ?? update.error ?? remove.error}
+      />
+      <InfoBanner>
+        A default is a template: creating one gives every current active member
+        a matching budget right away, and a member who joins later gets one too.
+        Editing or deleting a default never rewrites a budget it already handed
+        out; members keep what they were given.
+      </InfoBanner>
+
+      {defaults.isLoading ? (
+        <p className="text-sm text-muted">Loading budget defaults…</p>
+      ) : rows.length === 0 && !addOpen ? (
+        <p className="text-sm text-muted">
+          This workspace has no budget defaults yet.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {rows.map((row) =>
+            editingDefault?.id === row.id ? (
+              <li key={row.id}>
+                <DefaultForm
+                  title={`Edit default (${providerLabel(row.provider_key_id)})`}
+                  submitLabel="Save changes"
+                  initial={row}
+                  providerLocked
+                  providerOptions={providerOptions}
+                  error={update.error}
+                  isPending={update.isPending}
+                  onSubmit={(body) =>
+                    update.mutate(
+                      {
+                        workspaceId,
+                        defaultId: row.id,
+                        body: {
+                          name: body.name,
+                          max_budget: body.max_budget,
+                          budget_duration_sec: body.budget_duration_sec,
+                        },
+                      },
+                      { onSuccess: () => setEditing(null) },
+                    )
+                  }
+                  onClose={() => setEditing(null)}
+                />
+              </li>
+            ) : (
+              <li
+                key={row.id}
+                className="flex flex-wrap items-center gap-3 rounded-lg border border-border bg-surface-alt px-3 py-2"
+              >
+                <span className="text-sm text-foreground">
+                  {row.name ?? "(unnamed default)"}
+                </span>
+                <Chip size="sm" color="default">
+                  {providerLabel(row.provider_key_id)}
+                </Chip>
+                <span className="text-sm text-muted">
+                  {row.max_budget === null
+                    ? "No limit"
+                    : usd.format(row.max_budget)}
+                  {row.budget_duration_sec
+                    ? ` / ${formatDuration(row.budget_duration_sec)}`
+                    : ""}
+                </span>
+                {canManageWorkspace ? (
+                  <span className="ml-auto flex items-center gap-2">
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      isDisabled={addOpen}
+                      onPress={() => {
+                        setAddOpen(false)
+                        setEditing(row.id)
+                      }}
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="danger-soft"
+                      onPress={() => setDeleting(row)}
+                    >
+                      Delete
+                    </Button>
+                  </span>
+                ) : null}
+              </li>
+            ),
+          )}
+        </ul>
+      )}
+
+      {addOpen ? (
+        <DefaultForm
+          title="Add budget default"
+          submitLabel="Add default"
+          initial={{
+            name: null,
+            provider_key_id: null,
+            max_budget: null,
+            budget_duration_sec: null,
+          }}
+          providerLocked={false}
+          providerOptions={providerOptions}
+          error={create.error}
+          isPending={create.isPending}
+          onSubmit={(body) =>
+            create.mutate(
+              { workspaceId, body },
+              { onSuccess: () => setAddOpen(false) },
+            )
+          }
+          onClose={() => setAddOpen(false)}
+        />
+      ) : null}
+
+      <ConfirmDialog
+        isOpen={deleting !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleting(null)
+        }}
+        heading="Delete budget default"
+        body={
+          <>
+            Delete <strong>{deleting?.name ?? "(unnamed default)"}</strong>?
+            Members who already got a budget from it keep it; a member joining
+            afterwards will not get one from this default.
+          </>
+        }
+        confirmLabel="Delete default"
+        isPending={remove.isPending}
+        error={remove.error}
+        onConfirm={() => {
+          if (deleting) {
+            remove.mutate(
+              { workspaceId, defaultId: deleting.id },
+              { onSuccess: () => setDeleting(null) },
+            )
+          }
+        }}
+      />
+    </div>
+  )
+}

--- a/web/src/features/workspaces/WorkspaceBudgetDefaultsPanel.tsx
+++ b/web/src/features/workspaces/WorkspaceBudgetDefaultsPanel.tsx
@@ -62,8 +62,14 @@ function providerLabel(providerKeyId: string | null): string {
 // `daysTouched` below); dividing by `DAY` unconditionally here would print a
 // fraction for one, e.g. "/ 0.041666666666666664 days" for 3,600.
 function formatDuration(seconds: number): string {
-  if (seconds % DAY === 0) return `${seconds / DAY} days`
-  if (seconds % HOUR === 0) return `${seconds / HOUR} hours`
+  if (seconds % DAY === 0) {
+    const days = seconds / DAY
+    return `${days} ${days === 1 ? "day" : "days"}`
+  }
+  if (seconds % HOUR === 0) {
+    const hours = seconds / HOUR
+    return `${hours} ${hours === 1 ? "hour" : "hours"}`
+  }
   return `${seconds}s`
 }
 

--- a/web/src/features/workspaces/WorkspaceMembersPage.test.tsx
+++ b/web/src/features/workspaces/WorkspaceMembersPage.test.tsx
@@ -71,4 +71,17 @@ describe("WorkspaceMembersPage", () => {
     // a different fact from "you are in no workspace".
     expect(await screen.findByText("No workspace selected")).toBeInTheDocument()
   })
+
+  it("enables management controls for a workspace owner even without an organization role", async () => {
+    // "member" at the organization level, but "owner" of the selected
+    // workspace itself: the server's OR rule
+    // (`_require_workspace_management_access`), which the page has to match.
+    mockApi({
+      memberships: [{ workspace_id: ALPHA, name: "Alpha", role: "owner" }],
+    })
+    renderPage()
+
+    await screen.findByText("Members of Alpha")
+    expect(await screen.findByRole("button", { name: "Remove" })).toBeEnabled()
+  })
 })

--- a/web/src/features/workspaces/WorkspaceMembersPage.tsx
+++ b/web/src/features/workspaces/WorkspaceMembersPage.tsx
@@ -1,4 +1,4 @@
-import { canManage } from "@/features/organization/roles"
+import { canManageWorkspace } from "@/features/organization/roles"
 import { WorkspaceMembersPanel } from "@/features/workspaces/WorkspaceMembersPanel"
 import {
   useOrganizationContext,
@@ -21,10 +21,10 @@ export function WorkspaceMembersPage() {
   const context = useOrganizationContext()
   const orgMembers = useOrganizationMembers()
 
-  // Workspace membership is not what grants management here: the organization's
-  // owners and admins manage every workspace in it, which is the rule the
+  // An organization's owners and admins manage every workspace in it, and so
+  // does an owner/admin of this workspace specifically, which is the rule the
   // workspace service enforces server-side.
-  const manages = canManage(context.data)
+  const manages = canManageWorkspace(context.data, selected?.role)
 
   if (!selected) {
     return (

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as SplatRouteImport } from './routes/$'
 import { Route as ActivityRouteImport } from './routes/activity'
 import { Route as AliasesRouteImport } from './routes/aliases'
+import { Route as BudgetDefaultsRouteImport } from './routes/budget-defaults'
 import { Route as BudgetsRouteImport } from './routes/budgets'
 import { Route as DocsRouteImport } from './routes/docs'
 import { Route as KeysRouteImport } from './routes/keys'
@@ -56,6 +57,11 @@ const ActivityRoute = ActivityRouteImport.update({
 const AliasesRoute = AliasesRouteImport.update({
   id: '/aliases',
   path: '/aliases',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BudgetDefaultsRoute = BudgetDefaultsRouteImport.update({
+  id: '/budget-defaults',
+  path: '/budget-defaults',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BudgetsRoute = BudgetsRouteImport.update({
@@ -185,6 +191,7 @@ export interface FileRoutesByFullPath {
   '/$': typeof SplatRoute
   '/activity': typeof ActivityRoute
   '/aliases': typeof AliasesRoute
+  '/budget-defaults': typeof BudgetDefaultsRoute
   '/budgets': typeof BudgetsRoute
   '/docs': typeof DocsRoute
   '/keys': typeof KeysRoute
@@ -215,6 +222,7 @@ export interface FileRoutesByTo {
   '/$': typeof SplatRoute
   '/activity': typeof ActivityRoute
   '/aliases': typeof AliasesRoute
+  '/budget-defaults': typeof BudgetDefaultsRoute
   '/budgets': typeof BudgetsRoute
   '/docs': typeof DocsRoute
   '/keys': typeof KeysRoute
@@ -244,6 +252,7 @@ export interface FileRoutesById {
   '/$': typeof SplatRoute
   '/activity': typeof ActivityRoute
   '/aliases': typeof AliasesRoute
+  '/budget-defaults': typeof BudgetDefaultsRoute
   '/budgets': typeof BudgetsRoute
   '/docs': typeof DocsRoute
   '/keys': typeof KeysRoute
@@ -276,6 +285,7 @@ export interface FileRouteTypes {
     | '/$'
     | '/activity'
     | '/aliases'
+    | '/budget-defaults'
     | '/budgets'
     | '/docs'
     | '/keys'
@@ -306,6 +316,7 @@ export interface FileRouteTypes {
     | '/$'
     | '/activity'
     | '/aliases'
+    | '/budget-defaults'
     | '/budgets'
     | '/docs'
     | '/keys'
@@ -334,6 +345,7 @@ export interface FileRouteTypes {
     | '/$'
     | '/activity'
     | '/aliases'
+    | '/budget-defaults'
     | '/budgets'
     | '/docs'
     | '/keys'
@@ -365,6 +377,7 @@ export interface RootRouteChildren {
   SplatRoute: typeof SplatRoute
   ActivityRoute: typeof ActivityRoute
   AliasesRoute: typeof AliasesRoute
+  BudgetDefaultsRoute: typeof BudgetDefaultsRoute
   BudgetsRoute: typeof BudgetsRoute
   DocsRoute: typeof DocsRoute
   KeysRoute: typeof KeysRoute
@@ -408,6 +421,13 @@ declare module '@tanstack/react-router' {
       path: '/aliases'
       fullPath: '/aliases'
       preLoaderRoute: typeof AliasesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/budget-defaults': {
+      id: '/budget-defaults'
+      path: '/budget-defaults'
+      fullPath: '/budget-defaults'
+      preLoaderRoute: typeof BudgetDefaultsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/budgets': {
@@ -626,6 +646,7 @@ const rootRouteChildren: RootRouteChildren = {
   SplatRoute: SplatRoute,
   ActivityRoute: ActivityRoute,
   AliasesRoute: AliasesRoute,
+  BudgetDefaultsRoute: BudgetDefaultsRoute,
   BudgetsRoute: BudgetsRoute,
   DocsRoute: DocsRoute,
   KeysRoute: KeysRoute,

--- a/web/src/routes/budget-defaults.tsx
+++ b/web/src/routes/budget-defaults.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { WorkspaceBudgetDefaultsPage } from "@/features/workspaces/WorkspaceBudgetDefaultsPage"
+
+export const Route = createFileRoute("/budget-defaults")({
+  component: WorkspaceBudgetDefaultsPage,
+})

--- a/web/src/shared/api/hooks.ts
+++ b/web/src/shared/api/hooks.ts
@@ -20,6 +20,7 @@ import type {
   CreateSearchToolRequest,
   CreateStoredProviderRequest,
   CreateUserRequest,
+  CreateWorkspaceBudgetDefaultRequest,
   CreateWorkspaceRequest,
   DashboardBuild,
   DiscoverableModelsResponse,
@@ -69,6 +70,7 @@ import type {
   UpdateStoredProviderRequest,
   UpdateToolSettingsRequest,
   UpdateUserRequest,
+  UpdateWorkspaceBudgetDefaultRequest,
   UpdateWorkspaceRequest,
   UsageBucket,
   UsageCount,
@@ -83,6 +85,7 @@ import type {
   UsageSummary,
   User,
   Workspace,
+  WorkspaceBudgetDefault,
   WorkspaceMember,
   WorkspaceMemberRole,
 } from "@/client"
@@ -1699,6 +1702,88 @@ export function useUpdateWorkspaceMemberRole() {
       // organization context, not from this key, so a roster change that moves
       // the caller in or out of a workspace has to refresh it too.
       void queryClient.invalidateQueries({ queryKey: [ORGANIZATIONS] })
+    },
+  })
+}
+
+// A workspace's budget-default templates. Nested under the workspaces key so
+// deleting a workspace drops them with it, same as `useWorkspaceMembers`.
+export function useWorkspaceBudgetDefaults(workspaceId: string | null) {
+  return useQuery({
+    queryKey: [WORKSPACES, workspaceId, "budget-defaults"],
+    queryFn: () =>
+      fetchAllPaged<WorkspaceBudgetDefault>(
+        `/v1/workspaces/${encodeURIComponent(workspaceId as string)}/member-budget-policies`,
+      ),
+    enabled: workspaceId !== null,
+    staleTime: 60_000,
+  })
+}
+
+export function useCreateWorkspaceBudgetDefault() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      workspaceId,
+      body,
+    }: {
+      workspaceId: string
+      body: CreateWorkspaceBudgetDefaultRequest
+    }) =>
+      apiFetch<WorkspaceBudgetDefault>(
+        `/v1/workspaces/${encodeURIComponent(workspaceId)}/member-budget-policies`,
+        { method: "POST", body: JSON.stringify(body) },
+      ),
+    onSuccess: (_data, { workspaceId }) => {
+      void queryClient.invalidateQueries({
+        queryKey: [WORKSPACES, workspaceId, "budget-defaults"],
+      })
+    },
+  })
+}
+
+export function useUpdateWorkspaceBudgetDefault() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      workspaceId,
+      defaultId,
+      body,
+    }: {
+      workspaceId: string
+      defaultId: string
+      body: UpdateWorkspaceBudgetDefaultRequest
+    }) =>
+      apiFetch<WorkspaceBudgetDefault>(
+        `/v1/workspaces/${encodeURIComponent(workspaceId)}/member-budget-policies/${encodeURIComponent(defaultId)}`,
+        { method: "PATCH", body: JSON.stringify(body) },
+      ),
+    onSuccess: (_data, { workspaceId }) => {
+      void queryClient.invalidateQueries({
+        queryKey: [WORKSPACES, workspaceId, "budget-defaults"],
+      })
+    },
+  })
+}
+
+export function useDeleteWorkspaceBudgetDefault() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      workspaceId,
+      defaultId,
+    }: {
+      workspaceId: string
+      defaultId: string
+    }) =>
+      apiFetch<void>(
+        `/v1/workspaces/${encodeURIComponent(workspaceId)}/member-budget-policies/${encodeURIComponent(defaultId)}`,
+        { method: "DELETE" },
+      ),
+    onSuccess: (_data, { workspaceId }) => {
+      void queryClient.invalidateQueries({
+        queryKey: [WORKSPACES, workspaceId, "budget-defaults"],
+      })
     },
   })
 }

--- a/web/src/tests/fixtures.ts
+++ b/web/src/tests/fixtures.ts
@@ -15,6 +15,7 @@ import type {
   UsageSeriesPoint,
   UsageTotals,
   Workspace,
+  WorkspaceBudgetDefault,
   WorkspaceMember,
 } from "@/client"
 
@@ -188,6 +189,22 @@ export function workspaceMember(
     status: "active",
     created_at: "2026-01-01T00:00:00+00:00",
     updated_at: null,
+    ...overrides,
+  }
+}
+
+export function workspaceBudgetDefault(
+  overrides: Partial<WorkspaceBudgetDefault> = {},
+): WorkspaceBudgetDefault {
+  return {
+    id: "66666666-6666-6666-6666-666666666666",
+    workspace_id: "44444444-4444-4444-4444-444444444444",
+    provider_key_id: null,
+    name: "Default member budget",
+    max_budget: 50.0,
+    budget_duration_sec: 2_592_000,
+    created_at: "2026-01-01T00:00:00+00:00",
+    updated_at: "2026-01-01T00:00:00+00:00",
     ...overrides,
   }
 }


### PR DESCRIPTION
## Description

Adds a workspace-level template for the per-member `scoped_budgets` ceiling (`scoped_budgets`, #633, has no notion of a template).

- `WorkspaceBudgetDefault` model + migration: one row per `(workspace_id, provider_key_id)`, no counters of its own.
- Materialization: creating a default fans it out into a `ScopedBudget(scope_type="workspace_member")` row for every existing active member; a member joining afterwards (`WorkspaceService.add_member`, workspace creation, or organization-member creation with `workspace_assignments`) gets one from every default already on the workspace. A member-specific override always wins over the template.
- Editing a default is **not retroactive**: members already materialized keep the value in effect at the time; only a member materialized afterwards sees the new one.
- Deleting a default **preserves** the `ScopedBudget` rows it already produced; a member joining afterwards no longer gets one from it.
- `services/tenancy/authorization.py` extracts `WorkspaceService`'s workspace-visibility and workspace-management checks into a shared module, so the new service enforces the same rules rather than a second, driftable copy.
- Routes: `/v1/workspaces/{workspace_id}/member-budget-policies` (master-key, standalone only), DTOs named `WorkspaceMemberBudgetPolicy*` per the issue, so the generated client stays recognizable against `otari-ai`'s hosted equivalent. That equivalent's now-removed CRUD surface (`208a552c`, `4ecdc263` in `otari-ai`'s history) is what the edit/delete semantics above are ported from.
- Dashboard: a "Budget defaults" page/panel beside Workspace Members, gated on the `workspaces` surface.
- Hardened against review findings: a `WorkspaceRepository.lock` closes the race between creating a default and a member joining concurrently; `materialize_for_default` batches its per-page existence check and insert, with a savepoint-based fallback so a single colliding row (e.g. a concurrent direct write to `/v1/scoped-budgets`) never fails the whole default; a suspended membership revived via `workspace_assignments` is materialized too; list endpoints are paginated; `budget_duration_sec` is bounded; the dashboard preserves a reset period it cannot represent in its days-only field instead of silently clearing it on save; and `canManageWorkspace` matches the server's organization-or-workspace-role rule (also applied to the pre-existing Members page, which had the same gap).

### Why a local (not top-level) import in `organization_service.py`

`WorkspaceBudgetDefaultService` reaches back into `OrganizationService` for its own authorization checks. A top-level import of it from `organization_service.py` would close that into a real cycle (A imports B, B imports A), so `_apply_workspace_assignments` imports it locally instead, the same kind of avoidance `workspace_service.py` already documents for `ScopedBudget` deletion. `tests/unit/test_service_module_imports.py` is extended to pin the new modules importing cleanly first, in a fresh interpreter.

### Testing

- `tests/integration/test_workspace_member_budget_policies.py`: materialization on create/join through all three membership-creation paths, member-override precedence, non-retroactive edit, delete-preserves-rows, uniqueness conflict, authorization (management vs. plain member, foreign workspace), a two-session race between creating a default and a member joining (confirmed to fail reliably without the lock and pass reliably with it).
- Regression: `test_scoped_budgets.py`, `test_tenancy_authorization.py`, `test_tenancy_races.py`, `test_tenancy_api.py`, `test_workspace_scope.py`, `test_service_module_imports.py`, full unit suite, all pass.
- Migration verified both directions against real PostgreSQL (upgrade, downgrade, re-upgrade).
- `make lint`, `make typecheck`, `make openapi-check`, `make postman-check`, `scripts/oss_edition_smoke.py`, all pass.
- Dashboard: `pnpm run lint`, `pnpm run typecheck`, `pnpm test`, `pnpm run build`, all pass.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Closes #642

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).
- [x] **M4 ledger:** this PR either needs no entry (an existing row already covers it and its target is unchanged), or the entry is appended to [otari-ai#1587](https://github.com/mozilla-ai/otari-ai/issues/1587). One entry per *change*, not per PR: a stack delivering one surface change gets one. See [.github/instructions/reconciliation-ledger.instructions.md](https://github.com/mozilla-ai/otari/blob/main/.github/instructions/reconciliation-ledger.instructions.md).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Claude Sonnet 5), via a background agent session.

**Any additional AI details you'd like to share:** Implementation, review-comment triage, and fixes were all done by the agent; a human (@tbille) is the operator directing the session.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds workspace-level per-member budget defaults for `scoped_budgets`.

- Adds controls to create, edit, and delete workspace defaults.
- Applies defaults to active members when defaults are created, members join, or memberships are reactivated.
- Preserves member-specific overrides and existing budgets.
- Makes default updates non-retroactive.
- Adds authorization, validation, pagination, concurrency handling, SDK support, and database migration updates.
- Adds dashboard navigation, UI controls, generated client types, and comprehensive tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
