### PR TITLE
fix(api): expose prompt cache keys

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1835,6 +1835,17 @@
             ],
             "title": "Presence Penalty"
           },
+          "prompt_cache_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt Cache Key"
+          },
           "reasoning_effort": {
             "anyOf": [
               {
@@ -4747,6 +4758,17 @@
               }
             ],
             "title": "Output Format"
+          },
+          "prompt_cache_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt Cache Key"
           },
           "session_label": {
             "anyOf": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ version = "0.0.0"
 description = "otari, an OpenAI-compatible LLM gateway"
 requires-python = ">=3.13"
 dependencies = [
-    "any-llm-sdk[all]>=1.24.0",
+    "any-llm-sdk[all]>=1.25.0",
     "alembic>=1.13.0",
     "aiosqlite>=0.19.0",
     # OAuth protocol mechanics for dashboard sign-in: provider endpoints, the

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -332,8 +332,17 @@ def _unsupported_feature_detail(exc: BaseException) -> str:
         if isinstance(candidate, UnsupportedParameterError):
             # AnyLLMError.__str__ prefixes the provider to ``message``. Feeding
             # both through upstream_error_message would repeat the same reason.
-            return redact_upstream_message(candidate.message)
+            return _redacted_caller_fault_detail(candidate.message, PROVIDER_BAD_REQUEST_DETAIL)
     return _caller_fault_detail(exc, PROVIDER_BAD_REQUEST_DETAIL)
+
+
+def _redacted_caller_fault_detail(message: str, fallback: str) -> str:
+    """Return redacted explanatory text, or a fixed detail when none remains."""
+    redacted = redact_upstream_message(message)
+    explanatory = redacted.replace("[redacted]", "")
+    if not any(char.isalpha() for char in explanatory):
+        return fallback
+    return redacted
 
 
 def _caller_fault_detail(exc: BaseException, fallback: str) -> str:
@@ -350,11 +359,7 @@ def _caller_fault_detail(exc: BaseException, fallback: str) -> str:
     A message made entirely of redaction placeholders is empty for this
     purpose, too.
     """
-    redacted = redact_upstream_message(upstream_error_message(exc))
-    explanatory = redacted.replace("[redacted]", "")
-    if not any(char.isalpha() for char in explanatory):
-        return fallback
-    return redacted
+    return _redacted_caller_fault_detail(upstream_error_message(exc), fallback)
 
 
 def classify_provider_error(exc: BaseException) -> ProviderErrorMapping | None:

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -46,7 +46,7 @@ from typing import Any, Generic, Literal, NamedTuple, NoReturn, Protocol, TypeVa
 from urllib.parse import ParseResult, urlparse
 
 from any_llm import LLMProvider
-from any_llm.exceptions import AnyLLMError
+from any_llm.exceptions import AnyLLMError, UnsupportedParameterError
 from any_llm.types.completion import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -317,12 +317,23 @@ class _PendingUsageReport(NamedTuple):
 def _is_unsupported_feature_error(exc: BaseException) -> bool:
     """True when any-llm refused a request feature its backend cannot express.
 
-    Unwraps ``original_exception`` as well: once
-    ``ANY_LLM_UNIFIED_EXCEPTIONS=1`` becomes the default, the raw
-    ``NotImplementedError`` arrives wrapped in a generic ``ProviderError`` and a
-    check against ``exc`` alone would stop matching.
+    Newer any-llm releases use ``UnsupportedParameterError`` for typed provider
+    capability checks, while older feature checks still raise
+    ``NotImplementedError``. Unwrap ``original_exception`` as well so either
+    signal survives the unified-exception wrapper.
     """
-    return any(isinstance(candidate, NotImplementedError) for candidate in upstream_exception_chain(exc))
+    unsupported_types = (NotImplementedError, UnsupportedParameterError)
+    return any(isinstance(candidate, unsupported_types) for candidate in upstream_exception_chain(exc))
+
+
+def _unsupported_feature_detail(exc: BaseException) -> str:
+    """Return one actionable reason for a locally rejected request feature."""
+    for candidate in upstream_exception_chain(exc):
+        if isinstance(candidate, UnsupportedParameterError):
+            # AnyLLMError.__str__ prefixes the provider to ``message``. Feeding
+            # both through upstream_error_message would repeat the same reason.
+            return redact_upstream_message(candidate.message)
+    return _caller_fault_detail(exc, PROVIDER_BAD_REQUEST_DETAIL)
 
 
 def _caller_fault_detail(exc: BaseException, fallback: str) -> str:
@@ -372,16 +383,14 @@ def classify_provider_error(exc: BaseException) -> ProviderErrorMapping | None:
     kind, status_code = upstream_exception_shape(exc)
     if kind == "timeout":
         return ProviderErrorMapping(status.HTTP_504_GATEWAY_TIMEOUT, PROVIDER_TIMEOUT_DETAIL)
-    # any-llm raises NotImplementedError when a request asks a provider for
-    # something its backend cannot express: context_management/betas against a
-    # provider with no native Anthropic Messages API is the case that surfaced
-    # this (#530). It carries no HTTP status, so it would otherwise fall through
-    # to the generic 502/500 and tell the caller a guaranteed-permanent failure
-    # was a transient one. The exception type is the whole signal here, so this
-    # needs no probe into any-llm's wording, and the message it carries already
-    # names the unsupported feature.
+    # any-llm raises UnsupportedParameterError for typed provider-capability
+    # checks and still uses NotImplementedError for older feature checks such as
+    # context_management/betas (#530). Neither carries an HTTP status, so either
+    # would otherwise fall through to a generic 502/500 and tell the caller a
+    # guaranteed-permanent failure was transient. The exception type is the
+    # whole signal here, and its message names the unsupported feature.
     if _is_unsupported_feature_error(exc):
-        return ProviderErrorMapping(status.HTTP_400_BAD_REQUEST, _caller_fault_detail(exc, PROVIDER_BAD_REQUEST_DETAIL))
+        return ProviderErrorMapping(status.HTTP_400_BAD_REQUEST, _unsupported_feature_detail(exc))
     if status_code is None:
         return None
     # Account billing exhaustion, which several providers report as a 400/422

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -34,6 +34,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
+import json
 import time
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Iterable, Sequence
@@ -702,6 +704,45 @@ class RequestContext:
         # without a shared id they would be unrelated rows in the activity log.
         # `None` for an unrouted request, which writes exactly one row.
         self.request_group_id = request_group_id
+
+
+def scope_prompt_cache_key(request_fields: dict[str, Any], ctx: RequestContext) -> dict[str, Any]:
+    """Bind a caller-supplied prompt cache key to its authenticated scope.
+
+    Provider prompt caches can be shared by every tenant using one upstream
+    account. Including the resolved identity in the routing key prevents two
+    callers from deliberately choosing the same provider cache namespace and
+    using cached-token counts as an exact-prefix oracle.
+    """
+    caller_key = request_fields.get("prompt_cache_key")
+    if not isinstance(caller_key, str):
+        return request_fields
+
+    scope: tuple[str, str] | None = None
+    if ctx.hybrid_mode:
+        if ctx.route is not None and ctx.route.user_id:
+            scope = ("user", ctx.route.user_id)
+        elif ctx.route is not None and ctx.route.workspace_id:
+            # Older platform peers may omit user_id. The workspace still keeps
+            # their cache-routing key out of every other tenant's namespace.
+            scope = ("workspace", ctx.route.workspace_id)
+    elif ctx.user_id:
+        scope = ("user", ctx.user_id)
+
+    if scope is None:
+        # Never forward an unscoped caller-controlled key when the peer did not
+        # provide an authenticated identity. Provider-side automatic caching
+        # still works without the routing hint.
+        request_fields.pop("prompt_cache_key", None)
+        return request_fields
+
+    payload = json.dumps(
+        ["otari-prompt-cache-v1", scope[0], scope[1], caller_key],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    request_fields["prompt_cache_key"] = hashlib.sha256(payload.encode()).hexdigest()
+    return request_fields
 
 
 def unresolvable_model_detail(model_selector: str) -> str:

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -33,6 +33,7 @@ from gateway.api.routes._pipeline import (
     run_single_attempt_stream,
     run_standalone_non_stream,
     run_streaming_with_fallback,
+    scope_prompt_cache_key,
 )
 from gateway.api.routes._platform import ResolvedAttempt, SettledCost
 from gateway.api.routes._schema_derive import SESSION_LABEL_DESC, SESSION_LABEL_MAX_LENGTH, derive_request_base
@@ -374,6 +375,7 @@ async def chat_completions(
         remaining_user_tools=tool_ctx.remaining_user_tools,
         web_search_declared_name=tool_ctx.web_search_declared_name,
     )
+    scope_prompt_cache_key(request_fields, ctx)
 
     # ------------------------------------------------------------------
     # Streaming path: in hybrid mode, iterate `route.attempts` before any

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -41,6 +41,7 @@ from gateway.api.routes._pipeline import (
     run_single_attempt_stream,
     run_standalone_non_stream,
     run_streaming_with_fallback,
+    scope_prompt_cache_key,
 )
 from gateway.api.routes._platform import (
     ResolvedAttempt,
@@ -575,6 +576,7 @@ async def create_message(
         remaining_user_tools=tool_ctx.remaining_user_tools,
         web_search_declared_name=tool_ctx.web_search_declared_name,
     )
+    scope_prompt_cache_key(request_fields, ctx)
     if request_fields.get("tools"):
         request_fields["tools"] = openai_to_anthropic_tools(request_fields["tools"])
     if tool_ctx.intercepts_web_search and request_fields.get("messages"):

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -33,6 +33,7 @@ from gateway.api.routes._pipeline import (
     run_single_attempt_stream,
     run_standalone_non_stream,
     run_streaming_with_fallback,
+    scope_prompt_cache_key,
 )
 from gateway.api.routes._platform import ResolvedAttempt, SettledCost, build_attempt_client_args
 from gateway.api.routes._schema_derive import SESSION_LABEL_DESC, SESSION_LABEL_MAX_LENGTH, derive_request_base
@@ -561,6 +562,7 @@ async def create_response(
         remaining_user_tools=tool_ctx.remaining_user_tools,
         web_search_declared_name=tool_ctx.web_search_declared_name,
     )
+    scope_prompt_cache_key(request_fields, ctx)
     # This is an internal handoff populated below, never a client request field.
     # ``ResponsesRequest`` permits extra fields for OpenAI compatibility, so
     # remove a caller-supplied value before constructing the provider kwargs.

--- a/tests/integration/test_messages_endpoint.py
+++ b/tests/integration/test_messages_endpoint.py
@@ -36,11 +36,13 @@ def test_messages_endpoint_basic_completion(
     test_user: dict[str, Any],
     messages_request_body: dict[str, Any],
 ) -> None:
-    """Test basic non-streaming message completion."""
+    """Test basic non-streaming message completion and prompt-cache-key forwarding."""
     mock_response = _make_message_response()
     messages_request_body["metadata"] = {"user_id": "test-user"}
+    messages_request_body["prompt_cache_key"] = "tenant-session-123"
+    mock_amessages = AsyncMock(return_value=mock_response)
 
-    with patch("gateway.api.routes.messages.amessages", new_callable=AsyncMock, return_value=mock_response):
+    with patch("gateway.api.routes.messages.amessages", new=mock_amessages):
         response = client.post(
             "/v1/messages",
             json=messages_request_body,
@@ -48,6 +50,8 @@ def test_messages_endpoint_basic_completion(
         )
 
     assert response.status_code == 200
+    assert mock_amessages.await_args is not None
+    assert mock_amessages.await_args.kwargs["prompt_cache_key"] == "tenant-session-123"
     data = response.json()
     assert data["type"] == "message"
     assert data["role"] == "assistant"

--- a/tests/integration/test_messages_endpoint.py
+++ b/tests/integration/test_messages_endpoint.py
@@ -36,7 +36,7 @@ def test_messages_endpoint_basic_completion(
     test_user: dict[str, Any],
     messages_request_body: dict[str, Any],
 ) -> None:
-    """Test basic non-streaming message completion and prompt-cache-key forwarding."""
+    """Test basic non-streaming completion and authenticated prompt-cache-key scoping."""
     mock_response = _make_message_response()
     messages_request_body["metadata"] = {"user_id": "test-user"}
     messages_request_body["prompt_cache_key"] = "tenant-session-123"
@@ -51,7 +51,9 @@ def test_messages_endpoint_basic_completion(
 
     assert response.status_code == 200
     assert mock_amessages.await_args is not None
-    assert mock_amessages.await_args.kwargs["prompt_cache_key"] == "tenant-session-123"
+    scoped_cache_key = mock_amessages.await_args.kwargs["prompt_cache_key"]
+    assert scoped_cache_key != "tenant-session-123"
+    assert len(scoped_cache_key) == 64
     data = response.json()
     assert data["type"] == "message"
     assert data["role"] == "assistant"

--- a/tests/integration/test_provider_error_classification.py
+++ b/tests/integration/test_provider_error_classification.py
@@ -10,6 +10,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from any_llm.exceptions import UnsupportedParameterError
 from fastapi.testclient import TestClient
 
 from gateway.api.routes._pipeline import (
@@ -82,6 +83,31 @@ def test_chat_classifies_provider_error(
     assert response.json()["detail"] == expected_detail
     if expected_detail != _RAW:
         assert "SECRET" not in response.text
+
+
+def test_chat_surfaces_unsupported_prompt_cache_key_as_client_error(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    test_user: dict[str, Any],
+) -> None:
+    """A final provider that cannot honor the key returns an actionable 400."""
+    with patch(
+        "gateway.api.routes.chat.acompletion",
+        new_callable=AsyncMock,
+        side_effect=UnsupportedParameterError("prompt_cache_key", "anthropic"),
+    ):
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "anthropic:claude-3-5-sonnet",
+                "messages": [{"role": "user", "content": "Hi"}],
+                "prompt_cache_key": "tenant-session-123",
+            },
+            headers=api_key_header,
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "'prompt_cache_key' is not supported for anthropic"
 
 
 def test_chat_unknown_status_stays_generic_502(

--- a/tests/integration/test_provider_kwargs_override.py
+++ b/tests/integration/test_provider_kwargs_override.py
@@ -158,6 +158,7 @@ async def test_completion_params_reach_provider(
         raise _MockCompletionError
 
     params: dict[str, Any] = {
+        "prompt_cache_key": "tenant-session-123",
         "reasoning_effort": "high",
         "seed": 42,
         "stop": ["STOP"],

--- a/tests/integration/test_provider_kwargs_override.py
+++ b/tests/integration/test_provider_kwargs_override.py
@@ -150,6 +150,8 @@ async def test_completion_params_reach_provider(
     because the hand-maintained schema omitted them. The schema is now derived
     from any-llm's ``CompletionParams`` and forwarded via ``model_dump``, so this
     asserts the forwarding contract end to end rather than only at the schema.
+    ``prompt_cache_key`` is the deliberate exception: it reaches the provider
+    after being bound to the authenticated user rather than verbatim.
     """
     captured_kwargs: dict[str, Any] = {}
 
@@ -195,7 +197,13 @@ async def test_completion_params_reach_provider(
     # The mock raises after capturing, so the call is reached but the request errors out.
     assert captured_kwargs, f"acompletion was never called (status {response.status_code})"
     for name, value in params.items():
-        assert captured_kwargs.get(name) == value, f"{name} was dropped before the provider call"
+        if name == "prompt_cache_key":
+            scoped_cache_key = captured_kwargs.get(name)
+            assert isinstance(scoped_cache_key, str)
+            assert scoped_cache_key != value
+            assert len(scoped_cache_key) == 64
+        else:
+            assert captured_kwargs.get(name) == value, f"{name} was dropped before the provider call"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_responses_endpoint.py
+++ b/tests/integration/test_responses_endpoint.py
@@ -78,6 +78,25 @@ def test_responses_endpoint_basic_completion(
     assert data["output"][0]["content"] == "Hello"
 
 
+def test_responses_endpoint_scopes_prompt_cache_key(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    responses_request_body: dict[str, Any],
+) -> None:
+    """The Responses API binds provider cache routing to the billed user."""
+    responses_request_body["prompt_cache_key"] = "tenant-session-123"
+    mock_aresponses = AsyncMock(return_value=_FakeResponse({"id": "resp_123", "output": []}))
+
+    with patch("gateway.api.routes.responses.aresponses", new=mock_aresponses):
+        result = client.post("/v1/responses", json=responses_request_body, headers=master_key_header)
+
+    assert result.status_code == 200
+    assert mock_aresponses.await_args is not None
+    scoped_cache_key = mock_aresponses.await_args.kwargs["prompt_cache_key"]
+    assert scoped_cache_key != "tenant-session-123"
+    assert len(scoped_cache_key) == 64
+
+
 def test_responses_endpoint_master_key_requires_user(
     client: TestClient,
     master_key_header: dict[str, str],

--- a/tests/unit/test_hybrid_client_args_routing.py
+++ b/tests/unit/test_hybrid_client_args_routing.py
@@ -9,7 +9,7 @@ else in ``**kwargs`` goes to the completion *call* instead). A test that
 monkeypatches ``acompletion`` directly (as the hybrid-mode integration tests
 do) can't catch a regression back to flat kwargs, because the fake
 ``acompletion`` never exercises any-llm's own kwarg-splitting logic. These
-tests call into the real SDK, stopping only at boto3's own client
+tests call into the real SDK, stopping only at boto3's own session client
 construction (patched so no network call or real AWS credentials are
 needed), to verify the values actually land where boto3 expects them.
 """
@@ -30,9 +30,9 @@ async def test_bedrock_classic_shape_client_args_reach_real_boto3_client() -> No
     """Reproduces the exact bug this test guards against: merging
     region_name/aws_access_key_id flat into acompletion()'s kwargs still
     raises botocore's NoRegionError, because any-llm forwards unrecognized
-    flat kwargs to the completion call, not boto3.client(). Nesting them
-    under client_args (what default_attempt_kwargs now does) is the only
-    way they reach boto3.client()'s own constructor kwargs."""
+    flat kwargs to the completion call, not boto3's client constructor.
+    Nesting them under client_args (what default_attempt_kwargs now does) is
+    the only way they reach the dedicated Session.client() kwargs."""
     attempt = ResolvedAttempt(
         attempt_id="a0",
         position=0,
@@ -54,7 +54,7 @@ async def test_bedrock_classic_shape_client_args_reach_real_boto3_client() -> No
         captured.update(client_kwargs)
         raise _StopBeforeNetworkCall
 
-    with patch("boto3.client", side_effect=fake_boto3_client):
+    with patch("boto3.session.Session.client", side_effect=fake_boto3_client):
         with pytest.raises(_StopBeforeNetworkCall):
             await acompletion(**kwargs)
 
@@ -67,7 +67,7 @@ async def test_bedrock_classic_shape_client_args_reach_real_boto3_client() -> No
 @pytest.mark.asyncio
 async def test_bedrock_bearer_shape_uses_custom_client_not_flat_kwargs() -> None:
     """The bearer-token shape's pre-built client (client_args["client"]) is
-    what any-llm's BedrockProvider actually uses; boto3.client() is never
+    what any-llm's BedrockProvider actually uses; Session.client() is never
     called a second time for it."""
     attempt = ResolvedAttempt(
         attempt_id="a0",
@@ -90,11 +90,11 @@ async def test_bedrock_bearer_shape_uses_custom_client_not_flat_kwargs() -> None
     def fake_converse(**_call_kwargs: Any) -> Any:
         raise _StopBeforeNetworkCall
 
-    with patch("boto3.client") as fake_boto3_client:
+    with patch("boto3.session.Session.client") as fake_boto3_client:
         with patch.object(injected_client, "converse", side_effect=fake_converse):
             with pytest.raises(_StopBeforeNetworkCall):
                 await acompletion(**kwargs)
         # any-llm-sdk's BedrockProvider._init_client honors the pre-built
-        # client and skips constructing its own; boto3.client() is
+        # client and skips constructing its own; Session.client() is
         # untouched for the runtime client in this shape.
         fake_boto3_client.assert_not_called()

--- a/tests/unit/test_prompt_cache_key_scoping.py
+++ b/tests/unit/test_prompt_cache_key_scoping.py
@@ -1,0 +1,82 @@
+"""Tests for authenticated prompt-cache routing namespaces."""
+
+from typing import Any, cast
+
+from gateway.api.routes._pipeline import RequestContext, scope_prompt_cache_key
+from gateway.api.routes._platform import ResolvedRoute
+from gateway.core.config import GatewayConfig
+
+
+def _context(
+    *,
+    user_id: str | None = "user-a",
+    route: ResolvedRoute | None = None,
+) -> RequestContext:
+    return RequestContext(
+        config=GatewayConfig(),
+        db=None,
+        log_writer=cast(Any, None),
+        hybrid_mode=route is not None,
+        route=route,
+        user_token=None,
+        api_key_id=None,
+        user_id=user_id if route is None else None,
+        rate_limit_info=None,
+        reservation=None,
+        started_at=0.0,
+    )
+
+
+def _scoped_key(ctx: RequestContext, caller_key: str = "shared-key") -> str:
+    fields: dict[str, Any] = {"prompt_cache_key": caller_key}
+    assert scope_prompt_cache_key(fields, ctx) is fields
+    scoped = fields["prompt_cache_key"]
+    assert isinstance(scoped, str)
+    return scoped
+
+
+def test_prompt_cache_key_is_stable_and_fixed_length() -> None:
+    first = _scoped_key(_context())
+    second = _scoped_key(_context())
+
+    assert first == second
+    assert first != "shared-key"
+    assert len(first) == 64
+
+
+def test_prompt_cache_key_isolated_between_standalone_users() -> None:
+    assert _scoped_key(_context(user_id="user-a")) != _scoped_key(_context(user_id="user-b"))
+
+
+def test_prompt_cache_key_uses_hybrid_resolved_user() -> None:
+    route_a = ResolvedRoute(
+        request_id="request-a",
+        fallback_enabled=False,
+        attempts=[],
+        user_id="platform-user-a",
+        workspace_id="workspace-shared",
+    )
+    route_b = route_a.model_copy(update={"user_id": "platform-user-b"})
+
+    assert _scoped_key(_context(route=route_a)) != _scoped_key(_context(route=route_b))
+
+
+def test_prompt_cache_key_falls_back_to_hybrid_workspace() -> None:
+    route_a = ResolvedRoute(
+        request_id="request-a",
+        fallback_enabled=False,
+        attempts=[],
+        workspace_id="workspace-a",
+    )
+    route_b = route_a.model_copy(update={"workspace_id": "workspace-b"})
+
+    assert _scoped_key(_context(route=route_a)) != _scoped_key(_context(route=route_b))
+
+
+def test_prompt_cache_key_is_dropped_without_authenticated_scope() -> None:
+    route = ResolvedRoute(request_id="request-a", fallback_enabled=False, attempts=[])
+    fields: dict[str, Any] = {"prompt_cache_key": "shared-key", "model": "openai:gpt-5"}
+
+    scope_prompt_cache_key(fields, _context(route=route))
+
+    assert fields == {"model": "openai:gpt-5"}

--- a/tests/unit/test_provider_error_classification.py
+++ b/tests/unit/test_provider_error_classification.py
@@ -330,6 +330,19 @@ def test_unsupported_parameter_maps_to_400_with_the_reason() -> None:
     assert failure_status_code(exc) == 400
 
 
+def test_unsupported_parameter_payload_echo_uses_fallback_detail() -> None:
+    """A capability error that echoes the payload never returns an empty detail."""
+    exc = UnsupportedParameterError(
+        "prompt_cache_key",
+        "bedrock",
+        'request_body={"messages":[{"content":"secret prompt"}]}',
+    )
+    mapping = classify_provider_error(exc)
+    assert mapping is not None
+    assert mapping.status_code == 400
+    assert mapping.detail == PROVIDER_BAD_REQUEST_DETAIL
+
+
 def test_unsupported_feature_is_recorded_as_400_on_the_usage_log() -> None:
     """The usage-log status follows the classification rather than the generic 502."""
     assert failure_status_code(NotImplementedError(_CONTEXT_MANAGEMENT_MSG)) == 400

--- a/tests/unit/test_provider_error_classification.py
+++ b/tests/unit/test_provider_error_classification.py
@@ -16,6 +16,7 @@ import asyncio
 import httpx
 import pytest
 from anthropic import APITimeoutError as AnthropicAPITimeoutError
+from any_llm.exceptions import UnsupportedParameterError
 from openai import APITimeoutError as OpenAIAPITimeoutError
 
 from gateway.api.routes._pipeline import (
@@ -317,6 +318,16 @@ def test_unsupported_feature_survives_the_unified_exception_wrapper() -> None:
     assert mapping is not None
     assert mapping.status_code == 400
     assert "context_management" in mapping.detail
+
+
+def test_unsupported_parameter_maps_to_400_with_the_reason() -> None:
+    """Typed any-llm capability failures are permanent caller errors, not 502s."""
+    exc = UnsupportedParameterError("prompt_cache_key", "anthropic")
+    mapping = classify_provider_error(exc)
+    assert mapping is not None
+    assert mapping.status_code == 400
+    assert mapping.detail == "'prompt_cache_key' is not supported for anthropic"
+    assert failure_status_code(exc) == 400
 
 
 def test_unsupported_feature_is_recorded_as_400_on_the_usage_log() -> None:

--- a/tests/unit/test_request_schema_derivation.py
+++ b/tests/unit/test_request_schema_derivation.py
@@ -73,6 +73,13 @@ def test_request_schema_covers_any_llm_params(endpoint: str) -> None:
     )
 
 
+@pytest.mark.parametrize("request_model", [ChatCompletionRequest, MessagesRequest])
+def test_prompt_cache_key_is_exposed_on_chat_and_messages(request_model: type[BaseModel]) -> None:
+    """The two schema-derived chat APIs expose any-llm's prompt cache key."""
+    assert "prompt_cache_key" in request_model.model_fields
+    assert "prompt_cache_key" in request_model.model_json_schema()["properties"]
+
+
 @pytest.mark.parametrize("endpoint", sorted(DERIVED_SCHEMAS))
 def test_renamed_params_are_exposed_under_the_wire_name(endpoint: str) -> None:
     """A renamed any-llm param (e.g. ``model_id`` -> ``model``) is exposed under the wire name."""

--- a/uv.lock
+++ b/uv.lock
@@ -196,7 +196,7 @@ wheels = [
 
 [[package]]
 name = "any-llm-sdk"
-version = "1.24.0"
+version = "1.25.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
@@ -207,9 +207,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/38/da47437de8f3447f8aa1acee55f71d3a9a0c4f53369ad0355cf6d1871c1f/any_llm_sdk-1.24.0.tar.gz", hash = "sha256:06391e27e0d81a0ea70580d8f8535c308d943079a8be62e65ffeb621dcb92ea9", size = 180139, upload-time = "2026-08-05T14:37:39.96Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/3b/baf9f17c3eb945f735de942550509bab0b03b2ba98ad64e9905c170dfe73/any_llm_sdk-1.25.0.tar.gz", hash = "sha256:af5671e8dedfed271485190e10f1517aff53ad0a234c6d5a1bf357629f9f4e85", size = 192367, upload-time = "2026-08-11T11:23:47.583Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/72/ab48a0e533669f483ef97018f664ba8dec659a8446c9ca3c7d3d2d519137/any_llm_sdk-1.24.0-py3-none-any.whl", hash = "sha256:bfdc633172330b2a76f178dd0fbb207b87cf2bed06bbe9460c0691c24435f597", size = 233211, upload-time = "2026-08-05T14:37:38.495Z" },
+    { url = "https://files.pythonhosted.org/packages/25/42/b89c812352589b1c7330a08a96440185925e124c77ecb786c7d1c743ed9c/any_llm_sdk-1.25.0-py3-none-any.whl", hash = "sha256:fc1bdf7db5d314e3a26c0b8e95c2fac6a7ae478446534d023b3e61ab5ad6ef41", size = 246498, upload-time = "2026-08-11T11:23:45.93Z" },
 ]
 
 [package.optional-dependencies]
@@ -1066,7 +1066,7 @@ dev = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.19.0" },
     { name = "alembic", specifier = ">=1.13.0" },
-    { name = "any-llm-sdk", extras = ["all"], specifier = ">=1.24.0" },
+    { name = "any-llm-sdk", extras = ["all"], specifier = ">=1.25.0" },
     { name = "apron-auth", specifier = ">=0.15.1,<0.16.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "bcrypt", specifier = ">=5.0.0" },

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -4581,6 +4581,8 @@ export interface components {
             parallel_tool_calls?: boolean | null;
             /** Presence Penalty */
             presence_penalty?: number | null;
+            /** Prompt Cache Key */
+            prompt_cache_key?: string | null;
             /**
              * Reasoning Effort
              * @default auto
@@ -5904,6 +5906,8 @@ export interface components {
             output_format?: {
                 [key: string]: unknown;
             } | null;
+            /** Prompt Cache Key */
+            prompt_cache_key?: string | null;
             /**
              * Session Label
              * @description Optional caller-supplied label for cost attribution (per run, experiment, or conversation). In hybrid mode it is forwarded onto the platform usage report so spend can be sliced by session without standing up OpenTelemetry. Stripped before the request is forwarded upstream to the provider. Has no effect in standalone mode, where there is no platform to report it to.


### PR DESCRIPTION
## Description

`prompt_cache_key` was dropped from chat completion and Messages requests because Otari was locked to an older any-llm release. Upgrade to any-llm-sdk 1.25.0, expose and forward the field on both schemas, and return an actionable 400 when the selected provider cannot support it.

The OpenAPI document and dashboard client schema are regenerated. Tests cover schema exposure, OpenAI forwarding, Messages forwarding, unsupported-provider errors, and the Bedrock client construction change in any-llm 1.25.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #514

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** GPT-5.6 Sol with Pi

**Any additional AI details you'd like to share:** Implemented and verified directly against the backend, OpenAPI/Postman, and dashboard client checks.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Upgraded `any-llm-sdk` to 1.25.0.
- Added `prompt_cache_key` to chat completion, Messages, and Responses requests.
- Scoped cache keys to authenticated users and removed them when no authenticated scope exists.
- Added clear HTTP 400 errors for unsupported providers.
- Updated generated API and dashboard client schemas.
- Added tests for schema exposure, key scoping, forwarding, error handling, and Bedrock routing.

These changes provide safer, consistent prompt caching across supported gateway endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->