### PR TITLE
test(e2e): seed the budget assignee before the app loads

### DIFF
--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -117,17 +117,24 @@ test.describe("dashboard core flows", () => {
   })
 
   test("assign the budget to a person", async ({ page }) => {
-    await login(page)
     // There is no page that creates a spend identity any more: one is minted
     // when a member is added or when a key is issued. Seeded over the API here
     // so this spec stays about the assignment, which is the part that moved onto
     // the budget form when the users page went away.
+    //
+    // The seed has to happen before `login(page)`, not after it. Loading the app
+    // fetches `GET /v1/users`, and `useUsers` caches it with `staleTime: 60_000`
+    // (web/src/shared/api/hooks.ts), so a list fetched before alice exists stays
+    // fresh through `BudgetsPage` mounting: no refetch, no alice in the combobox,
+    // and the option click below waits out the 30s test timeout. Seeding first
+    // makes the order deterministic instead of a race with the app's own request.
     const created = await page.request.post("/v1/users", {
       headers: { "Otari-Key": MASTER_KEY },
       data: { user_id: "alice@example.com" },
     })
     expect(created.ok() || created.status() === 409).toBeTruthy()
 
+    await login(page)
     await openOrganization(page)
     await nav(page).getByRole("link", { name: "Spend & budgets" }).click()
     const budgetRow = page.getByRole("row", { name: /e2e-budget/ })


### PR DESCRIPTION
## Description

`dashboard.spec.ts` "assign the budget to a person" seeded alice through `POST /v1/users` **after** `login(page)`, so the seed raced the app's own `GET /v1/users`. `useUsers` caches that list with `staleTime: 60_000` (`web/src/shared/api/hooks.ts`), so when the app's fetch won the race, the cached list held no alice and was still fresh when `BudgetsPage` mounted: no refetch, no alice option in the combobox, and the option click waited out the 30s test timeout. Which request lands first is machine timing, so the test is green locally and red on some CI runners (it took down the `e2e` job on #772, where no frontend file was touched).

The fix is to seed before `login(page)`. The comment now records why the order matters, since the two lines look freely reorderable.

## Evidence

A harness that forces the losing order (a 1.5s wait after `login`, before the interaction), same commit both ways:

| | Test 6 |
| --- | --- |
| `main` (0dfb88d), forced order | fails, 30.1s timeout |
| this branch, forced order | passes, 436ms |

Plus three clean runs of the `onboarding` project on this branch: 11 passed each time, test 6 at 438ms, 457ms, 606ms. `pnpm --dir web run lint` is clean.

The same failure was also reproduced unforced on `698be2b`: 1 failure in 3 runs, identical locator and timeout, with no source change at all, which is what showed this was never a regression in the PR it blocked.

No other test in this spec writes over the API after `login(page)`: the routing rename and the PNG share already seed first, and the API-key test reads the row this test creates, on a page load that happens afterward.

Unblocks the `e2e` check on #772, which needs a rebase onto this once it lands.

## PR Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None; found while diagnosing the `e2e` failure on #772.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Scope note for the checklist: this changes one Playwright spec, so the checks that apply are `pnpm --dir web run lint` and the `onboarding` project itself, both quoted above. No Python, no API surface, no docs affected.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code

**Any additional AI details you'd like to share:**

The diagnosis, the fix, and the before/after harness runs were done by the agent.

- [x] I am an AI Agent filling out this form (check box if true)

Authored by Claude Opus 5 (1M context) via Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Moved Alice’s test data setup before login in the budget assignment test.
- Added a comment that explains why this order prevents stale user data.
- This removes the race condition and makes the Playwright test reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->