### PR TITLE
feat(gateway): price imported usage at organization rates

### DIFF
--- a/docs/external-usage.md
+++ b/docs/external-usage.md
@@ -232,6 +232,33 @@ cache-read and cache-write rates apply when configured. The result is an
 API-rate estimate, not an invoice or a subscription charge. Configure prices with
 `POST /v1/pricing` (set `effective_at` at or before the events you import).
 
+Organization rate overrides apply here too, resolved in the same order a live
+request resolves them: the importing key's organization first
+(`POST /v1/organizations/me/pricing`), then the deployment price list, then the
+default pricing dataset. The organization comes off the workspace the importing
+key belongs to, never off the request body. Because the timestamp that decides is
+the event's own, an override created today does not reprice usage from before its
+`effective_from`: backfill an old batch and it settles at whatever rate was in
+force when the usage happened.
+
+**Importing with the master key prices at the default workspace's organization.**
+The master key is not bound to a workspace, so an import made with it lands in
+the default workspace the same way any other deployment-wide write does, and it
+is that workspace's organization whose overrides apply. On a deployment running
+more than one organization, import each organization's usage with a key
+belonging to it; a master-key import of another organization's usage will price
+at the default organization's rates, not that organization's own.
+
+**A row's cost is settled by the import that created it.** Ingest is idempotent
+on `(source, source_event_id)`, so re-submitting a batch does not recost the rows
+already stored, and changing a rate afterwards does not reach back either. Rows
+imported before an override existed therefore keep the price they were imported
+at, and an organization that adds its first override can see two unit costs for
+one model in cost analytics: the old rows at the deployment rate, the new ones at
+its own. To bring the old rows into line, recost them with
+`POST /v1/usage/set-price`, which takes explicit per-1M rates and touches
+imported rows only.
+
 Pricing is **optional** for imported usage. `require_pricing` is a
 budget-enforcement safety gate, and imported usage is budget-exempt, so a model
 with no configured price is not rejected: the row lands with `cost: null` and you

--- a/src/gateway/services/external_usage_service.py
+++ b/src/gateway/services/external_usage_service.py
@@ -2,12 +2,13 @@
 
 Subscription-backed agents (e.g. Claude Code) never route through the gateway, so
 their usage is invisible to Otari. This service accepts normalized, content-free
-usage events, prices them at the effective configured rate for the event's
-timestamp, and records them as ``usage_logs`` rows with a ``source`` provenance
-tag. Imported rows are attributed to a user and carry their real (API-equivalent)
-cost, but are always ``counts_toward_budget=False``: retrospective usage cannot be
-reserved, so it is recorded and shown in cost analytics without ever gating or
-mutating ``users.spend``.
+usage events, prices them at the rate effective for the event's own timestamp
+(the importing workspace's organization override where it has one, otherwise the
+deployment price list), and records them as ``usage_logs`` rows with a ``source``
+provenance tag. Imported rows are attributed to a user and carry their real
+(API-equivalent) cost, but are always ``counts_toward_budget=False``:
+retrospective usage cannot be reserved, so it is recorded and shown in cost
+analytics without ever gating or mutating ``users.spend``.
 
 Idempotency: rows are keyed by ``(source, source_event_id)`` (a unique constraint).
 Re-submitting a batch counts already-present events as duplicates and never creates
@@ -18,6 +19,7 @@ completions, and tool payloads are rejected by the request schema, not stored.
 import uuid
 from datetime import datetime
 from decimal import Decimal
+from typing import NamedTuple
 
 from fastapi import HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -29,11 +31,14 @@ from gateway.core.metered_pricing import BillableUsage, ChargeLine, billable_usa
 from gateway.log_config import logger
 from gateway.models.entities import APIKey, ModelPricing, UsageLog, User
 from gateway.services.pricing_service import (
+    OverridePeriod,
     default_model_pricing,
     default_pricing_enabled,
+    load_organization_override_index,
     normalize_effective_at,
+    resolve_organization_override,
 )
-from gateway.services.workspace_scope import resolve_workspace_id
+from gateway.services.workspace_scope import organization_for_workspace_id, resolve_workspace_id
 
 # Bounds. Batch size mirrors the /v1/usage list `limit` cap; the error list is
 # capped so one bad batch can't return an unbounded payload; the IN() list is
@@ -200,17 +205,39 @@ def _model_keys(provider: str, model: str) -> list[str]:
     return [f"{provider}:{model}", f"{provider}/{model}"]
 
 
+class BatchPricing(NamedTuple):
+    """Every rate a batch could resolve against, preloaded.
+
+    Two shapes because the two tables are two shapes: ``model_pricing`` is a
+    version series per key (the newest row effective at or before the timestamp
+    wins) and ``organization_model_pricing`` is a set of periods per key (the
+    period containing the timestamp wins). Both are kept whole rather than
+    collapsed to a rate, because a batch carries one timestamp per event.
+    """
+
+    deployment: dict[str, list[tuple[datetime, ModelPricing]]]
+    overrides: dict[str, list[OverridePeriod]]
+
+
 async def _load_pricing_index(
-    db: AsyncSession, pairs: set[tuple[str, str]]
-) -> dict[str, list[tuple[datetime, ModelPricing]]]:
-    """Load every stored pricing row for the batch's (provider, model) pairs in a
-    single query, so pricing is resolved in memory instead of once per event.
+    db: AsyncSession, pairs: set[tuple[str, str]], organization_id: uuid.UUID | None
+) -> BatchPricing:
+    """Load every stored rate for the batch's (provider, model) pairs up front, so
+    pricing is resolved in memory instead of once per event.
 
     A Claude Code batch carries a few models but a distinct timestamp per event, so
     a per-event ``find_model_pricing`` would issue ~one query per event (an N+1). We
