### PR TITLE
test(usage): take the fuse out of the external-events fixture

### DIFF
--- a/tests/integration/test_external_usage_events.py
+++ b/tests/integration/test_external_usage_events.py
@@ -4,6 +4,7 @@ Covers auth, content-free validation, idempotency, historical + cache pricing,
 budget isolation, and the read-surface (source filter, by_source, CSV).
 """
 
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
@@ -48,10 +49,25 @@ def _seed_pricing(
     assert resp.status_code == 200, resp.text
 
 
+# An hour ago, not a fixed date. `GET /v1/usage/summary` bounds itself to the
+# last 30 days when the caller names no window (`_DEFAULT_SUMMARY_LOOKBACK`), so
+# a literal timestamp puts every summary assertion in this file on a fuse: it
+# passes until the day the clock is 30 days past it, then fails everywhere at
+# once with nothing in the diff to explain it. That day was 2026-08-21, between
+# one green run on `main` and the next.
+#
+# The per-run pricing revision this would churn on a *shared* database (see
+# `web/e2e/parity-data.ts`, which backdates for exactly that reason) is not a
+# concern here: the integration fixtures own their database and drop it in
+# teardown.
+def _event_timestamp() -> str:
+    return (datetime.now(UTC) - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+
+
 def _event(source_event_id: str = "req_1", **overrides: Any) -> dict[str, Any]:
     event: dict[str, Any] = {
         "source_event_id": source_event_id,
-        "timestamp": "2026-07-22T12:34:56Z",
+        "timestamp": _event_timestamp(),
         "provider": "anthropic",
         "model": "claude-sonnet-4-6",
         "status": "success",
@@ -326,6 +342,9 @@ def test_historical_pricing(
     """An event is priced at the rate effective at its own timestamp."""
     _seed_user(client, master_key_header)
     # Old cheap rate effective a year before the event; new expensive rate after.
+    # Both relative to the event, for the reason `_event_timestamp` gives: the
+    # boundary this test is about is "before and after the event", never a date.
+    now = datetime.now(UTC)
     _seed_pricing(
         client,
         master_key_header,
@@ -333,7 +352,7 @@ def test_historical_pricing(
         output_price=1.0,
         cache_read_price=0.0,
         cache_write_price=0.0,
-        effective_at="2025-01-01T00:00:00Z",
+        effective_at=(now - timedelta(days=365)).isoformat().replace("+00:00", "Z"),
     )
     _seed_pricing(
         client,
@@ -342,10 +361,10 @@ def test_historical_pricing(
         output_price=1000.0,
         cache_read_price=0.0,
         cache_write_price=0.0,
-        effective_at="2026-07-23T00:00:00Z",
+        effective_at=(now + timedelta(days=1)).isoformat().replace("+00:00", "Z"),
     )
 
-    # Event timestamp (2026-07-22) precedes the new rate, so the cheap rate applies.
+    # The event is an hour old, so it precedes the new rate and is priced cheap.
     resp = _post(
         client,
         master_key_header,


### PR DESCRIPTION
## Description

`main` has been red since 13:02 UTC today, and nothing merged in the window that touched usage.

`_event` in `tests/integration/test_external_usage_events.py` stamped every imported event `2026-07-22T12:34:56Z`, while two of the tests in the file read `GET /v1/usage/summary` without naming a window. That endpoint bounds itself to the last 30 days when the caller names none (`_DEFAULT_SUMMARY_LOOKBACK`), so the fixture's row sat inside the window until the clock passed 30 days from it and then fell out. The last green run on `main` was 12:20 UTC; the boundary was crossed at 12:34 UTC.

The timestamp is now an hour before whenever the test runs. The one test that genuinely cares about the date, pricing at the rate effective at the event's own timestamp, derives both of its rates from the event rather than naming years: the boundary it is about is "before and after the event", never a calendar date.

The per-run pricing revision a clock-derived `effective_at` would churn on a shared database (which is why `web/e2e/parity-data.ts` deliberately backdates its own) is not a concern here: the integration fixtures own their database and drop it in teardown.

`test_usage_summary.py`'s fixed dates are all paired with explicit `start_date`/`end_date`, so this file was the only one with the fuse lit.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None. Found while a PR's CI went red without the PR having changed anything near it.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Verified: the 19 tests in that file, the 179 usage-related integration tests, `uv run mypy`, and `ruff`. No source change, so no generated artifact moves.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 5 (1M context) via Claude Code

**Any additional AI details you'd like to share:**

Found by reproducing the failure on `main` with the PR's commits absent, then bisecting to a commit whose CI was green, which is what pointed at the clock rather than at a change.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the integration test fixture to use a recent event timestamp.
- Adjusted pricing test dates relative to the event timestamp.
- Prevented failures caused by the default 30-day usage window and fixed calendar dates.
- No source or generated artifacts changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->