### PR TITLE
fix(gateway): stop purpose-hint injection from corrupting list-shaped system content

### DIFF
--- a/src/gateway/services/mcp_loop.py
+++ b/src/gateway/services/mcp_loop.py
@@ -71,6 +71,12 @@ def inject_purpose_hints(
 ) -> list[dict[str, Any]]:
     """Prepend or extend the system message with per-tool usage hints.
 
+    The merge target is the first message whose ``role`` is ``"system"``, wherever
+    it sits (a ``developer`` message may legally precede it); one is inserted at
+    the front when the conversation has none. ``content`` may be a string or a
+    list of content parts, so a list keeps its shape and gains a leading text
+    part rather than being stringified.
+
     Header resolution priority:
       1. ``header`` arg (per-request override, set from the request body)
       2. ``OTARI_TOOLS_HEADER`` env (per-deployment override)

--- a/src/gateway/services/mcp_loop.py
+++ b/src/gateway/services/mcp_loop.py
@@ -86,11 +86,21 @@ def inject_purpose_hints(
     block = "\n".join(lines)
 
     out = list(messages)
-    if out and out[0].get("role") == "system":
-        existing = out[0].get("content") or ""
-        out[0] = {**out[0], "content": f"{existing}\n\n{block}" if existing else block}
-    else:
+    system_idx = next((i for i, m in enumerate(out) if m.get("role") == "system"), None)
+    if system_idx is None:
         out.insert(0, {"role": "system", "content": block})
+        return out
+
+    existing = out[system_idx].get("content")
+    if existing is None:
+        new_content: Any = block
+    elif isinstance(existing, str):
+        new_content = f"{existing}\n\n{block}" if existing else block
+    elif isinstance(existing, list):
+        new_content = [{"type": "text", "text": block}, *existing]
+    else:
+        new_content = block
+    out[system_idx] = {**out[system_idx], "content": new_content}
     return out
 
 

--- a/tests/unit/test_mcp_loop.py
+++ b/tests/unit/test_mcp_loop.py
@@ -159,6 +159,51 @@ def test_inject_purpose_hints_extends_existing_system() -> None:
     assert out[0]["role"] == "system"
     assert "be helpful" in out[0]["content"]
     assert "cal" in out[0]["content"]
+    # regression: string content behaves exactly as today (existing text kept ahead of the hint block)
+    assert out[0]["content"] == "be helpful\n\nYou have access to the following tools:\n- cal: use it"
+
+
+def test_inject_purpose_hints_no_system_inserts_at_front() -> None:
+    """Regression: with no system message present, one is still inserted at index 0."""
+    msgs = [{"role": "user", "content": "hi"}]
+    out = inject_purpose_hints(msgs, [("cal", "for scheduling")])
+    assert len(out) == 2
+    assert out[0] == {"role": "system", "content": "You have access to the following tools:\n- cal: for scheduling"}
+    assert out[1] == {"role": "user", "content": "hi"}
+
+
+def test_inject_purpose_hints_preserves_list_shaped_system_content() -> None:
+    """List-shaped system content (Anthropic-style cache_control parts) must not be stringified into a repr."""
+    msgs = [
+        {"role": "system", "content": [{"type": "text", "text": "be helpful"}]},
+        {"role": "user", "content": "hi"},
+    ]
+    out = inject_purpose_hints(msgs, [("cal", "for scheduling")])
+    assert out[0]["role"] == "system"
+    content = out[0]["content"]
+    assert isinstance(content, list)
+    # the hint block is prepended as its own text part; the original part survives untouched.
+    assert content[0] == {"type": "text", "text": "You have access to the following tools:\n- cal: for scheduling"}
+    assert content[1] == {"type": "text", "text": "be helpful"}
+    # no repr() debris anywhere in the output.
+    assert "{'type'" not in str(content[0]["text"])
+    assert "{'type'" not in str(content[1]["text"])
+    assert len([m for m in out if m.get("role") == "system"]) == 1
+
+
+def test_inject_purpose_hints_developer_then_system_extends_the_system_message() -> None:
+    """A developer message ahead of system must not cause a second system message to be inserted."""
+    msgs = [
+        {"role": "developer", "content": "dev preamble"},
+        {"role": "system", "content": "be helpful"},
+        {"role": "user", "content": "hi"},
+    ]
+    out = inject_purpose_hints(msgs, [("cal", "for scheduling")])
+    system_messages = [m for m in out if m.get("role") == "system"]
+    assert len(system_messages) == 1
+    assert [m["role"] for m in out] == ["developer", "system", "user"]
+    assert "be helpful" in out[1]["content"]
+    assert "cal" in out[1]["content"]
 
 
 def test_finalize_tool_calls_orders_by_index() -> None:

--- a/tests/unit/test_mcp_loop.py
+++ b/tests/unit/test_mcp_loop.py
@@ -174,7 +174,7 @@ def test_inject_purpose_hints_no_system_inserts_at_front() -> None:
 
 def test_inject_purpose_hints_preserves_list_shaped_system_content() -> None:
     """List-shaped system content (Anthropic-style cache_control parts) must not be stringified into a repr."""
-    msgs = [
+    msgs: list[dict[str, Any]] = [
         {"role": "system", "content": [{"type": "text", "text": "be helpful"}]},
         {"role": "user", "content": "hi"},
     ]


### PR DESCRIPTION
## Description

`inject_purpose_hints` (`src/gateway/services/mcp_loop.py:66-94`) merges the MCP purpose-hint block into the leading system message with a bare f-string and no type check on the content shape. Two bugs come out of that:

1. **List-shaped system content gets stringified into a Python repr.** OpenAI's chat contract allows `content` on a system message to be either a string or a list of content-part dicts (the shape needed for `cache_control`-style caching). At `mcp_loop.py:90-91` (before the fix), `f"{existing}\n\n{block}"` calls `str()`/`repr()` on the list when `existing` is a list, so the model receives the literal Python repr of the content parts as prompt text, e.g. `"[{'type': 'text', 'text': 'be helpful'}]\n\nYou have access to the following tools:\n..."`. The original system prompt survives only as quoted debris inside that repr.

2. **A system message not at index 0 causes a second system message to be inserted.** The merge check only tested `out[0].get("role") == "system"` (`mcp_loop.py:89`). Nothing in the OpenAI chat contract requires `system` to be the first message, and a `developer` message (o1-class models) commonly precedes it. When `system` sits at index >= 1, the `else` branch ran and inserted a *second* system message at the front, so the hints land on a message the caller never wrote while the caller's actual system message is untouched.

Both are reachable from the wire: `ChatCompletionRequest.messages` (`src/gateway/api/routes/chat.py:80`) is typed `list[dict[str, Any]]`, and its validator (`chat.py:103`) only checks for a `role` key — content shape and message order are unconstrained. `chat.py:263` calls `inject_purpose_hints(kwargs["messages"], hints, header=header)` on wire-supplied messages whenever any configured MCP server has a `purpose_hint`. Any caller sending list-shaped system content, or a `developer` message ahead of `system`, gets a silently corrupted request on every call.

`src/gateway/services/tool_format.py:98-105` (`inject_purpose_hints_anthropic`, used by the `/v1/messages` and Responses routes) already has the correct fix for the content-shape half of this: an isinstance ladder over `None` / `str` / `list` / `else` that keeps a list a list. The chat-completions path is the one place that never got that ladder. This PR brings it in line: scans for the first message with `role == "system"` instead of testing index 0 only, and branches on the existing content's type the same way `tool_format.py` does, rather than assuming `str`.

## PR Type

- [x] Bug Fix

## Relevant issues

Fixes #590

## What I ran

```
uv sync --frozen
uv run pytest tests/unit/test_mcp_loop.py -v
```

RED (source reverted to the pre-fix version, new tests left in place):
```
FAILED tests/unit/test_mcp_loop.py::test_inject_purpose_hints_preserves_list_shaped_system_content
FAILED tests/unit/test_mcp_loop.py::test_inject_purpose_hints_developer_then_system_extends_the_system_message
2 failed, 26 passed in 79.55s
```

GREEN (fix restored):
```
28 passed in 74.89s
```

`uv run pytest tests/unit` (the full unit suite) did not finish in this environment after 10+ minutes at ~16% progress, so I scoped the RED/GREEN runs to `tests/unit/test_mcp_loop.py`, which is the file covering this change, rather than block on that.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (Claude Code)

**Any additional AI details you'd like to share:**

Written in conjunction with my pair programmer Claude. The finding was verified against upstream before any code was written, and the fix is covered by tests that fail against the unpatched source.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Updated `inject_purpose_hints` to handle system messages consistently across message layouts.

- Preserves list-shaped system content.
- Extends the first system message wherever it appears.
- Prevents duplicate system messages when a developer message appears first.
- Preserves existing string-content behavior.
- Adds regression tests for these cases and for conversations without a system message.

Targeted tests pass: 28 tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
