### PR TITLE
feat(mcp): let a workspace configure its own MCP servers

### DIFF
--- a/alembic/versions/c5e9a1d3f7b2_add_workspace_mcp_servers.py
+++ b/alembic/versions/c5e9a1d3f7b2_add_workspace_mcp_servers.py
@@ -1,0 +1,61 @@
+"""Add the workspace-scoped MCP server table.
+
+One row is one MCP server a workspace has configured: a URL, an optional
+bearer token encrypted with ``OTARI_SECRET_KEY``, and the purpose hint and
+tool allow-list the tool loop already understands from an inline
+``mcp_servers`` entry. A request references them by id with
+``mcp_server_ids``, which until now was hybrid-only.
+
+``(workspace_id, name)`` is unique: the name is how an operator and the tool
+loop both identify a server, so two rows sharing one within a workspace would
+silently hide a server rather than fail.
+
+``workspace_id`` cascades, matching ``workspace_budget_defaults`` and the
+provider-key tables: this is a workspace-owned configuration row, not durable
+request-plane history like ``usage_logs`` or ``api_keys``.
+
+Revision ID: c5e9a1d3f7b2
+Revises: b3d5f7a9c1e6
+Create Date: 2026-08-21
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c5e9a1d3f7b2"
+down_revision: str | Sequence[str] | None = "b3d5f7a9c1e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_UNIQUE_NAME = "uq_workspace_mcp_servers_workspace_name"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workspace_mcp_servers",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("workspace_id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("url", sa.String(), nullable=False),
+        sa.Column("encrypted_token", sa.Text(), nullable=True),
+        sa.Column("purpose_hint", sa.Text(), nullable=True),
+        sa.Column("allowed_tools", sa.JSON(), nullable=True),
+        sa.Column("enabled", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspace.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("workspace_id", "name", name=_UNIQUE_NAME),
+    )
+    op.create_index(
+        op.f("ix_workspace_mcp_servers_workspace_id"),
+        "workspace_mcp_servers",
+        ["workspace_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_workspace_mcp_servers_workspace_id"), table_name="workspace_mcp_servers")
+    op.drop_table("workspace_mcp_servers")

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -8,10 +8,12 @@ Add MCP as a top-level request field, not a `tools` entry.
 Use either or both of:
 
 - `mcp_servers`: inline MCP server configs the gateway should connect to directly
-- `mcp_server_ids`: workspace-scoped MCP server ids resolved through otari.ai (hybrid mode only)
+- `mcp_server_ids`: ids of MCP servers your workspace has configured
 
-In hybrid mode, Otari resolves `mcp_server_ids` first and appends the resulting
-server configs to any inline `mcp_servers`.
+Otari resolves `mcp_server_ids` first and appends the resulting server configs
+to any inline `mcp_servers`. Where it resolves them depends on the mode:
+standalone reads the servers the workspace configured on this gateway, hybrid
+resolves them through otari.ai.
 
 When the model emits an MCP tool call, Otari:
 
@@ -46,10 +48,10 @@ The loop stops when the model returns a normal assistant response or hits
 - `purpose_hint`: optional hint Otari prepends to the system message to help the model choose the tool
 - `allowed_tools`: optional allow-list; only these tools are exposed from that server
 
-## Workspace-scoped servers (hybrid only)
+## Workspace-scoped servers
 
-In hybrid mode, you can reference servers stored in otari.ai by id instead of
-inlining their configs:
+Reference servers your workspace has configured by id, instead of inlining
+their configs:
 
 ```json
 {
@@ -59,13 +61,52 @@ inlining their configs:
 }
 ```
 
-Otari resolves those ids through the platform before the request runs. In
-standalone mode, `mcp_server_ids` returns `400`.
+The workspace is the one your API key belongs to; it is never read from a
+header. An id that names no server in that workspace returns `404`, and a
+server that is configured but disabled is skipped rather than refusing the
+request.
+
+### Configuring them (standalone)
+
+Manage a workspace's servers with the master key, under
+`/v1/workspaces/{workspace_id}/mcp-servers`:
+
+```bash
+curl -X POST http://localhost:8000/v1/workspaces/$WORKSPACE_ID/mcp-servers \
+  -H "Otari-Key: $OTARI_MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "github",
+        "url": "https://mcp.example.com/github",
+        "authorization_token": "ghp_...",
+        "purpose_hint": "Use for repository and issue lookups",
+        "allowed_tools": ["list_issues", "get_issue"]
+      }'
+```
+
+`GET` lists them, `PATCH /{server_id}` updates one, and `DELETE /{server_id}`
+removes it. Every operation, including the list, needs an organization
+owner/admin or an owner/admin of that workspace.
+
+- The `authorization_token` is encrypted at rest with `OTARI_SECRET_KEY` and is
+  never returned. Responses carry `has_token` instead. On a `PATCH`, omit the
+  field to leave the stored token alone, send `""` to clear it, or send a value
+  to rotate it.
+- `name` is unique within a workspace; a duplicate is refused with `409`.
+- `enabled: false` keeps the row and its token but takes the server out of
+  every request that names it.
+- The URL is checked for SSRF safety when it is stored as well as when a
+  request uses it, and must be `https://` when a token is set.
+- A workspace may configure up to 50 servers.
+
+In hybrid mode these routes are not mounted: the servers live in otari.ai and
+are managed there.
 
 ## Limits and safety
 
 - `mcp_servers` and `mcp_server_ids` cannot be combined with `otari_code_execution` or `otari_web_search` in the same request yet
 - `max_tool_iterations` optionally caps the loop; default is `10`, max is `25`
+- `mcp_server_ids` accepts at most 50 ids, which is also the most servers a workspace can have
 - MCP URLs are validated to reduce SSRF risk; by default, private and reserved addresses are blocked, loopback is allowed, and `http://` is rejected when `authorization_token` is present
 - `OTARI_MCP_ALLOW_LOOPBACK=false` disables loopback; `OTARI_MCP_ALLOW_PRIVATE_HOSTS=true` relaxes the private-host restriction
 

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1667,6 +1667,7 @@
                   "format": "uuid",
                   "type": "string"
                 },
+                "maxItems": 50,
                 "type": "array"
               },
               {
@@ -4538,6 +4539,7 @@
                   "format": "uuid",
                   "type": "string"
                 },
+                "maxItems": 50,
                 "type": "array"
               },
               {
@@ -6944,6 +6946,7 @@
                   "format": "uuid",
                   "type": "string"
                 },
+                "maxItems": 50,
                 "type": "array"
               },
               {
@@ -10966,6 +10969,242 @@
           "name"
         ],
         "title": "WorkspaceCreate",
+        "type": "object"
+      },
+      "WorkspaceMcpServerCreate": {
+        "description": "Request body for registering a server.\n\n``authorization_token`` is never stored as sent: it is encrypted with\n``OTARI_SECRET_KEY`` and only the ciphertext is kept, the same convention\n`entities.ProviderCredential` and `OrgProviderKey` already use.",
+        "properties": {
+          "allowed_tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "maxLength": 256,
+                  "type": "string"
+                },
+                "maxItems": 200,
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Allow-list of tool names; null exposes every tool the server offers",
+            "title": "Allowed Tools"
+          },
+          "authorization_token": {
+            "anyOf": [
+              {
+                "maxLength": 8192,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Bearer token for the server; requires an https URL. Encrypted at rest, never returned",
+            "title": "Authorization Token"
+          },
+          "enabled": {
+            "default": true,
+            "description": "Whether a request naming this server actually reaches it",
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "name": {
+            "description": "Label for the server, unique within the workspace",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "purpose_hint": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Hint prepended to the system message to help the model choose",
+            "title": "Purpose Hint"
+          },
+          "url": {
+            "description": "Streamable HTTP MCP endpoint",
+            "maxLength": 2048,
+            "minLength": 1,
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "url"
+        ],
+        "title": "WorkspaceMcpServerCreate",
+        "type": "object"
+      },
+      "WorkspaceMcpServerPublic": {
+        "description": "The API-facing shape. Never carries the token, only whether one is set.\n\nNo ``last4``-style prefix either, unlike `OrgProviderKeyPublic`: a provider\nkey's last four digits let an operator match a stored key against the one\nin their provider's console, and there is no equivalent workflow for an MCP\nbearer token.",
+        "properties": {
+          "allowed_tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Tools"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "has_token": {
+            "title": "Has Token",
+            "type": "boolean"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "purpose_hint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Purpose Hint"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          },
+          "url": {
+            "title": "Url",
+            "type": "string"
+          },
+          "workspace_id": {
+            "format": "uuid",
+            "title": "Workspace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "workspace_id",
+          "name",
+          "url",
+          "purpose_hint",
+          "allowed_tools",
+          "enabled",
+          "has_token",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "WorkspaceMcpServerPublic",
+        "type": "object"
+      },
+      "WorkspaceMcpServerUpdate": {
+        "description": "Partial update. Only the fields the caller sets are applied.\n\n``authorization_token`` has three states rather than two, which is what a\nwrite-only field needs: omit it to leave the stored token alone, send\n``\"\"`` to clear it, send a value to rotate it. An explicit ``null`` also\nleaves it alone, matching the platform: a client that serializes its whole\nform back, with an empty token box it never filled in, must not destroy a\ntoken it was never shown.",
+        "properties": {
+          "allowed_tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "maxLength": 256,
+                  "type": "string"
+                },
+                "maxItems": 200,
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Tools"
+          },
+          "authorization_token": {
+            "anyOf": [
+              {
+                "maxLength": 8192,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Authorization Token"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "name": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "purpose_hint": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Purpose Hint"
+          },
+          "url": {
+            "maxLength": 2048,
+            "minLength": 1,
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "title": "WorkspaceMcpServerUpdate",
+        "type": "object"
+      },
+      "WorkspaceMcpServersPublic": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceMcpServerPublic"
+            },
+            "title": "Data",
+            "type": "array"
+          }
+        },
+        "required": [
+          "data",
+          "count"
+        ],
+        "title": "WorkspaceMcpServersPublic",
         "type": "object"
       },
       "WorkspaceMemberBudgetPoliciesPublic": {
@@ -20786,6 +21025,277 @@
         "summary": "Create Workspace Activation Key",
         "tags": [
           "workspace-activation"
+        ]
+      }
+    },
+    "/v1/workspaces/{workspace_id}/mcp-servers": {
+      "get": {
+        "description": "List the MCP servers configured for a workspace.\n\nOrganization owners/admins or this workspace's owners/admins. Reads are\ngated like writes because these rows name the endpoints the gateway\nconnects to on the workspace's behalf. Authorization tokens are never\nincluded; each server reports only whether it has one.",
+        "operationId": "list_workspace_mcp_servers_v1_workspaces__workspace_id__mcp_servers_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Number of records to skip",
+            "in": "query",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of records to skip",
+              "minimum": 0,
+              "title": "Skip",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "description": "Maximum number of records to return",
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceMcpServersPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "List Workspace Mcp Servers",
+        "tags": [
+          "mcp-servers"
+        ]
+      },
+      "post": {
+        "description": "Register an MCP server for a workspace. Organization owners/admins or this workspace's owners/admins.\n\nThe authorization token is encrypted at rest and never returned. The URL\nis checked for SSRF safety here as well as on the request path, and must\nuse https when a token is set. A name already used in this workspace is\nrefused with a 409.",
+        "operationId": "create_workspace_mcp_server_v1_workspaces__workspace_id__mcp_servers_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceMcpServerCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceMcpServerPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Create Workspace Mcp Server",
+        "tags": [
+          "mcp-servers"
+        ]
+      }
+    },
+    "/v1/workspaces/{workspace_id}/mcp-servers/{server_id}": {
+      "delete": {
+        "description": "Delete a server and the token stored with it. Organization owners/admins or this workspace's owners/admins.",
+        "operationId": "delete_workspace_mcp_server_v1_workspaces__workspace_id__mcp_servers__server_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "server_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Server Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Delete Workspace Mcp Server",
+        "tags": [
+          "mcp-servers"
+        ]
+      },
+      "patch": {
+        "description": "Update a server. Organization owners/admins or this workspace's owners/admins.\n\nOnly the fields sent are applied. Omit `authorization_token` to leave the\nstored token alone, send an empty string to clear it, or send a value to\nrotate it.",
+        "operationId": "update_workspace_mcp_server_v1_workspaces__workspace_id__mcp_servers__server_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Workspace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "server_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Server Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceMcpServerUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceMcpServerPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Update Workspace Mcp Server",
+        "tags": [
+          "mcp-servers"
         ]
       }
     },

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -5520,6 +5520,173 @@
     {
       "item": [
         {
+          "name": "List Workspace Mcp Servers",
+          "request": {
+            "description": "List the MCP servers configured for a workspace.\n\nOrganization owners/admins or this workspace's owners/admins. Reads are\ngated like writes because these rows name the endpoints the gateway\nconnects to on the workspace's behalf. Authorization tokens are never\nincluded; each server reports only whether it has one.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "workspaces",
+                ":workspace_id",
+                "mcp-servers"
+              ],
+              "query": [
+                {
+                  "description": "Number of records to skip",
+                  "disabled": true,
+                  "key": "skip",
+                  "value": ""
+                },
+                {
+                  "description": "Maximum number of records to return",
+                  "disabled": true,
+                  "key": "limit",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/workspaces/:workspace_id/mcp-servers?skip=&limit=",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "workspace_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Create Workspace Mcp Server",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"name\": \"string\",\n  \"url\": \"string\"\n}"
+            },
+            "description": "Register an MCP server for a workspace. Organization owners/admins or this workspace's owners/admins.\n\nThe authorization token is encrypted at rest and never returned. The URL\nis checked for SSRF safety here as well as on the request path, and must\nuse https when a token is set. A name already used in this workspace is\nrefused with a 409.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "workspaces",
+                ":workspace_id",
+                "mcp-servers"
+              ],
+              "raw": "{{baseUrl}}/v1/workspaces/:workspace_id/mcp-servers",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "workspace_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Update Workspace Mcp Server",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"allowed_tools\": [\n    \"string\"\n  ],\n  \"authorization_token\": \"string\",\n  \"enabled\": false,\n  \"name\": \"string\",\n  \"purpose_hint\": \"string\",\n  \"url\": \"string\"\n}"
+            },
+            "description": "Update a server. Organization owners/admins or this workspace's owners/admins.\n\nOnly the fields sent are applied. Omit `authorization_token` to leave the\nstored token alone, send an empty string to clear it, or send a value to\nrotate it.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "PATCH",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "workspaces",
+                ":workspace_id",
+                "mcp-servers",
+                ":server_id"
+              ],
+              "raw": "{{baseUrl}}/v1/workspaces/:workspace_id/mcp-servers/:server_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "workspace_id",
+                  "value": ""
+                },
+                {
+                  "description": "path parameter",
+                  "key": "server_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Workspace Mcp Server",
+          "request": {
+            "description": "Delete a server and the token stored with it. Organization owners/admins or this workspace's owners/admins.",
+            "header": [],
+            "method": "DELETE",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "workspaces",
+                ":workspace_id",
+                "mcp-servers",
+                ":server_id"
+              ],
+              "raw": "{{baseUrl}}/v1/workspaces/:workspace_id/mcp-servers/:server_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "workspace_id",
+                  "value": ""
+                },
+                {
+                  "description": "path parameter",
+                  "key": "server_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "name": "mcp-servers"
+    },
+    {
+      "item": [
+        {
           "name": "List Workspace Budget Defaults",
           "request": {
             "description": "List the budget defaults attached to a workspace. Any member may read it.",

--- a/scripts/sdk_codegen/sdk-endpoints.txt
+++ b/scripts/sdk_codegen/sdk-endpoints.txt
@@ -240,3 +240,11 @@ DELETE /v1/workspaces/{workspace_id}/provider-keys/{key_id}               # dash
 GET /v1/workspaces/{workspace_id}/provider-keys/{key_id}/models           # dashboard-only
 POST /v1/workspaces/{workspace_id}/provider-keys/{key_id}/models          # dashboard-only
 DELETE /v1/workspaces/{workspace_id}/provider-keys/{key_id}/models/{model} # dashboard-only
+# Workspace-scoped MCP servers (otari#658): a master-key operator surface for
+# registering the endpoints a workspace's requests may reach, alongside the
+# tenancy admin rows above. An SDK caller does not manage these; it names them
+# by id in `mcp_server_ids` on a completion request, which is already covered.
+GET /v1/workspaces/{workspace_id}/mcp-servers                             # operator surface
+POST /v1/workspaces/{workspace_id}/mcp-servers                            # operator surface
+PATCH /v1/workspaces/{workspace_id}/mcp-servers/{server_id}               # operator surface
+DELETE /v1/workspaces/{workspace_id}/mcp-servers/{server_id}              # operator surface

--- a/src/gateway/AGENTS.md
+++ b/src/gateway/AGENTS.md
@@ -97,8 +97,17 @@ workspace row is a veto and a refinement and never a grant, and no row means no 
 (MCP, which has no deployment-level server list to narrow, is the stated exception). The
 question is [#655](https://github.com/mozilla-ai/otari/issues/655) and the reasoning is in
 the PR that answered it,
-[#678](https://github.com/mozilla-ai/otari/pull/678). Read both before building any of
-#654, #656, #657 or #658, each of which settles its own surface under the rule above.
+[#678](https://github.com/mozilla-ai/otari/pull/678). Read both before building
+any of #654, #656 or #657, each of which settles its own surface under the rule above.
+
+MCP's own surface is the one that has landed (#658). `workspace_mcp_servers`
+(`models/entities.py`) holds a workspace's configured servers, with the bearer token
+encrypted by the same `secret_box` the two stores above use; it is managed over
+`/v1/workspaces/{workspace_id}/mcp-servers` through
+`services/tenancy/workspace_mcp_server_service.py`, and read on the request path by
+`_pipeline._resolve_mcp_server_ids`, the standalone half of an `mcp_server_ids` field the
+platform answers in hybrid mode. There is no overlay and no cache: it resolves per
+request against `ctx.db`, which is what the decision above says the seam should do.
 
 ## The first-request setup guide
 `services/tenancy/workspace_activation_service.py` is the state behind the dashboard's setup guide (`routes/workspace_activation.py`, `/v1/workspaces/{id}/activation`): whether to offer it, the API key it hands out, what the workspace's traffic says about the attempt, and the dismissal that retires it. Ported from the platform's `WorkspaceActivationService`, and the one departure to know is that **activation is derived, not recorded**: the first successful `source="gateway"` row in `usage_logs` for the workspace *is* the evidence, read through `ix_usage_logs_workspace_source_status_timestamp`. The platform stores that telemetry in columns because its usage pipeline is asynchronous and crosses services; here the row is written by this process into this database, so a second copy could only drift. `workspace_activation_state` therefore holds one row per workspace carrying what cannot be observed elsewhere (the dismissal, when a key was last issued, and which key it was).

--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -42,6 +42,7 @@ from gateway.api.routes import (
     usage,
     users,
     workspace_activation,
+    workspace_mcp_servers,
     workspace_member_budget_policies,
     workspaces,
 )
@@ -86,6 +87,7 @@ def register_routers(app: FastAPI, config: GatewayConfig) -> None:
     app.include_router(invitations.router)
     app.include_router(workspace_member_budget_policies.router)
     app.include_router(workspace_activation.router)
+    app.include_router(workspace_mcp_servers.router)
     app.include_router(org_provider_keys.org_router)
     app.include_router(org_provider_keys.workspace_router)
     app.include_router(budgets.router)

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -33,6 +33,7 @@ Settlement invariants owned here:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import time
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine
@@ -156,7 +157,10 @@ from gateway.services.sandbox_backend import (
     SandboxNotReachableError,
 )
 from gateway.services.scoped_budget_service import BudgetScopeRequest
+from gateway.services.secret_box import SecretBoxUnavailableError, SecretDecryptionError
+from gateway.services.tenancy.errors import WorkspaceMcpServerNotFoundError
 from gateway.services.tenancy.org_provider_key_service import cached_org_model_restriction
+from gateway.services.tenancy.workspace_mcp_server_service import resolve_workspace_mcp_servers
 from gateway.services.tool_usage import (
     MAX_TOOL_NAMES,
     OVERFLOW_TOOL_NAME,
@@ -188,7 +192,8 @@ ChunkT = TypeVar("ChunkT")
 DB_UNAVAILABLE_DETAIL = "Database session unavailable"
 API_KEY_VALIDATION_FAILED_DETAIL = "API key validation failed"
 API_KEY_NO_USER_DETAIL = "API key has no associated user"
-MCP_SERVER_IDS_HYBRID_ONLY_DETAIL = "mcp_server_ids is only available in hybrid mode"
+MCP_SERVER_IDS_UNAVAILABLE_DETAIL = "mcp_server_ids is unavailable for this request"
+MCP_SERVER_TOKEN_UNREADABLE_DETAIL = "A configured MCP server's authorization token could not be read"
 NO_RESOLVABLE_PROVIDER_DETAIL = "Authorization service returned no resolvable provider"
 PROVIDER_ERROR_DETAIL = "LLM provider error"
 PROVIDER_TIMEOUT_DETAIL = "LLM provider timeout"
@@ -1624,6 +1629,47 @@ def merge_policy_guardrails(
     return list(merged.values())
 
 
+async def _resolve_mcp_server_ids(
+    adapter: FormatAdapter[Any, Any],
+    ctx: RequestContext,
+    mcp_server_ids: list[uuid.UUID],
+) -> list[McpServerConfig]:
+    """Swap a request's ``mcp_server_ids`` for the configs they name.
+
+    One field, two sources, chosen by mode: hybrid asks the platform, which
+    owns the workspace's stored servers there, and standalone reads
+    ``workspace_mcp_servers`` for the workspace the request's key belongs to
+    (otari#658). The workspace is `RequestContext.workspace_id`, resolved at
+    auth off the key and never from a header, which is the seam otari#655
+    settled; MCP is the exception that decision names, since there is no
+    deployment-wide server list for a workspace row to narrow.
+
+    Both modes refuse an unknown id with a 404, so a caller moving between them
+    sees one contract. A standalone request with no database session or no
+    resolved workspace cannot resolve anything, and is refused rather than
+    served with the ids silently dropped.
+    """
+    if ctx.hybrid_mode:
+        assert ctx.user_token is not None  # guaranteed by the hybrid-mode preamble
+        return await _resolve_platform_mcp_servers(
+            config=ctx.config,
+            user_token=ctx.user_token,
+            mcp_server_ids=mcp_server_ids,
+        )
+
+    if ctx.db is None or ctx.workspace_id is None:
+        raise adapter.error(400, MCP_SERVER_IDS_UNAVAILABLE_DETAIL, ErrorKind.INVALID_REQUEST)
+    try:
+        return await resolve_workspace_mcp_servers(ctx.db, workspace_id=ctx.workspace_id, server_ids=mcp_server_ids)
+    except WorkspaceMcpServerNotFoundError as exc:
+        raise adapter.error(404, exc.message, ErrorKind.INVALID_REQUEST) from exc
+    except (SecretBoxUnavailableError, SecretDecryptionError) as exc:
+        # The operator's problem, not the caller's, and the underlying message
+        # names the environment variable, so it stays in the log.
+        logger.error("MCP server token could not be decrypted for workspace %s: %s", ctx.workspace_id, exc)
+        raise adapter.error(500, MCP_SERVER_TOKEN_UNREADABLE_DETAIL, ErrorKind.API) from exc
+
+
 async def prepare_gateway_tools(
     *,
     adapter: FormatAdapter[Any, Any],
@@ -1643,9 +1689,9 @@ async def prepare_gateway_tools(
     ``block``-mode flags raise 403 here (provider never called);
     ``monitor``-mode flags annotate the response header and fall through.
 
-    ``mcp_server_ids`` is hybrid-only: standalone mode has no platform to
-    resolve the ids against, so the field is rejected with a 400 rather than
-    silently ignored. The sandbox and web_search opt-ins follow the wire shape
+    ``mcp_server_ids`` resolves against the platform in hybrid mode and against
+    the request's own workspace in standalone; see
+    :func:`_resolve_mcp_server_ids`. The sandbox and web_search opt-ins follow the wire shape
     of Anthropic / OpenAI tool entries; their backend URLs are operator
     controlled (no per-request URL override, which would be an SSRF surface).
     The three backends are mutually exclusive for now.
@@ -1662,16 +1708,8 @@ async def prepare_gateway_tools(
             merge_policy_guardrails(ctx, guardrails), guardrail_text, response=response, config=ctx.config
         )
 
-        if mcp_server_ids and not ctx.hybrid_mode:
-            raise adapter.error(400, MCP_SERVER_IDS_HYBRID_ONLY_DETAIL, ErrorKind.INVALID_REQUEST)
-        if ctx.hybrid_mode and mcp_server_ids:
-            assert ctx.user_token is not None  # guaranteed by the hybrid-mode preamble
-            resolved_mcp_servers = await _resolve_platform_mcp_servers(
-                config=ctx.config,
-                user_token=ctx.user_token,
-                mcp_server_ids=mcp_server_ids,
-            )
-            mcp_servers = (mcp_servers or []) + resolved_mcp_servers
+        if mcp_server_ids:
+            mcp_servers = (mcp_servers or []) + await _resolve_mcp_server_ids(adapter, ctx, mcp_server_ids)
 
         if mcp_servers:
             await _validate_mcp_server_urls(adapter, mcp_servers)
@@ -1792,6 +1830,23 @@ async def prepare_gateway_tools(
         await _require_tool_pricing(adapter, ctx, use_sandbox=use_sandbox, use_web_search=use_web_search)
     except HTTPException:
         await release_reservation(ctx)
+        raise
+    except SQLAlchemyError:
+        # Two reads in this block touch the database (the workspace MCP servers
+        # above, and `_require_tool_pricing`), and a failure in either is not an
+        # `HTTPException`, so without this arm it would leave `users.reserved`
+        # holding the estimate until the budget's next reset, or forever for a
+        # budget with no reset period. The rollback comes first because a failed
+        # statement leaves the session unusable and `release_reservation` writes:
+        # releasing on a poisoned session raises `PendingRollbackError` and the
+        # hold survives anyway. Both calls are best-effort so a database that is
+        # still refusing work re-raises the original failure rather than a
+        # confusing second one.
+        if ctx.db is not None:
+            with contextlib.suppress(SQLAlchemyError):
+                await ctx.db.rollback()
+        with contextlib.suppress(SQLAlchemyError):
+            await release_reservation(ctx)
         raise
 
     return ToolContext(

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -41,7 +41,7 @@ from gateway.core.config import GatewayConfig
 from gateway.core.usage import GatewayUsage
 from gateway.log_config import logger
 from gateway.models.guardrails import GuardrailConfig
-from gateway.models.mcp import McpServerConfig
+from gateway.models.mcp import MAX_MCP_SERVER_IDS, McpServerConfig
 from gateway.services.log_writer import LogWriter
 from gateway.services.mcp_loop import (
     MAX_TOOL_ITERATIONS_CAP,
@@ -110,7 +110,9 @@ class ChatCompletionRequest(derive_request_base(CompletionParams)):  # type: ign
         return v
 
     mcp_servers: list[McpServerConfig] | None = None
-    mcp_server_ids: list[uuid.UUID] | None = None
+    # Bounded on the list arm, not the union, so the ceiling caps the number of
+    # ids rather than the length of any one value (see `core/sql.MAX_FILTER_VALUES`).
+    mcp_server_ids: Annotated[list[uuid.UUID], Field(max_length=MAX_MCP_SERVER_IDS)] | None = None
     guardrails: list[GuardrailConfig] | None = Field(default=None, max_length=8)
     tools_header: str | None = Field(
         default=None,

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -53,7 +53,7 @@ from gateway.core.config import GatewayConfig
 from gateway.core.usage import GatewayUsage
 from gateway.log_config import logger
 from gateway.models.guardrails import GuardrailConfig
-from gateway.models.mcp import McpServerConfig
+from gateway.models.mcp import MAX_MCP_SERVER_IDS, McpServerConfig
 from gateway.services.log_writer import LogWriter
 from gateway.services.mcp_loop import ToolBackend
 from gateway.services.mcp_loop_messages import (
@@ -88,7 +88,9 @@ class MessagesRequest(derive_request_base(MessagesParams)):  # type: ignore[misc
 
     # Gateway-internal: identical semantics to ChatCompletionRequest.
     mcp_servers: list[McpServerConfig] | None = None
-    mcp_server_ids: list[uuid.UUID] | None = None
+    # Bounded on the list arm, not the union, so the ceiling caps the number of
+    # ids rather than the length of any one value (see `core/sql.MAX_FILTER_VALUES`).
+    mcp_server_ids: Annotated[list[uuid.UUID], Field(max_length=MAX_MCP_SERVER_IDS)] | None = None
     guardrails: list[GuardrailConfig] | None = Field(default=None, max_length=8)
     tools_header: str | None = None
     max_tool_iterations: int | None = Field(default=None, ge=1, le=MAX_TOOL_ITERATIONS_CAP)

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -41,7 +41,7 @@ from gateway.core.config import GatewayConfig
 from gateway.core.usage import GatewayUsage
 from gateway.log_config import logger
 from gateway.models.guardrails import GuardrailConfig
-from gateway.models.mcp import McpServerConfig
+from gateway.models.mcp import MAX_MCP_SERVER_IDS, McpServerConfig
 from gateway.services.log_writer import LogWriter
 from gateway.services.mcp_loop import ToolBackend
 from gateway.services.mcp_loop_responses import (
@@ -88,7 +88,9 @@ class ResponsesRequest(derive_request_base(ResponsesParams)):  # type: ignore[mi
 
     # Gateway-internal: identical semantics to ChatCompletionRequest.
     mcp_servers: list[McpServerConfig] | None = None
-    mcp_server_ids: list[uuid.UUID] | None = None
+    # Bounded on the list arm, not the union, so the ceiling caps the number of
+    # ids rather than the length of any one value (see `core/sql.MAX_FILTER_VALUES`).
+    mcp_server_ids: Annotated[list[uuid.UUID], Field(max_length=MAX_MCP_SERVER_IDS)] | None = None
     guardrails: list[GuardrailConfig] | None = Field(default=None, max_length=8)
     tools_header: str | None = None
     max_tool_iterations: int | None = Field(default=None, ge=1, le=MAX_TOOL_ITERATIONS_CAP)

--- a/src/gateway/api/routes/workspace_mcp_servers.py
+++ b/src/gateway/api/routes/workspace_mcp_servers.py
@@ -1,0 +1,115 @@
+"""Workspace-scoped MCP server management (standalone mode only).
+
+Thin composition over
+`gateway.services.tenancy.workspace_mcp_server_service`, following
+`routes/workspace_member_budget_policies.py`'s shape: master key on the
+router, plus the caller's tenancy identity for the per-workspace role check
+the service runs. A request reaches these servers by naming their ids in
+``mcp_server_ids``; see `docs/mcp.md`.
+
+Hybrid mode does not mount this router. There the same rows live on the
+platform and are managed from otari.ai, which is also what resolves them for a
+request.
+"""
+
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.api.deps import CurrentIdentity, get_db, verify_master_key
+from gateway.api.routes.organizations import Message
+from gateway.services.tenancy.workspace_mcp_server_service import (
+    WorkspaceMcpServerCreate,
+    WorkspaceMcpServerPublic,
+    WorkspaceMcpServerService,
+    WorkspaceMcpServersPublic,
+    WorkspaceMcpServerUpdate,
+)
+
+# Auth is declared on the router, matching `routes/workspaces.py`: every
+# handler here needs the master key, and a future one that forgot the
+# decorator would be unauthenticated with nothing to notice.
+router = APIRouter(
+    prefix="/v1/workspaces/{workspace_id}/mcp-servers",
+    tags=["mcp-servers"],
+    dependencies=[Depends(verify_master_key)],
+)
+
+
+def get_workspace_mcp_server_service(db: Annotated[AsyncSession, Depends(get_db)]) -> WorkspaceMcpServerService:
+    """Build the service on the request's session."""
+    return WorkspaceMcpServerService(db)
+
+
+WorkspaceMcpServerServiceDep = Annotated[WorkspaceMcpServerService, Depends(get_workspace_mcp_server_service)]
+
+
+@router.get("")
+async def list_workspace_mcp_servers(
+    service: WorkspaceMcpServerServiceDep,
+    current_identity: CurrentIdentity,
+    workspace_id: uuid.UUID,
+    skip: Annotated[int, Query(ge=0, description="Number of records to skip")] = 0,
+    limit: Annotated[int, Query(ge=1, le=1000, description="Maximum number of records to return")] = 100,
+) -> WorkspaceMcpServersPublic:
+    """List the MCP servers configured for a workspace.
+
+    Organization owners/admins or this workspace's owners/admins. Reads are
+    gated like writes because these rows name the endpoints the gateway
+    connects to on the workspace's behalf. Authorization tokens are never
+    included; each server reports only whether it has one.
+    """
+    return await service.list_servers(user=current_identity, workspace_id=workspace_id, skip=skip, limit=limit)
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def create_workspace_mcp_server(
+    service: WorkspaceMcpServerServiceDep,
+    current_identity: CurrentIdentity,
+    workspace_id: uuid.UUID,
+    body: WorkspaceMcpServerCreate,
+) -> WorkspaceMcpServerPublic:
+    """Register an MCP server for a workspace. Organization owners/admins or this workspace's owners/admins.
+
+    The authorization token is encrypted at rest and never returned. The URL
+    is checked for SSRF safety here as well as on the request path, and must
+    use https when a token is set. A name already used in this workspace is
+    refused with a 409.
+    """
+    return await service.create_server(user=current_identity, workspace_id=workspace_id, request=body)
+
+
+@router.patch("/{server_id}")
+async def update_workspace_mcp_server(
+    service: WorkspaceMcpServerServiceDep,
+    current_identity: CurrentIdentity,
+    workspace_id: uuid.UUID,
+    server_id: uuid.UUID,
+    body: WorkspaceMcpServerUpdate,
+) -> WorkspaceMcpServerPublic:
+    """Update a server. Organization owners/admins or this workspace's owners/admins.
+
+    Only the fields sent are applied. Omit `authorization_token` to leave the
+    stored token alone, send an empty string to clear it, or send a value to
+    rotate it.
+    """
+    return await service.update_server(
+        user=current_identity,
+        workspace_id=workspace_id,
+        server_id=server_id,
+        request=body,
+    )
+
+
+@router.delete("/{server_id}")
+async def delete_workspace_mcp_server(
+    service: WorkspaceMcpServerServiceDep,
+    current_identity: CurrentIdentity,
+    workspace_id: uuid.UUID,
+    server_id: uuid.UUID,
+) -> Message:
+    """Delete a server and the token stored with it. Organization owners/admins or this workspace's owners/admins."""
+    await service.delete_server(user=current_identity, workspace_id=workspace_id, server_id=server_id)
+    return Message(message="MCP server deleted")

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -1364,3 +1364,62 @@ class WorkspaceActivationState(Base):
         default=lambda: datetime.now(UTC),
         onupdate=lambda: datetime.now(UTC),
     )
