### PR TITLE
fix(guardrails): let a mandated endpoint's failure follow its own on_unavailable setting

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -297,6 +297,10 @@ Tenancy above users and keys; see [Access control](access-control.md#organizatio
 | `POST` | `/v1/organizations/me/pricing` | Set the organization's rate for a model over a period. | Master key |
 | `PUT` | `/v1/organizations/me/pricing/{pricing_id}` | Replace an override's rates and period. | Master key |
 | `DELETE` | `/v1/organizations/me/pricing/{pricing_id}` | Remove an override, returning the model to the deployment price list. | Master key |
+| `GET` | `/v1/organizations/me/guardrails` | List the guardrails the organization mandates over its workspaces, paged. | Master key |
+| `POST` | `/v1/organizations/me/guardrails` | Mandate a guardrail, optionally with an endpoint and credential of its own. | Master key |
+| `PATCH` | `/v1/organizations/me/guardrails/{guardrail_id}` | Change an entry's profile, endpoint, credential, modes, or scope. | Master key |
+| `DELETE` | `/v1/organizations/me/guardrails/{guardrail_id}` | Stop mandating a guardrail, discarding its credential and scope. | Master key |
 | `POST` | `/v1/organizations/me/member-invitations` | Invite a member by email; emails an accept link if mail is configured. | Master key |
 | `DELETE` | `/v1/organizations/me/member-invitations/{invitation_id}` | Revoke an unaccepted invitation (cancels it, suspends the membership). | Master key |
 

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -48,6 +48,13 @@ configured, malformed response) **fails closed**: the request is rejected with a
 `502` rather than forwarded unchecked. A `monitor` guardrail fails open, since it
 was never enforcing.
 
+A mandated entry whose endpoint fails its safety check counts as unevaluable
+too, and takes the same two paths. That covers a host that has stopped
+resolving, so an organization's endpoint going away is an outage of that entry
+rather than a refusal of every request scoped to it. A `url` you send in the
+request body is different: it is yours to fix, so a URL that fails the check is
+a `400` naming what was wrong with it.
+
 Set `"on_unavailable": "monitor"` on an entry to trade that enforcement for
 availability: the request is served and the check is recorded as inconclusive.
 `"on_unavailable": "block"` is the default and the pre-existing behavior. An

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -96,7 +96,12 @@ owner/admin or an owner/admin of that workspace.
 - `enabled: false` keeps the row and its token but takes the server out of
   every request that names it.
 - The URL is checked for SSRF safety when it is stored as well as when a
-  request uses it, and must be `https://` when a token is set.
+  request uses it, and must be `https://` when a token is set. A stored URL that
+  passes the first check and fails the second, because the host it resolves to
+  moved, refuses the request with a `500`: the endpoint is a workspace setting
+  the caller cannot see or fix, so the reason goes to the log rather than into
+  the response. A URL sent in the request body is yours to fix and still fails
+  with a `400` naming what was wrong with it.
 - A workspace may configure up to 50 servers.
 
 In hybrid mode these routes are not mounted: the servers live in otari.ai and

--- a/src/gateway/api/routes/_helpers.py
+++ b/src/gateway/api/routes/_helpers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException, Request, Response, status
@@ -262,6 +262,7 @@ async def apply_input_guardrails(
     response: Response,
     config: GatewayConfig | None = None,
     credentials: Mapping[str, str] | None = None,
+    mandated: Collection[str] | None = None,
 ) -> None:
     """Enforce the input guardrails for a request before the provider call.
 
@@ -271,7 +272,11 @@ async def apply_input_guardrails(
     the merge happens so every completion endpoint enforces a mandate alike).
     ``credentials`` carries the bearer credential an organization entry stores
     for the endpoint it names, keyed by profile; it never comes from the request
-    body.
+    body. ``mandated`` names the profiles a layer above the caller supplied,
+    which is what decides whether a URL that fails its safety check is the
+    caller's malformed request (a 400 naming their own URL) or a stored entry
+    being unevaluable (governed by its ``mode`` / ``on_unavailable``, with the
+    endpoint kept out of the response).
 
     No-op when ``guardrails`` is empty/None (zero overhead for the common
     case). On a ``block``-mode flag, raises ``403`` and the provider is never
@@ -293,8 +298,9 @@ async def apply_input_guardrails(
         bytes are streamed).
 
     Raises:
-        HTTPException: ``400`` when a guardrail's ``url`` override fails the
-            SSRF/scheme safety check; ``403`` when a ``block`` guardrail flags
+        HTTPException: ``400`` when a *caller-supplied* guardrail's ``url``
+            fails the SSRF/scheme safety check (a mandated entry's failure is a
+            502 or a recorded inconclusive instead, per its own settings); ``403`` when a ``block`` guardrail flags
             the input; ``502`` when a ``block`` guardrail that fails closed can't
             be evaluated. The 502 body names the profile and not the endpoint,
             which goes to the log instead.
@@ -307,7 +313,13 @@ async def apply_input_guardrails(
     # override mutates config, so it hot-applies on the next request.
     default_url = (config.guardrails_url if config is not None else None) or otari_env("GUARDRAILS_URL") or None
     try:
-        verdict = await run_input_guardrails(guardrails, input_text, default_url=default_url, credentials=credentials)
+        verdict = await run_input_guardrails(
+            guardrails,
+            input_text,
+            default_url=default_url,
+            credentials=credentials,
+            mandated=mandated,
+        )
     except UnsafeURLError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except GuardrailsNotReachableError as exc:
@@ -340,8 +352,5 @@ async def apply_input_guardrails(
         # Non-blocking: surface the verdict for observability (monitor mode, or
         # a passing block-mode check). Header value is kept compact and free of
         # the freeform `explanation` to avoid oversized / non-ASCII headers.
-        summary = [
-            {"profile": r.profile, "mode": r.mode, "valid": r.valid, "score": r.score}
-            for r in verdict.results
-        ]
+        summary = [{"profile": r.profile, "mode": r.mode, "valid": r.valid, "score": r.score} for r in verdict.results]
         response.headers[GUARDRAILS_RESULT_HEADER] = json.dumps(summary, separators=(",", ":"))

--- a/src/gateway/api/routes/_helpers.py
+++ b/src/gateway/api/routes/_helpers.py
@@ -300,10 +300,11 @@ async def apply_input_guardrails(
     Raises:
         HTTPException: ``400`` when a *caller-supplied* guardrail's ``url``
             fails the SSRF/scheme safety check (a mandated entry's failure is a
-            502 or a recorded inconclusive instead, per its own settings); ``403`` when a ``block`` guardrail flags
-            the input; ``502`` when a ``block`` guardrail that fails closed can't
-            be evaluated. The 502 body names the profile and not the endpoint,
-            which goes to the log instead.
+            502 or a recorded inconclusive instead, per its own settings);
+            ``403`` when a ``block`` guardrail flags the input; ``502`` when a
+            ``block`` guardrail that fails closed can't be evaluated. The 502
+            body names the profile and not the endpoint, which goes to the log
+            instead.
     """
     if not guardrails:
         return
