### PR TITLE
feat(dashboard): give dashboard sessions a user identity

### DIFF
--- a/alembic/versions/b6d8f0a2c4e7_dashboard_sessions_carry_an_identity.py
+++ b/alembic/versions/b6d8f0a2c4e7_dashboard_sessions_carry_an_identity.py
@@ -1,0 +1,127 @@
+"""Give a dashboard session the identity it resolves to.
+
+Adds ``user_id`` to ``dashboard_sessions``, so a session answers "who is
+calling" rather than only "the master key was presented once". It names a
+tenancy identity, and that identity's ``active_organization_id`` is the
+organization the session acts in.
+
+NOT NULL, because a session naming nobody is exactly the state the column
+exists to remove. Existing rows are bound to the identity master-key auth
+already resolves to, the bootstrap operator named by the
+``tenancy_bootstrap_user_id`` marker, so a signed-in operator stays signed in
+across the upgrade. A deployment that has never served a tenancy request has no
+such identity, and provisioning is lazy, so there is nothing to attribute its
+sessions to: those rows are deleted and the operator signs in once more. That
+is the same outcome a master-key rotation already produces, and it is preferred
+over seeding an identity here, which would duplicate provisioning (organization,
+workspace, memberships, attribution user, marker) in SQL and drift from it.
+
+CASCADE on the foreign key: deleting an identity revokes its sessions instead of
+leaving a live cookie pointing at a row that is gone.
+
+Revision ID: b6d8f0a2c4e7
+Revises: 7ff4e082eb0c
+Create Date: 2026-08-20 00:00:00.000000
+
+"""
+
+import uuid
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b6d8f0a2c4e7"
+down_revision: str | Sequence[str] | None = "7ff4e082eb0c"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Must match provisioning_service, which anchors the operator identity here.
+BOOTSTRAP_IDENTITY_KEY = "tenancy_bootstrap_user_id"
+
+_USER_ID_INDEX = "ix_dashboard_sessions_user_id"
+_USER_ID_FK = "fk_dashboard_sessions_user_id"
+
+
+def _dashboard_sessions(*, with_user_id: bool, user_id_nullable: bool = True) -> sa.Table:
+    """The table as it stands at each ``batch_alter_table`` below.
+
+    ``copy_from`` is what keeps SQLite's table rebuild from dropping what
+    reflection could not see, so the expiry index is declared here rather than
+    left to be rediscovered. The foreign key is not declared: a rebuild that
+    omits ``user_id`` drops it either way, which is all the downgrade needs.
+    """
+    columns = [
+        sa.Column("token_hash", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+    ]
+    if with_user_id:
+        columns.insert(1, sa.Column("user_id", sa.Uuid(), nullable=user_id_nullable))
+    table = sa.Table(
+        "dashboard_sessions",
+        sa.MetaData(),
+        *columns,
+        sa.PrimaryKeyConstraint("token_hash"),
+    )
+    sa.Index("ix_dashboard_sessions_expires_at", table.c.expires_at)
+    return table
+
+
+def _bootstrap_identity_id(bind: sa.engine.Connection) -> uuid.UUID | None:
+    """The identity every master-key request already resolves to, if one exists.
+
+    Both halves are checked. The marker can name an identity that is gone (the
+    runtime treats that as "not provisioned yet" and re-provisions), and binding
+    a session to it would fail the foreign key added below.
+    """
+    marker = bind.execute(
+        sa.text("SELECT value FROM runtime_settings WHERE key = :key"),
+        {"key": BOOTSTRAP_IDENTITY_KEY},
+    ).scalar()
+    if marker is None:
+        return None
+    try:
+        identity = uuid.UUID(str(marker))
+    except ValueError:
+        return None
+    # A bound ``sa.Uuid`` parameter rather than a rendered literal: the type is
+    # native on PostgreSQL and CHAR(32) hex on SQLite, and a hand-written
+    # literal that matches one engine joins to nothing on the other.
+    found = bind.execute(
+        sa.text('SELECT id FROM "user" WHERE id = :id').bindparams(sa.bindparam("id", identity, type_=sa.Uuid())),
+    ).scalar()
+    return identity if found is not None else None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    bind = op.get_bind()
+    op.add_column("dashboard_sessions", sa.Column("user_id", sa.Uuid(), nullable=True))
+
+    operator = _bootstrap_identity_id(bind)
+    if operator is not None:
+        bind.execute(
+            sa.text("UPDATE dashboard_sessions SET user_id = :owner WHERE user_id IS NULL").bindparams(
+                sa.bindparam("owner", operator, type_=sa.Uuid())
+            )
+        )
+    bind.execute(sa.text("DELETE FROM dashboard_sessions WHERE user_id IS NULL"))
+
+    with op.batch_alter_table("dashboard_sessions", copy_from=_dashboard_sessions(with_user_id=True)) as batch:
+        batch.alter_column("user_id", existing_type=sa.Uuid(), nullable=False)
+        batch.create_foreign_key(_USER_ID_FK, "user", ["user_id"], ["id"], ondelete="CASCADE")
+    op.create_index(op.f(_USER_ID_INDEX), "dashboard_sessions", ["user_id"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # The index goes first: SQLite refuses to drop a column an index covers, and
+    # the rebuild below is driven by a definition that no longer mentions it.
+    op.drop_index(op.f(_USER_ID_INDEX), table_name="dashboard_sessions")
+    with op.batch_alter_table(
+        "dashboard_sessions",
+        copy_from=_dashboard_sessions(with_user_id=True, user_id_nullable=False),
+    ) as batch:
+        batch.drop_column("user_id")

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -118,6 +118,14 @@ Removing a member suspends their membership rather than deleting it, which keeps
 
 Granting the `owner` role is an owner's to give. An admin manages members, workspaces and roles, and cannot promote anyone (themselves included) to owner, nor add one.
 
+### Dashboard sessions and identity
+
+Signing in to the dashboard exchanges the master key for a session: an opaque token in an HttpOnly cookie, stored only as a SHA-256 hash, revocable server-side, expiring on `dashboard_session_ttl_hours`. Each session names the identity it was minted for, so a cookie-authenticated request resolves a user and, through that user's `active_organization_id`, the organization it is acting in. `POST /v1/auth/session` returns both ids alongside the expiry.
+
+Master-key sign-in binds the session to the operator identity described above, which is the same identity a request carrying the master key in a header resolves to, so the two credentials answer for the same organization. A session is revoked on sign-out, on master-key rotation (every session, with the rotating tab's own re-minted for the same identity), when the master key changes across a restart, and when the identity it names is deleted or deactivated. Sign-in flows that authenticate a person rather than the deployment are a separate track; they mint the same kind of session, bound to whoever signed in.
+
+An opaque session token is the settled shape here, not a stopgap: it is revocable, which a bearer JWT is not, and [mozilla-ai/otari-ai#1716](https://github.com/mozilla-ai/otari-ai/issues/1716) settled that sessions are the steady-state dashboard login. **The platform's JWT `Token` therefore does not survive the rehome.** Anything on the platform frontend that reads or stores a bearer token changes when its pages arrive: the credential is an HttpOnly cookie the page's own script cannot read, sent automatically and same-origin only, so there is no token to attach to a header and no expiry to decode out of a payload. Sign-in state comes from the session endpoint's response and from a 401 bounce, not from inspecting a token.
+
 ### Adopting an existing tenancy
 
 Provisioning adopts an organization whose slug is `default`, which is the one it would have created itself. It cannot adopt any other, because every route is scoped to the organization the operator identity is currently pointed at, and there is no route to list, switch, or fetch an organization by id. So an organization this deployment did not provision is unreachable through the API until the operator identity points at it.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -528,6 +528,11 @@ put it behind HTTPS, as the security notes below describe.
   server, expires the cookie, and clears any cached admin data. Rotating the
   master key revokes every session and re-mints the one you are using, so other
   signed-in browsers are logged out.
+- **A session is signed in as someone.** It names the operator identity it was
+  minted for, which is what the Organization pages scope themselves to; see
+  [Access control](access-control.md#dashboard-sessions-and-identity). Deleting
+  or deactivating that identity signs its browsers out immediately rather than
+  when the cookie expires.
 - **Log out on a machine you share.** A session runs for its full
   `dashboard_session_ttl_hours` with no idle timeout, so an unattended browser
   stays signed in until the cookie expires. Use **Log out** when you are done on

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -7153,15 +7153,29 @@
       "SessionResponse": {
         "description": "A freshly minted dashboard session (the token travels only in the cookie).",
         "properties": {
+          "active_organization_id": {
+            "description": "The organization that identity is acting in, which scopes every tenancy surface.",
+            "format": "uuid",
+            "title": "Active Organization Id",
+            "type": "string"
+          },
           "expires_at": {
             "description": "When the session cookie stops being accepted.",
             "format": "date-time",
             "title": "Expires At",
             "type": "string"
+          },
+          "user_id": {
+            "description": "The identity this session speaks for.",
+            "format": "uuid",
+            "title": "User Id",
+            "type": "string"
           }
         },
         "required": [
-          "expires_at"
+          "expires_at",
+          "user_id",
+          "active_organization_id"
         ],
         "title": "SessionResponse",
         "type": "object"
@@ -11278,7 +11292,7 @@
         ]
       },
       "post": {
-        "description": "Verify the master key and set the HttpOnly session cookie.\n\nThe rate-limit check deliberately runs only after a failed verification,\nnot before it: a pre-verification gate can't know whether *this* attempt\nwould have succeeded, so once an IP has used up its failure quota it\nwould end up blocking that IP's legitimate owner too, not just further\nattackers. The issue this implements explicitly rules that out. The\nDB/hash lookup this exposes to repeated attempts only runs when no fixed\nmaster_key is configured (the auto-generated bootstrap-key path); with a\nconfigured master_key, verification is a constant-time string compare,\nnot a DB round trip.",
+        "description": "Verify the master key and set the HttpOnly session cookie.\n\nThe session is bound to the bootstrap operator identity, so every request it\nlater authenticates resolves a user and that user's active organization\nrather than only \"the master key was presented once\". The response names\nboth, so a client knows who it is signed in as without a second call.\n\nThe rate-limit check deliberately runs only after a failed verification,\nnot before it: a pre-verification gate can't know whether *this* attempt\nwould have succeeded, so once an IP has used up its failure quota it\nwould end up blocking that IP's legitimate owner too, not just further\nattackers. The issue this implements explicitly rules that out. The\nDB/hash lookup this exposes to repeated attempts only runs when no fixed\nmaster_key is configured (the auto-generated bootstrap-key path); with a\nconfigured master_key, verification is a constant-time string compare,\nnot a DB round trip.",
         "operationId": "create_session_v1_auth_session_post",
         "requestBody": {
           "content": {
@@ -15970,7 +15984,7 @@
     },
     "/v1/settings/master-key/rotate": {
       "post": {
-        "description": "Regenerate the database-backed master key and invalidate the old one.\n\nOnly the first-run generated master key can be rotated here. When a master\nkey is supplied through config or ``OTARI_MASTER_KEY``, the dashboard cannot\ninvalidate it; the operator must change that value and restart instead.\n\nEvery dashboard session is revoked with the rotation (a session only proves\npossession of the now-dead key); the caller's own session is re-minted under\nthe new key so the tab that performed the rotation stays signed in.",
+        "description": "Regenerate the database-backed master key and invalidate the old one.\n\nOnly the first-run generated master key can be rotated here. When a master\nkey is supplied through config or ``OTARI_MASTER_KEY``, the dashboard cannot\ninvalidate it; the operator must change that value and restart instead.\n\nEvery dashboard session is revoked with the rotation (a session only proves\npossession of the now-dead key); the caller's own session is re-minted under\nthe new key, for the same identity it named, so the tab that performed the\nrotation stays signed in as who it was. A caller that authenticated with a\nheader key has no session identity to re-mint for, so it is not handed one:\nit was not signed in to the dashboard to begin with.",
         "operationId": "rotate_master_key_v1_settings_master_key_rotate_post",
         "responses": {
           "200": {

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -435,7 +435,7 @@
               },
               "raw": "{\n  \"master_key\": \"string\"\n}"
             },
-            "description": "Verify the master key and set the HttpOnly session cookie.\n\nThe rate-limit check deliberately runs only after a failed verification,\nnot before it: a pre-verification gate can't know whether *this* attempt\nwould have succeeded, so once an IP has used up its failure quota it\nwould end up blocking that IP's legitimate owner too, not just further\nattackers. The issue this implements explicitly rules that out. The\nDB/hash lookup this exposes to repeated attempts only runs when no fixed\nmaster_key is configured (the auto-generated bootstrap-key path); with a\nconfigured master_key, verification is a constant-time string compare,\nnot a DB round trip.",
+            "description": "Verify the master key and set the HttpOnly session cookie.\n\nThe session is bound to the bootstrap operator identity, so every request it\nlater authenticates resolves a user and that user's active organization\nrather than only \"the master key was presented once\". The response names\nboth, so a client knows who it is signed in as without a second call.\n\nThe rate-limit check deliberately runs only after a failed verification,\nnot before it: a pre-verification gate can't know whether *this* attempt\nwould have succeeded, so once an IP has used up its failure quota it\nwould end up blocking that IP's legitimate owner too, not just further\nattackers. The issue this implements explicitly rules that out. The\nDB/hash lookup this exposes to repeated attempts only runs when no fixed\nmaster_key is configured (the auto-generated bootstrap-key path); with a\nconfigured master_key, verification is a constant-time string compare,\nnot a DB round trip.",
             "header": [
               {
                 "key": "Content-Type",
@@ -3342,7 +3342,7 @@
         {
           "name": "Rotate Master Key",
           "request": {
-            "description": "Regenerate the database-backed master key and invalidate the old one.\n\nOnly the first-run generated master key can be rotated here. When a master\nkey is supplied through config or ``OTARI_MASTER_KEY``, the dashboard cannot\ninvalidate it; the operator must change that value and restart instead.\n\nEvery dashboard session is revoked with the rotation (a session only proves\npossession of the now-dead key); the caller's own session is re-minted under\nthe new key so the tab that performed the rotation stays signed in.",
+            "description": "Regenerate the database-backed master key and invalidate the old one.\n\nOnly the first-run generated master key can be rotated here. When a master\nkey is supplied through config or ``OTARI_MASTER_KEY``, the dashboard cannot\ninvalidate it; the operator must change that value and restart instead.\n\nEvery dashboard session is revoked with the rotation (a session only proves\npossession of the now-dead key); the caller's own session is re-minted under\nthe new key, for the same identity it named, so the tab that performed the\nrotation stays signed in as who it was. A caller that authenticated with a\nheader key has no session identity to re-mint for, so it is not handed one:\nit was not signed in to the dashboard to begin with.",
             "header": [],
             "method": "POST",
             "url": {

--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -15,7 +15,7 @@ from gateway.log_config import logger
 from gateway.metrics import record_auth_failure
 from gateway.models.entities import APIKey
 from gateway.models.tenancy import User as TenancyUser
-from gateway.services.dashboard_session_service import SESSION_COOKIE_NAME, is_valid_dashboard_session
+from gateway.services.dashboard_session_service import SESSION_COOKIE_NAME, resolve_dashboard_session
 from gateway.services.file_store import FileStore
 from gateway.services.log_writer import LogWriter
 from gateway.services.master_key_service import hash_master_key, is_generated_master_key, load_master_key_hash
@@ -191,7 +191,9 @@ def _header_credentials_present(request: Request) -> bool:
     Header credentials always win over the dashboard session cookie: an API
     client that sends a key gets exactly today's behavior (including failures),
     and the cookie is only consulted for requests that present nothing else,
-    i.e. the browser-driven dashboard.
+    i.e. the browser-driven dashboard. ``get_session_identity`` applies that
+    rule, so a cookie is never resolved for a request that carries a header
+    credential.
     """
     return bool(
         request.headers.get(API_KEY_HEADER)
@@ -207,24 +209,35 @@ def _header_credentials_present(request: Request) -> bool:
 _COOKIE_SAFE_FETCH_SITES = ("same-origin", "none")
 
 
-async def _session_cookie_authenticates(request: Request, config: GatewayConfig, db: AsyncSession) -> bool:
-    """Whether a valid dashboard session cookie grants master-key authority.
+async def get_session_identity(
+    request: Request,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+) -> TenancyUser | None:
+    """The identity a valid dashboard session cookie authenticates, or None.
+
+    A session cookie grants master-key authority *and* names who is using it, so
+    this is both the credential check and the identity resolution: the callers
+    below treat a non-None result as authenticated, and ``get_current_identity``
+    reuses the same resolved identity. Declared as a dependency rather than
+    called directly so FastAPI's per-request cache means one lookup however many
+    of them a route pulls in.
 
     ``SameSite=Strict`` on the cookie is the primary CSRF control; the
     Sec-Fetch-Site check is belt-and-braces for clients that send the header.
     Standalone-only: hybrid mode has no dashboard or management API.
     """
-    if config.is_hybrid_mode:
-        return False
+    if config.is_hybrid_mode or _header_credentials_present(request):
+        return None
     token = request.cookies.get(SESSION_COOKIE_NAME)
     if not token:
-        return False
+        return None
     fetch_site = request.headers.get("Sec-Fetch-Site")
     if fetch_site is not None and fetch_site not in _COOKIE_SAFE_FETCH_SITES:
         record_auth_failure("cross_site_cookie")
-        return False
+        return None
     try:
-        return await is_valid_dashboard_session(db, token)
+        return await resolve_dashboard_session(db, token)
     except SQLAlchemyError as exc:
         record_auth_failure("db_error")
         raise HTTPException(
@@ -286,22 +299,27 @@ async def verify_master_key(
     request: Request,
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
+    session_identity: Annotated[TenancyUser | None, Depends(get_session_identity)],
 ) -> str | None:
     """Verify master key from Otari-Key header or the dashboard session cookie.
 
     Args:
         request: FastAPI request object
+        db: Database session
         config: Gateway configuration
+        session_identity: The identity behind a dashboard session cookie, if any
 
     Returns:
         The raw master key when header-authenticated, or None when a dashboard
         session cookie authenticated the request (the raw key is not available).
+        Which identity that session speaks for is read with
+        ``get_current_identity``, not from this return value.
 
     Raises:
         HTTPException: If master key is not configured or invalid
 
     """
-    if not _header_credentials_present(request) and await _session_cookie_authenticates(request, config, db):
+    if session_identity is not None:
         return None
     token = _extract_bearer_token(request, config)
 
@@ -327,6 +345,7 @@ async def verify_api_key_or_master_key(
     request: Request,
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
+    session_identity: Annotated[TenancyUser | None, Depends(get_session_identity)],
 ) -> tuple[APIKey | None, bool]:
     """Verify either API key or master key from Otari-Key header.
 
@@ -337,6 +356,7 @@ async def verify_api_key_or_master_key(
         request: FastAPI request object
         db: Database session
         config: Gateway configuration
+        session_identity: The identity behind a dashboard session cookie, if any
 
     Returns:
         Tuple of (APIKey object or None, is_master_key boolean)
@@ -345,7 +365,7 @@ async def verify_api_key_or_master_key(
         HTTPException: If key is invalid, inactive, or expired
 
     """
-    if not _header_credentials_present(request) and await _session_cookie_authenticates(request, config, db):
+    if session_identity is not None:
         return None, True
 
     token = _extract_bearer_token(request, config)
@@ -371,22 +391,30 @@ async def get_db_if_needed(
 
 async def get_current_identity(
     db: Annotated[AsyncSession, Depends(get_db)],
+    session_identity: Annotated[TenancyUser | None, Depends(get_session_identity)],
     _master_key: Annotated[str | None, Depends(verify_master_key)],
 ) -> TenancyUser:
     """Resolve the tenancy identity acting on this request.
 
-    Standalone Otari authenticates an operator with the master key (or the
-    dashboard session cookie minted from it), which names no user, while every
-    tenancy surface needs an identity with an active organization and a role.
-    Depending on ``verify_master_key`` first keeps the credential check exactly
-    where the rest of the management API has it; the identity behind that
-    credential is the deployment's bootstrap operator, provisioned on first use
-    (otari-ai#1716 option A, see `gateway.services.tenancy.provisioning_service`).
+    A dashboard session names the identity it was minted for, so a
+    cookie-authenticated request resolves that identity and, through its
+    ``active_organization_id``, the organization it is acting in. No second
+    lookup: ``verify_master_key`` already resolved it through the same cached
+    dependency to decide the cookie authenticates at all.
 
-    Per-session identities land with the sign-in flow that retires the master key
-    as a login. Until then every authenticated caller is the one operator, which
-    is what a single-tenant standalone deployment already means.
+    A header master key names nobody, so it falls back to the deployment's
+    bootstrap operator, provisioned on first use (otari-ai#1716 option A, see
+    `gateway.services.tenancy.provisioning_service`). That is also the identity
+    master-key sign-in binds a session to, so both credentials resolve to the
+    same operator on a standalone deployment; the difference matters once the
+    per-user sign-in flows mint sessions for other identities.
+
+    Depending on ``verify_master_key`` keeps the credential check exactly where
+    the rest of the management API has it, and keeps a request with no credential
+    at all from provisioning anything.
     """
+    if session_identity is not None:
+        return session_identity
     return await ensure_bootstrap_identity(db)
 
 
@@ -409,6 +437,7 @@ __all__ = [
     "get_config",
     "get_current_identity",
     "get_db",
+    "get_session_identity",
     "reset_config",
     "set_config",
     "get_db_if_needed",

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -55,7 +55,7 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.api.deps import verify_api_key_or_master_key
+from gateway.api.deps import get_session_identity, verify_api_key_or_master_key
 from gateway.api.routes._attempts import walk_attempts
 from gateway.api.routes._helpers import apply_input_guardrails, resolve_user_id
 from gateway.api.routes._platform import (
@@ -1083,7 +1083,10 @@ async def resolve_request_context(
     else:
         if db is None:
             raise adapter.error(500, DB_UNAVAILABLE_DETAIL, ErrorKind.API)
-        api_key, is_master_key = await verify_api_key_or_master_key(raw_request, db, config)
+        # The dashboard session cookie is resolved explicitly here: this is a
+        # direct call rather than a route dependency, so FastAPI cannot inject it.
+        session_identity = await get_session_identity(raw_request, db, config)
+        api_key, is_master_key = await verify_api_key_or_master_key(raw_request, db, config, session_identity)
         api_key_id = api_key.id if api_key else None
         try:
             user_id = resolve_user_id(

--- a/src/gateway/api/routes/auth_session.py
+++ b/src/gateway/api/routes/auth_session.py
@@ -4,9 +4,17 @@
 held in an HttpOnly cookie, so the dashboard never persists the raw key in the
 browser and a sign-in survives tab closes and restarts. ``DELETE`` is sign-out.
 The cookie is honored by the master-key auth dependencies in
-``gateway.api.deps`` when a request carries no header credentials.
+``gateway.api.deps`` when a request carries no header credentials, and it names
+the identity it was minted for, so those dependencies resolve a caller from it.
+
+The master key names nobody, so a session minted here speaks for the
+deployment's bootstrap operator, which is the same identity a header master key
+resolves to (`gateway.services.tenancy.provisioning_service`). A session bound
+to some other identity is what the per-user sign-in flows add; nothing about the
+cookie or this contract changes when they do.
 """
 
+import uuid
 from datetime import datetime
 from typing import Annotated
 
@@ -28,6 +36,7 @@ from gateway.services.dashboard_session_service import (
     request_is_https,
     revoke_dashboard_session,
 )
+from gateway.services.tenancy.provisioning_service import ensure_bootstrap_identity
 
 router = APIRouter(prefix="/v1/auth/session", tags=["auth"])
 
@@ -42,6 +51,10 @@ class SessionResponse(BaseModel):
     """A freshly minted dashboard session (the token travels only in the cookie)."""
 
     expires_at: datetime = Field(description="When the session cookie stops being accepted.")
+    user_id: uuid.UUID = Field(description="The identity this session speaks for.")
+    active_organization_id: uuid.UUID = Field(
+        description="The organization that identity is acting in, which scopes every tenancy surface."
+    )
 
 
 def _check_login_rate_limit(request: Request) -> None:
@@ -88,6 +101,11 @@ async def create_session(
 ) -> SessionResponse:
     """Verify the master key and set the HttpOnly session cookie.
 
+    The session is bound to the bootstrap operator identity, so every request it
+    later authenticates resolves a user and that user's active organization
+    rather than only "the master key was presented once". The response names
+    both, so a client knows who it is signed in as without a second call.
+
     The rate-limit check deliberately runs only after a failed verification,
     not before it: a pre-verification gate can't know whether *this* attempt
     would have succeeded, so once an IP has used up its failure quota it
@@ -103,7 +121,13 @@ async def create_session(
         _check_login_rate_limit(request)
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid master key")
     try:
-        token, expires_at = await create_dashboard_session(db, config.dashboard_session_ttl_hours)
+        # Provisions the tenancy root on a first-ever sign-in, and resolves the
+        # same operator every time after that. It commits its own work, which is
+        # why it runs before the session row is staged rather than beside it.
+        identity = await ensure_bootstrap_identity(db)
+        token, expires_at = await create_dashboard_session(
+            db, config.dashboard_session_ttl_hours, user_id=identity.id
+        )
         await db.commit()
     except SQLAlchemyError:
         await db.rollback()
@@ -114,7 +138,11 @@ async def create_session(
             detail="Database error",
         ) from None
     apply_session_cookie(response, token, expires_at, secure=request_is_https(request))
-    return SessionResponse(expires_at=expires_at)
+    return SessionResponse(
+        expires_at=expires_at,
+        user_id=identity.id,
+        active_organization_id=identity.active_organization_id,
+    )
 
 
 @router.delete("", status_code=status.HTTP_204_NO_CONTENT)

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -17,7 +17,13 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.api.deps import get_config, get_db_if_needed, get_log_writer, verify_api_key_or_master_key
+from gateway.api.deps import (
+    get_config,
+    get_db_if_needed,
+    get_log_writer,
+    get_session_identity,
+    verify_api_key_or_master_key,
+)
 from gateway.api.routes._helpers import latest_user_text, routing_signal_from_messages
 from gateway.api.routes._normalize import normalize_request_messages
 from gateway.api.routes._pipeline import (
@@ -716,7 +722,9 @@ async def count_message_tokens(
         else:
             if db is None:
                 raise _anthropic_error(_ERR_API, DB_UNAVAILABLE_DETAIL, status.HTTP_500_INTERNAL_SERVER_ERROR)
-            await verify_api_key_or_master_key(raw_request, db, config)
+            # Resolved explicitly: a direct call gets no dependency injection.
+            session_identity = await get_session_identity(raw_request, db, config)
+            await verify_api_key_or_master_key(raw_request, db, config, session_identity)
     except HTTPException as exc:
         # Keep /v1/messages/count_tokens auth errors in the Anthropic envelope too.
         raise _ensure_anthropic_error(exc) from exc

--- a/src/gateway/api/routes/settings.py
+++ b/src/gateway/api/routes/settings.py
@@ -22,10 +22,10 @@ from pydantic import BaseModel, Field
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.api.deps import get_config, get_db, verify_master_key
+from gateway.api.deps import get_config, get_db, get_session_identity, verify_master_key
 from gateway.core.config import GatewayConfig
+from gateway.models.tenancy import User as TenancyUser
 from gateway.services.dashboard_session_service import (
-    SESSION_COOKIE_NAME,
     apply_session_cookie,
     create_dashboard_session,
     record_session_key_marker,
@@ -380,6 +380,7 @@ async def rotate_master_key(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
     authenticated_key: Annotated[str | None, Depends(verify_master_key)],
+    session_identity: Annotated[TenancyUser | None, Depends(get_session_identity)],
 ) -> RotateMasterKeyResponse:
     """Regenerate the database-backed master key and invalidate the old one.
 
@@ -389,7 +390,10 @@ async def rotate_master_key(
 
     Every dashboard session is revoked with the rotation (a session only proves
     possession of the now-dead key); the caller's own session is re-minted under
-    the new key so the tab that performed the rotation stays signed in.
+    the new key, for the same identity it named, so the tab that performed the
+    rotation stays signed in as who it was. A caller that authenticated with a
+    header key has no session identity to re-mint for, so it is not handed one:
+    it was not signed in to the dashboard to begin with.
     """
     if config.master_key is not None:
         raise HTTPException(
@@ -416,9 +420,9 @@ async def rotate_master_key(
         # Keep the startup key-change check in step, so a restart after this
         # rotation does not revoke the session re-minted below.
         await record_session_key_marker(db, hashed)
-        if SESSION_COOKIE_NAME in request.cookies:
+        if session_identity is not None:
             session_token, session_expires_at = await create_dashboard_session(
-                db, config.dashboard_session_ttl_hours
+                db, config.dashboard_session_ttl_hours, user_id=session_identity.id
             )
         await db.commit()
     except MasterKeyRotationConflictError as exc:

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -356,18 +356,35 @@ class RuntimeSetting(Base):
 
 
 class DashboardSession(Base):
-    """A server-side admin-dashboard sign-in session.
+    """A server-side admin-dashboard sign-in session, held by one identity.
 
     Minted when an operator signs in to the dashboard with the master key: the
     browser holds only an opaque token in an HttpOnly cookie and this table
     stores the token's SHA-256 hash, so neither the master key nor a usable
     session credential is ever persisted in JS-readable storage. Sessions
     expire on a TTL and are revoked on sign-out and on master-key rotation.
+
+    ``user_id`` is what lets a session resolve a caller rather than only prove
+    that the master key was presented once. It names a tenancy identity
+    (`models.tenancy.User`), whose ``active_organization_id`` is the
+    organization the session acts in, so a tenancy surface reads its scope off
+    the session. Master-key sign-in binds the session to the deployment's
+    bootstrap operator; a per-user sign-in flow binds it to whoever
+    authenticated.
+
+    NOT NULL on purpose: a session that names nobody cannot answer "who is
+    calling", which is the whole point of the column, and the migration that
+    added it bound existing sessions to that same bootstrap operator. CASCADE
+    on the foreign key, so deleting an identity revokes its sessions rather
+    than leaving a live cookie pointing at a row that is gone.
     """
 
     __tablename__ = "dashboard_sessions"
 
     token_hash: Mapped[str] = mapped_column(primary_key=True)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("user.id", ondelete="CASCADE"), nullable=False, index=True
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
 

--- a/src/gateway/services/dashboard_session_service.py
+++ b/src/gateway/services/dashboard_session_service.py
@@ -6,26 +6,41 @@ its SHA-256 hash stored in the ``dashboard_sessions`` table. This lets a
 sign-in survive tab closes and browser restarts without ever persisting the
 master key (or any JS-readable credential) in the browser.
 
+Every session names the identity it was minted for, so it resolves a caller and
+that caller's active organization rather than only proving the master key was
+presented once. Master-key sign-in binds the session to the deployment's
+bootstrap operator (`services.tenancy.provisioning_service`); a per-user sign-in
+flow binds it to whoever authenticated.
+
+An opaque token, deliberately, rather than the platform's JWT ``Token``: this
+session is revocable server-side, which a bearer JWT is not, and the cookie,
+HTTPS and rate-limit machinery around it already works. otari-ai#1716 settled
+that sessions are the steady-state dashboard login, so the platform's JWT does
+not survive the rehome (see ``docs/access-control.md``).
+
 Sessions live in the database, not process memory, so every worker and replica
 accepts them and a revocation is seen everywhere. They expire on a TTL
-(``dashboard_session_ttl_hours``) and are revoked on sign-out and on master-key
-rotation.
+(``dashboard_session_ttl_hours``) and are revoked on sign-out, on master-key
+rotation, and (through the foreign key) when their identity is deleted.
 """
 
 import hashlib
 import secrets
+import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
 from fastapi import Request, Response
-from sqlalchemy import delete, update
+from sqlalchemy import delete, select, update
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
 
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import DashboardSession, RuntimeSetting
+from gateway.models.tenancy import User
 from gateway.services.master_key_service import hash_master_key
 
 SESSION_COOKIE_NAME = "otari_dashboard_session"
@@ -47,8 +62,14 @@ def _as_utc(value: datetime) -> datetime:
     return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
 
 
-async def create_dashboard_session(db: AsyncSession, ttl_hours: int) -> tuple[str, datetime]:
-    """Stage a new session row and return ``(token, expires_at)``.
+async def create_dashboard_session(
+    db: AsyncSession, ttl_hours: int, *, user_id: uuid.UUID
+) -> tuple[str, datetime]:
+    """Stage a new session row for ``user_id`` and return ``(token, expires_at)``.
+
+    ``user_id`` names the tenancy identity the session speaks for, and is
+    required rather than defaulted: a session that names nobody cannot resolve a
+    caller, which is the reason the column exists.
 
     Expired rows are pruned opportunistically here, so the table stays small
     without a background task. The caller owns the transaction and must commit
@@ -58,16 +79,51 @@ async def create_dashboard_session(db: AsyncSession, ttl_hours: int) -> tuple[st
     await db.execute(delete(DashboardSession).where(DashboardSession.expires_at < now))
     token = f"{_SESSION_TOKEN_PREFIX}{secrets.token_urlsafe(32)}"
     expires_at = now + timedelta(hours=ttl_hours)
-    db.add(DashboardSession(token_hash=hash_session_token(token), created_at=now, expires_at=expires_at))
+    db.add(
+        DashboardSession(
+            token_hash=hash_session_token(token),
+            user_id=user_id,
+            created_at=now,
+            expires_at=expires_at,
+        )
+    )
     return token, expires_at
 
 
-async def is_valid_dashboard_session(db: AsyncSession, token: str) -> bool:
-    """Whether a session token matches a stored, unexpired session."""
-    row = await db.get(DashboardSession, hash_session_token(token))
+async def resolve_dashboard_session(db: AsyncSession, token: str) -> User | None:
+    """Return the identity a stored, unexpired session token speaks for.
+
+    One query joining the session to its identity, rather than two lookups or a
+    lazy ``relationship()`` (which raises ``MissingGreenlet`` on an
+    ``AsyncSession``), because this runs on every cookie-authenticated request.
+
+    Three things make a token resolve to nothing, and all three mean "not
+    authenticated": no such session, an expired one, and one whose identity has
+    been deactivated. That last is why the identity is loaded here rather than
+    trusted from the session row: deactivating an operator has to end their
+    dashboard access, not wait out the TTL.
+
+    Expiry is compared in Python, as the rest of this module does: SQLite hands
+    the stored timestamp back naive, so the check goes through ``_as_utc``.
+    """
+    row = (
+        await db.execute(
+            select(DashboardSession, User)
+            .join(User, col(User.id) == DashboardSession.user_id)
+            .where(DashboardSession.token_hash == hash_session_token(token))
+        )
+    ).first()
     if row is None:
-        return False
-    return _as_utc(row.expires_at) >= datetime.now(UTC)
+        return None
+    # Annotated rather than tuple-unpacked: a two-entity ``Row`` types as ``Any``
+    # under mypy strict, and the return type is what callers rely on.
+    session: DashboardSession = row[0]
+    identity: User = row[1]
+    if _as_utc(session.expires_at) < datetime.now(UTC):
+        return None
+    if not identity.is_active:
+        return None
+    return identity
 
 
 async def revoke_dashboard_session(db: AsyncSession, token: str) -> None:

--- a/tests/integration/test_tenancy_api.py
+++ b/tests/integration/test_tenancy_api.py
@@ -174,13 +174,21 @@ def test_the_dashboard_session_cookie_also_authenticates(
     test_config: Any,
     master_key_header: dict[str, str],
 ) -> None:
-    """The tenancy routes accept what the rest of the management API accepts."""
+    """The tenancy routes accept what the rest of the management API accepts.
+
+    And resolve the same identity from it: a session names the operator it was
+    minted for (#647), so the cookie answers for the organization the master key
+    answers for rather than for whatever provisioning happens to run next.
+    """
     signed_in = client.post("/v1/auth/session", json={"master_key": test_config.master_key})
     assert signed_in.status_code == 200, signed_in.text
 
     response = client.get("/v1/organizations/me")
 
     assert response.status_code == 200, response.text
+    by_key = client.get("/v1/organizations/me", headers=master_key_header)
+    assert signed_in.json()["active_organization_id"] == by_key.json()["organization"]["id"]
+    assert response.json()["organization"]["id"] == by_key.json()["organization"]["id"]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_dashboard_session.py
+++ b/tests/unit/test_dashboard_session.py
@@ -377,6 +377,45 @@ def test_rotation_re_mints_the_session_for_the_same_identity(tmp_path: Path, mon
         assert client.get("/v1/organizations/me").status_code == 200
 
 
+_COMPLETION_BODY = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]}
+
+
+def test_the_cookie_authenticates_the_request_plane_too(tmp_path: Path) -> None:
+    """The two auth sites that resolve the cookie by hand rather than by injection.
+
+    ``resolve_request_context`` and ``/v1/messages/count_tokens`` call the auth
+    dependency directly, so FastAPI cannot inject the session identity and each
+    has to resolve it itself. The cookie check used to sit inside
+    ``verify_api_key_or_master_key``, which meant every caller got it for free; a
+    site left un-updated when it moved out would stop accepting the cookie and
+    nothing else in this file would notice.
+
+    Chat stops at the master-key user gate rather than at 401: a cookie carries
+    master-key authority, and a master key has to name the user it spends for.
+    """
+    with TestClient(create_app(_config(tmp_path))) as client:
+        _sign_in(client)
+
+        assert client.post("/v1/messages/count_tokens", json=_COMPLETION_BODY).status_code == 200
+
+        chat = client.post("/v1/chat/completions", json=_COMPLETION_BODY)
+        assert chat.status_code == 400, chat.text
+        assert "'user' field is required" in chat.json()["detail"]
+
+
+def test_the_request_plane_still_refuses_anonymous_and_cross_site_callers(tmp_path: Path) -> None:
+    """Hoisting the cookie check out of the dependency must not have loosened it."""
+    with TestClient(create_app(_config(tmp_path))) as client:
+        assert client.post("/v1/chat/completions", json=_COMPLETION_BODY).status_code == 401
+        assert client.post("/v1/messages/count_tokens", json=_COMPLETION_BODY).status_code == 401
+
+        _sign_in(client)
+        cross_site = {"Sec-Fetch-Site": "cross-site"}
+        assert client.post("/v1/chat/completions", json=_COMPLETION_BODY, headers=cross_site).status_code == 401
+        counted = client.post("/v1/messages/count_tokens", json=_COMPLETION_BODY, headers=cross_site)
+        assert counted.status_code == 401
+
+
 def _rate_limited_config(tmp_path: Path, *, limit: int | None) -> GatewayConfig:
     return GatewayConfig(
         database_url=f"sqlite:///{tmp_path / 'session-rate-limit-test.db'}",

--- a/tests/unit/test_dashboard_session.py
+++ b/tests/unit/test_dashboard_session.py
@@ -1,9 +1,15 @@
-"""Dashboard sign-in sessions: mint, cookie auth, revocation, and rotation.
+"""Dashboard sign-in sessions: mint, identity, cookie auth, revocation, rotation.
 
 Covers the fix for the dashboard losing its sign-in on every tab close or
 browser restart (issue #338): the master key is exchanged once for an HttpOnly
 session cookie that the master-key auth dependencies accept when a request
 carries no header credentials.
+
+It also covers what issue #647 added on top: a session names the identity it was
+minted for, so a cookie-authenticated request resolves a user and that user's
+active organization rather than only proving the master key was presented once.
+The revocation paths are re-asserted here rather than trusted, since binding an
+identity to a session is the change most likely to break them silently.
 """
 
 from datetime import UTC, datetime, timedelta
@@ -11,7 +17,7 @@ from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, update
+from sqlalchemy import create_engine, text, update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import sessionmaker
 
@@ -21,6 +27,7 @@ from gateway.main import create_app
 from gateway.models.entities import DashboardSession
 from gateway.services import master_key_service
 from gateway.services.dashboard_session_service import SESSION_COOKIE_NAME
+from gateway.services.tenancy.provisioning_service import BOOTSTRAP_IDENTITY_KEY
 
 MASTER_KEY = "sk-test-master"
 
@@ -233,6 +240,141 @@ def test_rotation_revokes_other_sessions_and_reminting_keeps_the_caller_signed_i
         for stale in (other_tab_session, rotating_session):
             client.cookies.set(SESSION_COOKIE_NAME, stale)
             assert client.get("/v1/settings").status_code == 401
+
+
+def _sessions(config: GatewayConfig) -> list[tuple[str, str]]:
+    """Every stored session as ``(token_hash, user_id)``, read outside the app.
+
+    A sync engine of its own, like the expiry test above: what is under test is
+    the row the request handler committed, not the ORM state of a live session.
+    """
+    engine = create_engine(config.database_url)
+    try:
+        with engine.connect() as connection:
+            return [
+                (str(row[0]), str(row[1]))
+                for row in connection.execute(text("SELECT token_hash, user_id FROM dashboard_sessions"))
+            ]
+    finally:
+        engine.dispose()
+
+
+def test_a_session_names_the_operator_identity(tmp_path: Path) -> None:
+    """The point of #647: the minted row resolves a user, and the response says who.
+
+    The identity is the deployment's bootstrap operator, the same one a header
+    master key resolves to, so both credentials answer for the same organization.
+    """
+    config = _config(tmp_path)
+    with TestClient(create_app(config)) as client:
+        signed_in = client.post("/v1/auth/session", json={"master_key": MASTER_KEY})
+        assert signed_in.status_code == 200, signed_in.text
+        body = signed_in.json()
+
+        operator = client.get("/v1/organizations/me", headers={"Otari-Key": MASTER_KEY})
+        assert operator.status_code == 200, operator.text
+        assert body["active_organization_id"] == operator.json()["organization"]["id"]
+
+        stored = _sessions(config)
+        assert [user_id for _, user_id in stored] == [body["user_id"].replace("-", "")]
+
+
+def test_the_cookie_resolves_that_identity_on_every_later_request(tmp_path: Path) -> None:
+    """A tenancy surface reads its scope off the session, with no key in sight."""
+    with TestClient(create_app(_config(tmp_path))) as client:
+        _sign_in(client)
+
+        by_cookie = client.get("/v1/organizations/me")
+        by_key = client.get("/v1/organizations/me", headers={"Otari-Key": MASTER_KEY})
+
+        assert by_cookie.status_code == 200, by_cookie.text
+        assert by_cookie.json()["organization"]["id"] == by_key.json()["organization"]["id"]
+        assert by_cookie.json()["role"] == "owner"
+
+
+def test_deactivating_the_identity_ends_its_sessions(tmp_path: Path) -> None:
+    """Deactivation has to end dashboard access now, not when the TTL runs out.
+
+    Which is why the identity is loaded on every cookie-authenticated request
+    rather than trusted from the session row.
+    """
+    config = _config(tmp_path)
+    with TestClient(create_app(config)) as client:
+        _sign_in(client)
+        assert client.get("/v1/settings").status_code == 200
+
+        engine = create_engine(config.database_url)
+        with engine.begin() as connection:
+            connection.execute(text('UPDATE "user" SET is_active = 0'))
+        engine.dispose()
+
+        assert client.get("/v1/settings").status_code == 401
+
+
+def test_deleting_the_identity_revokes_its_sessions(tmp_path: Path) -> None:
+    """The foreign key is CASCADE, so no cookie outlives the identity it names.
+
+    ``PRAGMA foreign_keys`` is enabled on this connection by hand: the gateway's
+    own engine sets it (``core.database``), and a plain ``create_engine`` here
+    would otherwise leave the session row behind with SQLite's default off.
+    """
+    config = _config(tmp_path)
+    with TestClient(create_app(config)) as client:
+        _sign_in(client)
+
+        engine = create_engine(config.database_url)
+        with engine.begin() as connection:
+            connection.execute(text("PRAGMA foreign_keys=ON"))
+            connection.execute(text('DELETE FROM "user"'))
+        engine.dispose()
+
+        assert _sessions(config) == []
+        assert client.get("/v1/settings").status_code == 401
+
+
+def test_a_first_sign_in_provisions_the_identity_it_binds_to(tmp_path: Path) -> None:
+    """Sign-in is the first tenancy-touching request on a fresh deployment.
+
+    Provisioning is lazy, so the session cannot be bound to an identity that
+    exists yet; it has to run before the row is staged. Without that the sign-in
+    would fail its foreign key on every fresh install.
+    """
+    config = _config(tmp_path)
+    with TestClient(create_app(config)) as client:
+        engine = create_engine(config.database_url)
+        with engine.connect() as connection:
+            assert connection.execute(text('SELECT COUNT(*) FROM "user"')).scalar_one() == 0
+
+        signed_in = client.post("/v1/auth/session", json={"master_key": MASTER_KEY})
+        assert signed_in.status_code == 200, signed_in.text
+
+        with engine.connect() as connection:
+            marker = connection.execute(
+                text("SELECT value FROM runtime_settings WHERE key = :key"),
+                {"key": BOOTSTRAP_IDENTITY_KEY},
+            ).scalar_one()
+        engine.dispose()
+
+        assert marker.replace("-", "") == signed_in.json()["user_id"].replace("-", "")
+
+
+def test_rotation_re_mints_the_session_for_the_same_identity(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Revoke-then-re-mint must not lose track of who the tab was signed in as."""
+    monkeypatch.setattr(master_key_service, "generate_master_key", lambda: "otari-mk-first")
+    config = GatewayConfig(
+        database_url=f"sqlite:///{tmp_path / 'rotation-identity.db'}",
+        require_pricing=False,
+    )
+    with TestClient(create_app(config)) as client:
+        signed_in = client.post("/v1/auth/session", json={"master_key": "otari-mk-first"})
+        assert signed_in.status_code == 200, signed_in.text
+        identity = signed_in.json()["user_id"].replace("-", "")
+
+        monkeypatch.setattr(master_key_service, "generate_master_key", lambda: "otari-mk-second")
+        assert client.post("/v1/settings/master-key/rotate").status_code == 200
+
+        assert [user_id for _, user_id in _sessions(config)] == [identity]
+        assert client.get("/v1/organizations/me").status_code == 200
 
 
 def _rate_limited_config(tmp_path: Path, *, limit: int | None) -> GatewayConfig:

--- a/tests/unit/test_tenancy_schema_chain.py
+++ b/tests/unit/test_tenancy_schema_chain.py
@@ -13,9 +13,11 @@ is the only coverage of that path. Driven against a real file database rather
 than in-memory because batch mode's rebuild is what is under test.
 
 The later revisions that reshape the same tables are exercised here too, for the
-same reason: the workspace scoping that rebuilds four request-plane tables, and
-the credential columns added to ``user``, whose downgrade depends on SQLite's
-refusal to drop an indexed column.
+same reason: the workspace scoping that rebuilds four request-plane tables, the
+credential columns added to ``user``, whose downgrade depends on SQLite's refusal
+to drop an indexed column, and the identity column added to
+``dashboard_sessions``, which rebuilds that table to tighten a column to NOT NULL
+and point it at ``user``.
 """
 
 import json
@@ -40,6 +42,12 @@ _ALEMBIC_DIR = Path(__file__).resolve().parents[2] / "alembic"
 _TENANCY_REVISION = "c4b6d8e0f2a3"
 _PREVIOUS_REVISION = "b2d4f6a8c0e1"
 _TENANCY_TABLES = {"user", "organization", "organization_member", "workspace", "workspace_member"}
+
+_SESSION_IDENTITY_REVISION = "b6d8f0a2c4e7"
+_BEFORE_SESSION_IDENTITY = "7ff4e082eb0c"
+_SESSION_USER_INDEX = "ix_dashboard_sessions_user_id"
+_SESSION_EXPIRY_INDEX = "ix_dashboard_sessions_expires_at"
+BOOTSTRAP_IDENTITY_KEY = "tenancy_bootstrap_user_id"
 
 _CREDENTIAL_REVISION = "f2a4c6d8b0e3"
 _BEFORE_CREDENTIALS = "a3c7e1b9d5f2"
@@ -400,3 +408,136 @@ def test_the_revision_chain_has_one_head() -> None:
     heads = ScriptDirectory.from_config(_alembic_config("sqlite://")).get_heads()
 
     assert len(heads) == 1, heads
+
+
+def _insert_session(connection: Connection, token_hash: str) -> None:
+    """Store one pre-#647 dashboard session: a token hash and its two timestamps."""
+    connection.execute(
+        text(
+            "INSERT INTO dashboard_sessions (token_hash, created_at, expires_at) "
+            "VALUES (:hash, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+        ),
+        {"hash": token_hash},
+    )
+
+
+def _mark_bootstrap_identity(connection: Connection, value: str) -> None:
+    """Point the provisioning marker at ``value``, in the dashed form it holds."""
+    connection.execute(
+        text("INSERT INTO runtime_settings (key, value, updated_at) VALUES (:key, :value, CURRENT_TIMESTAMP)"),
+        {"key": BOOTSTRAP_IDENTITY_KEY, "value": value},
+    )
+
+
+def _at_revision(tmp_path: Path, name: str, revision: str) -> tuple[Config, Engine]:
+    """A SQLite database migrated to one revision, for a step-by-step upgrade."""
+    url = f"sqlite:///{tmp_path / name}"
+    config = _alembic_config(url)
+    command.upgrade(config, revision)
+    return config, create_engine(url)
+
+
+def test_a_live_session_is_bound_to_the_bootstrap_operator(tmp_path: Path) -> None:
+    """The signed-in operator stays signed in across the upgrade.
+
+    ``user_id`` is NOT NULL, so an existing session has to be attributed to
+    someone, and the only right answer is the identity master-key auth already
+    resolves to: the one the provisioning marker names.
+    """
+    config, engine = _at_revision(tmp_path, "session-backfill.db", _BEFORE_SESSION_IDENTITY)
+    with engine.begin() as connection:
+        identity = _insert_identity(connection)
+        _mark_bootstrap_identity(connection, str(uuid.UUID(identity)))
+        _insert_session(connection, "hash-of-a-live-session")
+
+    command.upgrade(config, _SESSION_IDENTITY_REVISION)
+
+    with engine.begin() as connection:
+        bound = connection.execute(text("SELECT token_hash, user_id FROM dashboard_sessions")).one()
+    assert bound == ("hash-of-a-live-session", identity)
+    engine.dispose()
+
+
+def test_a_session_with_nobody_to_name_is_revoked(tmp_path: Path) -> None:
+    """A deployment that never served a tenancy request has no identity to bind to.
+
+    Provisioning is lazy, so there is nothing to attribute the row to and the
+    column cannot be null: the session is revoked and the operator signs in once
+    more, which is what a master-key rotation already does to them.
+    """
+    config, engine = _at_revision(tmp_path, "session-unattributed.db", _BEFORE_SESSION_IDENTITY)
+    with engine.begin() as connection:
+        _insert_session(connection, "hash-of-an-unattributed-session")
+
+    command.upgrade(config, _SESSION_IDENTITY_REVISION)
+
+    with engine.begin() as connection:
+        assert connection.execute(text("SELECT COUNT(*) FROM dashboard_sessions")).scalar_one() == 0
+    engine.dispose()
+
+
+def test_a_marker_naming_a_missing_identity_revokes_rather_than_failing(tmp_path: Path) -> None:
+    """The marker can outlive the row it names, and the runtime tolerates that.
+
+    Binding a session to it would fail the foreign key mid-upgrade, so the
+    revision checks that the identity exists rather than trusting the marker.
+    """
+    config, engine = _at_revision(tmp_path, "session-stale-marker.db", _BEFORE_SESSION_IDENTITY)
+    with engine.begin() as connection:
+        _mark_bootstrap_identity(connection, str(uuid.uuid4()))
+        _insert_session(connection, "hash-of-a-session-whose-operator-is-gone")
+
+    command.upgrade(config, _SESSION_IDENTITY_REVISION)
+
+    with engine.begin() as connection:
+        assert connection.execute(text("SELECT COUNT(*) FROM dashboard_sessions")).scalar_one() == 0
+    engine.dispose()
+
+
+def test_the_session_identity_column_cascades_from_its_identity(sqlite_at_head: tuple[Config, Engine]) -> None:
+    """Deleting an identity revokes its sessions instead of orphaning them."""
+    _, engine = sqlite_at_head
+    foreign_keys = [
+        fk for fk in inspect(engine).get_foreign_keys("dashboard_sessions") if fk["referred_table"] == "user"
+    ]
+
+    assert [tuple(fk["constrained_columns"]) for fk in foreign_keys] == [("user_id",)]
+    assert foreign_keys[0]["options"].get("ondelete") == "CASCADE"
+
+
+def test_the_session_identity_revision_round_trips(sqlite_at_head: tuple[Config, Engine]) -> None:
+    """Down drops the column and its index; up puts them back.
+
+    The expiry index is the one that has to survive both directions: the table is
+    rebuilt in each, and a rebuild driven by reflection alone is what loses it
+    (hence ``copy_from`` in the revision).
+    """
+    config, engine = sqlite_at_head
+
+    command.downgrade(config, _BEFORE_SESSION_IDENTITY)
+
+    inspector = inspect(engine)
+    columns = {column["name"] for column in inspector.get_columns("dashboard_sessions")}
+    indexes = {index["name"] for index in inspector.get_indexes("dashboard_sessions")}
+    assert "user_id" not in columns
+    assert _SESSION_USER_INDEX not in indexes
+    assert _SESSION_EXPIRY_INDEX in indexes
+
+    command.upgrade(config, _SESSION_IDENTITY_REVISION)
+
+    inspector = inspect(engine)
+    assert "user_id" in {column["name"] for column in inspector.get_columns("dashboard_sessions")}
+    assert {_SESSION_USER_INDEX, _SESSION_EXPIRY_INDEX} <= {
+        index["name"] for index in inspector.get_indexes("dashboard_sessions")
+    }
+
+
+def test_the_migrated_session_table_matches_the_model(sqlite_at_head: tuple[Config, Engine]) -> None:
+    """Hand-written revision, so nothing else would notice the two drifting apart."""
+    _, engine = sqlite_at_head
+
+    declared = SQLModel.metadata.tables["dashboard_sessions"]
+    migrated = {column["name"]: column for column in inspect(engine).get_columns("dashboard_sessions")}
+
+    assert set(migrated) == set(declared.columns.keys())
+    assert migrated["user_id"]["nullable"] is False

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -316,6 +316,11 @@ export interface paths {
          * Create Session
          * @description Verify the master key and set the HttpOnly session cookie.
          *
+         *     The session is bound to the bootstrap operator identity, so every request it
+         *     later authenticates resolves a user and that user's active organization
+         *     rather than only "the master key was presented once". The response names
+         *     both, so a client knows who it is signed in as without a second call.
+         *
          *     The rate-limit check deliberately runs only after a failed verification,
          *     not before it: a pre-verification gate can't know whether *this* attempt
          *     would have succeeded, so once an IP has used up its failure quota it
@@ -2097,7 +2102,10 @@ export interface paths {
          *
          *     Every dashboard session is revoked with the rotation (a session only proves
          *     possession of the now-dead key); the caller's own session is re-minted under
-         *     the new key so the tab that performed the rotation stays signed in.
+         *     the new key, for the same identity it named, so the tab that performed the
+         *     rotation stays signed in as who it was. A caller that authenticated with a
+         *     header key has no session identity to re-mint for, so it is not handed one:
+         *     it was not signed in to the dashboard to begin with.
          */
         post: operations["rotate_master_key_v1_settings_master_key_rotate_post"];
         delete?: never;
@@ -5757,11 +5765,23 @@ export interface components {
          */
         SessionResponse: {
             /**
+             * Active Organization Id
+             * Format: uuid
+             * @description The organization that identity is acting in, which scopes every tenancy surface.
+             */
+            active_organization_id: string;
+            /**
              * Expires At
              * Format: date-time
              * @description When the session cookie stops being accepted.
              */
             expires_at: string;
+            /**
+             * User Id
+             * Format: uuid
+             * @description The identity this session speaks for.
+             */
+            user_id: string;
         };
         /**
          * SetPricingRequest


### PR DESCRIPTION
## Description

`dashboard_sessions` proved that the master key had been presented once and named nobody, so every tenancy surface fell back to the deployment's bootstrap operator and no per-user sign-in could build on it. Sessions now carry `user_id` (FK to `user.id`, `ON DELETE CASCADE`, indexed), and the cookie-auth dependency resolves that identity in one join instead of returning a bare boolean. A cookie-authenticated request therefore resolves a user and, through its `active_organization_id`, the organization it is acting in; `POST /v1/auth/session` returns both ids beside the expiry.

The opaque-token-and-cookie shape stays rather than the platform's JWT `Token`: this session is revocable server side, and the cookie, HTTPS, and rate-limit machinery already works. mozilla-ai/otari-ai#1716 settled that sessions are the steady-state dashboard login, so **the platform's JWT does not survive the rehome**. That is written down in `docs/access-control.md` so the frontend port (#653) does not have to discover it.

Behavior worth knowing:

- Master-key sign-in provisions and binds the bootstrap operator, so that login path is unchanged and still the one master-key holders use.
- Deactivating or deleting an identity ends its sessions immediately, the second through the cascade, instead of waiting out the TTL.
- Rotation still revokes every session and re-mints the caller's own, now for the identity that session named. A header-authenticated caller carrying a stale cookie is no longer handed a fresh one.
- The migration binds existing sessions to the identity the `tenancy_bootstrap_user_id` marker names, so a signed-in operator stays signed in. A deployment that never provisioned tenancy has nobody to attribute them to, so those rows are revoked and the operator signs in once more, which is what a master-key rotation already does to them.

**One open question for the reviewer:** preserving sessions by backfilling, as above, versus revoking every session on upgrade for a simpler migration. I chose to preserve, because the bootstrap operator is exactly the identity master-key auth already resolved to.

Backend only on purpose: the only change under `web/` is the regenerated `src/client/schema.ts`, which the CI drift check requires.

Verification beyond the checklist below: the migration round-trips upgrade, downgrade, upgrade on SQLite and on PostgreSQL, and I ran the real upgrade in place, signing in on `main`, migrating that database onto this branch, and confirming the pre-upgrade cookie still authenticates. `uv run alembic heads` returns one head. Integration ran against a local PostgreSQL 18 rather than Testcontainers, since the sandbox has no Docker.

## PR Type
<!-- Check all that apply -->

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #647. Unblocks #649, #650, #651, #652, and #653.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5, via the Claude Code CLI.

**Any additional AI details you'd like to share:**

Implemented from the issue in one session, with the design decisions (keep the opaque session, NOT NULL rather than a nullable column, backfill rather than revoke) made in discussion with @njbrake. Every check in the list above was run locally before the PR was opened, and the migration was exercised on both engines and through a live upgrade in place.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this PR description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Link dashboard sessions to user identities and active organizations.
- Return `user_id`, `active_organization_id`, and session expiry from `POST /v1/auth/session`.
- Revoke sessions when identities are deactivated or deleted.
- Preserve session behavior during master-key rotation.
- Backfill existing sessions during migration and revoke sessions without a valid identity.
- Update authentication documentation, client schema, and test coverage.

## Technical notes

- Dashboard authentication continues to use opaque tokens and cookies.
- Platform JWT authentication is not used for dashboard sessions.
- Session identity resolution now supports protected API and message routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->