### PR TITLE
test(pricing): scope the absent-rate assertion to the row it is about

### DIFF
--- a/web/src/features/organization/RateOverridesCard.test.tsx
+++ b/web/src/features/organization/RateOverridesCard.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { screen, waitFor } from "@testing-library/react"
+import { screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
@@ -115,14 +115,20 @@ describe("RateOverridesCard", () => {
 
     await renderPage()
 
-    await screen.findByText("openai:gpt-4o")
+    const row = (await screen.findByText("openai:gpt-4o")).closest(
+      '[role="row"]',
+    )
+    expect(row).not.toBeNull()
+    const cells = within(row as HTMLElement)
+
     // `formatCost` renders null as "$0.00", so the absent check has to sit in
     // front of it; an unset cache rate must read as "no rate stored", not as a
     // negotiated zero.
-    expect(screen.queryByText("$0.00")).not.toBeInTheDocument()
-    // Exactly the two cache columns the table renders, not "at least one": a
-    // count pins which cells are absent rather than merely that some are.
-    expect(await screen.findAllByText("—")).toHaveLength(2)
+    expect(cells.queryByText("$0.00")).not.toBeInTheDocument()
+    // Scoped to this row, and counted: page-scoped it would pass on the right
+    // total while proving nothing about which cells are absent, since an
+    // unrelated cell could supply or remove a match. Two is both cache columns.
+    expect(cells.getAllByText("—")).toHaveLength(2)
   })
 
   it("explains itself when the organization has no overrides", async () => {


### PR DESCRIPTION
## Description

Picks up the one CodeRabbit finding on #677 that arrived after it merged.

`screen.findAllByText("—")` searched the whole render, so the count was right by coincidence rather than by construction: an unrelated cell could supply or remove a match and the assertion would still pass while proving nothing about the two cache columns it names. Scoped to the override's own row with `within`.

Verified load-bearing by giving the fixture a cache-read rate, which makes it report 1 where 2 is expected. Page-scoped, that mutation could have been masked by any other cell rendering an em dash.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI
- [x] Test

## Relevant issues

Follow-up to #677 (merged); no issue.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). This *is* the test change; it tightens an existing assertion rather than adding a case.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). `pnpm run lint`, `pnpm run typecheck` and the feature's Vitest suite pass. Test-only change to one dashboard spec, so the backend suites are untouched by it.
- [x] Documentation was updated where necessary. None needed.
- [x] If the API contract changed, I regenerated the OpenAPI spec. No API surface touched.
- [x] **M4 ledger:** no entry. Test-only.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 4.8 (1M context) via Claude Code.

**Any additional AI details you'd like to share:**

This is separated out because #677 merged between the review landing and the fix being pushed, so the commit ended up on a recreated branch with nowhere to go.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)