@@ -352,5 +353,8 @@ async def apply_input_guardrails(
         # Non-blocking: surface the verdict for observability (monitor mode, or
         # a passing block-mode check). Header value is kept compact and free of
         # the freeform `explanation` to avoid oversized / non-ASCII headers.
-        summary = [{"profile": r.profile, "mode": r.mode, "valid": r.valid, "score": r.score} for r in verdict.results]
+        summary = [
+            {"profile": r.profile, "mode": r.mode, "valid": r.valid, "score": r.score}
+            for r in verdict.results
+        ]
         response.headers[GUARDRAILS_RESULT_HEADER] = json.dumps(summary, separators=(",", ":"))

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -1643,11 +1643,27 @@ def _overlay_mandate(merged: dict[str, GuardrailConfig], mandated: Iterable[Guar
         )
 
 
+@dataclass(frozen=True)
+class EffectiveGuardrails:
+    """The guardrails a request runs, and what the runner needs to know about them.
+
+    Three fields rather than a list, because two of the three answer questions
+    the list cannot: which entries carry a credential, and which came from a
+    layer the caller does not control. The second decides how a URL that fails
+    its safety check is reported, so it has to survive the merge rather than be
+    re-derived from a config the merge has already flattened.
+    """
+
+    configs: list[GuardrailConfig] | None
+    credentials: dict[str, str]
+    mandated: frozenset[str]
+
+
 def merge_guardrail_layers(
     ctx: RequestContext,
     requested: list[GuardrailConfig] | None,
     organization: Sequence[ResolvedOrganizationGuardrail],
-) -> tuple[list[GuardrailConfig] | None, dict[str, str]]:
+) -> EffectiveGuardrails:
     """The effective guardrails for this request, and the credentials they need.
 
     Three layers fold in one order, each able to add a check or tighten one and
@@ -1663,26 +1679,29 @@ def merge_guardrail_layers(
     secret on would be sending it somewhere it was never meant for.
 
     Returns the caller's own list unchanged, `None` included, when no layer
-    mandated anything, alongside an empty credential map: that is the shape
+    mandated anything, alongside an empty credential map and an empty mandated set: that is the shape
     `apply_input_guardrails` treats as "no guardrails ran", and it is what keeps
     a deployment that configures nothing behaving exactly as it did.
     """
-    mandated = ctx.plan.guardrails if ctx.plan is not None else []
-    if not organization and not mandated:
-        return requested, {}
+    policy = ctx.plan.guardrails if ctx.plan is not None else []
+    if not organization and not policy:
+        return EffectiveGuardrails(requested, {}, frozenset())
 
     # Caller entries first, so a mandating layer of the same profile overwrites them.
     merged: dict[str, GuardrailConfig] = {guardrail.profile: guardrail for guardrail in requested or []}
     credentials: dict[str, str] = {}
+    mandated: set[str] = set()
     for entry in organization:
         _overlay_mandate(merged, (entry.config,))
+        mandated.add(entry.config.profile)
         if entry.credential:
             credentials[entry.config.profile] = entry.credential
-    if mandated:
-        _overlay_mandate(merged, mandated)
-        for guardrail in mandated:
+    if policy:
+        _overlay_mandate(merged, policy)
+        for guardrail in policy:
+            mandated.add(guardrail.profile)
             credentials.pop(guardrail.profile, None)
-    return list(merged.values()), credentials
+    return EffectiveGuardrails(list(merged.values()), credentials, frozenset(mandated))
 
 
 async def _resolve_organization_guardrails(
@@ -1810,15 +1829,14 @@ async def prepare_gateway_tools(
         # rather than at each route, so every completion endpoint enforces a
         # mandate identically and none can forget to. `guardrails` as passed is
         # the caller's own list.
-        effective_guardrails, guardrail_credentials = merge_guardrail_layers(
-            ctx, guardrails, await _resolve_organization_guardrails(adapter, ctx)
-        )
+        effective = merge_guardrail_layers(ctx, guardrails, await _resolve_organization_guardrails(adapter, ctx))
         await apply_input_guardrails(
-            effective_guardrails,
+            effective.configs,
             guardrail_text,
             response=response,
             config=ctx.config,
-            credentials=guardrail_credentials,
+            credentials=effective.credentials,
+            mandated=effective.mandated,
         )
 
         if mcp_server_ids:
@@ -2032,10 +2050,10 @@ async def prepare_gateway_tools(
         await release_reservation(ctx)
         raise
     except SQLAlchemyError:
-        # Four reads in this block touch the database (the workspace MCP servers,
-        # the workspace code-execution policy and the workspace web-search
-        # configuration above, and `_require_tool_pricing`), and a failure in any
-        # of them is not an
+        # Five reads in this block touch the database (the organization's
+        # guardrails, the workspace MCP servers, the workspace code-execution
+        # policy and the workspace web-search configuration above, and
+        # `_require_tool_pricing`), and a failure in any of them is not an
         # `HTTPException`, so without this arm it would leave `users.reserved`
         # holding the estimate until the budget's next reset, or forever for a
         # budget with no reset period. The rollback comes first because a failed

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -1679,9 +1679,10 @@ def merge_guardrail_layers(
     secret on would be sending it somewhere it was never meant for.
 
     Returns the caller's own list unchanged, `None` included, when no layer
-    mandated anything, alongside an empty credential map and an empty mandated set: that is the shape
-    `apply_input_guardrails` treats as "no guardrails ran", and it is what keeps
-    a deployment that configures nothing behaving exactly as it did.
+    mandated anything, alongside an empty credential map and an empty mandated
+    set: that is the shape `apply_input_guardrails` treats as "no guardrails
+    ran", and it is what keeps a deployment that configures nothing behaving
+    exactly as it did.
     """
     policy = ctx.plan.guardrails if ctx.plan is not None else []
     if not organization and not policy:

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -210,6 +210,7 @@ API_KEY_VALIDATION_FAILED_DETAIL = "API key validation failed"
 API_KEY_NO_USER_DETAIL = "API key has no associated user"
 MCP_SERVER_IDS_UNAVAILABLE_DETAIL = "mcp_server_ids is unavailable for this request"
 MCP_SERVER_TOKEN_UNREADABLE_DETAIL = "A configured MCP server's authorization token could not be read"
+MCP_SERVER_URL_UNSAFE_DETAIL = "A configured MCP server's URL failed its safety check"
 NO_RESOLVABLE_PROVIDER_DETAIL = "Authorization service returned no resolvable provider"
 PROVIDER_ERROR_DETAIL = "LLM provider error"
 PROVIDER_TIMEOUT_DETAIL = "LLM provider timeout"
@@ -1586,11 +1587,32 @@ class ToolContext:
         return bool(self.mcp_server_configs) or self.use_sandbox or self.use_web_search
 
 
-async def _validate_mcp_server_urls(adapter: FormatAdapter[Any, Any], mcp_servers: list[McpServerConfig]) -> None:
-    """SSRF/scheme safety check for every MCP server URL in this request.
+async def _validate_mcp_server_urls(
+    adapter: FormatAdapter[Any, Any],
+    mcp_servers: list[McpServerConfig],
+    *,
+    stored: bool = False,
+    workspace_id: uuid.UUID | None = None,
+) -> None:
+    """SSRF/scheme safety check for the MCP server URLs in this request.
 
-    Covers both request-body-supplied servers and platform-resolved ones
-    (``mcp_server_ids``): both land in the same merged list before this runs.
+    Called once per source rather than over the merged list, because a failure
+    means different things for the two and the caller is owed a different
+    answer:
+
+    * A **request-body** server is the caller's own, so a rejection is their
+      malformed request and the reason travels back to them, naming the URL they
+      sent. That is the pre-existing behavior.
+    * A **stored** server (resolved from ``mcp_server_ids``) is workspace
+      configuration the caller can neither see nor fix, and the rejection names
+      the host and the range it resolved into. ``routes/workspace_mcp_servers``
+      gates even the *read* of those rows behind the master key, on the grounds
+      that they name the endpoints this gateway connects to, so echoing one to
+      any key holder gives away what that gate is there to withhold. It answers
+      the way an unreadable stored token already does: a fixed 500 detail, with
+      the reason and the workspace in the log, since a stored endpoint that
+      fails its check is the operator's problem and not the caller's.
+
     Runs concurrently since each check does an independent DNS lookup;
     ``asyncio.gather`` (default ``return_exceptions=False``) propagates the
     first ``UnsafeURLError`` it sees as soon as it's raised. Note this does
@@ -1613,7 +1635,10 @@ async def _validate_mcp_server_urls(adapter: FormatAdapter[Any, Any], mcp_server
             )
         )
     except UnsafeURLError as exc:
-        raise adapter.error(400, str(exc), ErrorKind.INVALID_REQUEST) from exc
+        if not stored:
+            raise adapter.error(400, str(exc), ErrorKind.INVALID_REQUEST) from exc
+        logger.error("Configured MCP server URL failed its safety check for workspace %s: %s", workspace_id, exc)
+        raise adapter.error(500, MCP_SERVER_URL_UNSAFE_DETAIL, ErrorKind.API) from exc
 
 
 def _overlay_mandate(merged: dict[str, GuardrailConfig], mandated: Iterable[GuardrailConfig]) -> None:
@@ -1840,11 +1865,17 @@ async def prepare_gateway_tools(
             mandated=effective.mandated,
         )
 
-        if mcp_server_ids:
-            mcp_servers = (mcp_servers or []) + await _resolve_mcp_server_ids(adapter, ctx, mcp_server_ids)
-
+        # Checked per source, not over the merged list: see
+        # `_validate_mcp_server_urls` for why a stored server's rejection cannot
+        # carry the same body a caller's own does.
         if mcp_servers:
             await _validate_mcp_server_urls(adapter, mcp_servers)
+        if mcp_server_ids:
+            stored_servers = await _resolve_mcp_server_ids(adapter, ctx, mcp_server_ids)
+            await _validate_mcp_server_urls(
+                adapter, stored_servers, stored=True, workspace_id=ctx.workspace_id
+            )
+            mcp_servers = (mcp_servers or []) + stored_servers
 
         sandbox_tool_entry, tools_after_sandbox = _extract_code_execution_tool(tools)
         # Read the effective config value (dashboard override / env / YAML), falling

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -1643,7 +1643,7 @@ class OrganizationGuardrail(Base):
     # and the scope rows below are not consulted. False means it runs only in
     # the workspaces named there, and a new workspace inherits nothing.
     applies_to_all_workspaces: Mapped[bool] = mapped_column(default=False, nullable=False)
-    # ``UtcDateTime`` for the reason its neighbours use it: these are serialized
+    # ``UtcDateTime`` for the reason its neighbors use it: these are serialized
     # with ``.isoformat()`` for the dashboard, and a plain ``DateTime(timezone=True)``
     # round-trips naive on SQLite.
     created_at: Mapped[datetime] = mapped_column(UtcDateTime(), default=lambda: datetime.now(UTC))

--- a/src/gateway/services/guardrails.py
+++ b/src/gateway/services/guardrails.py
@@ -208,8 +208,12 @@ async def run_input_guardrails(
     even though it isn't evaluated yet. This intentionally preserves the
     coverage the removed parse-time Pydantic validator had (see
     :mod:`gateway.models.guardrails`): when output enforcement is built, its
-    code path can assume the URL was already validated instead of needing to
-    remember to add the check itself.
+    code path can assume a *caller's* URL was already validated instead of
+    needing to remember to add the check itself. A ``mandated`` entry's failure
+    is the exception, because it is not an outright rejection: it is held until
+    the per-entry loop below reaches that profile, so an output-only mandate's
+    failure has nowhere to land yet and is dropped. Output enforcement has to
+    consume it the way the input loop does rather than assume it never happened.
 
     Failure handling depends on the guardrail's ``mode`` and its
     ``on_unavailable``:
@@ -306,14 +310,21 @@ async def run_input_guardrails(
                     input_text=input_text,
                     credential=credentials.get(cfg.profile),
                 )
-            except GuardrailsNotReachableError:
+            except GuardrailsNotReachableError as exc:
                 if cfg.mode == "block" and cfg.on_unavailable == "block":
                     raise  # fail closed: an enforcing guardrail must not be skipped
+                # The reason belongs here and nowhere else: the fail-closed arm
+                # above hands its message to `apply_input_guardrails`, which logs
+                # it, but this arm serves the request, so this line is the only
+                # record that a check an organization mandated did not run. It
+                # names the endpoint for the same reason that one does, and for
+                # the same audience.
                 logger.warning(
-                    "guardrail %r could not be evaluated (mode=%s on_unavailable=%s); failing open",
+                    "guardrail %r could not be evaluated (mode=%s on_unavailable=%s); failing open: %s",
                     cfg.profile,
                     cfg.mode,
                     cfg.on_unavailable,
+                    exc,
                 )
                 results.append(
                     GuardrailResult(

--- a/src/gateway/services/guardrails.py
+++ b/src/gateway/services/guardrails.py
@@ -27,13 +27,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass, field
 
 import httpx
 
 from gateway.models.guardrails import GuardrailConfig
-from gateway.services.url_safety import validate_mcp_url
+from gateway.services.url_safety import UnsafeURLError, validate_mcp_url
 
 logger = logging.getLogger(__name__)
 
@@ -174,8 +174,21 @@ async def run_input_guardrails(
     *,
     default_url: str | None,
     credentials: Mapping[str, str] | None = None,
+    mandated: Collection[str] | None = None,
 ) -> GuardrailVerdict:
     """Run every input-direction guardrail and return the aggregate verdict.
+
+    ``mandated`` names the profiles that came from a layer above the caller (an
+    organization entry or a routing policy) rather than from the request body.
+    It decides what an unsafe or unresolvable URL *means*, which is not the same
+    question for the two sources: a caller who sent a bad URL sent a malformed
+    request and is told so, while a mandated entry's URL is stored
+    configuration the caller cannot see or fix, so failing to validate it is the
+    guardrail being unevaluable and is governed by ``mode`` and
+    ``on_unavailable`` like any other evaluation failure. Without this a
+    transient DNS failure on an organization's endpoint refused every request
+    from every workspace it was scoped to, including entries explicitly
+    configured to fail open.
 
     ``credentials`` maps a profile name to the bearer credential its entry
     carries, and is populated only for guardrails an organization mandates
@@ -222,26 +235,48 @@ async def run_input_guardrails(
         GuardrailsNotReachableError: if a ``block``-mode guardrail with
             ``on_unavailable="block"`` can't be evaluated.
     """
-    # A caller-supplied `url` override is SSRF-checked here rather than at
-    # request-body-parse time (the check does a DNS lookup that must be
-    # awaited). Covers every configured guardrail regardless of `on`
-    # direction (see docstring above): deliberately runs before the
-    # input-only filter/early-return below, so an output-only guardrail's
-    # url is validated even though it isn't evaluated yet. Unlike
-    # GuardrailsNotReachableError below, an unsafe URL is a malformed
-    # request, not a runtime failure: it always rejects the request
-    # (mode-independent) via UnsafeURLError, which this function
-    # deliberately does not catch; the caller (apply_input_guardrails)
-    # maps it to a 400.
+    # A `url` override is SSRF-checked here rather than at request-body-parse
+    # time (the check does a DNS lookup that must be awaited). Covers every
+    # configured guardrail regardless of `on` direction (see docstring above):
+    # deliberately runs before the input-only filter/early-return below, so an
+    # output-only guardrail's url is validated even though it isn't evaluated
+    # yet.
+    #
+    # What a failure *means* then depends on where the URL came from.
+    # `return_exceptions=True` is what lets that be decided per entry rather
+    # than by whichever check happened to fail first:
+    #
+    # * A caller's own URL is a malformed request, so it rejects the request
+    #   mode-independently and the reason travels back to them. That is the
+    #   pre-existing behavior and the message names a host they supplied.
+    # * A *mandated* entry's URL is stored configuration the caller can neither
+    #   see nor fix, so the same failure is the guardrail being unevaluable and
+    #   goes through the `mode` / `on_unavailable` handling below. Its message
+    #   names an endpoint an organization configured, so it stays out of the
+    #   response for the same reason the 502 path keeps it out (otari#654).
+    #
+    # Either way the unsafe endpoint is never actually called.
     credentials = credentials or {}
+    mandated = frozenset(mandated or ())
+    unsafe: dict[str, UnsafeURLError] = {}
     if guardrails:
-        await asyncio.gather(
+        # Paired with its URL rather than filtered in place, so what reaches
+        # `validate_mcp_url` is a `str` and not a `str | None` narrowed by
+        # inspection.
+        checked = [(g.profile, g.url) for g in guardrails if g.url is not None]
+        outcomes = await asyncio.gather(
             *(
-                validate_mcp_url(g.url, has_authorization_token=bool(credentials.get(g.profile)))
-                for g in guardrails
-                if g.url is not None
-            )
+                validate_mcp_url(url, has_authorization_token=bool(credentials.get(profile)))
+                for profile, url in checked
+            ),
+            return_exceptions=True,
         )
+        for (profile, _), outcome in zip(checked, outcomes, strict=True):
+            if not isinstance(outcome, BaseException):
+                continue
+            if not isinstance(outcome, UnsafeURLError) or profile not in mandated:
+                raise outcome
+            unsafe[profile] = outcome
 
     input_guardrails = [g for g in guardrails if "input" in g.on]
     if not input_guardrails:
@@ -252,6 +287,12 @@ async def run_input_guardrails(
         for cfg in input_guardrails:
             base_url = (cfg.url or default_url or "").rstrip("/")
             try:
+                if (unsafe_url := unsafe.get(cfg.profile)) is not None:
+                    raise GuardrailsNotReachableError(
+                        f"guardrail profile {cfg.profile!r} names an endpoint that failed the "
+                        f"safety check: {unsafe_url}",
+                        public_detail=_unevaluated_detail(cfg.profile),
+                    )
                 if not base_url:
                     raise GuardrailsNotReachableError(
                         f"guardrail profile {cfg.profile!r} requested but no guardrails service is "

--- a/src/gateway/services/tenancy/organization_guardrail_service.py
+++ b/src/gateway/services/tenancy/organization_guardrail_service.py
@@ -730,14 +730,12 @@ class OrganizationGuardrailService:
         `workspace_code_execution_policy_service._commit`: SQLAlchemy leaves a
         session with a failed flush unusable, so a caller that skips the
         rollback gets ``PendingRollbackError`` from the next statement instead
-        of the error that actually happened. ``IntegrityError`` is re-raised for
-        the unique-profile handling above, after the rollback.
+        of the error that actually happened. Everything is re-raised after the
+        rollback, ``IntegrityError`` included, which is what the unique-profile
+        handling above catches.
         """
         try:
             await self.db.commit()
-        except IntegrityError:
-            await self.db.rollback()
-            raise
         except Exception:
             await self.db.rollback()
             raise

--- a/tests/integration/test_organization_guardrail_enforcement.py
+++ b/tests/integration/test_organization_guardrail_enforcement.py
@@ -10,6 +10,7 @@ all, what it was sent, and what the verdict did to the request.
 
 from __future__ import annotations
 
+import ipaddress
 import json
 from collections.abc import Iterator
 from typing import Any, cast
@@ -244,6 +245,53 @@ def test_a_request_whose_tenancy_will_not_resolve_is_refused_rather_than_uncheck
     detail = response.json()["detail"]
     assert detail["error"]["message"] == "Organization guardrails could not be resolved for this request"
     assert guardrails.calls == [], "and the provider was never reached either"
+
+
+def test_an_endpoint_that_stops_resolving_honors_the_entrys_own_fail_open(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    master_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A DNS blip on the organization's endpoint must not refuse every scoped request.
+
+    The URL safety check runs ahead of the per-entry loop, so an entry set to
+    serve unchecked when its service is unreachable was refusing the request
+    anyway, with a 400 that named the endpoint. Both halves are asserted here:
+    the configured fail-open holds, and nothing about the endpoint reaches the
+    caller.
+    """
+    monkeypatch.setenv("OTARI_GUARDRAILS_URL", _DEPLOYMENT_URL)
+
+    # A hostname rather than the IP literal the other cases use, because the
+    # literal never reaches a resolver. Resolvable when the entry is stored and
+    # not when the request arrives, which is the ordinary shape of this: an
+    # endpoint that was fine at configuration time and is not fine now.
+    async def resolves(_host: str) -> list[Any]:
+        return [ipaddress.ip_address("93.184.216.34")]
+
+    monkeypatch.setattr("gateway.services.url_safety._resolve_all_async", resolves)
+    _mandate(
+        client,
+        master_key_header,
+        profile="prompt-injection",
+        mode="monitor",
+        on_unavailable="monitor",
+        url="https://guardrails.internal.corp.example/validate",
+        applies_to_all_workspaces=True,
+    )
+
+    async def unresolvable(_host: str) -> list[Any]:
+        return []
+
+    monkeypatch.setattr("gateway.services.url_safety._resolve_all_async", unresolvable)
+    guardrails = _Guardrails(valid=True)
+
+    response = _post(client, api_key_header, _REQUEST, guardrails, monkeypatch)
+
+    assert response.status_code == 200, response.text
+    assert guardrails.calls == [], "and the endpoint that failed the check is never contacted"
+    assert "guardrails.internal.corp.example" not in response.text
 
 
 def test_a_monitor_entry_annotates_the_response_and_serves_it(

--- a/tests/integration/test_organization_guardrail_enforcement.py
+++ b/tests/integration/test_organization_guardrail_enforcement.py
@@ -247,7 +247,7 @@ def test_a_request_whose_tenancy_will_not_resolve_is_refused_rather_than_uncheck
     assert guardrails.calls == [], "and the provider was never reached either"
 
 
-def test_an_endpoint_that_stops_resolving_honors_the_entrys_own_fail_open(
+def test_an_entry_whose_endpoint_stops_resolving_still_honors_its_fail_open(
     client: TestClient,
     api_key_header: dict[str, str],
     master_key_header: dict[str, str],
@@ -358,7 +358,7 @@ def test_a_disabled_entry_stops_running_without_being_deleted(
     assert guardrails.calls == []
 
 
-def test_the_entrys_endpoint_and_credential_are_what_the_check_is_sent_with(
+def test_the_configured_endpoint_and_credential_are_what_the_check_is_sent_with(
     client: TestClient,
     api_key_header: dict[str, str],
     master_key_header: dict[str, str],

--- a/tests/integration/test_routing_policies.py
+++ b/tests/integration/test_routing_policies.py
@@ -552,7 +552,7 @@ def test_a_price_aimed_at_a_user_scoped_policy_is_refused_without_naming_candida
 
 
 def test_a_static_policy_resolves_on_a_non_completion_endpoint(client: TestClient) -> None:
-    """ "An alias is a one-target policy" has to be true everywhere, not just on
+    """"An alias is a one-target policy" has to be true everywhere, not just on
     the completion routes, or the two concepts are not actually the same thing.
     """
     _create_user(client)
@@ -952,7 +952,9 @@ def test_still_under_the_cap_is_a_usable_threshold(client: TestClient) -> None:
 def test_a_stored_policy_may_not_point_at_an_alias(client: TestClient) -> None:
     alias = client.post("/v1/aliases", json={"name": "cheap", "target": "openai:gpt-5-nano"}, headers=HEADERS)
     assert alias.status_code == 200, alias.text
-    resp = client.post("/v1/routing/policies", json={"name": "chained", "spec": _spec("cheap:x")}, headers=HEADERS)
+    resp = client.post(
+        "/v1/routing/policies", json={"name": "chained", "spec": _spec("cheap:x")}, headers=HEADERS
+    )
     assert resp.status_code == 400
     assert "chaining" in resp.json()["detail"]
 
@@ -985,9 +987,12 @@ def test_policy_management_requires_the_master_key(client: TestClient) -> None:
     # Only an operator may decide which models a name reaches; otherwise a caller
     # could widen their own access by writing a policy.
     assert client.get("/v1/routing/policies", headers=caller).status_code in (401, 403)
-    assert client.post(
-        "/v1/routing/policies", json={"name": "sneaky", "spec": _spec("openai:gpt-5-mini")}, headers=caller
-    ).status_code in (401, 403)
+    assert (
+        client.post(
+            "/v1/routing/policies", json={"name": "sneaky", "spec": _spec("openai:gpt-5-mini")}, headers=caller
+        ).status_code
+        in (401, 403)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1203,7 +1208,9 @@ def guarded_client(routing_config: GatewayConfig) -> Generator[TestClient]:
                     "policies": {
                         "guarded": {
                             "select": [{"default": "openai:gpt-5-mini"}],
-                            "guardrails": [{"profile": "prompt-injection", "mode": "block", "on_unavailable": "block"}],
+                            "guardrails": [
+                                {"profile": "prompt-injection", "mode": "block", "on_unavailable": "block"}
+                            ],
                         }
                     }
                 }

--- a/tests/integration/test_routing_policies.py
+++ b/tests/integration/test_routing_policies.py
@@ -552,7 +552,7 @@ def test_a_price_aimed_at_a_user_scoped_policy_is_refused_without_naming_candida
 
 
 def test_a_static_policy_resolves_on_a_non_completion_endpoint(client: TestClient) -> None:
-    """"An alias is a one-target policy" has to be true everywhere, not just on
+    """ "An alias is a one-target policy" has to be true everywhere, not just on
     the completion routes, or the two concepts are not actually the same thing.
     """
     _create_user(client)
@@ -952,9 +952,7 @@ def test_still_under_the_cap_is_a_usable_threshold(client: TestClient) -> None:
 def test_a_stored_policy_may_not_point_at_an_alias(client: TestClient) -> None:
     alias = client.post("/v1/aliases", json={"name": "cheap", "target": "openai:gpt-5-nano"}, headers=HEADERS)
     assert alias.status_code == 200, alias.text
-    resp = client.post(
-        "/v1/routing/policies", json={"name": "chained", "spec": _spec("cheap:x")}, headers=HEADERS
-    )
+    resp = client.post("/v1/routing/policies", json={"name": "chained", "spec": _spec("cheap:x")}, headers=HEADERS)
     assert resp.status_code == 400
     assert "chaining" in resp.json()["detail"]
 
@@ -987,12 +985,9 @@ def test_policy_management_requires_the_master_key(client: TestClient) -> None:
     # Only an operator may decide which models a name reaches; otherwise a caller
     # could widen their own access by writing a policy.
     assert client.get("/v1/routing/policies", headers=caller).status_code in (401, 403)
-    assert (
-        client.post(
-            "/v1/routing/policies", json={"name": "sneaky", "spec": _spec("openai:gpt-5-mini")}, headers=caller
-        ).status_code
-        in (401, 403)
-    )
+    assert client.post(
+        "/v1/routing/policies", json={"name": "sneaky", "spec": _spec("openai:gpt-5-mini")}, headers=caller
+    ).status_code in (401, 403)
 
 
 # ---------------------------------------------------------------------------
@@ -1208,9 +1203,7 @@ def guarded_client(routing_config: GatewayConfig) -> Generator[TestClient]:
                     "policies": {
                         "guarded": {
                             "select": [{"default": "openai:gpt-5-mini"}],
-                            "guardrails": [
-                                {"profile": "prompt-injection", "mode": "block", "on_unavailable": "block"}
-                            ],
+                            "guardrails": [{"profile": "prompt-injection", "mode": "block", "on_unavailable": "block"}],
                         }
                     }
                 }
@@ -1278,7 +1271,12 @@ def test_a_blocking_policy_guardrail_refuses_the_request(guarded_client: TestCli
     provider = AsyncMock(return_value=_completion("gpt-5-mini"))
 
     async def flagged(
-        guardrails: Any, input_text: str, *, default_url: str | None, credentials: Any = None
+        guardrails: Any,
+        input_text: str,
+        *,
+        default_url: str | None,
+        credentials: Any = None,
+        mandated: Any = None,
     ) -> Any:
         from gateway.services.guardrails import GuardrailResult, GuardrailVerdict
 

--- a/tests/integration/test_workspace_mcp_servers.py
+++ b/tests/integration/test_workspace_mcp_servers.py
@@ -13,6 +13,7 @@ hostname through DNS, so a test naming one would pass or fail on whether the
 runner has egress.
 """
 
+import ipaddress
 import time
 import uuid
 from collections.abc import Iterator
@@ -677,6 +678,60 @@ async def test_prepare_gateway_tools_is_unchanged_when_nothing_is_configured(asy
 
     assert tool_ctx.mcp_server_configs is not None
     assert [server.name for server in tool_ctx.mcp_server_configs] == ["inline"]
+
+
+async def test_a_stored_servers_unsafe_url_is_not_named_to_the_caller(
+    async_db: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A workspace's stored endpoint is not the caller's to see, so the refusal does not name it.
+
+    The rows are master-key gated even for reading, because they name the
+    endpoints this gateway connects to. A URL that was safe when it was stored
+    and resolves privately later would otherwise hand the host and the range it
+    landed in to any key holder, through a 400 on the completion path.
+    """
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+
+    # A hostname rather than the IP literal the other cases use, since a literal
+    # never reaches a resolver. Safe when the row is written and not when the
+    # request arrives, which is the shape this actually takes: an endpoint that
+    # was fine at configuration time and has since moved.
+    async def public(_host: str) -> list[object]:
+        return [ipaddress.ip_address("93.184.216.34")]
+
+    monkeypatch.setattr("gateway.services.url_safety._resolve_all_async", public)
+    stored = await service.create_server(
+        user=owner,
+        workspace_id=workspace.id,
+        request=_create(name="internal", url="https://mcp.internal.corp.example/mcp"),
+    )
+
+    async def private(_host: str) -> list[object]:
+        return [ipaddress.ip_address("10.11.12.13")]
+
+    monkeypatch.setattr("gateway.services.url_safety._resolve_all_async", private)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await prepare_gateway_tools(
+            adapter=chat._ADAPTER,
+            ctx=_request_context(async_db, workspace.id, organization.id),
+            response=Response(),
+            guardrails=None,
+            guardrail_text="",
+            tools=None,
+            mcp_servers=None,
+            mcp_server_ids=[stored.id],
+            max_tool_iterations=None,
+            tools_header=None,
+        )
+
+    assert exc_info.value.status_code == 500
+    detail = str(exc_info.value.detail)
+    assert "10.11.12.13" not in detail
+    assert "mcp.internal.corp.example" not in detail
 
 
 async def test_prepare_gateway_tools_refuses_an_unknown_id(async_db: AsyncSession) -> None:

--- a/tests/unit/test_attempt_walker.py
+++ b/tests/unit/test_attempt_walker.py
@@ -305,7 +305,9 @@ async def test_empty_plan_is_a_500_that_leaks_nothing() -> None:
         raise AssertionError("must not be called")
 
     with pytest.raises(HTTPException) as exc_info:
-        await walk_attempts(attempts=[], base_request_fields={}, run_attempt=run_attempt, max_tool_iterations=10)
+        await walk_attempts(
+            attempts=[], base_request_fields={}, run_attempt=run_attempt, max_tool_iterations=10
+        )
 
     assert exc_info.value.status_code == 500
     assert exc_info.value.detail == EMPTY_PLAN_DETAIL
@@ -399,7 +401,9 @@ def _request_context(plan: Any) -> Any:
 def _ctx_with_guardrails(*guardrails: Any) -> Any:
     from gateway.services.routing import CompiledPlan
 
-    return _request_context(CompiledPlan(policy_name="p", attempts=[_attempt(1, "m")], guardrails=list(guardrails)))
+    return _request_context(
+        CompiledPlan(policy_name="p", attempts=[_attempt(1, "m")], guardrails=list(guardrails))
+    )
 
 
 def _guardrail(

--- a/tests/unit/test_attempt_walker.py
+++ b/tests/unit/test_attempt_walker.py
@@ -305,9 +305,7 @@ async def test_empty_plan_is_a_500_that_leaks_nothing() -> None:
         raise AssertionError("must not be called")
 
     with pytest.raises(HTTPException) as exc_info:
-        await walk_attempts(
-            attempts=[], base_request_fields={}, run_attempt=run_attempt, max_tool_iterations=10
-        )
+        await walk_attempts(attempts=[], base_request_fields={}, run_attempt=run_attempt, max_tool_iterations=10)
 
     assert exc_info.value.status_code == 500
     assert exc_info.value.detail == EMPTY_PLAN_DETAIL
@@ -401,9 +399,7 @@ def _request_context(plan: Any) -> Any:
 def _ctx_with_guardrails(*guardrails: Any) -> Any:
     from gateway.services.routing import CompiledPlan
 
-    return _request_context(
-        CompiledPlan(policy_name="p", attempts=[_attempt(1, "m")], guardrails=list(guardrails))
-    )
+    return _request_context(CompiledPlan(policy_name="p", attempts=[_attempt(1, "m")], guardrails=list(guardrails)))
 
 
 def _guardrail(
@@ -419,52 +415,52 @@ def _guardrail(
 def test_a_mandated_guardrail_is_applied_when_the_caller_asked_for_nothing() -> None:
     from gateway.api.routes._pipeline import merge_guardrail_layers
 
-    merged, _ = merge_guardrail_layers(_ctx_with_guardrails(_guardrail("prompt-injection")), None, [])
+    merged = merge_guardrail_layers(_ctx_with_guardrails(_guardrail("prompt-injection")), None, [])
 
-    assert merged is not None
-    assert [g.profile for g in merged] == ["prompt-injection"]
-    assert merged[0].mode == "block"
+    assert merged.configs is not None
+    assert [g.profile for g in merged.configs] == ["prompt-injection"]
+    assert merged.configs[0].mode == "block"
 
 
 def test_a_caller_cannot_weaken_a_mandated_guardrail() -> None:
     from gateway.api.routes._pipeline import merge_guardrail_layers
 
-    merged, _ = merge_guardrail_layers(
+    merged = merge_guardrail_layers(
         _ctx_with_guardrails(_guardrail("prompt-injection", mode="block", on_unavailable="block")),
         [_guardrail("prompt-injection", mode="monitor", on_unavailable="monitor")],
         [],
     )
 
-    assert merged is not None and len(merged) == 1
-    assert merged[0].mode == "block"
-    assert merged[0].on_unavailable == "block"
+    assert merged.configs is not None and len(merged.configs) == 1
+    assert merged.configs[0].mode == "block"
+    assert merged.configs[0].on_unavailable == "block"
 
 
 def test_a_caller_may_tighten_a_mandated_guardrail() -> None:
     from gateway.api.routes._pipeline import merge_guardrail_layers
 
-    merged, _ = merge_guardrail_layers(
+    merged = merge_guardrail_layers(
         _ctx_with_guardrails(_guardrail("prompt-injection", mode="monitor", on_unavailable="monitor")),
         [_guardrail("prompt-injection", mode="block", on_unavailable="block")],
         [],
     )
 
-    assert merged is not None
-    assert merged[0].mode == "block"
-    assert merged[0].on_unavailable == "block"
+    assert merged.configs is not None
+    assert merged.configs[0].mode == "block"
+    assert merged.configs[0].on_unavailable == "block"
 
 
 def test_a_caller_may_add_their_own_guardrails_alongside_a_mandate() -> None:
     from gateway.api.routes._pipeline import merge_guardrail_layers
 
-    merged, _ = merge_guardrail_layers(
+    merged = merge_guardrail_layers(
         _ctx_with_guardrails(_guardrail("prompt-injection")),
         [_guardrail("pii", mode="monitor")],
         [],
     )
 
-    assert merged is not None
-    assert sorted(g.profile for g in merged) == ["pii", "prompt-injection"]
+    assert merged.configs is not None
+    assert sorted(g.profile for g in merged.configs) == ["pii", "prompt-injection"]
 
 
 def test_an_unrouted_request_keeps_exactly_the_callers_guardrails() -> None:
@@ -472,5 +468,5 @@ def test_an_unrouted_request_keeps_exactly_the_callers_guardrails() -> None:
 
     unrouted = _request_context(None)
     caller = [_guardrail("pii", mode="monitor")]
-    assert merge_guardrail_layers(unrouted, caller, []) == (caller, {})
-    assert merge_guardrail_layers(unrouted, None, []) == (None, {})
+    assert merge_guardrail_layers(unrouted, caller, []).configs is caller
+    assert merge_guardrail_layers(unrouted, None, []).configs is None

--- a/tests/unit/test_guardrails_service.py
+++ b/tests/unit/test_guardrails_service.py
@@ -6,6 +6,7 @@ Stubs the guardrails service ``POST /validate`` contract with an
 
 from __future__ import annotations
 
+import ipaddress
 import json
 from collections.abc import Callable
 
@@ -380,6 +381,40 @@ async def test_a_mandated_endpoint_failure_is_not_named_to_the_caller(monkeypatc
     assert "guardrails.internal.corp.example" in str(exc.value), "the log still gets the endpoint"
     assert "guardrails.internal.corp.example" not in exc.value.public_detail
     assert exc.value.public_detail == "guardrail profile 'pi' could not be evaluated"
+
+
+@pytest.mark.asyncio
+async def test_a_mandated_endpoint_in_a_private_range_is_never_contacted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The safety property the mode handling must not weaken.
+
+    A resolvable but unsafe endpoint takes the same path as an unresolvable one,
+    so a `monitor` entry serves the request. What it must never do is call the
+    endpoint anyway, which is what the check was there to prevent.
+    """
+    from gateway.services import url_safety
+
+    async def _private(_host: str) -> list[object]:
+        return [ipaddress.ip_address("10.1.2.3")]
+
+    monkeypatch.setattr(url_safety, "_resolve_all_async", _private)
+    called = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, json={"profile": "pi", "result": {"valid": True}})
+
+    _patch_transport(monkeypatch, handler)
+    verdict = await run_input_guardrails(
+        [GuardrailConfig(profile="pi", url=_STORED_URL, mode="monitor", on_unavailable="monitor")],
+        "x",
+        default_url=_URL,
+        mandated={"pi"},
+    )
+
+    assert verdict.blocked is False
+    assert verdict.results[0].valid is None
+    assert called is False, "the private-range endpoint must never be contacted"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_guardrails_service.py
+++ b/tests/unit/test_guardrails_service.py
@@ -319,3 +319,78 @@ async def test_the_no_url_message_survives_whole(monkeypatch: pytest.MonkeyPatch
         await run_input_guardrails([GuardrailConfig(profile="prompt-injection", mode="block")], "x", default_url=None)
 
     assert "OTARI_GUARDRAILS_URL" in exc.value.public_detail
+
+
+def _unresolvable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every hostname fail to resolve, which `validate_mcp_url` refuses."""
+    from gateway.services import url_safety
+
+    async def _fails(_host: str) -> list[object]:
+        return []
+
+    monkeypatch.setattr(url_safety, "_resolve_all_async", _fails)
+
+
+_STORED_URL = "https://guardrails.internal.corp.example/validate"
+
+
+@pytest.mark.asyncio
+async def test_a_mandated_endpoint_that_will_not_resolve_honors_its_own_fail_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A DNS blip on an organization's endpoint must not refuse the request it was told to serve.
+
+    The URL check runs ahead of the per-entry loop, so before otari#654 threaded
+    `mandated` through, an `UnsafeURLError` bypassed `mode` / `on_unavailable`
+    entirely and every request from every scoped workspace got a 400.
+    """
+    _unresolvable(monkeypatch)
+    called = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, json={"profile": "pi", "result": {"valid": True}})
+
+    _patch_transport(monkeypatch, handler)
+    verdict = await run_input_guardrails(
+        [GuardrailConfig(profile="pi", url=_STORED_URL, mode="monitor", on_unavailable="monitor")],
+        "x",
+        default_url=_URL,
+        mandated={"pi"},
+    )
+
+    assert verdict.blocked is False
+    assert verdict.results[0].valid is None, "recorded as inconclusive, not as a pass"
+    assert called is False, "and the endpoint that failed the check is never contacted"
+
+
+@pytest.mark.asyncio
+async def test_a_mandated_endpoint_failure_is_not_named_to_the_caller(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail-closed still refuses, without disclosing an endpoint the caller never chose."""
+    _unresolvable(monkeypatch)
+    with pytest.raises(GuardrailsNotReachableError) as exc:
+        await run_input_guardrails(
+            [GuardrailConfig(profile="pi", url=_STORED_URL, mode="block", on_unavailable="block")],
+            "x",
+            default_url=_URL,
+            mandated={"pi"},
+        )
+
+    assert "guardrails.internal.corp.example" in str(exc.value), "the log still gets the endpoint"
+    assert "guardrails.internal.corp.example" not in exc.value.public_detail
+    assert exc.value.public_detail == "guardrail profile 'pi' could not be evaluated"
+
+
+@pytest.mark.asyncio
+async def test_a_callers_own_bad_url_is_still_their_malformed_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unchanged for the request-body case: they chose the URL, so they are told about it."""
+    _unresolvable(monkeypatch)
+    with pytest.raises(UnsafeURLError) as exc:
+        await run_input_guardrails(
+            [GuardrailConfig(profile="pi", url=_STORED_URL, mode="monitor", on_unavailable="monitor")],
+            "x",
+            default_url=_URL,
+        )
+
+    assert "guardrails.internal.corp.example" in str(exc.value)

--- a/tests/unit/test_organization_guardrail_layers.py
+++ b/tests/unit/test_organization_guardrail_layers.py
@@ -79,65 +79,70 @@ def test_no_layer_asked_for_anything_leaves_the_request_exactly_as_it_was() -> N
     """The zero-rows requirement: no organization entries, no policy, no change."""
     caller = [_guardrail("pii", mode="monitor")]
 
-    assert merge_guardrail_layers(_ctx(), caller, []) == (caller, {})
-    assert merge_guardrail_layers(_ctx(), None, []) == (None, {})
+    unrouted = merge_guardrail_layers(_ctx(), caller, [])
+    assert unrouted.configs is caller
+    assert unrouted.credentials == {} and unrouted.mandated == frozenset()
+
+    empty = merge_guardrail_layers(_ctx(), None, [])
+    assert empty.configs is None
+    assert empty.credentials == {} and empty.mandated == frozenset()
 
 
 def test_an_organization_guardrail_runs_when_the_caller_asked_for_nothing() -> None:
-    effective, credentials = merge_guardrail_layers(_ctx(), None, [_organization(_guardrail("prompt-injection"))])
+    merged = merge_guardrail_layers(_ctx(), None, [_organization(_guardrail("prompt-injection"))])
 
-    assert effective is not None
-    assert [g.profile for g in effective] == ["prompt-injection"]
-    assert effective[0].mode == "block"
-    assert credentials == {}
+    assert merged.configs is not None
+    assert [g.profile for g in merged.configs] == ["prompt-injection"]
+    assert merged.configs[0].mode == "block"
+    assert merged.credentials == {}
 
 
 def test_a_caller_cannot_weaken_what_the_organization_mandated() -> None:
-    effective, _ = merge_guardrail_layers(
+    merged = merge_guardrail_layers(
         _ctx(),
         [_guardrail("prompt-injection", mode="monitor", on_unavailable="monitor")],
         [_organization(_guardrail("prompt-injection", mode="block", on_unavailable="block"))],
     )
 
-    assert effective is not None and len(effective) == 1
-    assert effective[0].mode == "block"
-    assert effective[0].on_unavailable == "block"
+    assert merged.configs is not None and len(merged.configs) == 1
+    assert merged.configs[0].mode == "block"
+    assert merged.configs[0].on_unavailable == "block"
 
 
 def test_a_caller_may_tighten_what_the_organization_mandated() -> None:
-    effective, _ = merge_guardrail_layers(
+    merged = merge_guardrail_layers(
         _ctx(),
         [_guardrail("prompt-injection", mode="block", on_unavailable="block")],
         [_organization(_guardrail("prompt-injection", mode="monitor", on_unavailable="monitor"))],
     )
 
-    assert effective is not None
-    assert effective[0].mode == "block"
-    assert effective[0].on_unavailable == "block"
+    assert merged.configs is not None
+    assert merged.configs[0].mode == "block"
+    assert merged.configs[0].on_unavailable == "block"
 
 
 def test_a_caller_may_add_their_own_guardrails_alongside_an_organization_mandate() -> None:
-    effective, _ = merge_guardrail_layers(
+    merged = merge_guardrail_layers(
         _ctx(),
         [_guardrail("pii", mode="monitor")],
         [_organization(_guardrail("prompt-injection"))],
     )
 
-    assert effective is not None
-    assert sorted(g.profile for g in effective) == ["pii", "prompt-injection"]
+    assert merged.configs is not None
+    assert sorted(g.profile for g in merged.configs) == ["pii", "prompt-injection"]
 
 
 def test_the_organization_owns_the_endpoint_for_a_profile_the_caller_also_named() -> None:
     """A caller cannot point a mandated check at a service of their choosing."""
-    effective, credentials = merge_guardrail_layers(
+    merged = merge_guardrail_layers(
         _ctx(),
         [_guardrail("prompt-injection", url="https://caller.example/guardrails")],
         [_organization(_guardrail("prompt-injection", url="https://org.example/guardrails"), credential="s3cret")],
     )
 
-    assert effective is not None
-    assert effective[0].url == "https://org.example/guardrails"
-    assert credentials == {"prompt-injection": "s3cret"}
+    assert merged.configs is not None
+    assert merged.configs[0].url == "https://org.example/guardrails"
+    assert merged.credentials == {"prompt-injection": "s3cret"}
 
 
 def test_the_policy_layer_is_outermost_and_takes_the_endpoint_from_the_organization() -> None:
@@ -147,36 +152,36 @@ def test_the_policy_layer_is_outermost_and_takes_the_endpoint_from_the_organizat
     policy's URL has replaced it, carrying the secret along would be sending it
     somewhere it was never meant for.
     """
-    effective, credentials = merge_guardrail_layers(
+    merged = merge_guardrail_layers(
         _ctx(_guardrail("prompt-injection", url="https://operator.example/guardrails")),
         None,
         [_organization(_guardrail("prompt-injection", url="https://org.example/guardrails"), credential="s3cret")],
     )
 
-    assert effective is not None and len(effective) == 1
-    assert effective[0].url == "https://operator.example/guardrails"
-    assert credentials == {}
+    assert merged.configs is not None and len(merged.configs) == 1
+    assert merged.configs[0].url == "https://operator.example/guardrails"
+    assert merged.credentials == {}
 
 
 def test_a_credential_survives_a_policy_that_mandates_a_different_profile() -> None:
-    effective, credentials = merge_guardrail_layers(
+    merged = merge_guardrail_layers(
         _ctx(_guardrail("pii")),
         None,
         [_organization(_guardrail("prompt-injection"), credential="s3cret")],
     )
 
-    assert effective is not None
-    assert sorted(g.profile for g in effective) == ["pii", "prompt-injection"]
-    assert credentials == {"prompt-injection": "s3cret"}
+    assert merged.configs is not None
+    assert sorted(g.profile for g in merged.configs) == ["pii", "prompt-injection"]
+    assert merged.credentials == {"prompt-injection": "s3cret"}
 
 
 def test_the_strictest_of_all_three_layers_wins() -> None:
-    effective, _ = merge_guardrail_layers(
+    merged = merge_guardrail_layers(
         _ctx(_guardrail("prompt-injection", mode="monitor", on_unavailable="monitor")),
         [_guardrail("prompt-injection", mode="monitor", on_unavailable="block")],
         [_organization(_guardrail("prompt-injection", mode="block", on_unavailable="monitor"))],
     )
 
-    assert effective is not None and len(effective) == 1
-    assert effective[0].mode == "block", "the organization's block survives two monitor layers"
-    assert effective[0].on_unavailable == "block", "and so does the caller's own"
+    assert merged.configs is not None and len(merged.configs) == 1
+    assert merged.configs[0].mode == "block", "the organization's block survives two monitor layers"
+    assert merged.configs[0].on_unavailable == "block", "and so does the caller's own"

--- a/tests/unit/test_tool_settings_read_sites.py
+++ b/tests/unit/test_tool_settings_read_sites.py
@@ -58,7 +58,12 @@ async def test_apply_input_guardrails_uses_config_url(monkeypatch: pytest.Monkey
     seen: dict[str, Any] = {}
 
     async def fake_run(
-        guardrails: Any, input_text: str, *, default_url: str | None, credentials: Any = None
+        guardrails: Any,
+        input_text: str,
+        *,
+        default_url: str | None,
+        credentials: Any = None,
+        mandated: Any = None,
     ) -> Any:
         seen["default_url"] = default_url
 

--- a/web/src/shared/components/ui.tsx
+++ b/web/src/shared/components/ui.tsx
@@ -201,7 +201,7 @@ export function StatCard({
   )
   // min-w-0 (not a fixed min) so the tile fits its grid track: with
   // grid-cols-2's minmax(0,1fr) columns, a larger min-width would overflow the
-  // track and overlap the neighbouring tile on narrow (mobile) viewports.
+  // track and overlap the neighboring tile on narrow (mobile) viewports.
   const cardClass = `flex-1 min-w-0 p-0 ${accent}`
   if (to) {
     return (

--- a/web/src/shared/components/ui.tsx
+++ b/web/src/shared/components/ui.tsx
@@ -756,7 +756,7 @@ export const INPUT_CLASS =
  *
  * Two tones and no more: `muted` states a fact about the row (which provider,
  * which scope, whether a credential is set), `warn` says the row is not doing
- * what its neighbours are. Lives here rather than in a feature folder because
+ * what its neighbors are. Lives here rather than in a feature folder because
  * the Tools cards each grew an identical copy.
  */
 export function Badge({


### PR DESCRIPTION
## Description

Follow-up to #752, fixing two bugs on the branch that validates an organization guardrail's endpoint. Both were found reviewing that PR after it merged, so neither is in main today.

`run_input_guardrails` SSRF-checks every entry's URL before the per-entry loop that reads `mode` and `on_unavailable`, and `apply_input_guardrails` mapped the resulting `UnsafeURLError` straight to a 400 carrying its message. That is the right shape while only a caller's own request body can reach it, and the wrong shape for a URL an organization stored, which the caller can neither see nor fix.

- **An ordinary DNS failure refused everything.** `validate_mcp_url` rejects a hostname that will not resolve, so a blip on an organization's endpoint returns 400 to every request from every workspace it is scoped to, including entries set to `on_unavailable: monitor`. The dashboard offers that setting as "serve it unchecked" and it was never consulted.
- **The refusal named the endpoint.** The organization's internal hostname, the address it resolved to, and advice to set an environment variable the caller cannot set, in a body any API key holder can read. #752 sanitized the 502 path two commits before it merged and missed this branch four lines above it.

The fix tells the two sources apart rather than moving the check. A caller who sends a bad URL sent a malformed request and is told what was wrong, unchanged. A mandated entry's URL failing validation is the guardrail being unevaluable, so it follows the same `mode` / `on_unavailable` handling as an unreachable service, with the endpoint kept to the log. `asyncio.gather` gains `return_exceptions=True` so the decision is per entry rather than made by whichever check failed first, which also preserves the up-front validation of output-direction entries the docstring promises.

`merge_guardrail_layers` returns an `EffectiveGuardrails` value instead of a pair, because the request path needs a third thing from it: which profiles came from a layer above the caller. That cannot be derived later, since the merge has already flattened the layers into one list.

The four behaviors, each covered by a test:

| case | before | after |
| --- | --- | --- |
| organization entry, `monitor` / `monitor` | 400, endpoint named | served, recorded inconclusive |
| organization entry, `block` / `block` | 400, endpoint named | 502, profile only |
| caller's own url | 400 with the reason | unchanged |
| organization entry, private-range host | 400 | served under monitor, never contacted |

The unsafe endpoint is never contacted on any of these paths. That property was never at risk and is now asserted rather than assumed.

Also carries five smaller fixes from the same review: the four organization guardrail routes were missing from `docs/api-reference.md`, a comment counting the database reads in `prepare_gateway_tools` was left stale by #752, `_commit` had an `except IntegrityError` arm doing what its `except Exception` arm already did, and two comments spelled `neighbours`.

## Update: the MCP sibling, folded in

The same disclosure was live one function below, for stored MCP servers, and is fixed here rather than left as the one half-swept case.

`_validate_mcp_server_urls` ran over the merged list of request-body servers and servers resolved from `mcp_server_ids`, mapping any `UnsafeURLError` to a 400 carrying the message, which names the host and the range it resolved into. For a caller's own server that is right. For a stored one it hands a workspace's internal endpoint to any API key holder, which is what `routes/workspace_mcp_servers` gates even the read of those rows behind the master key to prevent.

It is reachable without anything unusual: the URL is checked when stored and again when a request uses it, so a server that was safe at configuration time and whose host has since moved into a private range fails the second check and the caller learns where it went.

The check now runs once per source instead of once over the merged list. A request-body server is unchanged. A stored one answers the way an unreadable stored token already does in `_resolve_mcp_server_ids`: a fixed 500 detail, with the reason and the workspace in the log. There is no `on_unavailable` equivalent here and none is invented, since a tool server has no mode contract to route a failure into, so the request is still refused and only the body and status change. `docs/mcp.md` gains the distinction.

Covered by an integration test that stores a server while its host resolves publicly and sends a request after it resolves privately, asserting the 500 names neither the hostname nor the address. Confirmed to fail without the fix.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Follow-up to #752, which implemented #654.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). Three unit tests over the three URL-failure paths, and one integration test that stores an endpoint while it resolves and sends a request after it stops, which fails without the fix.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`), plus `pnpm --dir web run lint` and `typecheck`. Full backend suite: 4033 passed, 10 skipped.
- [x] Documentation was updated where necessary. The `api-reference.md` rows above; no user-facing behavior needed a docs change beyond them.
- [x] If the API contract changed, I regenerated the OpenAPI spec. No route or schema changed, and `make openapi-check` and `make postman-check` confirm no drift.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Claude Opus 5)

**Any additional AI details you'd like to share:**

Found by an independent review agent run against #752 with no knowledge of how it was built, after three earlier review passes and 14 bot and human threads had missed it. Both halves were reproduced in isolation before any code changed, and the integration test was confirmed to fail without the fix rather than assumed to cover it. Prose is the model's; the decisions are Nathan's.

- [x] I am an AI Agent filling out this form (check box if true)
