### PR TITLE
feat(gateway): consult ModelProviderPort when no stored credential serves a candidate

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -121,7 +121,7 @@ flowchart LR
     SVC --> TP
 ```
 
-> **Where the ports are today.** `src/gateway/ports/` holds five of them, `ModelProviderPort`, `BillingPort`, `EntitlementPort`, `GrowthSignalPort` and `TelemetryStoragePort`, each with a working core adapter in `src/gateway/adapters/`. Only the last has core callers: the OTLP receiver, the telemetry read endpoints, and the purge paths all resolve it. The other four are still the seam's mechanism rather than its surface, so the choices they describe (which credential to use, when to meter) are made by the mode switch and the hand-wired dependencies described next. The remaining ports in the table above arrive as they gain callers.
+> **Where the ports are today.** `src/gateway/ports/` holds five of them, `ModelProviderPort`, `BillingPort`, `EntitlementPort`, `GrowthSignalPort` and `TelemetryStoragePort`, each with a working core adapter in `src/gateway/adapters/`. Two have core callers: `TelemetryStoragePort` is resolved by the OTLP receiver, the telemetry read endpoints and the purge paths, and `ModelProviderPort` is asked on the standalone dispatch path (`resolve_dispatch_provider` in `api/routes/_pipeline.py`) for a candidate the credential ladder could not serve, after an organization's key, a stored instance and `config.yml` have all missed. A routed multi-candidate chain does not reach it yet: those candidates are credentialed by the routing compiler, which is synchronous and does no I/O. The other three are still the seam's mechanism rather than its surface, so the choices they describe (which credential to use, when to meter) are made by the mode switch and the hand-wired dependencies described next. The remaining ports in the table above arrive as they gain callers.
 
 ## How a port is resolved
 

--- a/src/gateway/AGENTS.md
+++ b/src/gateway/AGENTS.md
@@ -12,7 +12,7 @@ read that first if a change touches mode selection.
 ## Ports, container, bootstrap
 `ports/` holds the domain-named `Protocol` interfaces the core depends on, `adapters/` holds Otari's own implementation of each, and `container.py` is the composition root that binds them, built once per app in `create_app` and read through the port dependencies in `api/deps.py`. `OTARI_BOOTSTRAP=module:callable` points at an overlay's register function, imported after the defaults are bound; unset, nothing is imported. Why the seam is shaped this way, and the rules for keeping it, are in [../../ARCHITECTURE.md](../../ARCHITECTURE.md); `scripts/check_architecture.py` enforces them.
 
-Two local consequences worth knowing before you use it. A port factory receives `AsyncSession | None`, because hybrid mode runs with no local database and an adapter resolved on a hybrid request has to say what it does without one. `TelemetryStoragePort` is the exception that proves the rule: every surface resolving it is standalone-only, so `get_telemetry_storage_port` names `get_db` rather than `PortSessionDep`, which hands the adapter the caller's session instead of opening a second one for the same request. And a capability earns its port when a second implementation is real, not before: four of the five that exist are still mechanism alone, with no core caller.
+Two local consequences worth knowing before you use it. A port factory receives `AsyncSession | None`, because hybrid mode runs with no local database and an adapter resolved on a hybrid request has to say what it does without one. `TelemetryStoragePort` is the exception that proves the rule: every surface resolving it is standalone-only, so `get_telemetry_storage_port` names `get_db` rather than `PortSessionDep`, which hands the adapter the caller's session instead of opening a second one for the same request. And a capability earns its port when a second implementation is real, not before: of the five that exist, two have core callers, `TelemetryStoragePort` and `ModelProviderPort` (the last rung of the credential ladder below), and the other three are still mechanism alone.
 
 ## Request lifecycle (chat completions)
 Read these together before changing request behavior, the flow spans several files.
@@ -93,6 +93,17 @@ wired into the lifespan, standalone-only.
   `POST /v1/search` work with no config file. Tools defined in the config file stay read-only.
 
 Their pages are in [../../web/AGENTS.md](../../web/AGENTS.md).
+
+Below both of them is one more rung, and it is deliberately last. When a candidate's
+credentials come back empty from `services/provider_kwargs.py` (no organization-scoped key,
+no stored instance, no `config.yml` entry, and no provider SDK environment variable),
+`resolve_dispatch_provider` asks `ModelProviderPort` whether this build can serve it from a
+deployment-owned fleet. The core adapter answers `None` for everything, so a build with no
+overlay behaves exactly as it did. Nothing here may move above BYO: an organization's own key
+is resolved first and is never displaced, and a resolved hosted credential re-keys usage and
+telemetry onto the credential's `response_provider`. A routed multi-candidate plan does not
+reach the port, because the routing compiler builds those candidates' kwargs synchronously
+and does no I/O.
 
 Neither store becomes workspace-keyed. Per-tenant tool configuration (web search, code
 execution, MCP servers, guardrails) is resolved at admission in `prepare_gateway_tools`

--- a/src/gateway/AGENTS.md
+++ b/src/gateway/AGENTS.md
@@ -94,16 +94,11 @@ wired into the lifespan, standalone-only.
 
 Their pages are in [../../web/AGENTS.md](../../web/AGENTS.md).
 
-Below both of them is one more rung, and it is deliberately last. When a candidate's
-credentials come back empty from `services/provider_kwargs.py` (no organization-scoped key,
-no stored instance, no `config.yml` entry, and no provider SDK environment variable),
-`resolve_dispatch_provider` asks `ModelProviderPort` whether this build can serve it from a
-deployment-owned fleet. The core adapter answers `None` for everything, so a build with no
-overlay behaves exactly as it did. Nothing here may move above BYO: an organization's own key
-is resolved first and is never displaced, and a resolved hosted credential re-keys usage and
-telemetry onto the credential's `response_provider`. A routed multi-candidate plan does not
-reach the port, because the routing compiler builds those candidates' kwargs synchronously
-and does no I/O.
+Below both stores is one more rung, deliberately last: when a candidate needed a credential
+and none of them had one, `resolve_dispatch_provider` asks `ModelProviderPort` whether this
+build serves it from a deployment-owned fleet. `_serve_from_hosted_credential` in
+`api/routes/_pipeline.py` is the whole of it and says why on each branch. Nothing here may
+move above BYO.
 
 Neither store becomes workspace-keyed. Per-tenant tool configuration (web search, code
 execution, MCP servers, guardrails) is resolved at admission in `prepare_gateway_tools`

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -808,9 +808,12 @@ async def _serve_from_hosted_credential(
         credential = await port.resolve_hosted_credential(
             organization_id=ctx.organization_id,
             workspace_id=ctx.workspace_id,
-            # The public name the caller addressed, which is the instance rather
-            # than the implementation; ``response_provider`` comes back naming
-            # whichever upstream actually serves it.
+            # The instance rather than the implementation: that is the name
+            # pricing, budgets and usage key on, and for a bare selector it is
+            # the one the caller wrote. (An alias resolves to its target first,
+            # so an aliased request names the target's instance here, never the
+            # alias.) ``response_provider`` comes back naming whichever upstream
+            # actually serves it.
             provider=resolved.instance,
             model=resolved.model,
         )
@@ -863,8 +866,34 @@ async def _serve_from_hosted_credential(
             resolved.model,
         )
         await release_reservation(ctx)
+        # Logged like the 400 and 403 refusals beside it: an operator watching
+        # the activity log during an overlay rollout would otherwise see dropped
+        # traffic as nothing at all.
+        await log_gateway_rejection(
+            db=ctx.db,
+            log_writer=ctx.log_writer,
+            api_key_id=ctx.api_key_id,
+            user_id=ctx.user_id,
+            model=resolved.model,
+            provider=resolved.instance,
+            endpoint=adapter.endpoint,
+            detail=HOSTED_CREDENTIAL_UNUSABLE_DETAIL,
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            started_at=ctx.started_at,
+        )
         raise adapter.error(502, HOSTED_CREDENTIAL_UNUSABLE_DETAIL, ErrorKind.API) from exc
 
+    # Re-keying moves what settlement prices on. The pricing and budget gates
+    # ran in the preamble against the name the caller asked for, and settlement
+    # reprices on ``instance``, so an overlay owes a pricing row for every
+    # ``response_provider`` it returns: without one the row's cost is NULL and
+    # the request settles free, which is `require_pricing` bypassed rather than
+    # enforced. A routed fallover to a differently priced candidate has an
+    # explicit guard for the same hazard (`top_up_reservation_for_attempt`
+    # refuses an unpriced candidate with a 402); this path has none, because the
+    # substitution is the adapter's decision rather than a plan's and refusing it
+    # here would make a build's own fleet unusable until it were priced. An
+    # overlay binding this port owns that.
     kwargs: dict[str, Any] = {"api_key": credential.api_key}
     if credential.api_base is not None:
         kwargs["api_base"] = credential.api_base

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -113,6 +113,7 @@ from gateway.models.entities import ModelPricing, UsageLog
 from gateway.models.guardrails import GuardrailConfig
 from gateway.models.mcp import McpServerConfig
 from gateway.models.money import to_usd
+from gateway.ports.model_provider_port import HostedAccessDeniedError, ModelProviderPort
 from gateway.rate_limit import RateLimitInfo, check_rate_limit
 from gateway.services.budget_service import (
     ZERO,
@@ -142,7 +143,7 @@ from gateway.services.pricing_service import (
     price_tool_calls,
     pricing_required_but_missing,
 )
-from gateway.services.provider_kwargs import ResolvedProvider, resolve_provider_selector
+from gateway.services.provider_kwargs import ResolvedProvider, credential_ladder_exhausted, resolve_provider_selector
 from gateway.services.routing import (
     BudgetState,
     CompiledPlan,
@@ -254,6 +255,11 @@ ORGANIZATION_GUARDRAILS_UNRESOLVABLE_DETAIL = "Organization guardrails could not
 ORGANIZATION_GUARDRAIL_CREDENTIAL_UNREADABLE_DETAIL = (
     "A configured organization guardrail's credential could not be read"
 )
+# The bound ``ModelProviderPort`` adapter answered with an upstream any-llm has
+# no implementation for, so there is nothing to dispatch against. Deliberately
+# says nothing about hosted inference or about which adapter answered: that is a
+# defect in this build, not something a caller can act on.
+HOSTED_CREDENTIAL_UNUSABLE_DETAIL = "No upstream provider is available to serve this model"
 SANDBOX_UNREACHABLE_DETAIL = (
     "code_execution sandbox unreachable. Check the sandbox URL in the dashboard's "
     "Tools settings, or OTARI_SANDBOX_URL, and that the container is running."
@@ -701,6 +707,7 @@ async def resolve_dispatch_provider(
     model_selector: str,
     *,
     adapter: FormatAdapter[Any, Any],
+    model_provider: ModelProviderPort,
 ) -> ResolvedProvider:
     """Get the ``ResolvedProvider`` for dispatch, reusing the one computed for
     the pricing/budget gate (``ctx.resolved_provider``) instead of resolving
@@ -712,11 +719,16 @@ async def resolve_dispatch_provider(
     check couldn't parse the selector (an unparseable selector has no
     pricing, but dispatch still needs its own resolution attempt so any-llm's
     own error surfaces instead of a stale gate-check failure).
+
+    Whichever of the two produced it, the result then passes through
+    :func:`_serve_from_hosted_credential`, which is where ``model_provider`` is
+    asked to serve a candidate no stored credential could. That is the last rung
+    and never displaces an earlier one; see that function.
     """
     if ctx.resolved_provider is not None:
-        return ctx.resolved_provider
+        return await _serve_from_hosted_credential(ctx, ctx.resolved_provider, adapter=adapter, port=model_provider)
     try:
-        return resolve_provider_selector(config, model_selector, ctx.user_id, workspace_id=ctx.workspace_id)
+        resolved = resolve_provider_selector(config, model_selector, ctx.user_id, workspace_id=ctx.workspace_id)
     except (ValueError, AnyLLMError) as exc:
         # The preamble deliberately tolerated this selector, so a reservation is
         # already held: refund it, then record the drop. The hold is not always
@@ -750,6 +762,119 @@ async def resolve_dispatch_provider(
             started_at=ctx.started_at,
         )
         _raise_for_unresolvable_model(model_selector, exc)
+    return await _serve_from_hosted_credential(ctx, resolved, adapter=adapter, port=model_provider)
+
+
+async def _serve_from_hosted_credential(
+    ctx: RequestContext,
+    resolved: ResolvedProvider,
+    *,
+    adapter: FormatAdapter[Any, Any],
+    port: ModelProviderPort,
+) -> ResolvedProvider:
+    """Ask ``ModelProviderPort`` to serve a candidate no stored credential could.
+
+    The last rung of the credential ladder and only the last. An organization's
+    own key, a stored provider instance and a ``config.yml`` entry are all
+    resolved upstream of here (``services/provider_kwargs.py``), and a candidate
+    any of them served comes back untouched, so BYO precedence is unchanged: the
+    port is asked when the ladder is exhausted and never before it. The core
+    adapter answers ``None`` for every candidate, which is what makes a build
+    with no overlay behave exactly as it did, rung for rung.
+
+    On a resolved credential the dispatch is re-keyed onto
+    ``response_provider``, the upstream that usage and telemetry name (which the
+    port documents as possibly differing from the public name the caller asked
+    for), and carries that credential alone: the ladder produced nothing to
+    merge with.
+    """
+    if ctx.organization_id is None:
+        # The port keys its access decision on the organization alone, so a
+        # request with no organization (no workspace resolved for it) has
+        # nothing to ask about.
+        return resolved
+    if ctx.plan is not None and len(ctx.plan.attempts) > 1:
+        # A multi-candidate plan dispatches from ``ctx.plan.attempts``, whose
+        # kwargs the routing compiler built; what this function returns is not
+        # what those candidates are called with. Asking anyway would meter a
+        # resolve that never serves, so a routed chain keeps the ladder's own
+        # answer for now. Reaching the port from the compiler is separate work:
+        # the compiler is synchronous and documented as doing no I/O.
+        return resolved
+    if not credential_ladder_exhausted(resolved.provider, resolved.kwargs):
+        return resolved
+
+    try:
+        credential = await port.resolve_hosted_credential(
+            organization_id=ctx.organization_id,
+            workspace_id=ctx.workspace_id,
+            # The public name the caller addressed, which is the instance rather
+            # than the implementation; ``response_provider`` comes back naming
+            # whichever upstream actually serves it.
+            provider=resolved.instance,
+            model=resolved.model,
+        )
+    except HostedAccessDeniedError as exc:
+        # The port owns this refusal precisely so a caller need not name the
+        # adapter that raised it, and the adapter's own wording is internal, so
+        # the response carries the same detail an organization-scoped model
+        # restriction already uses. A reservation is held by this point, so it
+        # is released here exactly as the unresolvable-selector branch above
+        # does; nothing outside this function refunds for it.
+        logger.info(
+            "Hosted inference refused for %s:%s workspace=%s: %s",
+            resolved.instance,
+            resolved.model,
+            exc.workspace_id,
+            exc,
+        )
+        denied_detail = model_not_allowed_detail(f"{resolved.instance}:{resolved.model}")
+        await release_reservation(ctx)
+        await log_gateway_rejection(
+            db=ctx.db,
+            log_writer=ctx.log_writer,
+            api_key_id=ctx.api_key_id,
+            user_id=ctx.user_id,
+            model=resolved.model,
+            provider=resolved.instance,
+            endpoint=adapter.endpoint,
+            detail=denied_detail,
+            status_code=status.HTTP_403_FORBIDDEN,
+            started_at=ctx.started_at,
+        )
+        raise adapter.error(403, denied_detail, ErrorKind.PERMISSION) from exc
+
+    if credential is None:
+        # This build has no hosted path for the candidate. The candidate is
+        # genuinely unserved, which is what it already was, so it goes to
+        # any-llm uncredentialed and fails there exactly as it does today.
+        return resolved
+
+    try:
+        upstream = LLMProvider(credential.response_provider)
+    except ValueError as exc:
+        # The adapter named an upstream any-llm does not implement, so nothing
+        # can be dispatched. That is a defect in this build rather than caller
+        # input: log it in full, refund, and surface a non-leaky 502.
+        logger.error(
+            "ModelProviderPort returned unknown response_provider %r for %s:%s",
+            credential.response_provider,
+            resolved.instance,
+            resolved.model,
+        )
+        await release_reservation(ctx)
+        raise adapter.error(502, HOSTED_CREDENTIAL_UNUSABLE_DETAIL, ErrorKind.API) from exc
+
+    kwargs: dict[str, Any] = {"api_key": credential.api_key}
+    if credential.api_base is not None:
+        kwargs["api_base"] = credential.api_base
+    return ResolvedProvider(
+        instance=credential.response_provider,
+        provider=upstream,
+        model=resolved.model,
+        kwargs=kwargs,
+        alias=resolved.alias,
+    )
 
 
 async def _bill_vision_side_call(

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -831,7 +831,12 @@ async def _serve_from_hosted_credential(
             exc.workspace_id,
             exc,
         )
-        denied_detail = model_not_allowed_detail(f"{resolved.instance}:{resolved.model}")
+        # Named to the caller the way every other ``model_not_allowed_detail``
+        # site names it: the selector they wrote. For an alias that is the alias,
+        # because keeping its target out of what a caller can see is the whole
+        # point of one (``docs/models.md``, "Target-hiding"); the log line above
+        # carries the resolved target for the operator.
+        denied_detail = model_not_allowed_detail(resolved.alias or f"{resolved.instance}:{resolved.model}")
         await release_reservation(ctx)
         await log_gateway_rejection(
             db=ctx.db,

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -765,6 +765,54 @@ async def resolve_dispatch_provider(
     return await _serve_from_hosted_credential(ctx, resolved, adapter=adapter, port=model_provider)
 
 
+async def _warn_if_hosted_upstream_is_unpriced(
+    ctx: RequestContext,
+    resolved: ResolvedProvider,
+    upstream: str,
+) -> None:
+    """Record that a re-keyed request is about to settle free, if it is.
+
+    The pricing and budget gates ran in the preamble against the name the caller
+    asked for, and settlement reprices on the instance the request actually
+    served under. So an overlay returning a ``response_provider`` it has not
+    priced settles the request at ``cost=NULL`` and releases the whole hold,
+    which is ``require_pricing`` bypassed rather than enforced. Refusing here is
+    deliberately not done (see the caller), but the routed-chain hazard this
+    resembles at least has a guard, and an operator should not have to infer this
+    one from a usage report. The settlement warning alone does not distinguish
+    it: an unpriced re-key looks exactly like an ordinary unpriced model there.
+
+    Best-effort, like the rejection log: observability must not be able to fail a
+    request that is otherwise about to succeed.
+    """
+    if ctx.db is None:
+        return
+    try:
+        pricing = await find_model_pricing(
+            ctx.db,
+            upstream,
+            resolved.model,
+            organization_id=ctx.organization_id,
+        )
+    except SQLAlchemyError:
+        logger.warning(
+            "Could not check pricing for hosted upstream %s:%s; it may settle at no cost",
+            upstream,
+            resolved.model,
+        )
+        return
+    if pricing is None:
+        logger.warning(
+            "ModelProviderPort re-keyed %s:%s onto %s:%s, which resolves no pricing: this "
+            "request will settle at no cost and release its whole budget hold. Price the "
+            "upstreams this build's adapter returns.",
+            resolved.instance,
+            resolved.model,
+            upstream,
+            resolved.model,
+        )
+
+
 async def _serve_from_hosted_credential(
     ctx: RequestContext,
     resolved: ResolvedProvider,
@@ -851,6 +899,45 @@ async def _serve_from_hosted_credential(
             started_at=ctx.started_at,
         )
         raise adapter.error(403, denied_detail, ErrorKind.PERMISSION) from exc
+    except Exception as exc:
+        # Everything an adapter can fail at that is not its own refusal. Resolving
+        # a hosted credential is expected to be a network call (that is what an
+        # overlay binds this port to do), so a timeout, a connection reset or a
+        # database error is ordinary here rather than exotic. Nothing above this
+        # would catch one: all three routes call ``resolve_dispatch_provider``
+        # outside any ``try`` that takes a bare exception, and ``gateway.main``
+        # registers handlers only for ``TenancyError`` and
+        # ``RequestValidationError``. Without this the reservation the preamble
+        # took stays on ``users.reserved`` until the budget resets, which for a
+        # budget with no period is forever.
+        #
+        # ``Exception`` and not ``BaseException``: ``asyncio.CancelledError`` is a
+        # disconnected client rather than a failed lookup, and swallowing it would
+        # both mislabel the outcome and mark a cancelled task as handled.
+        logger.error(
+            "ModelProviderPort failed to resolve a credential for %s:%s: %s",
+            resolved.instance,
+            resolved.model,
+            exc,
+            exc_info=True,
+        )
+        await release_reservation(ctx)
+        await log_gateway_rejection(
+            db=ctx.db,
+            log_writer=ctx.log_writer,
+            api_key_id=ctx.api_key_id,
+            user_id=ctx.user_id,
+            model=resolved.model,
+            provider=resolved.instance,
+            endpoint=adapter.endpoint,
+            detail=HOSTED_CREDENTIAL_UNUSABLE_DETAIL,
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            started_at=ctx.started_at,
+        )
+        # The same detail the unusable-``response_provider`` branch below returns:
+        # from the caller's side both are "this build could not put an upstream
+        # behind your request", and which internal step failed is not theirs.
+        raise adapter.error(502, HOSTED_CREDENTIAL_UNUSABLE_DETAIL, ErrorKind.API) from exc
 
     if credential is None:
         # This build has no hosted path for the candidate. The candidate is
@@ -899,6 +986,8 @@ async def _serve_from_hosted_credential(
     # substitution is the adapter's decision rather than a plan's and refusing it
     # here would make a build's own fleet unusable until it were priced. An
     # overlay binding this port owns that.
+    await _warn_if_hosted_upstream_is_unpriced(ctx, resolved, credential.response_provider)
+
     kwargs: dict[str, Any] = {"api_key": credential.api_key}
     if credential.api_base is not None:
         kwargs["api_base"] = credential.api_base

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -14,7 +14,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import Field, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.api.deps import get_config, get_db_if_needed, get_log_writer
+from gateway.api.deps import ModelProviderPortDep, get_config, get_db_if_needed, get_log_writer
 from gateway.api.routes._helpers import latest_user_text, routing_signal_from_messages
 from gateway.api.routes._normalize import normalize_request_messages
 from gateway.api.routes._pipeline import (
@@ -296,6 +296,7 @@ async def chat_completions(
     db: Annotated[AsyncSession | None, Depends(get_db_if_needed)],
     config: Annotated[GatewayConfig, Depends(get_config)],
     log_writer: Annotated[LogWriter, Depends(get_log_writer)],
+    model_provider: ModelProviderPortDep,
 ) -> ChatCompletion | StreamingResponse:
     """OpenAI-compatible chat completions endpoint.
 
@@ -414,7 +415,9 @@ async def chat_completions(
         # Standalone path: single attempt, no fallback (no `route.attempts`).
         # Resolve the instance to its implementation; dispatch any-llm against
         # ``implementation:model`` while billing/logging key on the instance.
-        resolved = await resolve_dispatch_provider(ctx, config, request.model, adapter=_ADAPTER)
+        resolved = await resolve_dispatch_provider(
+            ctx, config, request.model, adapter=_ADAPTER, model_provider=model_provider
+        )
         call_kwargs = {**resolved.kwargs, **request_fields, "model": resolved.dispatch_model}
         return await run_single_attempt_stream(
             adapter=_ADAPTER,
@@ -452,7 +455,9 @@ async def chat_completions(
             session_label=request.session_label,
         )
 
-    resolved = await resolve_dispatch_provider(ctx, config, request.model, adapter=_ADAPTER)
+    resolved = await resolve_dispatch_provider(
+        ctx, config, request.model, adapter=_ADAPTER, model_provider=model_provider
+    )
     call_kwargs = {**resolved.kwargs, **request_fields, "model": resolved.dispatch_model}
     return await run_standalone_non_stream(
         adapter=_ADAPTER,

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import (
+    ModelProviderPortDep,
     get_config,
     get_db_if_needed,
     get_log_writer,
@@ -491,6 +492,7 @@ async def create_message(
     db: Annotated[AsyncSession | None, Depends(get_db_if_needed)],
     config: Annotated[GatewayConfig, Depends(get_config)],
     log_writer: Annotated[LogWriter, Depends(get_log_writer)],
+    model_provider: ModelProviderPortDep,
 ) -> dict[str, Any] | StreamingResponse:
     """Anthropic Messages API-compatible endpoint.
 
@@ -615,7 +617,9 @@ async def create_message(
                 raise_all_streaming_attempts_failed(_ADAPTER, exc, route)
 
         # Standalone: single attempt streaming.
-        resolved = await resolve_dispatch_provider(ctx, config, request.model, adapter=_ADAPTER)
+        resolved = await resolve_dispatch_provider(
+            ctx, config, request.model, adapter=_ADAPTER, model_provider=model_provider
+        )
         call_kwargs = {**resolved.kwargs, **request_fields, "model": resolved.dispatch_model}
         return await run_single_attempt_stream(
             adapter=_ADAPTER,
@@ -659,7 +663,9 @@ async def create_message(
         return result.model_dump(exclude_none=True)
 
     # Standalone non-stream path
-    resolved = await resolve_dispatch_provider(ctx, config, request.model, adapter=_ADAPTER)
+    resolved = await resolve_dispatch_provider(
+        ctx, config, request.model, adapter=_ADAPTER, model_provider=model_provider
+    )
     call_kwargs = {**resolved.kwargs, **request_fields, "model": resolved.dispatch_model}
     result = await run_standalone_non_stream(
         adapter=_ADAPTER,

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -14,7 +14,7 @@ from openresponses_types.types import Usage as OpenResponsesUsage
 from pydantic import ConfigDict, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.api.deps import get_config, get_db_if_needed, get_log_writer
+from gateway.api.deps import ModelProviderPortDep, get_config, get_db_if_needed, get_log_writer
 from gateway.api.routes._helpers import latest_user_text, routing_signal_from_text, text_from_content
 from gateway.api.routes._normalize import normalize_request_messages
 from gateway.api.routes._pipeline import (
@@ -437,6 +437,7 @@ async def create_response(
     db: Annotated[AsyncSession | None, Depends(get_db_if_needed)],
     config: Annotated[GatewayConfig, Depends(get_config)],
     log_writer: Annotated[LogWriter, Depends(get_log_writer)],
+    model_provider: ModelProviderPortDep,
 ) -> dict[str, Any] | StreamingResponse:
     """OpenAI-compatible Responses endpoint.
 
@@ -523,7 +524,9 @@ async def create_response(
                 )
             raise
     else:
-        resolved = await resolve_dispatch_provider(ctx, config, request_body.model, adapter=_ADAPTER)
+        resolved = await resolve_dispatch_provider(
+            ctx, config, request_body.model, adapter=_ADAPTER, model_provider=model_provider
+        )
         # ``provider`` is the underlying implementation handed to any-llm;
         # ``billing_instance`` is the otari routing key pricing/usage key on.
         provider, model = resolved.provider, resolved.model

--- a/src/gateway/services/provider_kwargs.py
+++ b/src/gateway/services/provider_kwargs.py
@@ -80,19 +80,39 @@ def keyless_placeholder_api_key(provider: LLMProvider, api_base: Any, api_key: A
 
 
 def credential_ladder_exhausted(provider: LLMProvider, kwargs: dict[str, Any]) -> bool:
-    """Whether nothing this gateway holds can credential a call to ``provider``.
-
-    True when :func:`get_provider_kwargs` produced nothing at all for the
-    candidate (no organization-scoped key, no stored instance, no ``config.yml``
-    entry, and so no keyless placeholder either) *and* the provider's own SDK
-    environment variable is unset, which any-llm would otherwise fall back to
-    before raising. The env check is the same one the keyless placeholder makes,
-    so both agree on what counts as a credential already in hand.
+    """Whether a credential was needed for ``provider`` and none was found.
 
     For a caller that has somewhere else to ask once every rung has missed; the
     ladder itself is unchanged and still the only thing consulted first.
+
+    Both halves of that sentence are load-bearing. **None was found** means
+    :func:`get_provider_kwargs` produced nothing at all for the candidate: no
+    organization-scoped key, no stored instance, no credential from a
+    ``config.yml`` entry (an instance declaring only ``provider_type``/``models``
+    leaves nothing behind once the meta keys are stripped), and so no keyless
+    placeholder either, *and* the provider's own SDK environment variable is
+    unset, which any-llm would otherwise fall back to before raising. That env
+    check is the same one the keyless placeholder makes, so both agree on what
+    counts as a credential already in hand.
+
+    **Was needed** excludes the providers any-llm calls with no credential at
+    all: the keyless local backends (ollama, llamacpp, llamafile) and Vertex AI,
+    which authenticates through the cloud SDK. They declare no credential
+    variable, so an empty ``kwargs`` for one of them is not a missing key, and
+    reporting it as exhausted would hand a request that already works to a
+    caller that might serve it from somewhere else. A deployment pointing at its
+    own backends is served upstream of anything reading this.
+
+    ``provider_credential_env_names`` returns ``None`` rather than ``()`` for a
+    provider it cannot inspect at all, and that stays exhausted: nothing is known
+    to serve the candidate, which is the same position an uncredentialed provider
+    with a declared variable is in.
     """
-    return not kwargs and not _provider_env_key_present(provider)
+    if kwargs:
+        return False
+    if provider_credential_env_names(provider.value) == ():
+        return False
+    return not _provider_env_key_present(provider)
 
 
 def get_provider_kwargs(

--- a/src/gateway/services/provider_kwargs.py
+++ b/src/gateway/services/provider_kwargs.py
@@ -79,6 +79,22 @@ def keyless_placeholder_api_key(provider: LLMProvider, api_base: Any, api_key: A
     return None
 
 
+def credential_ladder_exhausted(provider: LLMProvider, kwargs: dict[str, Any]) -> bool:
+    """Whether nothing this gateway holds can credential a call to ``provider``.
+
+    True when :func:`get_provider_kwargs` produced nothing at all for the
+    candidate (no organization-scoped key, no stored instance, no ``config.yml``
+    entry, and so no keyless placeholder either) *and* the provider's own SDK
+    environment variable is unset, which any-llm would otherwise fall back to
+    before raising. The env check is the same one the keyless placeholder makes,
+    so both agree on what counts as a credential already in hand.
+
+    For a caller that has somewhere else to ask once every rung has missed; the
+    ladder itself is unchanged and still the only thing consulted first.
+    """
+    return not kwargs and not _provider_env_key_present(provider)
+
+
 def get_provider_kwargs(
     config: GatewayConfig,
     provider: LLMProvider,

--- a/src/gateway/services/provider_kwargs.py
+++ b/src/gateway/services/provider_kwargs.py
@@ -80,6 +80,24 @@ _KEYLESS_SELF_HOSTED_PROVIDERS = frozenset({"vllm", "lmstudio", "cascadia", "ota
 # nothing is configured and nothing can serve it anyway).
 _AMBIENT_CREDENTIAL_PROVIDERS = frozenset({"bedrock", "sagemaker"})
 
+# Keys ``get_provider_kwargs`` can return that credential nothing on their own:
+# transport tuning an operator attached to an instance. An instance carrying only
+# these has been *described* and not credentialed, so it must not count as a rung
+# that answered. ``api_base`` is deliberately absent: an instance with a base URL
+# and no key takes the keyless placeholder, so it never reaches a caller alone.
+_NON_CREDENTIAL_KWARGS = frozenset({"client_args"})
+
+
+def _kwargs_carry_a_credential(kwargs: dict[str, Any]) -> bool:
+    """Whether anything in a resolved provider's kwargs could authenticate a call.
+
+    Emptiness is not the question: ``providers.openai: {client_args: {timeout:
+    60}}`` resolves a non-empty dict with no credential in it, and a key written
+    as ``api_key:`` with no value resolves ``None``. Both mean the ladder found a
+    provider entry and no way to call it.
+    """
+    return any(value for key, value in kwargs.items() if key not in _NON_CREDENTIAL_KWARGS)
+
 
 def _provider_env_key_present(provider: LLMProvider) -> bool:
     """Whether the provider's native API-key env var (e.g. OPENAI_API_KEY) is set.
@@ -113,11 +131,13 @@ def credential_ladder_exhausted(provider: LLMProvider, kwargs: dict[str, Any]) -
     ladder itself is unchanged and still the only thing consulted first.
 
     Both halves of that sentence are load-bearing. **None was found** means
-    :func:`get_provider_kwargs` produced nothing at all for the candidate: no
-    organization-scoped key, no stored instance, no credential from a
-    ``config.yml`` entry (an instance declaring only ``provider_type``/``models``
-    leaves nothing behind once the meta keys are stripped), and so no keyless
-    placeholder either, *and* the provider's own SDK environment variable is
+    :func:`get_provider_kwargs` produced no credential for the candidate: no
+    organization-scoped key, no stored instance, nothing usable from a
+    ``config.yml`` entry (one declaring only ``provider_type``/``models`` leaves
+    nothing behind once the meta keys are stripped, and one carrying only
+    ``client_args`` leaves nothing that can authenticate a call, per
+    :func:`_kwargs_carry_a_credential`), and so no keyless placeholder either,
+    *and* the provider's own SDK environment variable is
     unset, which any-llm would otherwise fall back to before raising. That env
     check is the same one the keyless placeholder makes, so both agree on what
     counts as a credential already in hand.
@@ -137,7 +157,7 @@ def credential_ladder_exhausted(provider: LLMProvider, kwargs: dict[str, Any]) -
     to serve the candidate, which is the same position an uncredentialed provider
     with a declared variable is in.
     """
-    if kwargs:
+    if _kwargs_carry_a_credential(kwargs):
         return False
     if provider.value in _KEYLESS_SELF_HOSTED_PROVIDERS or provider.value in _AMBIENT_CREDENTIAL_PROVIDERS:
         return False

--- a/src/gateway/services/provider_kwargs.py
+++ b/src/gateway/services/provider_kwargs.py
@@ -53,6 +53,33 @@ _INSTANCE_META_KEYS = ("provider_type", "models")
 # tolerance (mozilla-ai/any-llm#1198).
 _KEYLESS_PLACEHOLDER_API_KEY = "otari-no-key-required"
 
+# Two sets of providers any-llm calls without an otari-visible credential, even
+# though each *declares* a credential environment variable.
+# ``provider_credential_env_names`` sees only the declaration, so it cannot tell
+# them from a keyed provider the way it can ollama/llamacpp/llamafile (which
+# declare the literal ``"None"``) or Vertex AI (which declares an empty name).
+# Both are written out by hand and both are drift-guarded in
+# ``tests/unit/test_provider_instances.py``.
+#
+# Local and LAN backends that never require a key: each overrides
+# ``_verify_and_set_api_key`` to return without raising and defaults to a
+# localhost or LAN base URL, so a bare ``vllm:my-model`` reaches a self-hosted
+# server today with nothing configured in otari at all.
+_KEYLESS_SELF_HOSTED_PROVIDERS = frozenset({"vllm", "lmstudio", "cascadia", "otari"})
+# Providers authenticating from cloud SDK credentials this gateway cannot see:
+# an EC2 instance profile, an SSO session, or an ambient boto3 chain. They are
+# the same category as Vertex AI's application default credentials, which
+# ``docs/configuration.md`` already groups with Bedrock, and they only reach here
+# with nothing configured, which is precisely the ambient case. Splitting the
+# category on whether any-llm happens to declare a variable name would be an
+# accident of upstream spelling rather than a difference in kind.
+#
+# Deliberately *not* here: gemini (raises ``MissingApiKeyError`` outright when no
+# key resolves, so it genuinely needs one) and azure/azureopenai (an Entra ID
+# deployment still needs an endpoint from config, so an empty ``kwargs`` means
+# nothing is configured and nothing can serve it anyway).
+_AMBIENT_CREDENTIAL_PROVIDERS = frozenset({"bedrock", "sagemaker"})
+
 
 def _provider_env_key_present(provider: LLMProvider) -> bool:
     """Whether the provider's native API-key env var (e.g. OPENAI_API_KEY) is set.
@@ -96,12 +123,14 @@ def credential_ladder_exhausted(provider: LLMProvider, kwargs: dict[str, Any]) -
     counts as a credential already in hand.
 
     **Was needed** excludes the providers any-llm calls with no credential at
-    all: the keyless local backends (ollama, llamacpp, llamafile) and Vertex AI,
-    which authenticates through the cloud SDK. They declare no credential
-    variable, so an empty ``kwargs`` for one of them is not a missing key, and
+    all, because an empty ``kwargs`` for one of those is not a missing key, and
     reporting it as exhausted would hand a request that already works to a
     caller that might serve it from somewhere else. A deployment pointing at its
-    own backends is served upstream of anything reading this.
+    own backends is served upstream of anything reading this. They come in two
+    shapes: those declaring no credential variable at all (the keyless local
+    backends ollama, llamacpp and llamafile, and Vertex AI, which authenticates
+    through the cloud SDK), and those declaring one any-llm does not insist on
+    (``_KEYLESS_SELF_HOSTED_PROVIDERS`` and ``_AMBIENT_CREDENTIAL_PROVIDERS``).
 
     ``provider_credential_env_names`` returns ``None`` rather than ``()`` for a
     provider it cannot inspect at all, and that stays exhausted: nothing is known
@@ -109,6 +138,8 @@ def credential_ladder_exhausted(provider: LLMProvider, kwargs: dict[str, Any]) -
     with a declared variable is in.
     """
     if kwargs:
+        return False
+    if provider.value in _KEYLESS_SELF_HOSTED_PROVIDERS or provider.value in _AMBIENT_CREDENTIAL_PROVIDERS:
         return False
     if provider_credential_env_names(provider.value) == ():
         return False
@@ -305,9 +336,7 @@ def resolve_provider_selector(
     )
 
 
-def resolve_static_policy_target(
-    config: GatewayConfig, model_selector: str, user_id: str | None = None
-) -> str | None:
+def resolve_static_policy_target(config: GatewayConfig, model_selector: str, user_id: str | None = None) -> str | None:
     """The single target of a static routing policy, or ``None``.
 
     ``None`` for a name that is not a policy, for a dynamic policy (whose target

--- a/tests/integration/test_hosted_credential_request_path.py
+++ b/tests/integration/test_hosted_credential_request_path.py
@@ -1,0 +1,184 @@
+"""An overlay-bound ``ModelProviderPort`` serves a request, end to end.
+
+``ModelProviderPort`` is only worth binding if the request path asks it
+(otari#757), and only worth asking if it cannot displace a credential the
+gateway already holds. Both are properties of a booted app rather than of a
+function, so this exercises them against one: the same config is served by a
+gateway with an overlay bootstrap and by a gateway without, and what reaches
+any-llm is compared.
+"""
+
+import sys
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from gateway.core.config import API_KEY_HEADER, GatewayConfig
+
+from .conftest import build_test_client
+
+HEADERS = {API_KEY_HEADER: "Bearer test-master-key"}
+
+# An overlay in miniature: one rebound port, a fleet that serves anything the
+# gateway itself could not credential, and one upstream the organization is
+# refused. Written to a file and imported by dotted path, because binding it
+# through ``OTARI_BOOTSTRAP`` is half of what is under test.
+OVERLAY_MODULE = '''
+from gateway.container import Container
+from gateway.ports.model_provider_port import HostedAccessDeniedError, HostedCredential, ModelProviderPort
+
+
+class FleetModelProviderAdapter:
+    """Serves a candidate from a deployment-owned fleet, and refuses one upstream."""
+
+    def __init__(self, session):
+        self.session = session
+
+    async def resolve_hosted_credential(self, *, organization_id, workspace_id, provider, model):
+        if provider == "mistral":
+            raise HostedAccessDeniedError(
+                "FleetAdapter: this organization has no mistral entitlement",
+                workspace_id=workspace_id,
+            )
+        return HostedCredential(
+            api_key="fleet-key",
+            api_base="https://fleet.test/v1",
+            response_provider="together",
+        )
+
+
+def register(container: Container) -> None:
+    container.bind(ModelProviderPort, FleetModelProviderAdapter)
+'''
+
+
+class _MockCompletionError(Exception):
+    """Raised to short-circuit the mocked acompletion after capturing kwargs."""
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_provider_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A developer's own shell keys would credential the ladder and skip the port."""
+    for name in ("OPENAI_API_KEY", "MISTRAL_API_KEY", "TOGETHER_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+def overlay_on_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[str]:
+    (tmp_path / "otari_fleet_overlay.py").write_text(OVERLAY_MODULE)
+    monkeypatch.syspath_prepend(str(tmp_path))
+    sys.modules.pop("otari_fleet_overlay", None)
+    yield "otari_fleet_overlay"
+    sys.modules.pop("otari_fleet_overlay", None)
+
+
+def _config(postgres_url: str, *, bootstrap: str | None = None) -> GatewayConfig:
+    return GatewayConfig(
+        database_url=postgres_url,
+        master_key="test-master-key",
+        auto_migrate=False,
+        require_pricing=False,
+        model_discovery=False,
+        # One provider the gateway credentials itself, so BYO precedence has
+        # something concrete to be checked against.
+        providers={"anthropic": {"api_key": "sk-ant"}},
+        bootstrap=bootstrap,
+    )
+
+
+@pytest.fixture
+def overlay_client(postgres_url: str, overlay_on_path: str) -> Generator[TestClient]:
+    yield from build_test_client(_config(postgres_url, bootstrap=f"{overlay_on_path}:register"))
+
+
+@pytest.fixture
+def plain_client(postgres_url: str) -> Generator[TestClient]:
+    """The same gateway with no bootstrap: the core adapter answers None for everything."""
+    yield from build_test_client(_config(postgres_url))
+
+
+def _create_user(client: TestClient, user_id: str = "u1") -> None:
+    response = client.post("/v1/users", json={"user_id": user_id, "alias": user_id}, headers=HEADERS)
+    assert response.status_code == 200, response.text
+
+
+def _post_chat_capture(client: TestClient, model: str) -> tuple[dict[str, object], int]:
+    """POST a completion with the provider call mocked; return its kwargs and the status."""
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(**kwargs: object) -> None:
+        captured.update(kwargs)
+        raise _MockCompletionError
+
+    with patch("gateway.api.routes.chat.acompletion", new=AsyncMock(side_effect=fake_acompletion)):
+        response = client.post(
+            "/v1/chat/completions",
+            json={"model": model, "messages": [{"role": "user", "content": "Hi"}], "user": "u1"},
+            headers=HEADERS,
+        )
+    return captured, response.status_code
+
+
+def test_the_overlay_fleet_serves_a_candidate_the_gateway_cannot(overlay_client: TestClient) -> None:
+    _create_user(overlay_client)
+
+    captured, _ = _post_chat_capture(overlay_client, "openai:gpt-4o")
+
+    assert captured, "the provider call was never made"
+    assert captured["api_key"] == "fleet-key"
+    assert captured["api_base"] == "https://fleet.test/v1"
+    # Dispatched against the upstream the credential named, not the one asked for.
+    assert captured["model"] == "together:gpt-4o"
+
+
+def test_the_plain_build_dispatches_the_same_candidate_uncredentialed(plain_client: TestClient) -> None:
+    """The acceptance case for every deployment with no overlay: nothing changed."""
+    _create_user(plain_client)
+
+    captured, _ = _post_chat_capture(plain_client, "openai:gpt-4o")
+
+    assert captured, "the provider call was never made"
+    assert "api_key" not in captured
+    assert "api_base" not in captured
+    assert captured["model"] == "openai:gpt-4o"
+
+
+def test_a_configured_provider_key_is_not_displaced_by_the_fleet(overlay_client: TestClient) -> None:
+    """BYO stays upstream: the port is asked last, and here it is not asked at all."""
+    _create_user(overlay_client)
+
+    captured, _ = _post_chat_capture(overlay_client, "anthropic:claude-opus-4")
+
+    assert captured["api_key"] == "sk-ant"
+    assert captured["model"] == "anthropic:claude-opus-4"
+
+
+def test_a_refused_upstream_answers_403_without_naming_the_adapter(overlay_client: TestClient) -> None:
+    _create_user(overlay_client)
+
+    captured, status_code = _post_chat_capture(overlay_client, "mistral:mistral-large-latest")
+
+    assert status_code == 403
+    assert captured == {}, "a refused request must never reach a provider"
+
+
+def test_the_refusal_body_carries_no_adapter_wording(overlay_client: TestClient) -> None:
+    _create_user(overlay_client)
+
+    with patch("gateway.api.routes.chat.acompletion", new=AsyncMock(side_effect=_MockCompletionError)):
+        response = overlay_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "mistral:mistral-large-latest",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "user": "u1",
+            },
+            headers=HEADERS,
+        )
+
+    assert response.status_code == 403
+    assert "FleetAdapter" not in response.text
+    assert "entitlement" not in response.text

--- a/tests/integration/test_hosted_credential_request_path.py
+++ b/tests/integration/test_hosted_credential_request_path.py
@@ -156,6 +156,22 @@ def test_a_configured_provider_key_is_not_displaced_by_the_fleet(overlay_client:
     assert captured["model"] == "anthropic:claude-opus-4"
 
 
+def test_a_keyless_local_backend_is_not_claimed_by_the_fleet(overlay_client: TestClient) -> None:
+    """Self-hosting stays a first-class path upstream of the port, even with an overlay bound.
+
+    ``ollama:llama3`` needs no credential at all, so an empty kwargs is not a
+    missing key and the fleet is never asked. Without this, a self-hoster's local
+    traffic would silently start being served (and metered) from somewhere else.
+    """
+    _create_user(overlay_client)
+
+    captured, _ = _post_chat_capture(overlay_client, "ollama:llama3")
+
+    assert captured, "the provider call was never made"
+    assert "api_key" not in captured
+    assert captured["model"] == "ollama:llama3"
+
+
 def test_a_refused_upstream_answers_403_without_naming_the_adapter(overlay_client: TestClient) -> None:
     _create_user(overlay_client)
 

--- a/tests/integration/test_hosted_credential_request_path.py
+++ b/tests/integration/test_hosted_credential_request_path.py
@@ -16,9 +16,12 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 from gateway.core.config import API_KEY_HEADER, GatewayConfig
 from gateway.log_config import logger as gateway_logger
+from gateway.models.entities import User
 
 from .conftest import build_test_client
 
@@ -40,6 +43,10 @@ class FleetModelProviderAdapter:
         self.session = session
 
     async def resolve_hosted_credential(self, *, organization_id, workspace_id, provider, model):
+        if provider == "groq":
+            # Stands in for the ordinary failure of a network-backed adapter:
+            # an httpx timeout, a reset connection, a database error.
+            raise RuntimeError("fleet credential service is unreachable")
         if provider == "mistral":
             raise HostedAccessDeniedError(
                 "FleetAdapter: this organization has no mistral entitlement",
@@ -192,9 +199,7 @@ def test_a_self_hosted_backend_declaring_a_key_is_not_claimed_by_the_fleet(overl
     assert captured["model"] == "vllm:my-model"
 
 
-def test_an_unpriced_re_keyed_upstream_is_logged(
-    overlay_client: TestClient, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_an_unpriced_re_keyed_upstream_is_logged(overlay_client: TestClient, caplog: pytest.LogCaptureFixture) -> None:
     """A request about to settle free says so in the log.
 
     The pricing gate ran against the name the caller asked for, and settlement
@@ -216,9 +221,65 @@ def test_an_unpriced_re_keyed_upstream_is_logged(
         gateway_logger.removeHandler(caplog.handler)
 
     assert captured["model"] == "together:gpt-4o"
-    assert any(
-        "re-keyed openai:gpt-4o onto together:gpt-4o" in record.getMessage() for record in caplog.records
-    ), f"no re-key pricing warning in {[r.getMessage() for r in caplog.records]}"
+    assert any("re-keyed openai:gpt-4o onto together:gpt-4o" in record.getMessage() for record in caplog.records), (
+        f"no re-key pricing warning in {[r.getMessage() for r in caplog.records]}"
+    )
+
+
+def test_an_adapter_failure_returns_the_budget_hold(overlay_client: TestClient, postgres_url: str) -> None:
+    """The reservation invariant, end to end against a real budget.
+
+    An overlay adapter that fetches credentials over the network fails the
+    ordinary ways, and `resolve_dispatch_provider` is called outside any `try`
+    that would catch one, with no global handler above it. Before the guard this
+    left the preamble's hold on `users.reserved` until the budget reset, which for
+    a budget with no period is forever. The unit tests assert the refund helper is
+    called; this one asserts the column it is called for.
+    """
+    budget = overlay_client.post(
+        "/v1/budgets", json={"max_budget": 100.0, "budget_duration_sec": 86400}, headers=HEADERS
+    ).json()
+    assert (
+        overlay_client.post(
+            "/v1/users", json={"user_id": "held", "budget_id": budget["budget_id"]}, headers=HEADERS
+        ).status_code
+        == 200
+    )
+    # Priced, so the preamble reserves a real estimate rather than zero. Without
+    # this the assertion below would hold whether or not anything was refunded.
+    assert (
+        overlay_client.post(
+            "/v1/pricing",
+            json={
+                "model_key": "groq:llama-3.3-70b",
+                "input_price_per_million": 1000.0,
+                "output_price_per_million": 1000.0,
+            },
+            headers=HEADERS,
+        ).status_code
+        == 200
+    )
+    key = overlay_client.post("/v1/keys", json={"user_id": "held"}, headers=HEADERS).json()["key"]
+
+    response = overlay_client.post(
+        "/v1/chat/completions",
+        json={"model": "groq:llama-3.3-70b", "messages": [{"role": "user", "content": "Hi" * 500}]},
+        headers={API_KEY_HEADER: f"Bearer {key}"},
+    )
+
+    assert response.status_code == 502
+    assert "fleet credential service" not in response.text
+
+    engine = create_engine(postgres_url)
+    try:
+        with sessionmaker(bind=engine)() as session:
+            user = session.query(User).filter(User.user_id == "held").one()
+            assert float(user.reserved) == pytest.approx(0.0), (
+                f"the budget hold leaked: users.reserved is {user.reserved}"
+            )
+            assert float(user.spend) == pytest.approx(0.0)
+    finally:
+        engine.dispose()
 
 
 def test_a_refused_upstream_answers_403_without_naming_the_adapter(overlay_client: TestClient) -> None:

--- a/tests/integration/test_hosted_credential_request_path.py
+++ b/tests/integration/test_hosted_credential_request_path.py
@@ -8,6 +8,7 @@ gateway with an overlay bootstrap and by a gateway without, and what reaches
 any-llm is compared.
 """
 
+import logging
 import sys
 from collections.abc import Generator
 from pathlib import Path
@@ -17,6 +18,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from gateway.core.config import API_KEY_HEADER, GatewayConfig
+from gateway.log_config import logger as gateway_logger
 
 from .conftest import build_test_client
 
@@ -188,6 +190,35 @@ def test_a_self_hosted_backend_declaring_a_key_is_not_claimed_by_the_fleet(overl
     assert "api_key" not in captured
     assert "api_base" not in captured
     assert captured["model"] == "vllm:my-model"
+
+
+def test_an_unpriced_re_keyed_upstream_is_logged(
+    overlay_client: TestClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A request about to settle free says so in the log.
+
+    The pricing gate ran against the name the caller asked for, and settlement
+    reprices on the upstream that served, so an unpriced ``response_provider``
+    settles at no cost and releases the whole hold. Refusing is deliberately left
+    out (an overlay's own fleet would be unusable until priced), which is why the
+    signal has to exist: without it the only trace is a generic unpriced-model
+    warning at settlement, indistinguishable from an ordinary unpriced model.
+    """
+    _create_user(overlay_client)
+
+    # The `gateway` logger does not propagate, so caplog only sees it once its
+    # handler is attached directly (the idiom in `test_provider_instances.py`).
+    gateway_logger.addHandler(caplog.handler)
+    caplog.set_level(logging.WARNING, logger="gateway")
+    try:
+        captured, _ = _post_chat_capture(overlay_client, "openai:gpt-4o")
+    finally:
+        gateway_logger.removeHandler(caplog.handler)
+
+    assert captured["model"] == "together:gpt-4o"
+    assert any(
+        "re-keyed openai:gpt-4o onto together:gpt-4o" in record.getMessage() for record in caplog.records
+    ), f"no re-key pricing warning in {[r.getMessage() for r in caplog.records]}"
 
 
 def test_a_refused_upstream_answers_403_without_naming_the_adapter(overlay_client: TestClient) -> None:

--- a/tests/integration/test_hosted_credential_request_path.py
+++ b/tests/integration/test_hosted_credential_request_path.py
@@ -62,7 +62,7 @@ class _MockCompletionError(Exception):
 @pytest.fixture(autouse=True)
 def _no_ambient_provider_keys(monkeypatch: pytest.MonkeyPatch) -> None:
     """A developer's own shell keys would credential the ladder and skip the port."""
-    for name in ("OPENAI_API_KEY", "MISTRAL_API_KEY", "TOGETHER_API_KEY"):
+    for name in ("OPENAI_API_KEY", "MISTRAL_API_KEY", "TOGETHER_API_KEY", "VLLM_API_KEY"):
         monkeypatch.delenv(name, raising=False)
 
 
@@ -170,6 +170,24 @@ def test_a_keyless_local_backend_is_not_claimed_by_the_fleet(overlay_client: Tes
     assert captured, "the provider call was never made"
     assert "api_key" not in captured
     assert captured["model"] == "ollama:llama3"
+
+
+def test_a_self_hosted_backend_declaring_a_key_is_not_claimed_by_the_fleet(overlay_client: TestClient) -> None:
+    """``vllm`` declares ``VLLM_API_KEY`` but any-llm never insists on it.
+
+    The same invariant as the case above, for the half of the keyless set the
+    declaration cannot identify: a bare ``vllm:my-model`` reaches a local vLLM at
+    any-llm's default ``http://localhost:8000/v1`` with nothing configured here,
+    so the fleet must not be asked about it.
+    """
+    _create_user(overlay_client)
+
+    captured, _ = _post_chat_capture(overlay_client, "vllm:my-model")
+
+    assert captured, "the provider call was never made"
+    assert "api_key" not in captured
+    assert "api_base" not in captured
+    assert captured["model"] == "vllm:my-model"
 
 
 def test_a_refused_upstream_answers_403_without_naming_the_adapter(overlay_client: TestClient) -> None:

--- a/tests/unit/test_bad_model_name_returns_400.py
+++ b/tests/unit/test_bad_model_name_returns_400.py
@@ -12,7 +12,7 @@ These tests cover:
 - resolve_dispatch_provider returns cached provider when ctx.resolved_provider is set
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from any_llm.exceptions import AnyLLMError
@@ -71,7 +71,9 @@ async def test_resolve_dispatch_provider_returns_cached() -> None:
     cached = MagicMock()
     ctx = _make_ctx(resolved_provider=cached)
     with patch("gateway.api.routes._pipeline.resolve_provider_selector") as mock_rps:
-        result = await resolve_dispatch_provider(ctx, _make_config(), "openai:gpt-4o", adapter=MagicMock())
+        result = await resolve_dispatch_provider(
+            ctx, _make_config(), "openai:gpt-4o", adapter=MagicMock(), model_provider=AsyncMock()
+        )
     assert result is cached
     mock_rps.assert_not_called()
 
@@ -85,7 +87,9 @@ async def test_resolve_dispatch_provider_unparseable_raises_400() -> None:
         side_effect=ValueError("Invalid model format"),
     ):
         with pytest.raises(HTTPException) as exc_info:
-            await resolve_dispatch_provider(ctx, _make_config(), "nosuchmodel", adapter=MagicMock())
+            await resolve_dispatch_provider(
+                ctx, _make_config(), "nosuchmodel", adapter=MagicMock(), model_provider=AsyncMock()
+            )
     assert exc_info.value.status_code == 400
     assert "nosuchmodel" in exc_info.value.detail
 
@@ -99,7 +103,9 @@ async def test_resolve_dispatch_provider_unknown_provider_raises_400() -> None:
         side_effect=AnyLLMError("Unsupported provider"),
     ):
         with pytest.raises(HTTPException) as exc_info:
-            await resolve_dispatch_provider(ctx, _make_config(), "nobody:model", adapter=MagicMock())
+            await resolve_dispatch_provider(
+                ctx, _make_config(), "nobody:model", adapter=MagicMock(), model_provider=AsyncMock()
+            )
     assert exc_info.value.status_code == 400
     assert "nobody:model" in exc_info.value.detail
 
@@ -113,6 +119,8 @@ async def test_resolve_dispatch_provider_fresh_resolution_succeeds() -> None:
         "gateway.api.routes._pipeline.resolve_provider_selector",
         return_value=fresh,
     ) as mock_rps:
-        result = await resolve_dispatch_provider(ctx, _make_config(), "openai:gpt-4o", adapter=MagicMock())
+        result = await resolve_dispatch_provider(
+            ctx, _make_config(), "openai:gpt-4o", adapter=MagicMock(), model_provider=AsyncMock()
+        )
     assert result is fresh
     mock_rps.assert_called_once()

--- a/tests/unit/test_bad_model_name_returns_400.py
+++ b/tests/unit/test_bad_model_name_returns_400.py
@@ -12,7 +12,7 @@ These tests cover:
 - resolve_dispatch_provider returns cached provider when ctx.resolved_provider is set
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from any_llm.exceptions import AnyLLMError
@@ -65,6 +65,19 @@ def _make_config() -> MagicMock:
     return MagicMock()
 
 
+class _NoHostedCredential:
+    """A ``ModelProviderPort`` that serves nothing, which is the core adapter's answer.
+
+    These tests are about the 400 mapping, not about the hosted-credential rung,
+    so the port is pinned to the answer that leaves a resolved provider untouched.
+    An ``AsyncMock`` would not: it answers every call with a truthy mock, which
+    sends the caller down the re-key path and fails on a nonsense provider name.
+    """
+
+    async def resolve_hosted_credential(self, **kwargs: object) -> None:
+        return None
+
+
 @pytest.mark.asyncio
 async def test_resolve_dispatch_provider_returns_cached() -> None:
     """When ctx.resolved_provider is set it is returned without calling resolve_provider_selector."""
@@ -72,7 +85,7 @@ async def test_resolve_dispatch_provider_returns_cached() -> None:
     ctx = _make_ctx(resolved_provider=cached)
     with patch("gateway.api.routes._pipeline.resolve_provider_selector") as mock_rps:
         result = await resolve_dispatch_provider(
-            ctx, _make_config(), "openai:gpt-4o", adapter=MagicMock(), model_provider=AsyncMock()
+            ctx, _make_config(), "openai:gpt-4o", adapter=MagicMock(), model_provider=_NoHostedCredential()
         )
     assert result is cached
     mock_rps.assert_not_called()
@@ -88,7 +101,7 @@ async def test_resolve_dispatch_provider_unparseable_raises_400() -> None:
     ):
         with pytest.raises(HTTPException) as exc_info:
             await resolve_dispatch_provider(
-                ctx, _make_config(), "nosuchmodel", adapter=MagicMock(), model_provider=AsyncMock()
+                ctx, _make_config(), "nosuchmodel", adapter=MagicMock(), model_provider=_NoHostedCredential()
             )
     assert exc_info.value.status_code == 400
     assert "nosuchmodel" in exc_info.value.detail
@@ -104,7 +117,7 @@ async def test_resolve_dispatch_provider_unknown_provider_raises_400() -> None:
     ):
         with pytest.raises(HTTPException) as exc_info:
             await resolve_dispatch_provider(
-                ctx, _make_config(), "nobody:model", adapter=MagicMock(), model_provider=AsyncMock()
+                ctx, _make_config(), "nobody:model", adapter=MagicMock(), model_provider=_NoHostedCredential()
             )
     assert exc_info.value.status_code == 400
     assert "nobody:model" in exc_info.value.detail
@@ -120,7 +133,7 @@ async def test_resolve_dispatch_provider_fresh_resolution_succeeds() -> None:
         return_value=fresh,
     ) as mock_rps:
         result = await resolve_dispatch_provider(
-            ctx, _make_config(), "openai:gpt-4o", adapter=MagicMock(), model_provider=AsyncMock()
+            ctx, _make_config(), "openai:gpt-4o", adapter=MagicMock(), model_provider=_NoHostedCredential()
         )
     assert result is fresh
     mock_rps.assert_called_once()

--- a/tests/unit/test_hosted_credential_port.py
+++ b/tests/unit/test_hosted_credential_port.py
@@ -208,6 +208,24 @@ async def test_provider_sdk_env_var_is_not_asked_about(monkeypatch: pytest.Monke
     assert port.calls == []
 
 
+@pytest.mark.parametrize("selector", ["ollama:llama3", "llamacpp:local", "vertexai:gemini-2.5-pro"])
+@pytest.mark.asyncio
+async def test_a_provider_needing_no_credential_is_not_asked_about(selector: str) -> None:
+    """any-llm calls these without a key, so an empty kwargs is not a missing one.
+
+    A bare ``ollama:llama3`` works today against a local backend. Reporting it as
+    unserved would hand a working request to a fleet that might answer it from
+    somewhere else, and self-hosting is a first-class path *upstream* of this
+    port (``ports/model_provider_port.py``).
+    """
+    port = RecordingPort(credential=HostedCredential(api_key="hosted", api_base=None, response_provider="openai"))
+    resolved = resolve_provider_selector(GatewayConfig(), selector)
+    assert resolved.kwargs == {}
+    result = await _dispatch(_ctx(resolved_provider=resolved), port, selector=selector)
+    assert result is resolved
+    assert port.calls == []
+
+
 @pytest.mark.asyncio
 async def test_request_without_an_organization_is_not_asked_about() -> None:
     """The port keys its access decision on the organization, so there is nothing to ask."""
@@ -267,9 +285,7 @@ async def test_overlay_adapter_serves_the_candidate() -> None:
 
 @pytest.mark.asyncio
 async def test_overlay_adapter_without_an_api_base_omits_it() -> None:
-    port = RecordingPort(
-        credential=HostedCredential(api_key="hosted-key", api_base=None, response_provider="openai")
-    )
+    port = RecordingPort(credential=HostedCredential(api_key="hosted-key", api_base=None, response_provider="openai"))
     result = await _dispatch(_ctx(resolved_provider=_uncredentialed()), port)
     assert result.kwargs == {"api_key": "hosted-key"}
     assert result.instance == "openai"
@@ -291,9 +307,7 @@ async def test_alias_relabeling_survives_a_hosted_credential() -> None:
     config = GatewayConfig(aliases={"fast": "openai:gpt-4o"})
     resolved = resolve_provider_selector(config, "fast")
     assert resolved.alias == "fast"
-    port = RecordingPort(
-        credential=HostedCredential(api_key="hosted-key", api_base=None, response_provider="together")
-    )
+    port = RecordingPort(credential=HostedCredential(api_key="hosted-key", api_base=None, response_provider="together"))
     result = await pipeline.resolve_dispatch_provider(
         _ctx(resolved_provider=resolved),
         config,
@@ -310,14 +324,25 @@ async def test_alias_relabeling_survives_a_hosted_credential() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_access_denied_becomes_a_403_that_names_no_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
+def _capture_settlement(monkeypatch: pytest.MonkeyPatch) -> tuple[list[object], list[dict[str, Any]]]:
+    """Record the refund and the activity-log row a refusal owes, without a database."""
     released: list[object] = []
+    rejections: list[dict[str, Any]] = []
 
     async def _record_release(ctx: pipeline.RequestContext) -> None:
         released.append(ctx)
 
+    async def _record_rejection(**kwargs: Any) -> None:
+        rejections.append(kwargs)
+
     monkeypatch.setattr(pipeline, "release_reservation", _record_release)
+    monkeypatch.setattr(pipeline, "log_gateway_rejection", _record_rejection)
+    return released, rejections
+
+
+@pytest.mark.asyncio
+async def test_access_denied_becomes_a_403_that_names_no_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
+    released, rejections = _capture_settlement(monkeypatch)
     port = RecordingPort(
         error=HostedAccessDeniedError(
             "AcmeHostedAdapter: organization is not entitled to together",
@@ -332,18 +357,17 @@ async def test_access_denied_becomes_a_403_that_names_no_adapter(monkeypatch: py
     detail = str(exc_info.value.detail)
     assert "openai:gpt-4o" in detail
     assert "AcmeHostedAdapter" not in detail
-    # The hold taken by the preamble is refunded before the refusal surfaces.
+    # The hold taken by the preamble is refunded before the refusal surfaces,
+    # and the drop is countable in the activity log rather than invisible.
     assert len(released) == 1
+    assert [row["status_code"] for row in rejections] == [403]
+    assert rejections[0]["provider"] == "openai"
+    assert rejections[0]["detail"] == detail
 
 
 @pytest.mark.asyncio
 async def test_unknown_response_provider_becomes_a_502(monkeypatch: pytest.MonkeyPatch) -> None:
-    released: list[object] = []
-
-    async def _record_release(ctx: pipeline.RequestContext) -> None:
-        released.append(ctx)
-
-    monkeypatch.setattr(pipeline, "release_reservation", _record_release)
+    released, rejections = _capture_settlement(monkeypatch)
     port = RecordingPort(
         credential=HostedCredential(api_key="hosted-key", api_base=None, response_provider="not-a-provider")
     )
@@ -355,6 +379,7 @@ async def test_unknown_response_provider_becomes_a_502(monkeypatch: pytest.Monke
     assert pipeline.HOSTED_CREDENTIAL_UNUSABLE_DETAIL in str(exc_info.value.detail)
     assert "not-a-provider" not in str(exc_info.value.detail)
     assert len(released) == 1
+    assert [row["status_code"] for row in rejections] == [502]
 
 
 # ---------------------------------------------------------------------------
@@ -365,9 +390,7 @@ async def test_unknown_response_provider_becomes_a_502(monkeypatch: pytest.Monke
 @pytest.mark.asyncio
 async def test_fresh_resolution_also_reaches_the_port() -> None:
     """``ctx.resolved_provider`` unset (the gate could not parse the selector) still asks."""
-    port = RecordingPort(
-        credential=HostedCredential(api_key="hosted-key", api_base=None, response_provider="openai")
-    )
+    port = RecordingPort(credential=HostedCredential(api_key="hosted-key", api_base=None, response_provider="openai"))
     result = await _dispatch(_ctx(resolved_provider=None), port)
     assert result.kwargs == {"api_key": "hosted-key"}
     assert len(port.calls) == 1

--- a/tests/unit/test_hosted_credential_port.py
+++ b/tests/unit/test_hosted_credential_port.py
@@ -38,7 +38,14 @@ WORKSPACE_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
 
 # Every provider these tests name; cleared so a developer's own shell key cannot
 # make `credential_ladder_exhausted` answer False and quietly skip the port.
-_PROVIDER_ENV_VARS = ("OPENAI_API_KEY", "TOGETHER_API_KEY")
+_PROVIDER_ENV_VARS = (
+    "OPENAI_API_KEY",
+    "TOGETHER_API_KEY",
+    "VLLM_API_KEY",
+    "LM_STUDIO_API_KEY",
+    "CASCADIA_API_KEY",
+    "OTARI_API_KEY",
+)
 
 
 @pytest.fixture(autouse=True)
@@ -208,12 +215,30 @@ async def test_provider_sdk_env_var_is_not_asked_about(monkeypatch: pytest.Monke
     assert port.calls == []
 
 
-@pytest.mark.parametrize("selector", ["ollama:llama3", "llamacpp:local", "vertexai:gemini-2.5-pro"])
+@pytest.mark.parametrize(
+    "selector",
+    [
+        "ollama:llama3",
+        "llamacpp:local",
+        "vertexai:gemini-2.5-pro",
+        # These four declare a credential env var that any-llm never insists on,
+        # so the declaration alone cannot tell them apart from a keyed provider.
+        "vllm:my-model",
+        "lmstudio:my-model",
+        "cascadia:my-model",
+        "otari:my-model",
+        # Ambient cloud credentials this gateway cannot see: an instance profile
+        # or SSO session serves these with nothing configured in otari at all.
+        "bedrock:anthropic.claude-sonnet-4-20250514-v1:0",
+        "sagemaker:my-endpoint",
+    ],
+)
 @pytest.mark.asyncio
 async def test_a_provider_needing_no_credential_is_not_asked_about(selector: str) -> None:
     """any-llm calls these without a key, so an empty kwargs is not a missing one.
 
-    A bare ``ollama:llama3`` works today against a local backend. Reporting it as
+    A bare ``ollama:llama3`` works today against a local backend, and a bare
+    ``bedrock:...`` works today off an EC2 instance profile. Reporting either as
     unserved would hand a working request to a fleet that might answer it from
     somewhere else, and self-hosting is a first-class path *upstream* of this
     port (``ports/model_provider_port.py``).
@@ -363,6 +388,28 @@ async def test_access_denied_becomes_a_403_that_names_no_adapter(monkeypatch: py
     assert [row["status_code"] for row in rejections] == [403]
     assert rejections[0]["provider"] == "openai"
     assert rejections[0]["detail"] == detail
+
+
+@pytest.mark.asyncio
+async def test_a_refused_alias_does_not_spell_its_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An alias hides its target, and a refusal is not an exception to that."""
+    _capture_settlement(monkeypatch)
+    config = GatewayConfig(aliases={"fast": "openai:gpt-4o"})
+    resolved = resolve_provider_selector(config, "fast")
+    port = RecordingPort(error=HostedAccessDeniedError("AcmeHostedAdapter: not entitled"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await pipeline.resolve_dispatch_provider(
+            _ctx(resolved_provider=resolved),
+            config,
+            "fast",
+            adapter=chat._ADAPTER,
+            model_provider=port,
+        )
+
+    detail = str(exc_info.value.detail)
+    assert "fast" in detail
+    assert "openai:gpt-4o" not in detail
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_hosted_credential_port.py
+++ b/tests/unit/test_hosted_credential_port.py
@@ -15,6 +15,7 @@ plain build:
 - an adapter naming an upstream any-llm does not implement becomes a 502.
 """
 
+import asyncio
 import uuid
 from typing import Any, cast
 
@@ -61,7 +62,10 @@ class RecordingPort:
         self,
         *,
         credential: HostedCredential | None = None,
-        error: Exception | None = None,
+        # ``BaseException`` and not ``Exception``: one case here raises
+        # ``asyncio.CancelledError``, which the call site must deliberately not
+        # catch, and typing this narrowly would make that case unexpressible.
+        error: BaseException | None = None,
     ) -> None:
         self.credential = credential
         self.error = error
@@ -251,6 +255,62 @@ async def test_a_provider_needing_no_credential_is_not_asked_about(selector: str
     assert port.calls == []
 
 
+@pytest.mark.parametrize(
+    ("provider_config", "label"),
+    [
+        ({"client_args": {"timeout": 60}}, "transport tuning only"),
+        ({"api_key": None}, "a key written with no value"),
+        ({"api_key": ""}, "an empty key"),
+        ({"client_args": {"timeout": 60}, "api_key": None}, "both"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_an_instance_with_no_usable_credential_still_reaches_the_port(
+    provider_config: dict[str, Any], label: str
+) -> None:
+    """A described instance is not a credentialed one.
+
+    ``get_provider_kwargs`` returns a non-empty dict for each of these, so testing
+    the dict for emptiness would report the ladder as having answered when it
+    found a provider entry and no way to call it. any-llm would then fail its own
+    missing-key check on a candidate this build could have served.
+    """
+    config = GatewayConfig(providers={"openai": provider_config})
+    resolved = resolve_provider_selector(config, "openai:gpt-4o")
+    assert resolved.kwargs, f"guard: {label} must resolve a non-empty kwargs dict"
+    port = RecordingPort(credential=HostedCredential(api_key="hosted-key", api_base=None, response_provider="openai"))
+
+    result = await pipeline.resolve_dispatch_provider(
+        _ctx(resolved_provider=resolved),
+        config,
+        "openai:gpt-4o",
+        adapter=chat._ADAPTER,
+        model_provider=port,
+    )
+
+    assert len(port.calls) == 1, f"the port was not asked despite {label}"
+    assert result.kwargs == {"api_key": "hosted-key"}
+
+
+@pytest.mark.asyncio
+async def test_client_args_alone_does_not_shadow_a_real_key() -> None:
+    """The converse: transport tuning beside a real key is still a credentialed rung."""
+    config = GatewayConfig(providers={"openai": {"api_key": "sk-real", "client_args": {"timeout": 60}}})
+    resolved = resolve_provider_selector(config, "openai:gpt-4o")
+    port = RecordingPort(credential=HostedCredential(api_key="hosted", api_base=None, response_provider="openai"))
+
+    result = await pipeline.resolve_dispatch_provider(
+        _ctx(resolved_provider=resolved),
+        config,
+        "openai:gpt-4o",
+        adapter=chat._ADAPTER,
+        model_provider=port,
+    )
+
+    assert port.calls == []
+    assert result.kwargs["api_key"] == "sk-real"
+
+
 @pytest.mark.asyncio
 async def test_request_without_an_organization_is_not_asked_about() -> None:
     """The port keys its access decision on the organization, so there is nothing to ask."""
@@ -410,6 +470,59 @@ async def test_a_refused_alias_does_not_spell_its_target(monkeypatch: pytest.Mon
     detail = str(exc_info.value.detail)
     assert "fast" in detail
     assert "openai:gpt-4o" not in detail
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        RuntimeError("adapter blew up"),
+        TimeoutError("upstream credential service timed out"),
+        ValueError("malformed adapter response"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_an_adapter_failure_refunds_and_becomes_a_502(
+    monkeypatch: pytest.MonkeyPatch, failure: Exception
+) -> None:
+    """Any failure but the port's own refusal still owes the reservation back.
+
+    An overlay adapter resolving credentials over the network fails the ordinary
+    ways: a timeout, a connection reset, a database error. `resolve_dispatch_provider`
+    is called outside any `try` that would catch one (`chat.py`, `responses.py`, and
+    the non-streaming half of `messages.py`; the streaming half's `try` catches
+    `HTTPException` alone), and `gateway.main` registers handlers only for
+    `TenancyError` and `RequestValidationError`, so nothing above this refunds. The
+    hold the preamble took would sit in `users.reserved` until the budget resets.
+    """
+    released, rejections = _capture_settlement(monkeypatch)
+    port = RecordingPort(error=failure)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _dispatch(_ctx(resolved_provider=_uncredentialed()), port)
+
+    assert exc_info.value.status_code == 502
+    assert pipeline.HOSTED_CREDENTIAL_UNUSABLE_DETAIL in str(exc_info.value.detail)
+    # Non-leaky: the adapter's own wording never reaches the caller.
+    assert str(failure) not in str(exc_info.value.detail)
+    assert len(released) == 1
+    assert [row["status_code"] for row in rejections] == [502]
+
+
+@pytest.mark.asyncio
+async def test_cancellation_is_not_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A cancelled request stays cancelled: it is not a hosted-inference failure.
+
+    `asyncio.CancelledError` derives from `BaseException`, so the `except Exception`
+    guard above lets it through. Turning a disconnect into a 502 would both lie about
+    what happened and, worse, mark the task as handled.
+    """
+    released, _ = _capture_settlement(monkeypatch)
+    port = RecordingPort(error=asyncio.CancelledError())
+
+    with pytest.raises(asyncio.CancelledError):
+        await _dispatch(_ctx(resolved_provider=_uncredentialed()), port)
+
+    assert released == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_hosted_credential_port.py
+++ b/tests/unit/test_hosted_credential_port.py
@@ -1,0 +1,373 @@
+"""Unit tests for the ``ModelProviderPort`` call on the standalone dispatch path.
+
+``resolve_dispatch_provider`` asks the port to serve a candidate the credential
+ladder could not (otari#757). What these tests pin down is the precedence and the
+plain build:
+
+- a build with no overlay (the container's own binding) leaves every candidate
+  exactly as the ladder left it, so nothing changes rung for rung;
+- a candidate the ladder credentialed never reaches the port at all, whether the
+  key came from ``config.yml``, a stored instance, an organization-scoped key, or
+  the provider's own SDK environment variable;
+- an overlay-bound adapter *is* reached, and its credential re-keys the dispatch
+  onto ``response_provider``;
+- ``HostedAccessDeniedError`` becomes a 403 that names no adapter, and refunds;
+- an adapter naming an upstream any-llm does not implement becomes a 502.
+"""
+
+import uuid
+from typing import Any, cast
+
+import pytest
+from any_llm import LLMProvider
+from fastapi import HTTPException
+
+from gateway.api.routes import _pipeline as pipeline
+from gateway.api.routes import chat
+from gateway.container import build_container
+from gateway.core.config import GatewayConfig
+from gateway.ports.model_provider_port import (
+    HostedAccessDeniedError,
+    HostedCredential,
+    ModelProviderPort,
+)
+from gateway.services.provider_kwargs import ResolvedProvider, resolve_provider_selector
+
+ORGANIZATION_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+WORKSPACE_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+# Every provider these tests name; cleared so a developer's own shell key cannot
+# make `credential_ladder_exhausted` answer False and quietly skip the port.
+_PROVIDER_ENV_VARS = ("OPENAI_API_KEY", "TOGETHER_API_KEY")
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_provider_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in _PROVIDER_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+class RecordingPort:
+    """A stand-in for an overlay-bound adapter, recording what it was asked."""
+
+    def __init__(
+        self,
+        *,
+        credential: HostedCredential | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self.credential = credential
+        self.error = error
+        self.calls: list[dict[str, Any]] = []
+
+    async def resolve_hosted_credential(
+        self,
+        *,
+        organization_id: uuid.UUID,
+        workspace_id: uuid.UUID | None,
+        provider: str,
+        model: str | None,
+    ) -> HostedCredential | None:
+        self.calls.append(
+            {
+                "organization_id": organization_id,
+                "workspace_id": workspace_id,
+                "provider": provider,
+                "model": model,
+            }
+        )
+        if self.error is not None:
+            raise self.error
+        return self.credential
+
+
+def _plain_build_port() -> ModelProviderPort:
+    """The adapter a build with no overlay actually runs, via the composition root."""
+    return build_container().resolve(ModelProviderPort, None)
+
+
+def _ctx(
+    *,
+    resolved_provider: ResolvedProvider | None,
+    organization_id: uuid.UUID | None = ORGANIZATION_ID,
+    workspace_id: uuid.UUID | None = WORKSPACE_ID,
+    plan: Any = None,
+) -> pipeline.RequestContext:
+    return pipeline.RequestContext(
+        config=GatewayConfig(),
+        db=None,
+        log_writer=cast(Any, object()),
+        hybrid_mode=False,
+        route=None,
+        user_token=None,
+        api_key_id=None,
+        user_id="user-1",
+        rate_limit_info=None,
+        reservation=None,
+        started_at=0.0,
+        workspace_id=workspace_id,
+        resolved_provider=resolved_provider,
+        plan=plan,
+        organization_id=organization_id,
+    )
+
+
+def _uncredentialed() -> ResolvedProvider:
+    """What the ladder produces for a candidate nothing in this gateway serves."""
+    resolved = resolve_provider_selector(GatewayConfig(), "openai:gpt-4o")
+    assert resolved.kwargs == {}, "guard: this candidate must reach the port uncredentialed"
+    return resolved
+
+
+async def _dispatch(
+    ctx: pipeline.RequestContext,
+    port: ModelProviderPort,
+    *,
+    selector: str = "openai:gpt-4o",
+) -> ResolvedProvider:
+    return await pipeline.resolve_dispatch_provider(
+        ctx,
+        GatewayConfig(),
+        selector,
+        adapter=chat._ADAPTER,
+        model_provider=port,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The plain build behaves exactly as it did
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_plain_build_leaves_an_uncredentialed_candidate_untouched() -> None:
+    """The core adapter answers None, so the candidate goes to any-llm as before."""
+    resolved = _uncredentialed()
+    result = await _dispatch(_ctx(resolved_provider=resolved), _plain_build_port())
+    assert result is resolved
+
+
+@pytest.mark.asyncio
+async def test_plain_build_leaves_a_credentialed_candidate_untouched() -> None:
+    config = GatewayConfig(providers={"openai": {"api_key": "sk-from-config"}})
+    resolved = resolve_provider_selector(config, "openai:gpt-4o")
+    result = await pipeline.resolve_dispatch_provider(
+        _ctx(resolved_provider=resolved),
+        config,
+        "openai:gpt-4o",
+        adapter=chat._ADAPTER,
+        model_provider=_plain_build_port(),
+    )
+    assert result is resolved
+    assert result.kwargs == {"api_key": "sk-from-config"}
+
+
+# ---------------------------------------------------------------------------
+# BYO precedence: the port is the last rung, never an earlier one
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_config_provider_key_is_not_asked_about() -> None:
+    port = RecordingPort(credential=HostedCredential(api_key="hosted", api_base=None, response_provider="openai"))
+    config = GatewayConfig(providers={"openai": {"api_key": "sk-from-config"}})
+    resolved = resolve_provider_selector(config, "openai:gpt-4o")
+    result = await pipeline.resolve_dispatch_provider(
+        _ctx(resolved_provider=resolved),
+        config,
+        "openai:gpt-4o",
+        adapter=chat._ADAPTER,
+        model_provider=port,
+    )
+    assert result.kwargs == {"api_key": "sk-from-config"}
+    assert port.calls == []
+
+
+@pytest.mark.asyncio
+async def test_organization_scoped_key_is_not_asked_about(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An organization's own key wins outright: the port is never consulted."""
+    monkeypatch.setattr(
+        "gateway.services.provider_kwargs.cached_org_provider_kwargs",
+        lambda workspace_id, provider: {"api_key": "sk-org-owned"},
+    )
+    resolved = resolve_provider_selector(GatewayConfig(), "openai:gpt-4o", workspace_id=WORKSPACE_ID)
+    assert resolved.kwargs == {"api_key": "sk-org-owned"}
+    port = RecordingPort(credential=HostedCredential(api_key="hosted", api_base=None, response_provider="openai"))
+    result = await _dispatch(_ctx(resolved_provider=resolved), port)
+    assert result is resolved
+    assert port.calls == []
+
+
+@pytest.mark.asyncio
+async def test_provider_sdk_env_var_is_not_asked_about(monkeypatch: pytest.MonkeyPatch) -> None:
+    """any-llm's own env fallback is a credential in hand, so it outranks the port."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-the-environment")
+    port = RecordingPort(credential=HostedCredential(api_key="hosted", api_base=None, response_provider="openai"))
+    result = await _dispatch(_ctx(resolved_provider=_uncredentialed()), port)
+    assert result.kwargs == {}
+    assert port.calls == []
+
+
+@pytest.mark.asyncio
+async def test_request_without_an_organization_is_not_asked_about() -> None:
+    """The port keys its access decision on the organization, so there is nothing to ask."""
+    port = RecordingPort(credential=HostedCredential(api_key="hosted", api_base=None, response_provider="openai"))
+    ctx = _ctx(resolved_provider=_uncredentialed(), organization_id=None, workspace_id=None)
+    result = await _dispatch(ctx, port)
+    assert result.kwargs == {}
+    assert port.calls == []
+
+
+@pytest.mark.asyncio
+async def test_multi_candidate_plan_is_not_asked_about() -> None:
+    """A routed chain dispatches from the plan's own kwargs, so asking would not serve it."""
+
+    class _Plan:
+        attempts = (object(), object())
+
+    port = RecordingPort(credential=HostedCredential(api_key="hosted", api_base=None, response_provider="openai"))
+    ctx = _ctx(resolved_provider=_uncredentialed(), plan=_Plan())
+    result = await _dispatch(ctx, port)
+    assert result.kwargs == {}
+    assert port.calls == []
+
+
+# ---------------------------------------------------------------------------
+# An overlay-bound adapter is reached
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_overlay_adapter_serves_the_candidate() -> None:
+    port = RecordingPort(
+        credential=HostedCredential(
+            api_key="hosted-key",
+            api_base="https://fleet.example/v1",
+            response_provider="together",
+        )
+    )
+    result = await _dispatch(_ctx(resolved_provider=_uncredentialed()), port)
+
+    assert port.calls == [
+        {
+            "organization_id": ORGANIZATION_ID,
+            "workspace_id": WORKSPACE_ID,
+            "provider": "openai",
+            "model": "gpt-4o",
+        }
+    ]
+    # Re-keyed onto the upstream that actually serves, which is what usage and
+    # telemetry name; the caller's model is untouched.
+    assert result.instance == "together"
+    assert result.provider is LLMProvider.TOGETHER
+    assert result.model == "gpt-4o"
+    assert result.dispatch_model == "together:gpt-4o"
+    assert result.kwargs == {"api_key": "hosted-key", "api_base": "https://fleet.example/v1"}
+
+
+@pytest.mark.asyncio
+async def test_overlay_adapter_without_an_api_base_omits_it() -> None:
+    port = RecordingPort(
+        credential=HostedCredential(api_key="hosted-key", api_base=None, response_provider="openai")
+    )
+    result = await _dispatch(_ctx(resolved_provider=_uncredentialed()), port)
+    assert result.kwargs == {"api_key": "hosted-key"}
+    assert result.instance == "openai"
+
+
+@pytest.mark.asyncio
+async def test_overlay_adapter_answering_none_leaves_the_candidate_alone() -> None:
+    """An overlay whose own credential is absent or disabled answers as the core does."""
+    port = RecordingPort(credential=None)
+    resolved = _uncredentialed()
+    result = await _dispatch(_ctx(resolved_provider=resolved), port)
+    assert result is resolved
+    assert len(port.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_alias_relabeling_survives_a_hosted_credential() -> None:
+    """The caller's display name is the alias, not whichever upstream served it."""
+    config = GatewayConfig(aliases={"fast": "openai:gpt-4o"})
+    resolved = resolve_provider_selector(config, "fast")
+    assert resolved.alias == "fast"
+    port = RecordingPort(
+        credential=HostedCredential(api_key="hosted-key", api_base=None, response_provider="together")
+    )
+    result = await pipeline.resolve_dispatch_provider(
+        _ctx(resolved_provider=resolved),
+        config,
+        "fast",
+        adapter=chat._ADAPTER,
+        model_provider=port,
+    )
+    assert result.alias == "fast"
+    assert result.instance == "together"
+
+
+# ---------------------------------------------------------------------------
+# Refusals
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_access_denied_becomes_a_403_that_names_no_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
+    released: list[object] = []
+
+    async def _record_release(ctx: pipeline.RequestContext) -> None:
+        released.append(ctx)
+
+    monkeypatch.setattr(pipeline, "release_reservation", _record_release)
+    port = RecordingPort(
+        error=HostedAccessDeniedError(
+            "AcmeHostedAdapter: organization is not entitled to together",
+            workspace_id=WORKSPACE_ID,
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _dispatch(_ctx(resolved_provider=_uncredentialed()), port)
+
+    assert exc_info.value.status_code == 403
+    detail = str(exc_info.value.detail)
+    assert "openai:gpt-4o" in detail
+    assert "AcmeHostedAdapter" not in detail
+    # The hold taken by the preamble is refunded before the refusal surfaces.
+    assert len(released) == 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_response_provider_becomes_a_502(monkeypatch: pytest.MonkeyPatch) -> None:
+    released: list[object] = []
+
+    async def _record_release(ctx: pipeline.RequestContext) -> None:
+        released.append(ctx)
+
+    monkeypatch.setattr(pipeline, "release_reservation", _record_release)
+    port = RecordingPort(
+        credential=HostedCredential(api_key="hosted-key", api_base=None, response_provider="not-a-provider")
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _dispatch(_ctx(resolved_provider=_uncredentialed()), port)
+
+    assert exc_info.value.status_code == 502
+    assert pipeline.HOSTED_CREDENTIAL_UNUSABLE_DETAIL in str(exc_info.value.detail)
+    assert "not-a-provider" not in str(exc_info.value.detail)
+    assert len(released) == 1
+
+
+# ---------------------------------------------------------------------------
+# The fresh-resolution branch reaches the port too
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fresh_resolution_also_reaches_the_port() -> None:
+    """``ctx.resolved_provider`` unset (the gate could not parse the selector) still asks."""
+    port = RecordingPort(
+        credential=HostedCredential(api_key="hosted-key", api_base=None, response_provider="openai")
+    )
+    result = await _dispatch(_ctx(resolved_provider=None), port)
+    assert result.kwargs == {"api_key": "hosted-key"}
+    assert len(port.calls) == 1

--- a/tests/unit/test_provider_instances.py
+++ b/tests/unit/test_provider_instances.py
@@ -14,7 +14,9 @@ from gateway.core.config import GatewayConfig, ModelCapabilityConfig, provider_c
 from gateway.log_config import logger as gateway_logger
 from gateway.services.model_capabilities import resolve_capabilities
 from gateway.services.provider_kwargs import (
+    _AMBIENT_CREDENTIAL_PROVIDERS,
     _KEYLESS_PLACEHOLDER_API_KEY,
+    _KEYLESS_SELF_HOSTED_PROVIDERS,
     get_provider_kwargs,
     keyless_placeholder_api_key,
     normalize_pricing_key,
@@ -226,6 +228,61 @@ def test_credential_env_names_empty_for_keyless_backends() -> None:
 def test_credential_env_names_none_for_unknown_provider() -> None:
     # Not "keyless": unknowable, which callers treat as no basis for a warning.
     assert provider_credential_env_names("not-a-real-provider") is None
+
+
+# Providers that override `_verify_and_set_api_key` and still genuinely require a
+# credential, so `credential_ladder_exhausted` is right to treat them as keyed.
+# gemini raises `MissingApiKeyError` when neither GEMINI_API_KEY nor
+# GOOGLE_API_KEY resolves; azure and azureopenai tolerate a missing key only for
+# an Entra ID deployment, which still needs an endpoint from config and so never
+# reaches the port with empty kwargs.
+_KEYED_DESPITE_OVERRIDING = frozenset({"gemini", "azure", "azureopenai"})
+
+
+def test_the_uncredentialed_provider_roster_has_not_drifted() -> None:
+    """Pin which providers any-llm calls without a credential otari can see.
+
+    `credential_ladder_exhausted` decides whether a candidate that resolved no
+    credential is genuinely unserved, and a wrong answer is not visible from
+    otari: on a build with an overlay bound to `ModelProviderPort` it silently
+    routes a working self-hosted or IAM-authenticated request to somebody else's
+    fleet. `provider_credential_env_names` cannot answer it, because it sees the
+    *declaration* and these providers declare a variable they do not insist on,
+    so the two sets are written out by hand in `provider_kwargs.py`.
+
+    This is the drift guard for both directions, which is why it asserts on the
+    whole roster rather than only on the names already listed. A provider that
+    stops overriding fails here (it now demands a key, and treating it as keyless
+    would break it); more importantly, an any-llm release that adds a *new*
+    keyless provider also fails here, instead of leaving a request that works
+    today quietly claimed by a fleet. Either way the fix is a human deciding
+    which set the name belongs in.
+
+    It reads a private method because that is where the fact lives: the public
+    surface reports the declaration, and the declaration is what misleads.
+    """
+    overriding = {
+        provider.value
+        for provider in LLMProvider
+        if AnyLLM.get_provider_class(provider.value)._verify_and_set_api_key is not AnyLLM._verify_and_set_api_key
+    }
+    # The `()`-declaring providers are handled by `provider_credential_env_names`
+    # itself and need no hand-written entry, so they are expected here but not in
+    # either set.
+    declares_nothing = {name for name in overriding if provider_credential_env_names(name) == ()}
+    classified = _KEYLESS_SELF_HOSTED_PROVIDERS | _AMBIENT_CREDENTIAL_PROVIDERS | _KEYED_DESPITE_OVERRIDING
+
+    assert overriding - declares_nothing == classified, (
+        "any-llm's uncredentialed-provider roster changed. Every provider overriding "
+        "_verify_and_set_api_key must be classified in provider_kwargs.py "
+        "(_KEYLESS_SELF_HOSTED_PROVIDERS / _AMBIENT_CREDENTIAL_PROVIDERS) or here "
+        "(_KEYED_DESPITE_OVERRIDING). Unclassified names are treated as keyed, which is "
+        "the direction that hands a working request to a hosted fleet."
+    )
+    # And nothing in either set has quietly started demanding a key.
+    for name in _KEYLESS_SELF_HOSTED_PROVIDERS | _AMBIENT_CREDENTIAL_PROVIDERS:
+        assert provider_credential_env_names(name), f"{name} no longer declares a credential variable"
+        assert name in overriding, f"any-llm now unconditionally requires a credential for {name}"
 
 
 def test_validate_rejects_instance_name_with_separator() -> None:


### PR DESCRIPTION
## Description

Otari can be extended by an outside build that plugs its own pieces into named slots. One of those slots is "where do the credentials come from when a request brings none of its own", and #756 built the slot but nothing ever looked in it, so a build that filled it correctly would still never be asked. This PR adds the question.

When a request names a model and the gateway cannot find any key for it, whether from the organization's own stored key, a provider configured in the dashboard, the config file, or the provider's own environment variable, it now asks the slot whether this particular build can serve the request from inference capacity the deployment itself owns. Otari's own answer is always "no", so a plain install behaves exactly as it did before, down to the same error for the same request. A build that supplies its own answer gets its credentials used, and the request is billed and logged against whichever upstream actually served it. If that build says the organization is not allowed to use that upstream, the caller gets a plain refusal that says nothing about how the decision was made, and the budget hold taken earlier in the request is given back.

**Where the call went, and why.** The issue left this open between `services/provider_kwargs.py` and `api/routes/_pipeline.py`. It went in `_pipeline.py`:

1. `provider_kwargs.py` cannot host it. `provider_store_service.py`'s docstring already states the constraint: "Resolution has to stay synchronous. `get_provider_kwargs` and `resolve_provider_selector` read `config.providers` directly and are called from the streaming hot path, which has no database session." That is the reason stored providers are an in-memory overlay rather than a lookup. Every port method is `async` and a port factory takes a session, so putting the call there would mean making the whole ladder async and re-entering it from `routing/knn.py`, `routing/decide.py`, `routing/compiler.py`, and the CLI.
2. The port keys its access decision on `organization_id`. `provider_kwargs.py` never sees one; `_pipeline.py` resolved it in the preamble already.
3. `resolve_dispatch_provider` is the single funnel all three standalone completion routes use for dispatch, so one call site covers chat, messages, and responses.

**Precedence is unchanged.** A new predicate, `credential_ladder_exhausted`, gates the call: the port is asked only when `get_provider_kwargs` produced nothing at all *and* the provider's own SDK environment variable is unset. It reuses the same env check the keyless placeholder makes, so both agree on what counts as a credential already in hand. BYO is resolved upstream and never displaced.

**Deliberately out of scope, and stated rather than silent:** a routed multi-candidate plan does not reach the port. Those candidates are credentialed by `routing/compiler.py`, which is synchronous and documented as doing no I/O, so what `resolve_dispatch_provider` returns is not what they are called with. Asking anyway would meter a resolve whose answer is discarded, so the code skips it explicitly and says so. `_passthrough.py` and `batches.py` are likewise untouched. Reaching the port from the compiler is separate work.

Three refusals the call site owns, each non-leaky: `HostedAccessDeniedError` becomes a 403 carrying the same detail an organization-scoped model restriction already uses, with the reservation refunded before it surfaces; `None` leaves the candidate exactly as it was; and an adapter naming an upstream any-llm does not implement is a defect in that build, logged in full and surfaced as a generic 502.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #757

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Tests: `tests/unit/test_hosted_credential_port.py` covers the plain build through the real `build_container()` binding, all four ways a BYO credential keeps the port unasked (config.yml, an organization-scoped key, the provider SDK env var, and a request with no organization), both refusals, alias preservation, and the multi-candidate skip. `tests/integration/test_hosted_credential_request_path.py` boots two real apps from one config, one with an `OTARI_BOOTSTRAP` overlay binding a fleet adapter and one without, and compares what reaches any-llm: `together:gpt-4o` with the fleet key and base versus `openai:gpt-4o` uncredentialed.

Also ran the full unit suite (2332 passed, 8 skipped), the full integration suite (1662 passed, 9 skipped), the OSS-edition smoke script, `make lint`, `make typecheck`, `make openapi-check` and `make postman-check`. The API contract did not change: the new route dependency injects no parameters, so the regenerated spec is byte-identical and neither generated artifact moved.

Docs: `ARCHITECTURE.md`'s "Where the ports are today" callout said nothing on the request path calls a port, which is no longer true; it now names both ports that have callers and the routed-chain gap. `src/gateway/AGENTS.md` gains the last rung of the credential ladder next to the runtime credential stores it sits below.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5, via the Claude Code CLI.

**Any additional AI details you'd like to share:**

Coordinated with the session on #758 (the dashboard entitlement seam, also following #756) to keep the vocabulary disjoint: "hosted credential" and "hosted inference" stay on the `ModelProviderPort` side, using the port's own wording from #756, and "entitlement" and "capability" stay on the `EntitlementPort` side. No files overlap.

One judgement worth flagging for review: a resolved credential re-keys `ResolvedProvider.instance` onto `response_provider`, because the port documents that field as the upstream usage and telemetry name. The pricing and budget gates ran earlier in the preamble against the name the caller asked for, so an overlay whose `response_provider` differs from the public name owes a pricing row for the upstream. That is the same property a routing fallover to a differently priced candidate already has, but it is a real consequence rather than an oversight.

- [x] I am an AI Agent filling out this form (check box if true)

_Note: this pull request description was drafted by Claude Opus 5 via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._
