### PR TITLE
fix(dashboard): open the organization rail inside the mobile drawer

### DIFF
--- a/web/src/app/AppShell.test.tsx
+++ b/web/src/app/AppShell.test.tsx
@@ -195,14 +195,17 @@ describe("AppShell responsive layout", () => {
     expect(container.querySelector("aside")?.className).toContain("w-[4.5rem]")
   })
 
-  it("closes the drawer when the viewport grows past the mobile breakpoint", async () => {
+  it("resets the submenu and preserves focus across the mobile breakpoint", async () => {
     const { listeners } = mockMatchMedia(true)
     const user = userEvent.setup()
-    await renderShell()
+    const { container } = await renderShell()
 
     await user.click(screen.getByRole("button", { name: "Open navigation" }))
+    await user.click(
+      await screen.findByRole("button", { name: "Organization" }),
+    )
     expect(
-      screen.getByRole("button", { name: "Close navigation" }),
+      await screen.findByRole("link", { name: "Members & roles" }),
     ).toBeInTheDocument()
 
     // Simulate crossing to a desktop viewport.
@@ -215,6 +218,23 @@ describe("AppShell responsive layout", () => {
     expect(
       screen.getByRole("button", { name: "Open navigation" }),
     ).toHaveAttribute("aria-expanded", "false")
+    // The focused submenu control unmounted, but focus stays on the navigation
+    // landmark rather than falling back to the document body.
+    expect(container.querySelector("aside")).toHaveFocus()
+
+    // Returning to mobile and reopening starts at the workspace level. The
+    // submenu belongs to the drawer that framed it and cannot survive the
+    // breakpoint transition.
+    act(() => {
+      listeners.forEach((cb) => {
+        cb({ matches: true } as MediaQueryListEvent)
+      })
+    })
+    await user.click(screen.getByRole("button", { name: "Open navigation" }))
+    expect(
+      await screen.findByRole("link", { name: "API keys" }),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: "Members & roles" })).toBeNull()
   })
 
   it("closes the drawer on Escape and restores focus to the toggle", async () => {

--- a/web/src/app/AppShell.test.tsx
+++ b/web/src/app/AppShell.test.tsx
@@ -584,8 +584,137 @@ describe("AppShell entitlement and flag gating", () => {
     // In: a footer entry, not a nav section.
     const enter = await screen.findByRole("link", { name: "Organization" })
     expect(enter).toHaveAttribute("href", "/organization/members")
+    // A link on the desk, where the rail it swaps to stays on screen to read.
+    // The drawer's submenu trigger is the mobile shape of this row and must not
+    // turn up beside it.
+    expect(screen.queryByRole("button", { name: "Organization" })).toBeNull()
     // Out only exists on the other rail.
     expect(screen.queryByText(/^Back to /)).toBeNull()
+  })
+
+  it("opens the organization rail inside the mobile drawer rather than navigating", async () => {
+    mockMatchMedia(true)
+    const user = userEvent.setup()
+    await renderShell()
+
+    await user.click(screen.getByRole("button", { name: "Open navigation" }))
+    await user.click(
+      await screen.findByRole("button", { name: "Organization" }),
+    )
+
+    // The rail swapped, one level down inside the drawer: the organization's
+    // destinations are all there to choose from, and the workspace's are not.
+    expect(
+      await screen.findByRole("link", { name: "Members & roles" }),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: "API keys" })).toBeNull()
+    // Nothing navigated, so the page behind the drawer is the one the menu was
+    // opened from, and the drawer is still over it.
+    expect(screen.getByText("PAGE CONTENT")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Close navigation" }),
+    ).toHaveAttribute("aria-expanded", "true")
+    // Focus follows the level, onto the control that leaves it again: the row
+    // that opened it is gone, so without this a keyboard or AT cursor would be
+    // dropped to the top of the document.
+    expect(screen.getByRole("button", { name: /^Back to / })).toHaveFocus()
+  })
+
+  it("dismisses the drawer once a destination on that submenu is chosen", async () => {
+    mockMatchMedia(true)
+    const user = userEvent.setup()
+    await renderShell()
+
+    await user.click(screen.getByRole("button", { name: "Open navigation" }))
+    await user.click(
+      await screen.findByRole("button", { name: "Organization" }),
+    )
+    await user.click(
+      await screen.findByRole("link", { name: "Members & roles" }),
+    )
+
+    // This is the tap that navigates, so this is the tap that closes.
+    expect(
+      screen.getByRole("button", { name: "Open navigation" }),
+    ).toHaveAttribute("aria-expanded", "false")
+    expect(screen.queryByText("PAGE CONTENT")).toBeNull()
+    // And the rail is now the organization one because the route says so, which
+    // is what the way back out belongs to.
+    expect(
+      await screen.findByRole("link", { name: /^Back to / }),
+    ).toBeInTheDocument()
+  })
+
+  it("returns to the workspace menu from the submenu, without navigating", async () => {
+    mockMatchMedia(true)
+    const user = userEvent.setup()
+    await renderShell()
+
+    await user.click(screen.getByRole("button", { name: "Open navigation" }))
+    await user.click(
+      await screen.findByRole("button", { name: "Organization" }),
+    )
+    // A button, not the link the organization rail's own head is: the page
+    // under the drawer never left the workspace, so there is nowhere to go.
+    await user.click(screen.getByRole("button", { name: /^Back to / }))
+
+    expect(
+      await screen.findByRole("link", { name: "API keys" }),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: "Members & roles" })).toBeNull()
+    expect(screen.getByText("PAGE CONTENT")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Close navigation" }),
+    ).toHaveAttribute("aria-expanded", "true")
+    // Focus comes back to the row that opened the level.
+    expect(screen.getByRole("button", { name: "Organization" })).toHaveFocus()
+  })
+
+  it("unwinds one level at a time on Escape", async () => {
+    mockMatchMedia(true)
+    const user = userEvent.setup()
+    await renderShell()
+
+    await user.click(screen.getByRole("button", { name: "Open navigation" }))
+    await user.click(
+      await screen.findByRole("button", { name: "Organization" }),
+    )
+
+    // The submenu first: taking the whole drawer would be the wrong amount of
+    // dismissal when the row you were after is the level above.
+    await user.keyboard("{Escape}")
+    expect(
+      await screen.findByRole("link", { name: "API keys" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Close navigation" }),
+    ).toHaveAttribute("aria-expanded", "true")
+
+    await user.keyboard("{Escape}")
+    expect(
+      screen.getByRole("button", { name: "Open navigation" }),
+    ).toHaveAttribute("aria-expanded", "false")
+  })
+
+  it("reopens the drawer on the workspace menu, not on the level it was left in", async () => {
+    mockMatchMedia(true)
+    const user = userEvent.setup()
+    await renderShell()
+
+    await user.click(screen.getByRole("button", { name: "Open navigation" }))
+    await user.click(
+      await screen.findByRole("button", { name: "Organization" }),
+    )
+    await user.click(screen.getByRole("button", { name: "Close navigation" }))
+    await user.click(screen.getByRole("button", { name: "Open navigation" }))
+
+    // The submenu belongs to the drawer that framed it. Surviving the close
+    // would show the organization's rows to someone reopening the menu from a
+    // workspace page, with no tap of theirs to explain it.
+    expect(
+      await screen.findByRole("link", { name: "API keys" }),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: "Members & roles" })).toBeNull()
   })
 
   it("offers Create workspace to a role the server would let create one", async () => {

--- a/web/src/app/AppShell.tsx
+++ b/web/src/app/AppShell.tsx
@@ -349,6 +349,7 @@ export function AppShell() {
   const toggleRef = useRef<HTMLButtonElement>(null)
   const orgNavTriggerRef = useRef<HTMLButtonElement>(null)
   const orgNavBackRef = useRef<HTMLButtonElement>(null)
+  const restoreSidebarFocusRef = useRef(false)
   const [collapsed, setCollapsed] = useState<boolean>(readStoredCollapsed)
   const [isMobile, setIsMobile] = useState<boolean>(readIsMobile)
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
@@ -393,8 +394,12 @@ export function AppShell() {
       return
     const query = window.matchMedia(MOBILE_QUERY)
     const onChange = (event: MediaQueryListEvent) => {
+      if (!event.matches) {
+        restoreSidebarFocusRef.current =
+          asideRef.current?.contains(document.activeElement) ?? false
+        closeMobileNav()
+      }
       setIsMobile(event.matches)
-      if (!event.matches) closeMobileNav()
     }
     // Safari < 14 (and some older engines) only expose the deprecated
     // addListener/removeListener; fall back to it so the shell doesn't throw.
@@ -424,11 +429,17 @@ export function AppShell() {
   // Focus management for the mobile drawer, which is a modal overlay: move focus
   // into it when it opens and restore focus to the toggle when it closes, so
   // keyboard and screen-reader users are neither stranded inside a hidden panel
-  // nor dropped back to the top of the document. The isMobile guard means a
-  // breakpoint change to desktop (which also closes the drawer) never yanks focus
-  // to the now-hidden toggle.
+  // nor dropped back to the top of the document. A breakpoint change to desktop
+  // keeps focus on the sidebar when it came from the drawer, rather than moving
+  // it to the now-hidden toggle or losing it when the submenu unmounts.
   useEffect(() => {
-    if (!isMobile) return
+    if (!isMobile) {
+      if (restoreSidebarFocusRef.current) {
+        restoreSidebarFocusRef.current = false
+        asideRef.current?.focus()
+      }
+      return
+    }
     if (mobileNavOpen) {
       asideRef.current?.focus()
     } else if (asideRef.current?.contains(document.activeElement)) {
@@ -524,7 +535,10 @@ export function AppShell() {
           // lives in that bar. While closed it is off-canvas, so inert takes its
           // links out of the tab order and the accessibility tree until opened.
           aria-label={isMobile ? "Navigation" : undefined}
-          tabIndex={isMobile ? -1 : undefined}
+          // Programmatically focusable on both layouts so a breakpoint change
+          // can preserve focus on the navigation landmark without adding it to
+          // the natural tab order.
+          tabIndex={-1}
           inert={isMobile && !mobileNavOpen ? true : undefined}
           className={clsx(
             "flex flex-col gap-4 border-r border-border bg-background-alt p-3 focus:outline-none",

--- a/web/src/app/AppShell.tsx
+++ b/web/src/app/AppShell.tsx
@@ -7,6 +7,7 @@ import type { IconType } from "react-icons"
 import {
   FiArrowLeft,
   FiChevronDown,
+  FiChevronRight,
   FiMenu,
   FiSettings,
   FiSidebar,
@@ -312,12 +313,6 @@ export function AppShell() {
   // workspace one, so the two never render together.
   const navContext = navContextForPath(pathname)
   const inOrganization = navContext === "organization"
-  // Filtered before it is indexed, so the divider and top margin below key off
-  // the first *rendered* section rather than the first registered one.
-  const visibleSections = visibleNavSections(
-    inOrganization ? ORG_NAV_SECTIONS : NAV_SECTIONS,
-    isVisible,
-  )
   const organization = useOrganizationContext()
   const { selected: selectedWorkspace } = useSelectedWorkspace()
   // Always true in a standalone deployment, where the one session is the local
@@ -352,9 +347,39 @@ export function AppShell() {
   const asideRef = useRef<HTMLElement>(null)
   const mainRef = useRef<HTMLElement>(null)
   const toggleRef = useRef<HTMLButtonElement>(null)
+  const orgNavTriggerRef = useRef<HTMLButtonElement>(null)
+  const orgNavBackRef = useRef<HTMLButtonElement>(null)
   const [collapsed, setCollapsed] = useState<boolean>(readStoredCollapsed)
   const [isMobile, setIsMobile] = useState<boolean>(readIsMobile)
   const [mobileNavOpen, setMobileNavOpen] = useState(false)
+  // The organization rail, opened as a level *inside* the drawer rather than by
+  // going to a page. Mobile only, and it exists because the two rails are a
+  // context switch rather than a section: on the desk the footer row can change
+  // the whole rail and leave you looking at it, while on a phone the same row
+  // navigated and the drawer closed over the result, so the rail it opened was
+  // never a thing you got to read. Here the row opens that rail in place, and
+  // choosing a destination in it is what dismisses the drawer.
+  const [mobileOrgNavOpen, setMobileOrgNavOpen] = useState(false)
+
+  // Every control that leaves the drawer goes through this rather than lowering
+  // the one flag it knows about, so the submenu cannot outlive the drawer that
+  // framed it: reopening the menu from a workspace page would otherwise land
+  // back on the organization rows the last tap left showing.
+  const closeMobileNav = useCallback(() => {
+    setMobileNavOpen(false)
+    setMobileOrgNavOpen(false)
+  }, [])
+
+  // Which of the two rails is drawn. The route decides it, except on mobile,
+  // where the drawer can be one level down inside the organization rail while
+  // the page behind it is still a workspace page.
+  const showOrganizationRail = inOrganization || (isMobile && mobileOrgNavOpen)
+  // Filtered before it is indexed, so the divider and top margin below key off
+  // the first *rendered* section rather than the first registered one.
+  const visibleSections = visibleNavSections(
+    showOrganizationRail ? ORG_NAV_SECTIONS : NAV_SECTIONS,
+    isVisible,
+  )
 
   // Track the mobile breakpoint so the sidebar can render as an off-canvas
   // drawer below it and as the fixed-width rail above it. Closing the drawer when
@@ -369,7 +394,7 @@ export function AppShell() {
     const query = window.matchMedia(MOBILE_QUERY)
     const onChange = (event: MediaQueryListEvent) => {
       setIsMobile(event.matches)
-      if (!event.matches) setMobileNavOpen(false)
+      if (!event.matches) closeMobileNav()
     }
     // Safari < 14 (and some older engines) only expose the deprecated
     // addListener/removeListener; fall back to it so the shell doesn't throw.
@@ -379,17 +404,22 @@ export function AppShell() {
     }
     query.addListener(onChange)
     return () => query.removeListener(onChange)
-  }, [])
+  }, [closeMobileNav])
 
-  // Escape closes the drawer, matching the dismissible-overlay convention.
+  // Escape closes the drawer, matching the dismissible-overlay convention. The
+  // organization submenu first when it is open, so one press unwinds one level
+  // rather than taking the whole menu with it when the row you were after is
+  // the level above.
   useEffect(() => {
     if (!mobileNavOpen) return
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setMobileNavOpen(false)
+      if (event.key !== "Escape") return
+      if (mobileOrgNavOpen) setMobileOrgNavOpen(false)
+      else setMobileNavOpen(false)
     }
     window.addEventListener("keydown", onKeyDown)
     return () => window.removeEventListener("keydown", onKeyDown)
-  }, [mobileNavOpen])
+  }, [mobileNavOpen, mobileOrgNavOpen])
 
   // Focus management for the mobile drawer, which is a modal overlay: move focus
   // into it when it opens and restore focus to the toggle when it closes, so
@@ -405,6 +435,26 @@ export function AppShell() {
       toggleRef.current?.focus()
     }
   }, [isMobile, mobileNavOpen])
+
+  // The submenu is a level inside the drawer rather than a second overlay, so it
+  // moves focus the way the drawer does: onto the control that leaves the level
+  // when it opens, and back onto the row that opened it when it closes. Both
+  // controls unmount when the level changes, so without this a tap would leave
+  // focus on an element that is gone and drop a keyboard or AT cursor to the top
+  // of the document.
+  useEffect(() => {
+    if (!isMobile || !mobileNavOpen) return
+    if (mobileOrgNavOpen) {
+      orgNavBackRef.current?.focus()
+      return
+    }
+    // Only when the control that closed the level has left focus behind it. On
+    // the render that opens the drawer, focus is on the panel itself, and
+    // pulling it down to the footer would skip the whole rail.
+    if (document.activeElement === document.body) {
+      orgNavTriggerRef.current?.focus()
+    }
+  }, [isMobile, mobileNavOpen, mobileOrgNavOpen])
 
   useEffect(() => {
     try {
@@ -506,20 +556,42 @@ export function AppShell() {
           {/* The scope the rail below belongs to. In the workspace context that
               is the switcher; in the organization context it is the way back
               out, which is how the prototype leaves that rail. */}
-          {inOrganization ? (
+          {showOrganizationRail ? (
             <div className="flex min-h-14 items-center">
-              <Link
-                to={workspaceLanding?.to ?? "/"}
-                onClick={() => setMobileNavOpen(false)}
-                className={navRowClass({ collapsed: effectiveCollapsed })}
-                aria-label={effectiveCollapsed ? backLabel : undefined}
-                title={effectiveCollapsed ? backLabel : undefined}
-              >
-                <FiArrowLeft aria-hidden="true" className={NAV_ICON_CLASS} />
-                {effectiveCollapsed ? null : (
-                  <span className="min-w-0 flex-1 truncate">{backLabel}</span>
-                )}
-              </Link>
+              {inOrganization ? (
+                <Link
+                  to={workspaceLanding?.to ?? "/"}
+                  onClick={closeMobileNav}
+                  className={navRowClass({ collapsed: effectiveCollapsed })}
+                  aria-label={effectiveCollapsed ? backLabel : undefined}
+                  title={effectiveCollapsed ? backLabel : undefined}
+                >
+                  <FiArrowLeft aria-hidden="true" className={NAV_ICON_CLASS} />
+                  {effectiveCollapsed ? null : (
+                    <span className="min-w-0 flex-1 truncate">{backLabel}</span>
+                  )}
+                </Link>
+              ) : (
+                // The submenu's way back, which closes a level rather than
+                // navigating: the page under the drawer is still the workspace
+                // page you opened the menu from, so there is nothing to go back
+                // *to* yet. Same row and same name as the link above, because it
+                // means the same thing to whoever reads it and differs only in
+                // whether the route has moved yet. `cursor-pointer` because a
+                // bare button resolves to the default arrow, which is the one
+                // thing `navRowClass` leaves to its call sites.
+                <button
+                  type="button"
+                  ref={orgNavBackRef}
+                  onClick={() => setMobileOrgNavOpen(false)}
+                  className={`${navRowClass()} cursor-pointer`}
+                >
+                  <FiArrowLeft aria-hidden="true" className={NAV_ICON_CLASS} />
+                  <span className="min-w-0 flex-1 truncate text-left">
+                    {backLabel}
+                  </span>
+                </button>
+              )}
             </div>
           ) : (
             <WorkspaceSwitcher collapsed={effectiveCollapsed} />
@@ -559,7 +631,7 @@ export function AppShell() {
                           key={item.to}
                           item={item}
                           currentPath={pathname}
-                          onNavigate={() => setMobileNavOpen(false)}
+                          onNavigate={closeMobileNav}
                           isVisible={isVisible}
                           collapsed={effectiveCollapsed}
                         />
@@ -580,7 +652,7 @@ export function AppShell() {
                           collapsed={effectiveCollapsed}
                           // Tapping a destination dismisses the mobile drawer so
                           // the page it landed on is visible, not behind it.
-                          onNavigate={() => setMobileNavOpen(false)}
+                          onNavigate={closeMobileNav}
                         />
                       ),
                     )}
@@ -606,25 +678,56 @@ export function AppShell() {
                 that an operator whose sidebar used to list Users, Budgets and
                 Settings needed to find where they went. Both were true and
                 neither survives the design: the box makes the footer read as a
-                button bar under the rail rather than as the end of it, and the
-                chevron promises a submenu that never opens. */}
-            {!inOrganization && managesOrganization ? (
-              <Link
-                to={organizationLanding?.to ?? "/organization/members"}
-                onClick={() => setMobileNavOpen(false)}
-                className={navRowClass({ collapsed: effectiveCollapsed })}
-                aria-label={effectiveCollapsed ? "Organization" : undefined}
-                title={
-                  effectiveCollapsed
-                    ? "Organization: members, spend and budgets, users, settings"
-                    : undefined
-                }
-              >
-                <FiSettings aria-hidden="true" className={NAV_ICON_CLASS} />
-                {effectiveCollapsed ? null : (
-                  <span className="min-w-0 flex-1 truncate">Organization</span>
-                )}
-              </Link>
+                button bar under the rail rather than as the end of it.
+
+                Two controls for one entry, because the rail behaves differently
+                under the two layouts. On the desk it navigates, and the rail it
+                swaps to is left on screen to read. On a phone the drawer closes
+                over whatever it navigated to, so the same tap would show the
+                organization's first page and never the rail that lists the
+                rest; there the row opens that rail inside the drawer instead,
+                and a destination in it is what dismisses the drawer. That is
+                also what earns the trailing chevron back: it promises a submenu
+                only where one now opens. */}
+            {!showOrganizationRail && managesOrganization ? (
+              isMobile ? (
+                // `cursor-pointer` because a bare button resolves to the default
+                // arrow, which is the one thing `navRowClass` leaves to its call
+                // sites (its other rows are links or HeroUI buttons).
+                <button
+                  type="button"
+                  ref={orgNavTriggerRef}
+                  onClick={() => setMobileOrgNavOpen(true)}
+                  className={`${navRowClass()} cursor-pointer`}
+                >
+                  <FiSettings aria-hidden="true" className={NAV_ICON_CLASS} />
+                  <span className="min-w-0 flex-1 truncate text-left">
+                    Organization
+                  </span>
+                  <FiChevronRight
+                    aria-hidden="true"
+                    className={NAV_ICON_CLASS}
+                  />
+                </button>
+              ) : (
+                <Link
+                  to={organizationLanding?.to ?? "/organization/members"}
+                  className={navRowClass({ collapsed: effectiveCollapsed })}
+                  aria-label={effectiveCollapsed ? "Organization" : undefined}
+                  title={
+                    effectiveCollapsed
+                      ? "Organization: members, spend and budgets, users, settings"
+                      : undefined
+                  }
+                >
+                  <FiSettings aria-hidden="true" className={NAV_ICON_CLASS} />
+                  {effectiveCollapsed ? null : (
+                    <span className="min-w-0 flex-1 truncate">
+                      Organization
+                    </span>
+                  )}
+                </Link>
+              )
             ) : null}
             {/* One control, not a stack of links: the guide, appearance, and
                 sign-out all live in its menu, which is how the prototype ends
@@ -632,7 +735,7 @@ export function AppShell() {
             {/* The design rules the account row off from the row above it, so
                 the control that ends the rail is not read as one more
                 destination in the group that changes context. */}
-            {!inOrganization && managesOrganization ? (
+            {!showOrganizationRail && managesOrganization ? (
               <div aria-hidden="true" className="h-px shrink-0 bg-border" />
             ) : null}
             <AccountMenu collapsed={effectiveCollapsed} />
@@ -650,7 +753,9 @@ export function AppShell() {
               <button
                 type="button"
                 ref={toggleRef}
-                onClick={() => setMobileNavOpen((value) => !value)}
+                onClick={() =>
+                  mobileNavOpen ? closeMobileNav() : setMobileNavOpen(true)
+                }
                 aria-label={
                   mobileNavOpen ? "Close navigation" : "Open navigation"
                 }

--- a/web/src/app/ConnectionStatus.tsx
+++ b/web/src/app/ConnectionStatus.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query"
-import { useSyncExternalStore } from "react"
+import { useEffect, useState } from "react"
 
 import { ApiError } from "@/shared/api/client"
 
@@ -16,27 +16,23 @@ function isUnreachable(error: unknown): boolean {
 // same wherever the operator is standing, and it clears itself the moment a
 // request succeeds again.
 function useGatewayUnreachable(): boolean {
-  const cache = useQueryClient().getQueryCache()
+  const queryClient = useQueryClient()
+  const [unreachable, setUnreachable] = useState(false)
 
-  // Read through `useSyncExternalStore` rather than by writing a subscription
-  // into state, and that is load-bearing rather than tidying: mounting a
-  // component that holds a query builds that query into this cache *during
-  // render*, and the cache notifies its subscribers synchronously. A `setState`
-  // in that callback is therefore an update to this component while a different
-  // one is rendering, which React warns about. Swapping the sidebar's head
-  // (leaving the mobile drawer's organization submenu remounts the workspace
-  // switcher, which holds two queries) is one way to reach it. This is the API
-  // for an external store that can change mid-render.
-  return useSyncExternalStore(
-    (onStoreChange) => cache.subscribe(onStoreChange),
-    () =>
+  useEffect(() => {
+    const cache = queryClient.getQueryCache()
+    const compute = () =>
       cache
         .getAll()
         .some(
           (query) =>
             query.state.status === "error" && isUnreachable(query.state.error),
-        ),
-  )
+        )
+    setUnreachable(compute())
+    return cache.subscribe(() => setUnreachable(compute()))
+  }, [queryClient])
+
+  return unreachable
 }
 
 // A bottom-right toast that surfaces a lost backend connection at the app level,

--- a/web/src/app/ConnectionStatus.tsx
+++ b/web/src/app/ConnectionStatus.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query"
-import { useEffect, useState } from "react"
+import { useSyncExternalStore } from "react"
 
 import { ApiError } from "@/shared/api/client"
 
@@ -16,23 +16,27 @@ function isUnreachable(error: unknown): boolean {
 // same wherever the operator is standing, and it clears itself the moment a
 // request succeeds again.
 function useGatewayUnreachable(): boolean {
-  const queryClient = useQueryClient()
-  const [unreachable, setUnreachable] = useState(false)
+  const cache = useQueryClient().getQueryCache()
 
-  useEffect(() => {
-    const cache = queryClient.getQueryCache()
-    const compute = () =>
+  // Read through `useSyncExternalStore` rather than by writing a subscription
+  // into state, and that is load-bearing rather than tidying: mounting a
+  // component that holds a query builds that query into this cache *during
+  // render*, and the cache notifies its subscribers synchronously. A `setState`
+  // in that callback is therefore an update to this component while a different
+  // one is rendering, which React warns about. Swapping the sidebar's head
+  // (leaving the mobile drawer's organization submenu remounts the workspace
+  // switcher, which holds two queries) is one way to reach it. This is the API
+  // for an external store that can change mid-render.
+  return useSyncExternalStore(
+    (onStoreChange) => cache.subscribe(onStoreChange),
+    () =>
       cache
         .getAll()
         .some(
           (query) =>
             query.state.status === "error" && isUnreachable(query.state.error),
-        )
-    setUnreachable(compute())
-    return cache.subscribe(() => setUnreachable(compute()))
-  }, [queryClient])
-
-  return unreachable
+        ),
+  )
 }
 
 // A bottom-right toast that surfaces a lost backend connection at the app level,

--- a/web/src/app/nav/rowStyles.ts
+++ b/web/src/app/nav/rowStyles.ts
@@ -104,6 +104,18 @@ const ROW_FOCUS =
  * Naming the family on the shared row is what keeps the rail one typeface
  * wherever a row is rendered, rather than patching the one heading that has a
  * control inside it.
+ *
+ * Deliberately no `cursor-pointer`, and it is the one thing a call site is left
+ * to name. Nearly every element this dresses already resolves to `pointer` on
+ * its own: the leaves and the footer's desktop rows are `Link`s, so the
+ * `<a href>` takes it from the user agent, and the expand triggers and the
+ * account control carry HeroUI's `.disclosure__trigger` or `.button`, which set
+ * `cursor: var(--cursor-interactive)`. The exceptions are the mobile drawer's
+ * two bare `<button>`s, the row that opens the organization submenu and the row
+ * that leaves it again, where the user agent gives a plain button the default
+ * arrow; both add the utility themselves. It stays out of the base because here
+ * it would also outrank `status-disabled`'s `--cursor-disabled` on the account
+ * control, so a disabled row would promise a click.
  */
 const ROW_BASE = `flex min-h-11 w-full items-center gap-3 rounded-lg px-3 font-sans text-sm font-medium leading-[1.375rem] ${NAV_TRANSITION} ${ROW_FOCUS}`
 


### PR DESCRIPTION
## Description

On a phone the sidebar's **Organization** row navigated, and the drawer closed over the result. So the rail that row swaps to was never a thing you got to read: you landed on the organization's first page and had to reopen the menu to reach any of the others. On the desk the same row is fine, because the rail it swaps to stays on screen beside the page.

Below the breakpoint that row is now a submenu trigger:

- It opens the organization rail one level down **inside** the drawer, with nothing routed yet. `showOrganizationRail = inOrganization || (isMobile && mobileOrgNavOpen)` drives the section list, the head of the rail, and the footer row, so the drawer swaps to the organization's own sections.
- The tap that picks a destination in it is the tap that navigates and dismisses the drawer.
- The head of that level is a "Back to `<workspace>`" **button**, not the link the organization rail's own head is: the page under the drawer never left the workspace, so there is nothing to go back to yet.
- Escape unwinds one level at a time (the submenu, then the drawer). Closing or reopening the drawer returns to the workspace menu, and crossing to a desktop viewport drops both, so a submenu cannot outlive the drawer that framed it.
- Focus follows the level in each direction. A breakpoint change that unmounts the submenu keeps focus on the navigation landmark.
- The trailing chevron is back on the row, now that it promises a submenu that opens. `rowStyles.ts` explains why those two bare buttons name `cursor-pointer` themselves while the shared row still does not.

**Desktop behavior is unchanged**: the row is still a `Link` to the remembered organization location, and the submenu trigger never renders beside it.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None filed; reported directly.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change, including opening without navigating, destination dismissal, back navigation, Escape unwinding, drawer and breakpoint resets, focus restoration, and unchanged desktop linking.
- [x] I ran the dashboard Definition of Done checks on Node 22: Biome checked 217 files, TypeScript passed, all 1,145 Vitest tests passed, and the production build succeeded.
- [x] Documentation was updated where necessary (the reasoning comments in `AppShell.tsx` and `rowStyles.ts`; no user-facing guide text changes, since the row keeps its name and its destinations).
- [x] If the API contract changed, I regenerated the OpenAPI spec. Not applicable: no backend change.

Not verified in a browser: signing in needs the deployment's master key. The behavior is covered at the `matchMedia` level in Vitest, and the mobile screenshot projects capture pages rather than menu states.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 5 in Claude Code and OpenAI Codex

**Any additional AI details you'd like to share:**

The bug report, the "treat Organization as a submenu" framing, and the scope (mobile only, no desktop change) came from the maintainer. AI agents implemented the change, added the tests, addressed review feedback, and prepared this description.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added mobile organization submenu navigation inside the drawer.
- Added back navigation, Escape handling, focus restoration, breakpoint reset, and drawer reset behavior.
- Preserved direct organization links on desktop.
- Updated `ConnectionStatus` to subscribe to query-cache state safely.
- Expanded `AppShell` tests for mobile and desktop navigation behavior.
- Documented cursor behavior for shared navigation row styles.

These changes make mobile organization navigation more predictable while preserving existing desktop behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->