### PR TITLE
fix(migrations): rejoin the two Alembic heads so upgrades run again

### DIFF
--- a/alembic/versions/c8f2a6b4e9d3_merge_scoped_budget_and_credential_heads.py
+++ b/alembic/versions/c8f2a6b4e9d3_merge_scoped_budget_and_credential_heads.py
@@ -1,0 +1,38 @@
+"""Rejoin the two migration heads into one.
+
+Two revisions were authored against ``a3c7e1b9d5f2`` in parallel and both
+landed: ``b6e8c2a4d7f1`` (scoped-budget reset alignment) and ``f2a4c6d8b0e3``
+(the nullable credential columns on ``user``). Neither is wrong and they touch
+different tables, but leaving both as heads makes ``alembic upgrade head``
+refuse to run at all ("Multiple head revisions are present"), so no deployment
+can upgrade past either one.
+
+This revision has no schema of its own. It exists only to name both parents, so
+``head`` resolves to a single revision again and the two branches apply in
+either order.
+
+One consequence is worth knowing rather than rediscovering: ``alembic downgrade
+-1`` from here reports "Ambiguous walk", because a relative step cannot say
+which of the two branches to walk down. That is how Alembic treats every merge
+point, not a defect of this revision. Downgrade to a named revision instead
+(``alembic downgrade b6e8c2a4d7f1``), which is unambiguous and reversible.
+
+Revision ID: c8f2a6b4e9d3
+Revises: b6e8c2a4d7f1, f2a4c6d8b0e3
+Create Date: 2026-08-20
+"""
+
+from collections.abc import Sequence
+
+revision: str = "c8f2a6b4e9d3"
+down_revision: str | Sequence[str] | None = ("b6e8c2a4d7f1", "f2a4c6d8b0e3")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Nothing to apply: this revision only rejoins the two branches."""
+
+
+def downgrade() -> None:
+    """Nothing to undo: this revision only rejoins the two branches."""

--- a/tests/unit/test_migration_single_head.py
+++ b/tests/unit/test_migration_single_head.py
@@ -1,0 +1,34 @@
+"""The migration graph resolves to exactly one head.
+
+``core.database`` and the ``otari migrate`` CLI both upgrade to ``"head"``,
+singular, so a second head is not a style problem: Alembic refuses the argument
+outright ("Multiple head revisions are present") and no deployment can migrate.
+
+Nothing in per-PR CI catches it, which is why this test exists. Two revisions
+authored against the same parent each pass on their own branch, and the graph
+only forks once both have merged, so the first red run is on ``main`` after the
+second merge. Asserting the invariant here moves the failure back onto the PR
+that would create it.
+
+The fix for a failure is a merge revision naming both heads
+(``down_revision = ("<a>", "<b>")``), not renumbering either branch.
+"""
+
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_migration_graph_has_a_single_head() -> None:
+    config = Config(str(_REPO_ROOT / "alembic.ini"))
+    config.set_main_option("script_location", str(_REPO_ROOT / "alembic"))
+
+    heads = ScriptDirectory.from_config(config).get_heads()
+
+    assert len(heads) == 1, (
+        f"Alembic has {len(heads)} heads ({', '.join(sorted(heads))}), so 'alembic upgrade head' fails "
+        "and no deployment can migrate. Add a merge revision whose down_revision names every head."
+    )


### PR DESCRIPTION
## Description

`alembic upgrade head` currently fails on `main`, so no deployment can migrate:

```
ERROR [alembic.util.messaging] Multiple head revisions are present for given argument 'head'
FAILED: Multiple head revisions are present for given argument 'head'
```

`b6e8c2a4d7f1` (#640) and `f2a4c6d8b0e3` (#667) were both authored against `a3c7e1b9d5f2` and both merged, so the graph forks and nothing resolves `head`. `command.upgrade(cfg, "head")` in `core.database` and `otari migrate` both take the singular argument, so both exit 1. The OSS-edition smoke gate has been red on `main` since #640 landed ([run 32349876418](https://github.com/mozilla-ai/otari/actions/runs/32349876418): `'otari migrate' exited 1`).

The merge revision carries no schema of its own. It names both parents so `head` is one revision again and the two branches apply in either order.

**Why the test comes with it.** Per-PR CI structurally cannot catch this: each revision passes alone on its own branch, and the fork only exists once the second one merges, so the first red run is always on `main`. `tests/unit/test_migration_single_head.py` asserts the invariant on every PR instead. Confirmed load-bearing by removing the merge revision, which turns it red naming both offending revisions.

**One known behavior, documented rather than left to be rediscovered.** `alembic downgrade -1` from a merge point reports "Ambiguous walk", because a relative step cannot pick which branch to walk down. That is how Alembic treats every merge revision, not something this one introduces. Downgrade to a named revision instead (`alembic downgrade b6e8c2a4d7f1`), which is unambiguous and re-upgrades cleanly.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

No issue filed; found while looking for a parent revision for #662.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). `make lint` and `make typecheck` pass. `tests/unit` passes in full (1842 passed, 9 skipped); `tests/integration` needs Docker for Testcontainers, which was unavailable locally, so it runs in CI. Also ran `uv run --frozen --no-dev python scripts/oss_edition_smoke.py`, the gate that is currently red on `main`, and it passes on this branch.
- [x] Documentation was updated where necessary. No user-facing docs change: the revision's own docstring carries the explanation, including the downgrade note above.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). No API surface changed, so the spec is untouched.
- [x] **M4 ledger:** this PR needs no entry. It adds no table, no contract, and no surface: the revision is a graph repair with an empty `upgrade()`. See [.github/instructions/reconciliation-ledger.instructions.md](instructions/reconciliation-ledger.instructions.md).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 4.8 (1M context) via Claude Code.

**Any additional AI details you'd like to share:**

The two-head fork was found while looking for a parent revision to hang #662's migration on, not by a CI notification. The failing gate on `main` was then confirmed against run 32349876418 before writing anything.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
