### PR TITLE
feat(architecture): land the ports package, composition container, and bootstrap hook

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,7 +79,7 @@ A **port** is a domain-named interface (a Python `Protocol`), named for what it 
 | `EntitlementPort` | Which capabilities a deployment is entitled to. |
 | `IdentityProviderPort` | Authenticating users/sign-in. |
 | `RoutingPort` | Choosing the provider/model attempts for a request. |
-| `ModelProviderPort` | Executing the model inference call. |
+| `ModelProviderPort` | Resolving the deployment-owned credential that serves a request bringing none. |
 | `CodeExecutionPort` | Running model-generated code in a sandbox. |
 | `BillingPort` | Metering and charging for usage. |
 | `GrowthSignalPort` | Telling an outside CRM or support messenger about a user's lifecycle. |
@@ -154,6 +154,8 @@ def register(container: Container) -> None:
 With nothing configured nothing is imported, the defaults stand, and Otari boots standalone. A selector that is set but cannot be loaded fails startup rather than quietly falling back, because a build nobody chose is worse than a gateway that will not start.
 
 A contributed router is the additive half of the seam, and it is gated rather than swapped: Otari mounts it behind `require_capability(...)`, which resolves `EntitlementPort` and answers a request for an unentitled capability with the same 404 a path nothing serves gets. That gate is the server-side half of the entitlement axis; hiding a nav item in the dashboard is not authorization.
+
+Entitlement is not authentication either, and the mount point adds none. A capability names no caller, so on an entitled deployment a contributed route is reachable by anyone unless the router says otherwise. A contribution declares the credential each of its routes needs on the route, the way Otari's own routers do; there is no router-level default to mount, because the right answer differs per route, a contributed route may be deliberately public, and the header check resolves a database session a hybrid gateway does not have.
 
 > **Where this lives in the tree.** The composition root is `src/gateway/container.py`; it is built once per app in `create_app` (`src/gateway/main.py`) and attached to `app.state` beside the other shared resources, so two apps in one process never share one. Ports are resolved from it through dependencies in `src/gateway/api/deps.py`, which is also where the rest of composition is still hand-wired: the container took over the ports, not every dependency, and a plain single-implementation service stays wired directly.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,7 +8,7 @@ This document is for contributors changing the *shape* of the system. It explain
 
 ## Status: this is a north-star document
 
-This describes the architecture the codebase is **heading toward**, not the whole of what exists today. Otari today is the gateway (the data plane) plus a standalone management API; the ports, the composition container, and the control-plane UI described below arrive as Otari grows into the full open-source base.
+This describes the architecture the codebase is **heading toward**, not the whole of what exists today. Otari today is the gateway (the data plane) plus a standalone management API; the ports package, the composition container, and the bootstrap hook are in the tree, and the rest, including the control-plane UI described below, arrives as Otari grows into the full open-source base.
 
 Read it with that in mind:
 
@@ -82,6 +82,7 @@ A **port** is a domain-named interface (a Python `Protocol`), named for what it 
 | `ModelProviderPort` | Executing the model inference call. |
 | `CodeExecutionPort` | Running model-generated code in a sandbox. |
 | `BillingPort` | Metering and charging for usage. |
+| `GrowthSignalPort` | Telling an outside CRM or support messenger about a user's lifecycle. |
 
 The cardinal property: **every port ships with a working adapter in Otari's core**, a real lightweight implementation or an honest [Null Object](https://en.wikipedia.org/wiki/Null_object_pattern). Otari must stand alone with no overlay present. `BillingPort`, for example, is a Null Object in the core: it is present and callable, and does nothing, so nothing in the core needs to know whether real billing exists anywhere.
 
@@ -104,6 +105,7 @@ flowchart LR
         MP[ModelProviderPort]
         CP[CodeExecutionPort]
         BP[BillingPort]
+        GP[GrowthSignalPort]
     end
     UI --> API --> SVC --> REPO --> MOD
     SVC --> AP
@@ -113,9 +115,10 @@ flowchart LR
     SVC --> MP
     SVC --> CP
     SVC --> BP
+    SVC --> GP
 ```
 
-> **Planned.** A `ports` package and its default adapters do not exist in `src/gateway/` yet. Today the equivalent choices (which credential to use, how to authenticate) are made by the mode switch and hand-wired dependencies described next. The ports formalize those seams as the control plane grows into this repository.
+> **Where the ports are today.** `src/gateway/ports/` holds four of them, `ModelProviderPort`, `BillingPort`, `EntitlementPort` and `GrowthSignalPort`, each with a working core adapter in `src/gateway/adapters/`. They are the seam's mechanism rather than its whole surface: nothing on the request path calls one yet, so the choices those four describe (which credential to use, when to meter) are still made by the mode switch and the hand-wired dependencies described next. The remaining ports in the table above arrive as they gain callers.
 
 ## How a port is resolved
 
@@ -124,20 +127,35 @@ Ports are resolved through a **composition root** and a small **container**, not
 - The **container** is a process-level registry of `Port -> factory` bindings, built **once at startup**. It is a plain Python object (a mapping of port to factory), not a third-party dependency-injection framework and not entry-point auto-discovery. Only a handful of ports ever need swapping, and only at startup, so a thin explicit registry is preferred: a contributor can read the whole wiring in one file, and there is no install-time magic to trace.
 - The **composition root** is the single place allowed to name a concrete adapter. It binds the defaults at startup. Everywhere else refers to the *port*, and asks the container for whichever adapter is bound.
 
-Illustrative shape of a resolution (planned; not yet in the tree):
+Shape of a resolution:
 
 ```python
-# composition root, at startup: bind the default adapters
-container.bind(RoutingPort, lambda session: FallbackRoutingAdapter(session))
+# composition root (src/gateway/container.py), at startup: bind the core adapters
+def _billing_adapter(session: AsyncSession | None) -> BillingPort:
+    return NullBillingAdapter(session)
 
