### PR TITLE
fix(dashboard): stop the bulk action bar sliding in from the left

### DIFF
--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -960,14 +960,18 @@ h6 {
 .otari-bulk-bar {
   animation: otari-bulk-bar-in 160ms ease-out;
 }
+/* Animates `translate`, not `transform`: the bar centers itself with Tailwind's
+ * `-translate-x-1/2`, which under Tailwind v4 sets the `translate` property, and
+ * a `transform` here would compose with it into a -100% offset for the length of
+ * the animation, so the bar slid in from half its width to the left. */
 @keyframes otari-bulk-bar-in {
   from {
     opacity: 0;
-    transform: translate(-50%, 0.5rem);
+    translate: -50% 0.5rem;
   }
   to {
     opacity: 1;
-    transform: translate(-50%, 0);
+    translate: -50% 0;
   }
 }
 


### PR DESCRIPTION
## Description

Selecting rows in any dashboard table made the bulk action bar appear about half its own width to the left of center and then slide into place, reading as a glitch rather than an entrance animation. Affected every `BulkActionBar` consumer: Keys, Models, Budgets, Activity.

`BulkActionBar` centers itself with Tailwind's `-translate-x-1/2`, which under Tailwind v4 compiles to the `translate` property rather than `transform`:

```css
.-translate-x-1\/2 {
  --tw-translate-x: calc(calc(1 / 2 * 100%) * -1);
  translate: var(--tw-translate-x) var(--tw-translate-y);
}
```

The `otari-bulk-bar-in` keyframes set `transform: translate(-50%, …)`, so both properties applied and composed into a -100% offset for the 160ms the animation ran; with no `forwards` fill the bar then snapped back to the correct -50%. The fix animates `translate` instead, so the centering and the entrance share one property.

CSS-only: two changed declarations in `web/src/styles/globals.css`, plus a comment recording why `transform` is the wrong property here, since reaching for it again would reintroduce the bug.

`prefers-reduced-motion: reduce` already disabled the animation, so that path was never affected.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Closes #734

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). **No tests added, at the author's explicit request to keep the PR minimal.** For the record, this bug class is not covered: `BulkActionBar.test.tsx` asserts rendering and behavior, not computed offsets, so a jsdom test would not have caught it and would not catch a recurrence. Catching it needs a browser-rendered check (the screenshot suite), which is on-demand and gitignored while the dashboard is mid-migration.
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). Ran Biome on the changed file (clean). Did not run the Python-side `make lint`/`typecheck`/`test`, which cover `src/gateway/` and are untouched by a `web/src/styles/globals.css` change; leaving this unchecked rather than implying the full suite was run.
- [x] Documentation was updated where necessary. (Not needed; the reasoning lives in a comment next to the keyframes.)
- [x] If the API contract changed, I regenerated the OpenAPI spec. (No API change.)

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code, Claude Opus 5 (1M context)

**Any additional AI details you'd like to share:**

The bug was reported from observed behavior; the Tailwind v4 `translate`-vs-`transform` cause was found by compiling the `-translate-x-1/2` utility against the repo's pinned `tailwindcss@4.3.3` and reading the emitted property, rather than inferred. Branch was built in a worktree off `origin/main` so the author's unrelated in-progress work stayed out of the diff.

- [x] I am an AI Agent filling out this form (check box if true)
