### PR TITLE
fix(usage): reserve the otari-ai: source prefix in external-usage ingest

### DIFF
--- a/docs/external-usage.md
+++ b/docs/external-usage.md
@@ -103,7 +103,7 @@ The body is a batch that shares a `source` and a default `user_id`:
 
 | Field | Required | Notes |
 | --- | --- | --- |
-| `source` | yes | Provenance slug, e.g. `claude_code`. Generic: add your own sources. |
+| `source` | yes | Provenance slug, e.g. `claude_code`. Generic: add your own sources. `gateway` and any slug starting with `otari-ai:` are reserved (otari.ai writes those tags itself) and rejected with a 422. |
 | `user_id` | with master key | Default attribution. Optional with an API key (binds to the key's user); required with the master key. Must be an existing user. |
 | `events` | yes | 1 to 1000 events. |
 

--- a/docs/external-usage.md
+++ b/docs/external-usage.md
@@ -182,7 +182,7 @@ Otari reads only the content-free usage attributes, preferring the
 | `gen_ai.usage.output_tokens` | output |
 | `gen_ai.usage.cache_read_tokens` (or `cached_tokens`) | cache read |
 | `gen_ai.usage.cache_write_tokens` | cache write |
-| `otari.client_name` | `source` (provenance) |
+| `otari.client_name` | `source` (provenance); a reserved slug (`gateway`, or anything starting with `otari-ai:`) falls back to `otel` |
 | `otari.user_session_label` / `otari.session_label` | session label |
 
 A record with no model/provider/tokens (a non-LLM span, a prompt log, a metric) is

--- a/src/gateway/api/routes/otlp.py
+++ b/src/gateway/api/routes/otlp.py
@@ -75,10 +75,10 @@ from gateway.services.agent_telemetry_service import (
 from gateway.services.agent_telemetry_service import ingest as ingest_telemetry
 from gateway.services.external_usage_service import (
     MAX_EVENTS_PER_BATCH,
-    RESERVED_SOURCES,
     ExternalEventsRequest,
     ExternalUsageEvent,
     ingest_external_events,
+    reserved_source_reason,
 )
 
 router = APIRouter(tags=["otel"])
@@ -206,9 +206,10 @@ def _resolve_timestamp(attrs: dict[str, Any], default: datetime | None) -> datet
 
 def _sanitize_source(name: str) -> str:
     slug = re.sub(r"[^A-Za-z0-9._:-]+", "-", name).strip("-")[:64]
-    # "gateway" is reserved for usage Otari served itself; a client claiming it
-    # would masquerade as native traffic (and fail the ingest schema with a 500).
-    if not slug or slug.lower() in RESERVED_SOURCES:
+    # "gateway" is reserved for usage Otari served itself and the `otari-ai:` prefix for
+    # the provenance tags otari.ai writes; a client claiming either would masquerade as
+    # those rows (and fail the ingest schema with a 500).
+    if not slug or reserved_source_reason(slug) is not None:
         return _DEFAULT_SOURCE
     return slug
 

--- a/src/gateway/services/external_usage_service.py
+++ b/src/gateway/services/external_usage_service.py
@@ -62,6 +62,24 @@ RESERVED_SOURCES = {"gateway"}
 RESERVED_SOURCE_PREFIXES = ("otari-ai:",)
 
 
+def reserved_source_reason(value: str) -> str | None:
+    """Why ``value`` may not be used as a provenance slug, or None when it is free.
+
+    Both ingest doors read this: the batch schema below turns it into a 422, and the
+    OTLP route falls back to its default source rather than 422-ing an exporter.
+    """
+    lowered = value.lower()
+    if lowered in RESERVED_SOURCES:
+        return "source 'gateway' is reserved for usage Otari served itself; pick another slug."
+    for prefix in RESERVED_SOURCE_PREFIXES:
+        if lowered.startswith(prefix):
+            return (
+                f"source prefix '{prefix}' is reserved for provenance tags otari.ai writes itself; "
+                "pick another slug."
+            )
+    return None
+
+
 class ExternalUsageEvent(BaseModel):
     """One imported usage event. Content-free: token counts and metadata only.
 
@@ -118,15 +136,9 @@ class ExternalEventsRequest(BaseModel):
     @field_validator("source")
     @classmethod
     def _not_reserved(cls, value: str) -> str:
-        lowered = value.lower()
-        if lowered in RESERVED_SOURCES:
-            raise ValueError("source 'gateway' is reserved for usage Otari served itself; pick another slug.")
-        for prefix in RESERVED_SOURCE_PREFIXES:
-            if lowered.startswith(prefix):
-                raise ValueError(
-                    f"source prefix '{prefix}' is reserved for provenance tags otari.ai writes itself; "
-                    "pick another slug."
-                )
+        reason = reserved_source_reason(value)
+        if reason is not None:
+            raise ValueError(reason)
         return value
 
 

--- a/src/gateway/services/external_usage_service.py
+++ b/src/gateway/services/external_usage_service.py
@@ -56,6 +56,10 @@ _MAX_TOKENS = 2_147_483_647
 # "gateway" tags rows Otari served itself; an import claiming it would masquerade
 # as native traffic in every provenance breakdown.
 RESERVED_SOURCES = {"gateway"}
+# otari.ai owns this namespace: its backfill stamps the rows it writes `otari-ai:gateway`,
+# `otari-ai:claude_code`, and so on. An import under the same prefix produces lookalike
+# rows that inflate reconciliation totals and read as a mismatch during a cutover.
+RESERVED_SOURCE_PREFIXES = ("otari-ai:",)
 
 
 class ExternalUsageEvent(BaseModel):
@@ -114,8 +118,15 @@ class ExternalEventsRequest(BaseModel):
     @field_validator("source")
     @classmethod
     def _not_reserved(cls, value: str) -> str:
-        if value.lower() in RESERVED_SOURCES:
+        lowered = value.lower()
+        if lowered in RESERVED_SOURCES:
             raise ValueError("source 'gateway' is reserved for usage Otari served itself; pick another slug.")
+        for prefix in RESERVED_SOURCE_PREFIXES:
+            if lowered.startswith(prefix):
+                raise ValueError(
+                    f"source prefix '{prefix}' is reserved for provenance tags otari.ai writes itself; "
+                    "pick another slug."
+                )
         return value
 
 

--- a/src/gateway/services/external_usage_service.py
+++ b/src/gateway/services/external_usage_service.py
@@ -70,9 +70,9 @@ def reserved_source_reason(value: str) -> str | None:
     """
     lowered = value.lower()
     if lowered in RESERVED_SOURCES:
-        return "source 'gateway' is reserved for usage Otari served itself; pick another slug."
+        return f"source '{lowered}' is reserved for usage Otari served itself; pick another slug."
     for prefix in RESERVED_SOURCE_PREFIXES:
-        if lowered.startswith(prefix):
+        if lowered.startswith(prefix.lower()):
             return (
                 f"source prefix '{prefix}' is reserved for provenance tags otari.ai writes itself; "
                 "pick another slug."

--- a/tests/integration/test_external_usage_events.py
+++ b/tests/integration/test_external_usage_events.py
@@ -502,6 +502,31 @@ def test_rejects_reserved_gateway_source(client: TestClient, master_key_header: 
     assert "reserved" in resp.text
 
 
+def test_rejects_reserved_otari_ai_source_prefix(client: TestClient, master_key_header: dict[str, str]) -> None:
+    """otari.ai stamps the rows its backfill writes `otari-ai:<slug>`; an import under
+    that prefix is a lookalike in every reconciliation total."""
+    _seed_user(client, master_key_header)
+    for source in ("otari-ai:gateway", "otari-ai:claude_code", "OTARI-AI:gateway"):
+        resp = _post(client, master_key_header, [_event()], source=source)
+        assert resp.status_code == 422, f"{source}: {resp.text}"
+        assert "reserved" in resp.text
+
+
+def test_accepts_source_with_colon_outside_the_reserved_prefix(
+    client: TestClient, master_key_header: dict[str, str], db_session: Session
+) -> None:
+    """The guard is a prefix check, not a ban on colons in a slug."""
+    _seed_user(client, master_key_header)
+    _seed_pricing(client, master_key_header)
+
+    resp = _post(client, master_key_header, [_event("colon_ok")], source="foo:bar")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["accepted"] == 1
+
+    row = db_session.query(UsageLog).filter(UsageLog.source_event_id == "colon_ok").one()
+    assert row.source == "foo:bar"
+
+
 def test_rejects_token_counts_above_column_width(client: TestClient, master_key_header: dict[str, str]) -> None:
     """Counts past the 32-bit column cap are a 422, not a DB error that 500s the batch."""
     _seed_user(client, master_key_header)

--- a/tests/integration/test_otlp.py
+++ b/tests/integration/test_otlp.py
@@ -476,3 +476,16 @@ def test_otlp_gateway_client_name_falls_back_to_otel_source(
     assert resp.status_code == 200, resp.text
     row = db_session.query(UsageLog).filter(UsageLog.source_event_id == "resp_reserved_1").one()
     assert row.source == "otel"
+
+
+def test_otlp_otari_ai_client_name_falls_back_to_otel_source(
+    client: TestClient, master_key_header: dict[str, str], db_session: Session
+) -> None:
+    """otari.ai writes `otari-ai:`-prefixed tags itself, so an exporter claiming one is
+    downgraded to the default source instead of 422-ing the whole export."""
+    headers = _exempt_key(client, master_key_header)
+    span = _span_record(**{"otari.client_name": "otari-ai:gateway", "gen_ai.response.id": "resp_reserved_2"})
+    resp = client.post("/v1/traces", json=_otlp_traces(span), headers=headers)
+    assert resp.status_code == 200, resp.text
+    row = db_session.query(UsageLog).filter(UsageLog.source_event_id == "resp_reserved_2").one()
+    assert row.source == "otel"

--- a/tests/unit/test_reserved_source_slugs.py
+++ b/tests/unit/test_reserved_source_slugs.py
@@ -1,0 +1,63 @@
+"""Unit tests for the provenance-slug reservation (``reserved_source_reason``).
+
+Two callers read it and neither is a good place to pin the case handling: the
+batch schema turns a reason into a 422 and the OTLP route swallows it into a
+fallback source, so both hide which spellings are reserved behind a status code.
+
+The boundary that matters is the colon. otari.ai's reconciliation scopes the rows
+it wrote with ``source LIKE 'otari-ai:%'``, so `otari-ai:` and anything under it
+is what collides; a bare `otari-ai` matches nothing there and stays a legal slug
+for an importer to use.
+"""
+
+import pytest
+
+from gateway.services.external_usage_service import reserved_source_reason
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "gateway",
+        "GATEWAY",
+        "Gateway",
+        "otari-ai:",
+        "otari-ai:gateway",
+        "otari-ai:claude_code",
+        "OTARI-AI:gateway",
+        "Otari-AI:Claude_Code",
+    ],
+)
+def test_reserved_slugs_are_refused(value: str) -> None:
+    reason = reserved_source_reason(value)
+    assert reason is not None
+    assert "reserved" in reason
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # The colon is the boundary: reconciliation scopes on `otari-ai:%`, so the
+        # bare name and a name that merely starts with it collide with nothing.
+        "otari-ai",
+        "otari-ai-mirror",
+        "otari_ai:gateway",
+        # A colon elsewhere is ordinary: the guard is a prefix check, not a ban on
+        # the character the slug pattern already allows.
+        "foo:bar",
+        "claude_code",
+        "gateway-mirror",
+        "not-gateway",
+        "otel",
+    ],
+)
+def test_free_slugs_are_allowed(value: str) -> None:
+    assert reserved_source_reason(value) is None
+
+
+def test_exact_match_message_names_the_matched_slug() -> None:
+    # The message is built from the value that matched, so a second entry in
+    # RESERVED_SOURCES cannot inherit "gateway" in its own rejection.
+    assert reserved_source_reason("GATEWAY") == (
+        "source 'gateway' is reserved for usage Otari served itself; pick another slug."
+    )


### PR DESCRIPTION
## Description

The external-usage `source` slug pattern allows a colon, so an importer could post rows tagged `otari-ai:gateway` or `otari-ai:claude_code`, the same tags otari.ai's backfill writes. Those lookalike rows inflate the migration's reconciliation totals and show up as a false MISMATCH during a cutover.

Any source starting with `otari-ai:` (case-insensitive) is now rejected with the same reserved-source 422 the bare `gateway` slug already gets. The exact-match `gateway` check is unchanged, and this is a prefix check rather than a colon ban, so `foo:bar` is still accepted. Validation on new imports only: no migration, no change to stored rows.

The OTLP route is the second door into the same rows: it derives a `source` from the caller-supplied `otari.client_name` and hands it to the batch schema, so the new reservation would have turned such an export into a 500. The reservation now lives in one `reserved_source_reason` helper that both doors read: a 422 for a direct import, and a fallback to the default `otel` source for an exporter, matching how `gateway` is already handled there.

Follow-up (not here): otari-ai#1815 reserves the same prefix in `usage_admin_service.py` and `workspace_activation_service.py`. Once both land, the three copies of the prefix could converge on one shared definition.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#1801

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code

**Any additional AI details you'd like to share:**

Implementation, tests, and the local check runs (`make lint`, `make typecheck`, the external-usage integration file, `tests/unit`, `make openapi-check`, `make postman-check`) were done by the agent.

- [x] I am an AI Agent filling out this form (check box if true)

Authored by Claude Opus 5 (1M context) via Claude Code.