-    instead pull the full effective-at history for every model key up front and pick
-    the effective row per timestamp below; the genai default fallback is memoized in
-    pricing_service and hits no database.
+    instead pull the full history for every model key in a fixed handful of queries
+    and pick what applies per timestamp below; the genai default fallback is
+    memoized in pricing_service and hits no database.
+
+    ``organization_id`` is the importing workspace's organization, resolved from
+    the authenticating key rather than from the request, exactly as the request
+    path resolves it. ``None`` skips the override query entirely, but that is a
+    guard rather than a common path: ``workspace.organization_id`` is NOT NULL
+    and a key's workspace is a RESTRICT foreign key, so an import that reaches
+    here has an organization and pays for the one extra indexed lookup whether or
+    not any override exists.
     """
     keys: set[str] = set()
     for provider, model in pairs:
@@ -227,35 +254,45 @@ async def _load_pricing_index(
             index.setdefault(row.model_key, []).append((normalize_effective_at(row.effective_at), row))
     for entries in index.values():
         entries.sort(key=lambda pair: pair[0])
-    return index
+    overrides: dict[str, list[OverridePeriod]] = {}
+    if organization_id is not None:
+        overrides = await load_organization_override_index(db, organization_id, keys)
+    return BatchPricing(deployment=index, overrides=overrides)
 
 
 def _resolve_pricing(
-    index: dict[str, list[tuple[datetime, ModelPricing]]],
+    index: BatchPricing,
     provider: str,
     model: str,
     timestamp: datetime,
 ) -> ModelPricing | None:
     """Effective pricing at the event timestamp, resolved from the preloaded index.
 
-    Mirrors ``find_model_pricing``: canonical key, then legacy key, then the genai
-    default (when enabled). Stored rows win over the default, and the newest row
-    effective at or before the timestamp is chosen, so historical rates are honored.
+    Mirrors ``find_model_pricing``, whole: the importing organization's own
+    override, then the canonical key, then the legacy key, then the genai default
+    (when enabled). Stored rows win over the default, and the newest row effective
+    at or before the timestamp is chosen, so historical rates are honored.
 
