### PR TITLE
docs(pricing): give the money migration's lock a measured figure

### DIFF
--- a/alembic/versions/a7c3e5d9b1f4_exact_money_columns.py
+++ b/alembic/versions/a7c3e5d9b1f4_exact_money_columns.py
@@ -32,9 +32,19 @@ changed.
 
 **On PostgreSQL this rewrites ``usage_logs``.** ``double precision`` to
 ``numeric`` is not binary-coercible, so the ALTER copies the whole table under
-an ACCESS EXCLUSIVE lock and needs transient space for a second copy. On a
-large usage table that is real downtime, and it runs at startup when
-``auto_migrate`` is set. Schedule it rather than discovering it.
+an ACCESS EXCLUSIVE lock, which blocks reads as well as writes, and needs
+transient room for a second copy of the table while it runs.
+
+Measured rather than guessed at, on a migrated schema with the real indexes in
+place: one million ``usage_logs`` rows (369 MB including indexes) take about
+2.3 seconds for that ALTER and about 2.9 seconds for the whole revision. So ten
+million rows is tens of seconds and a hundred million is a few minutes, on
+local disk with nothing else running; network-attached storage or a table under
+load will be slower. It is a pause, not an outage, but it is a pause that
+happens at startup when ``auto_migrate`` is set, which is the part worth
+knowing: a deployment with real usage history should run ``otari migrate``
+deliberately rather than let the next restart do it while requests are
+arriving.
 
 SQLite gets the same DDL through a table rebuild, though there the change is
 declarative: SQLite has no numeric storage class, so the values stay REAL and


### PR DESCRIPTION
## Description

The money migration's docstring called the `usage_logs` rewrite "real downtime" without saying how long, which is the kind of warning an operator either over-reacts to or skims past. It now carries the measurement instead, taken on a migrated schema with the real indexes in place: one million `usage_logs` rows (369 MB including indexes) is about **2.3 seconds** for that ALTER and about **2.9 seconds** for the whole revision, so ten million rows is tens of seconds and a hundred million is a few minutes, on local disk with nothing else running.

The operational part is kept and sharpened rather than dropped: the ACCESS EXCLUSIVE lock blocks reads as well as writes, the ALTER needs transient room for a second copy of the table, and the revision runs at startup when `auto_migrate` is set, so a deployment with real usage history should run `otari migrate` deliberately rather than let the next restart do it while requests are arriving.

Docstring only. The migration itself is untouched, and the diff contains no executable line.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Follows #683, which introduced the wording. Related follow-ups from that PR: #690 and #691.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). No test changes: the diff is a docstring, and the existing migration chain tests (`tests/unit/test_exact_money_schema_chain.py`, `tests/unit/test_migration_single_head.py`) were run and pass.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). No contract change.

**How the figures were taken.** A database migrated to the revision before this one, seeded with 1,000,000 `usage_logs` rows through the real schema so every index is present, then timed twice: `ALTER TABLE usage_logs ALTER COLUMN cost TYPE numeric(18,6) USING cost::numeric` on its own at 2,343 ms, and `alembic upgrade` across the whole revision at 2.9 s. PostgreSQL 18, local disk, no concurrent load. Reproduced against merged `main` rather than the branch the wording came from.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5, via the Claude Code CLI.

**Any additional AI details you'd like to share:**

Note: this PR description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the migration documentation with measured timing estimates for rewriting `usage_logs`.
- Clarified lock behavior, temporary storage needs, and deployment guidance.
- No executable migration code changed.

These updates help teams plan migrations safely and avoid unexpected startup pauses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->