-# dependency: refers to the port and the container, never a concrete adapter
-def get_routing(session: SessionDep, container: ContainerDep) -> RoutingPort:
-    return container.routing(session)
+container.bind(BillingPort, _billing_adapter)
+
+# dependency (src/gateway/api/deps.py): names the port and the container, never an adapter
+def get_billing_port(db: PortSessionDep, container: ContainerDep) -> BillingPort:
+    return container.resolve(BillingPort, db)
 ```
 
-An overlay (or your own deployment) rebinds ports to its own adapters **without editing any Otari source file**, by supplying a bootstrap module that the container invokes at startup, selected declaratively by configuration (a planned `OTARI_BOOTSTRAP` setting pointing at a registration function). With nothing configured, the defaults stand and Otari boots standalone.
+The session a factory receives is the request's, and it is `None` in hybrid mode, where the gateway has no local database at all. An adapter that needs one has to say what it does without.
 
-> **Where this lives in the tree.** Today, composition is hand-wired as FastAPI dependencies in `src/gateway/api/deps.py`, and shared resources are attached to `app.state` when the app is built in `create_app` (`src/gateway/main.py`). The container formalizes exactly that hand-wiring: it is built once in `create_app` and resolved through the dependencies in `deps.py`. When the control plane grows into this repository, this is where the composition root lands. It replaces the hand-wiring in `deps.py` rather than living somewhere new.
+An overlay (or your own deployment) rebinds ports to its own adapters **without editing any Otari source file**, by supplying a bootstrap module that the container invokes at startup, selected declaratively by configuration: `OTARI_BOOTSTRAP=module:callable`. The callable is imported once, after the core defaults are bound, and receives the container:
+
+```python
+def register(container: Container) -> None:
+    container.bind(BillingPort, _wallet_billing_adapter)
+    container.contribute_router(RouterContribution(capability="billing", router=wallet_router))
+```
+
+With nothing configured nothing is imported, the defaults stand, and Otari boots standalone. A selector that is set but cannot be loaded fails startup rather than quietly falling back, because a build nobody chose is worse than a gateway that will not start.
+
+A contributed router is the additive half of the seam, and it is gated rather than swapped: Otari mounts it behind `require_capability(...)`, which resolves `EntitlementPort` and answers a request for an unentitled capability with the same 404 a path nothing serves gets. That gate is the server-side half of the entitlement axis; hiding a nav item in the dashboard is not authorization.
+
+> **Where this lives in the tree.** The composition root is `src/gateway/container.py`; it is built once per app in `create_app` (`src/gateway/main.py`) and attached to `app.state` beside the other shared resources, so two apps in one process never share one. Ports are resolved from it through dependencies in `src/gateway/api/deps.py`, which is also where the rest of composition is still hand-wired: the container took over the ports, not every dependency, and a plain single-implementation service stays wired directly.
 
 Not every service goes through a port. Most code has a single implementation and stays plain (see [when a capability earns a port](#cardinal-rules-for-contributors)); only capabilities with a real second implementation are resolved through the container.
 
@@ -170,9 +188,14 @@ The first is about *where the code is running* and the second about *what this c
 
 In the dashboard both meet on one nav entry, which is where the vocabulary earns its keep: `web/src/app/nav/registry.ts` declares a destination's `surface` and `capability`, and `useNavVisibility` composes them as AND, so either one hides the link and the shell answers the route behind it with a panel rather than a page. An overlay replaces `web/src/app/nav/overlaySections.ts` to register its own destinations, without editing a base source file.
 
-Be clear about how much of that is built. The surface axis is real and served: `GET /v1/bootstrap` answers it. **`EntitlementPort` is not implemented anywhere in `src/gateway/`, and no endpoint serves entitlements**, so the entitlement axis resolves entirely in the browser, from the constant that is the default value of the context in `web/src/shared/hooks/useEntitlements.tsx`. It grants `BASE_CAPABILITIES` and reports everything else absent, which is the behavior the core adapter above describes, in the only place there is currently anything to put it. That constant is itself empty, because no base nav entry is gated on a capability: the one candidate is routing, whose split this document still marks provisional. An overlay answers it for real by rendering `EntitlementProvider`.
+Be clear about how much of that is built. The surface axis is real and served: `GET /v1/bootstrap` answers it. `EntitlementPort` now exists on both sides of the wire, but **no endpoint serves entitlements to the browser**, so the two halves answer independently:
 
-That is sound while every capability the axis gates belongs to an overlay, since a deployment with no overlay has nothing to withhold. It stops being sound when an overlay mounts a router into this process, because hiding a link is not authorization and that route has to refuse for itself, on `EntitlementPort` and a `require_capability` dependency. The axis does not enforce against the operator, who owns the process; do not let a surface built on the client gate assume a resolver exists.
+- **In the browser**, the axis resolves from the constant that is the default value of the context in `web/src/shared/hooks/useEntitlements.tsx`. It grants `BASE_CAPABILITIES` and reports everything else absent. An overlay answers it for real by rendering `EntitlementProvider`.
+- **On the server**, `EntitlementPort` resolves through the container, and its core adapter (`src/gateway/adapters/entitlement_adapter.py`) answers with its own `BASE_CAPABILITIES`. That is what `require_capability` gates a contributed router on, so a route an overlay mounts into this process refuses for itself rather than trusting a hidden link. Hiding a link is not authorization; this is the half that is.
+
+Both constants are empty, and deliberately so: no base nav entry and no base route is gated on a capability, because the one candidate is routing, whose split this document still marks provisional. They are meant to agree, so a capability the base grows is added to both at once.
+
+The axis does not enforce against the operator, who owns the process; do not let a surface built on the client gate assume a resolver exists.
 
 ## Cardinal rules for contributors
 
@@ -186,18 +209,18 @@ These are the rules that keep the boundary from eroding. They apply to anyone ad
 6. **An overlay never edits an Otari source file.** It registers into the extension points Otari exposes (the container, the router list, the nav registry) and supplies configuration. If extending an overlay *requires* editing an Otari file, that is a missing seam, and the seam belongs in Otari. Supplying configuration or a bootstrap module is not editing the core.
 7. **Introduce a port only when it earns one.** A port that will only ever have one implementation is ceremony with no benefit. A capability earns a port only when a genuine second implementation is real, or a hard boundary (intellectual property, or a hosted service) runs through it. Plain CRUD and infrastructure (user, team, and trace management, and the bulk of orgs/workspaces management) stay concrete in the core. "Most of the management plane is core" and "most services are not ports" are the same statement.
 
-These rules are meant to be enforced mechanically, not only in review. A boundary check (planned: a `check_architecture.py` script run in CI) asserts the layering, for example: ports may import models, exceptions, and core, but not services, API, or any adapter; services may import ports but not a concrete adapter; only the composition root may import an adapter. This document is the human-readable companion to that check; the two are kept in step so the boundary the doc describes is the boundary CI enforces.
+These rules are enforced mechanically, not only in review. The boundary check (`scripts/check_architecture.py`, run by `make lint` in CI) asserts the layering: ports may import models, exceptions, and core, but not services, the API, or any adapter; services may import ports but not a concrete adapter; only the composition root may import an adapter. This document is the human-readable companion to that check; the two are kept in step so the boundary the doc describes is the boundary CI enforces.
 
 ## How to add a capability
 
 A step-by-step recipe for adding a capability without crossing the boundary. The `AuthzPort` seam is the reference template every later capability copies.
 
 1. **Decide whether you need a port at all.** Apply rule 7. If the capability is plain management CRUD with no second implementation on the horizon, skip the ceremony: write a normal service and repository in the core and stop here. Only continue if a second implementation is genuinely on the table, or a hard boundary runs through it.
-2. **Define the port.** Add a domain-named `Protocol` to the core `ports` package (planned location: `src/gateway/ports/`). It may depend on models, exceptions, and core only, never on services, the API, or an adapter.
+2. **Define the port.** Add a domain-named `Protocol` to `src/gateway/ports/`, one module per port. Its methods are `async`. It may depend on models, exceptions, and core only, never on services, the API, or an adapter.
 3. **Route callers through the port.** Services depend on the port, resolved from the container; they never name a concrete adapter.
-4. **Ship a working core adapter.** Add a real lightweight implementation, or an honest Null Object, to the core adapters package. Verify the capability behaves correctly with only this adapter present.
-5. **Bind the default in the composition root.** Register `Port -> core factory` in the container built at startup in `create_app`, and resolve it through a dependency in `deps.py`.
-6. **If the capability has API or UI surface, add and gate it.** Add its router to the central additive router list (a planned mechanism) and register its nav item into the nav registry (`web/src/app/nav/registry.ts`), each gated by an entitlement. Do not swap anything on this side; add surface and make it conditional.
+4. **Ship a working core adapter.** Add a real lightweight implementation, or an honest Null Object, to `src/gateway/adapters/`. Verify the capability behaves correctly with only this adapter present.
+5. **Bind the default in the composition root.** Register `Port -> core factory` in `build_container` (`src/gateway/container.py`), through a named factory function whose return type is the port, so the type checker verifies the adapter satisfies it. Resolve it through a dependency in `deps.py`.
+6. **If the capability has API or UI surface, add and gate it.** A core router is registered in `register_routers` (`src/gateway/api/main.py`); an overlay's is recorded on the container with `contribute_router` and mounted behind the capability it names. Register its nav item into the nav registry (`web/src/app/nav/registry.ts`), gated by the same entitlement. Do not swap anything on this side; add surface and make it conditional.
 7. **Verify Otari still stands alone.** It must boot standalone with only the core adapters bound (no overlay bootstrap configured) and pass its smoke suite, and the boundary check must pass. Both are automated: `uv run --frozen --no-dev python scripts/oss_edition_smoke.py` is the smoke suite (run by `.github/workflows/otari-oss-edition.yml` on any pull request that touches the app, the migrations, or dependency resolution), and `make check-architecture` is the boundary check.
 
 Once the seam exists, an overlay adds its own adapter by registering it through these same extension points, with zero edits to Otari's source. Building the seam is core work; using it is overlay work.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -215,6 +215,20 @@ build, since a deployment that meant to load an overlay should not serve traffic
 without it. The module has to be importable by the gateway process, so install it
 into the same environment or put it on `PYTHONPATH`.
 
+A contributed router is mounted behind its capability gate and nothing else.
+That gate answers "is this deployment licensed for this surface", which names no
+caller, so **authentication is the contribution's own job**: declare the
+credential each route needs on the route, the way Otari's own routers do. Otari
+mounts no router-level default, because the right answer differs per route, a
+contributed route may be deliberately public, and the header check needs a
+database session a hybrid gateway does not have.
+
+Treat this like a credential rather than a feature flag: naming a module here
+runs that module's code inside the gateway process at startup. It is read only
+from the environment or `config.yml`, never from the dashboard, so whoever can
+set it already owns the process; keep it under the same control as
+`OTARI_SECRET_KEY` and `OTARI_MASTER_KEY`.
+
 The interfaces this exposes are not frozen while Otari is pre-1.0. Pin a released
 tag and expect the shapes to move.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,6 +184,39 @@ Note the `require_pricing` interaction: it defaults to `true` (fail-closed), so 
 | `OTARI_PORT` | Server bind port |
 | `OTARI_AUTO_MIGRATE` | Auto-run migrations on startup |
 | `OTARI_BOOTSTRAP_API_KEY` | Create first-use API key |
+| `OTARI_BOOTSTRAP` | Composition-root bootstrap for a build that layers its own adapters onto Otari, as a `module:callable` selector. Unrelated to `OTARI_BOOTSTRAP_API_KEY`; see [Extending Otari with a bootstrap module](#extending-otari-with-a-bootstrap-module). |
+
+### Extending Otari with a bootstrap module
+
+Most deployments never set this. It exists for a build that layers its own
+implementations onto Otari (an in-process **overlay**, in the vocabulary of
+[ARCHITECTURE.md](../ARCHITECTURE.md)) without forking or editing Otari's source.
+
+`OTARI_BOOTSTRAP=my_overlay.bootstrap:register` names a module and a callable in
+it. Otari imports the module once at startup, after binding its own default
+implementation for every port, and calls it with the composition-root container.
+The callable can rebind a port to its own implementation and contribute routers
+of its own, each mounted behind the capability it names:
+
+```python
+from gateway.container import Container, RouterContribution
+from gateway.ports.billing_port import BillingPort
+
+
+def register(container: Container) -> None:
+    container.bind(BillingPort, _wallet_billing_adapter)
+    container.contribute_router(RouterContribution(capability="billing", router=wallet_router))
+```
+
+Leave it unset and nothing is imported: Otari's own defaults stand and the
+gateway behaves exactly as it does today. Set it to something that cannot be
+imported and the gateway refuses to start, rather than quietly running the plain
+build, since a deployment that meant to load an overlay should not serve traffic
+without it. The module has to be importable by the gateway process, so install it
+into the same environment or put it on `PYTHONPATH`.
+
+The interfaces this exposes are not frozen while Otari is pre-1.0. Pin a released
+tag and expect the shapes to move.
 
 ### Mail
 

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -7,6 +7,8 @@ Enforces:
 3. Repository boundaries: repositories must not import services or the API layer.
 4. Naming conventions: repository modules end in _repository.py.
 5. OSS/enterprise boundary: OSS code must not import the enterprise overlay.
+6. Port boundaries: a port may describe the domain but not import a caller or an adapter.
+7. Composition root: only gateway/container.py may name a concrete adapter.
 
 Usage:
     uv run python scripts/check_architecture.py
@@ -63,9 +65,28 @@ RULES: dict[str, LayerRule] = {
         "description": "OSS test suite",
     },
     "gateway/services": {
-        "allowed": ["gateway.repositories", "gateway.models", "gateway.core", "gateway.auth"],
-        "forbidden": ["gateway.api"],
+        "allowed": ["gateway.repositories", "gateway.models", "gateway.core", "gateway.auth", "gateway.ports"],
+        # A service depends on the port and gets its adapter from the container;
+        # naming a concrete adapter would pin the capability to one
+        # implementation and defeat the seam (ARCHITECTURE.md, rule 5).
+        "forbidden": ["gateway.api", "gateway.adapters"],
         "description": "Services",
+    },
+    # The API layer resolves a port through the container in deps.py; only the
+    # composition root (gateway/container.py) may name a concrete adapter.
+    "gateway/api": {
+        "allowed": [
+            "gateway.api",
+            "gateway.container",
+            "gateway.ports",
+            "gateway.services",
+            "gateway.repositories",
+            "gateway.models",
+            "gateway.core",
+            "gateway.auth",
+        ],
+        "forbidden": ["gateway.adapters"],
+        "description": "API layer",
     },
     "gateway/api/routes": {
         # Routes reuse repository helpers (e.g. get_active_user) per the
@@ -84,7 +105,7 @@ RULES: dict[str, LayerRule] = {
     },
     "gateway/repositories": {
         "allowed": ["gateway.models"],
-        "forbidden": ["gateway.services", "gateway.api"],
+        "forbidden": ["gateway.services", "gateway.api", "gateway.adapters"],
         "description": "Repositories",
     },
     # Leaf data types shared across layers (e.g. the routing Attempt, which
@@ -94,22 +115,26 @@ RULES: dict[str, LayerRule] = {
     # merely wants the shape.
     "gateway/types": {
         "allowed": [],
-        "forbidden": ["gateway.api", "gateway.services", "gateway.repositories", "gateway.core"],
+        "forbidden": ["gateway.api", "gateway.services", "gateway.repositories", "gateway.core", "gateway.adapters"],
         "description": "Shared types",
     },
-    # Open-core boundary scaffolding. Ports (domain-named interfaces) and their
-    # adapters get their own layers so future boundary rules have a place to
-    # land (see ARCHITECTURE.md). Intentionally no-op until the first port
-    # arrives: with empty "forbidden" lists nothing is enforced and the check
-    # stays green.
+    # Open-core boundary. A port is a domain-named interface the core depends
+    # on, so it sits below every layer that resolves one: it may describe the
+    # domain (models, exceptions, core) and nothing else. Reaching into services
+    # or the API would make the interface depend on one of its own callers, and
+    # reaching for an adapter would name the implementation the port exists to
+    # keep unnamed.
     "gateway/ports": {
-        "allowed": [],
-        "forbidden": [],
+        "allowed": ["gateway.models", "gateway.exceptions", "gateway.core"],
+        "forbidden": ["gateway.api", "gateway.services", "gateway.repositories", "gateway.adapters"],
         "description": "Ports",
     },
+    # An adapter implements a port and may use the layers below it to do so, but
+    # it is driven, never driving: the API layer reaches it through the
+    # container, not the other way round.
     "gateway/adapters": {
-        "allowed": [],
-        "forbidden": [],
+        "allowed": ["gateway.ports", "gateway.services", "gateway.repositories", "gateway.models", "gateway.core"],
+        "forbidden": ["gateway.api"],
         "description": "Adapters",
     },
 }

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -54,7 +54,13 @@ RULES: dict[str, LayerRule] = {
     # composed.
     "gateway": {
         "allowed": [],
-        "forbidden": ["gateway.overlay", "overlay"],
+        # gateway.adapters is banned at the root, not only in the layers below,
+        # because rule 7 is "only the composition root may name a concrete
+        # adapter" and a layer-by-layer ban leaves every unlayered module
+        # (gateway/main.py, gateway/cli.py, gateway/core, gateway/auth, ...)
+        # free to shortcut past the seam. COMPOSITION_ROOT and the adapters
+        # package itself are the two exemptions; see check_file.
+        "forbidden": ["gateway.overlay", "overlay", "gateway.adapters"],
         "description": "OSS base",
     },
     # The OSS test suite answers to the same boundary: a test of overlay
@@ -140,6 +146,14 @@ RULES: dict[str, LayerRule] = {
 }
 
 
+# The one file allowed to name a concrete adapter, and the package the adapters
+# themselves live in (an adapter may of course refer to its siblings). Everything
+# else under gateway/ answers to the root rule's ban above.
+COMPOSITION_ROOT = "gateway/container.py"
+ADAPTERS_PACKAGE = "gateway/adapters/"
+ADAPTER_IMPORT = "gateway.adapters"
+
+
 def _matches(module: str, prefix: str) -> bool:
     """Return whether a module path is the prefix module itself or lives inside it."""
     return module == prefix or module.startswith(prefix + ".")
@@ -186,6 +200,8 @@ def check_file(file_path: Path, src_root: Path) -> list[tuple[int, str, str]]:
         reverse=True,
     )
     forbidden = [(prefix, layer_rule["description"]) for _, layer_rule in matches for prefix in layer_rule["forbidden"]]
+    if relative_path == COMPOSITION_ROOT or relative_path.startswith(ADAPTERS_PACKAGE):
+        forbidden = [entry for entry in forbidden if entry[0] != ADAPTER_IMPORT]
     if not forbidden:
         return []
 

--- a/scripts/oss_edition_smoke.py
+++ b/scripts/oss_edition_smoke.py
@@ -87,8 +87,8 @@ WORKING_PREFIX = "/working"
 # hybrid mode (GatewayConfig.effective_mode) and quietly turn the gate into a
 # check of the other edition; OTARI_DATABASE_URL or the CLI's DATABASE_URL would
 # point the run at a database nobody meant to smoke. OTARI_BOOTSTRAP, the overlay
-# selector ARCHITECTURE.md describes, is covered by the same sweep on the day it
-# exists.
+# selector, is covered by the same sweep, which is what keeps this a gate on the
+# plain build rather than on whatever overlay a developer had exported.
 SCRUBBED_ENV_PREFIXES = ("OTARI_",)
 SCRUBBED_ENV_VARS = frozenset({"DATABASE_URL"})
 

--- a/src/gateway/AGENTS.md
+++ b/src/gateway/AGENTS.md
@@ -9,6 +9,11 @@ layering, the budget/reservation lifecycle, migrations, config/logging), read
 The two runtime modes and the OSS/enterprise seam are in the root `AGENTS.md`;
 read that first if a change touches mode selection.
 
+## Ports, container, bootstrap
+`ports/` holds the domain-named `Protocol` interfaces the core depends on, `adapters/` holds Otari's own implementation of each, and `container.py` is the composition root that binds them, built once per app in `create_app` and read through the port dependencies in `api/deps.py`. `OTARI_BOOTSTRAP=module:callable` points at an overlay's register function, imported after the defaults are bound; unset, nothing is imported. Why the seam is shaped this way, and the rules for keeping it, are in [../../ARCHITECTURE.md](../../ARCHITECTURE.md); `scripts/check_architecture.py` enforces them.
+
+Two local consequences worth knowing before you use it. A port factory receives `AsyncSession | None`, because hybrid mode runs with no local database and an adapter resolved on a hybrid request has to say what it does without one. And nothing on the request path calls a port yet: the four that exist are the mechanism, and a capability earns its port when a second implementation is real, not before.
+
 ## Request lifecycle (chat completions)
 Read these together before changing request behavior, the flow spans several files.
 

--- a/src/gateway/adapters/__init__.py
+++ b/src/gateway/adapters/__init__.py
@@ -1,0 +1,12 @@
+"""Adapters: Otari's own implementation of every port in ``gateway.ports``.
+
+The cardinal property of the seam is that each port ships with a working
+adapter here, a real lightweight one or an honest Null Object, so Otari stands
+alone with no overlay present (``ARCHITECTURE.md``, rule 3). An overlay binds
+richer adapters of its own through the bootstrap hook and never edits this
+package.
+
+Only the composition root (``gateway.container``) names anything in here. Every
+other layer refers to the port and asks the container for whatever is bound,
+which is what ``scripts/check_architecture.py`` enforces.
+"""

--- a/src/gateway/adapters/billing_adapter.py
+++ b/src/gateway/adapters/billing_adapter.py
@@ -1,0 +1,57 @@
+"""Null Object billing adapter, for a deployment that bills nobody.
+
+Satisfies :class:`gateway.ports.billing_port.BillingPort` with the honest
+answer for a deployment that owes nothing: an operator running Otari pays their
+own upstream bill for their own users, so there is nothing to meter, hold, or
+charge.
+
+Every method does nothing and neither gate ever refuses, so the request path
+runs unchanged with no funding model in it. Budgets still bound what a request
+may spend; they are a separate capability, enforced in
+``gateway.services.budget_service``, and are unaffected by this.
+"""
+
+import uuid
+from decimal import Decimal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class NullBillingAdapter:
+    """``BillingPort`` adapter for a deployment that does not bill.
+
+    Holds no state, so the request's database session is unused.
+    """
+
+    def __init__(self, session: AsyncSession | None) -> None:
+        # Accepted to match the container's per-request factory; unused, because
+        # there is no funding record to read or write.
+        del session
+
+    async def apply_due_credit(self, *, organization_id: uuid.UUID) -> None:
+        return None
+
+    async def require_funds_on_deposit(self, *, organization_id: uuid.UUID) -> None:
+        # Returns rather than raises: nothing is owed here, so no request is
+        # ever refused for want of funds.
+        return None
+
+    async def require_unheld_funds(self, *, organization_id: uuid.UUID) -> None:
+        return None
+
+    async def hold(self, *, organization_id: uuid.UUID, amount: Decimal) -> None:
+        return None
+
+    async def release_hold(self, *, organization_id: uuid.UUID, amount: Decimal) -> None:
+        return None
+
+    async def charge(
+        self,
+        *,
+        organization_id: uuid.UUID,
+        amount: Decimal,
+        description: str | None = None,
+        actor_user_id: uuid.UUID | None = None,
+        api_key_id: str | None = None,
+    ) -> None:
+        return None

--- a/src/gateway/adapters/entitlement_adapter.py
+++ b/src/gateway/adapters/entitlement_adapter.py
@@ -1,0 +1,38 @@
+"""Entitlement adapter granting the base build's capability set.
+
+Satisfies :class:`gateway.ports.entitlement_port.EntitlementPort` with the
+fixed set of capabilities Otari's base build ships. An overlay binds a real
+resolver behind the same port.
+"""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# The capabilities Otari's base build ships and therefore entitles.
+#
+# **Empty, because nothing in the base is gated on a capability yet.** That is
+# not an oversight: the one candidate is routing, and ARCHITECTURE.md marks how
+# far the core base extends before an overlay adapter takes over as provisional
+# and not a contributor's to assume. So the base withholds nothing and declares
+# nothing, and the axis waits for a real decision instead of anticipating one.
+#
+# This is the server-side half of ``BASE_CAPABILITIES`` in
+# ``web/src/shared/hooks/useEntitlements.tsx``; the two are meant to agree, so a
+# capability the base grows is added to both at once. Leave an overlay-only
+# capability (billing, for example) out of both, which is what makes a gate on
+# it refuse in this build.
+BASE_CAPABILITIES: frozenset[str] = frozenset()
+
+
+class BaseEntitlementAdapter:
+    """Entitlement adapter granting the fixed base capability set.
+
+    The set is per deployment, so the request's database session is unused.
+    """
+
+    def __init__(self, session: AsyncSession | None) -> None:
+        # Accepted to match the container's per-request factory; unused, because
+        # the base entitlement set is static per deployment.
+        del session
+
+    async def entitlements(self) -> set[str]:
+        return set(BASE_CAPABILITIES)

--- a/src/gateway/adapters/growth_signal_adapter.py
+++ b/src/gateway/adapters/growth_signal_adapter.py
@@ -1,0 +1,67 @@
+"""Null Object growth-signal adapter, for a build with no outside vendor.
+
+Satisfies :class:`gateway.ports.growth_signal_port.GrowthSignalPort` with the
+honest answer for a deployment that runs its own users on its own channels:
+nothing is scheduled, so no HTTP call, background task, or vendor credential is
+ever reached for want of a growth or support integration.
+"""
+
+import uuid
+from datetime import datetime
+
+from fastapi import BackgroundTasks
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.ports.growth_signal_port import GrowthActivationEvent
+
+
+class NullGrowthSignalAdapter:
+    """``GrowthSignalPort`` adapter for a build with no CRM or messenger vendor.
+
+    Holds no state, so the request's database session is unused.
+    """
+
+    def __init__(self, session: AsyncSession | None) -> None:
+        # Accepted to match the container's per-request factory; unused, because
+        # there is nothing to schedule.
+        del session
+
+    async def record_signup(
+        self,
+        *,
+        background_tasks: BackgroundTasks,
+        user_id: uuid.UUID,
+        email: str,
+        full_name: str | None,
+        created_at: datetime,
+    ) -> None:
+        return None
+
+    async def record_activation(
+        self,
+        *,
+        background_tasks: BackgroundTasks,
+        event: GrowthActivationEvent,
+        user_id: uuid.UUID,
+        email: str,
+    ) -> None:
+        return None
+
+    async def record_profile_updated(
+        self,
+        *,
+        background_tasks: BackgroundTasks,
+        user_id: uuid.UUID,
+        email: str,
+        full_name: str | None,
+    ) -> None:
+        return None
+
+    async def record_account_deleted(
+        self,
+        *,
+        background_tasks: BackgroundTasks,
+        user_id: uuid.UUID,
+        email: str,
+    ) -> None:
+        return None

--- a/src/gateway/adapters/growth_signal_adapter.py
+++ b/src/gateway/adapters/growth_signal_adapter.py
@@ -7,7 +7,9 @@ ever reached for want of a growth or support integration.
 """
 
 import uuid
+from collections.abc import Mapping
 from datetime import datetime
+from typing import Any
 
 from fastapi import BackgroundTasks
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -44,6 +46,17 @@ class NullGrowthSignalAdapter:
         event: GrowthActivationEvent,
         user_id: uuid.UUID,
         email: str,
+    ) -> None:
+        return None
+
+    async def record_onboarding_completed(
+        self,
+        *,
+        background_tasks: BackgroundTasks,
+        user_id: uuid.UUID,
+        email: str,
+        answers: Mapping[str, Any],
+        full_name: str | None,
     ) -> None:
         return None
 

--- a/src/gateway/adapters/model_provider_adapter.py
+++ b/src/gateway/adapters/model_provider_adapter.py
@@ -1,0 +1,39 @@
+"""Core adapter for ``ModelProviderPort``: no hosted-inference fleet.
+
+Satisfies :class:`gateway.ports.model_provider_port.ModelProviderPort` with
+Otari's own answer: there is no fleet here to proxy to. Every candidate that
+reaches this adapter has already failed the caller's BYO-credential lookup, and
+a deployment pointing at its own backends resolves a credential the ordinary
+way well upstream of this port, so what remains is genuinely unserved and this
+adapter's whole contract is saying so. An overlay binds a hosted-inference
+adapter behind the same port.
+"""
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.ports.model_provider_port import HostedCredential
+
+
+class SelfHostedModelProviderAdapter:
+    """Core adapter: a self-hosted deployment has no hosted account to consult.
+
+    Session-agnostic: the answer is a deployment-wide constant, not something
+    that depends on the request's data.
+    """
+
+    def __init__(self, session: AsyncSession | None) -> None:
+        # Accepted to match the container's per-request factory; unused, because
+        # the core answer never depends on the session.
+        del session
+
+    async def resolve_hosted_credential(
+        self,
+        *,
+        organization_id: uuid.UUID,
+        workspace_id: uuid.UUID | None,
+        provider: str,
+        model: str | None,
+    ) -> HostedCredential | None:
+        return None

--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -1,5 +1,5 @@
 import secrets
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from datetime import UTC, datetime
 from typing import Annotated
 
@@ -9,12 +9,17 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.auth.models import hash_key
+from gateway.container import Container
 from gateway.core.config import API_KEY_HEADER, X_API_KEY_HEADER, GatewayConfig
 from gateway.core.database import create_session, get_db
 from gateway.log_config import logger
 from gateway.metrics import record_auth_failure
 from gateway.models.entities import APIKey
 from gateway.models.tenancy import User as TenancyUser
+from gateway.ports.billing_port import BillingPort
+from gateway.ports.entitlement_port import EntitlementPort
+from gateway.ports.growth_signal_port import GrowthSignalPort
+from gateway.ports.model_provider_port import ModelProviderPort
 from gateway.services.dashboard_session_service import SESSION_COOKIE_NAME, resolve_dashboard_session
 from gateway.services.file_store import FileStore
 from gateway.services.log_writer import LogWriter
@@ -421,6 +426,77 @@ async def get_current_identity(
 CurrentIdentity = Annotated[TenancyUser, Depends(get_current_identity)]
 
 
+# =============================================================================
+# Composition root
+# =============================================================================
+#
+# Every port is resolved here and nowhere else: a dependency names the port and
+# asks the container for whichever adapter this build bound to it, so no route
+# or service ever names a concrete adapter (ARCHITECTURE.md, rule 5).
+
+
+def get_container(request: Request) -> Container:
+    """Return the composition-root container this app was built with."""
+    container: Container | None = getattr(request.app.state, "container", None)
+    if container is None:
+        msg = "Composition root not initialized"
+        raise RuntimeError(msg)
+    return container
+
+
+ContainerDep = Annotated[Container, Depends(get_container)]
+# ``get_db_if_needed`` and not ``get_db``: hybrid mode runs with no local
+# database at all, so a port resolved on a hybrid request gets ``None`` rather
+# than a session that cannot be opened. Every core adapter ignores it.
+PortSessionDep = Annotated[AsyncSession | None, Depends(get_db_if_needed)]
+
+
+def get_billing_port(db: PortSessionDep, container: ContainerDep) -> BillingPort:
+    """Resolve the billing adapter this build bound at startup."""
+    return container.resolve(BillingPort, db)
+
+
+def get_entitlement_port(db: PortSessionDep, container: ContainerDep) -> EntitlementPort:
+    """Resolve the entitlement adapter this build bound at startup."""
+    return container.resolve(EntitlementPort, db)
+
+
+def get_growth_signal_port(db: PortSessionDep, container: ContainerDep) -> GrowthSignalPort:
+    """Resolve the growth-signal adapter this build bound at startup."""
+    return container.resolve(GrowthSignalPort, db)
+
+
+def get_model_provider_port(db: PortSessionDep, container: ContainerDep) -> ModelProviderPort:
+    """Resolve the model-provider adapter this build bound at startup."""
+    return container.resolve(ModelProviderPort, db)
+
+
+BillingPortDep = Annotated[BillingPort, Depends(get_billing_port)]
+EntitlementPortDep = Annotated[EntitlementPort, Depends(get_entitlement_port)]
+GrowthSignalPortDep = Annotated[GrowthSignalPort, Depends(get_growth_signal_port)]
+ModelProviderPortDep = Annotated[ModelProviderPort, Depends(get_model_provider_port)]
+
+
+def require_capability(capability: str) -> Callable[[EntitlementPort], Awaitable[None]]:
+    """Build a dependency that refuses a request unless the deployment is entitled.
+
+    The gate every contributed router is mounted behind. A refusal carries the
+    same status and body as a request for a path nothing serves (404 with the
+    framework's wording), so the response alone does not reveal whether the
+    surface exists. The surface itself stays mounted: it appears in the OpenAPI
+    document, and a request with an unsupported method meets the router's 405
+    before this gate. The refusal is logged, so an operator can tell "not
+    entitled" from "not mounted" where the client cannot.
+    """
+
+    async def _require(entitlements: EntitlementPortDep) -> None:
+        if capability not in await entitlements.entitlements():
+            logger.warning("Refused a request to a surface gated on capability %r: not entitled", capability)
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not Found")
+
+    return _require
+
+
 def get_log_writer(request: Request) -> LogWriter:
     writer: LogWriter = request.app.state.log_writer
     return writer
@@ -433,8 +509,14 @@ def get_file_store(request: Request) -> FileStore:
 
 
 __all__ = [
+    "BillingPortDep",
+    "ContainerDep",
     "CurrentIdentity",
+    "EntitlementPortDep",
+    "GrowthSignalPortDep",
+    "ModelProviderPortDep",
     "get_config",
+    "get_container",
     "get_current_identity",
     "get_db",
     "get_session_identity",
@@ -444,6 +526,7 @@ __all__ = [
     "get_file_store",
     "get_log_writer",
     "is_valid_master_key",
+    "require_capability",
     "verify_api_key",
     "verify_api_key_or_master_key",
     "verify_master_key",

--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -448,6 +448,14 @@ ContainerDep = Annotated[Container, Depends(get_container)]
 # ``get_db_if_needed`` and not ``get_db``: hybrid mode runs with no local
 # database at all, so a port resolved on a hybrid request gets ``None`` rather
 # than a session that cannot be opened. Every core adapter ignores it.
+#
+# The consequence to know before an adapter writes anything: FastAPI caches a
+# dependency per callable, so this shares one session with a route that also
+# takes ``get_db_if_needed`` (the data-plane routes do) and opens a *second,
+# independent* one for a route that takes ``get_db`` (the management-plane
+# routes do). A port's "joins the caller's unit of work" therefore holds only
+# for the first kind. A route that means to commit a port's writes with its own
+# must take its session from ``get_db_if_needed`` too.
 PortSessionDep = Annotated[AsyncSession | None, Depends(get_db_if_needed)]
 
 

--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -1,5 +1,6 @@
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 
+from gateway.api.deps import require_capability
 from gateway.api.routes import (
     agent_telemetry,
     aliases,
@@ -47,10 +48,34 @@ from gateway.api.routes import (
     workspace_member_budget_policies,
     workspaces,
 )
+from gateway.container import Container
 from gateway.core.config import GatewayConfig
 
 
 def register_routers(app: FastAPI, config: GatewayConfig) -> None:
+    """Mount Otari's own routers, then whatever the bootstrap contributed."""
+    _register_core_routers(app, config)
+    _register_contributed_routers(app)
+
+
+def _register_contributed_routers(app: FastAPI) -> None:
+    """Mount the routers this build's bootstrap contributed, each behind its gate.
+
+    The additive half of the extension seam: an overlay records a router on the
+    container and Otari mounts it, gated on the capability it names. Mounted in
+    both modes, because an overlay may extend the data plane as readily as the
+    management plane. With no bootstrap configured there are none, so this is a
+    no-op for the plain build.
+    """
+    container: Container = app.state.container
+    for contribution in container.router_contributions():
+        app.include_router(
+            contribution.router,
+            dependencies=[Depends(require_capability(contribution.capability))],
+        )
+
+
+def _register_core_routers(app: FastAPI, config: GatewayConfig) -> None:
     app.include_router(chat.router)
     app.include_router(health.router)
     # Registered in both modes on purpose: the deployment bootstrap is how a

--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -56,6 +56,15 @@ def register_routers(app: FastAPI, config: GatewayConfig) -> None:
     """Mount Otari's own routers, then whatever the bootstrap contributed."""
     _register_core_routers(app, config)
     _register_contributed_routers(app)
+    if config.is_hybrid_mode:
+        # Last, and after the contributed routers on purpose. These are
+        # ``{path:path}`` catch-alls over whole management prefixes
+        # (/v1/organizations, /v1/usage, ...), and FastAPI serves the first
+        # route that matches, so registering them earlier would swallow an
+        # overlay route under any of those prefixes and answer "manage this via
+        # the platform UI" instead. They are a fallback for a path nothing else
+        # serves, so they are mounted like one.
+        app.include_router(hybrid_mode.router)
 
 
 def _register_contributed_routers(app: FastAPI) -> None:
@@ -66,6 +75,10 @@ def _register_contributed_routers(app: FastAPI) -> None:
     both modes, because an overlay may extend the data plane as readily as the
     management plane. With no bootstrap configured there are none, so this is a
     no-op for the plain build.
+
+    Mounted after Otari's own routers and before the hybrid stubs, so a
+    contribution cannot take a path the core already serves and the hybrid
+    stubs' catch-alls cannot take one the contribution serves.
     """
     container: Container = app.state.container
     for contribution in container.router_contributions():
@@ -88,7 +101,8 @@ def _register_core_routers(app: FastAPI, config: GatewayConfig) -> None:
     app.include_router(responses.router)
 
     if config.is_hybrid_mode:
-        app.include_router(hybrid_mode.router)
+        # The hybrid stub router is mounted by register_routers, after the
+        # contributed routers; see the note there.
         return  # Remaining routers (including batches) are standalone-mode only
 
     app.include_router(auth_session.router)

--- a/src/gateway/container.py
+++ b/src/gateway/container.py
@@ -1,0 +1,275 @@
+"""Composition root: the one place that names a concrete adapter.
+
+The container is a process-level registry of ``Port -> factory`` bindings,
+built once per app in ``create_app`` and read per request through
+``gateway.api.deps``. It is a plain mapping, deliberately not a
+dependency-injection framework and not entry-point auto-discovery: only a
+handful of ports ever need swapping, and only at startup, so the whole wiring
+is readable in this one file and there is no install-time magic to trace
+(``ARCHITECTURE.md``, "How a port is resolved").
+
+Every port is bound here to a working core adapter, real or Null Object, so
+Otari runs with no overlay present and behaves as it does today. Only real
+ports belong here. A plain, single-implementation service stays wired directly
+as an ordinary FastAPI dependency; routing one through the container would
+claim a swap point that does not exist.
+
+An overlay rebinds ports without editing any Otari source file, by pointing
+``OTARI_BOOTSTRAP`` at a ``module:callable`` selector. The callable receives
+this container after the core defaults are bound, and may rebind any port and
+contribute routers of its own. Unset, the defaults stand.
+"""
+
+import importlib
+from collections.abc import Callable, ItemsView
+from dataclasses import dataclass
+from typing import Any, TypeVar, cast
+
+from fastapi import APIRouter
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.adapters.billing_adapter import NullBillingAdapter
+from gateway.adapters.entitlement_adapter import BaseEntitlementAdapter
+from gateway.adapters.growth_signal_adapter import NullGrowthSignalAdapter
+from gateway.adapters.model_provider_adapter import SelfHostedModelProviderAdapter
+from gateway.log_config import logger
+from gateway.ports.billing_port import BillingPort
+from gateway.ports.entitlement_port import EntitlementPort
+from gateway.ports.growth_signal_port import GrowthSignalPort
+from gateway.ports.model_provider_port import ModelProviderPort
+
+T = TypeVar("T")
+
+# The registry key: the port's ``Protocol`` class object itself, so a caller
+# names the port and nothing else. Spelled ``Callable[..., T]`` rather than the
+# more obvious ``type[T]`` because a Protocol class is abstract, and mypy
+# refuses one where ``type[T]`` is expected on the assumption that the argument
+# is about to be instantiated. A key is never instantiated; the callable form
+# keys on the same class object and still carries ``T`` through to
+# :meth:`Container.resolve`.
+PortKey = Callable[..., T]
+# A port is resolved per request against that request's database session; an
+# adapter that needs no session ignores it. The session is ``None`` in hybrid
+# mode, where the gateway has no local database at all (``init_db`` is skipped,
+# see ``gateway.main``) and its control plane lives at the other end of the
+# resolve protocol, so an adapter that needs one must say what it does without.
+PortFactory = Callable[[AsyncSession | None], T]
+Register = Callable[["Container"], None]
+
+
+@dataclass(frozen=True)
+class RouterContribution:
+    """One router an overlay mounts on top of Otari's own.
+
+    The additive half of the seam: nothing is swapped here, a surface is added
+    and made conditional. Every route the router exposes is served only when
+    the deployment is entitled to ``capability``, resolved through
+    ``EntitlementPort``, because hiding a link in a dashboard is not
+    authorization and a route mounted into this process has to refuse for
+    itself.
+    """
+
+    capability: str
+    router: APIRouter
+
+
+class ContainerError(Exception):
+    """Base error for composition-root wiring failures."""
+
+
+class PortNotBoundError(ContainerError):
+    """Raised when a port is resolved but no adapter has been bound to it."""
+
+    def __init__(self, port: PortKey[Any]) -> None:
+        name = getattr(port, "__name__", repr(port))
+        super().__init__(f"No adapter is bound for port {name}")
+        self.port = port
+
+
+class BootstrapError(ContainerError):
+    """Raised when the bootstrap module ``OTARI_BOOTSTRAP`` names cannot be loaded."""
+
+
+class Container:
+    """A registry mapping each port to the adapter that satisfies it.
+
+    Built once per app with the core bindings plus whatever the configured
+    bootstrap rebinds, then read per request. Attached to ``app.state`` rather
+    than kept module-global, so two apps in one process (as the test suite
+    builds) never share one.
+    """
+
+    def __init__(self) -> None:
+        self._factories: dict[Any, PortFactory[Any]] = {}
+        self._router_contributions: list[RouterContribution] = []
+        # One line naming what this container was built from, logged by
+        # build_container and asserted on by tests.
+        self.summary = "unbuilt"
+
+    def bind(self, port: PortKey[T], factory: PortFactory[T]) -> None:
+        """Bind ``port`` to ``factory``, so a bootstrap can replace a core default.
+
+        A later bind for the same port replaces an earlier one.
+        """
+        self._factories[port] = factory
+
+    def bindings(self) -> ItemsView[Any, PortFactory[Any]]:
+        """Return a snapshot of the (port, factory) pairs bound so far.
+
+        A snapshot rather than a live view, so iterating it stays safe while a
+        bootstrap binds. For the composition root itself, which compares a
+        bootstrap's bindings against the defaults to report what it rebound.
+        Not a resolution path; callers use :meth:`resolve`.
+        """
+        return dict(self._factories).items()
+
+    def resolve(self, port: PortKey[T], session: AsyncSession | None) -> T:
+        """Return the adapter bound to ``port``, built for this request's session.
+
+        Raises:
+            PortNotBoundError: If no adapter has been bound to ``port``.
+
+        """
+        factory = self._factories.get(port)
+        if factory is None:
+            raise PortNotBoundError(port)
+        return cast(T, factory(session))
+
+    def contribute_router(self, contribution: RouterContribution) -> None:
+        """Record a router this build mounts on top of Otari's own."""
+        self._router_contributions.append(contribution)
+
+    def router_contributions(self) -> tuple[RouterContribution, ...]:
+        """Return the recorded router contributions, in contribution order."""
+        return tuple(self._router_contributions)
+
+
+def _billing_adapter(session: AsyncSession | None) -> BillingPort:
+    """Build the core ``BillingPort`` adapter for one request."""
+    return NullBillingAdapter(session)
+
+
+def _entitlement_adapter(session: AsyncSession | None) -> EntitlementPort:
+    """Build the core ``EntitlementPort`` adapter for one request."""
+    return BaseEntitlementAdapter(session)
+
+
+def _model_provider_adapter(session: AsyncSession | None) -> ModelProviderPort:
+    """Build the core ``ModelProviderPort`` adapter for one request."""
+    return SelfHostedModelProviderAdapter(session)
+
+
+def _growth_signal_adapter(session: AsyncSession | None) -> GrowthSignalPort:
+    """Build the core ``GrowthSignalPort`` adapter for one request."""
+    return NullGrowthSignalAdapter(session)
+
+
+def _load_register(selector: str) -> Register:
+    """Load the register callable a ``module:callable`` selector names.
+
+    Surrounding whitespace is ignored. A bootstrap module that exists but fails
+    to import is reported as its own failure, distinct from a selector naming a
+    module that is not there.
+
+    Raises:
+        BootstrapError: If the selector is malformed, its module or attribute
+            cannot be imported, or the attribute is not callable.
+
+    """
+    module_path, separator, attribute = selector.strip().partition(":")
+    if not separator or not module_path or not attribute:
+        msg = f"OTARI_BOOTSTRAP must be 'module:callable', got {selector!r}"
+        raise BootstrapError(msg)
+
+    try:
+        module = importlib.import_module(module_path)
+    except ModuleNotFoundError as error:
+        # The named module (or a package on its path) being absent is a wrong
+        # selector; anything else missing is a broken bootstrap.
+        missing = error.name or ""
+        if module_path == missing or module_path.startswith(missing + "."):
+            msg = f"Bootstrap module {module_path!r} was not found"
+        else:
+            msg = f"Bootstrap module {module_path!r} failed to import"
+        raise BootstrapError(msg) from error
+    except ImportError as error:
+        msg = f"Bootstrap module {module_path!r} failed to import"
+        raise BootstrapError(msg) from error
+
+    register = getattr(module, attribute, None)
+    if register is None:
+        msg = f"Bootstrap module {module_path!r} has no attribute {attribute!r}"
+        raise BootstrapError(msg)
+    if not callable(register):
+        msg = f"Bootstrap {selector!r} is not callable"
+        raise BootstrapError(msg)
+
+    return cast(Register, register)
+
+
+def build_container(bootstrap_selector: str | None = None) -> Container:
+    """Build the composition-root container for this deployment.
+
+    Binds the core adapters, then, if a selector is given, lets the bootstrap it
+    names rebind ports and contribute routers. With no selector the core
+    defaults stand and Otari boots standalone.
+
+    Raises:
+        BootstrapError: If the selector is present but blank, or names a
+            bootstrap that cannot be loaded.
+
+    """
+    container = Container()
+    # Core port bindings. A bootstrap may rebind any of these below; unset,
+    # these stand and the gateway behaves exactly as it does with no overlay.
+    #
+    # Billing has no core implementation, so the default is the Null Object:
+    # this deployment runs billing-free, holding and charging nothing.
+    container.bind(BillingPort, _billing_adapter)
+    # Entitlement: the base grants the capability set it ships, which is
+    # currently empty, and reports every overlay-only capability as absent.
+    container.bind(EntitlementPort, _entitlement_adapter)
+    # Model inference: the base has no hosted-inference fleet, so every
+    # candidate with no BYO credential is unavailable. Self-hosting is served
+    # upstream of this port, not behind it.
+    container.bind(ModelProviderPort, _model_provider_adapter)
+    # Growth and support-messenger notifications: the base has no vendor of its
+    # own, so every lifecycle event is a no-op.
+    container.bind(GrowthSignalPort, _growth_signal_adapter)
+
+    if bootstrap_selector is None:
+        # No selector is a legitimate deployment (the plain open-source one), so
+        # it is recorded rather than refused. Worth stating even so: which build
+        # a process is running is otherwise invisible until traffic exposes it.
+        container.summary = f"no bootstrap, core defaults for {_port_names(container)}"
+        logger.info("Composition root: %s", container.summary)
+        return container
+    if not bootstrap_selector.strip():
+        # A blank-but-present selector is a broken deployment rather than a
+        # request for the plain build: something set OTARI_BOOTSTRAP and lost
+        # its value. Refusing to boot beats silently running a build nobody
+        # chose. (An empty string never reaches here: the config layer reads
+        # OTARI_BOOTSTRAP="" as unset, like every other scalar. Whitespace does.)
+        msg = "OTARI_BOOTSTRAP is set but blank; unset it to run without a bootstrap"
+        raise BootstrapError(msg)
+
+    defaults = dict(container.bindings())
+    _load_register(bootstrap_selector)(container)
+    rebound = sorted(_port_name(port) for port, factory in container.bindings() if defaults.get(port) is not factory)
+    container.summary = f"{bootstrap_selector} rebound {', '.join(rebound) or 'no ports'}"
+    contributed = ", ".join(contribution.capability for contribution in container.router_contributions())
+    if contributed:
+        container.summary += f", contributed routers for {contributed}"
+    logger.info("Composition root: %s", container.summary)
+    return container
+
+
+def _port_name(port: PortKey[Any]) -> str:
+    """Return a port's name for a log line."""
+    name: str = getattr(port, "__name__", repr(port))
+    return name
+
+
+def _port_names(container: Container) -> str:
+    """Return the bound ports' names, for the startup log."""
+    return ", ".join(sorted(_port_name(port) for port, _ in container.bindings()))

--- a/src/gateway/container.py
+++ b/src/gateway/container.py
@@ -278,7 +278,20 @@ def build_container(bootstrap_selector: str | None = None) -> Container:
         raise BootstrapError(msg)
 
     defaults = dict(container.bindings())
-    _load_register(bootstrap_selector)(container)
+    outcome = _load_register(bootstrap_selector)(container)
+    if inspect.isawaitable(outcome):
+        # The same silent drop the ``iscoroutinefunction`` guard refuses, by the
+        # route that guard cannot see: a callable *object* whose ``__call__`` is
+        # ``async def`` is not a coroutine function, so it passes every check
+        # above and its body never runs until awaited. Closing the coroutine
+        # keeps the refusal from also emitting "was never awaited" at whatever
+        # point the garbage collector gets to it.
+        outcome.close()
+        msg = (
+            f"Bootstrap {bootstrap_selector!r} returned an awaitable; the container is built "
+            "synchronously, so register must run to completion when called"
+        )
+        raise BootstrapError(msg)
     rebound = sorted(_port_name(port) for port, factory in container.bindings() if defaults.get(port) is not factory)
     container.summary = f"{bootstrap_selector} rebound {', '.join(rebound) or 'no ports'}"
     contributed = ", ".join(contribution.capability for contribution in container.router_contributions())

--- a/src/gateway/container.py
+++ b/src/gateway/container.py
@@ -21,6 +21,7 @@ contribute routers of its own. Unset, the defaults stand.
 """
 
 import importlib
+import inspect
 from collections.abc import Callable, ItemsView
 from dataclasses import dataclass
 from typing import Any, TypeVar, cast
@@ -67,6 +68,18 @@ class RouterContribution:
     ``EntitlementPort``, because hiding a link in a dashboard is not
     authorization and a route mounted into this process has to refuse for
     itself.
+
+    **Entitlement is not authentication, and the mount point adds none.**
+    ``capability`` answers "is this build licensed for this surface", a
+    deployment-wide question that names no caller, so on an entitled deployment
+    a contributed route is reachable by anyone unless the router says otherwise.
+    Declare the credential each route needs on the route, the way Otari's own
+    routers do (``verify_master_key`` or ``verify_api_key_or_master_key`` per
+    route in ``gateway.api.routes``); Otari mounts no router-level default here
+    because there is no single right answer to mount. The choice differs per
+    route, a contributed route may be deliberately public, and
+    ``verify_api_key_or_master_key`` resolves ``get_db``, which has no session
+    to open in hybrid mode.
     """
 
     capability: str
@@ -173,7 +186,8 @@ def _load_register(selector: str) -> Register:
 
     Raises:
         BootstrapError: If the selector is malformed, its module or attribute
-            cannot be imported, or the attribute is not callable.
+            cannot be imported, or the attribute is not callable or is a
+            coroutine function.
 
     """
     module_path, separator, attribute = selector.strip().partition(":")
@@ -202,6 +216,16 @@ def _load_register(selector: str) -> Register:
         raise BootstrapError(msg)
     if not callable(register):
         msg = f"Bootstrap {selector!r} is not callable"
+        raise BootstrapError(msg)
+    if inspect.iscoroutinefunction(register):
+        # An ``async def register`` is callable, so it passes the check above,
+        # and calling it only builds a coroutine nobody awaits: every bind and
+        # every contribution in it is silently dropped and the gateway serves
+        # the plain build. That is the one outcome this whole path exists to
+        # prevent, and it is an easy mistake to make when every port method is
+        # async, so it is refused by name rather than left to a stray
+        # "coroutine was never awaited" warning in the startup log.
+        msg = f"Bootstrap {selector!r} is async; the container is built synchronously, so register must be a plain def"
         raise BootstrapError(msg)
 
     return cast(Register, register)

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -542,6 +542,15 @@ class GatewayConfig(BaseSettings):
         default=True,
         description="Create a first-use API key on startup when no API keys exist",
     )
+    bootstrap: str | None = Field(
+        default=None,
+        description=(
+            "Composition-root bootstrap, as a 'module:callable' selector (OTARI_BOOTSTRAP). "
+            "Imported once at startup after the core adapters are bound, and called with the "
+            "container so an overlay can rebind ports and contribute routers. Unset means "
+            "nothing is imported. Unrelated to bootstrap_api_key."
+        ),
+    )
     log_writer_strategy: str = Field(
         default="single",
         description="How usage log rows are written: 'single' (inline) or 'batch' (background).",

--- a/src/gateway/main.py
+++ b/src/gateway/main.py
@@ -14,6 +14,7 @@ from typing_extensions import override
 
 from gateway.api.deps import set_config
 from gateway.api.main import register_routers
+from gateway.container import build_container
 from gateway.core.config import API_KEY_HEADER, X_API_KEY_HEADER, GatewayConfig
 from gateway.core.database import create_session, init_db
 from gateway.dashboard import DASHBOARD_PACKAGE_PATH, get_dashboard_build_id, get_dashboard_dir
@@ -647,6 +648,13 @@ def create_app(config: GatewayConfig) -> FastAPI:
 
     app.state.config = config
     app.state.gateway_mode = config.effective_mode
+
+    # The composition root, built before the routers because a bootstrap may
+    # contribute some of them. Per app rather than module-global, for the same
+    # reason config is: two apps in one process must not share one. A bootstrap
+    # that cannot be loaded raises here, so a deployment that named one and got
+    # it wrong fails to start instead of quietly running the plain build.
+    app.state.container = build_container(config.bootstrap)
 
     register_routers(app, config)
     app.add_exception_handler(TenancyError, _tenancy_error_handler)

--- a/src/gateway/ports/__init__.py
+++ b/src/gateway/ports/__init__.py
@@ -1,0 +1,14 @@
+"""Ports: the domain-named interfaces Otari's core depends on.
+
+Each port is a seam between the core and whichever build supplies its adapter,
+and each ships with a working adapter in ``gateway.adapters`` so Otari stands
+alone with no overlay present. Only a capability with a real second
+implementation earns one; plain, single-implementation services stay concrete
+(``ARCHITECTURE.md``, "Cardinal rules for contributors", rule 7).
+
+Ports are asynchronous ``Protocol`` classes: an adapter satisfies one by shape,
+without importing or subclassing it, which is what lets an overlay implement a
+port it only depends on structurally. The composition-root container
+(``gateway.container``) keys its registry on the protocol class object itself,
+so a caller names the port and never a concrete adapter.
+"""

--- a/src/gateway/ports/billing_port.py
+++ b/src/gateway/ports/billing_port.py
@@ -13,7 +13,9 @@ whether real billing exists anywhere.
 
 Every method joins the caller's unit of work and commits nothing, so a hold,
 the charge that consumes it, and whatever record the caller keeps of them
-either all land or none do.
+either all land or none do. That holds only where the caller's session is the
+one the port was resolved against; see ``PortSessionDep`` in
+``gateway.api.deps`` for which routes share it and which do not.
 
 Each gate is a decision, not a reading: it either returns or raises
 :class:`InsufficientFundsError`. Callers get no funding amounts to interpret,

--- a/src/gateway/ports/billing_port.py
+++ b/src/gateway/ports/billing_port.py
@@ -1,0 +1,130 @@
+"""Funding decisions for requests the deployment itself pays for.
+
+The seam between the core and whichever build pays for a request that runs on
+credentials the deployment owns. A request served from the caller's own
+provider key never reaches this port: that caller is billed by their upstream
+directly. Only deployment-paid traffic does, because only there does the
+deployment owe the upstream bill and so has something to meter.
+
+Billing is the overlay-only row of ``ARCHITECTURE.md``'s capability lines: the
+core adapter is a Null Object, so a deployment can serve deployment-paid
+traffic with no funding model at all, and nothing in the core needs to know
+whether real billing exists anywhere.
+
+Every method joins the caller's unit of work and commits nothing, so a hold,
+the charge that consumes it, and whatever record the caller keeps of them
+either all land or none do.
+
+Each gate is a decision, not a reading: it either returns or raises
+:class:`InsufficientFundsError`. Callers get no funding amounts to interpret,
+so "this deployment does not bill" and "this organization is out of funds"
+cannot be confused at a call site.
+"""
+
+import uuid
+from decimal import Decimal
+from typing import Protocol
+
+
+class InsufficientFundsError(Exception):
+    """Raised when an organization's funds cannot cover a deployment-paid request.
+
+    The port owns this error so a caller can refuse a request without naming
+    the funding model that produced it. An adapter may raise a subclass
+    carrying its own wording; ``available`` is the amount the decision was made
+    against, in USD, and is zero when the organization has no funding record at
+    all.
+    """
+
+    def __init__(self, available: Decimal, message: str | None = None) -> None:
+        super().__init__(message or f"Insufficient funds (${available:.2f}) to serve this request.")
+        self.available = available
+
+
+class BillingPort(Protocol):
+    """What a build must answer to serve a request on deployment-paid credentials.
+
+    Amounts are USD, and ``Decimal`` throughout for the reason the rest of the
+    money path is (see ``src/gateway/AGENTS.md``, "Cost math").
+    """
+
+    async def apply_due_credit(self, *, organization_id: uuid.UUID) -> None:
+        """Grant any credit the organization is owed by now.
+
+        Idempotent: credit already granted for the current period is not
+        granted twice, so a caller may invoke this as often as it likes.
+        """
+        ...
+
+    async def require_funds_on_deposit(self, *, organization_id: uuid.UUID) -> None:
+        """Refuse unless the organization has funds paid in.
+
+        Counts what the organization has paid in and disregards holds, so it
+        answers "may this organization be served at all", a question about the
+        account rather than about what is currently in flight. It claims
+        nothing: two callers can pass this gate on the same funds, and
+        :meth:`hold` is what settles between them.
+
+        Raises:
+            InsufficientFundsError: If the organization has no funds paid in.
+
+        """
+        ...
+
+    async def require_unheld_funds(self, *, organization_id: uuid.UUID) -> None:
+        """Refuse unless the organization has funds no hold has claimed.
+
+        The gate for a deployment-paid request with no upper-bound cost to
+        hold. :meth:`hold` would wave such a request through for want of an
+        amount, yet the deployment still owes the upstream bill, so an
+        organization whose funds are entirely held must not be served on the
+        strength of that.
+
+        Raises:
+            InsufficientFundsError: If every fund the organization has is held.
+
+        """
+        ...
+
+    async def hold(self, *, organization_id: uuid.UUID, amount: Decimal) -> None:
+        """Claim ``amount`` against the organization's unheld funds.
+
+        Decided and claimed as one step, so overlapping requests cannot both be
+        served on the same funds. Every hold is ended by :meth:`release_hold`,
+        whether or not it is charged.
+
+        Raises:
+            InsufficientFundsError: If the unheld funds cannot cover ``amount``.
+
+        """
+        ...
+
+    async def release_hold(self, *, organization_id: uuid.UUID, amount: Decimal) -> None:
+        """Return a hold of ``amount`` to the organization's unheld funds.
+
+        Not idempotent: whoever placed a hold decides once that it is over, and
+        calls this exactly once for it.
+        """
+        ...
+
+    async def charge(
+        self,
+        *,
+        organization_id: uuid.UUID,
+        amount: Decimal,
+        description: str | None = None,
+        actor_user_id: uuid.UUID | None = None,
+        api_key_id: str | None = None,
+    ) -> None:
+        """Charge ``amount`` for a request already served.
+
+        Records the charge even when the organization cannot cover it: the
+        deployment has already paid for that request upstream, so dropping the
+        charge would give the compute away. What is charged is bounded by the
+        hold taken beforehand, and the gates above refuse the next request.
+
+        ``description``, ``actor_user_id`` and ``api_key_id`` attribute the
+        charge, so an adapter that keeps a ledger can trace it back to the
+        request that incurred it.
+        """
+        ...

--- a/src/gateway/ports/entitlement_port.py
+++ b/src/gateway/ports/entitlement_port.py
@@ -1,0 +1,34 @@
+"""Which capabilities a deployment is entitled to.
+
+The licensing axis of ``ARCHITECTURE.md``, "Deployment and entitlements": is
+this capability enabled for this deployment at all? Scoped per deployment,
+never per user, and composed with (never merged into) the surface axis that
+``GET /v1/bootstrap`` answers.
+
+The core adapter grants the base build's capability set and reports every
+overlay-only capability as absent; an overlay binds a real resolver behind the
+same port. The dashboard resolves the same axis in the browser, from
+``BASE_CAPABILITIES`` in ``web/src/shared/hooks/useEntitlements.tsx``, and the
+two answers are meant to agree: hiding a link is not authorization, so a router
+an overlay contributes is gated on this port server-side as well
+(``gateway.api.deps.require_capability``).
+"""
+
+from typing import Protocol
+
+
+class EntitlementPort(Protocol):
+    """The capability names this deployment is licensed for."""
+
+    async def entitlements(self) -> set[str]:
+        """Return the capability names the current deployment is entitled to.
+
+        Takes no subject, so it answers at deployment grain; an adapter that
+        needs to resolve more finely would extend the seam with the context it
+        needs.
+
+        Capability names are open-ended domain strings rather than a closed
+        enum: an overlay ships capabilities the base does not, so the base
+        cannot enumerate them.
+        """
+        ...

--- a/src/gateway/ports/growth_signal_port.py
+++ b/src/gateway/ports/growth_signal_port.py
@@ -1,0 +1,101 @@
+"""Lifecycle notifications for whichever CRM or support messenger a build runs.
+
+The seam between the core and whichever build tells an outside vendor about a
+user's lifecycle: signup, activation milestones, profile edits, and account
+deletion. The core has no growth-marketing or support-messaging vendor of its
+own, and that is the point: an operator running Otari serves their own users on
+their own channels, and nothing about those users' lifecycle should reach a
+vendor the deployment never chose. So the core adapter is a Null Object, and an
+overlay binds one that fans these out to the vendors it runs.
+
+Every method is fire-and-forget: it schedules work on the caller's
+``BackgroundTasks`` and returns immediately, never raising, so a vendor outage
+can never affect the request that triggered it. That is why these methods
+return nothing and take a ``BackgroundTasks`` rather than doing the work inline
+and handing back a result: there is nothing for a caller to act on, only
+something to fire and forget.
+
+Stability: this interface is not frozen while Otari is pre-1.0. Splitting the
+CRM and the support messenger behind two ports, should they need to vary
+independently, is an anticipated change; overlay authors should expect the
+shape to move.
+"""
+
+import uuid
+from datetime import datetime
+from enum import StrEnum
+from typing import Protocol
+
+from fastapi import BackgroundTasks
+
+
+class GrowthActivationEvent(StrEnum):
+    """A lifecycle milestone worth notifying a vendor about.
+
+    Owned by the port rather than by whichever vendor answers it, so a caller
+    never imports a vendor-flavored constant: it names the milestone in domain
+    terms and leaves the vendor's own vocabulary to the adapter.
+    """
+
+    SIGNED_UP = "signed_up"
+    API_KEY_CREATED = "api_key_created"  # pragma: allowlist secret
+    FIRST_ROUTE_CONFIGURED = "first_route_configured"
+    FIRST_REQUEST_ROUTED = "first_request_routed"
+    BUDGET_RULE_SET = "budget_rule_set"
+
+
+class GrowthSignalPort(Protocol):
+    """What a build does with a user lifecycle event, if anything."""
+
+    async def record_signup(
+        self,
+        *,
+        background_tasks: BackgroundTasks,
+        user_id: uuid.UUID,
+        email: str,
+        full_name: str | None,
+        created_at: datetime,
+    ) -> None:
+        """Notify of a brand-new account, immediately after it is created."""
+        ...
+
+    async def record_activation(
+        self,
+        *,
+        background_tasks: BackgroundTasks,
+        event: GrowthActivationEvent,
+        user_id: uuid.UUID,
+        email: str,
+    ) -> None:
+        """Notify that a user crossed an activation milestone.
+
+        Callers detect first occurrence themselves, as they already must to
+        decide whether to call this at all; an adapter may additionally
+        de-duplicate on its own end, so a redundant call is safe.
+        """
+        ...
+
+    async def record_profile_updated(
+        self,
+        *,
+        background_tasks: BackgroundTasks,
+        user_id: uuid.UUID,
+        email: str,
+        full_name: str | None,
+    ) -> None:
+        """Notify of an edited display name worth reflecting on the vendor's record."""
+        ...
+
+    async def record_account_deleted(
+        self,
+        *,
+        background_tasks: BackgroundTasks,
+        user_id: uuid.UUID,
+        email: str,
+    ) -> None:
+        """Notify that an account was deleted, so a vendor can mark it churned.
+
+        Called with primitives captured before the delete, so an adapter must
+        not assume the user row still exists when its background task runs.
+        """
+        ...

--- a/src/gateway/ports/growth_signal_port.py
+++ b/src/gateway/ports/growth_signal_port.py
@@ -1,8 +1,8 @@
 """Lifecycle notifications for whichever CRM or support messenger a build runs.
 
 The seam between the core and whichever build tells an outside vendor about a
-user's lifecycle: signup, activation milestones, profile edits, and account
-deletion. The core has no growth-marketing or support-messaging vendor of its
+user's lifecycle: signup, activation milestones, onboarding, profile edits, and
+account deletion. The core has no growth-marketing or support-messaging vendor of its
 own, and that is the point: an operator running Otari serves their own users on
 their own channels, and nothing about those users' lifecycle should reach a
 vendor the deployment never chose. So the core adapter is a Null Object, and an
@@ -22,9 +22,10 @@ shape to move.
 """
 
 import uuid
+from collections.abc import Mapping
 from datetime import datetime
 from enum import StrEnum
-from typing import Protocol
+from typing import Any, Protocol
 
 from fastapi import BackgroundTasks
 
@@ -72,6 +73,33 @@ class GrowthSignalPort(Protocol):
         Callers detect first occurrence themselves, as they already must to
         decide whether to call this at all; an adapter may additionally
         de-duplicate on its own end, so a redundant call is safe.
+        """
+        ...
+
+    async def record_onboarding_completed(
+        self,
+        *,
+        background_tasks: BackgroundTasks,
+        user_id: uuid.UUID,
+        email: str,
+        answers: Mapping[str, Any],
+        full_name: str | None,
+    ) -> None:
+        """Notify that a user completed onboarding, with their raw answers.
+
+        ``answers`` are the validated onboarding answers keyed by question key.
+        The port carries no vendor property mapping: turning an answer into a
+        vendor's object model (a CRM contact property, say) is the adapter's
+        job, so a caller never builds a vendor-shaped property dict itself.
+        That split is the whole reason the answers cross the seam in domain
+        terms.
+
+        Nothing calls this yet, because the questions and the answers they
+        produce are not in this tree: the reconciled tenancy schema carries no
+        onboarding columns (see ``gateway.models.tenancy``). The method is
+        here because the seam is where the split belongs whenever they arrive,
+        and because the answers are an argument rather than a column read, so
+        the port does not wait on the schema.
         """
         ...
 

--- a/src/gateway/ports/model_provider_port.py
+++ b/src/gateway/ports/model_provider_port.py
@@ -1,0 +1,91 @@
+"""Deployment-owned inference credentials for a request that brings none.
+
+The seam between the core and whichever build serves a request that carries no
+BYO provider key. A caller's own stored key never reaches this port: resolving
+one is identical in every build, so it stays a plain, unseamed lookup upstream
+of here. Only what happens when there is no BYO key varies, and hosted
+inference (a metered fleet the deployment owns and proxies to) is the "core
+port + hosted adapter" row of ``ARCHITECTURE.md``'s capability lines.
+
+Self-hosting is a first-class path *upstream* of this port, not behind it: a
+deployment pointing at its own backends resolves a credential the ordinary way
+and never asks here. So the core adapter answers "unavailable" for every
+candidate by design rather than by omission, and an overlay binds an adapter
+that resolves against the upstreams it owns.
+
+Stability: this interface is not frozen while Otari is pre-1.0. Overlay authors
+should pin a released tag and expect the shape to move.
+"""
+
+import uuid
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class HostedCredential:
+    """A resolved, deployment-owned connection that can serve one candidate.
+
+    ``response_provider`` is the upstream name usage and telemetry key on, which
+    may differ from the public managed name the caller asked for, matching
+    ``provider`` on a resolve attempt (``docs/hybrid-mode-protocol.md``).
+
+    Returned only when the credential is actually usable. A build that cannot
+    serve a candidate (its own credential for it is absent, disabled, or
+    undecryptable) answers ``None`` from
+    :meth:`ModelProviderPort.resolve_hosted_credential` rather than a value
+    carrying an empty key.
+    """
+
+    api_key: str
+    api_base: str | None
+    response_provider: str
+
+
+class HostedAccessDeniedError(Exception):
+    """Raised when an organization may not use the upstream that would serve a candidate.
+
+    The port owns this error so a caller can handle a refusal without naming
+    the adapter that produced it. An adapter may raise a subclass carrying its
+    own wording. ``workspace_id`` is attribution only, never part of the access
+    decision (which keys on the organization alone), and is ``None`` for a
+    caller with no workspace context.
+    """
+
+    def __init__(self, message: str, workspace_id: uuid.UUID | None = None) -> None:
+        super().__init__(message)
+        self.workspace_id = workspace_id
+
+
+class ModelProviderPort(Protocol):
+    """What a build must answer to serve a candidate that brings no BYO key."""
+
+    async def resolve_hosted_credential(
+        self,
+        *,
+        organization_id: uuid.UUID,
+        workspace_id: uuid.UUID | None,
+        provider: str,
+        model: str | None,
+    ) -> HostedCredential | None:
+        """Resolve a deployment-owned credential to serve ``provider``.
+
+        ``model`` narrows which upstream serves the candidate (by its
+        per-model catalog entry, say); ``None`` means no specific model, which
+        resolves to the provider's default upstream. ``workspace_id`` is
+        ``None`` for a caller with no workspace context; it is attribution
+        only, never part of the access decision, which keys on
+        ``organization_id`` alone.
+
+        Returns:
+            ``None`` when this build has no hosted-inference path for this
+            candidate at all: the core answer for every candidate, and an
+            overlay's honest answer when its own credential for the candidate
+            is absent, disabled, or undecryptable.
+
+        Raises:
+            HostedAccessDeniedError: If the organization may not use the
+                upstream that would serve ``model``.
+
+        """
+        ...

--- a/tests/integration/test_bootstrap_overlay.py
+++ b/tests/integration/test_bootstrap_overlay.py
@@ -16,8 +16,11 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+from gateway.api.deps import reset_config
 from gateway.container import Container
 from gateway.core.config import GatewayConfig
+from gateway.core.database import reset_db
+from gateway.main import create_app
 
 from .conftest import build_test_client
 
@@ -46,6 +49,13 @@ async def overlay_withheld() -> dict[str, str]:
     return {"source": "overlay"}
 
 
+# Under a prefix the hybrid stub router claims with a ``{path:path}`` catch-all,
+# so mounting order decides which one answers.
+@granted_router.get("/v1/organizations/overlay-probe")
+async def overlay_probe_under_a_stub_prefix() -> dict[str, str]:
+    return {"source": "overlay"}
+
+
 class ProbeEntitlementAdapter:
     """Grants one capability, so the other contributed router stays refused."""
 
@@ -64,12 +74,21 @@ def register(container: Container) -> None:
 
 
 @pytest.fixture
-def overlay_on_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
-    """Write the overlay module somewhere importable and return its dotted path."""
+def overlay_on_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[str]:
+    """Write the overlay module somewhere importable and return its dotted path.
+
+    Dropped from ``sys.modules`` on the way in, so this test's file is what
+    loads, and again on the way out, so the module object does not outlive the
+    ``tmp_path`` it was imported from. ``monkeypatch.delitem(..., raising=False)``
+    does not manage the second: on a name that is absent it records no undo
+    entry, so teardown would restore the first such test's module rather than
+    clearing it.
+    """
     (tmp_path / "otari_test_overlay.py").write_text(OVERLAY_MODULE)
     monkeypatch.syspath_prepend(str(tmp_path))
-    monkeypatch.delitem(sys.modules, "otari_test_overlay", raising=False)
-    return "otari_test_overlay"
+    sys.modules.pop("otari_test_overlay", None)
+    yield "otari_test_overlay"
+    sys.modules.pop("otari_test_overlay", None)
 
 
 @pytest.fixture
@@ -125,3 +144,34 @@ def test_nothing_is_mounted_or_rebound_without_a_selector(client: TestClient) ->
     container: Container = client.app.state.container  # type: ignore[attr-defined]
     assert container.router_contributions() == ()
     assert container.summary.startswith("no bootstrap, core defaults for ")
+
+
+def test_a_contributed_route_wins_over_the_hybrid_stub_catch_all(
+    overlay_on_path: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The hybrid stubs are ``{path:path}`` catch-alls over whole management
+    # prefixes, and FastAPI serves the first matching route, so a contributed
+    # route under one of them is only reachable if the stubs are mounted last.
+    # Mounted earlier it would silently answer "manage this via the platform
+    # UI" and the overlay's handler would never run.
+    monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
+    config = GatewayConfig(
+        mode="hybrid",
+        platform={"base_url": "http://localhost:8100/api/v1"},
+        bootstrap=f"{overlay_on_path}:register",
+    )
+    app = create_app(config)
+
+    try:
+        with TestClient(app) as client:
+            response = client.get("/v1/organizations/overlay-probe")
+            # The stub still answers a path the overlay does not serve.
+            stub_response = client.get("/v1/organizations/something-else")
+    finally:
+        reset_config()
+        reset_db()
+
+    assert response.status_code == 200
+    assert response.json() == {"source": "overlay"}
+    assert stub_response.status_code == 404
+    assert stub_response.json()["detail"].startswith("This endpoint is not available in hybrid mode")

--- a/tests/integration/test_bootstrap_overlay.py
+++ b/tests/integration/test_bootstrap_overlay.py
@@ -1,0 +1,127 @@
+"""The bootstrap hook, end to end on a running app.
+
+``OTARI_BOOTSTRAP`` is the whole of how a build layers itself onto Otari
+without editing an Otari source file: it names a callable that receives the
+composition-root container after the core adapters are bound, and may rebind a
+port and contribute routers. What that buys is only real on a booted app, so
+this exercises both halves against one: a rebound ``EntitlementPort`` decides
+which of two contributed routers answers, and the plain build (no selector set)
+mounts neither.
+"""
+
+import sys
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway.container import Container
+from gateway.core.config import GatewayConfig
+
+from .conftest import build_test_client
+
+# An overlay in miniature: it rebinds one port and contributes two routers, one
+# gated on a capability it grants and one on a capability it does not. Written
+# to a file and imported by dotted path, because the import is the mechanism
+# under test.
+OVERLAY_MODULE = '''
+from fastapi import APIRouter
+
+from gateway.container import Container, RouterContribution
+
+from gateway.ports.entitlement_port import EntitlementPort
+
+granted_router = APIRouter()
+withheld_router = APIRouter()
+
+
+@granted_router.get("/v1/overlay-probe")
+async def overlay_probe() -> dict[str, str]:
+    return {"source": "overlay"}
+
+
+@withheld_router.get("/v1/overlay-withheld")
+async def overlay_withheld() -> dict[str, str]:
+    return {"source": "overlay"}
+
+
+class ProbeEntitlementAdapter:
+    """Grants one capability, so the other contributed router stays refused."""
+
+    def __init__(self, session):
+        self.session = session
+
+    async def entitlements(self):
+        return {"probe"}
+
+
+def register(container: Container) -> None:
+    container.bind(EntitlementPort, ProbeEntitlementAdapter)
+    container.contribute_router(RouterContribution(capability="probe", router=granted_router))
+    container.contribute_router(RouterContribution(capability="unlicensed", router=withheld_router))
+'''
+
+
+@pytest.fixture
+def overlay_on_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Write the overlay module somewhere importable and return its dotted path."""
+    (tmp_path / "otari_test_overlay.py").write_text(OVERLAY_MODULE)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.delitem(sys.modules, "otari_test_overlay", raising=False)
+    return "otari_test_overlay"
+
+
+@pytest.fixture
+def bootstrap_config(postgres_url: str, overlay_on_path: str) -> GatewayConfig:
+    return GatewayConfig(
+        database_url=postgres_url,
+        master_key="test-master-key",
+        auto_migrate=False,
+        require_pricing=False,
+        model_discovery=False,
+        bootstrap=f"{overlay_on_path}:register",
+    )
+
+
+@pytest.fixture
+def bootstrap_client(bootstrap_config: GatewayConfig) -> Generator[TestClient]:
+    yield from build_test_client(bootstrap_config)
+
+
+def test_a_contributed_route_is_served_when_the_capability_is_entitled(
+    bootstrap_client: TestClient,
+) -> None:
+    response = bootstrap_client.get("/v1/overlay-probe")
+
+    assert response.status_code == 200
+    assert response.json() == {"source": "overlay"}
+
+
+def test_a_contributed_route_is_refused_when_the_capability_is_not_entitled(
+    bootstrap_client: TestClient,
+) -> None:
+    # Mounted, but gated: the refusal is indistinguishable from a path nothing
+    # serves, so the response does not disclose that the surface exists.
+    response = bootstrap_client.get("/v1/overlay-withheld")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not Found"}
+
+
+def test_the_rebound_port_is_what_the_gateway_resolves(bootstrap_client: TestClient) -> None:
+    container: Container = bootstrap_client.app.state.container  # type: ignore[attr-defined]
+
+    assert "otari_test_overlay:register rebound EntitlementPort" in container.summary
+    assert "contributed routers for probe, unlicensed" in container.summary
+
+
+def test_nothing_is_mounted_or_rebound_without_a_selector(client: TestClient) -> None:
+    # The acceptance case for every deployment that runs no overlay: the same
+    # app, built with OTARI_BOOTSTRAP unset, serves neither contributed path and
+    # imports nothing.
+    assert client.get("/v1/overlay-probe").status_code == 404
+    assert client.get("/v1/overlay-withheld").status_code == 404
+    container: Container = client.app.state.container  # type: ignore[attr-defined]
+    assert container.router_contributions() == ()
+    assert container.summary.startswith("no bootstrap, core defaults for ")

--- a/tests/unit/test_check_architecture.py
+++ b/tests/unit/test_check_architecture.py
@@ -54,21 +54,18 @@ def test_relative_import_above_src_root_is_ignored(tmp_path: Path) -> None:
     assert check.check_file(file_path, tmp_path) == []
 
 
-def test_nested_and_enclosing_layer_rules_both_apply(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # A broader gateway/api rule declared first must neither shadow the nested
-    # routes rule nor stop applying to files under it, whatever the order.
-    broadened = {
-        "gateway/api": {"allowed": [], "forbidden": ["gateway.db"], "description": "API"},
-        **check.RULES,
-    }
-    monkeypatch.setattr(check, "RULES", broadened)
+def test_nested_and_enclosing_layer_rules_both_apply(tmp_path: Path) -> None:
+    # The real rules already have the shape this guards: gateway/api is declared
+    # before the nested gateway/api/routes, and a route file must answer to
+    # both. Declaring one first must neither shadow the nested rule nor stop
+    # applying to files under it.
     file_path = _write(
         tmp_path,
         "gateway/api/routes/users.py",
-        "from gateway.db import engine\nfrom sqlalchemy.orm import Session\n",
+        "from gateway.adapters.billing_adapter import NullBillingAdapter\nfrom sqlalchemy.orm import Session\n",
     )
     assert check.check_file(file_path, tmp_path) == [
-        (1, "gateway.db", "Forbidden import in API"),
+        (1, "gateway.adapters.billing_adapter", "Forbidden import in API layer"),
         (2, "sqlalchemy.orm", "Forbidden import in API routes"),
     ]
 
@@ -115,11 +112,67 @@ def test_api_route_may_import_repositories(tmp_path: Path) -> None:
     assert check.check_file(file_path, tmp_path) == []
 
 
-def test_ports_and_adapters_scaffolding_is_noop(tmp_path: Path) -> None:
-    ports_file = _write(tmp_path, "gateway/ports/billing.py", "from gateway.api.routes import chat\n")
-    adapters_file = _write(tmp_path, "gateway/adapters/null_billing.py", "from gateway.api.routes import chat\n")
-    assert check.check_file(ports_file, tmp_path) == []
-    assert check.check_file(adapters_file, tmp_path) == []
+@pytest.mark.parametrize(
+    "forbidden",
+    ["gateway.api.deps", "gateway.services.budget_service", "gateway.adapters.billing_adapter"],
+)
+def test_port_may_not_import_a_caller_or_an_adapter(tmp_path: Path, forbidden: str) -> None:
+    # A port is the interface its callers depend on, so it sits below them, and
+    # naming an adapter would name the implementation it exists to keep unnamed.
+    file_path = _write(tmp_path, "gateway/ports/billing_port.py", f"from {forbidden} import thing\n")
+    assert check.check_file(file_path, tmp_path) == [(1, forbidden, "Forbidden import in Ports")]
+
+
+def test_port_may_describe_the_domain(tmp_path: Path) -> None:
+    file_path = _write(
+        tmp_path,
+        "gateway/ports/billing_port.py",
+        "from gateway.models.money import USD\nfrom gateway.core.config import GatewayConfig\n",
+    )
+    assert check.check_file(file_path, tmp_path) == []
+
+
+def test_adapter_may_not_import_the_api_layer(tmp_path: Path) -> None:
+    file_path = _write(tmp_path, "gateway/adapters/billing_adapter.py", "from gateway.api.deps import get_db\n")
+    assert check.check_file(file_path, tmp_path) == [(1, "gateway.api.deps", "Forbidden import in Adapters")]
+
+
+def test_adapter_may_use_the_layers_below_it(tmp_path: Path) -> None:
+    file_path = _write(
+        tmp_path,
+        "gateway/adapters/billing_adapter.py",
+        "from gateway.ports.billing_port import BillingPort\nfrom gateway.services.budget_service import reserve\n",
+    )
+    assert check.check_file(file_path, tmp_path) == []
+
+
+def test_service_may_not_name_a_concrete_adapter(tmp_path: Path) -> None:
+    # Only the composition root binds a concrete adapter; a service depends on
+    # the port and takes whatever the container resolved.
+    file_path = _write(
+        tmp_path,
+        "gateway/services/thing.py",
+        "from gateway.adapters.billing_adapter import NullBillingAdapter\n",
+    )
+    assert check.check_file(file_path, tmp_path) == [
+        (1, "gateway.adapters.billing_adapter", "Forbidden import in Services")
+    ]
+
+
+def test_service_may_import_a_port(tmp_path: Path) -> None:
+    file_path = _write(tmp_path, "gateway/services/thing.py", "from gateway.ports.billing_port import BillingPort\n")
+    assert check.check_file(file_path, tmp_path) == []
+
+
+def test_the_composition_root_may_name_a_concrete_adapter(tmp_path: Path) -> None:
+    # gateway/container.py answers only to the gateway root rule, which is what
+    # leaves it the one file allowed to name an adapter.
+    file_path = _write(
+        tmp_path,
+        "gateway/container.py",
+        "from gateway.adapters.billing_adapter import NullBillingAdapter\n",
+    )
+    assert check.check_file(file_path, tmp_path) == []
 
 
 def test_shared_types_may_not_import_other_gateway_layers(tmp_path: Path) -> None:
@@ -206,9 +259,7 @@ def test_test_suite_importing_the_overlay_is_flagged(tmp_path: Path) -> None:
     ]
 
 
-def test_main_discovers_tests_root_and_fails_on_overlay_import(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_main_discovers_tests_root_and_fails_on_overlay_import(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Unlike the check_file() tests above, this exercises main() itself: that
     # it walks TESTS_ROOT (not just GATEWAY_ROOT) and resolves those paths
     # against REPO_ROOT, using the gateway-composed overlay spelling.

--- a/tests/unit/test_check_architecture.py
+++ b/tests/unit/test_check_architecture.py
@@ -165,14 +165,39 @@ def test_service_may_import_a_port(tmp_path: Path) -> None:
 
 
 def test_the_composition_root_may_name_a_concrete_adapter(tmp_path: Path) -> None:
-    # gateway/container.py answers only to the gateway root rule, which is what
-    # leaves it the one file allowed to name an adapter.
+    # The one file exempted from the root rule's ban on gateway.adapters, which
+    # is what leaves it the one file allowed to name an adapter.
     file_path = _write(
         tmp_path,
         "gateway/container.py",
         "from gateway.adapters.billing_adapter import NullBillingAdapter\n",
     )
     assert check.check_file(file_path, tmp_path) == []
+
+
+def test_an_adapter_may_name_its_siblings(tmp_path: Path) -> None:
+    file_path = _write(
+        tmp_path,
+        "gateway/adapters/billing_adapter.py",
+        "from gateway.adapters.entitlement_adapter import BaseEntitlementAdapter\n",
+    )
+    assert check.check_file(file_path, tmp_path) == []
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    ["gateway/main.py", "gateway/cli.py", "gateway/core/config.py", "gateway/auth/models.py", "gateway/db/base.py"],
+)
+def test_an_unlayered_module_may_not_name_a_concrete_adapter(tmp_path: Path, relative_path: str) -> None:
+    # The gap a layer-by-layer ban leaves: these answer to no gateway/<layer>
+    # rule, so without the root rule's ban they could shortcut past the
+    # container and pin a capability to one implementation. gateway/main.py is
+    # where that shortcut would most naturally be written, since it is already
+    # the file that builds the container.
+    file_path = _write(tmp_path, relative_path, "from gateway.adapters.billing_adapter import NullBillingAdapter\n")
+    assert check.check_file(file_path, tmp_path) == [
+        (1, "gateway.adapters.billing_adapter", "Forbidden import in OSS base")
+    ]
 
 
 def test_shared_types_may_not_import_other_gateway_layers(tmp_path: Path) -> None:

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -1,0 +1,223 @@
+"""Composition-root container and bootstrap hook.
+
+Covers the mechanism itself: the core defaults every deployment gets, what a
+bootstrap may change about them, and how a broken selector is reported. The
+end-to-end path (an overlay module rebinding a port and adding a route to a
+running app) is in ``tests/integration/test_bootstrap_overlay.py``.
+"""
+
+import sys
+from pathlib import Path
+from typing import Protocol, cast
+
+import pytest
+from fastapi import APIRouter
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.adapters.billing_adapter import NullBillingAdapter
+from gateway.adapters.entitlement_adapter import BaseEntitlementAdapter
+from gateway.adapters.growth_signal_adapter import NullGrowthSignalAdapter
+from gateway.adapters.model_provider_adapter import SelfHostedModelProviderAdapter
+from gateway.container import (
+    BootstrapError,
+    Container,
+    PortNotBoundError,
+    RouterContribution,
+    build_container,
+)
+from gateway.ports.billing_port import BillingPort
+from gateway.ports.entitlement_port import EntitlementPort
+from gateway.ports.growth_signal_port import GrowthSignalPort
+from gateway.ports.model_provider_port import ModelProviderPort
+
+# The core adapters ignore the session, so a placeholder stands in for one; a
+# unit test of the wiring has no database and needs none.
+NO_SESSION = cast(AsyncSession, None)
+
+
+class UnusedPort(Protocol):
+    """A port nothing binds, for the not-bound path."""
+
+    async def do_nothing(self) -> None: ...
+
+
+class _ReboundBilling(NullBillingAdapter):
+    """Stands in for an overlay's own billing adapter."""
+
+
+def _write_bootstrap(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, name: str, body: str) -> None:
+    """Write an importable bootstrap module and put it on ``sys.path``."""
+    (tmp_path / f"{name}.py").write_text(body)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+def test_core_defaults_are_bound_for_every_port() -> None:
+    container = build_container()
+
+    assert isinstance(container.resolve(BillingPort, NO_SESSION), NullBillingAdapter)
+    assert isinstance(container.resolve(EntitlementPort, NO_SESSION), BaseEntitlementAdapter)
+    assert isinstance(container.resolve(ModelProviderPort, NO_SESSION), SelfHostedModelProviderAdapter)
+    assert isinstance(container.resolve(GrowthSignalPort, NO_SESSION), NullGrowthSignalAdapter)
+
+
+def test_no_selector_contributes_no_routers_and_says_so() -> None:
+    container = build_container()
+
+    assert container.router_contributions() == ()
+    assert container.summary.startswith("no bootstrap, core defaults for ")
+    for port in (BillingPort, EntitlementPort, GrowthSignalPort, ModelProviderPort):
+        assert port.__name__ in container.summary
+
+
+def test_resolve_refuses_a_port_nothing_bound() -> None:
+    container = build_container()
+
+    with pytest.raises(PortNotBoundError, match="UnusedPort"):
+        container.resolve(UnusedPort, NO_SESSION)
+
+
+def test_a_later_bind_replaces_an_earlier_one() -> None:
+    container = build_container()
+    replacement = _ReboundBilling
+
+    container.bind(BillingPort, replacement)
+
+    assert dict(container.bindings())[BillingPort] is replacement
+    assert isinstance(container.resolve(BillingPort, NO_SESSION), _ReboundBilling)
+
+
+def test_bindings_is_a_snapshot_not_a_live_view() -> None:
+    container = build_container()
+    before = dict(container.bindings())
+
+    container.bind(BillingPort, _ReboundBilling)
+
+    assert before[BillingPort] is not dict(container.bindings())[BillingPort]
+
+
+def test_bootstrap_rebinds_a_port_and_contributes_a_router(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_bootstrap(
+        tmp_path,
+        monkeypatch,
+        "probe_bootstrap",
+        """
+from fastapi import APIRouter
+
+from gateway.container import Container, RouterContribution
+from gateway.ports.entitlement_port import EntitlementPort
+
+router = APIRouter()
+
+
+class ProbeEntitlements:
+    def __init__(self, session):
+        self.session = session
+
+    async def entitlements(self):
+        return {"probe"}
+
+
+def register(container: Container) -> None:
+    container.bind(EntitlementPort, ProbeEntitlements)
+    container.contribute_router(RouterContribution(capability="probe", router=router))
+""",
+    )
+
+    container = build_container("probe_bootstrap:register")
+
+    entitlements = container.resolve(EntitlementPort, NO_SESSION)
+    assert type(entitlements).__name__ == "ProbeEntitlements"
+    assert not isinstance(entitlements, BaseEntitlementAdapter)
+    assert [contribution.capability for contribution in container.router_contributions()] == ["probe"]
+    assert container.summary == ("probe_bootstrap:register rebound EntitlementPort, contributed routers for probe")
+
+
+def test_bootstrap_that_rebinds_nothing_leaves_the_core_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_bootstrap(
+        tmp_path,
+        monkeypatch,
+        "inert_bootstrap",
+        "def register(container):\n    return None\n",
+    )
+
+    container = build_container("inert_bootstrap:register")
+
+    assert isinstance(container.resolve(BillingPort, NO_SESSION), NullBillingAdapter)
+    assert container.summary == "inert_bootstrap:register rebound no ports"
+
+
+def test_a_selector_with_surrounding_whitespace_still_loads(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_bootstrap(
+        tmp_path,
+        monkeypatch,
+        "spaced_bootstrap",
+        "def register(container):\n    return None\n",
+    )
+
+    container = build_container("  spaced_bootstrap:register  ")
+
+    assert "rebound no ports" in container.summary
+
+
+@pytest.mark.parametrize(
+    ("selector", "message"),
+    [
+        ("no_colon_here", "must be 'module:callable'"),
+        (":register", "must be 'module:callable'"),
+        ("module_only:", "must be 'module:callable'"),
+        ("   ", "set but blank"),
+    ],
+)
+def test_a_malformed_selector_refuses_to_boot(selector: str, message: str) -> None:
+    with pytest.raises(BootstrapError, match=message):
+        build_container(selector)
+
+
+def test_a_missing_bootstrap_module_is_reported_as_not_found() -> None:
+    with pytest.raises(BootstrapError, match="was not found"):
+        build_container("gateway_bootstrap_that_does_not_exist:register")
+
+
+def test_a_bootstrap_whose_own_import_fails_is_reported_as_such(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A module that exists but reaches for something that does not: distinct
+    # from a wrong selector, and the message has to say which it was, or an
+    # operator debugs the wrong half.
+    _write_bootstrap(
+        tmp_path,
+        monkeypatch,
+        "broken_bootstrap",
+        "import a_dependency_that_is_not_installed\n\n\ndef register(container):\n    return None\n",
+    )
+
+    with pytest.raises(BootstrapError, match="failed to import"):
+        build_container("broken_bootstrap:register")
+
+
+def test_a_bootstrap_missing_its_callable_is_refused(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_bootstrap(tmp_path, monkeypatch, "empty_bootstrap", "value = 1\n")
+
+    with pytest.raises(BootstrapError, match="has no attribute 'register'"):
+        build_container("empty_bootstrap:register")
+
+
+def test_a_bootstrap_attribute_that_is_not_callable_is_refused(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write_bootstrap(tmp_path, monkeypatch, "value_bootstrap", "register = 1\n")
+
+    with pytest.raises(BootstrapError, match="is not callable"):
+        build_container("value_bootstrap:register")
+
+
+def test_router_contributions_keep_their_order() -> None:
+    container = Container()
+    first = RouterContribution(capability="one", router=APIRouter())
+    second = RouterContribution(capability="two", router=APIRouter())
+
+    container.contribute_router(first)
+    container.contribute_router(second)
+
+    assert container.router_contributions() == (first, second)

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -7,6 +7,7 @@ running app) is in ``tests/integration/test_bootstrap_overlay.py``.
 """
 
 import sys
+from collections.abc import Generator
 from pathlib import Path
 from typing import Protocol, cast
 
@@ -45,11 +46,35 @@ class _ReboundBilling(NullBillingAdapter):
     """Stands in for an overlay's own billing adapter."""
 
 
+# Every module name _write_bootstrap has handed out this test, so the autouse
+# fixture below can take each back out of sys.modules afterwards.
+_WRITTEN: set[str] = set()
+
+
+@pytest.fixture(autouse=True)
+def _forget_written_bootstraps() -> Generator[None]:
+    """Leave ``sys.modules`` as the test found it.
+
+    A written bootstrap is imported from ``tmp_path``, which is gone by the next
+    test, so the module object must not outlive the test that wrote it.
+    ``monkeypatch.delitem(..., raising=False)`` does not manage this on its own:
+    on a name that is absent it records no undo entry (see ``MonkeyPatch``), so
+    teardown restores whichever module the *first* such test left behind instead
+    of clearing it, and that stale module is what survives the suite.
+    """
+    _WRITTEN.clear()
+    yield
+    for name in _WRITTEN:
+        sys.modules.pop(name, None)
+    _WRITTEN.clear()
+
+
 def _write_bootstrap(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, name: str, body: str) -> None:
     """Write an importable bootstrap module and put it on ``sys.path``."""
     (tmp_path / f"{name}.py").write_text(body)
     monkeypatch.syspath_prepend(str(tmp_path))
-    monkeypatch.delitem(sys.modules, name, raising=False)
+    sys.modules.pop(name, None)
+    _WRITTEN.add(name)
 
 
 def test_core_defaults_are_bound_for_every_port() -> None:
@@ -210,6 +235,26 @@ def test_a_bootstrap_attribute_that_is_not_callable_is_refused(tmp_path: Path, m
 
     with pytest.raises(BootstrapError, match="is not callable"):
         build_container("value_bootstrap:register")
+
+
+def test_an_async_bootstrap_is_refused_rather_than_silently_dropped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # An ``async def register`` is callable, so without an explicit check it
+    # passes every guard and the container calls it, gets a coroutine nobody
+    # awaits, and boots the plain build with the selector's bindings silently
+    # discarded. That is the failure this path exists to refuse, and every port
+    # method being async makes it the easy mistake to make.
+    _write_bootstrap(
+        tmp_path,
+        monkeypatch,
+        "async_bootstrap",
+        "from gateway.ports.billing_port import BillingPort\n\n\n"
+        "async def register(container):\n    container.bind(BillingPort, _ReboundBilling)\n",
+    )
+
+    with pytest.raises(BootstrapError, match="is async"):
+        build_container("async_bootstrap:register")
 
 
 def test_router_contributions_keep_their_order() -> None:

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -257,6 +257,27 @@ def test_an_async_bootstrap_is_refused_rather_than_silently_dropped(
         build_container("async_bootstrap:register")
 
 
+def test_an_async_callable_object_bootstrap_is_refused_too(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The hole the iscoroutinefunction guard alone leaves: an instance whose
+    # __call__ is async is callable and is *not* a coroutine function, so it
+    # passes every guard, gets called, and returns a coroutine whose body never
+    # ran. Same silent drop, different route in, so it is refused at the result
+    # instead of at the callable.
+    _write_bootstrap(
+        tmp_path,
+        monkeypatch,
+        "async_callable_bootstrap",
+        "class Register:\n"
+        "    async def __call__(self, container):\n"
+        "        raise AssertionError('the body must never run')\n"
+        "\n\n"
+        "register = Register()\n",
+    )
+
+    with pytest.raises(BootstrapError, match="returned an awaitable"):
+        build_container("async_callable_bootstrap:register")
+
+
 def test_router_contributions_keep_their_order() -> None:
     container = Container()
     first = RouterContribution(capability="one", router=APIRouter())

--- a/tests/unit/test_oss_edition_smoke.py
+++ b/tests/unit/test_oss_edition_smoke.py
@@ -57,7 +57,7 @@ def _post(url: str, *, headers: dict[str, str] | None = None) -> tuple[int, Any]
     [
         "OTARI_MODE",  # selects hybrid mode outright
         "OTARI_AI_TOKEN",  # a platform token selects hybrid mode when mode is unset
-        "OTARI_BOOTSTRAP",  # the planned overlay selector
+        "OTARI_BOOTSTRAP",  # the overlay selector, which would boot a build nobody chose
         "OTARI_PLATFORM_BASE_URL",  # the platform block, which only hybrid reads
         "OTARI_DATABASE_URL",  # would smoke a database nobody chose
         # A name the scrub has never heard of, so a regression from the prefix

--- a/web/src/shared/hooks/useEntitlements.tsx
+++ b/web/src/shared/hooks/useEntitlements.tsx
@@ -51,6 +51,11 @@ export interface Entitlements {
  * entry gated on a capability that is not listed disappears from every
  * deployment, and the two lists live in different files, so `registry.test.ts`
  * fails when they disagree.
+ *
+ * This has a server-side twin in `src/gateway/adapters/entitlement_adapter.py`,
+ * which is what gates a route rather than a link. The two are meant to agree,
+ * and nothing checks that they do, so a capability the base grows is added to
+ * both at once.
  */
 export const BASE_CAPABILITIES: readonly string[] = []
 


### PR DESCRIPTION
## Description

Otari is meant to be extendable: someone should be able to bolt their own billing, their own hosted inference, or their own extra API pages onto it without forking the project or editing its files. The architecture doc has described how that would work for a while, but none of it was actually built. This PR builds it. Otari now defines a handful of named slots for the pieces it hands off to somebody else, ships its own working (mostly do-nothing) version of each so it still runs perfectly well on its own, and reads one environment variable at startup that lets an outside build swap any of them out and add pages of its own. If you do not set that variable, nothing is imported and the gateway behaves exactly as it did before.

Three pieces:

- **`src/gateway/ports/`**: four async `Protocol` interfaces, the ones the first overlay binds. `ModelProviderPort`, `BillingPort`, `EntitlementPort`, `GrowthSignalPort`.
- **`src/gateway/adapters/` + `src/gateway/container.py`**: a working core adapter for every port, real or Null Object, bound in a plain port-to-factory mapping built once per app in `create_app` and read through port dependencies in `api/deps.py`.
- **Bootstrap hook**: `OTARI_BOOTSTRAP=module:callable` is imported after the defaults are bound and handed the container, so a build can rebind a port and contribute routers. A selector that is set but cannot be loaded fails startup rather than quietly running the plain build.

A contributed router is mounted behind `require_capability`, which resolves `EntitlementPort` and answers an unentitled request with the same 404 a path nothing serves gets. ARCHITECTURE.md said that gate was needed the moment an overlay could mount a router into this process, and now it can.

Three departures from the platform's sync reference, each deliberate:

1. A port factory receives `AsyncSession | None`. Hybrid mode never calls `init_db`, so a port resolved on a hybrid request has no session and an adapter has to say what it does without one.
2. The container keys on the `Protocol` class through a `Callable[..., T]` alias rather than `type[T]`, because mypy strict refuses an abstract class where `type[T]` is expected. The core bindings go through named factory functions whose return type is the port, so conformance is still checked (verified by breaking an adapter method name and watching mypy catch it).
3. `check_architecture.py`'s ports and adapters entries were placeholders waiting for the first port. They now enforce what ARCHITECTURE.md says: a port may describe the domain but not import a caller or an adapter, and only the composition root may name a concrete adapter.

Nothing on the request path calls a port yet, and no behavior changes in either mode. This is the mechanism; a capability earns its port when a second implementation is real.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #753

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Tests: `tests/unit/test_container.py` covers the defaults, rebinding, and every way a selector can be broken; `tests/integration/test_bootstrap_overlay.py` boots a real app against a temporary overlay module that rebinds `EntitlementPort` and contributes two routers, one entitled and one not, and asserts the plain build mounts neither. Also ran the full unit and integration suites, the OSS-edition smoke script, `make openapi-check` and `make postman-check`. The API contract did not change, and the committed spec is verified unchanged.

Docs: ARCHITECTURE.md's Planned callouts for the ports package, the container, and `OTARI_BOOTSTRAP` are replaced with what is now in the tree, the entitlement section is corrected to describe both halves, `docs/configuration.md` gains the env var and a short section on writing a bootstrap module, and `src/gateway/AGENTS.md` gains a pointer.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5, via the Claude Code CLI.

**Any additional AI details you'd like to share:**

Written against the sync reference implementation in `otari-ai` (`backend/app/ports/`, `backend/app/container.py`, `backend/overlay/bootstrap.py`), which the issue names. Mostly an async conversion, with the three departures listed above. One review note from @njbrake on the first draft: `record_onboarding_completed` had been cut from `GrowthSignalPort` on the grounds that nothing here could supply onboarding answers. That was wrong, and the second commit restores it. The platform's onboarding question registry is OSS-owned and names no vendor; only the HubSpot property mapping is enterprise-side, so this port method is precisely that boundary and cutting it moved the line by accident.

Separately worth its own issue: otari carries the activation half of onboarding (`workspace_activation_service.py`) but not the profile survey, and `models/tenancy.py` excludes onboarding columns from the reconciled schema. Given the registry is OSS-owned upstream, that exclusion is worth revisiting.

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this pull request description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added four async ports for model providers, billing, entitlements, and growth signals.
- Added default adapters and an application-level composition container.
- Added optional `OTARI_BOOTSTRAP=module:callable` support for port rebinding and route contributions.
- Protected contributed routes with entitlement checks.
- Updated router ordering so contributed routes take precedence over hybrid fallback routes.
- Strengthened architecture rules and expanded documentation.
- Added unit and integration tests for defaults, overlays, bootstrap errors, routing, and entitlement behavior.

Existing behavior remains unchanged when `OTARI_BOOTSTRAP` is unset. The changes provide a clear extension point for standalone and hybrid deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->