-    One deliberate divergence: per-organization rate overrides
-    (``organization_model_pricing``) are *not* consulted, so imported usage prices
-    against the deployment list even when the organization has overridden a model.
-    That is a known inconsistency, held back rather than missed. The overrides
-    carry interval periods where this index carries an effective-at series, so
-    honoring them here is a second resolution shape rather than one more lookup,
-    and which external-usage ingest survives the rehome at all is still an open
-    decision (otari-ai#1751, which folds in exactly this ingest question). Building
-    it into this path before that lands risks writing it twice.
+    **The timestamp is the event's own, not the import's.** Usage imported today
+    for last month prices at the rate that was in force last month, on both
+    layers, which is what makes an imported row comparable to a gateway row from
+    the same instant. Note this is about the *first* import of an event, not a
+    re-import: ingest is idempotent on ``(source, source_event_id)`` and never
+    updates a row, so a row's cost is settled once, by the rate table as it stood
+    when that row landed.
+
+    An override wins on either key spelling before the deployment list is
+    consulted on either, because that is the order ``find_model_pricing`` applies:
+    it asks ``_find_organization_override`` for all candidate keys at once and
+    only falls through to ``_find_by_model_key`` when that misses.
     """
     lookup = normalize_effective_at(timestamp)
+    override = resolve_organization_override(index.overrides, _model_keys(provider, model), lookup)
+    if override is not None:
+        return override
     for key in _model_keys(provider, model):
         match: ModelPricing | None = None
-        for effective_at, row in index.get(key, ()):
+        for effective_at, row in index.deployment.get(key, ()):
             if effective_at <= lookup:
                 match = row
             else:
@@ -447,7 +484,14 @@ async def ingest_external_events(
                 await db.execute(select(User.user_id).where(User.user_id.in_(chunk), User.deleted_at.is_(None)))
             ).scalars().all()
         )
-    pricing_index = await _load_pricing_index(db, {(e.provider, e.model) for e in request.events})
+    # The organization comes off the workspace the key named, never off the
+    # request: the organization decides what an event costs, so taking it from
+    # something the importer controls would let one import at another
+    # organization's negotiated rate.
+    pricing_organization_id = await organization_for_workspace_id(db, usage_workspace_id)
+    pricing_index = await _load_pricing_index(
+        db, {(e.provider, e.model) for e in request.events}, pricing_organization_id
+    )
 
     for index, event in enumerate(request.events):
         target_user, bind_error = _resolve_target_user(

--- a/src/gateway/services/pricing_service.py
+++ b/src/gateway/services/pricing_service.py
@@ -1,9 +1,10 @@
 """Shared pricing lookup utilities."""
 
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Sequence
 from datetime import UTC, date, datetime
 from decimal import Decimal
+from typing import NamedTuple
 
 from genai_prices import Usage, calc_price
 from genai_prices.types import PriceCalculation, TieredPrices
@@ -17,6 +18,10 @@ from gateway.models.entities import ModelPricing, OrganizationModelPricing
 # A zero-token usage is enough to resolve a model's per-million rates from
 # genai-prices without depending on real token counts.
 _ZERO_USAGE = Usage(input_tokens=0, output_tokens=0)
+
+# Bound on the model keys named in one ``IN()`` list, so a batched override load
+# stays under SQLite's default limit of 999 bind parameters in a statement.
+_KEY_CHUNK = 500
 
 
 # Process-wide toggle for the genai-prices default fallback, set once at startup
@@ -361,9 +366,7 @@ def _override_as_model_pricing(override: OrganizationModelPricing) -> ModelPrici
     is naive, and a caller comparing it against an aware timestamp would raise
     rather than compare.
     """
-    effective_at = override.effective_from
-    if effective_at.tzinfo is None:
-        effective_at = effective_at.replace(tzinfo=UTC)
+    effective_at = normalize_effective_at(override.effective_from)
     return ModelPricing(
         model_key=override.model_key,
         effective_at=effective_at,
@@ -426,6 +429,91 @@ async def _find_organization_override(
     )
     override = (await db.execute(stmt)).scalar_one_or_none()
     return _override_as_model_pricing(override) if override is not None else None
+
+
+class OverridePeriod(NamedTuple):
+    """One organization override, normalized for in-memory resolution.
+
+    The stored row carries a period and a rate; this carries the period beside
+    the rate already presented as a ``ModelPricing``, so a caller resolving many
+    timestamps against one preloaded set does the conversion once per row rather
+    than once per timestamp.
+    """
+
+    effective_from: datetime
+    effective_to: datetime | None
+    pricing: ModelPricing
+
+
+async def load_organization_override_index(
+    db: AsyncSession,
+    organization_id: uuid.UUID,
+    model_keys: Iterable[str],
+) -> dict[str, list[OverridePeriod]]:
+    """Every override period this organization holds for ``model_keys``.
+
+    The bulk counterpart to :func:`_find_organization_override`, for a caller
+    pricing a batch of events that share an organization but each carry their own
+    timestamp: one query for the whole batch instead of one per event. The
+    periods are returned rather than a rate, because which one applies is decided
+    per event by :func:`resolve_organization_override`.
+
+    Chunked over the key list for the same reason the batch's other ``IN()``
+    lookups are: a batch naming many models would otherwise exceed SQLite's
+    default bound on bind parameters in one statement.
+    """
+    keys = sorted(set(model_keys))
+    index: dict[str, list[OverridePeriod]] = {}
+    for start in range(0, len(keys), _KEY_CHUNK):
+        chunk = keys[start : start + _KEY_CHUNK]
+        stmt = select(OrganizationModelPricing).where(
+            OrganizationModelPricing.organization_id == organization_id,
+            OrganizationModelPricing.model_key.in_(chunk),
+        )
+        for row in (await db.execute(stmt)).scalars():
+            # ``effective_to`` keeps its ``None``: an open-ended period means "no
+            # end", where ``normalize_effective_at`` would read it as "ends now".
+            effective_to = normalize_effective_at(row.effective_to) if row.effective_to is not None else None
+            index.setdefault(row.model_key, []).append(
+                OverridePeriod(
+                    normalize_effective_at(row.effective_from), effective_to, _override_as_model_pricing(row)
+                )
+            )
+    for periods in index.values():
+        periods.sort(key=lambda period: period.effective_from)
+    return index
+
+
+def resolve_organization_override(
+    index: dict[str, list[OverridePeriod]],
+    model_keys: Sequence[str],
+    as_of: datetime,
+) -> ModelPricing | None:
+    """The override applying at ``as_of``, resolved from a preloaded index.
+
+    The in-memory statement of the same rule :func:`_find_organization_override`
+    expresses in SQL, and it has to stay the same rule: an event priced through
+    this path and the same event priced through the request path must resolve to
+    one rate (``tests/unit/test_organization_pricing_resolution.py`` pins that).
+
+    Key preference before period: ``model_keys`` is ordered (canonical
+    ``provider:model`` before the legacy ``provider/model``), and the first key
+    holding *any* applicable period wins, exactly as the SQL ``CASE`` plus
+    ``LIMIT 1`` decides it. The period test is half-open, ``effective_from``
+    inclusive and ``effective_to`` exclusive, so two adjacent periods that share
+    an instant resolve to the later one. Within a key the newest applicable
+    period wins, which is the in-memory form of ``effective_from DESC``.
+    """
+    for model_key in model_keys:
+        match: ModelPricing | None = None
+        for period in index.get(model_key, ()):
+            if period.effective_from > as_of:
+                break
+            if period.effective_to is None or period.effective_to > as_of:
+                match = period.pricing
+        if match is not None:
+            return match
+    return None
 
 
 async def _find_by_model_key(db: AsyncSession, model_key: str, as_of: datetime) -> ModelPricing | None:

--- a/tests/integration/test_external_usage_events.py
+++ b/tests/integration/test_external_usage_events.py
@@ -1,7 +1,8 @@
 """Integration tests for POST /v1/usage/external-events.
 
 Covers auth, content-free validation, idempotency, historical + cache pricing,
-budget isolation, and the read-surface (source filter, by_source, CSV).
+organization-scoped rates, budget isolation, and the read-surface (source filter,
+by_source, CSV).
 """
 
 from datetime import UTC, datetime, timedelta
@@ -12,7 +13,8 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from gateway.models.entities import UsageLog, User
+from gateway.models.entities import OrganizationModelPricing, UsageLog, User
+from gateway.models.tenancy import Organization
 
 _SRC = "claude_code"
 _MODEL_KEY = "anthropic:claude-sonnet-4-6"
@@ -446,6 +448,154 @@ def test_historical_pricing(
     assert resp.json()["accepted"] == 1
     row = db_session.query(UsageLog).filter(UsageLog.source_event_id == "hist").one()
     assert row.cost == pytest.approx(1.0)  # 1M input * $1/M, cheap rate
+
+
+def test_organization_override_prices_imported_usage_at_the_event_timestamp(
+    client: TestClient, master_key_header: dict[str, str], db_session: Session
+) -> None:
+    """An imported event prices at its organization's rate, as of its own timestamp.
+
+    The wiring this proves is the one the unit tests cannot reach: the importing
+    key names a workspace, the workspace names the organization, and that is the
+    organization whose rates ingest resolves against. Nothing is read from the
+    request body.
+
+    Two events either side of the override's start, in one batch imported after
+    both, so the same run shows the rate applying *and* shows it applying by the
+    event's clock rather than the importer's. Priced at the older rate is the
+    correct answer for the older event even though the newer rate is in force at
+    the moment of import.
+    """
+    _seed_user(client, master_key_header)
+    now = datetime.now(UTC)
+    _seed_pricing(
+        client,
+        master_key_header,
+        input_price=1.0,
+        output_price=1.0,
+        cache_read_price=0.0,
+        cache_write_price=0.0,
+        effective_at=(now - timedelta(days=365)).isoformat().replace("+00:00", "Z"),
+    )
+    override_from = now - timedelta(minutes=30)
+    created = client.post(
+        "/v1/organizations/me/pricing",
+        json={
+            "model_key": _MODEL_KEY,
+            "input_price_per_million": 5.0,
+            "output_price_per_million": 5.0,
+            "effective_from": override_from.isoformat(),
+        },
+        headers=master_key_header,
+    )
+    assert created.status_code == 201, created.text
+
+    # One million input tokens and nothing else, so the cost reads straight off
+    # the input rate.
+    tokens: dict[str, Any] = {
+        "input_tokens": 1_000_000,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
+    resp = _post(
+        client,
+        master_key_header,
+        [
+            _event(
+                "org-before",
+                timestamp=(override_from - timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
+                **tokens,
+            ),
+            _event(
+                "org-after",
+                timestamp=(override_from + timedelta(minutes=10)).isoformat().replace("+00:00", "Z"),
+                **tokens,
+            ),
+        ],
+    )
+    assert resp.json()["accepted"] == 2, resp.text
+
+    before = db_session.query(UsageLog).filter(UsageLog.source_event_id == "org-before").one()
+    after = db_session.query(UsageLog).filter(UsageLog.source_event_id == "org-after").one()
+    assert before.cost == pytest.approx(1.0), "predates the override, so the deployment list still prices it"
+    assert after.cost == pytest.approx(5.0), "inside the override period, so the organization's rate prices it"
+
+
+def test_imported_usage_is_unchanged_when_no_override_exists(
+    client: TestClient, master_key_header: dict[str, str], db_session: Session
+) -> None:
+    """The other half of the definition of done: nothing moves without an override."""
+    _seed_user(client, master_key_header)
+    _seed_pricing(
+        client,
+        master_key_header,
+        input_price=1.0,
+        output_price=1.0,
+        cache_read_price=0.0,
+        cache_write_price=0.0,
+    )
+
+    resp = _post(
+        client,
+        master_key_header,
+        [_event("no-override", input_tokens=1_000_000, output_tokens=0, cache_read_tokens=0, cache_write_tokens=0)],
+    )
+    assert resp.json()["accepted"] == 1, resp.text
+
+    row = db_session.query(UsageLog).filter(UsageLog.source_event_id == "no-override").one()
+    assert row.cost == pytest.approx(1.0)
+
+
+def test_another_organizations_override_does_not_price_an_import(
+    client: TestClient, master_key_header: dict[str, str], db_session: Session
+) -> None:
+    """Whose rates apply is decided by the importing key's workspace, nothing else.
+
+    The tenant boundary on the import path. A second organization holding a rate
+    for the same model must not reach an import it has no relationship to, and
+    the way that could break is subtle: resolving the organization from the
+    *event* (its user, its session label) instead of from the workspace the
+    importing key belongs to would look correct in a single-organization test and
+    leak rates in a real deployment.
+    """
+    _seed_user(client, master_key_header)
+    _seed_pricing(
+        client,
+        master_key_header,
+        input_price=1.0,
+        output_price=1.0,
+        cache_read_price=0.0,
+        cache_write_price=0.0,
+    )
+
+    # A far cheaper rate for the same model, in an organization the importing
+    # credential has nothing to do with. Written straight to the table: the route
+    # is scoped to `/me`, so this is not reachable through the API by design.
+    other = Organization(name="Other", slug="other-import-org")
+    db_session.add(other)
+    db_session.flush()
+    db_session.add(
+        OrganizationModelPricing(
+            organization_id=other.id,
+            model_key=_MODEL_KEY,
+            input_price_per_million=0.01,
+            output_price_per_million=0.01,
+            effective_from=datetime.now(UTC) - timedelta(days=365),
+            pricing_tiers=[],
+        )
+    )
+    db_session.commit()
+
+    resp = _post(
+        client,
+        master_key_header,
+        [_event("cross-org", input_tokens=1_000_000, output_tokens=0, cache_read_tokens=0, cache_write_tokens=0)],
+    )
+    assert resp.json()["accepted"] == 1, resp.text
+
+    row = db_session.query(UsageLog).filter(UsageLog.source_event_id == "cross-org").one()
+    assert row.cost == pytest.approx(1.0), "the deployment rate, never another organization's override"
 
 
 def test_read_surface_source_filter_and_summary(

--- a/tests/integration/test_external_usage_events.py
+++ b/tests/integration/test_external_usage_events.py
@@ -14,7 +14,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from gateway.models.entities import OrganizationModelPricing, UsageLog, User
-from gateway.models.tenancy import Organization
+from gateway.models.tenancy import Organization, Workspace
 
 _SRC = "claude_code"
 _MODEL_KEY = "anthropic:claude-sonnet-4-6"
@@ -106,21 +106,23 @@ def _make_key(
     *,
     exclude_from_budget: bool = True,
     reject_user_mismatch: bool | None = None,
+    workspace_id: str | None = None,
 ) -> dict[str, str]:
     """Create an API key bound to `user_id` and return its auth header.
 
-    Import keys must be budget-exempt, so that is the default here.
+    Import keys must be budget-exempt, so that is the default here. Passing
+    `workspace_id` puts the key in a named workspace instead of the default one,
+    which is what lets a test import as an organization other than the default.
     """
-    resp = client.post(
-        "/v1/keys",
-        json={
-            "key_name": f"importer-{user_id}",
-            "user_id": user_id,
-            "exclude_from_budget": exclude_from_budget,
-            "reject_user_mismatch": reject_user_mismatch,
-        },
-        headers=master_key_header,
-    )
+    body: dict[str, Any] = {
+        "key_name": f"importer-{user_id}",
+        "user_id": user_id,
+        "exclude_from_budget": exclude_from_budget,
+        "reject_user_mismatch": reject_user_mismatch,
+    }
+    if workspace_id is not None:
+        body["workspace_id"] = workspace_id
+    resp = client.post("/v1/keys", json=body, headers=master_key_header)
     assert resp.status_code == 200, resp.text
     return {"Otari-Key": f"Bearer {resp.json()['key']}"}
 
@@ -455,10 +457,10 @@ def test_organization_override_prices_imported_usage_at_the_event_timestamp(
 ) -> None:
     """An imported event prices at its organization's rate, as of its own timestamp.
 
-    The wiring this proves is the one the unit tests cannot reach: the importing
-    key names a workspace, the workspace names the organization, and that is the
-    organization whose rates ingest resolves against. Nothing is read from the
-    request body.
+    Imported here with the master key, which has no key row and therefore lands
+    in the default workspace: this covers the deployment-wide branch and the
+    timestamp rule, not the key-to-workspace wiring. That wiring is a separate
+    test below, because the master key cannot demonstrate it.
 
     Two events either side of the override's start, in one batch imported after
     both, so the same run shows the rate applying *and* shows it applying by the
@@ -596,6 +598,80 @@ def test_another_organizations_override_does_not_price_an_import(
 
     row = db_session.query(UsageLog).filter(UsageLog.source_event_id == "cross-org").one()
     assert row.cost == pytest.approx(1.0), "the deployment rate, never another organization's override"
+
+
+def test_a_keys_import_prices_at_its_own_organizations_rate(
+    client: TestClient, master_key_header: dict[str, str], db_session: Session
+) -> None:
+    """The key-to-workspace-to-organization wiring, on the recommended import path.
+
+    Every other pricing test here imports with the master key, which has no key
+    row and lands in the default workspace, so none of them can tell "resolved the
+    importing key's organization" apart from "used the default organization for
+    everything". This one can, because three rates are in play and they disagree:
+    the deployment list says 1.0, the *default* organization says 5.0, and the
+    organization the importing key actually belongs to says 0.25. Only the last is
+    correct, and each wrong answer names a different bug.
+    """
+    _seed_user(client, master_key_header, "dev-org-b")
+    _seed_pricing(
+        client,
+        master_key_header,
+        input_price=1.0,
+        output_price=1.0,
+        cache_read_price=0.0,
+        cache_write_price=0.0,
+    )
+    # The trap: an override on the default organization, which is where a
+    # master-key import lands and where a regression would wrongly resolve to.
+    default_override = client.post(
+        "/v1/organizations/me/pricing",
+        json={
+            "model_key": _MODEL_KEY,
+            "input_price_per_million": 5.0,
+            "output_price_per_million": 5.0,
+            "effective_from": (datetime.now(UTC) - timedelta(days=365)).isoformat(),
+        },
+        headers=master_key_header,
+    )
+    assert default_override.status_code == 201, default_override.text
+
+    # A second organization, with its own workspace and its own much cheaper rate.
+    other = Organization(name="Other Co", slug="other-co-import")
+    db_session.add(other)
+    db_session.flush()
+    workspace = Workspace(name="Other Platform", organization_id=other.id)
+    db_session.add(workspace)
+    db_session.flush()
+    db_session.add(
+        OrganizationModelPricing(
+            organization_id=other.id,
+            model_key=_MODEL_KEY,
+            input_price_per_million=0.25,
+            output_price_per_million=0.25,
+            effective_from=datetime.now(UTC) - timedelta(days=365),
+            pricing_tiers=[],
+        )
+    )
+    db_session.commit()
+    workspace_id = str(workspace.id)
+
+    headers = _make_key(client, master_key_header, "dev-org-b", workspace_id=workspace_id)
+    resp = _post(
+        client,
+        headers,
+        [_event("key-org", input_tokens=1_000_000, output_tokens=0, cache_read_tokens=0, cache_write_tokens=0)],
+        user_id=None,
+    )
+    assert resp.json()["accepted"] == 1, resp.text
+
+    row = db_session.query(UsageLog).filter(UsageLog.source_event_id == "key-org").one()
+    assert row.cost == pytest.approx(0.25), (
+        "1.0 means overrides were skipped; 5.0 means the default organization was used "
+        "instead of the importing key's own"
+    )
+    # The row and the rate agree on which workspace this import belonged to.
+    assert str(row.workspace_id) == workspace_id
 
 
 def test_read_surface_source_filter_and_summary(

--- a/tests/unit/test_organization_pricing_resolution.py
+++ b/tests/unit/test_organization_pricing_resolution.py
@@ -25,6 +25,7 @@ from sqlmodel import SQLModel
 import gateway.models  # noqa: F401  (registers every table on the shared metadata)
 from gateway.models.entities import ModelPricing, OrganizationModelPricing
 from gateway.models.tenancy import Organization
+from gateway.services.external_usage_service import _load_pricing_index, _resolve_pricing
 from gateway.services.organization_pricing_service import (
     OrganizationPricingService,
     validate_period,
@@ -639,5 +640,271 @@ def test_the_deployment_price_list_also_prefers_the_canonical_tool_key() -> None
         # Both resolve the canonical row: 1_000_000 / 1e6 == $1.00 per call.
         assert gate.input_price_per_million == 1_000_000.0
         assert total == 1.0
+
+    _run(scenario)
+
+
+# =============================================================================
+# The import path (external usage ingest)
+#
+# `external_usage_service` resolves a batch's rates from a preloaded index rather
+# than one `find_model_pricing` per event, so it states the resolution order a
+# second time. These pin that the second statement is the same rule, and that it
+# reads the event's own timestamp rather than the import's.
+# =============================================================================
+
+
+async def _imported_rate(
+    session: AsyncSession,
+    organization_id: uuid.UUID | None,
+    as_of: datetime,
+    *,
+    provider: str = "openai",
+    model: str = "gpt-4o",
+) -> float | None:
+    """The input rate an event at ``as_of`` would be imported at."""
+    index = await _load_pricing_index(session, {(provider, model)}, organization_id)
+    pricing = _resolve_pricing(index, provider, model, as_of)
+    return None if pricing is None else float(pricing.input_price_per_million)
+
+
+async def _requested_rate(
+    session: AsyncSession,
+    organization_id: uuid.UUID | None,
+    as_of: datetime,
+    *,
+    provider: str = "openai",
+    model: str = "gpt-4o",
+) -> float | None:
+    """The input rate a live request at ``as_of`` would be billed at."""
+    pricing = await find_model_pricing(session, provider, model, as_of=as_of, organization_id=organization_id)
+    return None if pricing is None else float(pricing.input_price_per_million)
+
+
+def test_an_imported_event_prices_at_the_organization_rate() -> None:
+    """The definition of done: imported usage stops pricing at the global rate."""
+
+    async def scenario(session: AsyncSession) -> None:
+        organization_id = await _organization(session)
+        await _deployment_price(session)
+        await _override(session, organization_id)
+
+        assert await _imported_rate(session, organization_id, _NOW) == _OVERRIDE_INPUT_RATE
+
+    _run(scenario)
+
+
+def test_an_imported_event_without_an_override_prices_exactly_as_before() -> None:
+    """The unchanged half: no override, and the deployment list still decides."""
+
+    async def scenario(session: AsyncSession) -> None:
+        organization_id = await _organization(session)
+        await _deployment_price(session)
+
+        assert await _imported_rate(session, organization_id, _NOW) == _DEPLOYMENT_INPUT_RATE
+        # And the ``None`` guard: unreachable from ingest itself, since
+        # ``workspace.organization_id`` is NOT NULL, but it must never reach the
+        # override table for any caller that does pass it.
+        assert await _imported_rate(session, None, _NOW) == _DEPLOYMENT_INPUT_RATE
+
+    _run(scenario)
+
+
+def test_an_imported_event_prices_at_the_rate_effective_for_its_own_timestamp() -> None:
+    """A rate that changed between the event and its import uses the older one.
+
+    The line the platform's ingest retirement (mozilla-ai/otari-ai#1750) depends
+    on. Getting it wrong is silent: a backfill would land costed at whatever rate
+    happened to be in force on the day someone ran the import, with nothing
+    failing to say so and no second import to correct it (ingest is idempotent,
+    so a row's cost is settled by the import that created it).
+    """
+
+    async def scenario(session: AsyncSession) -> None:
+        organization_id = await _organization(session)
+        await _deployment_price(session)
+        changed_at = _NOW - timedelta(days=5)
+        await _override(
+            session,
+            organization_id,
+            rate=1.0,
+            effective_from=_NOW - timedelta(days=10),
+            effective_to=changed_at,
+        )
+        await _override(session, organization_id, rate=2.0, effective_from=changed_at)
+
+        # The event is a week old; the import is happening at _NOW, under the
+        # newer rate.
+        assert await _imported_rate(session, organization_id, _NOW - timedelta(days=7)) == 1.0
+        assert await _imported_rate(session, organization_id, _NOW) == 2.0
+        # Half-open, the same as everywhere else: the boundary instant belongs to
+        # the period that starts on it.
+        assert await _imported_rate(session, organization_id, changed_at) == 2.0
+        assert await _imported_rate(session, organization_id, changed_at - timedelta(seconds=1)) == 1.0
+
+    _run(scenario)
+
+
+def test_an_imported_event_after_the_last_period_ends_falls_back() -> None:
+    """``effective_to`` is exclusive, and here nothing succeeds the period it ends.
+
+    The adjacent-period case above cannot show this: when a later period starts on
+    the same instant, an inclusive and an exclusive ``effective_to`` both land on
+    the later period anyway. With no successor they differ, and an inclusive one
+    would keep charging a retired rate for the instant it retired.
+    """
+
+    async def scenario(session: AsyncSession) -> None:
+        organization_id = await _organization(session)
+        await _deployment_price(session)
+        ended_at = _NOW - timedelta(days=1)
+        await _override(
+            session,
+            organization_id,
+            effective_from=_NOW - timedelta(days=5),
+            effective_to=ended_at,
+        )
+
+        just_before = ended_at - timedelta(seconds=1)
+        assert await _imported_rate(session, organization_id, just_before) == _OVERRIDE_INPUT_RATE
+        assert await _imported_rate(session, organization_id, ended_at) == _DEPLOYMENT_INPUT_RATE
+        # And the request path agrees, which is the point of stating the rule twice.
+        assert await _requested_rate(session, organization_id, ended_at) == _DEPLOYMENT_INPUT_RATE
+
+    _run(scenario)
+
+
+def test_an_imported_event_predating_every_override_falls_back() -> None:
+    """Before the first period there is no override, not the earliest one."""
+
+    async def scenario(session: AsyncSession) -> None:
+        organization_id = await _organization(session)
+        await _deployment_price(session)
+        await _override(session, organization_id, effective_from=_NOW - timedelta(days=2))
+
+        assert await _imported_rate(session, organization_id, _NOW - timedelta(days=3)) == _DEPLOYMENT_INPUT_RATE
+
+    _run(scenario)
+
+
+def test_an_imported_event_does_not_price_at_another_organizations_rate() -> None:
+    """The tenant boundary holds on the import path too.
+
+    The organization is resolved from the workspace the importing key named, so
+    an importer cannot reach a rate it does not own; this covers the resolution
+    itself refusing an organization it was not given.
+    """
+
+    async def scenario(session: AsyncSession) -> None:
+        theirs = await _organization(session, "theirs")
+        mine = await _organization(session, "mine")
+        await _deployment_price(session)
+        await _override(session, theirs, rate=0.01)
+
+        assert await _imported_rate(session, mine, _NOW) == _DEPLOYMENT_INPUT_RATE
+
+    _run(scenario)
+
+
+def test_an_imported_event_resolves_an_override_on_the_legacy_slash_key() -> None:
+    """Both key spellings are candidates here, as they are in find_model_pricing."""
+
+    async def scenario(session: AsyncSession) -> None:
+        organization_id = await _organization(session)
+        await _deployment_price(session)
+        await _override(session, organization_id, model_key="openai/gpt-4o")
+
+        assert await _imported_rate(session, organization_id, _NOW) == _OVERRIDE_INPUT_RATE
+
+    _run(scenario)
+
+
+def test_an_override_on_either_spelling_outranks_the_deployment_row() -> None:
+    """Order is override-then-deployment, not per-key override-then-deployment.
+
+    ``find_model_pricing`` asks for an override across every candidate key at
+    once and only then reads the deployment list, so a legacy-spelled override
+    beats a canonically-spelled deployment row. Resolving key by key instead
+    would invert that, and the same event would price differently depending on
+    which path saw it.
+    """
+
+    async def scenario(session: AsyncSession) -> None:
+        organization_id = await _organization(session)
+        await _deployment_price(session)  # canonical `openai:gpt-4o`
+        await _override(session, organization_id, model_key="openai/gpt-4o")
+
+        assert await _imported_rate(session, organization_id, _NOW) == _OVERRIDE_INPUT_RATE
+        assert await _requested_rate(session, organization_id, _NOW) == _OVERRIDE_INPUT_RATE
+
+    _run(scenario)
+
+
+def test_the_canonical_override_wins_over_the_legacy_one_on_both_paths() -> None:
+    """Key preference, not whichever period happened to be written later."""
+
+    async def scenario(session: AsyncSession) -> None:
+        organization_id = await _organization(session)
+        await _deployment_price(session)
+        await _override(session, organization_id, rate=4.0, model_key="openai:gpt-4o")
+        await _override(session, organization_id, rate=9.0, model_key="openai/gpt-4o")
+
+        assert await _imported_rate(session, organization_id, _NOW) == 4.0
+        assert await _requested_rate(session, organization_id, _NOW) == 4.0
+
+    _run(scenario)
+
+
+@pytest.mark.parametrize("offset_days", [-3, -1, 0, 1, 3, 7])
+def test_the_import_path_and_the_request_path_agree_at_every_offset(offset_days: int) -> None:
+    """One event, two paths, one rate, whatever the timestamp.
+
+    The guard the second statement of the resolution order needs: the SQL form
+    (`_find_organization_override`) and the in-memory form
+    (`resolve_organization_override`) are different code, and only a test that
+    runs both over the same rows keeps them one rule.
+    """
+
+    async def scenario(session: AsyncSession) -> None:
+        organization_id = await _organization(session)
+        await _deployment_price(session)
+        await _override(
+            session,
+            organization_id,
+            rate=1.0,
+            effective_from=_NOW - timedelta(days=6),
+            effective_to=_NOW - timedelta(days=2),
+        )
+        await _override(session, organization_id, rate=2.0, effective_from=_NOW)
+
+        as_of = _NOW + timedelta(days=offset_days)
+        assert await _imported_rate(session, organization_id, as_of) == await _requested_rate(
+            session, organization_id, as_of
+        )
+
+    _run(scenario)
+
+
+def test_the_import_path_does_not_persist_a_resolved_override() -> None:
+    """The transient-``ModelPricing`` contract, on the path that writes rows.
+
+    Ingest builds ``UsageLog`` rows and commits them in the same session it
+    resolved pricing in, so an override that attached to the session would be
+    flushed into ``model_pricing`` as a deployment-wide price by that commit.
+    """
+
+    async def scenario(session: AsyncSession) -> None:
+        organization_id = await _organization(session)
+        await _override(session, organization_id)
+        await session.commit()
+
+        index = await _load_pricing_index(session, {("openai", "gpt-4o")}, organization_id)
+        pricing = _resolve_pricing(index, "openai", "gpt-4o", _NOW)
+        assert pricing is not None
+        assert pricing not in session
+        await session.commit()
+
+        stored = (await session.execute(ModelPricing.__table__.select())).all()
+        assert stored == []
 
     _run(scenario)


### PR DESCRIPTION
## Description

Otari lets an organization negotiate its own price for a model, and until now that price only applied to traffic that actually went through the gateway. Usage imported from somewhere else, like a Claude Code session, was always costed at the deployment's standard price list, so an organization could set a rate, watch it work on one screen, and watch it be ignored on another. This changes imported usage to look up the organization's own rate first, the same way a live request already does.

The other half is timing. Imported usage is a record of something that already happened, sometimes weeks ago, so it is costed at whatever rate was in force back then rather than the rate in force at the moment of import. Backfill last month's usage today and it settles at last month's price. This matters more than it sounds, because an import happens once: the same event submitted twice is recognized and skipped, so whatever a row costs when it first lands is what it costs permanently. Rows imported before an organization set up its rate keep the old price, and `POST /v1/usage/set-price` is how you bring them into line; the docs now say so.

<details>
<summary>Implementation notes</summary>

`ingest_external_events` resolves the importing key's organization from its workspace (never from the request body) and passes it to the batch pricing load. `_resolve_pricing` then applies the order `find_model_pricing` applies: an override on either key spelling, then the deployment canonical key, then the legacy key, then the genai-prices default.

The two paths necessarily state the override rule twice, because a batch resolves one preloaded index against many timestamps where a request resolves one row at one timestamp. `pricing_service` now owns both statements next to each other: `load_organization_override_index` and `resolve_organization_override` sit beside the SQL `_find_organization_override`, and a parametrized test runs both forms over the same rows at six offsets so they cannot drift apart.

This removes the "one deliberate divergence" note that `_resolve_pricing` carried, which held the override lookup back pending mozilla-ai/otari-ai#1751. mozilla-ai/otari-ai#1750 needs it now.

Scope note: #741 as filed asked for the whole organization-scoped pricing plane. #674 landed that on 2026-08-20 and khaledosman re-scoped the issue to this one bullet. I verified the rest is present on `main` before starting and built none of it.
</details>

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #741

Unblocks mozilla-ai/otari-ai#1750 on this side.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

The contract did not change (no route or schema edits); `make openapi-check` and `make postman-check` both confirm the committed artifacts are current. Also ran the OSS-edition smoke gate, which passes.

New tests were confirmed to fail without the fix and pass with it: 12 unit tests in `test_organization_pricing_resolution.py` and 3 integration tests in `test_external_usage_events.py`. They were mutation-checked rather than just run: dropping the override lookup, dropping the `organization_id` filter, pricing at import time instead of the event timestamp, reversing the canonical/legacy key preference, and reading `effective_to` as inclusive are each caught by at least one test.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via the Claude Code CLI.

**Any additional AI details you'd like to share:**

Implemented and tested by the model through back-and-forth with @njbrake. The re-scope check (confirming the gap still existed on today's `main` before writing anything) was done first at his instruction, after five issues in this milestone were found to have been filed from a stale inventory.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added organization-specific pricing for imported usage events.
- Imported events now use the importing key’s organization and the rate effective at the event timestamp.
- Existing imported costs remain unchanged unless updated through `POST /v1/usage/set-price`.
- Added pricing and integration test coverage for organization isolation, fallback behavior, key selection, and timestamp-based pricing.
- Documented pricing behavior, retries, workspace selection, and recosting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->