+
+
+class WorkspaceMcpServer(Base):
+    """One MCP server a workspace has configured, referenced by id from a request.
+
+    Ported from otari-ai's ``mcp_server`` table (otari#658). A request names
+    stored servers with ``mcp_server_ids``; hybrid mode resolves those ids
+    through the platform and standalone mode resolves them here, against the
+    workspace the request's key belongs to. There is no deployment-wide MCP
+    server list for these rows to narrow, which is why MCP is the stated
+    exception to the "a workspace row never grants" rule in
+    ``src/gateway/AGENTS.md``.
+
+    ``encrypted_token`` holds the server's bearer token, Fernet-encrypted with
+    ``OTARI_SECRET_KEY`` (``services/secret_box.py``), the same treatment
+    ``ProviderCredential.encrypted_api_key`` gets. Nothing serializes it: the
+    public shape carries ``has_token`` and no prefix or suffix of the value,
+    because unlike a provider key's ``last4`` there is no operator workflow
+    here that needs to tell two tokens apart at a glance.
+
+    ``enabled`` is a workspace-level off switch that keeps the row and its
+    token: a disabled server is skipped at resolve rather than refusing the
+    request, so a caller whose stored id list outlives one server's
+    decommissioning still gets the rest.
+
+    CASCADE, not the ``RESTRICT`` the request-plane tables above use: this is a
+    workspace-owned configuration row, like ``workspace_budget_defaults``, with
+    no meaning once its workspace is gone.
+    """
+
+    __tablename__ = "workspace_mcp_servers"
+    __table_args__ = (
+        # Duplicate names within one workspace are rejected at the database, not
+        # only in the service layer, so two concurrent creates cannot both land
+        # (otari#658's third Definition-of-Done item). The name is what an
+        # operator recognizes a server by and what the tool loop labels its
+        # tools with, so collapsing two onto one name would silently hide a
+        # server.
+        UniqueConstraint("workspace_id", "name", name="uq_workspace_mcp_servers_workspace_name"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("workspace.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(nullable=False)
+    url: Mapped[str] = mapped_column(nullable=False)
+    encrypted_token: Mapped[str | None] = mapped_column(Text, default=None)
+    purpose_hint: Mapped[str | None] = mapped_column(Text, default=None)
+    allowed_tools: Mapped[list[str] | None] = mapped_column(JSON, default=None)
+    enabled: Mapped[bool] = mapped_column(default=True, nullable=False)
+    # ``UtcDateTime`` for the same reason ``WorkspaceBudgetDefault``'s are: these
+    # go over the wire and a naive SQLite round-trip would drop the offset.
+    created_at: Mapped[datetime] = mapped_column(UtcDateTime(), default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(
+        UtcDateTime(),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )

--- a/src/gateway/models/mcp.py
+++ b/src/gateway/models/mcp.py
@@ -4,6 +4,18 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+# Ceiling on ``mcp_server_ids`` in one request. A workspace can hold at most 50
+# configured servers, in standalone (``MAX_MCP_SERVERS_PER_WORKSPACE`` in
+# ``services/tenancy/workspace_mcp_server_service.py``) and on the platform,
+# which uses the same value, so no reachable request loses anything. It is
+# declared separately from that constant rather than imported: a wire bound has
+# to be enforceable at parse time, with no database and no mode to consult, and
+# a models module reaching into a service to learn its own limits would be the
+# wrong direction. Without it a single request could hand the resolver an
+# unbounded ``IN`` list, which is why the usage filters carry the same kind of
+# ceiling (``core/sql.MAX_FILTER_VALUES``).
+MAX_MCP_SERVER_IDS = 50
+
 
 class McpServerConfig(BaseModel):
     """Inline MCP server configuration accepted on the chat completions request.

--- a/src/gateway/services/tenancy/errors.py
+++ b/src/gateway/services/tenancy/errors.py
@@ -408,7 +408,7 @@ class WorkspaceProviderKeyOverrideConflictError(TenancyValidationError):
 
 
 class SecretBoxUnavailableTenancyError(TenancyError):
-    """`OTARI_SECRET_KEY` is not configured, so a provider key cannot be stored.
+    """`OTARI_SECRET_KEY` is not configured, so a secret cannot be stored.
 
     Wraps `services.secret_box.SecretBoxUnavailableError` as a tenancy error so
     the route stays thin (see the module docstring): the underlying error
@@ -417,10 +417,14 @@ class SecretBoxUnavailableTenancyError(TenancyError):
     request, and a missing secret key is a deployment configuration gap the
     caller cannot fix. Blaming the client here would also keep the condition
     out of 5xx error-rate alerting, which is exactly the audience that can.
+
+    ``stored`` names what could not be stored, so the message points at the
+    surface the caller was using. It defaults to the provider credentials this
+    error was written for; workspace MCP servers pass their own.
     """
 
-    def __init__(self) -> None:
-        super().__init__("OTARI_SECRET_KEY is not set; it is required to store provider credentials")
+    def __init__(self, stored: str = "provider credentials") -> None:
+        super().__init__(f"OTARI_SECRET_KEY is not set; it is required to store {stored}")
 
 
 # The two below are pricing errors in a tenancy module, because the status
@@ -562,6 +566,48 @@ class WorkspaceAlreadyActivatedError(TenancyConflictError):
         super().__init__("This workspace has already served a successful request")
 
 
+class WorkspaceMcpServerNotFoundError(TenancyNotFoundError):
+    def __init__(self, mcp_server_id: object):
+        super().__init__(f"MCP server {mcp_server_id} not found")
+
+
+class WorkspaceMcpServerAlreadyExistsError(TenancyConflictError):
+    """A workspace already has an MCP server under this name.
+
+    Refused rather than collapsed onto the existing row: the name is what the
+    tool loop labels a server's tools with, so silently reusing it would point
+    a caller's request at a different endpoint than the one they just
+    configured.
+    """
+
+    def __init__(self, workspace_id: object, name: object):
+        super().__init__(f"Workspace {workspace_id} already has an MCP server named '{name}'")
+
+
+class WorkspaceMcpServerUnsafeUrlError(TenancyValidationError):
+    """The URL failed the same SSRF and TLS checks a request-body MCP server faces.
+
+    Carries the reason from `services.url_safety.UnsafeURLError` verbatim: it
+    names the host and the range it resolved into, which is what an operator
+    needs to fix the entry, and it is the operator's own URL either way (this
+    surface is management-gated, not a caller-supplied endpoint).
+    """
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+
+
+class WorkspaceMcpServerLimitReachedError(TenancyValidationError):
+    """The workspace already holds as many MCP servers as it may.
+
+    A resolved request opens a session to every server it names, so the cap
+    bounds the fan-out one workspace can ask a gateway process for.
+    """
+
+    def __init__(self, workspace_id: object, limit: int):
+        super().__init__(f"Workspace {workspace_id} already has the maximum of {limit} MCP servers")
+
+
 __all__ = [
     "CurrentPasswordIncorrectError",
     "CurrentPasswordRequiredError",
@@ -614,6 +660,10 @@ __all__ = [
     "WorkspaceBudgetDefaultBudgetNotFoundError",
     "WorkspaceBudgetDefaultNotFoundError",
     "WorkspaceInUseError",
+    "WorkspaceMcpServerAlreadyExistsError",
+    "WorkspaceMcpServerLimitReachedError",
+    "WorkspaceMcpServerNotFoundError",
+    "WorkspaceMcpServerUnsafeUrlError",
     "WorkspaceMemberAlreadyExistsError",
     "WorkspaceMemberNotFoundError",
     "WorkspaceNameRequiredError",

--- a/src/gateway/services/tenancy/workspace_mcp_server_service.py
+++ b/src/gateway/services/tenancy/workspace_mcp_server_service.py
@@ -1,0 +1,480 @@
+"""Workspace-scoped MCP server configuration: CRUD, and the request-path resolve.
+
+Ported from otari-ai's `MCPServerService` (otari#658). The platform stores an
+MCP server per workspace, encrypts its bearer token on save, decrypts it when
+the gateway asks for it by id, and never returns it in a public response. This
+module is the same thing against the local database, for a standalone
+deployment that has no platform to ask.
+
+**Where it plugs in.** A request names stored servers with `mcp_server_ids`.
+Hybrid mode resolves those through the platform
+(`api/routes/_platform._resolve_platform_mcp_servers`); standalone mode
+resolves them here, through :func:`resolve_workspace_mcp_servers`, called at
+admission in `prepare_gateway_tools` where the request's session is live and
+`RequestContext.workspace_id` already names the workspace its key belongs to.
+That is the seam otari#655 settled and otari#678 wrote down; MCP is the
+exception that decision names, because there is no deployment-wide server list
+for a workspace row to narrow, so a row here is the only source of the
+configuration rather than a narrowing of one.
+
+**Deliberate divergences from the platform's version**, all of them because a
+standalone deployment is not a hosted multi-tenant one:
+
+- Authorization is this repository's own workspace check
+  (`services.tenancy.authorization`), so a workspace owner/admin qualifies and
+  not only an organization owner/admin. The platform's stricter *shape* is
+  kept: every operation including the list read is management-gated, because
+  these rows decide which external endpoints the gateway connects to and
+  authenticates against on the workspace's behalf.
+- URL safety is one check in this layer rather than the platform's split
+  between a synchronous ingress validator and a service-layer SSRF pass. This
+  repository's `validate_mcp_url` is a single async function that already does
+  both, and these routes are async, so the reason for the split does not apply.
+- No analytics events, and no `status` field on the public shape (the
+  platform's is a hosted dashboard affordance; this repository has no page for
+  these rows yet).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Annotated
+
+from pydantic import BaseModel, Field, model_validator
+from pydantic.json_schema import SkipJsonSchema
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.models.entities import WorkspaceMcpServer
+from gateway.models.mcp import McpServerConfig
+from gateway.models.tenancy import User
+from gateway.repositories.tenancy import WorkspaceRepository
+from gateway.services.secret_box import (
+    SecretBoxUnavailableError,
+    decrypt_secret,
+    encrypt_secret,
+)
+from gateway.services.tenancy import authorization
+from gateway.services.tenancy.errors import (
+    SecretBoxUnavailableTenancyError,
+    WorkspaceMcpServerAlreadyExistsError,
+    WorkspaceMcpServerLimitReachedError,
+    WorkspaceMcpServerNotFoundError,
+    WorkspaceMcpServerUnsafeUrlError,
+)
+from gateway.services.tenancy.organization_service import OrganizationService
+from gateway.services.url_safety import UnsafeURLError, validate_mcp_url
+
+# What a workspace may configure. A resolved request opens a session to every
+# server it names, so this bounds the fan-out one workspace can ask a gateway
+# process for. Same value the platform uses: generous for any real setup, low
+# enough that the list is not a resource in itself.
+MAX_MCP_SERVERS_PER_WORKSPACE = 50
+
+# Bounds on the tool allow-list, which is arbitrary JSON stored on the row and
+# read again on the completion path. Every other field here is bounded; without
+# these two the list is the one way to put an unbounded value in the table.
+MAX_ALLOWED_TOOLS = 200
+MAX_TOOL_NAME_LENGTH = 256
+
+_MAX_LIST_LIMIT = 1000
+
+# Sentinel for "this PATCH did not mention the token", which is not the same as
+# "this PATCH set it to null": see `WorkspaceMcpServerUpdate`.
+_UNSET = object()
+
+
+class WorkspaceMcpServerCreate(BaseModel):
+    """Request body for registering a server.
+
+    ``authorization_token`` is never stored as sent: it is encrypted with
+    ``OTARI_SECRET_KEY`` and only the ciphertext is kept, the same convention
+    `entities.ProviderCredential` and `OrgProviderKey` already use.
+    """
+
+    name: str = Field(min_length=1, max_length=128, description="Label for the server, unique within the workspace")
+    url: str = Field(min_length=1, max_length=2048, description="Streamable HTTP MCP endpoint")
+    authorization_token: str | None = Field(
+        default=None,
+        max_length=8192,
+        description="Bearer token for the server; requires an https URL. Encrypted at rest, never returned",
+    )
+    purpose_hint: str | None = Field(
+        default=None, max_length=2000, description="Hint prepended to the system message to help the model choose"
+    )
+    allowed_tools: list[Annotated[str, Field(max_length=MAX_TOOL_NAME_LENGTH)]] | None = Field(
+        default=None,
+        max_length=MAX_ALLOWED_TOOLS,
+        description="Allow-list of tool names; null exposes every tool the server offers",
+    )
+    enabled: bool = Field(default=True, description="Whether a request naming this server actually reaches it")
+
+
+class WorkspaceMcpServerUpdate(BaseModel):
+    """Partial update. Only the fields the caller sets are applied.
+
+    ``authorization_token`` has three states rather than two, which is what a
+    write-only field needs: omit it to leave the stored token alone, send
+    ``""`` to clear it, send a value to rotate it. An explicit ``null`` also
+    leaves it alone, matching the platform: a client that serializes its whole
+    form back, with an empty token box it never filled in, must not destroy a
+    token it was never shown.
+    """
+
+    # ``SkipJsonSchema[None]`` on the three that back NOT NULL columns: ``None``
+    # is this schema's "not sent" marker, and the validator below refuses it as a
+    # value, so the published schema must not advertise ``null`` as accepted.
+    # Without it the OpenAPI spec and the generated TypeScript client tell a
+    # client that ``{"url": null}`` is valid and the server answers 422.
+    name: Annotated[str, Field(min_length=1, max_length=128)] | SkipJsonSchema[None] = None
+    url: Annotated[str, Field(min_length=1, max_length=2048)] | SkipJsonSchema[None] = None
+    authorization_token: str | None = Field(default=None, max_length=8192)
+    purpose_hint: str | None = Field(default=None, max_length=2000)
+    allowed_tools: list[Annotated[str, Field(max_length=MAX_TOOL_NAME_LENGTH)]] | None = Field(
+        default=None, max_length=MAX_ALLOWED_TOOLS
+    )
+    enabled: bool | SkipJsonSchema[None] = None
+
+    @model_validator(mode="after")
+    def _reject_explicit_nulls(self) -> WorkspaceMcpServerUpdate:
+        """Refuse an explicit ``null`` for a column that cannot hold one.
+
+        ``None`` is this schema's "not sent" marker, so a caller that means to
+        clear a required field is expressing something the row cannot store.
+        Caught here rather than at the flush: a ``NOT NULL`` violation arrives
+        as the same ``IntegrityError`` the unique index raises, and the service
+        would report a name collision that never happened.
+        ``purpose_hint`` and ``allowed_tools`` are nullable and are deliberately
+        clearable this way, and the token has its own three-state rule above.
+        """
+        nulled = [
+            field
+            for field in ("name", "url", "enabled")
+            if field in self.model_fields_set and getattr(self, field) is None
+        ]
+        if nulled:
+            raise ValueError(f"{', '.join(nulled)} cannot be null; omit the field to leave it unchanged")
+        return self
+
+
+class WorkspaceMcpServerPublic(BaseModel):
+    """The API-facing shape. Never carries the token, only whether one is set.
+
+    No ``last4``-style prefix either, unlike `OrgProviderKeyPublic`: a provider
+    key's last four digits let an operator match a stored key against the one
+    in their provider's console, and there is no equivalent workflow for an MCP
+    bearer token.
+    """
+
+    id: uuid.UUID
+    workspace_id: uuid.UUID
+    name: str
+    url: str
+    purpose_hint: str | None
+    allowed_tools: list[str] | None
+    enabled: bool
+    has_token: bool
+    created_at: str
+    updated_at: str
+
+    @classmethod
+    def from_model(cls, server: WorkspaceMcpServer) -> WorkspaceMcpServerPublic:
+        return cls(
+            id=server.id,
+            workspace_id=server.workspace_id,
+            name=server.name,
+            url=server.url,
+            purpose_hint=server.purpose_hint,
+            allowed_tools=server.allowed_tools,
+            enabled=server.enabled,
+            has_token=server.encrypted_token is not None,
+            created_at=server.created_at.isoformat(),
+            updated_at=server.updated_at.isoformat(),
+        )
+
+
+class WorkspaceMcpServersPublic(BaseModel):
+    data: list[WorkspaceMcpServerPublic]
+    count: int
+
+
+async def _validate_url(url: str, *, has_token: bool) -> None:
+    """Run the same SSRF/TLS check a request-body MCP server faces, at write time.
+
+    Checked here as well as on the request path (`_validate_mcp_server_urls`)
+    rather than instead of it: this catches an operator's mistake at the moment
+    they make it, and the request-path check is what still holds when DNS moves
+    under a URL that was safe when it was stored.
+    """
+    try:
+        await validate_mcp_url(url, has_authorization_token=has_token)
+    except UnsafeURLError as exc:
+        raise WorkspaceMcpServerUnsafeUrlError(str(exc)) from exc
+
+
+def _encrypted(token: str) -> str:
+    try:
+        return encrypt_secret(token)
+    except SecretBoxUnavailableError:
+        raise SecretBoxUnavailableTenancyError("MCP server authorization tokens") from None
+
+
+async def resolve_workspace_mcp_servers(
+    db: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    server_ids: list[uuid.UUID],
+) -> list[McpServerConfig]:
+    """Swap a request's ``mcp_server_ids`` for the workspace's stored configs.
+
+    The standalone counterpart of `_platform._resolve_platform_mcp_servers`,
+    and deliberately the same contract: ids are de-duplicated with their order
+    preserved, an id naming no server *in this workspace* raises
+    :class:`WorkspaceMcpServerNotFoundError` (the platform answers 404 for the
+    same case, so the two modes refuse identically), and a disabled server is
+    skipped rather than refused, so one decommissioned server does not break a
+    caller whose stored id list still names it.
+
+    No authorization check, and none is missing: ``workspace_id`` comes off the
+    key that authenticated the request (`services/workspace_scope.py`), never
+    off a header, so there is no caller-supplied scope here to verify. An id
+    belonging to another workspace is simply not found, which is also what
+    keeps this from being an existence oracle across tenants.
+
+    Raises `secret_box.SecretDecryptionError` when a stored token will not
+    decrypt. Dropping the token and connecting anyway would silently send an
+    unauthenticated request to a server the workspace configured a credential
+    for, so the request fails instead.
+    """
+    if not server_ids:
+        return []
+
+    ordered_ids = list(dict.fromkeys(server_ids))
+    rows = (
+        (
+            await db.execute(
+                select(WorkspaceMcpServer).where(
+                    WorkspaceMcpServer.workspace_id == workspace_id,
+                    WorkspaceMcpServer.id.in_(ordered_ids),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    by_id = {row.id: row for row in rows}
+
+    missing = [server_id for server_id in ordered_ids if server_id not in by_id]
+    if missing:
+        raise WorkspaceMcpServerNotFoundError(missing[0])
+
+    resolved: list[McpServerConfig] = []
+    for server_id in ordered_ids:
+        row = by_id[server_id]
+        if not row.enabled:
+            continue
+        resolved.append(
+            McpServerConfig(
+                name=row.name,
+                url=row.url,
+                authorization_token=decrypt_secret(row.encrypted_token) if row.encrypted_token else None,
+                purpose_hint=row.purpose_hint,
+                allowed_tools=row.allowed_tools,
+            )
+        )
+    return resolved
+
+
+class WorkspaceMcpServerService:
+    """CRUD for a workspace's MCP servers. Every operation is management-gated."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.organizations = OrganizationService(db)
+
+    async def _require_management(self, user: User, workspace_id: uuid.UUID) -> uuid.UUID:
+        """Resolve the workspace and confirm the caller may manage it.
+
+        Reads are gated too, unlike the workspace surfaces beside this one
+        (`workspace_budget_default_service` opens its list to any member).
+        These rows name the external endpoints this gateway will connect to,
+        and which of them carry a credential, which is the platform's own
+        reason for admin-gating its reads; the URL of a workspace's internal
+        tool server is not something every member needs.
+        """
+        workspace = await authorization.resolve_visible_workspace(
+            self.db, user=user, workspace_id=workspace_id, organizations=self.organizations
+        )
+        await authorization.require_workspace_management_access(
+            self.db, user=user, workspace=workspace, organizations=self.organizations
+        )
+        return workspace.id
+
+    async def _get_or_404(self, workspace_id: uuid.UUID, server_id: uuid.UUID) -> WorkspaceMcpServer:
+        server = await self.db.get(WorkspaceMcpServer, server_id)
+        if server is None or server.workspace_id != workspace_id:
+            raise WorkspaceMcpServerNotFoundError(server_id)
+        return server
+
+    async def list_servers(
+        self,
+        *,
+        user: User,
+        workspace_id: uuid.UUID,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> WorkspaceMcpServersPublic:
+        """List a page of the workspace's servers, plus the total."""
+        await self._require_management(user, workspace_id)
+        limit = min(limit, _MAX_LIST_LIMIT)
+
+        count = (
+            await self.db.execute(
+                select(func.count())
+                .select_from(WorkspaceMcpServer)
+                .where(WorkspaceMcpServer.workspace_id == workspace_id)
+            )
+        ).scalar_one()
+        servers = (
+            (
+                await self.db.execute(
+                    select(WorkspaceMcpServer)
+                    .where(WorkspaceMcpServer.workspace_id == workspace_id)
+                    .order_by(WorkspaceMcpServer.created_at, WorkspaceMcpServer.id)
+                    .offset(skip)
+                    .limit(limit)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return WorkspaceMcpServersPublic(
+            data=[WorkspaceMcpServerPublic.from_model(server) for server in servers],
+            count=count,
+        )
+
+    async def create_server(
+        self,
+        *,
+        user: User,
+        workspace_id: uuid.UUID,
+        request: WorkspaceMcpServerCreate,
+    ) -> WorkspaceMcpServerPublic:
+        """Register a server, encrypting its token before it is stored."""
+        resolved_workspace_id = await self._require_management(user, workspace_id)
+        await _validate_url(request.url, has_token=bool(request.authorization_token))
+
+        # "At most N rows for this workspace" spans a variable set of rows, so no
+        # single unique index can hold it and the count below would otherwise be
+        # a read that a concurrent create invalidates before this one inserts.
+        # Same lock, for the same read-decide-write reason, that
+        # `workspace_budget_default_service` and `org_provider_key_service` take.
+        await WorkspaceRepository(self.db).lock(resolved_workspace_id)
+
+        count = (
+            await self.db.execute(
+                select(func.count())
+                .select_from(WorkspaceMcpServer)
+                .where(WorkspaceMcpServer.workspace_id == resolved_workspace_id)
+            )
+        ).scalar_one()
+        if count >= MAX_MCP_SERVERS_PER_WORKSPACE:
+            raise WorkspaceMcpServerLimitReachedError(workspace_id, MAX_MCP_SERVERS_PER_WORKSPACE)
+
+        server = WorkspaceMcpServer(
+            workspace_id=resolved_workspace_id,
+            name=request.name,
+            url=request.url,
+            encrypted_token=_encrypted(request.authorization_token) if request.authorization_token else None,
+            purpose_hint=request.purpose_hint,
+            allowed_tools=request.allowed_tools,
+            enabled=request.enabled,
+        )
+        self.db.add(server)
+        # The unique index is the arbiter, not a preceding existence check: two
+        # concurrent creates of the same name would both pass such a check and
+        # one would still have to lose here. It is also the only constraint this
+        # table can violate, which is what makes the blanket catch exact: the
+        # schema validated every column before this point.
+        try:
+            await self.db.flush()
+        except IntegrityError:
+            await self.db.rollback()
+            raise WorkspaceMcpServerAlreadyExistsError(workspace_id, request.name) from None
+
+        await self.db.commit()
+        await self.db.refresh(server)
+        return WorkspaceMcpServerPublic.from_model(server)
+
+    async def update_server(
+        self,
+        *,
+        user: User,
+        workspace_id: uuid.UUID,
+        server_id: uuid.UUID,
+        request: WorkspaceMcpServerUpdate,
+    ) -> WorkspaceMcpServerPublic:
+        """Apply a partial update. See :class:`WorkspaceMcpServerUpdate` for the token's three states."""
+        resolved_workspace_id = await self._require_management(user, workspace_id)
+        server = await self._get_or_404(resolved_workspace_id, server_id)
+        fields = request.model_dump(exclude_unset=True)
+
+        new_token = fields.pop("authorization_token", _UNSET)
+        if new_token == "":
+            effective_has_token = False
+        elif isinstance(new_token, str):
+            effective_has_token = True
+        else:  # omitted, or an explicit null
+            effective_has_token = server.encrypted_token is not None
+
+        # Re-validated against the *effective* post-update state, and only when
+        # the URL or the token actually moves. A PATCH that sets only a token is
+        # still checked against the stored URL, which is the only place an http
+        # URL newly paired with a bearer token can be caught. A metadata-only
+        # edit (rename, disable, change the tool list) does no DNS lookup at
+        # all, so disabling a server never depends on its host still resolving.
+        url_changed = "url" in fields and fields["url"] != server.url
+        if url_changed or isinstance(new_token, str):
+            await _validate_url(fields.get("url") or server.url, has_token=effective_has_token)
+
+        if new_token == "":
+            server.encrypted_token = None
+        elif isinstance(new_token, str):
+            server.encrypted_token = _encrypted(new_token)
+
+        for field, value in fields.items():
+            setattr(server, field, value)
+
+        # Read before the flush: the rollback below expires every loaded
+        # instance, so reading ``server.name`` inside the handler would emit a
+        # lazy SELECT from a synchronous context and raise ``MissingGreenlet``
+        # instead of the conflict the caller is owed.
+        attempted_name = server.name
+        try:
+            await self.db.flush()
+        except IntegrityError:
+            await self.db.rollback()
+            raise WorkspaceMcpServerAlreadyExistsError(workspace_id, attempted_name) from None
+
+        await self.db.commit()
+        await self.db.refresh(server)
+        return WorkspaceMcpServerPublic.from_model(server)
+
+    async def delete_server(self, *, user: User, workspace_id: uuid.UUID, server_id: uuid.UUID) -> None:
+        """Delete a server and the token stored with it."""
+        resolved_workspace_id = await self._require_management(user, workspace_id)
+        server = await self._get_or_404(resolved_workspace_id, server_id)
+        await self.db.delete(server)
+        await self.db.commit()
+
+
+__all__ = [
+    "MAX_MCP_SERVERS_PER_WORKSPACE",
+    "WorkspaceMcpServerCreate",
+    "WorkspaceMcpServerPublic",
+    "WorkspaceMcpServerService",
+    "WorkspaceMcpServerUpdate",
+    "WorkspaceMcpServersPublic",
+    "resolve_workspace_mcp_servers",
+]

--- a/tests/integration/test_hybrid_mode_surface.py
+++ b/tests/integration/test_hybrid_mode_surface.py
@@ -99,6 +99,11 @@ def test_hybrid_mode_disables_dashboard_management_endpoints(monkeypatch: pytest
             "/v1/pricing",
             "/v1/organizations/me",
             "/v1/workspaces",
+            # A workspace's MCP servers are stored with a bearer token, and in
+            # hybrid mode they live on the platform. Listed explicitly rather
+            # than left to the `/v1/workspaces` entry above: this is a distinct
+            # router, so re-mounting it would not show up in that check.
+            "/v1/workspaces/11111111-1111-1111-1111-111111111111/mcp-servers",
         ):
             response = client.get(path)
             assert response.status_code == 404, path

--- a/tests/integration/test_workspace_mcp_servers.py
+++ b/tests/integration/test_workspace_mcp_servers.py
@@ -1,0 +1,762 @@
+"""Workspace-scoped MCP servers: CRUD, encryption at rest, and request-path resolution.
+
+Exercised at the service layer, matching `test_org_provider_keys.py` and
+`test_workspace_member_budget_policies.py`: the API can only ever act as the
+one bootstrap operator identity a standalone deployment has, who is always an
+owner, so the authorization rules that matter (a plain member refused, another
+organization's workspace invisible) are only reachable by calling the service
+with identities built at whatever role a case needs.
+
+URLs here are IP literals in public ranges, or are rejected before any lookup
+happens (a bad scheme, a token on ``http://``). ``validate_mcp_url`` resolves a
+hostname through DNS, so a test naming one would pass or fail on whether the
+runner has egress.
+"""
+
+import time
+import uuid
+from collections.abc import Iterator
+
+import pytest
+from fastapi import HTTPException, Response
+from pydantic import ValidationError
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.api.routes import chat
+from gateway.api.routes._pipeline import RequestContext, prepare_gateway_tools
+from gateway.api.routes.chat import ChatCompletionRequest
+from gateway.core.config import GatewayConfig
+from gateway.models.entities import WorkspaceMcpServer
+from gateway.models.mcp import MAX_MCP_SERVER_IDS, McpServerConfig
+from gateway.models.tenancy import Organization, User, Workspace
+from gateway.repositories.tenancy import (
+    OrganizationMemberRepository,
+    OrganizationRepository,
+    UserRepository,
+    WorkspaceMemberRepository,
+    WorkspaceRepository,
+)
+from gateway.services.secret_box import decrypt_secret, generate_secret_key
+from gateway.services.tenancy.errors import (
+    NotAuthorizedError,
+    WorkspaceMcpServerAlreadyExistsError,
+    WorkspaceMcpServerLimitReachedError,
+    WorkspaceMcpServerNotFoundError,
+    WorkspaceMcpServerUnsafeUrlError,
+    WorkspaceNotFoundError,
+)
+from gateway.services.tenancy.workspace_mcp_server_service import (
+    MAX_ALLOWED_TOOLS,
+    MAX_MCP_SERVERS_PER_WORKSPACE,
+    WorkspaceMcpServerCreate,
+    WorkspaceMcpServerService,
+    WorkspaceMcpServerUpdate,
+    resolve_workspace_mcp_servers,
+)
+
+pytestmark = pytest.mark.asyncio
+
+# A public IP literal, so the safety check never reaches a DNS resolver.
+PUBLIC_URL = "https://93.184.216.34/mcp"
+OTHER_PUBLIC_URL = "https://93.184.216.35/mcp"
+
+
+async def _organization(db: AsyncSession, *, slug: str = "acme") -> Organization:
+    return await OrganizationRepository(db).create_organization(name=slug.title(), slug=slug, created_by_user_id=None)
+
+
+async def _member(db: AsyncSession, organization: Organization, *, role: str, full_name: str) -> User:
+    user = await UserRepository(db).create_local_identity(
+        full_name=full_name,
+        active_organization_id=organization.id,
+    )
+    await OrganizationMemberRepository(db).create_membership(
+        organization_id=organization.id, user_id=user.id, role=role
+    )
+    return user
+
+
+async def _workspace(
+    db: AsyncSession, organization: Organization, *, name: str = "Default", owner: User | None = None
+) -> Workspace:
+    workspace = await WorkspaceRepository(db).create_workspace(
+        name=name, organization_id=organization.id, created_by_user_id=owner.id if owner else None
+    )
+    if owner is not None:
+        await WorkspaceMemberRepository(db).create(workspace_id=workspace.id, user_id=owner.id, role="owner")
+    return workspace
+
+
+@pytest.fixture(autouse=True)
+def _secret_key(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("OTARI_SECRET_KEY", generate_secret_key())
+    yield
+
+
+def _create(**overrides: object) -> WorkspaceMcpServerCreate:
+    fields: dict[str, object] = {"name": "github", "url": PUBLIC_URL}
+    fields.update(overrides)
+    return WorkspaceMcpServerCreate(**fields)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# CRUD
+# --------------------------------------------------------------------------- #
+
+
+async def test_crud_round_trip(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+
+    created = await service.create_server(
+        user=owner,
+        workspace_id=workspace.id,
+        request=_create(purpose_hint="Repository lookups", allowed_tools=["list_issues"]),
+    )
+    assert created.workspace_id == workspace.id
+    assert created.has_token is False
+    assert created.enabled is True
+    assert created.allowed_tools == ["list_issues"]
+
+    listed = await service.list_servers(user=owner, workspace_id=workspace.id)
+    assert listed.count == 1
+    assert [server.id for server in listed.data] == [created.id]
+
+    updated = await service.update_server(
+        user=owner,
+        workspace_id=workspace.id,
+        server_id=created.id,
+        request=WorkspaceMcpServerUpdate(name="github-enterprise", enabled=False),
+    )
+    assert updated.name == "github-enterprise"
+    assert updated.enabled is False
+    assert updated.url == PUBLIC_URL, "an omitted field is left in place"
+
+    await service.delete_server(user=owner, workspace_id=workspace.id, server_id=created.id)
+    assert (await service.list_servers(user=owner, workspace_id=workspace.id)).count == 0
+
+
+async def test_unknown_server_id_is_not_found(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+
+    with pytest.raises(WorkspaceMcpServerNotFoundError):
+        await service.delete_server(user=owner, workspace_id=workspace.id, server_id=uuid.uuid4())
+
+
+async def test_another_workspaces_server_is_not_found(async_db: AsyncSession) -> None:
+    """A server id is scoped to its workspace on every read, not only on the list."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    first = await _workspace(async_db, organization, name="First", owner=owner)
+    second = await _workspace(async_db, organization, name="Second", owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+
+    created = await service.create_server(user=owner, workspace_id=first.id, request=_create())
+
+    with pytest.raises(WorkspaceMcpServerNotFoundError):
+        await service.update_server(
+            user=owner,
+            workspace_id=second.id,
+            server_id=created.id,
+            request=WorkspaceMcpServerUpdate(name="renamed"),
+        )
+
+
+async def test_server_count_is_capped_per_workspace(async_db: AsyncSession, monkeypatch: pytest.MonkeyPatch) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+
+    for index in range(3):
+        await service.create_server(user=owner, workspace_id=workspace.id, request=_create(name=f"server-{index}"))
+
+    monkeypatch.setattr(
+        "gateway.services.tenancy.workspace_mcp_server_service.MAX_MCP_SERVERS_PER_WORKSPACE",
+        3,
+    )
+    with pytest.raises(WorkspaceMcpServerLimitReachedError):
+        await service.create_server(user=owner, workspace_id=workspace.id, request=_create(name="server-4"))
+
+    assert MAX_MCP_SERVERS_PER_WORKSPACE >= 3, "the shipped cap is not what this test pins"
+
+
+async def test_creating_a_server_locks_the_workspace(async_db: AsyncSession, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The cap is a read-decide-write, so it takes the workspace row lock before counting.
+
+    A count that is not serialized against a concurrent create is a check two
+    callers can both pass at the ceiling. Asserted through the lock rather than
+    by racing two sessions, because the race is precisely what the lock makes
+    unobservable.
+    """
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+
+    locked: list[uuid.UUID] = []
+    original = WorkspaceRepository.lock
+
+    async def recording_lock(self: WorkspaceRepository, workspace_id: uuid.UUID) -> None:
+        locked.append(workspace_id)
+        await original(self, workspace_id)
+
+    monkeypatch.setattr(WorkspaceRepository, "lock", recording_lock)
+    await WorkspaceMcpServerService(async_db).create_server(
+        user=owner, workspace_id=workspace.id, request=_create()
+    )
+
+    assert locked == [workspace.id]
+
+
+# --------------------------------------------------------------------------- #
+# Duplicate names
+# --------------------------------------------------------------------------- #
+
+
+async def test_duplicate_name_in_one_workspace_is_rejected(async_db: AsyncSession) -> None:
+    """otari#658's third Definition-of-Done item: rejected, never silently collapsed."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    # Read before the refused create: the rollback that maps the IntegrityError
+    # expires every loaded instance, and reading one back is synchronous IO
+    # this session cannot do.
+    workspace_id = workspace.id
+    service = WorkspaceMcpServerService(async_db)
+
+    await service.create_server(user=owner, workspace_id=workspace_id, request=_create(name="github"))
+    with pytest.raises(WorkspaceMcpServerAlreadyExistsError):
+        await service.create_server(
+            user=owner, workspace_id=workspace_id, request=_create(name="github", url=OTHER_PUBLIC_URL)
+        )
+
+    await async_db.refresh(owner)
+    listed = await service.list_servers(user=owner, workspace_id=workspace_id)
+    assert listed.count == 1
+    assert listed.data[0].url == PUBLIC_URL, "the first server survives the refused create untouched"
+
+
+async def test_rename_onto_an_existing_name_is_rejected(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    workspace_id = workspace.id  # see the note in the create-side test above
+    service = WorkspaceMcpServerService(async_db)
+
+    await service.create_server(user=owner, workspace_id=workspace_id, request=_create(name="github"))
+    second = await service.create_server(
+        user=owner, workspace_id=workspace_id, request=_create(name="jira", url=OTHER_PUBLIC_URL)
+    )
+
+    with pytest.raises(WorkspaceMcpServerAlreadyExistsError):
+        await service.update_server(
+            user=owner,
+            workspace_id=workspace_id,
+            server_id=second.id,
+            request=WorkspaceMcpServerUpdate(name="github"),
+        )
+
+    await async_db.refresh(owner)
+    listed = await service.list_servers(user=owner, workspace_id=workspace_id)
+    assert sorted(server.name for server in listed.data) == ["github", "jira"]
+
+
+async def test_the_same_name_in_two_workspaces_is_fine(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    first = await _workspace(async_db, organization, name="First", owner=owner)
+    second = await _workspace(async_db, organization, name="Second", owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+
+    await service.create_server(user=owner, workspace_id=first.id, request=_create(name="github"))
+    await service.create_server(user=owner, workspace_id=second.id, request=_create(name="github"))
+
+    assert (await service.list_servers(user=owner, workspace_id=first.id)).count == 1
+    assert (await service.list_servers(user=owner, workspace_id=second.id)).count == 1
+
+
+# --------------------------------------------------------------------------- #
+# The token: encrypted at rest, never returned
+# --------------------------------------------------------------------------- #
+
+
+async def test_token_is_encrypted_at_rest_and_never_returned(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+
+    created = await service.create_server(
+        user=owner, workspace_id=workspace.id, request=_create(authorization_token="ghp_secret_value")
+    )
+    assert created.has_token is True
+    assert "ghp_secret_value" not in created.model_dump_json()
+
+    listed = await service.list_servers(user=owner, workspace_id=workspace.id)
+    assert "ghp_secret_value" not in listed.model_dump_json()
+
+    stored = (
+        await async_db.execute(select(WorkspaceMcpServer).where(WorkspaceMcpServer.id == created.id))
+    ).scalar_one()
+    assert stored.encrypted_token is not None
+    assert stored.encrypted_token != "ghp_secret_value"
+    assert decrypt_secret(stored.encrypted_token) == "ghp_secret_value"
+
+
+async def test_token_update_semantics(async_db: AsyncSession) -> None:
+    """Omitted leaves it, an empty string clears it, a value rotates it."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+
+    created = await service.create_server(
+        user=owner, workspace_id=workspace.id, request=_create(authorization_token="first")
+    )
+
+    unchanged = await service.update_server(
+        user=owner,
+        workspace_id=workspace.id,
+        server_id=created.id,
+        request=WorkspaceMcpServerUpdate(purpose_hint="Now with a hint"),
+    )
+    assert unchanged.has_token is True
+    stored = await async_db.get(WorkspaceMcpServer, created.id)
+    assert stored is not None and stored.encrypted_token is not None
+    assert decrypt_secret(stored.encrypted_token) == "first"
+
+    await service.update_server(
+        user=owner,
+        workspace_id=workspace.id,
+        server_id=created.id,
+        request=WorkspaceMcpServerUpdate(authorization_token="second"),
+    )
+    stored = await async_db.get(WorkspaceMcpServer, created.id)
+    assert stored is not None and stored.encrypted_token is not None
+    assert decrypt_secret(stored.encrypted_token) == "second"
+
+    cleared = await service.update_server(
+        user=owner,
+        workspace_id=workspace.id,
+        server_id=created.id,
+        request=WorkspaceMcpServerUpdate(authorization_token=""),
+    )
+    assert cleared.has_token is False
+    stored = await async_db.get(WorkspaceMcpServer, created.id)
+    assert stored is not None and stored.encrypted_token is None
+
+
+# --------------------------------------------------------------------------- #
+# URL validation
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_token_on_a_plain_http_url_is_rejected(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+
+    with pytest.raises(WorkspaceMcpServerUnsafeUrlError):
+        await service.create_server(
+            user=owner,
+            workspace_id=workspace.id,
+            request=_create(url="http://93.184.216.34/mcp", authorization_token="secret"),
+        )
+
+
+async def test_a_non_http_scheme_is_rejected(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+
+    with pytest.raises(WorkspaceMcpServerUnsafeUrlError):
+        await service.create_server(user=owner, workspace_id=workspace.id, request=_create(url="ftp://example/mcp"))
+
+
+async def test_adding_a_token_to_a_stored_http_url_is_rejected(async_db: AsyncSession) -> None:
+    """The check runs against the effective merged state, not only against what the PATCH carried."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+
+    created = await service.create_server(
+        user=owner, workspace_id=workspace.id, request=_create(url="http://93.184.216.34/mcp")
+    )
+    with pytest.raises(WorkspaceMcpServerUnsafeUrlError):
+        await service.update_server(
+            user=owner,
+            workspace_id=workspace.id,
+            server_id=created.id,
+            request=WorkspaceMcpServerUpdate(authorization_token="secret"),
+        )
+
+
+async def test_a_metadata_only_update_does_not_revalidate_the_url(async_db: AsyncSession) -> None:
+    """Disabling a server must not depend on its host still passing the SSRF check."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+
+    created = await service.create_server(
+        user=owner, workspace_id=workspace.id, request=_create(url="http://93.184.216.34/mcp")
+    )
+    disabled = await service.update_server(
+        user=owner,
+        workspace_id=workspace.id,
+        server_id=created.id,
+        request=WorkspaceMcpServerUpdate(enabled=False),
+    )
+    assert disabled.enabled is False
+
+
+# --------------------------------------------------------------------------- #
+# The role gate
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_plain_member_may_neither_read_nor_write(async_db: AsyncSession) -> None:
+    """Reads are gated too: these rows name the endpoints the gateway connects to."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    member = await _member(async_db, organization, role="member", full_name="Member")
+    await WorkspaceMemberRepository(async_db).create(workspace_id=workspace.id, user_id=member.id, role="member")
+    service = WorkspaceMcpServerService(async_db)
+
+    with pytest.raises(NotAuthorizedError):
+        await service.list_servers(user=member, workspace_id=workspace.id)
+    with pytest.raises(NotAuthorizedError):
+        await service.create_server(user=member, workspace_id=workspace.id, request=_create())
+
+
+async def test_a_workspace_admin_may_manage_without_organization_admin(async_db: AsyncSession) -> None:
+    """This repository's own rule, and a deliberate widening of the platform's org-admin-only gate."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    member = await _member(async_db, organization, role="member", full_name="Workspace Admin")
+    await WorkspaceMemberRepository(async_db).create(workspace_id=workspace.id, user_id=member.id, role="admin")
+    service = WorkspaceMcpServerService(async_db)
+
+    created = await service.create_server(user=member, workspace_id=workspace.id, request=_create())
+    assert created.name == "github"
+
+
+async def test_another_organizations_workspace_is_invisible(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db, slug="acme")
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    other_organization = await _organization(async_db, slug="other")
+    other_owner = await _member(async_db, other_organization, role="owner", full_name="Other Owner")
+    other_workspace = await _workspace(async_db, other_organization, name="Theirs", owner=other_owner)
+    service = WorkspaceMcpServerService(async_db)
+
+    with pytest.raises(WorkspaceNotFoundError):
+        await service.list_servers(user=owner, workspace_id=other_workspace.id)
+
+
+# --------------------------------------------------------------------------- #
+# Request-path resolution
+# --------------------------------------------------------------------------- #
+
+
+async def test_resolve_returns_decrypted_configs_in_request_order(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+
+    first = await service.create_server(
+        user=owner,
+        workspace_id=workspace.id,
+        request=_create(name="github", authorization_token="ghp_token", allowed_tools=["list_issues"]),
+    )
+    second = await service.create_server(
+        user=owner,
+        workspace_id=workspace.id,
+        request=_create(name="jira", url=OTHER_PUBLIC_URL, purpose_hint="Tickets"),
+    )
+
+    resolved = await resolve_workspace_mcp_servers(
+        async_db,
+        workspace_id=workspace.id,
+        server_ids=[second.id, first.id, second.id],
+    )
+    assert [server.name for server in resolved] == ["jira", "github"], "de-duplicated, request order preserved"
+    assert resolved[0].purpose_hint == "Tickets"
+    assert resolved[1].authorization_token == "ghp_token"
+    assert resolved[1].allowed_tools == ["list_issues"]
+
+
+async def test_resolve_skips_a_disabled_server(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+
+    created = await service.create_server(
+        user=owner, workspace_id=workspace.id, request=_create(enabled=False)
+    )
+
+    assert await resolve_workspace_mcp_servers(async_db, workspace_id=workspace.id, server_ids=[created.id]) == []
+
+
+async def test_resolve_refuses_an_id_from_another_workspace(async_db: AsyncSession) -> None:
+    """Not found, not forbidden: the answer must not tell one workspace what another one holds."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    first = await _workspace(async_db, organization, name="First", owner=owner)
+    second = await _workspace(async_db, organization, name="Second", owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+
+    created = await service.create_server(user=owner, workspace_id=first.id, request=_create())
+
+    with pytest.raises(WorkspaceMcpServerNotFoundError):
+        await resolve_workspace_mcp_servers(async_db, workspace_id=second.id, server_ids=[created.id])
+
+
+async def test_resolve_on_a_workspace_that_configured_nothing(async_db: AsyncSession) -> None:
+    """otari#678's zero-rows requirement: no rows changes nothing, and names nothing.
+
+    A deployment that has configured no MCP servers behaves exactly as it did
+    before this table existed: a request that names no ids resolves to no
+    servers, and one that names an id is refused rather than served with the
+    id quietly dropped.
+    """
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+
+    assert await resolve_workspace_mcp_servers(async_db, workspace_id=workspace.id, server_ids=[]) == []
+
+    with pytest.raises(WorkspaceMcpServerNotFoundError):
+        await resolve_workspace_mcp_servers(async_db, workspace_id=workspace.id, server_ids=[uuid.uuid4()])
+
+
+async def test_deleting_a_workspace_takes_its_servers(async_db: AsyncSession) -> None:
+    """The FK cascades: a configuration row has no meaning once its workspace is gone."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+    created = await service.create_server(user=owner, workspace_id=workspace.id, request=_create())
+
+    stored_workspace = await async_db.get(Workspace, workspace.id)
+    assert stored_workspace is not None
+    await async_db.delete(stored_workspace)
+    await async_db.commit()
+
+    assert await async_db.get(WorkspaceMcpServer, created.id) is None
+
+
+# --------------------------------------------------------------------------- #
+# The request path
+# --------------------------------------------------------------------------- #
+
+
+def _request_context(db: AsyncSession, workspace_id: uuid.UUID) -> RequestContext:
+    """A standalone request context of the shape the completion preamble builds."""
+    return RequestContext(
+        config=GatewayConfig(),
+        db=db,
+        log_writer=None,  # type: ignore[arg-type]
+        hybrid_mode=False,
+        route=None,
+        user_token=None,
+        api_key_id="key-1",
+        user_id="user-1",
+        rate_limit_info=None,
+        reservation=None,
+        started_at=time.monotonic(),
+        workspace_id=workspace_id,
+    )
+
+
+async def test_prepare_gateway_tools_hands_the_tool_loop_the_workspaces_servers(async_db: AsyncSession) -> None:
+    """otari#658's second Definition-of-Done item, at the seam otari#678 named.
+
+    `prepare_gateway_tools` is where admission resolves tool policy, and
+    `ToolContext` is what the tool loop reads, so a stored server reaching
+    `mcp_server_configs` with its token decrypted is the tool loop reaching it.
+    """
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+    stored = await service.create_server(
+        user=owner,
+        workspace_id=workspace.id,
+        request=_create(name="github", authorization_token="ghp_token"),
+    )
+
+    tool_ctx = await prepare_gateway_tools(
+        adapter=chat._ADAPTER,
+        ctx=_request_context(async_db, workspace.id),
+        response=Response(),
+        guardrails=None,
+        guardrail_text="",
+        tools=None,
+        mcp_servers=None,
+        mcp_server_ids=[stored.id],
+        max_tool_iterations=None,
+        tools_header=None,
+    )
+
+    assert tool_ctx.use_tool_loop is True
+    assert tool_ctx.mcp_server_configs is not None
+    assert [server.name for server in tool_ctx.mcp_server_configs] == ["github"]
+    assert tool_ctx.mcp_server_configs[0].authorization_token == "ghp_token"
+
+
+async def test_prepare_gateway_tools_merges_stored_servers_after_inline_ones(async_db: AsyncSession) -> None:
+    """Same order the hybrid path uses: the caller's inline servers first, then the resolved ones."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+    stored = await service.create_server(user=owner, workspace_id=workspace.id, request=_create(name="stored"))
+
+    tool_ctx = await prepare_gateway_tools(
+        adapter=chat._ADAPTER,
+        ctx=_request_context(async_db, workspace.id),
+        response=Response(),
+        guardrails=None,
+        guardrail_text="",
+        tools=None,
+        mcp_servers=[McpServerConfig(name="inline", url=OTHER_PUBLIC_URL)],
+        mcp_server_ids=[stored.id],
+        max_tool_iterations=None,
+        tools_header=None,
+    )
+
+    assert tool_ctx.mcp_server_configs is not None
+    assert [server.name for server in tool_ctx.mcp_server_configs] == ["inline", "stored"]
+
+
+async def test_prepare_gateway_tools_is_unchanged_when_nothing_is_configured(async_db: AsyncSession) -> None:
+    """otari#678's zero-rows requirement on the request path itself.
+
+    A deployment that has configured no workspace MCP servers keeps serving an
+    inline ``mcp_servers`` request exactly as it did, and a request that names
+    no ids never touches the new table.
+    """
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+
+    tool_ctx = await prepare_gateway_tools(
+        adapter=chat._ADAPTER,
+        ctx=_request_context(async_db, workspace.id),
+        response=Response(),
+        guardrails=None,
+        guardrail_text="",
+        tools=None,
+        mcp_servers=[McpServerConfig(name="inline", url=PUBLIC_URL)],
+        mcp_server_ids=None,
+        max_tool_iterations=None,
+        tools_header=None,
+    )
+
+    assert tool_ctx.mcp_server_configs is not None
+    assert [server.name for server in tool_ctx.mcp_server_configs] == ["inline"]
+
+
+async def test_prepare_gateway_tools_refuses_an_unknown_id(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await prepare_gateway_tools(
+            adapter=chat._ADAPTER,
+            ctx=_request_context(async_db, workspace.id),
+            response=Response(),
+            guardrails=None,
+            guardrail_text="",
+            tools=None,
+            mcp_servers=None,
+            mcp_server_ids=[uuid.uuid4()],
+            max_tool_iterations=None,
+            tools_header=None,
+        )
+
+    assert exc_info.value.status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# Request-shape bounds
+# --------------------------------------------------------------------------- #
+
+
+async def test_an_explicit_null_on_a_required_field_is_refused() -> None:
+    """``None`` is this schema's "not sent" marker, so clearing a NOT NULL column is a 422.
+
+    Without this the value reaches the flush and comes back as the same
+    ``IntegrityError`` a duplicate name raises, which the service would then
+    report as a name collision that never happened.
+    """
+    for field in ("name", "url", "enabled"):
+        with pytest.raises(ValidationError):
+            WorkspaceMcpServerUpdate(**{field: None})
+
+
+async def test_the_published_schema_does_not_advertise_null_where_it_is_refused() -> None:
+    """The generated client must not tell a caller that a payload the server 422s is valid.
+
+    ``name``/``url``/``enabled`` back NOT NULL columns and the validator above
+    refuses an explicit ``null`` for them, so they are omittable but not
+    nullable. The three that really can be cleared stay nullable.
+    """
+    properties = WorkspaceMcpServerUpdate.model_json_schema()["properties"]
+
+    for field, json_type in (("name", "string"), ("url", "string"), ("enabled", "boolean")):
+        assert properties[field].get("type") == json_type, field
+        assert "anyOf" not in properties[field], f"{field} is advertised as nullable"
+
+    for field in ("purpose_hint", "allowed_tools", "authorization_token"):
+        assert {"type": "null"} in properties[field]["anyOf"], f"{field} should stay clearable"
+
+
+async def test_a_nullable_field_can_still_be_cleared(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+    created = await service.create_server(
+        user=owner, workspace_id=workspace.id, request=_create(purpose_hint="Repository lookups")
+    )
+
+    cleared = await service.update_server(
+        user=owner,
+        workspace_id=workspace.id,
+        server_id=created.id,
+        request=WorkspaceMcpServerUpdate(purpose_hint=None),
+    )
+    assert cleared.purpose_hint is None
+
+
+async def test_the_tool_allow_list_is_bounded() -> None:
+    """The one field that is arbitrary JSON, and so the one that could otherwise be unbounded."""
+    with pytest.raises(ValidationError):
+        WorkspaceMcpServerCreate(name="github", url=PUBLIC_URL, allowed_tools=["t"] * (MAX_ALLOWED_TOOLS + 1))
+    with pytest.raises(ValidationError):
+        WorkspaceMcpServerCreate(name="github", url=PUBLIC_URL, allowed_tools=["t" * 300])
+
+
+async def test_mcp_server_ids_is_bounded_on_the_request() -> None:
+    """A workspace holds at most 50 servers in either mode, so a longer list can only be waste."""
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest(
+            model="openai:gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            mcp_server_ids=[uuid.uuid4() for _ in range(MAX_MCP_SERVER_IDS + 1)],
+        )

--- a/tests/unit/test_mcp_server_id_resolve.py
+++ b/tests/unit/test_mcp_server_id_resolve.py
@@ -11,7 +11,8 @@ import pytest
 
 from gateway.api.routes import _platform as platform_module
 from gateway.api.routes._platform import _resolve_platform_mcp_servers
-from gateway.models.mcp import McpServerConfig
+from gateway.models.mcp import MAX_MCP_SERVER_IDS, McpServerConfig
+from gateway.services.tenancy.workspace_mcp_server_service import MAX_MCP_SERVERS_PER_WORKSPACE
 
 
 def _config(*, base_url: str | None = "https://platform.local") -> Any:
@@ -180,3 +181,15 @@ async def test_resolve_422_collapses_to_502(monkeypatch: pytest.MonkeyPatch) -> 
     with pytest.raises(HTTPException) as ei:
         await _resolve_platform_mcp_servers(_config(), "tk", [uuid.uuid4()])
     assert ei.value.status_code == 502
+
+
+def test_the_request_bound_admits_every_server_a_workspace_can_hold() -> None:
+    """`MAX_MCP_SERVER_IDS` justifies itself by matching the per-workspace cap, so pin that.
+
+    They are declared separately on purpose (a wire bound has to be checkable at
+    parse time, with no database and no mode to consult), which is exactly what
+    lets them drift. Raising the service cap alone would leave a workspace able
+    to store more servers than one request may name, surfacing as a 422 with
+    nothing pointing at the cause.
+    """
+    assert MAX_MCP_SERVER_IDS >= MAX_MCP_SERVERS_PER_WORKSPACE

--- a/tests/unit/test_pipeline_settlement.py
+++ b/tests/unit/test_pipeline_settlement.py
@@ -21,6 +21,7 @@ import uuid
 from collections.abc import AsyncIterator
 from decimal import Decimal
 from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
 from any_llm import LLMProvider
@@ -34,6 +35,7 @@ from any_llm.types.completion import (
     CompletionUsage,
 )
 from fastapi import BackgroundTasks, HTTPException, Response
+from sqlalchemy.exc import SQLAlchemyError
 
 import gateway.api.routes._pipeline as pipeline
 import gateway.streaming as streaming
@@ -53,6 +55,7 @@ from gateway.api.routes._platform import ResolvedAttempt, ResolvedRoute, Settled
 from gateway.core.config import GatewayConfig
 from gateway.rate_limit import RateLimitInfo
 from gateway.services.budget_service import ReservationHandle
+from gateway.services.tenancy.errors import WorkspaceMcpServerNotFoundError
 
 ADAPTERS = [
     pytest.param(chat._ADAPTER, id="chat"),
@@ -1064,7 +1067,8 @@ async def test_tool_misconfiguration_400_releases_reservation(monkeypatch: pytes
 
 
 @pytest.mark.asyncio
-async def test_mcp_server_ids_in_standalone_releases_reservation(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_mcp_server_ids_without_a_workspace_releases_reservation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Standalone resolution needs a workspace; with none, the ids are refused rather than dropped."""
     settlement = _Settlement()
     settlement.install(monkeypatch)
 
@@ -1076,6 +1080,78 @@ async def test_mcp_server_ids_in_standalone_releases_reservation(monkeypatch: py
 
     assert exc_info.value.status_code == 400
     assert settlement.refunded == 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_mcp_server_id_releases_reservation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An id naming no server in the request's workspace is a 404, the same answer hybrid mode gives."""
+    settlement = _Settlement()
+    settlement.install(monkeypatch)
+
+    async def missing(*args: Any, **kwargs: Any) -> list[Any]:
+        raise WorkspaceMcpServerNotFoundError("11111111-1111-1111-1111-111111111111")
+
+    monkeypatch.setattr(pipeline, "resolve_workspace_mcp_servers", missing)
+
+    ctx = _ctx(GatewayConfig(), db=cast(Any, object()), reservation=_reservation(), workspace_id=uuid.uuid4())
+    with pytest.raises(HTTPException) as exc_info:
+        await _call_prepare_gateway_tools(
+            ctx, mcp_server_ids=[cast(Any, "11111111-1111-1111-1111-111111111111")]
+        )
+
+    assert exc_info.value.status_code == 404
+    assert settlement.refunded == 1
+
+
+@pytest.mark.asyncio
+async def test_a_database_failure_releases_the_reservation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A `SQLAlchemyError` is not an `HTTPException`, and must still not leave the hold behind.
+
+    Two reads in `prepare_gateway_tools` touch the database, so a failure in
+    either would otherwise escape the release and hold the estimate against
+    `users.reserved` until the budget's next reset.
+    """
+    settlement = _Settlement()
+    settlement.install(monkeypatch)
+
+    async def failing(*args: Any, **kwargs: Any) -> list[Any]:
+        raise SQLAlchemyError("connection reset")
+
+    monkeypatch.setattr(pipeline, "resolve_workspace_mcp_servers", failing)
+
+    db = AsyncMock()
+    ctx = _ctx(GatewayConfig(), db=cast(Any, db), reservation=_reservation(), workspace_id=uuid.uuid4())
+    with pytest.raises(SQLAlchemyError):
+        await _call_prepare_gateway_tools(
+            ctx, mcp_server_ids=[cast(Any, "11111111-1111-1111-1111-111111111111")]
+        )
+
+    assert settlement.refunded == 1
+    assert db.rollback.await_count == 1, "the session is rolled back first, or the release cannot run"
+
+
+@pytest.mark.asyncio
+async def test_a_release_that_also_fails_reraises_the_original(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A database still refusing work must surface the first failure, not a second one."""
+    settlement = _Settlement()
+    settlement.install(monkeypatch)
+
+    async def failing(*args: Any, **kwargs: Any) -> list[Any]:
+        raise SQLAlchemyError("connection reset")
+
+    async def failing_release(*args: Any, **kwargs: Any) -> None:
+        raise SQLAlchemyError("still down")
+
+    monkeypatch.setattr(pipeline, "resolve_workspace_mcp_servers", failing)
+    monkeypatch.setattr(pipeline, "release_reservation", failing_release)
+
+    db = AsyncMock()
+    db.rollback.side_effect = SQLAlchemyError("still down")
+    ctx = _ctx(GatewayConfig(), db=cast(Any, db), reservation=_reservation(), workspace_id=uuid.uuid4())
+    with pytest.raises(SQLAlchemyError, match="connection reset"):
+        await _call_prepare_gateway_tools(
+            ctx, mcp_server_ids=[cast(Any, "11111111-1111-1111-1111-111111111111")]
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_service_module_imports.py
+++ b/tests/unit/test_service_module_imports.py
@@ -38,6 +38,10 @@ _MODULES = [
     # here for the same reason as the two above them.
     "gateway.services.tenancy.workspace_budget_default_service",
     "gateway.services.tenancy.authorization",
+    # workspace_mcp_server_service reaches authorization and organization_service
+    # the same way, and is additionally imported from the request pipeline, which
+    # is a second entry point into the graph.
+    "gateway.services.tenancy.workspace_mcp_server_service",
 ]
 
 

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -2968,6 +2968,68 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/workspaces/{workspace_id}/mcp-servers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Workspace Mcp Servers
+         * @description List the MCP servers configured for a workspace.
+         *
+         *     Organization owners/admins or this workspace's owners/admins. Reads are
+         *     gated like writes because these rows name the endpoints the gateway
+         *     connects to on the workspace's behalf. Authorization tokens are never
+         *     included; each server reports only whether it has one.
+         */
+        get: operations["list_workspace_mcp_servers_v1_workspaces__workspace_id__mcp_servers_get"];
+        put?: never;
+        /**
+         * Create Workspace Mcp Server
+         * @description Register an MCP server for a workspace. Organization owners/admins or this workspace's owners/admins.
+         *
+         *     The authorization token is encrypted at rest and never returned. The URL
+         *     is checked for SSRF safety here as well as on the request path, and must
+         *     use https when a token is set. A name already used in this workspace is
+         *     refused with a 409.
+         */
+        post: operations["create_workspace_mcp_server_v1_workspaces__workspace_id__mcp_servers_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/workspaces/{workspace_id}/mcp-servers/{server_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Workspace Mcp Server
+         * @description Delete a server and the token stored with it. Organization owners/admins or this workspace's owners/admins.
+         */
+        delete: operations["delete_workspace_mcp_server_v1_workspaces__workspace_id__mcp_servers__server_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Workspace Mcp Server
+         * @description Update a server. Organization owners/admins or this workspace's owners/admins.
+         *
+         *     Only the fields sent are applied. Omit `authorization_token` to leave the
+         *     stored token alone, send an empty string to clear it, or send a value to
+         *     rotate it.
+         */
+        patch: operations["update_workspace_mcp_server_v1_workspaces__workspace_id__mcp_servers__server_id__patch"];
+        trace?: never;
+    };
     "/v1/workspaces/{workspace_id}/member-budget-policies": {
         parameters: {
             query?: never;
@@ -7787,6 +7849,116 @@ export interface components {
             description?: string | null;
             /** Name */
             name: string;
+        };
+        /**
+         * WorkspaceMcpServerCreate
+         * @description Request body for registering a server.
+         *
+         *     ``authorization_token`` is never stored as sent: it is encrypted with
+         *     ``OTARI_SECRET_KEY`` and only the ciphertext is kept, the same convention
+         *     `entities.ProviderCredential` and `OrgProviderKey` already use.
+         */
+        WorkspaceMcpServerCreate: {
+            /**
+             * Allowed Tools
+             * @description Allow-list of tool names; null exposes every tool the server offers
+             */
+            allowed_tools?: string[] | null;
+            /**
+             * Authorization Token
+             * @description Bearer token for the server; requires an https URL. Encrypted at rest, never returned
+             */
+            authorization_token?: string | null;
+            /**
+             * Enabled
+             * @description Whether a request naming this server actually reaches it
+             * @default true
+             */
+            enabled: boolean;
+            /**
+             * Name
+             * @description Label for the server, unique within the workspace
+             */
+            name: string;
+            /**
+             * Purpose Hint
+             * @description Hint prepended to the system message to help the model choose
+             */
+            purpose_hint?: string | null;
+            /**
+             * Url
+             * @description Streamable HTTP MCP endpoint
+             */
+            url: string;
+        };
+        /**
+         * WorkspaceMcpServerPublic
+         * @description The API-facing shape. Never carries the token, only whether one is set.
+         *
+         *     No ``last4``-style prefix either, unlike `OrgProviderKeyPublic`: a provider
+         *     key's last four digits let an operator match a stored key against the one
+         *     in their provider's console, and there is no equivalent workflow for an MCP
+         *     bearer token.
+         */
+        WorkspaceMcpServerPublic: {
+            /** Allowed Tools */
+            allowed_tools: string[] | null;
+            /** Created At */
+            created_at: string;
+            /** Enabled */
+            enabled: boolean;
+            /** Has Token */
+            has_token: boolean;
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Name */
+            name: string;
+            /** Purpose Hint */
+            purpose_hint: string | null;
+            /** Updated At */
+            updated_at: string;
+            /** Url */
+            url: string;
+            /**
+             * Workspace Id
+             * Format: uuid
+             */
+            workspace_id: string;
+        };
+        /**
+         * WorkspaceMcpServerUpdate
+         * @description Partial update. Only the fields the caller sets are applied.
+         *
+         *     ``authorization_token`` has three states rather than two, which is what a
+         *     write-only field needs: omit it to leave the stored token alone, send
+         *     ``""`` to clear it, send a value to rotate it. An explicit ``null`` also
+         *     leaves it alone, matching the platform: a client that serializes its whole
+         *     form back, with an empty token box it never filled in, must not destroy a
+         *     token it was never shown.
+         */
+        WorkspaceMcpServerUpdate: {
+            /** Allowed Tools */
+            allowed_tools?: string[] | null;
+            /** Authorization Token */
+            authorization_token?: string | null;
+            /** Enabled */
+            enabled?: boolean;
+            /** Name */
+            name?: string;
+            /** Purpose Hint */
+            purpose_hint?: string | null;
+            /** Url */
+            url?: string;
+        };
+        /** WorkspaceMcpServersPublic */
+        WorkspaceMcpServersPublic: {
+            /** Count */
+            count: number;
+            /** Data */
+            data: components["schemas"]["WorkspaceMcpServerPublic"][];
         };
         /** WorkspaceMemberBudgetPoliciesPublic */
         WorkspaceMemberBudgetPoliciesPublic: {
@@ -12722,6 +12894,145 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ActivationApiKeyPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_workspace_mcp_servers_v1_workspaces__workspace_id__mcp_servers_get: {
+        parameters: {
+            query?: {
+                /** @description Number of records to skip */
+                skip?: number;
+                /** @description Maximum number of records to return */
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                workspace_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkspaceMcpServersPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_workspace_mcp_server_v1_workspaces__workspace_id__mcp_servers_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspace_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkspaceMcpServerCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkspaceMcpServerPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_workspace_mcp_server_v1_workspaces__workspace_id__mcp_servers__server_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspace_id: string;
+                server_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Message"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_workspace_mcp_server_v1_workspaces__workspace_id__mcp_servers__server_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspace_id: string;
+                server_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WorkspaceMcpServerUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WorkspaceMcpServerPublic"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Description

Standalone deployments can now configure MCP servers per workspace. `mcp_server_ids` was hybrid-only and returned a 400 outside it; it now resolves in both modes, through the platform in hybrid and against a new `workspace_mcp_servers` table in standalone. Tokens are Fernet-encrypted at rest and absent from every response (`has_token` instead), names are unique per workspace at the database, and URLs face the same SSRF and TLS checks a request-body server does.

Ported from otari-ai's `MCPServerService` rather than designed fresh. Three deliberate divergences: this repository's own workspace authorization (a workspace owner/admin qualifies, not only an organization owner/admin), one async URL check in the service instead of the platform's split between a sync ingress validator and a service-layer SSRF pass, and no analytics or capability-status field. Its stricter read gate is kept: every operation including the list needs management access, since these rows name the endpoints the gateway connects to and authenticates against.

Resolution follows #678 exactly: at admission in `prepare_gateway_tools`, off `RequestContext.workspace_id`, against the request's live session, landing on `ToolContext`. No overlay, no cache. MCP is the exception that decision names, having no deployment-wide list to narrow.

**Two contract changes**, both unreachable while the field was hybrid-only. An unknown id is now 404 in both modes rather than a standalone 400, and `mcp_server_ids` gains a ceiling of 50, the most servers a workspace can hold on either side.

**Not included:** a dashboard page. The issue carries `area/dashboard`, but its Definition of Done is entirely backend and the generated client already has the types. Happy to follow up if you want the UI in this milestone.

Worth noting before merge: your own comment on #658 asks whether any otari.ai users actually use the MCP server feature, and floats deferring it out of m5 if not. That question is still open.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #658.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). 29 new integration tests covering CRUD, encryption at rest, the token's three update states, URL validation, the role gate, resolution, and the zero-rows case #678 asks each of the four surfaces for.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). All pass. One caveat on the integration suite: the sandbox has no Docker, so I ran it against a local PostgreSQL 18 via `TEST_DATABASE_URL`. The first full run was clean at 1509 passed. A second run after review fixes took 44 minutes instead of 12 under load and reported one failure in `test_agent_telemetry_read.py` plus two socket-timeout errors in `test_otlp_metrics.py`; all three pass in isolation and none touch this change. Also ran the OSS-edition smoke gate, and the migration up, down and up again on PostgreSQL with `alembic check` showing no drift.
- [x] Documentation was updated where necessary. `docs/mcp.md` and `src/gateway/AGENTS.md`.
- [x] If the API contract changed, I regenerated the OpenAPI spec. Postman collection, `sdk-endpoints.txt` and `web/src/client/schema.ts` regenerated too.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Claude Opus 5)

**Any additional AI details you'd like to share:**

Grounded in the otari-ai implementation this issue describes, read directly rather than reconstructed from the issue text, and in #678's recorded decision. A fresh reviewer agent read the diff cold and found a real bug: an explicit `null` on a required field reached a NOT NULL column and came back as a 409 naming a name conflict that did not exist. Fixed, along with two unbounded-input findings. Prose is the model's; the decisions are Nathan's.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYFMEkk1ppKiP6CXuDeBPZ

_Note: this PR description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added workspace-scoped MCP server management with create, list, update, and delete operations.
- Added encrypted token storage. API responses expose only `has_token`.
- Added workspace authorization, unique server names, URL safety checks, and server limits.
- Enabled MCP server resolution in standalone and hybrid deployments.
- Added disabled-server handling, request limits, documentation, API artifacts, migration, and integration tests.
- No dashboard UI is included.

## Technical notes

- `mcp_server_ids` supports up to 50 IDs.
- Unknown server IDs return `404`.
- Tokens use Fernet encryption at rest.
- Workspace deletion cascades to its MCP server configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->