### PR TITLE
feat(platform): return settled cost inline

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -245,6 +245,7 @@ These are only relevant when running connected to [otari.ai](https://otari.ai). 
 | `PLATFORM_MANAGEMENT_URL` | `https://otari.ai` | Control plane a connected gateway points its operator at, published by `GET /v1/bootstrap`. Must be an absolute `http(s)` URL; the gateway refuses to start otherwise |
 | `PLATFORM_RESOLVE_TIMEOUT_MS` | `5000` | Timeout for provider resolution calls |
 | `PLATFORM_USAGE_TIMEOUT_MS` | `5000` | Timeout for usage reporting calls |
+| `PLATFORM_USAGE_INLINE_TIMEOUT_MS` | `1500` | Budget for the successful usage report awaited to attach inline cost. Expiry returns the response without cost while the report continues |
 | `PLATFORM_USAGE_MAX_RETRIES` | `3` | Max retries for transient usage reporting failures |
 | `STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS` | `2000` | Per-attempt timeout waiting for first streamed chunk |
 | `STREAMING_FALLBACK_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS` | `0` | Extra first-chunk grace for the sole/final attempt, added on top of the per-attempt budget. `0` = no grace (unchanged) |

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -354,6 +354,31 @@ A successful attempt that completes without provider usage data still sends a
 final report, but omits `usage` so the platform can record it as unavailable
 rather than as an explicit zero-token result.
 
+| Platform response | Gateway behavior |
+|---|---|
+| Completed success with `usage_status: "reported"` and non-null `pricing.source` | Validate the correlation id and attach `cost_usd` plus `pricing_source`. |
+| Completed response without a price source, with unavailable usage, or for a failed attempt | Return the provider response without inline cost. An unpriced `0.000000` is a placeholder, not a priced zero. |
+| `202` or legacy `204` | Return the provider response without inline cost. |
+| Terminal 4xx, including `404` and `410` | Do not retry or attach inline cost. |
+| Invalid body, correlation mismatch, reporting failure, or expired inline budget | Preserve the provider response and omit inline cost. |
+
+### Inline response fields
+
+| API format | Non-streaming placement | Streaming placement |
+|---|---|---|
+| Chat Completions | `usage.cost_usd`, `usage.pricing_source` | Terminal usage chunk: `usage.cost_usd`, `usage.pricing_source` |
+| Messages | `usage.cost_usd`, `usage.pricing_source` | `message_delta.usage.cost_usd`, `message_delta.usage.pricing_source` |
+| Responses | `usage.cost_usd`, `usage.pricing_source` | `response.completed.response.usage.cost_usd`, `response.completed.response.usage.pricing_source` |
+
+The fields always appear together, and `pricing_source` is never null. The cost
+is the platform's exact six-decimal string, and its source is `organization`,
+`managed`, or `genai_prices`; Otari never calculates or converts it locally,
+and settlement failure never fails the model response. A priced zero includes
+both fields, while unavailable, pending, legacy, unpriced,
+or carrier-less results include neither. Provider token usage is otherwise
+unchanged, and standalone responses never include these fields. Use
+`GET /request-costs/{request_id}` when a durable value is required.
+
 `session_label` is an optional caller-supplied label for cost attribution (per
 run, experiment, or conversation). A caller sets it on the request body
 (`session_label` on the chat/messages/responses request); Otari strips it before
@@ -436,11 +461,12 @@ SSE channel, where only an error string is available. Treat a missing
 
 ### Retry semantics
 
-The usage endpoint is called as a background task on Otari side. It
-retries on transient failures (timeout, network error, 5xx) up to
-`PLATFORM_USAGE_MAX_RETRIES` times with exponential backoff
-(`0.25s`, `0.5s`, `1s`). It does **not** retry on `401`, `404`, `409`, `422`;
-those are treated as terminal client errors.
+Otari awaits the successful report at the response's terminal boundary for up
+to `PLATFORM_USAGE_INLINE_TIMEOUT_MS`; expiry omits inline cost but leaves the
+report running. Failed-attempt reports remain background work, so they can
+arrive after the success report. Reports retry timeouts, network errors, and
+5xx responses up to `PLATFORM_USAGE_MAX_RETRIES` with exponential backoff, but
+not terminal 4xx responses.
 
 ## Streaming
 
@@ -466,10 +492,16 @@ The mechanism is a per-attempt **first-chunk gate**. For each attempt:
 3. Once a first chunk is in hand, commit. Stitch it back onto the iterator
    and start flushing SSE chunks to the client.
 
-**Latency contract:** zero added latency in the success case: the first
-chunk is held only for the microseconds it takes to call the SSE response
-builder. In the failure case, each abandoned non-final attempt costs at most the
-failover budget; the final attempt costs at most budget + grace.
+**Latency contract:** content streams immediately. In hybrid mode, only the
+terminal usage suffix waits for settlement, bounded by
+`PLATFORM_USAGE_INLINE_TIMEOUT_MS`, with keepalives during the wait. An early
+carrier, timeout, mid-stream failure, or legacy `204` response skips inline cost
+without reshaping the stream. Non-final attempts still cost at most the
+first-chunk failover budget, and the final attempt at most that budget plus its
+grace period.
+
+Hybrid Chat Completions forces `stream_options.include_usage: true` so a
+terminal carrier exists; standalone mode preserves the caller's value.
 
 **What this catches:** auth errors (`401`/`403`), rate-limits (`429`),
 upstream `5xx`, connection failures, hung connections, "stream opens but
@@ -492,6 +524,7 @@ flag.
 | `OTARI_AI_TOKEN` | none | Setting this enables hybrid mode. |
 | `PLATFORM_RESOLVE_TIMEOUT_MS` | `5000` | Per-resolve timeout. |
 | `PLATFORM_USAGE_TIMEOUT_MS` | `5000` | Per-usage-report timeout. |
+| `PLATFORM_USAGE_INLINE_TIMEOUT_MS` | `1500` | Budget for the one usage report the response path waits on to attach inline cost. Expiry ships the response without cost; the report itself continues. |
 | `PLATFORM_USAGE_MAX_RETRIES` | `3` | Max retries for transient usage-report failures. |
 | `STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS` | `2000` | Per-attempt budget for the streaming first-chunk gate. |
 | `STREAMING_FALLBACK_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS` | `0` | Extra first-chunk grace for the sole/final attempt, on top of the budget. `0` = unchanged. |

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -138,9 +138,9 @@ After each attempt (success or failure), Otari reports usage:
 POST {base_url}/gateway/usage
 ```
 
-Reports include token counts, status, and error information. When supported,
-priced successful requests also include the platform-settled cost in their usage
-object. See the [hybrid-mode protocol](hybrid-mode-protocol.md#inline-response-fields)
+Reports include token counts, status, and error information. For priced successful
+requests, the gateway attaches the platform-settled cost to the caller response
+usage object. See the [hybrid-mode protocol](hybrid-mode-protocol.md#inline-response-fields)
 for field placement and compatibility details.
 
 ### MCP server resolution

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -138,7 +138,10 @@ After each attempt (success or failure), Otari reports usage:
 POST {base_url}/gateway/usage
 ```
 
-Reports include token counts, status, and any error information. Transient failures are retried with exponential backoff.
+Reports include token counts, status, and error information. When supported,
+priced successful requests also include the platform-settled cost in their usage
+object. See the [hybrid-mode protocol](hybrid-mode-protocol.md#inline-response-fields)
+for field placement and compatibility details.
 
 ### MCP server resolution
 

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -67,6 +67,7 @@ from gateway.api.routes._platform import (
     _STREAM_FIRST_CHUNK_TIMEOUT_MS_TOOL_LOOP_KEY,
     ResolvedAttempt,
     ResolvedRoute,
+    SettledCost,
     _classify_upstream_error,
     _extract_platform_user_token,
     _report_platform_usage,
@@ -97,7 +98,7 @@ from gateway.core.env import otari_env
 from gateway.core.usage import cache_read_tokens_of, cache_write_1h_tokens_of, cache_write_tokens_of
 from gateway.inflight import track_request
 from gateway.log_config import logger
-from gateway.metrics import record_abandoned_attempt, record_cost, record_tokens
+from gateway.metrics import record_abandoned_attempt, record_cost, record_inline_cost_settlement, record_tokens
 from gateway.model_labeling import relabel_model
 from gateway.models.entities import ModelPricing, UsageLog
 from gateway.models.guardrails import GuardrailConfig
@@ -456,6 +457,14 @@ class FormatAdapter(Protocol, Generic[ResultT, ChunkT]):
 
     def extract_usage(self, result: ResultT) -> CompletionUsage | None: ...
 
+    def attach_cost(self, value: ResultT | ChunkT, settlement: SettledCost) -> bool:
+        """Attach settlement to an existing usage carrier; return whether one existed."""
+        ...
+
+    def is_stream_cost_carrier(self, chunk: ChunkT) -> bool:
+        """Whether this chunk is the terminal usage object that should carry cost."""
+        ...
+
     # When True (chat, responses) a successful non-streaming call without
     # provider usage data still writes a usage-log row; messages skips the row.
     log_success_without_usage: bool
@@ -464,7 +473,12 @@ class FormatAdapter(Protocol, Generic[ResultT, ChunkT]):
 
     async def open_provider_stream(self, kwargs: dict[str, Any]) -> AsyncIterator[ChunkT]: ...
 
-    def prepare_stream_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+    def prepare_stream_kwargs(
+        self,
+        kwargs: dict[str, Any],
+        *,
+        require_usage: bool = False,
+    ) -> dict[str, Any]:
         """Normalize per-call kwargs for a streaming dispatch (e.g. force
         ``stream=True`` or inject ``stream_options``)."""
         ...
@@ -2316,23 +2330,20 @@ async def open_stream(
 # Streaming settlement (the single copy of the callback bundle)
 # ---------------------------------------------------------------------------
 
-# Strong references to in-flight fire-and-forget usage-report tasks. Without
-# these, asyncio only holds a weak reference and a scheduled report can be
-# garbage collected before it runs; a done-callback discards each task once
-# it finishes.
-_USAGE_REPORT_TASKS: set[asyncio.Task[None]] = set()
+# Strong references to in-flight usage-report tasks. Reports awaited for inline
+# cost remain tracked after a timeout or caller cancellation, so accounting can
+# still complete in the background.
+_USAGE_REPORT_TASKS: set[asyncio.Task[SettledCost | None]] = set()
 
 
-def _schedule_usage_report(coro: Coroutine[Any, Any, None], correlation_id: str) -> None:
-    """Run a platform usage report in the background without losing it.
-
-    Keeps the task strongly referenced until it completes and logs a failed
-    report instead of letting the exception vanish with the task object.
-    """
+def _start_usage_report(
+    coro: Coroutine[Any, Any, SettledCost | None],
+    correlation_id: str,
+) -> asyncio.Task[SettledCost | None]:
     task = asyncio.create_task(coro)
     _USAGE_REPORT_TASKS.add(task)
 
-    def _finalize(finished: asyncio.Task[None]) -> None:
+    def _finalize(finished: asyncio.Task[SettledCost | None]) -> None:
         _USAGE_REPORT_TASKS.discard(finished)
         if finished.cancelled():
             return
@@ -2345,6 +2356,49 @@ def _schedule_usage_report(coro: Coroutine[Any, Any, None], correlation_id: str)
             )
 
     task.add_done_callback(_finalize)
+    return task
+
+
+def _schedule_usage_report(
+    coro: Coroutine[Any, Any, SettledCost | None],
+    correlation_id: str,
+) -> None:
+    """Run a platform usage report in the background without losing it."""
+    _start_usage_report(coro, correlation_id)
+
+
+def _inline_settlement_timeout_seconds(config: GatewayConfig) -> float:
+    return int(config.platform.get("usage_inline_timeout_ms", 1500)) / 1000
+
+
+async def _await_usage_report(
+    coro: Coroutine[Any, Any, SettledCost | None],
+    correlation_id: str,
+    config: GatewayConfig,
+) -> SettledCost | None:
+    """Await one report under the inline budget without cancelling accounting."""
+    task = _start_usage_report(coro, correlation_id)
+    try:
+        settlement = await asyncio.wait_for(
+            asyncio.shield(task),
+            timeout=_inline_settlement_timeout_seconds(config),
+        )
+    except asyncio.CancelledError:
+        raise
+    except (asyncio.TimeoutError, TimeoutError):
+        logger.info(
+            "Inline settlement budget expired; responding without cost correlation_id=%s",
+            correlation_id,
+        )
+        record_inline_cost_settlement("timeout")
+        return None
+    except Exception:
+        # The tracked task finalizer logs the failure without exposing details.
+        record_inline_cost_settlement("unattached")
+        return None
+    if settlement is None:
+        record_inline_cost_settlement("unattached")
+    return settlement
 
 
 def build_streaming_response(
@@ -2390,10 +2444,10 @@ def build_streaming_response(
     """
     platform_active = platform_correlation_id is not None
 
-    async def _on_complete(usage_data: CompletionUsage) -> None:
+    async def _on_complete(usage_data: CompletionUsage) -> SettledCost | None:
         if platform_active:
             assert platform_correlation_id is not None
-            _schedule_usage_report(
+            return await _await_usage_report(
                 _report_platform_usage(
                     config=config,
                     correlation_id=platform_correlation_id,
@@ -2403,10 +2457,10 @@ def build_streaming_response(
                     is_final_attempt=True,
                 ),
                 platform_correlation_id,
+                config,
             )
-            return
         if db is None or log_writer is None:
-            return
+            return None
         actual_cost = await log_usage(
             db=db,
             log_writer=log_writer,
@@ -2423,6 +2477,7 @@ def build_streaming_response(
         )
         if reservation is not None:
             await reconcile_reservation(db, reservation, actual_cost or 0.0)
+        return None
 
     async def _on_no_usage() -> None:
         # Stream completed but the provider sent no usage data. Report the
@@ -2430,7 +2485,7 @@ def build_streaming_response(
         # reservation per stream_missing_usage_policy instead of billing $0.
         if platform_active:
             assert platform_correlation_id is not None
-            _schedule_usage_report(
+            settlement = await _await_usage_report(
                 _report_platform_usage(
                     config=config,
                     correlation_id=platform_correlation_id,
@@ -2440,7 +2495,10 @@ def build_streaming_response(
                     is_final_attempt=True,
                 ),
                 platform_correlation_id,
+                config,
             )
+            if settlement is not None:
+                record_inline_cost_settlement("unattached")
             return
         if db is None or log_writer is None or reservation is None:
             return
@@ -2560,6 +2618,14 @@ def build_streaming_response(
                 return
         await refund_reservation(db, reservation)
 
+    def _attach_inline_cost(value: Any, settlement: SettledCost) -> bool:
+        if value is None:
+            record_inline_cost_settlement("unattached")
+            return False
+        attached = adapter.attach_cost(value, settlement)
+        record_inline_cost_settlement("attached" if attached else "unattached")
+        return attached
+
     # StreamingResponse builds its own response object, so headers we want on
     # the wire have to be passed in here; assigning to the dependency-injected
     # ``Response`` object does not propagate to streaming responses.
@@ -2582,6 +2648,9 @@ def build_streaming_response(
             on_incomplete=_on_incomplete,
             display_model=display_model,
             keepalive_interval_seconds=config.streaming_keepalive_interval_ms / 1000,
+            settle_before_done=platform_active,
+            is_cost_carrier=adapter.is_stream_cost_carrier if platform_active else None,
+            attach_settlement=_attach_inline_cost if platform_active else None,
         ),
         media_type="text/event-stream",
         headers=headers,
@@ -2890,6 +2959,7 @@ async def run_streaming_with_fallback(
     async def _build_for_attempt(attempt: ResolvedAttempt) -> AsyncIterator[ChunkT]:
         completion_kwargs = adapter.prepare_stream_kwargs(
             adapter.attempt_kwargs(attempt, base_request_fields),
+            require_usage=True,
         )
         if pool_for_loop is None:
             return await adapter.open_provider_stream(completion_kwargs)
@@ -3077,6 +3147,7 @@ async def run_platform_non_stream(
     # the success-response path (non-blocking), but also stash the error reports
     # so they can be flushed inline if the request ends in an exception.
     pending_error_reports: list[_PendingUsageReport] = []
+    successful_report: tuple[ResolvedAttempt, Any] | None = None
 
     def _report_attempt_outcome(
         attempt: ResolvedAttempt,
@@ -3085,6 +3156,10 @@ async def run_platform_non_stream(
         error_class: str | None,
         is_final_attempt: bool,
     ) -> None:
+        nonlocal successful_report
+        if outcome == "success":
+            successful_report = (attempt, usage)
+            return
         background_tasks.add_task(
             _report_platform_usage,
             config,
@@ -3095,16 +3170,15 @@ async def run_platform_non_stream(
             session_label,
             is_final_attempt=is_final_attempt,
         )
-        if outcome != "success":
-            pending_error_reports.append(
-                _PendingUsageReport(
-                    attempt_id=attempt.attempt_id,
-                    outcome=outcome,
-                    usage=usage,
-                    error_class=error_class,
-                    is_final_attempt=is_final_attempt,
-                )
+        pending_error_reports.append(
+            _PendingUsageReport(
+                attempt_id=attempt.attempt_id,
+                outcome=outcome,
+                usage=usage,
+                error_class=error_class,
+                is_final_attempt=is_final_attempt,
             )
+        )
 
     def _on_attempt_success(attempt: ResolvedAttempt) -> None:
         response.headers["X-Correlation-ID"] = attempt.attempt_id
@@ -3113,7 +3187,7 @@ async def run_platform_non_stream(
                 response.headers[key] = value
 
     try:
-        return await run_platform_attempts(
+        result = await run_platform_attempts(
             route=route,
             attempts=attempts,
             base_request_fields=base_request_fields,
@@ -3147,6 +3221,35 @@ async def run_platform_non_stream(
         # I/O during teardown.
         await _flush_pending_usage_reports(config, pending_error_reports, route.request_id, session_label)
         raise
+
+    if successful_report is None:
+        return result
+    attempt, usage = successful_report
+    settlement = await _await_usage_report(
+        _report_platform_usage(
+            config=config,
+            correlation_id=attempt.attempt_id,
+            outcome="success",
+            usage=usage,
+            session_label=session_label,
+            is_final_attempt=True,
+        ),
+        attempt.attempt_id,
+        config,
+    )
+    if settlement is not None:
+        try:
+            attached = adapter.attach_cost(result, settlement)
+        except Exception as exc:
+            logger.warning(
+                "Failed to attach inline settlement correlation_id=%s: %s",
+                attempt.attempt_id,
+                exc,
+            )
+            record_inline_cost_settlement("unattached")
+        else:
+            record_inline_cost_settlement("attached" if attached else "unattached")
+    return result
 
 
 def _attribution_for(ctx: RequestContext, attempt: Attempt, *, absorbed: bool = False) -> RoutingAttribution | None:

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -2377,11 +2377,12 @@ async def _await_usage_report(
     config: GatewayConfig,
 ) -> SettledCost | None:
     """Await one report under the inline budget without cancelling accounting."""
+    timeout_seconds = _inline_settlement_timeout_seconds(config)
     task = _start_usage_report(coro, correlation_id)
     try:
         settlement = await asyncio.wait_for(
             asyncio.shield(task),
-            timeout=_inline_settlement_timeout_seconds(config),
+            timeout=timeout_seconds,
         )
     except asyncio.CancelledError:
         raise

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -40,12 +40,13 @@ from gateway.services.web_search_backend import WebSearchNotReachableError
 T = TypeVar("T")
 
 # Status codes returned by the platform's usage-report endpoint that the
-# gateway should NOT retry. Auth / payment-required / not-found / conflict /
-# unprocessable are all permanent rejection signals — retrying would just
+# gateway should NOT retry. Auth, payment-required, not-found, conflict, gone,
+# and unprocessable are all permanent rejection signals: retrying would just
 # hammer the platform (an overdrawn or missing wallet won't recover within the
-# retry window). 402 is already excluded by the >= 500 retry predicate below;
-# listing it keeps the intent explicit and robust to changes in that predicate.
-_USAGE_NON_RETRYABLE_STATUS_CODES = {401, 402, 404, 409, 422}
+# retry window). Several of these are already excluded by the >= 500 retry
+# predicate below; listing them keeps the intent explicit and robust to changes
+# in that predicate.
+_USAGE_NON_RETRYABLE_STATUS_CODES = {401, 402, 404, 409, 410, 422}
 
 # Statuses on which the billing-message probe runs. A 402 is payment required by
 # definition, so it is handled directly in ``is_provider_billing_error`` without
@@ -1063,7 +1064,7 @@ async def _report_platform_usage(
                     cost_usd=completed.cost_usd,
                     pricing_source=completed.pricing.source,
                 )
-            if response.status_code in _USAGE_NON_RETRYABLE_STATUS_CODES or response.status_code == 410:
+            if response.status_code in _USAGE_NON_RETRYABLE_STATUS_CODES:
                 return None
             should_retry = response.status_code >= 500
         except (httpx.TimeoutException, httpx.NetworkError):

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -128,7 +128,7 @@ class _UsagePricing(BaseModel):
 
 
 class _CompletedUsageSettlement(BaseModel):
-    correlation_id: uuid.UUID
+    correlation_id: str
     status: Literal["completed"]
     outcome: Literal["success"]
     cost_usd: str = Field(pattern=r"^-?\d+\.\d{6}$")
@@ -1035,14 +1035,13 @@ async def _report_platform_usage(
                     return None
                 try:
                     completed = _CompletedUsageSettlement.model_validate(response.json())
-                    expected_correlation_id = uuid.UUID(correlation_id)
                 except (ValueError, ValidationError):
                     logger.warning(
                         "Platform usage report returned an invalid completed body correlation_id=%s",
                         correlation_id,
                     )
                     return None
-                if completed.correlation_id != expected_correlation_id:
+                if completed.correlation_id != correlation_id:
                     logger.warning(
                         "Platform usage report correlation mismatch expected=%s received=%s",
                         correlation_id,

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -25,7 +25,7 @@ from any_llm.types.completion import CompletionUsage
 from fastapi import HTTPException, Request, status
 from openai import APIConnectionError as _OpenAIAPIConnectionError
 from openai import APITimeoutError as _OpenAIAPITimeoutError
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, ValidationError
 
 from gateway.core.config import GatewayConfig
 from gateway.core.usage import cache_read_tokens_of, cache_write_tokens_of
@@ -114,6 +114,27 @@ class ResolvedAttempt(BaseModel):
     Bedrock's ``region_name``/``aws_access_key_id``). Sourced only from the
     trusted platform peer, never from the caller's request body. See
     ``default_attempt_kwargs``, which merges these in non-overridably."""
+
+
+class SettledCost(BaseModel):
+    """An attachable platform settlement: a priced cost and the basis for it."""
+
+    cost_usd: str = Field(pattern=r"^-?\d+\.\d{6}$")
+    pricing_source: str
+
+
+class _UsagePricing(BaseModel):
+    source: str | None
+
+
+class _CompletedUsageSettlement(BaseModel):
+    correlation_id: uuid.UUID
+    status: Literal["completed"]
+    outcome: Literal["success"]
+    cost_usd: str = Field(pattern=r"^-?\d+\.\d{6}$")
+    currency: Literal["USD"]
+    usage_status: Literal["reported", "unavailable"]
+    pricing: _UsagePricing
 
 
 class ResolvedRoute(BaseModel):
@@ -956,7 +977,7 @@ async def _report_platform_usage(
     session_label: str | None = None,
     *,
     is_final_attempt: bool,
-) -> None:
+) -> SettledCost | None:
     """POST a usage record back to the platform with bounded retries.
 
     ``is_final_attempt`` tells the platform that no later planned fallback will
@@ -967,7 +988,7 @@ async def _report_platform_usage(
     """
     platform_base_url = config.platform.get("base_url")
     if not platform_base_url:
-        return
+        return None
 
     timeout_ms = int(config.platform.get("usage_timeout_ms", 5000))
     max_retries = int(config.platform.get("usage_max_retries", 3))
@@ -1007,16 +1028,52 @@ async def _report_platform_usage(
                 body=payload,
                 timeout_seconds=timeout_ms / 1000,
             )
-            if response.status_code == 204:
-                return
-            if response.status_code in _USAGE_NON_RETRYABLE_STATUS_CODES:
-                return
+            if response.status_code in {202, 204}:
+                return None
+            if response.status_code == 200:
+                if outcome != "success":
+                    return None
+                try:
+                    completed = _CompletedUsageSettlement.model_validate(response.json())
+                    expected_correlation_id = uuid.UUID(correlation_id)
+                except (ValueError, ValidationError):
+                    logger.warning(
+                        "Platform usage report returned an invalid completed body correlation_id=%s",
+                        correlation_id,
+                    )
+                    return None
+                if completed.correlation_id != expected_correlation_id:
+                    logger.warning(
+                        "Platform usage report correlation mismatch expected=%s received=%s",
+                        correlation_id,
+                        completed.correlation_id,
+                    )
+                    return None
+                if completed.usage_status != "reported" or completed.pricing.source is None:
+                    # Settlement succeeded but no pricing source was applied, so
+                    # ``cost_usd`` is a placeholder zero rather than a priced amount.
+                    # Inlining it would read as "this request was free".
+                    logger.debug(
+                        "Platform settlement is not attachable correlation_id=%s usage_status=%s priced=%s",
+                        correlation_id,
+                        completed.usage_status,
+                        completed.pricing.source is not None,
+                    )
+                    return None
+                return SettledCost(
+                    cost_usd=completed.cost_usd,
+                    pricing_source=completed.pricing.source,
+                )
+            if response.status_code in _USAGE_NON_RETRYABLE_STATUS_CODES or response.status_code == 410:
+                return None
             should_retry = response.status_code >= 500
         except (httpx.TimeoutException, httpx.NetworkError):
             should_retry = True
 
         if not should_retry or attempt == max_retries:
-            return
+            return None
 
         await asyncio.sleep(delay_seconds)
         delay_seconds *= 2
+
+    return None

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -34,7 +34,7 @@ from gateway.api.routes._pipeline import (
     run_standalone_non_stream,
     run_streaming_with_fallback,
 )
-from gateway.api.routes._platform import ResolvedAttempt
+from gateway.api.routes._platform import ResolvedAttempt, SettledCost
 from gateway.api.routes._schema_derive import SESSION_LABEL_DESC, SESSION_LABEL_MAX_LENGTH, derive_request_base
 from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
@@ -171,15 +171,43 @@ class _ChatAdapter:
             return None
         return GatewayUsage.from_completion_usage(result.usage)
 
+    def attach_cost(
+        self,
+        value: ChatCompletion | ChatCompletionChunk,
+        settlement: SettledCost,
+    ) -> bool:
+        if value.usage is None:
+            return False
+        value.usage = value.usage.model_copy(
+            update={
+                "cost_usd": settlement.cost_usd,
+                "pricing_source": settlement.pricing_source,
+            }
+        )
+        return True
+
+    def is_stream_cost_carrier(self, chunk: ChatCompletionChunk) -> bool:
+        # OpenAI's include_usage chunk carries usage and no choices. Requiring
+        # the terminal shape prevents usage stamped onto content chunks from
+        # making an early chunk the carrier and buffering the whole stream.
+        return chunk.usage is not None and not chunk.choices
+
     async def call_provider(self, kwargs: dict[str, Any]) -> ChatCompletion:
         return await acompletion(**kwargs)  # type: ignore[return-value]
 
     async def open_provider_stream(self, kwargs: dict[str, Any]) -> AsyncIterator[ChatCompletionChunk]:
         return await acompletion(**kwargs)  # type: ignore[return-value]
 
-    def prepare_stream_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
-        if kwargs.get("stream_options") is None:
-            kwargs["stream_options"] = {"include_usage": True}
+    def prepare_stream_kwargs(
+        self,
+        kwargs: dict[str, Any],
+        *,
+        require_usage: bool = False,
+    ) -> dict[str, Any]:
+        options = dict(kwargs.get("stream_options") or {})
+        if require_usage or "include_usage" not in options:
+            options["include_usage"] = True
+        kwargs["stream_options"] = options
         return kwargs
 
     async def run_tool_loop(

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -204,10 +204,11 @@ class _ChatAdapter:
         *,
         require_usage: bool = False,
     ) -> dict[str, Any]:
-        options = dict(kwargs.get("stream_options") or {})
-        if require_usage or "include_usage" not in options:
-            options["include_usage"] = True
-        kwargs["stream_options"] = options
+        options = kwargs.get("stream_options")
+        if options is None:
+            kwargs["stream_options"] = {"include_usage": True}
+        elif require_usage:
+            kwargs["stream_options"] = {**options, "include_usage": True}
         return kwargs
 
     async def run_tool_loop(

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -37,6 +37,7 @@ from gateway.api.routes._pipeline import (
 )
 from gateway.api.routes._platform import (
     ResolvedAttempt,
+    SettledCost,
     _extract_platform_user_token,
     _resolve_platform_credentials,
 )
@@ -364,13 +365,45 @@ class _MessagesAdapter:
             return None
         return _billable_messages_usage(result.usage)
 
+    def attach_cost(
+        self,
+        value: MessageResponse | MessageStreamEvent,
+        settlement: SettledCost,
+    ) -> bool:
+        usage: Any
+        if isinstance(value, MessageResponse):
+            usage = value.usage
+        elif isinstance(value, MessageDeltaEvent):
+            usage = value.usage
+        else:
+            return False
+        if usage is None:
+            return False
+        updated = usage.model_copy(
+            update={
+                "cost_usd": settlement.cost_usd,
+                "pricing_source": settlement.pricing_source,
+            }
+        )
+        value.usage = updated
+        return True
+
+    def is_stream_cost_carrier(self, chunk: MessageStreamEvent) -> bool:
+        return isinstance(chunk, MessageDeltaEvent)
+
     async def call_provider(self, kwargs: dict[str, Any]) -> MessageResponse:
         return await amessages(**kwargs)  # type: ignore[return-value]
 
     async def open_provider_stream(self, kwargs: dict[str, Any]) -> AsyncIterator[MessageStreamEvent]:
         return await amessages(**kwargs)  # type: ignore[return-value]
 
-    def prepare_stream_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+    def prepare_stream_kwargs(
+        self,
+        kwargs: dict[str, Any],
+        *,
+        require_usage: bool = False,
+    ) -> dict[str, Any]:
+        del require_usage
         kwargs["stream"] = True
         return kwargs
 

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -34,7 +34,7 @@ from gateway.api.routes._pipeline import (
     run_standalone_non_stream,
     run_streaming_with_fallback,
 )
-from gateway.api.routes._platform import ResolvedAttempt, build_attempt_client_args
+from gateway.api.routes._platform import ResolvedAttempt, SettledCost, build_attempt_client_args
 from gateway.api.routes._schema_derive import SESSION_LABEL_DESC, SESSION_LABEL_MAX_LENGTH, derive_request_base
 from gateway.api.routes._tools import _strip_gateway_fields
 from gateway.core.config import GatewayConfig
@@ -278,13 +278,45 @@ class _ResponsesAdapter:
     def extract_usage(self, result: ResponsesResponse) -> CompletionUsage | None:
         return _usage_to_completion_usage(getattr(result, "usage", None))
 
+    def attach_cost(
+        self,
+        value: ResponsesResponse | ResponseStreamEvent,
+        settlement: SettledCost,
+    ) -> bool:
+        response_obj: Any = getattr(value, "response", None)
+        target: Any = response_obj if getattr(value, "type", None) == "response.completed" else value
+        usage = getattr(target, "usage", None)
+        if usage is None:
+            return False
+        target.usage = usage.model_copy(
+            update={
+                "cost_usd": settlement.cost_usd,
+                "pricing_source": settlement.pricing_source,
+            }
+        )
+        return True
+
+    def is_stream_cost_carrier(self, chunk: ResponseStreamEvent) -> bool:
+        response_obj: Any = getattr(chunk, "response", None)
+        return (
+            chunk.type == "response.completed"
+            and response_obj is not None
+            and getattr(response_obj, "usage", None) is not None
+        )
+
     async def call_provider(self, kwargs: dict[str, Any]) -> ResponsesResponse:
         return await aresponses(**kwargs)  # type: ignore[return-value]
 
     async def open_provider_stream(self, kwargs: dict[str, Any]) -> AsyncIterator[ResponseStreamEvent]:
         return await aresponses(**kwargs)  # type: ignore[return-value]
 
-    def prepare_stream_kwargs(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+    def prepare_stream_kwargs(
+        self,
+        kwargs: dict[str, Any],
+        *,
+        require_usage: bool = False,
+    ) -> dict[str, Any]:
+        del require_usage
         kwargs["stream"] = True
         return kwargs
 

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -1245,12 +1245,29 @@ class GatewayConfig(BaseSettings):
     @field_validator("platform")
     @classmethod
     def _validate_platform_streaming_timeouts(cls, platform: dict[str, Any]) -> dict[str, Any]:
-        """Reject non-sensical streaming first-chunk timeout settings at load time.
+        """Reject non-sensical platform timeout settings at load time.
 
-        The per-attempt first-chunk budgets must be positive: a zero or negative
-        wait would treat every attempt as instantly hung. The terminal-attempt
-        extra grace must be non-negative, since it is added on top of the budget.
+        The per-attempt first-chunk and inline-settlement budgets must be
+        positive. The terminal-attempt extra grace must be non-negative, since
+        it is added on top of the first-chunk budget.
         """
+        inline_key = "usage_inline_timeout_ms"
+        if inline_key in platform:
+            raw_inline_timeout = platform[inline_key]
+            try:
+                inline_timeout = int(raw_inline_timeout)
+            except (TypeError, ValueError):
+                raise ValueError(
+                    f"{inline_key} must be a positive integer, got {raw_inline_timeout!r}"
+                ) from None
+            if (
+                isinstance(raw_inline_timeout, bool)
+                or (isinstance(raw_inline_timeout, float) and not raw_inline_timeout.is_integer())
+                or inline_timeout <= 0
+            ):
+                raise ValueError(f"{inline_key} must be a positive integer, got {raw_inline_timeout!r}")
+            platform[inline_key] = inline_timeout
+
         positive_ms_keys = (
             "streaming_first_chunk_timeout_ms",
             "streaming_first_chunk_timeout_ms_tool_loop",

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -1465,6 +1465,9 @@ def _apply_platform_env_overrides(config: dict[str, Any]) -> None:
         "PLATFORM_MANAGEMENT_URL": ("management_url", str),
         "PLATFORM_RESOLVE_TIMEOUT_MS": ("resolve_timeout_ms", int),
         "PLATFORM_USAGE_TIMEOUT_MS": ("usage_timeout_ms", int),
+        # Budget for the one usage report the response path waits on. Expiry
+        # detaches the wait without cancelling the accounting report.
+        "PLATFORM_USAGE_INLINE_TIMEOUT_MS": ("usage_inline_timeout_ms", int),
         "PLATFORM_USAGE_MAX_RETRIES": ("usage_max_retries", int),
         # Per-attempt budget for streaming fallback: how long to wait for the
         # first chunk from each attempt before treating it as hung and moving

--- a/src/gateway/metrics.py
+++ b/src/gateway/metrics.py
@@ -68,6 +68,13 @@ ABANDONED_ATTEMPTS = Counter(
     registry=REGISTRY,
 )
 
+INLINE_COST_SETTLEMENTS = Counter(
+    "gateway_inline_cost_settlements",
+    "Inline platform cost settlement outcomes on the hybrid response path",
+    ["outcome"],
+    registry=REGISTRY,
+)
+
 RATE_LIMIT_HITS = Counter(
     "gateway_rate_limit_hits",
     "Total number of rate limit hits",
@@ -203,6 +210,11 @@ def record_abandoned_attempt(provider: str, model: str, reason: str, position: i
     plan length.
     """
     ABANDONED_ATTEMPTS.labels(provider=provider, model=model, reason=reason, position=str(position)).inc()
+
+
+def record_inline_cost_settlement(outcome: str) -> None:
+    """Record an attached, unattached, or timed-out inline settlement."""
+    INLINE_COST_SETTLEMENTS.labels(outcome=outcome).inc()
 
 
 def record_rate_limit_hit() -> None:

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -25,6 +25,10 @@ S = TypeVar("S")  # Settlement type, opaque to this module
 
 
 DEFAULT_FIRST_CHUNK_TIMEOUT_SECONDS = 2.0
+# Most chunks held behind a designated cost carrier, the carrier included. The
+# real terminal suffix is short (a usage chunk, or ``message_delta`` plus
+# ``message_stop``); anything longer means the carrier was not terminal, and the
+# stream resumes rather than waiting on settlement to release the rest.
 _MAX_TERMINAL_BUFFER_CHUNKS = 4
 
 
@@ -189,7 +193,10 @@ async def streaming_generator(
             pending. 0 disables.
         settle_before_done: Buffer the designated terminal suffix and settle usage
             before emitting it. Standalone callers leave this false.
-        is_cost_carrier: Identifies the terminal provider object that can carry cost.
+        is_cost_carrier: Identifies a provider object that can carry cost. The last
+            match in the stream wins, so a predicate that also matches a non-terminal
+            object (a chat tool loop forwards one usage chunk per iteration) costs no
+            buffering beyond the chunks between that match and the next one.
         attach_settlement: Mutates that carrier with the opaque settlement value.
 
     """
@@ -199,7 +206,7 @@ async def streaming_generator(
     terminal_buffer: list[Any] = []
     cost_carrier: Any | None = None
     buffering_terminal = False
-    buffering_abandoned = False
+    overflow_logged = False
     settlement_task: asyncio.Task[S | None] | None = None
 
     keepalive_interval = keepalive_interval_seconds if fmt.keepalive else 0.0
@@ -220,30 +227,40 @@ async def streaming_generator(
                     usage = _merge_usage(usage, chunk_usage)
                     has_usage = True
 
-                if buffering_terminal:
+                if settle_before_done and is_cost_carrier is not None and is_cost_carrier(chunk):
+                    # A later carrier supersedes an earlier one. A chat tool loop
+                    # forwards one ``include_usage`` chunk per iteration, so the
+                    # first one is not terminal; flushing here keeps the next
+                    # iteration's answer streaming instead of holding it behind a
+                    # carrier that is not the last, and leaves cost on the chunk
+                    # that really ends the stream.
+                    for buffered_chunk in terminal_buffer:
+                        yield _format(buffered_chunk)
+                    terminal_buffer.clear()
+                    cost_carrier = chunk
                     terminal_buffer.append(chunk)
-                    if len(terminal_buffer) > _MAX_TERMINAL_BUFFER_CHUNKS:
-                        logger.warning(
-                            "Terminal usage carrier arrived too early for %s; disabling inline cost",
-                            label,
-                        )
+                    buffering_terminal = True
+                    continue
+
+                if buffering_terminal:
+                    if len(terminal_buffer) >= _MAX_TERMINAL_BUFFER_CHUNKS:
+                        # The designated carrier was not terminal after all. Stop
+                        # holding it so the stream keeps flowing, but stay open to
+                        # a later carrier rather than giving up on cost outright.
+                        if not overflow_logged:
+                            logger.warning(
+                                "Terminal usage carrier was not terminal for %s; streaming without holding it",
+                                label,
+                            )
+                            overflow_logged = True
                         for buffered_chunk in terminal_buffer:
                             yield _format(buffered_chunk)
                         terminal_buffer.clear()
                         cost_carrier = None
                         buffering_terminal = False
-                        buffering_abandoned = True
-                    continue
-
-                if (
-                    settle_before_done
-                    and not buffering_abandoned
-                    and is_cost_carrier is not None
-                    and is_cost_carrier(chunk)
-                ):
-                    cost_carrier = chunk
+                        yield _format(chunk)
+                        continue
                     terminal_buffer.append(chunk)
-                    buffering_terminal = True
                     continue
 
                 yield _format(chunk)
@@ -251,7 +268,7 @@ async def streaming_generator(
         # Once the upstream is exhausted, hybrid mode settles before emitting
         # the buffered terminal suffix. Standalone mode retains the historical
         # order: chunks, done marker, then reconciliation.
-        if settle_before_done and not buffering_abandoned:
+        if settle_before_done:
             settled = True
             settlement: S | None = None
             try:
@@ -285,19 +302,14 @@ async def streaming_generator(
             terminal_buffer.clear()
             yield fmt.done_marker
         else:
-            for buffered_chunk in terminal_buffer:
-                yield _format(buffered_chunk)
-            terminal_buffer.clear()
             yield fmt.done_marker
+
+            # Settle on normal completion. Guard the callbacks so a logging failure
+            # can't be mistaken for an incomplete (disconnected) stream.
             settled = True
             try:
                 if has_usage:
-                    settlement = await on_complete(usage)
-                    if settle_before_done and settlement is not None and attach_settlement is not None:
-                        try:
-                            attach_settlement(None, settlement)
-                        except Exception as attach_err:
-                            logger.error("Failed to attach streaming settlement for %s: %s", label, attach_err)
+                    await on_complete(usage)
                 elif on_no_usage is not None:
                     await on_no_usage()
             except Exception as log_err:

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -21,9 +21,11 @@ from gateway.model_labeling import relabel_model
 
 A = TypeVar("A")  # Attempt-like, opaque to this module
 C = TypeVar("C")  # Chunk type emitted by the upstream stream
+S = TypeVar("S")  # Settlement type, opaque to this module
 
 
 DEFAULT_FIRST_CHUNK_TIMEOUT_SECONDS = 2.0
+_MAX_TERMINAL_BUFFER_CHUNKS = 4
 
 
 @dataclass(frozen=True)
@@ -148,13 +150,16 @@ async def streaming_generator(
     format_chunk: Callable[[Any], str],
     extract_usage: Callable[[Any], CompletionUsage | None],
     fmt: StreamFormat,
-    on_complete: Callable[[CompletionUsage], Awaitable[None]],
+    on_complete: Callable[[CompletionUsage], Awaitable[S | None]],
     on_error: Callable[[BaseException], Awaitable[None]],
     label: str,
     on_no_usage: Callable[[], Awaitable[None]] | None = None,
     on_incomplete: Callable[[], Awaitable[None]] | None = None,
     display_model: str | None = None,
     keepalive_interval_seconds: float = 0.0,
+    settle_before_done: bool = False,
+    is_cost_carrier: Callable[[Any], bool] | None = None,
+    attach_settlement: Callable[[Any, S], bool] | None = None,
 ) -> AsyncGenerator[str, None]:
     """Shared SSE streaming generator with usage tracking and error handling.
 
@@ -180,19 +185,29 @@ async def streaming_generator(
             (e.g. client disconnect mid-stream). Used to release any budget
             reservation so it does not leak.
         keepalive_interval_seconds: Emit ``fmt.keepalive`` whenever the upstream has
-            produced nothing for this long, so an intermediary with a read timeout
-            (Cloudflare's default Proxy Read Timeout is 125s) does not sever a
-            connection that is merely waiting on a slow time-to-first-token.
-            Transport-level only: keepalives never reach usage accounting, and they
-            do not extend any first-chunk or failover deadline, which stay in charge
-            of giving up on a hung upstream. 0 disables.
+            produced nothing for this long, including while terminal settlement is
+            pending. 0 disables.
+        settle_before_done: Buffer the designated terminal suffix and settle usage
+            before emitting it. Standalone callers leave this false.
+        is_cost_carrier: Identifies the terminal provider object that can carry cost.
+        attach_settlement: Mutates that carrier with the opaque settlement value.
 
     """
     usage = CompletionUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
     has_usage = False
     settled = False
+    terminal_buffer: list[Any] = []
+    cost_carrier: Any | None = None
+    buffering_terminal = False
+    buffering_abandoned = False
+    settlement_task: asyncio.Task[S | None] | None = None
 
     keepalive_interval = keepalive_interval_seconds if fmt.keepalive else 0.0
+
+    def _format(chunk: Any) -> str:
+        if display_model is not None:
+            chunk = relabel_model(chunk, display_model)
+        return format_chunk(chunk)
 
     try:
         async with aclosing(_chunks_or_keepalive(stream, keepalive_interval)) as source:
@@ -204,32 +219,105 @@ async def streaming_generator(
                 if chunk_usage:
                     usage = _merge_usage(usage, chunk_usage)
                     has_usage = True
-                if display_model is not None:
-                    chunk = relabel_model(chunk, display_model)
-                yield format_chunk(chunk)
-        yield fmt.done_marker
 
-        # Settle on normal completion. Guard the callbacks so a logging failure
-        # can't be mistaken for an incomplete (disconnected) stream.
-        settled = True
-        try:
-            if has_usage:
-                await on_complete(usage)
-            elif on_no_usage is not None:
-                await on_no_usage()
-        except Exception as log_err:
-            logger.error("Failed to log streaming usage for %s: %s", label, log_err)
+                if buffering_terminal:
+                    terminal_buffer.append(chunk)
+                    if len(terminal_buffer) > _MAX_TERMINAL_BUFFER_CHUNKS:
+                        logger.warning(
+                            "Terminal usage carrier arrived too early for %s; disabling inline cost",
+                            label,
+                        )
+                        for buffered_chunk in terminal_buffer:
+                            yield _format(buffered_chunk)
+                        terminal_buffer.clear()
+                        cost_carrier = None
+                        buffering_terminal = False
+                        buffering_abandoned = True
+                    continue
+
+                if (
+                    settle_before_done
+                    and not buffering_abandoned
+                    and is_cost_carrier is not None
+                    and is_cost_carrier(chunk)
+                ):
+                    cost_carrier = chunk
+                    terminal_buffer.append(chunk)
+                    buffering_terminal = True
+                    continue
+
+                yield _format(chunk)
+
+        # Once the upstream is exhausted, hybrid mode settles before emitting
+        # the buffered terminal suffix. Standalone mode retains the historical
+        # order: chunks, done marker, then reconciliation.
+        if settle_before_done and not buffering_abandoned:
+            settled = True
+            settlement: S | None = None
+            try:
+                if has_usage:
+                    if keepalive_interval > 0:
+                        async def _settle() -> S | None:
+                            return await on_complete(usage)
+
+                        settlement_task = asyncio.create_task(_settle())
+                        while not settlement_task.done():
+                            done, _ = await asyncio.wait(
+                                (settlement_task,),
+                                timeout=keepalive_interval,
+                            )
+                            if not done:
+                                yield fmt.keepalive
+                        settlement = settlement_task.result()
+                    else:
+                        settlement = await on_complete(usage)
+                elif on_no_usage is not None:
+                    await on_no_usage()
+            except Exception as log_err:
+                logger.error("Failed to log streaming usage for %s: %s", label, log_err)
+            if settlement is not None and attach_settlement is not None:
+                try:
+                    attach_settlement(cost_carrier, settlement)
+                except Exception as attach_err:
+                    logger.error("Failed to attach streaming settlement for %s: %s", label, attach_err)
+            for buffered_chunk in terminal_buffer:
+                yield _format(buffered_chunk)
+            terminal_buffer.clear()
+            yield fmt.done_marker
+        else:
+            for buffered_chunk in terminal_buffer:
+                yield _format(buffered_chunk)
+            terminal_buffer.clear()
+            yield fmt.done_marker
+            settled = True
+            try:
+                if has_usage:
+                    settlement = await on_complete(usage)
+                    if settle_before_done and settlement is not None and attach_settlement is not None:
+                        try:
+                            attach_settlement(None, settlement)
+                        except Exception as attach_err:
+                            logger.error("Failed to attach streaming settlement for %s: %s", label, attach_err)
+                elif on_no_usage is not None:
+                    await on_no_usage()
+            except Exception as log_err:
+                logger.error("Failed to log streaming usage for %s: %s", label, log_err)
     except asyncio.CancelledError:
-        # Client disconnect / request cancellation mid-stream. CancelledError is a
-        # BaseException (not caught by `except Exception` below), so handle it
-        # explicitly: settle as incomplete and let cancellation propagate — do not
-        # emit an SSE error payload or call on_error.
+        if settlement_task is not None and not settlement_task.done():
+            settlement_task.cancel()
+            with suppress(BaseException):
+                await settlement_task
         if not settled and on_incomplete is not None:
             with suppress(Exception):
                 await on_incomplete()
         settled = True
         raise
     except Exception as e:
+        # A carrier may have been buffered just before the upstream failed. It
+        # remains an ordinary provider event and must precede the safe error.
+        for buffered_chunk in terminal_buffer:
+            yield _format(buffered_chunk)
+        terminal_buffer.clear()
         yield fmt.error_payload
         if fmt.yield_done_on_error:
             yield fmt.done_marker
@@ -240,9 +328,11 @@ async def streaming_generator(
             logger.error("Failed to log streaming error usage: %s", log_err)
         logger.error("Streaming error for %s: %s", label, e)
     finally:
+        if settlement_task is not None and not settlement_task.done():
+            settlement_task.cancel()
+            with suppress(BaseException):
+                await settlement_task
         if not settled and on_incomplete is not None:
-            # Reached on client disconnect / generator cancellation before the
-            # stream finished — release the reservation so it does not leak.
             try:
                 await on_incomplete()
             except Exception as log_err:

--- a/src/gateway/streaming.py
+++ b/src/gateway/streaming.py
@@ -248,7 +248,7 @@ async def streaming_generator(
                         # holding it so the stream keeps flowing, but stay open to
                         # a later carrier rather than giving up on cost outright.
                         if not overflow_logged:
-                            logger.warning(
+                            logger.debug(
                                 "Terminal usage carrier was not terminal for %s; streaming without holding it",
                                 label,
                             )

--- a/tests/integration/test_config_env_loading.py
+++ b/tests/integration/test_config_env_loading.py
@@ -398,6 +398,7 @@ def test_load_config_platform_env_overrides(tmp_path: Path, monkeypatch: pytest.
     monkeypatch.setenv("PLATFORM_BASE_URL", "http://localhost:8100/api/v1")
     monkeypatch.setenv("PLATFORM_RESOLVE_TIMEOUT_MS", "1234")
     monkeypatch.setenv("PLATFORM_USAGE_TIMEOUT_MS", "2345")
+    monkeypatch.setenv("PLATFORM_USAGE_INLINE_TIMEOUT_MS", "150")
     monkeypatch.setenv("PLATFORM_USAGE_MAX_RETRIES", "7")
 
     config = load_config(str(config_file))
@@ -406,6 +407,7 @@ def test_load_config_platform_env_overrides(tmp_path: Path, monkeypatch: pytest.
     assert config.platform["base_url"] == "http://localhost:8100/api/v1"
     assert config.platform["resolve_timeout_ms"] == 1234
     assert config.platform["usage_timeout_ms"] == 2345
+    assert config.platform["usage_inline_timeout_ms"] == 150
     assert config.platform["usage_max_retries"] == 7
 
 

--- a/tests/integration/test_hybrid_mode_chat.py
+++ b/tests/integration/test_hybrid_mode_chat.py
@@ -102,7 +102,18 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
             )
 
         usage_reports.append(body)
-        return httpx.Response(204)
+        return httpx.Response(
+            200,
+            json={
+                "correlation_id": body["correlation_id"],
+                "status": "completed",
+                "outcome": "success",
+                "cost_usd": "0.012345",
+                "currency": "USD",
+                "usage_status": "reported",
+                "pricing": {"source": "managed"},
+            },
+        )
 
     async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
         assert kwargs["model"] == "openai:gpt-4o-mini"
@@ -138,6 +149,8 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
 
     assert response.status_code == 200
     assert response.headers["X-Correlation-ID"] == "7af2c39d-4eb8-4b3f-8242-46a97f7d5e68"
+    assert response.json()["usage"]["cost_usd"] == "0.012345"
+    assert response.json()["usage"]["pricing_source"] == "managed"
     assert usage_reports == [
         {
             "correlation_id": "7af2c39d-4eb8-4b3f-8242-46a97f7d5e68",
@@ -838,6 +851,89 @@ def test_hybrid_mode_forwards_resolve_400_detail(
 # ---------------------------------------------------------------------------
 # Streaming fallback (v1.1)
 # ---------------------------------------------------------------------------
+
+
+def test_hybrid_mode_streaming_returns_inline_cost_and_forces_usage(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from collections.abc import AsyncIterator
+
+    from any_llm.types.completion import ChatCompletionChunk
+
+    attempt_id = "3f1b6a1e-0000-4000-8000-000000000005"
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json={
+                    "request_id": "req-stream-inline",
+                    "fallback_enabled": False,
+                    "attempts": [
+                        {
+                            "attempt_id": attempt_id,
+                            "position": 0,
+                            "provider": "openai",
+                            "model": "gpt-4o-mini",
+                            "api_key": "sk-platform-key",
+                            "managed": True,
+                        }
+                    ],
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "correlation_id": body["correlation_id"],
+                "status": "completed",
+                "outcome": "success",
+                "cost_usd": "0.012345",
+                "currency": "USD",
+                "usage_status": "reported",
+                "pricing": {"source": "managed"},
+            },
+        )
+
+    async def fake_acompletion(**kwargs: Any) -> AsyncIterator[ChatCompletionChunk]:
+        assert kwargs["stream_options"]["include_usage"] is True
+
+        async def stream() -> AsyncIterator[ChatCompletionChunk]:
+            yield ChatCompletionChunk(
+                id="chunk-usage",
+                choices=[],
+                created=0,
+                model="gpt-4o-mini",
+                object="chat.completion.chunk",
+                usage=CompletionUsage(prompt_tokens=10, completion_tokens=7, total_tokens=17),
+            )
+
+        return stream()
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.chat.acompletion", fake_acompletion)
+
+    with platform_client.stream(
+        "POST",
+        "/v1/chat/completions",
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+            "stream_options": {"include_usage": False},
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    ) as response:
+        assert response.status_code == 200, response.read().decode()
+        wire = response.read().decode()
+
+    assert '"cost_usd":"0.012345"' in wire
+    assert '"pricing_source":"managed"' in wire
 
 
 def test_hybrid_mode_streaming_falls_through_on_first_attempt_failure(

--- a/tests/integration/test_hybrid_mode_messages.py
+++ b/tests/integration/test_hybrid_mode_messages.py
@@ -148,6 +148,7 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     usage_reports: list[dict[str, Any]] = []
+    attempt_id = "3f1b6a1e-0000-4000-8000-000000000002"
 
     async def fake_post_platform(
         url: str,
@@ -158,10 +159,23 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
         if url.endswith("/gateway/provider-keys/resolve"):
             return httpx.Response(
                 200,
-                json=_resolve_payload([_attempt(0, "att-1", "claude-3-5-sonnet-20241022", "sk-platform-key")]),
+                json=_resolve_payload(
+                    [_attempt(0, attempt_id, "claude-3-5-sonnet-20241022", "sk-platform-key")]
+                ),
             )
         usage_reports.append(body)
-        return httpx.Response(204)
+        return httpx.Response(
+            200,
+            json={
+                "correlation_id": body["correlation_id"],
+                "status": "completed",
+                "outcome": "success",
+                "cost_usd": "0.012345",
+                "currency": "USD",
+                "usage_status": "reported",
+                "pricing": {"source": "managed"},
+            },
+        )
 
     async def fake_amessages(**kwargs: Any) -> MessageResponse:
         assert kwargs["model"] == "anthropic:claude-3-5-sonnet-20241022"
@@ -182,11 +196,13 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
     )
 
     assert response.status_code == 200, response.text
-    assert response.headers["X-Correlation-ID"] == "att-1"
+    assert response.headers["X-Correlation-ID"] == attempt_id
     assert response.headers["X-Otari-Request-ID"] == "req-1"
+    assert response.json()["usage"]["cost_usd"] == "0.012345"
+    assert response.json()["usage"]["pricing_source"] == "managed"
     assert usage_reports == [
         {
-            "correlation_id": "att-1",
+            "correlation_id": attempt_id,
             "status": "success",
             "is_final_attempt": True,
             "usage": {
@@ -729,15 +745,9 @@ def test_hybrid_mode_tool_loop_streaming_sets_correlation_id_and_reports_usage(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Tool-loop streaming in hybrid mode must honor the platform contract:
-    X-Correlation-ID + X-Otari-Request-ID headers, and usage reported back
-    via _report_platform_usage on stream complete.
-
-    Regression test for the issue where ``_stream_messages`` was the
-    standalone helper and silently dropped the platform metadata when
-    invoked for platform + tool_loop streaming.
-    """
+    """Tool-loop streaming returns settled cost on the terminal usage event."""
     usage_reports: list[dict[str, Any]] = []
+    attempt_id = "3f1b6a1e-0000-4000-8000-000000000003"
 
     async def fake_post_platform(
         url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
@@ -745,10 +755,23 @@ def test_hybrid_mode_tool_loop_streaming_sets_correlation_id_and_reports_usage(
         if url.endswith("/gateway/provider-keys/resolve"):
             return httpx.Response(
                 200,
-                json=_resolve_payload([_attempt(0, "stream-att-1", "claude-3-5-sonnet-20241022", "sk-platform")]),
+                json=_resolve_payload(
+                    [_attempt(0, attempt_id, "claude-3-5-sonnet-20241022", "sk-platform")]
+                ),
             )
         usage_reports.append(body)
-        return httpx.Response(204)
+        return httpx.Response(
+            200,
+            json={
+                "correlation_id": body["correlation_id"],
+                "status": "completed",
+                "outcome": "success",
+                "cost_usd": "0.012345",
+                "currency": "USD",
+                "usage_status": "reported",
+                "pricing": {"source": "managed"},
+            },
+        )
 
     monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
 
@@ -793,18 +816,15 @@ def test_hybrid_mode_tool_loop_streaming_sets_correlation_id_and_reports_usage(
             headers={"Authorization": "Bearer user_test_token"},
         ) as response:
             assert response.status_code == 200, response.read().decode()
-            assert response.headers["X-Correlation-ID"] == "stream-att-1"
+            assert response.headers["X-Correlation-ID"] == attempt_id
             assert response.headers["X-Otari-Request-ID"] == "req-1"
-            # Consume the stream so on_complete fires.
-            for _ in response.iter_bytes():
-                pass
+            wire = response.read().decode()
 
-    # _report_platform_usage scheduled via asyncio.create_task; give the loop
-    # a moment to drain. TestClient's lifespan generally runs to completion
-    # by the time the with-block exits.
+    assert '"cost_usd":"0.012345"' in wire
+    assert '"pricing_source":"managed"' in wire
     success_reports = [r for r in usage_reports if r.get("status") == "success"]
     assert success_reports, "expected a success usage report for the hybrid-mode tool-loop stream"
-    assert success_reports[0]["correlation_id"] == "stream-att-1"
+    assert success_reports[0]["correlation_id"] == attempt_id
 
 
 def test_hybrid_mode_tool_loop_streaming_forwards_session_label(

--- a/tests/integration/test_hybrid_mode_responses.py
+++ b/tests/integration/test_hybrid_mode_responses.py
@@ -117,6 +117,7 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     usage_reports: list[dict[str, Any]] = []
+    attempt_id = "3f1b6a1e-0000-4000-8000-000000000002"
 
     async def fake_post_platform(
         url: str,
@@ -127,10 +128,21 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
         if url.endswith("/gateway/provider-keys/resolve"):
             return httpx.Response(
                 200,
-                json=_resolve_payload([_attempt(0, "att-1", "gpt-4o-mini", "sk-platform-key")]),
+                json=_resolve_payload([_attempt(0, attempt_id, "gpt-4o-mini", "sk-platform-key")]),
             )
         usage_reports.append(body)
-        return httpx.Response(204)
+        return httpx.Response(
+            200,
+            json={
+                "correlation_id": body["correlation_id"],
+                "status": "completed",
+                "outcome": "success",
+                "cost_usd": "0.012345",
+                "currency": "USD",
+                "usage_status": "reported",
+                "pricing": {"source": "managed"},
+            },
+        )
 
     async def fake_aresponses(**kwargs: Any) -> Response:
         assert kwargs["api_key"] == "sk-platform-key"
@@ -146,11 +158,13 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
     )
 
     assert response.status_code == 200, response.text
-    assert response.headers["X-Correlation-ID"] == "att-1"
+    assert response.headers["X-Correlation-ID"] == attempt_id
     assert response.headers["X-Otari-Request-ID"] == "req-1"
+    assert response.json()["usage"]["cost_usd"] == "0.012345"
+    assert response.json()["usage"]["pricing_source"] == "managed"
     assert usage_reports == [
         {
-            "correlation_id": "att-1",
+            "correlation_id": attempt_id,
             "status": "success",
             "is_final_attempt": True,
             "usage": {
@@ -668,13 +682,9 @@ def test_hybrid_mode_tool_loop_streaming_sets_correlation_id_and_reports_usage(
     platform_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Tool-loop streaming in hybrid mode must honor the platform contract:
-    X-Correlation-ID + X-Otari-Request-ID headers + usage report via
-    _report_platform_usage on complete. Regression test for the issue where
-    ``_stream_responses`` was the standalone helper and silently dropped the
-    platform metadata when invoked for platform + tool_loop.
-    """
+    """Tool-loop streaming returns settled cost on response.completed."""
     usage_reports: list[dict[str, Any]] = []
+    attempt_id = "3f1b6a1e-0000-4000-8000-000000000004"
 
     async def fake_post_platform(
         url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
@@ -682,10 +692,21 @@ def test_hybrid_mode_tool_loop_streaming_sets_correlation_id_and_reports_usage(
         if url.endswith("/gateway/provider-keys/resolve"):
             return httpx.Response(
                 200,
-                json=_resolve_payload([_attempt(0, "stream-att-1", "gpt-4o-mini", "sk-platform")]),
+                json=_resolve_payload([_attempt(0, attempt_id, "gpt-4o-mini", "sk-platform")]),
             )
         usage_reports.append(body)
-        return httpx.Response(204)
+        return httpx.Response(
+            200,
+            json={
+                "correlation_id": body["correlation_id"],
+                "status": "completed",
+                "outcome": "success",
+                "cost_usd": "0.012345",
+                "currency": "USD",
+                "usage_status": "reported",
+                "pricing": {"source": "managed"},
+            },
+        )
 
     monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
 
@@ -722,14 +743,15 @@ def test_hybrid_mode_tool_loop_streaming_sets_correlation_id_and_reports_usage(
             headers={"Authorization": "Bearer user_test_token"},
         ) as response:
             assert response.status_code == 200, response.read().decode()
-            assert response.headers["X-Correlation-ID"] == "stream-att-1"
+            assert response.headers["X-Correlation-ID"] == attempt_id
             assert response.headers["X-Otari-Request-ID"] == "req-1"
-            for _ in response.iter_bytes():
-                pass
+            wire = response.read().decode()
 
+    assert '"cost_usd":"0.012345"' in wire
+    assert '"pricing_source":"managed"' in wire
     success_reports = [r for r in usage_reports if r.get("status") == "success"]
     assert success_reports, "expected a success usage report for the hybrid-mode tool-loop stream"
-    assert success_reports[0]["correlation_id"] == "stream-att-1"
+    assert success_reports[0]["correlation_id"] == attempt_id
     assert success_reports[0]["is_final_attempt"] is True
 
 

--- a/tests/unit/test_gateway_metrics.py
+++ b/tests/unit/test_gateway_metrics.py
@@ -16,6 +16,7 @@ from gateway.metrics import (
     record_auth_failure,
     record_budget_exceeded,
     record_cost,
+    record_inline_cost_settlement,
     record_rate_limit_hit,
     record_tokens,
 )
@@ -58,6 +59,16 @@ def test_record_cost_observes_histogram() -> None:
 
     assert _sample("gateway_request_cost_dollars_count", labels) - before_count == 1.0
     assert _sample("gateway_request_cost_dollars_sum", labels) >= 1.23
+
+
+@pytest.mark.parametrize("outcome", ["attached", "unattached", "timeout"])
+def test_record_inline_cost_settlement_increments_counter(outcome: str) -> None:
+    labels = {"outcome": outcome}
+    before = _sample("gateway_inline_cost_settlements_total", labels)
+
+    record_inline_cost_settlement(outcome)
+
+    assert _sample("gateway_inline_cost_settlements_total", labels) - before == 1.0
 
 
 def test_record_rate_limit_hit_increments_counter() -> None:

--- a/tests/unit/test_inline_platform_cost.py
+++ b/tests/unit/test_inline_platform_cost.py
@@ -1,0 +1,225 @@
+"""Focused tests for inline platform-cost wire placement."""
+
+from typing import Any, cast
+
+import pytest
+from any_llm.types.completion import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    ChatCompletionMessage,
+    Choice,
+    CompletionUsage,
+)
+from any_llm.types.messages import (
+    MessageDelta,
+    MessageDeltaEvent,
+    MessageDeltaUsage,
+    MessageResponse,
+    MessageStartEvent,
+    MessageUsage,
+    TextBlock,
+)
+from any_llm.types.responses import Response
+from openai.types.responses import ResponseCompletedEvent, ResponseUsage
+from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+
+from gateway.api.routes import chat, messages, responses
+from gateway.api.routes._platform import SettledCost
+
+_SETTLEMENT = SettledCost(cost_usd="0.012345", pricing_source="managed")
+
+
+def _chat_response(*, usage: CompletionUsage | None = None) -> ChatCompletion:
+    return ChatCompletion(
+        id="cmpl-1",
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                message=ChatCompletionMessage(role="assistant", content="hi"),
+            )
+        ],
+        created=0,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        usage=usage,
+    )
+
+
+def _chat_usage_chunk() -> ChatCompletionChunk:
+    return ChatCompletionChunk(
+        id="chunk-1",
+        choices=[],
+        created=0,
+        model="gpt-4o-mini",
+        object="chat.completion.chunk",
+        usage=CompletionUsage(prompt_tokens=10, completion_tokens=7, total_tokens=17),
+    )
+
+
+def _message_usage() -> MessageUsage:
+    return MessageUsage(
+        input_tokens=10,
+        output_tokens=7,
+        cache_creation_input_tokens=None,
+        cache_read_input_tokens=None,
+        cache_creation=None,
+        server_tool_use=None,
+        service_tier=None,
+    )
+
+
+def _message_response() -> MessageResponse:
+    return MessageResponse(
+        id="msg-1",
+        type="message",
+        role="assistant",
+        model="claude-sonnet-4-0",
+        content=[TextBlock(type="text", text="hi", citations=None)],
+        stop_reason=cast(Any, "end_turn"),
+        stop_sequence=None,
+        usage=_message_usage(),
+        container=None,
+    )
+
+
+def _message_delta() -> MessageDeltaEvent:
+    return MessageDeltaEvent(
+        type="message_delta",
+        delta=MessageDelta(stop_reason=cast(Any, "end_turn"), stop_sequence=None),
+        usage=MessageDeltaUsage.model_validate(
+            {
+                "input_tokens": None,
+                "output_tokens": 7,
+                "cache_creation_input_tokens": None,
+                "cache_read_input_tokens": None,
+            }
+        ),
+    )
+
+
+def _message_start() -> MessageStartEvent:
+    return MessageStartEvent(type="message_start", message=_message_response())
+
+
+def _response(*, usage: ResponseUsage | None = None) -> Response:
+    return Response(
+        id="resp-1",
+        created_at=0.0,
+        model="gpt-4o-mini",
+        object="response",
+        status="completed",
+        output=[],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+        usage=usage,
+        error=None,
+        incomplete_details=None,
+        instructions=None,
+        metadata=None,
+        temperature=None,
+        top_p=None,
+    )
+
+
+def _response_usage() -> ResponseUsage:
+    return ResponseUsage(
+        input_tokens=10,
+        input_tokens_details=InputTokensDetails(cached_tokens=0),
+        output_tokens=7,
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
+        total_tokens=17,
+    )
+
+
+def _response_completed() -> ResponseCompletedEvent:
+    return ResponseCompletedEvent(
+        type="response.completed",
+        response=_response(usage=_response_usage()),
+        sequence_number=0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("adapter", "value", "usage_getter"),
+    [
+        (
+            chat._ADAPTER,
+            _chat_response(usage=CompletionUsage(prompt_tokens=10, completion_tokens=7, total_tokens=17)),
+            lambda value: value.usage,
+        ),
+        (chat._ADAPTER, _chat_usage_chunk(), lambda value: value.usage),
+        (messages._ADAPTER, _message_response(), lambda value: value.usage),
+        (messages._ADAPTER, _message_delta(), lambda value: value.usage),
+        (responses._ADAPTER, _response(usage=_response_usage()), lambda value: value.usage),
+        (responses._ADAPTER, _response_completed(), lambda value: value.response.usage),
+    ],
+)
+def test_adapter_attaches_inline_cost(adapter: Any, value: Any, usage_getter: Any) -> None:
+    assert adapter.attach_cost(value, _SETTLEMENT) is True
+
+    usage = usage_getter(value)
+    assert usage.cost_usd == "0.012345"
+    assert usage.pricing_source == "managed"
+
+
+@pytest.mark.parametrize(
+    ("adapter", "event"),
+    [
+        (chat._ADAPTER, _chat_usage_chunk()),
+        (messages._ADAPTER, _message_delta()),
+        (responses._ADAPTER, _response_completed()),
+    ],
+)
+def test_terminal_events_serialize_inline_cost(adapter: Any, event: Any) -> None:
+    adapter.attach_cost(event, _SETTLEMENT)
+
+    chunk = adapter.format_chunk(event)
+
+    assert '"cost_usd":"0.012345"' in chunk
+    assert '"pricing_source":"managed"' in chunk
+
+
+def test_format_chunk_unchanged_without_inline_cost() -> None:
+    event = _message_delta()
+    assert messages._ADAPTER.format_chunk(event) == (
+        f"event: {event.type}\ndata: {event.model_dump_json(exclude_none=True)}\n\n"
+    )
+
+
+def test_chat_carrier_is_only_terminal_usage_chunk() -> None:
+    assert chat._ADAPTER.is_stream_cost_carrier(_chat_usage_chunk()) is True
+    content_chunk = _chat_usage_chunk().model_copy(
+        update={
+            "choices": [
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="hi"),
+                )
+            ]
+        }
+    )
+    assert chat._ADAPTER.is_stream_cost_carrier(content_chunk) is False
+
+
+def test_message_start_is_not_carrier() -> None:
+    assert messages._ADAPTER.is_stream_cost_carrier(_message_start()) is False
+    assert messages._ADAPTER.is_stream_cost_carrier(_message_delta()) is True
+
+
+def test_response_completed_with_usage_is_carrier() -> None:
+    assert responses._ADAPTER.is_stream_cost_carrier(_response_completed()) is True
+
+
+@pytest.mark.parametrize(
+    ("adapter", "value"),
+    [
+        (chat._ADAPTER, _chat_response()),
+        (responses._ADAPTER, _response()),
+    ],
+)
+def test_adapter_does_not_synthesize_usage(adapter: Any, value: Any) -> None:
+    assert adapter.attach_cost(value, _SETTLEMENT) is False
+    assert value.usage is None

--- a/tests/unit/test_pipeline_settlement.py
+++ b/tests/unit/test_pipeline_settlement.py
@@ -765,11 +765,11 @@ async def test_carrier_overflow_resumes_streaming_and_settles_on_a_later_carrier
     reporter = _BlockedReporter()
     reporter.install(monkeypatch)
     reporter.release.set()
-    warnings: list[str] = []
+    debug_messages: list[str] = []
 
     class _LoggerRecorder:
-        def warning(self, msg: str, *args: Any) -> None:
-            warnings.append(msg % args if args else msg)
+        def debug(self, msg: str, *args: Any) -> None:
+            debug_messages.append(msg % args if args else msg)
 
         def __getattr__(self, name: str) -> Any:
             return lambda *args, **kwargs: None
@@ -798,7 +798,7 @@ async def test_carrier_overflow_resumes_streaming_and_settles_on_a_later_carrier
     assert '"cost_usd":"0.012345"' in terminal
     assert '"cost_usd"' not in next(part for part in emitted if _chunk_id(part) == "u1")
     assert emitted[-1] == "data: [DONE]\n\n"
-    assert sum("was not terminal" in message for message in warnings) == 1
+    assert sum("was not terminal" in message for message in debug_messages) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_pipeline_settlement.py
+++ b/tests/unit/test_pipeline_settlement.py
@@ -26,9 +26,11 @@ from any_llm.types.completion import (
     ChatCompletionChunk,
     ChatCompletionMessage,
     Choice,
+    ChoiceDelta,
+    ChunkChoice,
     CompletionUsage,
 )
-from fastapi import HTTPException, Response
+from fastapi import BackgroundTasks, HTTPException, Response
 
 import gateway.api.routes._pipeline as pipeline
 from gateway.api.routes import chat, messages, responses
@@ -37,10 +39,12 @@ from gateway.api.routes._pipeline import (
     ToolContext,
     build_streaming_response,
     prepare_gateway_tools,
+    run_platform_non_stream,
     run_single_attempt_stream,
     run_standalone_non_stream,
     stream_first_chunk_timeout_seconds,
 )
+from gateway.api.routes._platform import ResolvedAttempt, ResolvedRoute, SettledCost
 from gateway.core.config import GatewayConfig
 from gateway.rate_limit import RateLimitInfo
 from gateway.services.budget_service import ReservationHandle
@@ -503,6 +507,141 @@ async def test_failed_platform_usage_report_logs_warning(
 
     assert warnings, "failed usage report was not logged"
     assert "corr-1" in warnings[0][1]
+
+
+@pytest.mark.asyncio
+async def test_platform_stream_holds_terminal_usage_until_cost_settles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reporter_started = asyncio.Event()
+    reporter_release = asyncio.Event()
+
+    async def fake_report(**kwargs: Any) -> SettledCost:
+        reporter_started.set()
+        await reporter_release.wait()
+        return SettledCost(cost_usd="0.012345", pricing_source="managed")
+
+    monkeypatch.setattr(pipeline, "_report_platform_usage", fake_report)
+
+    async def stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield ChatCompletionChunk(
+            id="content-1",
+            choices=[
+                ChunkChoice(
+                    delta=ChoiceDelta(content="hello", role="assistant"),
+                    finish_reason=None,
+                    index=0,
+                )
+            ],
+            created=0,
+            model="gpt-4",
+            object="chat.completion.chunk",
+            usage=None,
+        )
+        yield _chunk(CompletionUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2))
+
+    response = build_streaming_response(
+        adapter=chat._ADAPTER,
+        stream=stream(),
+        provider=LLMProvider.OPENAI,
+        model="gpt-4",
+        config=GatewayConfig(platform={"usage_inline_timeout_ms": 1000}),
+        db=None,
+        log_writer=None,
+        api_key_id=None,
+        user_id=None,
+        rate_limit_info=None,
+        reservation=None,
+        platform_correlation_id="corr-1",
+    )
+    iterator = cast(AsyncIterator[Any], response.body_iterator)
+
+    first = await iterator.__anext__()
+    assert "hello" in first
+    pending_terminal: asyncio.Future[Any] = asyncio.ensure_future(iterator.__anext__())
+    await asyncio.wait_for(reporter_started.wait(), timeout=1)
+    assert not pending_terminal.done()
+
+    reporter_release.set()
+    terminal = await asyncio.wait_for(pending_terminal, timeout=1)
+    assert '"cost_usd":"0.012345"' in terminal
+    assert '"pricing_source":"managed"' in terminal
+
+
+@pytest.mark.asyncio
+async def test_inline_settlement_timeout_leaves_accounting_report_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracked: set[asyncio.Task[SettledCost | None]] = set()
+    monkeypatch.setattr(pipeline, "_USAGE_REPORT_TASKS", tracked)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_report() -> SettledCost:
+        started.set()
+        await release.wait()
+        return SettledCost(cost_usd="0.012345", pricing_source="managed")
+
+    result = await pipeline._await_usage_report(
+        slow_report(),
+        "corr-timeout",
+        GatewayConfig(platform={"usage_inline_timeout_ms": 10}),
+    )
+
+    assert result is None
+    assert started.is_set()
+    assert len(tracked) == 1
+    task = next(iter(tracked))
+    assert not task.cancelled()
+
+    release.set()
+    assert await asyncio.wait_for(task, timeout=1) == SettledCost(
+        cost_usd="0.012345",
+        pricing_source="managed",
+    )
+
+
+@pytest.mark.asyncio
+async def test_platform_non_stream_awaits_and_attaches_settlement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reporter_finished = False
+
+    async def fake_acompletion(**kwargs: Any) -> ChatCompletion:
+        return _completion(usage=_usage())
+
+    async def fake_report(**kwargs: Any) -> SettledCost:
+        nonlocal reporter_finished
+        await asyncio.sleep(0)
+        reporter_finished = True
+        return SettledCost(cost_usd="0.012345", pricing_source="managed")
+
+    monkeypatch.setattr(chat, "acompletion", fake_acompletion)
+    monkeypatch.setattr(pipeline, "_report_platform_usage", fake_report)
+    attempt = ResolvedAttempt(
+        attempt_id="3f1b6a1e-0000-4000-8000-000000000002",
+        position=0,
+        provider="openai",
+        model="gpt-4",
+        api_key="sk-test",
+        managed=True,
+    )
+
+    result = await run_platform_non_stream(
+        adapter=chat._ADAPTER,
+        route=ResolvedRoute(request_id="req-1", fallback_enabled=False, attempts=[attempt]),
+        base_request_fields={"messages": [{"role": "user", "content": "hi"}]},
+        tool_ctx=_tool_ctx(),
+        response=Response(),
+        background_tasks=BackgroundTasks(),
+        config=GatewayConfig(platform={"usage_inline_timeout_ms": 1000}),
+        rate_limit_info=None,
+    )
+
+    assert reporter_finished is True
+    assert result.usage is not None
+    assert getattr(result.usage, "cost_usd", None) == "0.012345"
+    assert getattr(result.usage, "pricing_source", None) == "managed"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pipeline_settlement.py
+++ b/tests/unit/test_pipeline_settlement.py
@@ -15,6 +15,7 @@ platform-fallback streaming paths. These tests pin that contract:
 """
 
 import asyncio
+import re
 import time
 from collections.abc import AsyncIterator
 from typing import Any, cast
@@ -33,6 +34,7 @@ from any_llm.types.completion import (
 from fastapi import BackgroundTasks, HTTPException, Response
 
 import gateway.api.routes._pipeline as pipeline
+import gateway.streaming as streaming
 from gateway.api.routes import chat, messages, responses
 from gateway.api.routes._pipeline import (
     RequestContext,
@@ -642,6 +644,272 @@ async def test_platform_non_stream_awaits_and_attaches_settlement(
     assert result.usage is not None
     assert getattr(result.usage, "cost_usd", None) == "0.012345"
     assert getattr(result.usage, "pricing_source", None) == "managed"
+
+
+# ---------------------------------------------------------------------------
+# Terminal cost buffering: only the last carrier is held
+# ---------------------------------------------------------------------------
+
+
+def _content_chunk(chunk_id: str, text: str) -> ChatCompletionChunk:
+    return ChatCompletionChunk(
+        id=chunk_id,
+        choices=[ChunkChoice(delta=ChoiceDelta(content=text, role="assistant"), finish_reason=None, index=0)],
+        created=0,
+        model="gpt-4",
+        object="chat.completion.chunk",
+        usage=None,
+    )
+
+
+def _usage_chunk(chunk_id: str, prompt_tokens: int) -> ChatCompletionChunk:
+    """An OpenAI ``include_usage`` chunk: usage, no choices."""
+    return ChatCompletionChunk(
+        id=chunk_id,
+        choices=[],
+        created=0,
+        model="gpt-4",
+        object="chat.completion.chunk",
+        usage=CompletionUsage(prompt_tokens=prompt_tokens, completion_tokens=1, total_tokens=prompt_tokens + 1),
+    )
+
+
+class _BlockedReporter:
+    """A usage reporter that parks until released, so ordering is observable."""
+
+    def __init__(self, settlement: SettledCost | None = None) -> None:
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self._settlement = settlement or SettledCost(cost_usd="0.012345", pricing_source="managed")
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def fake_report(**kwargs: Any) -> SettledCost | None:
+            self.started.set()
+            await self.release.wait()
+            return self._settlement
+
+        monkeypatch.setattr(pipeline, "_report_platform_usage", fake_report)
+
+
+def _build_platform_stream(
+    stream: AsyncIterator[ChatCompletionChunk],
+    *,
+    config: GatewayConfig | None = None,
+    display_model: str | None = None,
+) -> AsyncIterator[str]:
+    response = build_streaming_response(
+        adapter=chat._ADAPTER,
+        stream=stream,
+        provider=LLMProvider.OPENAI,
+        model="gpt-4",
+        config=config or GatewayConfig(platform={"usage_inline_timeout_ms": 5000}),
+        db=None,
+        log_writer=None,
+        api_key_id=None,
+        user_id=None,
+        rate_limit_info=None,
+        reservation=None,
+        display_model=display_model,
+        platform_correlation_id="corr-1",
+    )
+    return cast(AsyncIterator[str], response.body_iterator)
+
+
+@pytest.mark.asyncio
+async def test_intermediate_usage_chunk_does_not_hold_the_final_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A chat tool loop forwards one ``include_usage`` chunk per iteration.
+
+    The first one matches the carrier predicate but is not terminal, so holding
+    it would park the next iteration's answer behind settlement and leave cost on
+    a chunk the client has already passed.
+    """
+    reporter = _BlockedReporter()
+    reporter.install(monkeypatch)
+
+    async def stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield _content_chunk("c0", "thinking")
+        yield _usage_chunk("u1", 10)  # iteration 1's usage chunk, not terminal
+        yield _content_chunk("c1", "final")
+        yield _content_chunk("c2", "answer")
+        yield _usage_chunk("u2", 20)  # the real terminal carrier
+
+    iterator = _build_platform_stream(stream())
+
+    # Everything up to the real terminal carrier streams without waiting.
+    streamed = [await asyncio.wait_for(iterator.__anext__(), timeout=1) for _ in range(4)]
+    assert [_chunk_id(part) for part in streamed] == ["c0", "u1", "c1", "c2"]
+    assert not reporter.started.is_set()
+
+    pending_terminal = asyncio.ensure_future(iterator.__anext__())
+    await asyncio.wait_for(reporter.started.wait(), timeout=1)
+    assert not pending_terminal.done()
+
+    reporter.release.set()
+    terminal = await asyncio.wait_for(pending_terminal, timeout=1)
+    assert _chunk_id(terminal) == "u2"
+    assert '"cost_usd":"0.012345"' in terminal
+    assert not any("cost_usd" in part for part in streamed)
+
+
+@pytest.mark.asyncio
+async def test_carrier_overflow_resumes_streaming_and_settles_on_a_later_carrier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """More chunks than the cap after a carrier means it was not terminal.
+
+    The held chunks are released in order and a later carrier still takes the
+    cost, so a long final answer neither stalls nor loses inline cost.
+    """
+    reporter = _BlockedReporter()
+    reporter.install(monkeypatch)
+    reporter.release.set()
+    warnings: list[str] = []
+
+    class _LoggerRecorder:
+        def warning(self, msg: str, *args: Any) -> None:
+            warnings.append(msg % args if args else msg)
+
+        def __getattr__(self, name: str) -> Any:
+            return lambda *args, **kwargs: None
+
+    monkeypatch.setattr(streaming, "logger", _LoggerRecorder())
+
+    async def stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield _usage_chunk("u1", 10)
+        for index in range(6):
+            yield _content_chunk(f"c{index}", f"part-{index}")
+        yield _usage_chunk("u2", 20)
+
+    emitted = [part async for part in _build_platform_stream(stream())]
+
+    assert [_chunk_id(part) for part in emitted if _chunk_id(part)] == [
+        "u1",
+        "c0",
+        "c1",
+        "c2",
+        "c3",
+        "c4",
+        "c5",
+        "u2",
+    ]
+    terminal = next(part for part in emitted if _chunk_id(part) == "u2")
+    assert '"cost_usd":"0.012345"' in terminal
+    assert '"cost_usd"' not in next(part for part in emitted if _chunk_id(part) == "u1")
+    assert emitted[-1] == "data: [DONE]\n\n"
+    assert sum("was not terminal" in message for message in warnings) == 1
+
+
+@pytest.mark.asyncio
+async def test_buffered_terminal_carrier_is_relabeled_to_the_display_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The buffered path must relabel exactly like the unbuffered one.
+
+    Hybrid passes no ``display_model`` today; this keeps the buffer from becoming
+    the reason a real provider model leaks past an alias later.
+    """
+    reporter = _BlockedReporter()
+    reporter.install(monkeypatch)
+    reporter.release.set()
+
+    async def stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield _content_chunk("c0", "hi")
+        yield _usage_chunk("u1", 10)
+
+    emitted = [part async for part in _build_platform_stream(stream(), display_model="my-alias")]
+
+    assert all("gpt-4" not in part for part in emitted)
+    terminal = next(part for part in emitted if _chunk_id(part) == "u1")
+    assert '"model":"my-alias"' in terminal
+    assert '"cost_usd":"0.012345"' in terminal
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_error_emits_the_buffered_carrier_before_the_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reporter = _BlockedReporter()
+    reporter.install(monkeypatch)
+    reporter.release.set()
+
+    async def stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield _content_chunk("c0", "hi")
+        yield _usage_chunk("u1", 10)
+        raise RuntimeError("upstream died")
+
+    emitted = [part async for part in _build_platform_stream(stream())]
+
+    assert [_chunk_id(part) for part in emitted if _chunk_id(part)] == ["c0", "u1"]
+    assert "cost_usd" not in "".join(emitted)
+    assert "An error occurred during streaming" in emitted[-2]
+    assert emitted[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_keepalives_continue_while_terminal_settlement_is_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reporter = _BlockedReporter()
+    reporter.install(monkeypatch)
+
+    async def stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield _usage_chunk("u1", 10)
+
+    iterator = _build_platform_stream(
+        stream(),
+        config=GatewayConfig(
+            streaming_keepalive_interval_ms=10,
+            platform={"usage_inline_timeout_ms": 5000},
+        ),
+    )
+
+    first = await asyncio.wait_for(iterator.__anext__(), timeout=1)
+    assert first == ": keepalive\n\n"
+
+    reporter.release.set()
+    rest = [part async for part in iterator]
+    assert _chunk_id(rest[0]) == "u1"
+    assert '"cost_usd":"0.012345"' in rest[0]
+
+
+@pytest.mark.asyncio
+async def test_cancellation_while_settling_leaves_the_report_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracked: set[asyncio.Task[SettledCost | None]] = set()
+    monkeypatch.setattr(pipeline, "_USAGE_REPORT_TASKS", tracked)
+    reporter = _BlockedReporter()
+    reporter.install(monkeypatch)
+
+    async def stream() -> AsyncIterator[ChatCompletionChunk]:
+        yield _usage_chunk("u1", 10)
+
+    iterator = _build_platform_stream(stream())
+    pending = asyncio.ensure_future(iterator.__anext__())
+    await asyncio.wait_for(reporter.started.wait(), timeout=1)
+
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+    await cast(Any, iterator).aclose()
+
+    assert len(tracked) == 1
+    report_task = next(iter(tracked))
+    assert not report_task.cancelled()
+
+    reporter.release.set()
+    assert await asyncio.wait_for(report_task, timeout=1) == SettledCost(
+        cost_usd="0.012345",
+        pricing_source="managed",
+    )
+
+
+def _chunk_id(part: str) -> str | None:
+    """The ``id`` of a chunk in an SSE data line, or None for a non-data frame."""
+    match = re.search(r'"id":"([^"]+)"', part)
+    return match.group(1) if match else None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_platform_timeout_config.py
+++ b/tests/unit/test_platform_timeout_config.py
@@ -17,9 +17,17 @@ def test_valid_streaming_timeouts_are_accepted() -> None:
             "streaming_first_chunk_timeout_ms": 2000,
             "streaming_first_chunk_timeout_ms_tool_loop": 30000,
             "streaming_final_attempt_extra_first_chunk_timeout_ms": 58000,
+            "usage_inline_timeout_ms": "1500",
         }
     )
     assert config.platform["streaming_final_attempt_extra_first_chunk_timeout_ms"] == 58000
+    assert config.platform["usage_inline_timeout_ms"] == 1500
+
+
+@pytest.mark.parametrize("bad_value", [0, -1, "bad", 1.5, True])
+def test_invalid_usage_inline_timeout_is_rejected(bad_value: object) -> None:
+    with pytest.raises(ValidationError, match="usage_inline_timeout_ms must be a positive integer"):
+        GatewayConfig(platform={"usage_inline_timeout_ms": bad_value})
 
 
 def test_zero_extra_grace_is_allowed() -> None:

--- a/tests/unit/test_run_platform_attempts.py
+++ b/tests/unit/test_run_platform_attempts.py
@@ -451,6 +451,25 @@ async def test_report_platform_usage_returns_completed_cost(monkeypatch: pytest.
 
 
 @pytest.mark.asyncio
+async def test_report_platform_usage_accepts_opaque_correlation_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    correlation_id = "01HX1ABCDEFGHJKMNPQRSTVWXYZ"
+    post_mock = AsyncMock(
+        return_value=httpx.Response(200, json=_completed_usage_body(correlation_id=correlation_id))
+    )
+    monkeypatch.setattr(_platform, "_post_platform", post_mock)
+
+    result = await _platform._report_platform_usage(
+        _usage_config(),
+        correlation_id,
+        "success",
+        CompletionUsage(prompt_tokens=10, completion_tokens=7, total_tokens=17),
+        is_final_attempt=True,
+    )
+
+    assert result == _platform.SettledCost(cost_usd="0.012345", pricing_source="managed")
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("status_code", [202, 204])
 async def test_report_platform_usage_returns_none_without_completed_cost(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_run_platform_attempts.py
+++ b/tests/unit/test_run_platform_attempts.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock
 
 import httpx
 import pytest
+from any_llm.types.completion import CompletionUsage
 from fastapi import HTTPException
 
 from gateway.api.routes import _platform
@@ -397,6 +398,211 @@ async def test_nonretryable_error_marks_first_attempt_final() -> None:
         )
 
     assert reports == [(attempts[0], "error", None, "http_400", True)]
+
+
+@pytest.mark.asyncio
+def _usage_config() -> GatewayConfig:
+    return cast(
+        GatewayConfig,
+        SimpleNamespace(
+            platform={"base_url": "http://platform", "usage_max_retries": 3},
+            platform_token="gw-test",
+        ),
+    )
+
+
+def _completed_usage_body(
+    *,
+    correlation_id: str = "3f1b6a1e-0000-4000-8000-000000000002",
+    cost_usd: str = "0.012345",
+    usage_status: str = "reported",
+    pricing_source: str | None = "managed",
+) -> dict[str, Any]:
+    return {
+        "request_id": "3f1b6a1e-0000-4000-8000-000000000001",
+        "correlation_id": correlation_id,
+        "status": "completed",
+        "outcome": "success",
+        "provider": "openai",
+        "model": "gpt-4o-mini",
+        "cost_usd": cost_usd,
+        "currency": "USD",
+        "usage_status": usage_status,
+        "usage": None,
+        "pricing": {"source": pricing_source, "reference": "price-1"},
+        "calculated_at": "2026-08-20T10:00:00Z",
+    }
+
+
+@pytest.mark.asyncio
+async def test_report_platform_usage_returns_completed_cost(monkeypatch: pytest.MonkeyPatch) -> None:
+    post_mock = AsyncMock(return_value=httpx.Response(200, json=_completed_usage_body()))
+    monkeypatch.setattr(_platform, "_post_platform", post_mock)
+
+    result = await _platform._report_platform_usage(
+        _usage_config(),
+        "3f1b6a1e-0000-4000-8000-000000000002",
+        "success",
+        CompletionUsage(prompt_tokens=10, completion_tokens=7, total_tokens=17),
+        is_final_attempt=True,
+    )
+
+    assert result == _platform.SettledCost(cost_usd="0.012345", pricing_source="managed")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [202, 204])
+async def test_report_platform_usage_returns_none_without_completed_cost(
+    monkeypatch: pytest.MonkeyPatch,
+    status_code: int,
+) -> None:
+    post_mock = AsyncMock(return_value=httpx.Response(status_code))
+    monkeypatch.setattr(_platform, "_post_platform", post_mock)
+
+    result = await _platform._report_platform_usage(
+        _usage_config(),
+        "3f1b6a1e-0000-4000-8000-000000000002",
+        "success",
+        None,
+        is_final_attempt=True,
+    )
+
+    assert result is None
+    post_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("cost_usd", "usage_status", "pricing_source", "expected"),
+    [
+        ("0.000000", "reported", None, None),
+        ("0.000000", "unavailable", None, None),
+        (
+            "0.000000",
+            "reported",
+            "managed",
+            _platform.SettledCost(cost_usd="0.000000", pricing_source="managed"),
+        ),
+    ],
+    ids=["unpriced", "unavailable", "priced-zero"],
+)
+async def test_report_platform_usage_applies_pricing_source_gate(
+    monkeypatch: pytest.MonkeyPatch,
+    cost_usd: str,
+    usage_status: str,
+    pricing_source: str | None,
+    expected: _platform.SettledCost | None,
+) -> None:
+    monkeypatch.setattr(
+        _platform,
+        "_post_platform",
+        AsyncMock(
+            return_value=httpx.Response(
+                200,
+                json=_completed_usage_body(
+                    cost_usd=cost_usd,
+                    usage_status=usage_status,
+                    pricing_source=pricing_source,
+                ),
+            )
+        ),
+    )
+
+    result = await _platform._report_platform_usage(
+        _usage_config(),
+        "3f1b6a1e-0000-4000-8000-000000000002",
+        "success",
+        None,
+        is_final_attempt=True,
+    )
+
+    assert result == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response",
+    [
+        httpx.Response(200, json={"status": "completed"}),
+        httpx.Response(410),
+        httpx.Response(
+            200,
+            json=_completed_usage_body(correlation_id="3f1b6a1e-0000-4000-8000-000000000003"),
+        ),
+    ],
+    ids=["malformed", "gone", "correlation-mismatch"],
+)
+async def test_report_platform_usage_ignores_non_attachable_responses(
+    monkeypatch: pytest.MonkeyPatch,
+    response: httpx.Response,
+) -> None:
+    post_mock = AsyncMock(return_value=response)
+    monkeypatch.setattr(_platform, "_post_platform", post_mock)
+
+    result = await _platform._report_platform_usage(
+        _usage_config(),
+        "3f1b6a1e-0000-4000-8000-000000000002",
+        "success",
+        None,
+        is_final_attempt=True,
+    )
+
+    assert result is None
+    post_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_report_platform_usage_ignores_failed_outcome_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    post_mock = AsyncMock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "request_id": "3f1b6a1e-0000-4000-8000-000000000001",
+                "status": "completed",
+                "outcome": "failed",
+                "cost_usd": "0.000000",
+                "currency": "USD",
+            },
+        )
+    )
+    monkeypatch.setattr(_platform, "_post_platform", post_mock)
+
+    result = await _platform._report_platform_usage(
+        _usage_config(),
+        "3f1b6a1e-0000-4000-8000-000000000002",
+        "error",
+        None,
+        is_final_attempt=True,
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_report_platform_usage_retries_then_returns_completed_cost(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    post_mock = AsyncMock(
+        side_effect=[
+            httpx.Response(500),
+            httpx.Response(200, json=_completed_usage_body()),
+        ]
+    )
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(_platform, "_post_platform", post_mock)
+    monkeypatch.setattr(asyncio, "sleep", sleep_mock)
+
+    result = await _platform._report_platform_usage(
+        _usage_config(),
+        "3f1b6a1e-0000-4000-8000-000000000002",
+        "success",
+        None,
+        is_final_attempt=True,
+    )
+
+    assert result == _platform.SettledCost(cost_usd="0.012345", pricing_source="managed")
+    assert post_mock.await_count == 2
+    sleep_mock.assert_awaited_once_with(0.25)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_run_platform_attempts.py
+++ b/tests/unit/test_run_platform_attempts.py
@@ -400,7 +400,6 @@ async def test_nonretryable_error_marks_first_attempt_final() -> None:
     assert reports == [(attempts[0], "error", None, "http_400", True)]
 
 
-@pytest.mark.asyncio
 def _usage_config() -> GatewayConfig:
     return cast(
         GatewayConfig,

--- a/tests/unit/test_run_platform_attempts.py
+++ b/tests/unit/test_run_platform_attempts.py
@@ -652,9 +652,9 @@ async def test_report_platform_usage_does_not_retry_on_402(monkeypatch: pytest.M
     assert post_mock.call_count == 1
     sleep_mock.assert_not_awaited()
     # Pin the classification itself, not just the (currently equivalent) retry
-    # behavior: 402 must stay in the non-retryable set even if the >= 500 retry
-    # predicate changes.
-    assert 402 in _platform._USAGE_NON_RETRYABLE_STATUS_CODES
+    # behavior: these must stay in the non-retryable set even if the >= 500
+    # retry predicate changes.
+    assert {402, 410} <= _platform._USAGE_NON_RETRYABLE_STATUS_CODES
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_stream_options_injection.py
+++ b/tests/unit/test_stream_options_injection.py
@@ -96,6 +96,22 @@ def test_standalone_stream_preserves_disabled_usage() -> None:
     assert kwargs["stream_options"]["include_usage"] is False
 
 
+def test_standalone_stream_preserves_empty_options() -> None:
+    kwargs = chat._ADAPTER.prepare_stream_kwargs(
+        {"stream_options": {}},
+        require_usage=False,
+    )
+    assert kwargs["stream_options"] == {}
+
+
+def test_standalone_stream_preserves_custom_options_without_usage() -> None:
+    kwargs = chat._ADAPTER.prepare_stream_kwargs(
+        {"stream_options": {"custom_field": "value"}},
+        require_usage=False,
+    )
+    assert kwargs["stream_options"] == {"custom_field": "value"}
+
+
 def test_preserves_client_stream_options() -> None:
     custom = {"include_usage": False, "custom_field": "value"}
     kwargs = _build_completion_kwargs(

--- a/tests/unit/test_stream_options_injection.py
+++ b/tests/unit/test_stream_options_injection.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+from gateway.api.routes import chat
 from gateway.api.routes.chat import ChatCompletionRequest
 
 
@@ -77,6 +78,22 @@ def test_no_injection_for_non_streaming() -> None:
         }
     )
     assert "stream_options" not in kwargs
+
+
+def test_hybrid_stream_forces_usage_when_client_disabled_it() -> None:
+    kwargs = chat._ADAPTER.prepare_stream_kwargs(
+        {"stream_options": {"include_usage": False, "custom_field": "value"}},
+        require_usage=True,
+    )
+    assert kwargs["stream_options"] == {"include_usage": True, "custom_field": "value"}
+
+
+def test_standalone_stream_preserves_disabled_usage() -> None:
+    kwargs = chat._ADAPTER.prepare_stream_kwargs(
+        {"stream_options": {"include_usage": False}},
+        require_usage=False,
+    )
+    assert kwargs["stream_options"]["include_usage"] is False
 
 
 def test_preserves_client_stream_options() -> None:


### PR DESCRIPTION
## Why

Hybrid clients need the platform's authoritative settled cost with the model response, without duplicating pricing logic in the gateway or requiring a second lookup.

## What changed

Await the successful usage report under a configurable inline budget and attach its exact cost and pricing source to existing usage objects across Chat Completions, Messages, and Responses. Streaming delays only the terminal usage suffix; unpriced, unavailable, legacy, and timed-out settlements keep the original response shape, while failed-attempt reporting and standalone behavior remain unchanged.

## Notes

- **Deployment dependency.** Blocked on deployment of mozilla-ai/otari-ai#1762.
- **Platform follow-up.** Add coverage for a success report arriving before an earlier attempt's failure report.
- **Platform follow-up.** Return `202` when result building fails after accounting commits, avoiding a retry that collides with settlement and returns `409`.
- **M4 ledger.** No entry is needed. The existing Pricing and request cost and Usage and observability rows cover this contract, and their targets are unchanged.

Fixes #672

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #672

## Checklist

- [ ] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).
- [x] **M4 ledger:** this PR either needs no entry (an existing row already covers it and its target is unchanged), or the entry is appended to [otari-ai#1587](https://github.com/mozilla-ai/otari-ai/issues/1587). One entry per *change*, not per PR: a stack delivering one surface change gets one. See [.github/instructions/reconciliation-ledger.instructions.md](instructions/reconciliation-ledger.instructions.md).

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Pi coding agent (`openai-codex/gpt-5.6-sol`)

**Any additional AI details you'd like to share:** Used to investigate CI and restore the required PR template sections.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added inline settled-cost reporting for platform-mode Chat Completions, Messages, and Responses.
- Added configurable timeout handling for successful usage settlement.
- Added cost and pricing details to response and terminal streaming usage objects.
- Preserved existing behavior for failed, unpriced, unavailable, timed-out, legacy, and standalone requests.
- Added documentation, metrics, configuration validation, and comprehensive tests.

## Technical notes

- Streaming responses delay only the terminal usage event.
- Added `PLATFORM_USAGE_INLINE_TIMEOUT_MS` with a default of 1500 ms.
- Preserved `/request-costs` fallback behavior when inline settlement is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->