### PR TITLE
feat(tenancy): scope the gateway survivals to a workspace

### DIFF
--- a/alembic/versions/c1e4a7b9d3f6_widen_alias_policy_uniqueness.py
+++ b/alembic/versions/c1e4a7b9d3f6_widen_alias_policy_uniqueness.py
@@ -28,7 +28,7 @@ the table, and a partial index carried through that rebuild by reflection is the
 part most likely to come back subtly wrong.
 
 Revision ID: c1e4a7b9d3f6
-Revises: a9c4e2b6d8f1
+Revises: a7f3c9e2b481
 Create Date: 2026-08-25
 """
 
@@ -38,7 +38,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "c1e4a7b9d3f6"
-down_revision: str | Sequence[str] | None = "a9c4e2b6d8f1"
+down_revision: str | Sequence[str] | None = "a7f3c9e2b481"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/c1e4a7b9d3f6_widen_alias_policy_uniqueness.py
+++ b/alembic/versions/c1e4a7b9d3f6_widen_alias_policy_uniqueness.py
@@ -28,7 +28,7 @@ the table, and a partial index carried through that rebuild by reflection is the
 part most likely to come back subtly wrong.
 
 Revision ID: c1e4a7b9d3f6
-Revises: a7f3c9e2b481
+Revises: c7a1e4d8f3b6
 Create Date: 2026-08-25
 """
 
@@ -38,7 +38,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "c1e4a7b9d3f6"
-down_revision: str | Sequence[str] | None = "a7f3c9e2b481"
+down_revision: str | Sequence[str] | None = "c7a1e4d8f3b6"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/alembic/versions/c1e4a7b9d3f6_widen_alias_policy_uniqueness.py
+++ b/alembic/versions/c1e4a7b9d3f6_widen_alias_policy_uniqueness.py
@@ -1,0 +1,177 @@
+"""Widen alias and routing-policy uniqueness to the workspace.
+
+``model_aliases`` and ``routing_policies`` have carried a ``workspace_id`` since
+``d5e7f1a2b3c4``, but their uniqueness stayed at ``(name, user_id)``: resolution
+read a process-wide cache keyed on name alone, so a second workspace's "fast"
+would have silently shadowed the first at request time. ``alias_service`` and
+``policy_store`` key that cache by workspace as of this change, so the
+constraints can finally say what the column already implies.
+
+Both tables get the same pair they had before, one column wider:
+
+* ``uq_<table>_workspace_name_user`` over ``(workspace_id, name, user_id)``.
+* ``uq_<table>_workspace_global_name``, a partial unique index over
+  ``(workspace_id, name)`` where ``user_id IS NULL``. The composite constraint
+  cannot cover the global rows, because SQLite and PostgreSQL both treat NULLs
+  in a unique index as distinct.
+
+Widening only ever admits rows, never rejects one: every pair that was unique
+under ``(name, user_id)`` is still unique under ``(workspace_id, name,
+user_id)``. The downgrade is the direction that can fail, and deliberately does
+rather than deleting rows: two workspaces each holding a "fast" alias have no
+representation in the narrower constraint, and dropping one of them is not a
+choice a migration gets to make silently.
+
+The partial indexes are dropped before the batch rebuild and recreated after.
+SQLite has no ``ALTER TABLE ... DROP CONSTRAINT``, so the batch block rebuilds
+the table, and a partial index carried through that rebuild by reflection is the
+part most likely to come back subtly wrong.
+
+Revision ID: c1e4a7b9d3f6
+Revises: a9c4e2b6d8f1
+Create Date: 2026-08-25
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c1e4a7b9d3f6"
+down_revision: str | Sequence[str] | None = "a9c4e2b6d8f1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_ALIAS_UQ_OLD = "uq_model_aliases_name_user"
+_ALIAS_UQ_NEW = "uq_model_aliases_workspace_name_user"
+_ALIAS_IX_OLD = "uq_model_aliases_global_name"
+_ALIAS_IX_NEW = "uq_model_aliases_workspace_global_name"
+
+_POLICY_UQ_OLD = "uq_routing_policies_name_user"
+_POLICY_UQ_NEW = "uq_routing_policies_workspace_name_user"
+_POLICY_IX_OLD = "uq_routing_policies_global_name"
+_POLICY_IX_NEW = "uq_routing_policies_workspace_global_name"
+
+
+def _model_aliases(*, workspace_scoped: bool) -> sa.Table:
+    """``model_aliases`` as it stands on one side of this revision.
+
+    Described explicitly rather than reflected, for the reason ``c3f7a9d1e5b8``
+    gives: SQLite reflection does not reliably name a unique constraint, so
+    ``drop_constraint`` could not address it and the batch recreate would swap it
+    silently on behavior SQLAlchemy has reserved the right to turn into an error.
+    """
+    meta = sa.MetaData()
+    return sa.Table(
+        "model_aliases",
+        meta,
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("target", sa.String(), nullable=False),
+        sa.Column("user_id", sa.String(), nullable=True),
+        sa.Column("workspace_id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="model_aliases_pkey"),
+        (
+            sa.UniqueConstraint("workspace_id", "name", "user_id", name=_ALIAS_UQ_NEW)
+            if workspace_scoped
+            else sa.UniqueConstraint("name", "user_id", name=_ALIAS_UQ_OLD)
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.user_id"], name="fk_model_aliases_user_id_users", ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"], ["workspace.id"], name="fk_model_aliases_workspace_id", ondelete="RESTRICT"
+        ),
+        # Declared because ``copy_from`` replaces reflection wholesale: an index
+        # left out here is an index SQLite's table rebuild drops on the floor.
+        # The two partial unique indexes are deliberately absent, being dropped
+        # before the rebuild and recreated after it.
+        sa.Index("ix_model_aliases_user_id", "user_id"),
+        sa.Index("ix_model_aliases_workspace_id", "workspace_id"),
+    )
+
+
+def _routing_policies(*, workspace_scoped: bool) -> sa.Table:
+    """``routing_policies`` as it stands on one side of this revision."""
+    meta = sa.MetaData()
+    return sa.Table(
+        "routing_policies",
+        meta,
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("spec", sa.JSON(), nullable=False),
+        sa.Column("user_id", sa.String(), nullable=True),
+        sa.Column("workspace_id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="routing_policies_pkey"),
+        (
+            sa.UniqueConstraint("workspace_id", "name", "user_id", name=_POLICY_UQ_NEW)
+            if workspace_scoped
+            else sa.UniqueConstraint("name", "user_id", name=_POLICY_UQ_OLD)
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.user_id"], name="fk_routing_policies_user_id_users", ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"], ["workspace.id"], name="fk_routing_policies_workspace_id", ondelete="RESTRICT"
+        ),
+        sa.Index("ix_routing_policies_user_id", "user_id"),
+        sa.Index("ix_routing_policies_workspace_id", "workspace_id"),
+    )
+
+
+def _global_index(name: str, table: str, columns: list[str]) -> None:
+    op.create_index(
+        name,
+        table,
+        columns,
+        unique=True,
+        sqlite_where=sa.text("user_id IS NULL"),
+        postgresql_where=sa.text("user_id IS NULL"),
+    )
+
+
+def upgrade() -> None:
+    op.drop_index(_ALIAS_IX_OLD, table_name="model_aliases")
+    with op.batch_alter_table(
+        "model_aliases", copy_from=_model_aliases(workspace_scoped=False)
+    ) as batch:
+        batch.drop_constraint(_ALIAS_UQ_OLD, type_="unique")
+        batch.create_unique_constraint(_ALIAS_UQ_NEW, ["workspace_id", "name", "user_id"])
+    _global_index(_ALIAS_IX_NEW, "model_aliases", ["workspace_id", "name"])
+
+    op.drop_index(_POLICY_IX_OLD, table_name="routing_policies")
+    with op.batch_alter_table(
+        "routing_policies", copy_from=_routing_policies(workspace_scoped=False)
+    ) as batch:
+        batch.drop_constraint(_POLICY_UQ_OLD, type_="unique")
+        batch.create_unique_constraint(_POLICY_UQ_NEW, ["workspace_id", "name", "user_id"])
+    _global_index(_POLICY_IX_NEW, "routing_policies", ["workspace_id", "name"])
+
+
+def downgrade() -> None:
+    """Narrow both constraints back, failing loudly on rows that need the wider one.
+
+    No row is deleted here. A name held by two workspaces is exactly the state
+    the widening exists to allow, and the narrower constraint has no room for it,
+    so the integrity error the recreate raises is the honest outcome: an operator
+    rolling back has to decide which row survives.
+    """
+    op.drop_index(_ALIAS_IX_NEW, table_name="model_aliases")
+    with op.batch_alter_table(
+        "model_aliases", copy_from=_model_aliases(workspace_scoped=True)
+    ) as batch:
+        batch.drop_constraint(_ALIAS_UQ_NEW, type_="unique")
+        batch.create_unique_constraint(_ALIAS_UQ_OLD, ["name", "user_id"])
+    _global_index(_ALIAS_IX_OLD, "model_aliases", ["name"])
+
+    op.drop_index(_POLICY_IX_NEW, table_name="routing_policies")
+    with op.batch_alter_table(
+        "routing_policies", copy_from=_routing_policies(workspace_scoped=True)
+    ) as batch:
+        batch.drop_constraint(_POLICY_UQ_NEW, type_="unique")
+        batch.create_unique_constraint(_POLICY_UQ_OLD, ["name", "user_id"])
+    _global_index(_POLICY_IX_OLD, "routing_policies", ["name"])

--- a/alembic/versions/d2f5b8c0e4a7_workspace_scope_survivals.py
+++ b/alembic/versions/d2f5b8c0e4a7_workspace_scope_survivals.py
@@ -1,0 +1,220 @@
+"""Scope routing memory, router preferences and files to a workspace.
+
+``d5e7f1a2b3c4`` scoped the four request-plane tables the dashboard bills and
+lists by. These three are the rest of what stays in the gateway rather than
+moving to the platform (otari-ai#1643): the learned router's example store, its
+preference audit trail, and uploaded file metadata. Same column, same shape, and
+the same backfill onto the deployment's default workspace, so a standalone
+gateway upgrades with nothing to re-issue and nothing to move.
+
+NOT NULL and ``RESTRICT``, matching ``api_keys.workspace_id``: "no workspace" is
+never a real state, and deleting a workspace must not silently take a user's
+uploads or a router's training data with it.
+
+``user_id`` is untouched on all three. The workspace is a second axis, not a
+replacement: the router still reads one user's examples, and a file still belongs
+to the user who uploaded it. What the workspace adds is that a user holding keys
+in two workspaces no longer has one workspace's rows visible from the other.
+
+The composite indexes on the two router tables are renamed rather than extended
+in place, because every read now leads with the workspace: they are dropped
+before the column arrives and recreated after it, so SQLite's table rebuild never
+has a stale one to carry through reflection.
+
+The ``server_default`` stays for the reason ``d5e7f1a2b3c4`` gives: the backfill
+needs it, and it protects no writer afterwards, since SQLAlchemy sends an
+explicit NULL for a mapped column it was given no value for.
+
+Revision ID: d2f5b8c0e4a7
+Revises: c1e4a7b9d3f6
+Create Date: 2026-08-25
+"""
+
+import uuid
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d2f5b8c0e4a7"
+down_revision: str | Sequence[str] | None = "c1e4a7b9d3f6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Must match provisioning_service and d5e7f1a2b3c4, which look the default up by
+# these values and only create one when the lookup misses.
+DEFAULT_ORGANIZATION_NAME = "Default organization"
+DEFAULT_ORGANIZATION_SLUG = "default"
+DEFAULT_WORKSPACE_NAME = "Default workspace"
+
+SCOPED_TABLES = ("routing_memory", "router_preferences", "file_objects")
+
+# Old name -> (new name, columns). Renamed because the workspace now leads every
+# read of these tables.
+RENAMED_INDEXES: dict[str, tuple[str, list[str]]] = {
+    "ix_routing_memory_user_model": (
+        "ix_routing_memory_workspace_user_model",
+        ["workspace_id", "user_id", "embedding_model"],
+    ),
+    "ix_routing_memory_user_created": (
+        "ix_routing_memory_workspace_user_created",
+        ["workspace_id", "user_id", "created_at"],
+    ),
+    "ix_routing_memory_user_model_task": (
+        "ix_routing_memory_workspace_user_model_task",
+        ["workspace_id", "user_id", "embedding_model", "task_id"],
+    ),
+    "ix_router_preferences_user_created": (
+        "ix_router_preferences_workspace_user_created",
+        ["workspace_id", "user_id", "created_at"],
+    ),
+}
+
+_INDEX_TABLE = {
+    "ix_routing_memory_user_model": "routing_memory",
+    "ix_routing_memory_user_created": "routing_memory",
+    "ix_routing_memory_user_model_task": "routing_memory",
+    "ix_router_preferences_user_created": "router_preferences",
+}
+
+_OLD_INDEX_COLUMNS: dict[str, list[str]] = {
+    "ix_routing_memory_user_model": ["user_id", "embedding_model"],
+    "ix_routing_memory_user_created": ["user_id", "created_at"],
+    "ix_routing_memory_user_model_task": ["user_id", "embedding_model", "task_id"],
+    "ix_router_preferences_user_created": ["user_id", "created_at"],
+}
+
+
+def _uuid_literal(bind: sa.engine.Connection, value: uuid.UUID) -> str:
+    """Render a UUID the way this dialect stores one.
+
+    ``sa.Uuid`` is native on PostgreSQL and CHAR(32) hex on SQLite, and a
+    ``server_default`` is raw SQL rather than a bound parameter, so the literal
+    has to match the storage form or every backfilled row reads back as a value
+    that joins to nothing.
+    """
+    return value.hex if bind.dialect.name == "sqlite" else str(value)
+
+
+def _default_workspace_id(bind: sa.engine.Connection) -> uuid.UUID:
+    """The workspace existing rows are backfilled onto.
+
+    ``d5e7f1a2b3c4`` runs before this and seeds the default when tenancy was
+    never touched, so the first lookup answers on every migrated database. The
+    fallbacks are here for the database an operator has since renamed or reshaped
+    by hand: adopt the oldest workspace before minting a second default, matching
+    ``services/workspace_scope.default_workspace_id``.
+    """
+    organization_id = bind.execute(
+        sa.text("SELECT id FROM organization WHERE slug = :slug"),
+        {"slug": DEFAULT_ORGANIZATION_SLUG},
+    ).scalar()
+    if organization_id is not None:
+        workspace_id = bind.execute(
+            sa.text("SELECT id FROM workspace WHERE organization_id = :org AND name = :name"),
+            {"org": _uuid_literal(bind, uuid.UUID(str(organization_id))), "name": DEFAULT_WORKSPACE_NAME},
+        ).scalar()
+        if workspace_id is not None:
+            return uuid.UUID(str(workspace_id))
+
+    # The id breaks a ``created_at`` tie so this and the runtime resolve the same
+    # row when one transaction created two workspaces.
+    workspace_id = bind.execute(
+        sa.text("SELECT id FROM workspace ORDER BY created_at, id LIMIT 1")
+    ).scalar()
+    if workspace_id is not None:
+        return uuid.UUID(str(workspace_id))
+
+    return _seed_default_workspace(bind)
+
+
+def _seed_default_workspace(bind: sa.engine.Connection) -> uuid.UUID:
+    """Create the default organization and workspace, returning the workspace id.
+
+    Only reachable on a database whose tenancy rows were removed after
+    ``d5e7f1a2b3c4`` seeded them, which the ``RESTRICT`` foreign keys make
+    possible exactly while no request-plane row references them. Seeding rather
+    than failing keeps that database upgradable, and the slug and name match what
+    provisioning looks up, so a later first boot adopts these rows.
+    """
+    organization_id = bind.execute(
+        sa.text("SELECT id FROM organization WHERE slug = :slug"),
+        {"slug": DEFAULT_ORGANIZATION_SLUG},
+    ).scalar()
+    if organization_id is None:
+        organization_id = uuid.uuid4()
+        bind.execute(
+            sa.text(
+                "INSERT INTO organization (id, name, slug, created_by_user_id, created_at) "
+                "VALUES (:id, :name, :slug, NULL, CURRENT_TIMESTAMP)"
+            ),
+            {
+                "id": _uuid_literal(bind, organization_id),
+                "name": DEFAULT_ORGANIZATION_NAME,
+                "slug": DEFAULT_ORGANIZATION_SLUG,
+            },
+        )
+    else:
+        organization_id = uuid.UUID(str(organization_id))
+
+    workspace_id = uuid.uuid4()
+    bind.execute(
+        sa.text(
+            "INSERT INTO workspace "
+            "(id, organization_id, name, description, created_by_user_id, "
+            " activation_classification, created_at) "
+            "VALUES (:id, :org, :name, NULL, NULL, 'eligible', CURRENT_TIMESTAMP)"
+        ),
+        {
+            "id": _uuid_literal(bind, workspace_id),
+            "org": _uuid_literal(bind, organization_id),
+            "name": DEFAULT_WORKSPACE_NAME,
+        },
+    )
+    return workspace_id
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    literal = _uuid_literal(bind, _default_workspace_id(bind))
+
+    for old_name in RENAMED_INDEXES:
+        op.drop_index(old_name, table_name=_INDEX_TABLE[old_name])
+
+    for table in SCOPED_TABLES:
+        op.add_column(
+            table,
+            sa.Column("workspace_id", sa.Uuid(), nullable=False, server_default=sa.text(f"'{literal}'")),
+        )
+        op.create_index(op.f(f"ix_{table}_workspace_id"), table, ["workspace_id"], unique=False)
+        # SQLite has no ``ALTER TABLE ... ADD CONSTRAINT``, so this rebuilds the
+        # table there. Reflection carries the remaining single-column indexes
+        # through; the composite ones were dropped above and are recreated below,
+        # so none of them depends on how well SQLite reflects a multi-column index.
+        with op.batch_alter_table(table) as batch:
+            batch.create_foreign_key(
+                f"fk_{table}_workspace_id",
+                "workspace",
+                ["workspace_id"],
+                ["id"],
+                ondelete="RESTRICT",
+            )
+
+    for old_name, (new_name, columns) in RENAMED_INDEXES.items():
+        op.create_index(new_name, _INDEX_TABLE[old_name], columns)
+
+
+def downgrade() -> None:
+    for old_name, (new_name, _columns) in RENAMED_INDEXES.items():
+        op.drop_index(new_name, table_name=_INDEX_TABLE[old_name])
+
+    for table in SCOPED_TABLES:
+        with op.batch_alter_table(table) as batch:
+            batch.drop_constraint(f"fk_{table}_workspace_id", type_="foreignkey")
+        # Dropped before the column: SQLite refuses ``DROP COLUMN`` while an index
+        # covers it.
+        op.drop_index(op.f(f"ix_{table}_workspace_id"), table_name=table)
+        op.drop_column(table, "workspace_id")
+
+    for old_name, columns in _OLD_INDEX_COLUMNS.items():
+        op.create_index(old_name, _INDEX_TABLE[old_name], columns)

--- a/alembic/versions/d2f5b8c0e4a7_workspace_scope_survivals.py
+++ b/alembic/versions/d2f5b8c0e4a7_workspace_scope_survivals.py
@@ -49,40 +49,39 @@ DEFAULT_WORKSPACE_NAME = "Default workspace"
 
 SCOPED_TABLES = ("routing_memory", "router_preferences", "file_objects")
 
-# Old name -> (new name, columns). Renamed because the workspace now leads every
-# read of these tables.
-RENAMED_INDEXES: dict[str, tuple[str, list[str]]] = {
-    "ix_routing_memory_user_model": (
+# The composite indexes that move. Each is dropped before the column arrives and
+# recreated after it, rather than being extended in place, because every read of
+# these tables now leads with the workspace.
+RENAMED_INDEXES: tuple[tuple[str, str, list[str], str, list[str]], ...] = (
+    (
+        "routing_memory",
+        "ix_routing_memory_user_model",
+        ["user_id", "embedding_model"],
         "ix_routing_memory_workspace_user_model",
         ["workspace_id", "user_id", "embedding_model"],
     ),
-    "ix_routing_memory_user_created": (
+    (
+        "routing_memory",
+        "ix_routing_memory_user_created",
+        ["user_id", "created_at"],
         "ix_routing_memory_workspace_user_created",
         ["workspace_id", "user_id", "created_at"],
     ),
-    "ix_routing_memory_user_model_task": (
+    (
+        "routing_memory",
+        "ix_routing_memory_user_model_task",
+        ["user_id", "embedding_model", "task_id"],
         "ix_routing_memory_workspace_user_model_task",
         ["workspace_id", "user_id", "embedding_model", "task_id"],
     ),
-    "ix_router_preferences_user_created": (
+    (
+        "router_preferences",
+        "ix_router_preferences_user_created",
+        ["user_id", "created_at"],
         "ix_router_preferences_workspace_user_created",
         ["workspace_id", "user_id", "created_at"],
     ),
-}
-
-_INDEX_TABLE = {
-    "ix_routing_memory_user_model": "routing_memory",
-    "ix_routing_memory_user_created": "routing_memory",
-    "ix_routing_memory_user_model_task": "routing_memory",
-    "ix_router_preferences_user_created": "router_preferences",
-}
-
-_OLD_INDEX_COLUMNS: dict[str, list[str]] = {
-    "ix_routing_memory_user_model": ["user_id", "embedding_model"],
-    "ix_routing_memory_user_created": ["user_id", "created_at"],
-    "ix_routing_memory_user_model_task": ["user_id", "embedding_model", "task_id"],
-    "ix_router_preferences_user_created": ["user_id", "created_at"],
-}
+)
 
 
 def _uuid_literal(bind: sa.engine.Connection, value: uuid.UUID) -> str:
@@ -178,8 +177,8 @@ def upgrade() -> None:
     bind = op.get_bind()
     literal = _uuid_literal(bind, _default_workspace_id(bind))
 
-    for old_name in RENAMED_INDEXES:
-        op.drop_index(old_name, table_name=_INDEX_TABLE[old_name])
+    for table, old_name, _old_columns, _new_name, _new_columns in RENAMED_INDEXES:
+        op.drop_index(old_name, table_name=table)
 
     for table in SCOPED_TABLES:
         op.add_column(
@@ -200,13 +199,13 @@ def upgrade() -> None:
                 ondelete="RESTRICT",
             )
 
-    for old_name, (new_name, columns) in RENAMED_INDEXES.items():
-        op.create_index(new_name, _INDEX_TABLE[old_name], columns)
+    for table, _old_name, _old_columns, new_name, new_columns in RENAMED_INDEXES:
+        op.create_index(new_name, table, new_columns)
 
 
 def downgrade() -> None:
-    for old_name, (new_name, _columns) in RENAMED_INDEXES.items():
-        op.drop_index(new_name, table_name=_INDEX_TABLE[old_name])
+    for table, _old_name, _old_columns, new_name, _new_columns in RENAMED_INDEXES:
+        op.drop_index(new_name, table_name=table)
 
     for table in SCOPED_TABLES:
         with op.batch_alter_table(table) as batch:
@@ -216,5 +215,5 @@ def downgrade() -> None:
         op.drop_index(op.f(f"ix_{table}_workspace_id"), table_name=table)
         op.drop_column(table, "workspace_id")
 
-    for old_name, columns in _OLD_INDEX_COLUMNS.items():
-        op.create_index(old_name, _INDEX_TABLE[old_name], columns)
+    for table, old_name, old_columns, _new_name, _new_columns in RENAMED_INDEXES:
+        op.create_index(old_name, table, old_columns)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -254,7 +254,7 @@ into something a text-only local model can read.
 | Method | Path | Description | Auth |
 |--------|------|-------------|------|
 | `POST` | `/v1/batches` | Create an async batch of LLM requests. | API key or master key |
-| `GET` | `/v1/batches` | List batches. Query param: `provider`. | API key or master key |
+| `GET` | `/v1/batches` | List batches. Query param: `provider`. A non-master key sees only the batches it owns in its own workspace, plus legacy ones carrying no owner marker or no recorded workspace; the master key sees all of them. Ownership is filtered after the provider call, so a page can come back with fewer items than `limit`. | API key or master key |
 | `GET` | `/v1/batches/{batch_id}` | Get batch status. Query param: `provider`. | API key or master key |
 | `POST` | `/v1/batches/{batch_id}/cancel` | Cancel a batch. Query param: `provider`. | API key or master key |
 | `GET` | `/v1/batches/{batch_id}/results` | Get batch results. Returns 409 if not complete. Query param: `provider`. | API key or master key |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -244,7 +244,7 @@ into something a text-only local model can read.
 | Method | Path | Description | Auth |
 |--------|------|-------------|------|
 | `POST` | `/v1/files` | Upload a file (multipart: `file`, `purpose`). Returns a file object with an `id`. | API key or master key |
-| `GET` | `/v1/files` | List the caller's files. Query params: `purpose`. | API key or master key |
+| `GET` | `/v1/files` | List the caller's files in the workspace of the key that authenticated them. Query params: `purpose`, and `workspace_id` to narrow a master-key listing to one workspace. | API key or master key |
 | `GET` | `/v1/files/{file_id}` | Get file metadata. | API key or master key |
 | `GET` | `/v1/files/{file_id}/content` | Download the raw file bytes. | API key or master key |
 | `DELETE` | `/v1/files/{file_id}` | Delete a file. | API key or master key |
@@ -352,9 +352,9 @@ An alias is a display name that resolves to one real model selector. See
 
 | Method | Path | Description | Auth |
 |--------|------|-------------|------|
-| `GET` | `/v1/aliases` | List every alias in force, from `config.yml` and from storage, in every scope. | Master key |
-| `POST` | `/v1/aliases` | Create or update a stored alias. Omit `user_id` for a global one. | Master key |
-| `DELETE` | `/v1/aliases/{name}` | Delete a stored alias. `user_id` query param selects the scope; omit it for the global one. Aliases from `config.yml` cannot be deleted here. | Master key |
+| `GET` | `/v1/aliases` | List every alias in force, from `config.yml` and from storage, in every scope. `workspace_id` narrows the stored ones to one workspace; `config.yml` aliases are deployment-wide and always listed. | Master key |
+| `POST` | `/v1/aliases` | Create or update a stored alias. Omit `user_id` for one every caller in the workspace sees, and `workspace_id` for the deployment's default workspace. | Master key |
+| `DELETE` | `/v1/aliases/{name}` | Delete a stored alias. `user_id` and `workspace_id` query params select the scope; omit them for the workspace-wide alias and the default workspace. Aliases from `config.yml` cannot be deleted here. | Master key |
 
 ### Routing policies
 
@@ -364,10 +364,10 @@ See [Routing policies](routing.md).
 
 | Method | Path | Description | Auth |
 |--------|------|-------------|------|
-| `GET` | `/v1/routing/policies` | List every policy in force, from `config.yml` and from storage, in every scope. | Master key |
-| `POST` | `/v1/routing/policies` | Create or update a stored policy. Body is `{name, spec, user_id?, rename_from?}`; `spec` is the same document a `routing.policies` entry takes. Omit `user_id` for a global one. `rename_from` renames an existing policy in the same scope to `name` on the same write: 404 if it does not exist, 409 if `name` is already taken. | Master key |
-| `POST` | `/v1/routing/policies/explain` | Compile a policy and return the plan without dispatching anything. Takes a saved `name`, an unsaved draft `spec`, or both (the draft wins). Optional `user_id`, `key_id`, `allowed_models`, `budget_used_pct`, `budget_remaining_usd` simulate the request. Returns the ordered candidates **and** the ones that were dropped, with reasons. For a weighted policy it also returns `router_weights`, the share each candidate takes once filtering is applied. | Master key |
-| `DELETE` | `/v1/routing/policies/{name}` | Delete a stored policy. `user_id` query param selects the scope. Policies from `config.yml` cannot be deleted here. | Master key |
+| `GET` | `/v1/routing/policies` | List every policy in force, from `config.yml` and from storage, in every scope. `workspace_id` narrows the stored ones to one workspace. | Master key |
+| `POST` | `/v1/routing/policies` | Create or update a stored policy. Body is `{name, spec, user_id?, workspace_id?, rename_from?}`; `spec` is the same document a `routing.policies` entry takes. Omit `user_id` for one every caller in the workspace sees, and `workspace_id` for the deployment's default workspace. `rename_from` renames an existing policy in the same scope to `name` on the same write: 404 if it does not exist, 409 if `name` is already taken. | Master key |
+| `POST` | `/v1/routing/policies/explain` | Compile a policy and return the plan without dispatching anything. Takes a saved `name`, an unsaved draft `spec`, or both (the draft wins). Optional `user_id`, `workspace_id`, `key_id`, `allowed_models`, `budget_used_pct`, `budget_remaining_usd` simulate the request. Returns the ordered candidates **and** the ones that were dropped, with reasons. For a weighted policy it also returns `router_weights`, the share each candidate takes once filtering is applied. | Master key |
+| `DELETE` | `/v1/routing/policies/{name}` | Delete a stored policy. `user_id` and `workspace_id` query params select the scope. Policies from `config.yml` cannot be deleted here. | Master key |
 
 Master key on every verb, including `explain`: the response enumerates a policy's
 targets, which is what a policy exists to keep off the wire.
@@ -383,8 +383,8 @@ are budget-checked and logged. See
 
 | Method | Path | Description | Auth |
 |--------|------|-------------|------|
-| `POST` | `/v1/routing/preferences/rank` | Record a batch of scored `examples` under `user_id`: each has a `prompt`, `scores` (selector to quality in `[0, 1]`), an optional `task_id` partition, and an optional `label_source`. Writes the examples the router votes over and returns each touched pool's progress toward the seed count. Up to 100 per call. A score key that no learned policy could route to is refused, because such records are unmatchable and cannot be deleted. | Master key |
-| `GET` | `/v1/routing/status` | For `user_id`: records and warmth per pool (the default pool plus each task partition), the router's tuning, and which policies depend on it. | Master key |
+| `POST` | `/v1/routing/preferences/rank` | Record a batch of scored `examples` under `user_id`, in `workspace_id` (optional, defaulting to the deployment's default workspace): each has a `prompt`, `scores` (selector to quality in `[0, 1]`), an optional `task_id` partition, and an optional `label_source`. Writes the examples the router votes over and returns each touched pool's progress toward the seed count. Up to 100 per call. A score key that no learned policy could route to is refused, because such records are unmatchable and cannot be deleted. | Master key |
+| `GET` | `/v1/routing/status` | For `user_id` in `workspace_id` (optional, defaulting to the deployment's default workspace): records and warmth per pool (the default pool plus each task partition), the router's tuning, and which policies depend on it. | Master key |
 
 ### Pricing
 

--- a/docs/files.md
+++ b/docs/files.md
@@ -57,6 +57,22 @@ an intentionally unpriced backend.
 You can also inline a file as a base64 `data:` URL (`file.file_data`) or send an
 `image_url` block, with or without uploading first.
 
+### Who can see an uploaded file
+
+A file belongs to the user who uploaded it and to the workspace the uploading API
+key belongs to. Both have to match for a request to reach it, on the listing, the
+metadata, the download, the delete, and the `file_id` references resolved out of
+a chat message. So a user who holds keys in two workspaces reaches each
+workspace's files only through that workspace's key, and anything they cannot see
+answers 404 rather than 403, which is what keeps a foreign id indistinguishable
+from a missing one.
+
+The workspace comes off the key rather than a header, because a caller controls
+its headers and not which key it holds. The master key is the exception: it is the
+operator acting deployment-wide and sees every workspace, narrowable with
+`GET /v1/files?workspace_id=<id>`. A master-key upload lands in the deployment's
+default workspace.
+
 ## What Otari does per attachment
 
 For each file/image block it resolves the **target model's** capabilities, then:

--- a/docs/models.md
+++ b/docs/models.md
@@ -345,11 +345,11 @@ The rules that follow from it:
   aliases and the configured ones plus their own, never another user's and never
   another workspace's. `GET /v1/aliases` is the master-key management view and
   lists every scope at once, narrowable with `?workspace_id=<id>`.
-- Target-hiding follows the scope. A global alias hides its target from
-  everyone's listing; a user-scoped one hides it from that user's listing only, so
-  another caller may still see the real model (subject to their own model access).
-  If you are using aliases to curate one catalog for everybody, keep those
-  aliases global.
+- Target-hiding follows the scope. A workspace-wide alias hides its target from
+  every listing in that workspace; a user-scoped one hides it from that user's
+  listing only, so another caller may still see the real model (subject to their
+  own model access). If you are using aliases to curate one catalog for everybody
+  in a workspace, keep those aliases workspace-wide.
 - That rule inverts when a user-scoped alias overrides a **`config.yml`** name.
   The override replaces the configured entry for that user, so the configured
   target is no longer among the names being withheld and it reappears in that

--- a/docs/models.md
+++ b/docs/models.md
@@ -283,7 +283,7 @@ Like named instances, aliases are a standalone-mode feature. In hybrid mode mode
 resolution and routing are owned by the otari.ai platform, so the local `aliases`
 map does not apply.
 
-### Runtime aliases, and scoping one to a user
+### Runtime aliases, and scoping one to a user or a workspace
 
 Aliases can also be created without a restart, through `/v1/aliases` (master key
 only) or the dashboard's Routing page, which lists and manages aliases alongside
@@ -292,21 +292,30 @@ request as a configured one; it is stored in the database rather than in
 `config.yml`, and the listing tells you which is which (`source: config` or
 `source: stored`).
 
-A runtime alias applies to every caller by default. Give it a `user_id` and it
-applies to that user alone:
+A runtime alias has two independent scopes. It belongs to one **workspace**, and
+within that workspace it applies to every caller unless you give it a `user_id`,
+which narrows it to that user alone. Omitting `workspace_id` means the
+deployment's default workspace, so a single-workspace deployment never names one:
 
 ```bash
-# Global: everyone resolves "fast" to gpt-5-mini.
+# Workspace-wide: everyone in the default workspace resolves "fast" to gpt-5-mini.
 curl -X POST http://localhost:8000/v1/aliases \
   -H "Authorization: Bearer <master-key>" \
   -H "Content-Type: application/json" \
   -d '{"name": "fast", "target": "openai:gpt-5-mini"}'
 
-# Scoped: alice alone resolves "fast" to a local model instead.
+# Scoped to a user: alice alone resolves "fast" to a local model instead.
 curl -X POST http://localhost:8000/v1/aliases \
   -H "Authorization: Bearer <master-key>" \
   -H "Content-Type: application/json" \
   -d '{"name": "fast", "target": "home_lab:qwen3", "user_id": "alice"}'
+
+# Scoped to a workspace: the platform team resolves "fast" to their own target,
+# and nobody outside that workspace sees it.
+curl -X POST http://localhost:8000/v1/aliases \
+  -H "Authorization: Bearer <master-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "fast", "target": "openai:gpt-5", "workspace_id": "<workspace-id>"}'
 ```
 
 Scoping is what lets one stable model name mean different things to different
@@ -316,18 +325,26 @@ the `model` they send.
 
 The rules that follow from it:
 
+- Which workspace a request resolves in comes off the API key that authenticated
+  it, never off a header: a caller controls its headers and not which key it
+  holds. A master-key request resolves in the default workspace, which is where
+  its own writes land.
+- A `config.yml` alias has no workspace. It comes from a file the deployment owns,
+  so it is in force in every one of them and is listed unscoped.
 - Resolution is most-specific-first: a user's own alias wins over a `config.yml`
-  alias, which wins over a global stored one. So a user-scoped alias may override
-  a configured name (that is a working override), while a *global* stored alias
-  may not (config would win, and the stored one would silently never be used, so
-  the API refuses it with a 400).
-- A name plus a scope is the identity. Creating `fast` for `alice` leaves the
-  global `fast` alone, and deleting either leaves the other in place. Deletes take
-  the scope as a query parameter: `DELETE /v1/aliases/fast?user_id=alice`, or omit
-  it for the global one.
-- `GET /v1/models` is scoped the same way, so a caller sees the global and
-  configured aliases plus their own, never another user's. `GET /v1/aliases` is
-  the master-key management view and lists every scope at once.
+  alias, which wins over the workspace-wide stored one. So a user-scoped alias may
+  override a configured name (that is a working override), while a
+  *workspace-wide* stored alias may not (config would win, and the stored one
+  would silently never be used, so the API refuses it with a 400).
+- A name plus both scopes is the identity. Creating `fast` for `alice` leaves the
+  workspace-wide `fast` alone, two workspaces can each hold their own `fast`, and
+  deleting any of them leaves the others in place. Deletes take the scope as query
+  parameters: `DELETE /v1/aliases/fast?user_id=alice&workspace_id=<id>`, omitting
+  either for the workspace-wide alias and the default workspace respectively.
+- `GET /v1/models` is scoped the same way, so a caller sees their workspace's
+  aliases and the configured ones plus their own, never another user's and never
+  another workspace's. `GET /v1/aliases` is the master-key management view and
+  lists every scope at once, narrowable with `?workspace_id=<id>`.
 - Target-hiding follows the scope. A global alias hides its target from
   everyone's listing; a user-scoped one hides it from that user's listing only, so
   another caller may still see the real model (subject to their own model access).

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1098,8 +1098,21 @@
                 "type": "null"
               }
             ],
-            "description": "User this alias belongs to. Omit for a global alias every caller sees. A user-scoped alias resolves only for that user and shadows a global one of the same name.",
+            "description": "User this alias belongs to. Omit for an alias every caller in the workspace sees. A user-scoped alias resolves only for that user and shadows the workspace-wide one of the same name.",
             "title": "User Id"
+          },
+          "workspace_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Workspace this alias belongs to. Omit for the deployment's default workspace. The alias resolves only for requests in that workspace, so two workspaces can each point the same name at a different model.",
+            "title": "Workspace Id"
           }
         },
         "required": [
@@ -1156,6 +1169,18 @@
               }
             ],
             "title": "User Id"
+          },
+          "workspace_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workspace Id"
           }
         },
         "required": [
@@ -3397,6 +3422,19 @@
             ],
             "description": "Evaluate conditions as this user.",
             "title": "User Id"
+          },
+          "workspace_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Resolve `name` and the policy's candidate selectors in this workspace. Omit for the deployment's default workspace.",
+            "title": "Workspace Id"
           }
         },
         "title": "ExplainRequest",
@@ -6523,8 +6561,21 @@
                 "type": "null"
               }
             ],
-            "description": "User this policy belongs to. Omit for a global policy every caller sees. A user-scoped policy resolves only for that user and shadows a global one of the same name.",
+            "description": "User this policy belongs to. Omit for a policy every caller in the workspace sees. A user-scoped policy resolves only for that user and shadows the workspace-wide one of the same name.",
             "title": "User Id"
+          },
+          "workspace_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Workspace this policy belongs to. Omit for the deployment's default workspace. The policy resolves only for requests in that workspace, so two workspaces can each define their own 'fast'.",
+            "title": "Workspace Id"
           }
         },
         "required": [
@@ -6587,6 +6638,18 @@
               }
             ],
             "title": "User Id"
+          },
+          "workspace_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workspace Id"
           }
         },
         "required": [
@@ -7125,6 +7188,19 @@
             "description": "Whose routing memory these examples belong to.",
             "title": "User Id",
             "type": "string"
+          },
+          "workspace_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Which workspace's routing memory these examples belong to. Omit for the deployment's default workspace. Only requests billing to that workspace vote over them.",
+            "title": "Workspace Id"
           }
         },
         "required": [
@@ -7865,7 +7941,7 @@
         "type": "object"
       },
       "RouterStatus": {
-        "description": "How warm this user's routing memory is, and what depends on it.\n\nRouting memory has no single warmth: it is a set of independent pools.\n``default_pool`` is what a request with no ``Otari-Router-Task`` header votes\nover (every record the user has, labeled or not) and ``tasks`` lists each\npartition, which only requests carrying that label use. Each crosses\n``seed_count`` on its own.",
+        "description": "How warm this user's routing memory is, and what depends on it.\n\nRouting memory has no single warmth: it is a set of independent pools.\n``default_pool`` is what a request with no ``Otari-Router-Task`` header votes\nover (every record the user has in this workspace, labeled or not) and\n``tasks`` lists each partition, which only requests carrying that label use.\nEach crosses ``seed_count`` on its own.",
         "properties": {
           "alpha": {
             "title": "Alpha",
@@ -7911,10 +7987,16 @@
           "user_id": {
             "title": "User Id",
             "type": "string"
+          },
+          "workspace_id": {
+            "format": "uuid",
+            "title": "Workspace Id",
+            "type": "string"
           }
         },
         "required": [
           "user_id",
+          "workspace_id",
           "embedding_model",
           "seed_count",
           "granularity",
@@ -13477,11 +13559,11 @@
     },
     "/v1/aliases": {
       "get": {
-        "description": "List every alias in force, from config.yml and from storage.\n\nEvery scope at once, global and user-scoped alike: this is the master-key\nmanagement view, not what any one caller resolves.",
+        "description": "List every alias in force, from config.yml and from storage.\n\nEvery scope at once, workspace-wide and user-scoped alike: this is the\nmaster-key management view, not what any one caller resolves.",
         "operationId": "list_aliases_v1_aliases_get",
         "parameters": [
           {
-            "description": "Only stored entries in this workspace. Config-file entries are always included. Every stored entry is in the deployment's default workspace today, because name uniqueness and the resolution cache are both deployment-wide, so this narrows to one workspace and finds the rest empty until those are scoped (otari-ai#1643).",
+            "description": "Only stored entries in this workspace. Config-file entries are always included, being deployment-wide. Omit to list the stored entries of every workspace.",
             "in": "query",
             "name": "workspace_id",
             "required": false,
@@ -13495,7 +13577,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Only stored entries in this workspace. Config-file entries are always included. Every stored entry is in the deployment's default workspace today, because name uniqueness and the resolution cache are both deployment-wide, so this narrows to one workspace and finds the rest empty until those are scoped (otari-ai#1643).",
+              "description": "Only stored entries in this workspace. Config-file entries are always included, being deployment-wide. Omit to list the stored entries of every workspace.",
               "title": "Workspace Id"
             }
           }
@@ -13540,7 +13622,7 @@
         ]
       },
       "post": {
-        "description": "Create or update a stored alias, global or scoped to one user.",
+        "description": "Create or update a stored alias in one workspace, optionally for one user.",
         "operationId": "set_alias_v1_aliases_post",
         "requestBody": {
           "content": {
@@ -13590,7 +13672,7 @@
     },
     "/v1/aliases/{name}": {
       "delete": {
-        "description": "Delete a stored alias in one scope.\n\nScoped by ``user_id`` for the same reason the upsert is: deleting the global\nalias must not take a user's override with it, and deleting an override must\nleave the global one serving everyone else.",
+        "description": "Delete a stored alias in one scope.\n\nScoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:\ndeleting one workspace's alias must not touch another's, deleting the\nworkspace-wide alias must not take a user's override with it, and deleting an\noverride must leave the workspace-wide one serving everyone else.",
         "operationId": "delete_alias_v1_aliases__name__delete",
         "parameters": [
           {
@@ -13603,7 +13685,7 @@
             }
           },
           {
-            "description": "Delete the alias scoped to this user. Omit to delete the global alias of that name.",
+            "description": "Delete the alias scoped to this user. Omit to delete the workspace-wide alias of that name.",
             "in": "query",
             "name": "user_id",
             "required": false,
@@ -13616,8 +13698,27 @@
                   "type": "null"
                 }
               ],
-              "description": "Delete the alias scoped to this user. Omit to delete the global alias of that name.",
+              "description": "Delete the alias scoped to this user. Omit to delete the workspace-wide alias of that name.",
               "title": "User Id"
+            }
+          },
+          {
+            "description": "Delete the alias in this workspace. Omit for the deployment's default workspace.",
+            "in": "query",
+            "name": "workspace_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Delete the alias in this workspace. Omit for the deployment's default workspace.",
+              "title": "Workspace Id"
             }
           }
         ],
@@ -14473,7 +14574,7 @@
     },
     "/v1/batches": {
       "get": {
-        "description": "List batches for a provider.\n\nNon-master keys only see batches they own (plus legacy batches without an\nownership marker); the page is filtered after the provider call, so a page\nmay contain fewer than ``limit`` items.",
+        "description": "List batches for a provider.\n\nNon-master keys only see batches they own in their own workspace (plus\nlegacy batches without an ownership marker, or without a recorded\nworkspace); the page is filtered after the provider call, so a page may\ncontain fewer than ``limit`` items.",
         "operationId": "list_batches_v1_batches_get",
         "parameters": [
           {
@@ -15245,7 +15346,7 @@
     },
     "/v1/files": {
       "get": {
-        "description": "List the authenticated user's uploaded files.",
+        "description": "List the authenticated user's uploaded files in the request's workspace.\n\n``workspace_id`` narrows a master-key listing to one workspace; a keyed\nrequest is already confined to its key's own and cannot widen or move it.",
         "operationId": "list_files_v1_files_get",
         "parameters": [
           {
@@ -15278,6 +15379,23 @@
                 }
               ],
               "title": "Purpose"
+            }
+          },
+          {
+            "in": "query",
+            "name": "workspace_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Workspace Id"
             }
           }
         ],
@@ -18845,11 +18963,11 @@
     },
     "/v1/routing/policies": {
       "get": {
-        "description": "List every routing policy in force, from config.yml and from storage.\n\nEvery scope at once, global and user-scoped alike: this is the master-key\nmanagement view, not what any one caller resolves.",
+        "description": "List every routing policy in force, from config.yml and from storage.\n\nEvery scope at once, workspace-wide and user-scoped alike: this is the\nmaster-key management view, not what any one caller resolves.",
         "operationId": "list_policies_v1_routing_policies_get",
         "parameters": [
           {
-            "description": "Only stored policies in this workspace. Config-file policies are always included. Every stored policy is in the deployment's default workspace today, because name uniqueness and the resolution cache are both deployment-wide, so this narrows to one workspace and finds the rest empty until those are scoped (otari-ai#1643).",
+            "description": "Only stored policies in this workspace. Config-file policies are always included, being deployment-wide. Omit to list the stored policies of every workspace.",
             "in": "query",
             "name": "workspace_id",
             "required": false,
@@ -18863,7 +18981,7 @@
                   "type": "null"
                 }
               ],
-              "description": "Only stored policies in this workspace. Config-file policies are always included. Every stored policy is in the deployment's default workspace today, because name uniqueness and the resolution cache are both deployment-wide, so this narrows to one workspace and finds the rest empty until those are scoped (otari-ai#1643).",
+              "description": "Only stored policies in this workspace. Config-file policies are always included, being deployment-wide. Omit to list the stored policies of every workspace.",
               "title": "Workspace Id"
             }
           }
@@ -18908,7 +19026,7 @@
         ]
       },
       "post": {
-        "description": "Create or update a stored policy, global or scoped to one user.\n\nThe spec is validated here and stored as given, so a row can never contain a\nbody this build would refuse at load. The cache is refreshed twice: once before\nvalidating (so the shadowing checks see other writers' policies) and once after\ncommitting (so this worker serves the new policy immediately).\n\n``rename_from`` renames the row instead of keying on ``name``. It is part of\nthis write rather than an endpoint of its own so that an edit which both renames\na policy and re-targets it cannot land half-applied, leaving the old name serving\nthe new spec. The new name is validated exactly as a fresh one is, because a\nrename can walk a policy into every collision a create can. Sending the field\nasserts the named policy is stored, so it never falls back to creating one.",
+        "description": "Create or update a stored policy in one workspace, optionally for one user.\n\nThe spec is validated here and stored as given, so a row can never contain a\nbody this build would refuse at load. The cache is refreshed twice: once before\nvalidating (so the shadowing checks see other writers' policies) and once after\ncommitting (so this worker serves the new policy immediately).\n\n``rename_from`` renames the row instead of keying on ``name``. It is part of\nthis write rather than an endpoint of its own so that an edit which both renames\na policy and re-targets it cannot land half-applied, leaving the old name serving\nthe new spec. The new name is validated exactly as a fresh one is, because a\nrename can walk a policy into every collision a create can. Sending the field\nasserts the named policy is stored, so it never falls back to creating one.",
         "operationId": "set_policy_v1_routing_policies_post",
         "requestBody": {
           "content": {
@@ -19008,7 +19126,7 @@
     },
     "/v1/routing/policies/{name}": {
       "delete": {
-        "description": "Delete a stored policy in one scope.\n\nScoped by ``user_id`` for the same reason the upsert is: deleting the global\npolicy must not take a user's override with it, and deleting an override must\nleave the global one serving everyone else.",
+        "description": "Delete a stored policy in one scope.\n\nScoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:\ndeleting one workspace's policy must not touch another's, deleting the\nworkspace-wide policy must not take a user's override with it, and deleting an\noverride must leave the workspace-wide one serving everyone else.",
         "operationId": "delete_policy_v1_routing_policies__name__delete",
         "parameters": [
           {
@@ -19021,7 +19139,7 @@
             }
           },
           {
-            "description": "Delete the policy scoped to this user. Omit to delete the global one.",
+            "description": "Delete the policy scoped to this user. Omit to delete the workspace-wide one.",
             "in": "query",
             "name": "user_id",
             "required": false,
@@ -19034,8 +19152,27 @@
                   "type": "null"
                 }
               ],
-              "description": "Delete the policy scoped to this user. Omit to delete the global one.",
+              "description": "Delete the policy scoped to this user. Omit to delete the workspace-wide one.",
               "title": "User Id"
+            }
+          },
+          {
+            "description": "Delete the policy in this workspace. Omit for the deployment's default workspace.",
+            "in": "query",
+            "name": "workspace_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Delete the policy in this workspace. Omit for the deployment's default workspace.",
+              "title": "Workspace Id"
             }
           }
         ],
@@ -19120,7 +19257,7 @@
     },
     "/v1/routing/status": {
       "get": {
-        "description": "Report how warm one user's routing memory is, per pool.\n\n``user_id`` is required rather than optional because there is no aggregate\nanswer: warmth is per user, and a total across users would describe a pool\nthat no request ever votes over.",
+        "description": "Report how warm one user's routing memory is in one workspace, per pool.\n\n``user_id`` is required rather than optional because there is no aggregate\nanswer: warmth is per user, and a total across users would describe a pool\nthat no request ever votes over. The same holds across workspaces, which is\nwhy ``workspace_id`` narrows rather than aggregating; it merely defaults\ninstead of being required, because a single-workspace deployment has one\nanswer.",
         "operationId": "routing_memory_status_v1_routing_status_get",
         "parameters": [
           {
@@ -19132,6 +19269,25 @@
               "description": "Whose routing memory to report on.",
               "title": "User Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "Which workspace's routing memory to report on. Omit for the default workspace.",
+            "in": "query",
+            "name": "workspace_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Which workspace's routing memory to report on. Omit for the default workspace.",
+              "title": "Workspace Id"
             }
           }
         ],

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -6543,7 +6543,7 @@
                 "type": "null"
               }
             ],
-            "description": "Current name of the policy to rename, in the same scope. The stored row keeps its id and created_at and takes `name` and `spec`. Sending it asserts that policy exists, so a name with no stored row is a 404 rather than a create, even when it equals `name`. Omit to create or update the policy named `name`. Renaming changes what callers must send as `model`; usage already recorded keeps the old name.",
+            "description": "Current name of the policy to rename, in the same scope, meaning the same workspace and the same user. A rename never moves a policy between them. The stored row keeps its id and created_at and takes `name` and `spec`. Sending it asserts that policy exists, so a name with no stored row is a 404 rather than a create, even when it equals `name`. Omit to create or update the policy named `name`. Renaming changes what callers must send as `model`; usage already recorded keeps the old name.",
             "title": "Rename From"
           },
           "spec": {

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -272,7 +272,7 @@
         {
           "name": "List Aliases",
           "request": {
-            "description": "List every alias in force, from config.yml and from storage.\n\nEvery scope at once, global and user-scoped alike: this is the master-key\nmanagement view, not what any one caller resolves.",
+            "description": "List every alias in force, from config.yml and from storage.\n\nEvery scope at once, workspace-wide and user-scoped alike: this is the\nmaster-key management view, not what any one caller resolves.",
             "header": [],
             "method": "GET",
             "url": {
@@ -285,7 +285,7 @@
               ],
               "query": [
                 {
-                  "description": "Only stored entries in this workspace. Config-file entries are always included. Every stored entry is in the deployment's default workspace today, because name uniqueness and the resolution cache are both deployment-wide, so this narrows to one workspace and finds the rest empty until those are scoped (otari-ai#1643).",
+                  "description": "Only stored entries in this workspace. Config-file entries are always included, being deployment-wide. Omit to list the stored entries of every workspace.",
                   "disabled": true,
                   "key": "workspace_id",
                   "value": ""
@@ -307,7 +307,7 @@
               },
               "raw": "{\n  \"name\": \"string\",\n  \"target\": \"string\"\n}"
             },
-            "description": "Create or update a stored alias, global or scoped to one user.",
+            "description": "Create or update a stored alias in one workspace, optionally for one user.",
             "header": [
               {
                 "key": "Content-Type",
@@ -330,7 +330,7 @@
         {
           "name": "Delete Alias",
           "request": {
-            "description": "Delete a stored alias in one scope.\n\nScoped by ``user_id`` for the same reason the upsert is: deleting the global\nalias must not take a user's override with it, and deleting an override must\nleave the global one serving everyone else.",
+            "description": "Delete a stored alias in one scope.\n\nScoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:\ndeleting one workspace's alias must not touch another's, deleting the\nworkspace-wide alias must not take a user's override with it, and deleting an\noverride must leave the workspace-wide one serving everyone else.",
             "header": [],
             "method": "DELETE",
             "url": {
@@ -344,13 +344,19 @@
               ],
               "query": [
                 {
-                  "description": "Delete the alias scoped to this user. Omit to delete the global alias of that name.",
+                  "description": "Delete the alias scoped to this user. Omit to delete the workspace-wide alias of that name.",
                   "disabled": true,
                   "key": "user_id",
                   "value": ""
+                },
+                {
+                  "description": "Delete the alias in this workspace. Omit for the deployment's default workspace.",
+                  "disabled": true,
+                  "key": "workspace_id",
+                  "value": ""
                 }
               ],
-              "raw": "{{baseUrl}}/v1/aliases/:name?user_id=",
+              "raw": "{{baseUrl}}/v1/aliases/:name?user_id=&workspace_id=",
               "variable": [
                 {
                   "description": "path parameter",
@@ -954,7 +960,7 @@
         {
           "name": "List Batches",
           "request": {
-            "description": "List batches for a provider.\n\nNon-master keys only see batches they own (plus legacy batches without an\nownership marker); the page is filtered after the provider call, so a page\nmay contain fewer than ``limit`` items.",
+            "description": "List batches for a provider.\n\nNon-master keys only see batches they own in their own workspace (plus\nlegacy batches without an ownership marker, or without a recorded\nworkspace); the page is filtered after the provider call, so a page may\ncontain fewer than ``limit`` items.",
             "header": [],
             "method": "GET",
             "url": {
@@ -1433,7 +1439,7 @@
         {
           "name": "List Files",
           "request": {
-            "description": "List the authenticated user's uploaded files.",
+            "description": "List the authenticated user's uploaded files in the request's workspace.\n\n``workspace_id`` narrows a master-key listing to one workspace; a keyed\nrequest is already confined to its key's own and cannot widen or move it.",
             "header": [],
             "method": "GET",
             "url": {
@@ -1456,9 +1462,15 @@
                   "disabled": true,
                   "key": "purpose",
                   "value": ""
+                },
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "workspace_id",
+                  "value": ""
                 }
               ],
-              "raw": "{{baseUrl}}/v1/files?user=&purpose="
+              "raw": "{{baseUrl}}/v1/files?user=&purpose=&workspace_id="
             }
           }
         },
@@ -3867,7 +3879,7 @@
         {
           "name": "List Policies",
           "request": {
-            "description": "List every routing policy in force, from config.yml and from storage.\n\nEvery scope at once, global and user-scoped alike: this is the master-key\nmanagement view, not what any one caller resolves.",
+            "description": "List every routing policy in force, from config.yml and from storage.\n\nEvery scope at once, workspace-wide and user-scoped alike: this is the\nmaster-key management view, not what any one caller resolves.",
             "header": [],
             "method": "GET",
             "url": {
@@ -3881,7 +3893,7 @@
               ],
               "query": [
                 {
-                  "description": "Only stored policies in this workspace. Config-file policies are always included. Every stored policy is in the deployment's default workspace today, because name uniqueness and the resolution cache are both deployment-wide, so this narrows to one workspace and finds the rest empty until those are scoped (otari-ai#1643).",
+                  "description": "Only stored policies in this workspace. Config-file policies are always included, being deployment-wide. Omit to list the stored policies of every workspace.",
                   "disabled": true,
                   "key": "workspace_id",
                   "value": ""
@@ -3903,7 +3915,7 @@
               },
               "raw": "{\n  \"name\": \"string\",\n  \"spec\": {}\n}"
             },
-            "description": "Create or update a stored policy, global or scoped to one user.\n\nThe spec is validated here and stored as given, so a row can never contain a\nbody this build would refuse at load. The cache is refreshed twice: once before\nvalidating (so the shadowing checks see other writers' policies) and once after\ncommitting (so this worker serves the new policy immediately).\n\n``rename_from`` renames the row instead of keying on ``name``. It is part of\nthis write rather than an endpoint of its own so that an edit which both renames\na policy and re-targets it cannot land half-applied, leaving the old name serving\nthe new spec. The new name is validated exactly as a fresh one is, because a\nrename can walk a policy into every collision a create can. Sending the field\nasserts the named policy is stored, so it never falls back to creating one.",
+            "description": "Create or update a stored policy in one workspace, optionally for one user.\n\nThe spec is validated here and stored as given, so a row can never contain a\nbody this build would refuse at load. The cache is refreshed twice: once before\nvalidating (so the shadowing checks see other writers' policies) and once after\ncommitting (so this worker serves the new policy immediately).\n\n``rename_from`` renames the row instead of keying on ``name``. It is part of\nthis write rather than an endpoint of its own so that an edit which both renames\na policy and re-targets it cannot land half-applied, leaving the old name serving\nthe new spec. The new name is validated exactly as a fresh one is, because a\nrename can walk a policy into every collision a create can. Sending the field\nasserts the named policy is stored, so it never falls back to creating one.",
             "header": [
               {
                 "key": "Content-Type",
@@ -3934,7 +3946,7 @@
                   "language": "json"
                 }
               },
-              "raw": "{\n  \"allowed_models\": [\n    \"string\"\n  ],\n  \"budget_remaining_usd\": 0,\n  \"budget_used_pct\": 0,\n  \"key_id\": \"string\",\n  \"name\": \"string\",\n  \"spec\": {},\n  \"user_id\": \"string\"\n}"
+              "raw": "{\n  \"allowed_models\": [\n    \"string\"\n  ],\n  \"budget_remaining_usd\": 0,\n  \"budget_used_pct\": 0,\n  \"key_id\": \"string\",\n  \"name\": \"string\",\n  \"spec\": {},\n  \"user_id\": \"string\",\n  \"workspace_id\": \"00000000-0000-0000-0000-000000000000\"\n}"
             },
             "description": "Compile a policy and return the plan, without dispatching anything.\n\nMaster-key gated, and deliberately so: the response enumerates the policy's\ntargets, which is exactly the information a policy exists to keep off the wire.\nIt is a management surface, not a caller-facing one.\n\nAccepts an unsaved ``spec`` as well as a saved ``name``, so a form can validate\nwhat the operator is about to save. The response includes dropped candidates\nwith reasons, which is the part that catches a \"failover\" policy that has\nquietly compiled down to a single attempt.",
             "header": [
@@ -3961,7 +3973,7 @@
         {
           "name": "Delete Policy",
           "request": {
-            "description": "Delete a stored policy in one scope.\n\nScoped by ``user_id`` for the same reason the upsert is: deleting the global\npolicy must not take a user's override with it, and deleting an override must\nleave the global one serving everyone else.",
+            "description": "Delete a stored policy in one scope.\n\nScoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:\ndeleting one workspace's policy must not touch another's, deleting the\nworkspace-wide policy must not take a user's override with it, and deleting an\noverride must leave the workspace-wide one serving everyone else.",
             "header": [],
             "method": "DELETE",
             "url": {
@@ -3976,13 +3988,19 @@
               ],
               "query": [
                 {
-                  "description": "Delete the policy scoped to this user. Omit to delete the global one.",
+                  "description": "Delete the policy scoped to this user. Omit to delete the workspace-wide one.",
                   "disabled": true,
                   "key": "user_id",
                   "value": ""
+                },
+                {
+                  "description": "Delete the policy in this workspace. Omit for the deployment's default workspace.",
+                  "disabled": true,
+                  "key": "workspace_id",
+                  "value": ""
                 }
               ],
-              "raw": "{{baseUrl}}/v1/routing/policies/:name?user_id=",
+              "raw": "{{baseUrl}}/v1/routing/policies/:name?user_id=&workspace_id=",
               "variable": [
                 {
                   "description": "path parameter",
@@ -4030,7 +4048,7 @@
         {
           "name": "Routing Memory Status",
           "request": {
-            "description": "Report how warm one user's routing memory is, per pool.\n\n``user_id`` is required rather than optional because there is no aggregate\nanswer: warmth is per user, and a total across users would describe a pool\nthat no request ever votes over.",
+            "description": "Report how warm one user's routing memory is in one workspace, per pool.\n\n``user_id`` is required rather than optional because there is no aggregate\nanswer: warmth is per user, and a total across users would describe a pool\nthat no request ever votes over. The same holds across workspaces, which is\nwhy ``workspace_id`` narrows rather than aggregating; it merely defaults\ninstead of being required, because a single-workspace deployment has one\nanswer.",
             "header": [],
             "method": "GET",
             "url": {
@@ -4048,9 +4066,15 @@
                   "disabled": false,
                   "key": "user_id",
                   "value": ""
+                },
+                {
+                  "description": "Which workspace's routing memory to report on. Omit for the default workspace.",
+                  "disabled": true,
+                  "key": "workspace_id",
+                  "value": ""
                 }
               ],
-              "raw": "{{baseUrl}}/v1/routing/status?user_id="
+              "raw": "{{baseUrl}}/v1/routing/status?user_id=&workspace_id="
             }
           }
         }

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -362,10 +362,14 @@ candidate actually answers, send the prompt to each of them through
 `POST /v1/chat/completions`; those calls are budget-checked and land in the usage log
 like any other request.
 
-**Memory is per user, even for a global policy.** The examples are that user's own
-prompts, so sharing them across users would let one caller's traffic steer another's.
-A policy every caller resolves therefore warms once per caller, and `user_id` is
-required on both `rank` and `status` because there is no aggregate answer.
+**Memory is per user and per workspace, even for a workspace-wide policy.** The
+examples are that user's own prompts, so sharing them across users would let one
+caller's traffic steer another's, and sharing them across workspaces would do the
+same across tenants for a user who holds keys in both. A policy every caller
+resolves therefore warms once per caller in each workspace. `user_id` is required
+on both `rank` and `status` because there is no aggregate answer; `workspace_id`
+is optional there and means the deployment's default workspace, so a
+single-workspace deployment never names one.
 
 **Teaching cannot be undone through the API yet.** There is no route that lists or
 deletes recorded examples, so `rank` refuses a score key that no learned policy could
@@ -498,7 +502,8 @@ dashboard's **Routing** page, and take effect on the worker that served the writ
 immediately; other workers and replicas converge within 30 seconds.
 
 ```bash
-# Create or update. Omit user_id for a policy every caller sees.
+# Create or update. Omit user_id for a policy every caller in the workspace sees,
+# and workspace_id for the deployment's default workspace.
 curl -X POST http://localhost:8000/v1/routing/policies \
   -H "Otari-Key: Bearer <master-key>" \
   -H "Content-Type: application/json" \
@@ -510,7 +515,9 @@ curl -X POST http://localhost:8000/v1/routing/policies \
         }
       }'
 
-# What is in force, from config.yml and storage alike, in every scope.
+# What is in force, from config.yml and storage alike, in every scope and every
+# workspace. Add ?workspace_id=<id> to narrow the stored ones to one workspace;
+# config.yml policies are deployment-wide, so they are always listed.
 curl http://localhost:8000/v1/routing/policies -H "Otari-Key: Bearer <master-key>"
 
 # Rename one. `rename_from` names the policy to move; `name` is what it becomes.
@@ -524,18 +531,26 @@ curl -X POST http://localhost:8000/v1/routing/policies \
         "spec": {"select": [{"default": "openai:gpt-5-mini"}]}
       }'
 
-# Delete one. user_id selects the scope; omit it for the global policy.
+# Delete one. user_id and workspace_id select the scope; omit user_id for the
+# workspace-wide policy and workspace_id for the default workspace.
 curl -X DELETE http://localhost:8000/v1/routing/policies/fast \
   -H "Otari-Key: Bearer <master-key>"
 ```
 
-A stored policy scoped to a user takes precedence over a `config.yml` policy of
-the same name, and a global stored policy is refused if one already exists in
-`config.yml`, because config wins during resolution and the stored one would be
-dead config.
+A stored policy resolves only for requests in its own workspace, which is read
+off the API key that authenticated them. Two workspaces can therefore each define
+`fast` and get their own; neither sees the other's.
+
+Within a workspace, a stored policy scoped to a user takes precedence over a
+`config.yml` policy of the same name, and a workspace-wide stored policy is
+refused if one already exists in `config.yml`, because config wins during
+resolution and the stored one would be dead config. A `config.yml` policy has no
+workspace: it comes from a file the deployment owns, so it is in force in all of
+them.
 
 A rename stays inside one scope, since who a policy applies to is the other half
-of its key; to move a policy between scopes, delete it and create it again. The
+of its key; to move a policy between scopes or workspaces, delete it and create
+it again. The
 new name goes through the same checks a fresh one does, so a rename cannot walk a
 policy into a collision a create would have refused. Two things a rename does not
 do: callers naming the old name start getting a 400, and usage already recorded

--- a/src/gateway/api/routes/_helpers.py
+++ b/src/gateway/api/routes/_helpers.py
@@ -1,18 +1,24 @@
 from __future__ import annotations
 
 import json
+import uuid
 from collections.abc import Collection, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException, Request, Response, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
 
 from gateway.core.config import CONVERSATION_HEADER, ROUTER_HEADER, ROUTER_TASK_HEADER
 from gateway.core.env import otari_env
 from gateway.log_config import logger
 from gateway.models.guardrails import GuardrailConfig
+from gateway.models.tenancy import Workspace
 from gateway.services.guardrails import GuardrailsNotReachableError, run_input_guardrails
 from gateway.services.routing.decide import RoutingSignal
 from gateway.services.url_safety import UnsafeURLError
+from gateway.services.workspace_scope import default_workspace_id
 
 if TYPE_CHECKING:
     from gateway.core.config import GatewayConfig
@@ -358,3 +364,28 @@ async def apply_input_guardrails(
             for r in verdict.results
         ]
         response.headers[GUARDRAILS_RESULT_HEADER] = json.dumps(summary, separators=(",", ":"))
+
+
+async def resolve_managed_workspace_id(db: AsyncSession, workspace_id: uuid.UUID | None) -> uuid.UUID:
+    """The workspace a master-key management write lands in, validated.
+
+    ``None`` means the deployment's default workspace, which is what an operator
+    acting deployment-wide gets everywhere else (``services/workspace_scope``),
+    and is where every row predating workspace scoping was backfilled.
+
+    A named workspace is checked rather than left to the foreign key, matching
+    ``POST /v1/keys``: an id naming no workspace is a bad request, and letting it
+    reach the constraint answers 500 "Database error" for a value the caller
+    supplied and can fix.
+    """
+    if workspace_id is None:
+        return await default_workspace_id(db)
+    named = (
+        await db.execute(select(col(Workspace.id)).where(col(Workspace.id) == workspace_id))
+    ).scalar_one_or_none()
+    if named is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Workspace '{workspace_id}' not found",
+        )
+    return named

--- a/src/gateway/api/routes/_normalize.py
+++ b/src/gateway/api/routes/_normalize.py
@@ -12,6 +12,7 @@ has no local DB / file store to resolve ``file_id`` references against.
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 from any_llm import LLMProvider
@@ -35,6 +36,7 @@ async def normalize_request_messages(
     raw_request: Request,
     user_id: str | None,
     instance: str | None = None,
+    workspace_id: uuid.UUID | None = None,
 ) -> tuple[list[dict[str, Any]], NormalizationStats]:
     """Normalize ``messages`` for the resolved ``provider/model``.
 
@@ -60,6 +62,7 @@ async def normalize_request_messages(
             db=db,
             file_store=file_store,
             user_id=user_id,
+            workspace_id=workspace_id,
         )
     except Exception as exc:  # noqa: BLE001 — never fail the request / leak the reservation
         logger.warning("content normalization failed; forwarding messages unchanged: %s", exc)

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -1288,7 +1288,7 @@ async def _compile_request_plan(
     else (a policy exists partly to keep its targets off the wire); the enumerated
     per-candidate reasons go to the activity log, which is a master-key surface.
     """
-    spec = resolve_effective_policy(config, model, user_id)
+    spec = resolve_effective_policy(config, model, user_id, workspace_id=workspace_id)
     if spec is None:
         return None
 
@@ -1315,6 +1315,7 @@ async def _compile_request_plan(
             user_id=user_id,
             allowlist=allowlist,
             signal=routing_signal() if routing_signal is not None else None,
+            workspace_id=workspace_id,
         )
 
     try:
@@ -1363,7 +1364,8 @@ async def resolve_request_context(
     estimate_cache_write_ttl: Literal["5m", "1h"] | None = None,
     routing_signal: Callable[[], RoutingSignal] | None = None,
     normalize_messages: Callable[
-        [str, LLMProvider | None, str, str | None], Awaitable[tuple[int, CompletionUsage | None]]
+        [str, LLMProvider | None, str, str | None, uuid.UUID | None],
+        Awaitable[tuple[int, CompletionUsage | None]],
     ]
     | None = None,
 ) -> RequestContext:
@@ -1727,7 +1729,17 @@ async def resolve_request_context(
         # provider-call settlement does not cover.
         if normalize_messages is not None:
             try:
-                post_chars, vision_usage = await normalize_messages(user_id, gate_impl, gate_model, gate_instance)
+                # The key's own workspace, not the resolved one: a master-key
+                # request has no key and resolves to the default workspace, which
+                # would narrow an operator's file references to it. `fetch_file`
+                # reads None as "every workspace", matching the /v1/files routes.
+                post_chars, vision_usage = await normalize_messages(
+                    user_id,
+                    gate_impl,
+                    gate_model,
+                    gate_instance,
+                    api_key.workspace_id if api_key is not None else None,
+                )
                 # Bill the vision describe side-call before the reservation
                 # top-up: its cost is already incurred by normalize_messages,
                 # so a 402 from the top-up below must not skip it (the refund

--- a/src/gateway/api/routes/aliases.py
+++ b/src/gateway/api/routes/aliases.py
@@ -6,9 +6,16 @@ live in a file this process does not own); these routes manage the
 ``model_aliases`` table, which means the same thing to a request but can change
 without a restart.
 
-A stored alias is either global (``user_id`` omitted) or scoped to one user, who
-is then the only caller that resolves it. See ``services/alias_service`` for the
-precedence between the layers.
+A stored alias belongs to one workspace, and within it is either global
+(``user_id`` omitted) or scoped to one user, who is then the only caller in that
+workspace that resolves it. A ``config.yml`` alias has no workspace and is in
+force in all of them. See ``services/alias_service`` for the precedence between
+the layers.
+
+Every verb here takes an optional ``workspace_id``; omitting it means the
+deployment's default workspace, which is where an operator acting deployment-wide
+writes and where every row predating workspace scoping was backfilled. A
+single-workspace deployment therefore never has to name one.
 """
 
 import uuid
@@ -21,13 +28,13 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, verify_master_key
+from gateway.api.routes._helpers import resolve_managed_workspace_id
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import ModelAlias
 from gateway.repositories.users_repository import get_active_user
 from gateway.services.alias_service import all_alias_names, refresh_alias_cache
 from gateway.services.policy_store import all_policy_names
-from gateway.services.workspace_scope import default_workspace_id
 
 router = APIRouter(prefix="/v1/aliases", tags=["aliases"])
 
@@ -40,8 +47,17 @@ class AliasRequest(BaseModel):
     user_id: str | None = Field(
         default=None,
         description=(
-            "User this alias belongs to. Omit for a global alias every caller sees. "
-            "A user-scoped alias resolves only for that user and shadows a global one of the same name."
+            "User this alias belongs to. Omit for an alias every caller in the workspace sees. "
+            "A user-scoped alias resolves only for that user and shadows the workspace-wide one "
+            "of the same name."
+        ),
+    )
+    workspace_id: uuid.UUID | None = Field(
+        default=None,
+        description=(
+            "Workspace this alias belongs to. Omit for the deployment's default workspace. "
+            "The alias resolves only for requests in that workspace, so two workspaces can each "
+            "point the same name at a different model."
         ),
     )
 
@@ -57,6 +73,9 @@ class AliasResponse(BaseModel):
     # The user this alias is scoped to, or null when it applies to every caller.
     # config.yml aliases are always global.
     user_id: str | None = None
+    # The workspace the stored row lives in. Null for a config.yml alias, which
+    # is deployment-wide and in force in every workspace.
+    workspace_id: uuid.UUID | None = None
     created_at: str | None = None
     updated_at: str | None = None
 
@@ -67,6 +86,7 @@ class AliasResponse(BaseModel):
             target=alias.target,
             source="stored",
             user_id=alias.user_id,
+            workspace_id=alias.workspace_id,
             created_at=alias.created_at.isoformat() if alias.created_at else None,
             updated_at=alias.updated_at.isoformat() if alias.updated_at else None,
         )
@@ -75,9 +95,9 @@ class AliasResponse(BaseModel):
 def _validate(config: GatewayConfig, name: str, target: str, user_id: str | None) -> None:
     """Apply the startup alias rules to a runtime write, as a 400.
 
-    A configured alias wins over a *global* stored one during resolution, so
-    storing a global name that shadows one would be accepted and then never take
-    effect. Refusing is the only answer that does not lie about what the gateway
+    A configured alias wins over a *workspace-wide* stored one during resolution,
+    so storing a workspace-wide name that shadows one would be accepted and then
+    never take effect. Refusing is the only answer that does not lie about what the gateway
     will do. A user-scoped alias is exempt: it outranks both other layers, so
     shadowing a configured name is a working override rather than dead data, and
     is the reason to scope an alias in the first place.
@@ -137,17 +157,15 @@ async def list_aliases(
     workspace_id: Annotated[
         uuid.UUID | None,
         Query(description=(
-            "Only stored entries in this workspace. Config-file entries are always included. "
-            "Every stored entry is in the deployment's default workspace today, because name "
-            "uniqueness and the resolution cache are both deployment-wide, so this narrows to "
-            "one workspace and finds the rest empty until those are scoped (otari-ai#1643)."
+            "Only stored entries in this workspace. Config-file entries are always included, "
+            "being deployment-wide. Omit to list the stored entries of every workspace."
         )),
     ] = None,
 ) -> list[AliasResponse]:
     """List every alias in force, from config.yml and from storage.
 
-    Every scope at once, global and user-scoped alike: this is the master-key
-    management view, not what any one caller resolves.
+    Every scope at once, workspace-wide and user-scoped alike: this is the
+    master-key management view, not what any one caller resolves.
     """
     statement = select(ModelAlias)
     if workspace_id is not None:
@@ -156,18 +174,25 @@ async def list_aliases(
         # it out would misreport what actually resolves.
         statement = statement.where(ModelAlias.workspace_id == workspace_id)
     rows = (await db.execute(statement.order_by(ModelAlias.name))).scalars().all()
-    # Keyed on (name, scope) rather than name: the same display name can exist
-    # globally and per user, and both are real rows to manage.
-    merged = {(row.name, row.user_id): AliasResponse.from_model(row) for row in rows}
-    # Config last, matching effective_aliases: if a global name somehow exists on
-    # both sides, list the one that would actually resolve rather than both.
+    # Keyed on (workspace, name, user) rather than name: the same display name can
+    # exist in several workspaces, and within one both workspace-wide and per
+    # user, and every one of those is a real row to manage.
+    merged: dict[tuple[uuid.UUID | None, str, str | None], AliasResponse] = {
+        (row.workspace_id, row.name, row.user_id): AliasResponse.from_model(row) for row in rows
+    }
+    # Config last, matching effective_aliases: a configured name beats the stored
+    # workspace-wide row in every workspace, so it is listed once, unscoped,
+    # instead of shadowing each workspace's row in place.
     merged.update(
         {
-            (name, None): AliasResponse(name=name, target=target, source="config")
+            (None, name, None): AliasResponse(name=name, target=target, source="config")
             for name, target in config.aliases.items()
         }
     )
-    return sorted(merged.values(), key=lambda alias: (alias.name, alias.user_id or ""))
+    return sorted(
+        merged.values(),
+        key=lambda alias: (alias.name, str(alias.workspace_id or ""), alias.user_id or ""),
+    )
 
 
 @router.post("", dependencies=[Depends(verify_master_key)])
@@ -176,17 +201,23 @@ async def set_alias(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> AliasResponse:
-    """Create or update a stored alias, global or scoped to one user."""
+    """Create or update a stored alias in one workspace, optionally for one user."""
     if request.user_id is not None:
         await _require_user(db, request.user_id)
+    workspace_id = await resolve_managed_workspace_id(db, request.workspace_id)
     await refresh_alias_cache(db)
     _validate(config, request.name, request.target, request.user_id)
 
-    # Scope is part of the identity: the upsert must not turn a global alias into
-    # a user-scoped one (or vice versa) just because the names match.
+    # Both scopes are part of the identity: the upsert must not turn one
+    # workspace's alias into another's, nor a workspace-wide alias into a
+    # user-scoped one (or vice versa), just because the names match.
     alias = (
         await db.execute(
-            select(ModelAlias).where(ModelAlias.name == request.name, ModelAlias.user_id == request.user_id)
+            select(ModelAlias).where(
+                ModelAlias.workspace_id == workspace_id,
+                ModelAlias.name == request.name,
+                ModelAlias.user_id == request.user_id,
+            )
         )
     ).scalar_one_or_none()
     if alias:
@@ -196,10 +227,7 @@ async def set_alias(
             name=request.name,
             target=request.target,
             user_id=request.user_id,
-            # See the note on RoutingPolicy: alias resolution reads a
-            # process-wide, name-keyed cache, so storing one outside the default
-            # workspace would show it as scoped while it resolved everywhere.
-            workspace_id=await default_workspace_id(db),
+            workspace_id=workspace_id,
         )
         db.add(alias)
 
@@ -229,21 +257,38 @@ async def delete_alias(
     config: Annotated[GatewayConfig, Depends(get_config)],
     user_id: Annotated[
         str | None,
-        Query(description="Delete the alias scoped to this user. Omit to delete the global alias of that name."),
+        Query(
+            description=(
+                "Delete the alias scoped to this user. Omit to delete the workspace-wide alias "
+                "of that name."
+            )
+        ),
+    ] = None,
+    workspace_id: Annotated[
+        uuid.UUID | None,
+        Query(description="Delete the alias in this workspace. Omit for the deployment's default workspace."),
     ] = None,
 ) -> None:
     """Delete a stored alias in one scope.
 
-    Scoped by ``user_id`` for the same reason the upsert is: deleting the global
-    alias must not take a user's override with it, and deleting an override must
-    leave the global one serving everyone else.
+    Scoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:
+    deleting one workspace's alias must not touch another's, deleting the
+    workspace-wide alias must not take a user's override with it, and deleting an
+    override must leave the workspace-wide one serving everyone else.
     """
+    target_workspace_id = await resolve_managed_workspace_id(db, workspace_id)
     alias = (
-        await db.execute(select(ModelAlias).where(ModelAlias.name == name, ModelAlias.user_id == user_id))
+        await db.execute(
+            select(ModelAlias).where(
+                ModelAlias.workspace_id == target_workspace_id,
+                ModelAlias.name == name,
+                ModelAlias.user_id == user_id,
+            )
+        )
     ).scalar_one_or_none()
     if alias is None:
-        scope = "global" if user_id is None else f"scoped to user '{user_id}'"
-        detail = f"Alias '{name}' ({scope}) not found"
+        scope = "workspace-wide" if user_id is None else f"scoped to user '{user_id}'"
+        detail = f"Alias '{name}' ({scope}) not found in workspace '{target_workspace_id}'"
         if user_id is None and name in config.aliases:
             detail = f"Alias '{name}' is defined in config.yml and cannot be deleted through the API."
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)

--- a/src/gateway/api/routes/aliases.py
+++ b/src/gateway/api/routes/aliases.py
@@ -6,7 +6,7 @@ live in a file this process does not own); these routes manage the
 ``model_aliases`` table, which means the same thing to a request but can change
 without a restart.
 
-A stored alias belongs to one workspace, and within it is either global
+A stored alias belongs to one workspace, and within it is either workspace-wide
 (``user_id`` omitted) or scoped to one user, who is then the only caller in that
 workspace that resolves it. A ``config.yml`` alias has no workspace and is in
 force in all of them. See ``services/alias_service`` for the precedence between
@@ -70,8 +70,8 @@ class AliasResponse(BaseModel):
     # "config" for a config.yml alias (read-only here) or "stored" for a row in
     # model_aliases. Only stored aliases can be edited or deleted.
     source: str
-    # The user this alias is scoped to, or null when it applies to every caller.
-    # config.yml aliases are always global.
+    # The user this alias is scoped to, or null when it applies to every caller
+    # in its workspace. config.yml aliases are never user-scoped.
     user_id: str | None = None
     # The workspace the stored row lives in. Null for a config.yml alias, which
     # is deployment-wide and in force in every workspace.
@@ -107,7 +107,7 @@ def _validate(config: GatewayConfig, name: str, target: str, user_id: str | None
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=(
                 f"'{name}' is already an alias in config.yml, pointing at '{config.aliases[name]}'. "
-                "Config aliases take precedence over global stored ones, so this one would never be used. "
+                "Config aliases take precedence over workspace-wide stored ones, so this one would never be used. "
                 "Rename it, scope it to a user, or edit config.yml."
             ),
         )

--- a/src/gateway/api/routes/batches.py
+++ b/src/gateway/api/routes/batches.py
@@ -233,13 +233,26 @@ def _authorize_record(
     risk, because a record-less batch has no stored workspace to leak --
     credentials there already resolve to the caller's own.
 
+    Both the owning user and the owning workspace have to match. The workspace
+    half is what stops a key in one workspace reaching a batch created in
+    another by the same user, which the user check alone allows and which would
+    then dispatch the lifecycle call against the creating workspace's
+    organization credential. ``record.workspace_id`` is NULL on a batch created
+    before the column existed; those fall through to the user check alone, the
+    same tolerance the metadata-anchored fallback already extends them.
+
     Raises 404 (not 403) on denial so a foreign key cannot probe which batch
     ids exist.
     """
     if is_master_key:
         return
     requester = str(api_key.user_id) if api_key and api_key.user_id else None
-    if record.user_id != requester:
+    denied = record.user_id != requester or (
+        record.workspace_id is not None
+        and api_key is not None
+        and record.workspace_id != api_key.workspace_id
+    )
+    if denied:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Batch '{batch_id}' not found",
@@ -579,9 +592,10 @@ async def list_batches(
 ) -> dict[str, Any]:
     """List batches for a provider.
 
-    Non-master keys only see batches they own (plus legacy batches without an
-    ownership marker); the page is filtered after the provider call, so a page
-    may contain fewer than ``limit`` items.
+    Non-master keys only see batches they own in their own workspace (plus
+    legacy batches without an ownership marker, or without a recorded
+    workspace); the page is filtered after the provider call, so a page may
+    contain fewer than ``limit`` items.
     """
     api_key, is_master_key = auth_result
     provider_enum, provider_kwargs = _resolve_batch_provider(
@@ -618,7 +632,15 @@ async def list_batches(
             return True
         record = records.get(batch.id)
         if record is not None:
-            return record.user_id == requester
+            # Same pair as `_authorize_record`, and tolerant of a NULL workspace
+            # for the same reason: a batch created before the column existed has
+            # no workspace to compare against.
+            in_workspace = (
+                record.workspace_id is None
+                or api_key is None
+                or record.workspace_id == api_key.workspace_id
+            )
+            return record.user_id == requester and in_workspace
         return _owns_batch(batch, api_key, is_master_key)
 
     return {"data": [{**batch.model_dump(), "provider": provider} for batch in batches if _visible(batch)]}

--- a/src/gateway/api/routes/batches.py
+++ b/src/gateway/api/routes/batches.py
@@ -230,7 +230,7 @@ def _authorize_record(
     credential before ever learning the batch is not theirs. Only the
     strict, record-based check needs to run this early; the legacy,
     metadata-anchored fallback (:func:`_authorize_legacy_batch`) has no such
-    risk, because a record-less batch has no stored workspace to leak --
+    risk, because a record-less batch has no stored workspace to leak:
     credentials there already resolve to the caller's own.
 
     Both the owning user and the owning workspace have to match. The workspace

--- a/src/gateway/api/routes/chat.py
+++ b/src/gateway/api/routes/chat.py
@@ -316,7 +316,11 @@ async def chat_completions(
         )
 
     async def _normalize(
-        user_id: str, provider: LLMProvider | None, model: str, instance: str | None
+        user_id: str,
+        provider: LLMProvider | None,
+        model: str,
+        instance: str | None,
+        workspace_id: uuid.UUID | None,
     ) -> tuple[int, CompletionUsage | None]:
         # Resolve uploaded file/image blocks into the wire payload (extract to
         # text for text-only models, inline for natively-capable ones) before
@@ -332,6 +336,7 @@ async def chat_completions(
             raw_request=raw_request,
             user_id=user_id,
             instance=instance,
+            workspace_id=workspace_id,
         )
         return len(str(request.messages)), stats.vision_usage()
 

--- a/src/gateway/api/routes/files.py
+++ b/src/gateway/api/routes/files.py
@@ -4,6 +4,14 @@ Stores uploaded files so they can later be referenced from chat messages by
 ``file_id``. The content normalizer (gateway.services.content_normalizer)
 resolves those references and either forwards them to natively-capable
 providers or extracts them to text for text-only local models.
+
+Files carry two scopes. ``user_id`` is the owner, resolved from the authenticated
+principal. ``workspace_id`` is the workspace the upload was made in, taken off the
+API key that authenticated it and never from a header, exactly as every other
+request-plane row does (``services/workspace_scope``). A keyed request is confined
+to its own key's workspace on every verb; a master-key request is the operator
+acting deployment-wide and sees every workspace, narrowable on the listing with
+``workspace_id``, matching ``GET /v1/keys``.
 """
 
 import mimetypes
@@ -26,12 +34,26 @@ from gateway.log_config import logger
 from gateway.models.entities import APIKey, FileObject
 from gateway.services.file_service import fetch_file
 from gateway.services.file_store import FileStore
+from gateway.services.workspace_scope import default_workspace_id
 
 router = APIRouter(prefix="/v1", tags=["files"])
 
 # OpenAI's documented file purposes plus a generic default. We don't enforce the
 # enum (forward-compat), but normalise the empty case to "user_data".
 _DEFAULT_PURPOSE = "user_data"
+
+
+def _request_workspace_id(auth_result: tuple[APIKey | None, bool]) -> uuid.UUID | None:
+    """The workspace a keyed request is confined to, or ``None`` for the master key.
+
+    Read off the key rather than from a header: a caller controls its headers and
+    not which key it holds, so a header here would let anyone reach another
+    workspace's files. ``None`` for the master key is deliberate, and is what keeps
+    an existing deployment's operator tooling working: the master key is the
+    operator acting deployment-wide, so it is not narrowed to any one workspace.
+    """
+    api_key, _is_master_key = auth_result
+    return api_key.workspace_id if api_key is not None else None
 
 
 def _resolve_user(
@@ -160,6 +182,10 @@ async def create_file(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File uploads are disabled")
 
     user_id = _resolve_user(auth_result, user, config)
+    # A master-key upload has no key to read a workspace off, so it lands in the
+    # default workspace: the operator acting deployment-wide, which is the same
+    # answer `resolve_workspace_id` gives every other master-key write.
+    workspace_id = _request_workspace_id(auth_result) or await default_workspace_id(db)
 
     file_id = f"file-{uuid.uuid4().hex}"
     storage_ref, size = await file_store.put_stream(file_id, _capped_chunks(file, config.files_max_bytes))
@@ -177,6 +203,7 @@ async def create_file(
     record = FileObject(
         id=file_id,
         user_id=user_id,
+        workspace_id=workspace_id,
         filename=file.filename or file_id,
         mime_type=_guess_mime(file.filename, file.content_type),
         bytes=size,
@@ -199,7 +226,9 @@ async def create_file(
             detail="Failed to store file",
         ) from exc
 
-    logger.info("Stored file %s (%d bytes) for user %s", file_id, size, user_id)
+    logger.info(
+        "Stored file %s (%d bytes) for user %s in workspace %s", file_id, size, user_id, workspace_id
+    )
     return record.to_dict()
 
 
@@ -210,16 +239,24 @@ async def list_files(
     config: Annotated[GatewayConfig, Depends(get_config)],
     user: str | None = None,
     purpose: str | None = None,
+    workspace_id: uuid.UUID | None = None,
 ) -> dict[str, Any]:
-    """List the authenticated user's uploaded files."""
+    """List the authenticated user's uploaded files in the request's workspace.
+
+    ``workspace_id`` narrows a master-key listing to one workspace; a keyed
+    request is already confined to its key's own and cannot widen or move it.
+    """
     if not config.files_enabled:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File uploads are disabled")
 
     user_id = _resolve_user(auth_result, user, config)
+    scope = _request_workspace_id(auth_result) or workspace_id
     stmt = select(FileObject).where(
         FileObject.user_id == user_id,
         FileObject.deleted_at.is_(None),
     )
+    if scope is not None:
+        stmt = stmt.where(FileObject.workspace_id == scope)
     if purpose is not None:
         stmt = stmt.where(FileObject.purpose == purpose)
     stmt = stmt.order_by(FileObject.created_at.desc())
@@ -242,7 +279,7 @@ async def get_file(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File uploads are disabled")
 
     user_id = _resolve_user(auth_result, user, config)
-    record = await fetch_file(db, file_id, user_id)
+    record = await fetch_file(db, file_id, user_id, workspace_id=_request_workspace_id(auth_result))
     if record is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
     return record.to_dict()
@@ -262,7 +299,7 @@ async def get_file_content(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File uploads are disabled")
 
     user_id = _resolve_user(auth_result, user, config)
-    record = await fetch_file(db, file_id, user_id)
+    record = await fetch_file(db, file_id, user_id, workspace_id=_request_workspace_id(auth_result))
     if record is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 
@@ -301,7 +338,7 @@ async def delete_file(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File uploads are disabled")
 
     user_id = _resolve_user(auth_result, user, config)
-    record = await fetch_file(db, file_id, user_id)
+    record = await fetch_file(db, file_id, user_id, workspace_id=_request_workspace_id(auth_result))
     if record is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File not found")
 

--- a/src/gateway/api/routes/files.py
+++ b/src/gateway/api/routes/files.py
@@ -250,6 +250,10 @@ async def list_files(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="File uploads are disabled")
 
     user_id = _resolve_user(auth_result, user, config)
+    # The key's own workspace wins over anything the caller sent, rather than
+    # 400ing on a mismatch: the parameter is a master-key narrowing, and a keyed
+    # request is confined either way, so refusing it would only add a way to get
+    # an error instead of the same answer.
     scope = _request_workspace_id(auth_result) or workspace_id
     stmt = select(FileObject).where(
         FileObject.user_id == user_id,

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -506,7 +506,11 @@ async def create_message(
     user_from_metadata = request.metadata.get("user_id") if request.metadata else None
 
     async def _normalize(
-        user_id: str, provider: LLMProvider | None, model: str, instance: str | None
+        user_id: str,
+        provider: LLMProvider | None,
+        model: str,
+        instance: str | None,
+        workspace_id: uuid.UUID | None,
     ) -> tuple[int, CompletionUsage | None]:
         # Resolve uploaded file/image blocks into the Anthropic wire payload
         # before the cost estimate. Standalone only; no-op when the files
@@ -521,6 +525,7 @@ async def create_message(
             raw_request=raw_request,
             user_id=user_id,
             instance=instance,
+            workspace_id=workspace_id,
         )
         return len(str(request.messages)) + len(str(request.system or "")), stats.vision_usage()
 

--- a/src/gateway/api/routes/models.py
+++ b/src/gateway/api/routes/models.py
@@ -1,6 +1,7 @@
 """OpenAI-compatible models listing endpoint with auto-discovery."""
 
 import calendar
+import uuid
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Annotated
 
@@ -316,7 +317,7 @@ def _dynamic_policy_model(policy_name: str) -> ModelObject:
 
 
 def _policy_catalog_entries(
-    config: GatewayConfig, caller_user_id: str | None
+    config: GatewayConfig, caller_user_id: str | None, caller_workspace_id: uuid.UUID | None
 ) -> tuple[dict[str, str], dict[str, PolicySpec]]:
     """Split the policies in force into ``{name: target}`` and dynamic ones.
 
@@ -333,7 +334,7 @@ def _policy_catalog_entries(
     """
     static: dict[str, str] = {}
     dynamic: dict[str, PolicySpec] = {}
-    for name, spec in effective_policies(config, caller_user_id).items():
+    for name, spec in effective_policies(config, caller_user_id, workspace_id=caller_workspace_id).items():
         if spec.is_dynamic:
             dynamic[name] = spec
         else:
@@ -430,10 +431,13 @@ async def list_models(
     pricing data from the model_pricing table when available. Models that only
     exist in the pricing table are also included for backward compatibility.
     """
-    # Aliases are scoped, so the catalog is too: a caller sees the global and
-    # configured ones plus their own, never another user's. A master-key caller
-    # has no user, so it sees the unscoped layers only.
+    # Aliases are scoped, so the catalog is too: a caller sees their workspace's
+    # aliases and the configured ones, plus their own user-scoped layer, never
+    # another user's and never another workspace's. A master-key caller has no key
+    # to read either off, so it sees the configured layer plus the default
+    # workspace's, which is where its own writes land.
     caller_user_id = auth[0].user_id if auth[0] is not None else None
+    caller_workspace_id = auth[0].workspace_id if auth[0] is not None else None
     pricing_map = await _get_pricing_map(db, provider_filter=provider)
     # Snapshot before phase 1 mutates ``pricing_map`` (it pops matched keys), so
     # alias pricing can still be looked up by the target's canonical key. Keys are
@@ -448,8 +452,8 @@ async def list_models(
     # priced from the target), so it joins the alias map and is listed the same
     # way. Startup validation refuses a policy that collides with an alias name,
     # so this merge cannot silently shadow one.
-    configured_aliases = effective_aliases(config, caller_user_id)
-    static_policies, dynamic_policies = _policy_catalog_entries(config, caller_user_id)
+    configured_aliases = effective_aliases(config, caller_user_id, workspace_id=caller_workspace_id)
+    static_policies, dynamic_policies = _policy_catalog_entries(config, caller_user_id, caller_workspace_id)
     aliases = {**configured_aliases, **static_policies}
     # Alias targets are withheld from every phase that could surface the real
     # model, discovery (phase 1) as well as pricing-only (phase 2): publishing the
@@ -659,9 +663,14 @@ async def get_model(
 ) -> ModelObject:
     """Get details for a specific model."""
     api_key, is_master_key = auth
-    # Same scoping as the listing: the caller's own aliases, plus the global and
-    # configured ones. None for a master-key caller.
-    aliases = effective_aliases(config, api_key.user_id if api_key is not None else None)
+    # Same scoping as the listing: the caller's own aliases, plus their
+    # workspace's and the configured ones. A master-key caller has neither, so it
+    # reads the configured layer and the default workspace's.
+    aliases = effective_aliases(
+        config,
+        api_key.user_id if api_key is not None else None,
+        workspace_id=api_key.workspace_id if api_key is not None else None,
+    )
 
     # Model access control: a denied model returns 404, indistinguishable from a
     # missing one, so this endpoint cannot be used to probe which models exist

--- a/src/gateway/api/routes/pricing.py
+++ b/src/gateway/api/routes/pricing.py
@@ -288,6 +288,13 @@ def _policy_pricing_detail(config: GatewayConfig, request: SetPricingRequest) ->
     Names the candidates when they are knowable, because the operator's next
     action is to price them: a policy resolves to one of its own selectors, and
     that is the key the price has to be stored under.
+
+    "Knowable" means resolvable in the default workspace, which is where this
+    master-key surface reads (``services/policy_store``). A policy that lives in
+    another workspace still triggers the refusal, because the name check above is
+    scope-blind, and falls back to the generic wording: the price would be dead
+    data either way, and guessing which workspace the operator meant would be
+    worse than not naming its candidates.
     """
     spec = resolve_effective_policy(config, request.model_key)
     if spec is None:

--- a/src/gateway/api/routes/responses.py
+++ b/src/gateway/api/routes/responses.py
@@ -454,7 +454,11 @@ async def create_response(
     max_output_tokens = raw_max_output if isinstance(raw_max_output, int) and raw_max_output >= 0 else None
 
     async def _normalize(
-        user_id: str, provider: LLMProvider | None, model: str, instance: str | None
+        user_id: str,
+        provider: LLMProvider | None,
+        model: str,
+        instance: str | None,
+        workspace_id: uuid.UUID | None,
     ) -> tuple[int, CompletionUsage | None]:
         # Resolve uploaded file/image blocks into the Responses input payload
         # before the cost estimate. Standalone only; no-op when the files
@@ -469,6 +473,7 @@ async def create_response(
             raw_request=raw_request,
             user_id=user_id,
             instance=instance,
+            workspace_id=workspace_id,
         )
         chars = len(str(request_body.input)) + len(str(getattr(request_body, "instructions", "") or ""))
         return chars, stats.vision_usage()

--- a/src/gateway/api/routes/routing.py
+++ b/src/gateway/api/routes/routing.py
@@ -237,7 +237,7 @@ def _validate_write(config: GatewayConfig, name: str, spec: PolicySpec, user_id:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=(
                 f"'{name}' is already a routing policy in config.yml. Config policies take precedence over "
-                "global stored ones, so this one would never be used. Rename it, scope it to a user, or "
+                "workspace-wide stored ones, so this one would never be used. Rename it, scope it to a user, or "
                 "edit config.yml."
             ),
         )

--- a/src/gateway/api/routes/routing.py
+++ b/src/gateway/api/routes/routing.py
@@ -6,9 +6,11 @@ request, what is tried after a retryable failure, and which guardrails always ru
 in a file this process does not own); these routes manage the ``routing_policies``
 table, which means the same thing to a request but can change without a restart.
 
-Scoping matches ``/v1/aliases``: a stored policy is either global (``user_id``
-omitted) or scoped to one user, who is then the only caller that resolves it. See
-``services/policy_store`` for precedence between the layers.
+Scoping matches ``/v1/aliases``: a stored policy belongs to one workspace and,
+within it, is either workspace-wide (``user_id`` omitted) or scoped to one user,
+who is then the only caller that resolves it. Omitting ``workspace_id`` means the
+deployment's default workspace, so a single-workspace deployment never names one.
+See ``services/policy_store`` for precedence between the layers.
 
 Master-key gated on every verb, like alias management. That is what makes a policy
 safe as a unit of access: only an operator can decide which models a name reaches,
@@ -25,6 +27,7 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, verify_master_key
+from gateway.api.routes._helpers import resolve_managed_workspace_id
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import RoutingPolicy
@@ -44,7 +47,6 @@ from gateway.services.routing import (
 )
 from gateway.services.routing.decide import explain_router_ordering
 from gateway.services.routing.knn import unpriced_router_candidates
-from gateway.services.workspace_scope import default_workspace_id
 
 router = APIRouter(prefix="/v1/routing/policies", tags=["routing"])
 
@@ -63,8 +65,17 @@ class PolicyRequest(BaseModel):
     user_id: str | None = Field(
         default=None,
         description=(
-            "User this policy belongs to. Omit for a global policy every caller sees. "
-            "A user-scoped policy resolves only for that user and shadows a global one of the same name."
+            "User this policy belongs to. Omit for a policy every caller in the workspace sees. "
+            "A user-scoped policy resolves only for that user and shadows the workspace-wide one "
+            "of the same name."
+        ),
+    )
+    workspace_id: uuid.UUID | None = Field(
+        default=None,
+        description=(
+            "Workspace this policy belongs to. Omit for the deployment's default workspace. "
+            "The policy resolves only for requests in that workspace, so two workspaces can each "
+            "define their own 'fast'."
         ),
     )
     rename_from: str | None = Field(
@@ -88,6 +99,9 @@ class PolicyResponse(BaseModel):
     # routing_policies. Only stored policies can be edited or deleted.
     source: str
     user_id: str | None = None
+    # The workspace the stored row lives in. Null for a config.yml policy, which
+    # is deployment-wide and in force in every workspace.
+    workspace_id: uuid.UUID | None = None
     # True when the selected candidate depends on request state (a condition or a
     # router), so the policy has no single target or price. Surfaced because it
     # changes where the policy can be used, and the dashboard needs to say so.
@@ -102,6 +116,7 @@ class PolicyResponse(BaseModel):
             spec=policy.spec,
             source="stored",
             user_id=policy.user_id,
+            workspace_id=policy.workspace_id,
             is_dynamic=is_dynamic,
             created_at=policy.created_at.isoformat() if policy.created_at else None,
             updated_at=policy.updated_at.isoformat() if policy.updated_at else None,
@@ -139,6 +154,13 @@ class ExplainRequest(BaseModel):
     name: str | None = Field(default=None, description="An existing policy to explain.")
     spec: dict[str, Any] | None = Field(default=None, description="An unsaved policy body to explain.")
     user_id: str | None = Field(default=None, description="Evaluate conditions as this user.")
+    workspace_id: uuid.UUID | None = Field(
+        default=None,
+        description=(
+            "Resolve `name` and the policy's candidate selectors in this workspace. "
+            "Omit for the deployment's default workspace."
+        ),
+    )
     key_id: str | None = Field(default=None, description="Evaluate conditions as this API key id.")
     allowed_models: list[str] | None = Field(
         default=None,
@@ -204,9 +226,9 @@ def _validated_spec(name: str, spec: dict[str, Any]) -> PolicySpec:
 def _validate_write(config: GatewayConfig, name: str, spec: PolicySpec, user_id: str | None) -> None:
     """Apply the startup policy rules to a runtime write, as a 400.
 
-    A configured policy wins over a *global* stored one during resolution, so
-    storing a global name that shadows one would be accepted and then never take
-    effect. Refusing is the only answer that does not lie about what the gateway
+    A configured policy wins over a *workspace-wide* stored one during resolution,
+    so storing a workspace-wide name that shadows one would be accepted and then
+    never take effect. Refusing is the only answer that does not lie about what the gateway
     will do. A user-scoped policy is exempt: it outranks both other layers, so
     shadowing a configured name is a working override rather than dead data.
     """
@@ -297,7 +319,9 @@ async def _require_user(db: AsyncSession, user_id: str) -> None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"User '{user_id}' not found")
 
 
-def _missing_policy_detail(config: GatewayConfig, name: str, user_id: str | None, verb: str) -> str:
+def _missing_policy_detail(
+    config: GatewayConfig, name: str, user_id: str | None, verb: str, workspace_id: uuid.UUID
+) -> str:
     """Explain a stored policy that is not there, naming the scope that was searched.
 
     A config.yml policy is visible in the listing but has no row, so "not found" on
@@ -306,15 +330,19 @@ def _missing_policy_detail(config: GatewayConfig, name: str, user_id: str | None
     """
     if user_id is None and name in config.routing.policies:
         return f"Routing policy '{name}' is defined in config.yml and cannot be {verb} through the API."
-    scope = "global" if user_id is None else f"scoped to user '{user_id}'"
-    return f"Routing policy '{name}' ({scope}) not found"
+    scope = "workspace-wide" if user_id is None else f"scoped to user '{user_id}'"
+    return f"Routing policy '{name}' ({scope}) not found in workspace '{workspace_id}'"
 
 
-async def _name_is_taken(db: AsyncSession, name: str, user_id: str | None) -> bool:
+async def _name_is_taken(db: AsyncSession, name: str, user_id: str | None, workspace_id: uuid.UUID) -> bool:
     """True when a stored policy already answers to ``name`` in this scope."""
     existing = (
         await db.execute(
-            select(RoutingPolicy.id).where(RoutingPolicy.name == name, RoutingPolicy.user_id == user_id)
+            select(RoutingPolicy.id).where(
+                RoutingPolicy.workspace_id == workspace_id,
+                RoutingPolicy.name == name,
+                RoutingPolicy.user_id == user_id,
+            )
         )
     ).scalar_one_or_none()
     return existing is not None
@@ -345,18 +373,16 @@ async def list_policies(
         uuid.UUID | None,
         Query(
             description=(
-                "Only stored policies in this workspace. Config-file policies are always included. "
-                "Every stored policy is in the deployment's default workspace today, because name "
-                "uniqueness and the resolution cache are both deployment-wide, so this narrows to "
-                "one workspace and finds the rest empty until those are scoped (otari-ai#1643)."
+                "Only stored policies in this workspace. Config-file policies are always included, "
+                "being deployment-wide. Omit to list the stored policies of every workspace."
             )
         ),
     ] = None,
 ) -> list[PolicyResponse]:
     """List every routing policy in force, from config.yml and from storage.
 
-    Every scope at once, global and user-scoped alike: this is the master-key
-    management view, not what any one caller resolves.
+    Every scope at once, workspace-wide and user-scoped alike: this is the
+    master-key management view, not what any one caller resolves.
     """
     statement = select(RoutingPolicy)
     if workspace_id is not None:
@@ -365,8 +391,9 @@ async def list_policies(
         # it out would misreport what actually resolves.
         statement = statement.where(RoutingPolicy.workspace_id == workspace_id)
     rows = (await db.execute(statement.order_by(RoutingPolicy.name))).scalars().all()
-    merged: dict[tuple[str, str | None], PolicyResponse] = {}
+    merged: dict[tuple[uuid.UUID | None, str, str | None], PolicyResponse] = {}
     for row in rows:
+        key = (row.workspace_id, row.name, row.user_id)
         try:
             parsed = PolicySpec.model_validate(row.spec)
         except ValidationError:
@@ -374,19 +401,23 @@ async def list_policies(
             # row this build cannot parse, and hiding it would make the dashboard
             # disagree with the database.
             logger.warning("Stored routing policy %r does not validate; listing it as-is", row.name)
-            merged[(row.name, row.user_id)] = PolicyResponse.from_model(row, is_dynamic=False)
+            merged[key] = PolicyResponse.from_model(row, is_dynamic=False)
             continue
-        merged[(row.name, row.user_id)] = PolicyResponse.from_model(row, is_dynamic=parsed.is_dynamic)
-    # Config last, matching effective_policies: if a global name somehow exists on
-    # both sides, list the one that would actually resolve rather than both.
+        merged[key] = PolicyResponse.from_model(row, is_dynamic=parsed.is_dynamic)
+    # Config last, matching effective_policies: a configured name beats the stored
+    # workspace-wide row in every workspace, so it is listed once, unscoped,
+    # instead of shadowing each workspace's row in place.
     for name, spec in config.routing.policies.items():
-        merged[(name, None)] = PolicyResponse(
+        merged[(None, name, None)] = PolicyResponse(
             name=name,
             spec=spec.model_dump(mode="json", exclude_none=True),
             source="config",
             is_dynamic=spec.is_dynamic,
         )
-    return sorted(merged.values(), key=lambda policy: (policy.name, policy.user_id or ""))
+    return sorted(
+        merged.values(),
+        key=lambda policy: (policy.name, str(policy.workspace_id or ""), policy.user_id or ""),
+    )
 
 
 @router.post("", dependencies=[Depends(verify_master_key)])
@@ -395,7 +426,7 @@ async def set_policy(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> PolicyResponse:
-    """Create or update a stored policy, global or scoped to one user.
+    """Create or update a stored policy in one workspace, optionally for one user.
 
     The spec is validated here and stored as given, so a row can never contain a
     body this build would refuse at load. The cache is refreshed twice: once before
@@ -411,20 +442,24 @@ async def set_policy(
     """
     if request.user_id is not None:
         await _require_user(db, request.user_id)
+    workspace_id = await resolve_managed_workspace_id(db, request.workspace_id)
     spec = _validated_spec(request.name, request.spec)
     await refresh_policy_cache(db)
     _validate_write(config, request.name, spec, request.user_id)
     await _validate_router_pricing(config, db, spec)
 
-    # Scope is part of the identity: the upsert must not turn a global policy into
-    # a user-scoped one (or vice versa) just because the names match. A rename moves
-    # the name half of that key and leaves the scope alone.
+    # Both scopes are part of the identity: the upsert must not turn one
+    # workspace's policy into another's, nor a workspace-wide policy into a
+    # user-scoped one (or vice versa), just because the names match. A rename
+    # moves the name half of that key and leaves both scopes alone.
     renaming = request.rename_from is not None and request.rename_from != request.name
     lookup_name = request.rename_from if request.rename_from is not None else request.name
     policy = (
         await db.execute(
             select(RoutingPolicy).where(
-                RoutingPolicy.name == lookup_name, RoutingPolicy.user_id == request.user_id
+                RoutingPolicy.workspace_id == workspace_id,
+                RoutingPolicy.name == lookup_name,
+                RoutingPolicy.user_id == request.user_id,
             )
         )
     ).scalar_one_or_none()
@@ -436,12 +471,12 @@ async def set_policy(
         if policy is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=_missing_policy_detail(config, lookup_name, request.user_id, "renamed"),
+                detail=_missing_policy_detail(config, lookup_name, request.user_id, "renamed", workspace_id),
             )
         if renaming:
             # Without this the rename would be an upsert onto the target name, silently
             # destroying whatever policy already answered to it.
-            if await _name_is_taken(db, request.name, request.user_id):
+            if await _name_is_taken(db, request.name, request.user_id, workspace_id):
                 raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=_name_taken_detail(request.name))
             policy.name = request.name
     # Round-tripped through the model so the stored document is normalized (defaults
@@ -455,10 +490,7 @@ async def set_policy(
             name=request.name,
             spec=stored_spec,
             user_id=request.user_id,
-            # Resolution is still deployment-wide, so everything lands in the
-            # default workspace: a policy stored elsewhere would be listed there
-            # and resolve everywhere, which is worse than not scoping it yet.
-            workspace_id=await default_workspace_id(db),
+            workspace_id=workspace_id,
         )
         db.add(policy)
 
@@ -471,7 +503,7 @@ async def set_policy(
         # catches it. Re-read rather than assuming: the same constraint class also
         # covers the user foreign key, and reporting a deleted user as a name clash
         # would send the operator after the wrong thing.
-        if await _name_is_taken(db, request.name, request.user_id):
+        if await _name_is_taken(db, request.name, request.user_id, workspace_id):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT, detail=_name_taken_detail(request.name)
             ) from None
@@ -487,10 +519,11 @@ async def set_policy(
     # An operator changing where traffic goes is worth a line in the log: this is the
     # object that decides which model spends money.
     logger.info(
-        "Routing policy written name=%s renamed_from=%s scope=%s candidates=%d dynamic=%s router=%s",
+        "Routing policy written name=%s renamed_from=%s workspace=%s scope=%s candidates=%d dynamic=%s router=%s",
         policy.name,
         request.rename_from if renaming else "-",
-        policy.user_id or "global",
+        policy.workspace_id,
+        policy.user_id or "workspace-wide",
         # A router entry contributes its whole pool, since the walker cascades
         # through the ranking. Counting one head candidate here logged
         # "candidates=1" for a policy that can dispatch three.
@@ -509,24 +542,34 @@ async def delete_policy(
     config: Annotated[GatewayConfig, Depends(get_config)],
     user_id: Annotated[
         str | None,
-        Query(description="Delete the policy scoped to this user. Omit to delete the global one."),
+        Query(description="Delete the policy scoped to this user. Omit to delete the workspace-wide one."),
+    ] = None,
+    workspace_id: Annotated[
+        uuid.UUID | None,
+        Query(description="Delete the policy in this workspace. Omit for the deployment's default workspace."),
     ] = None,
 ) -> None:
     """Delete a stored policy in one scope.
 
-    Scoped by ``user_id`` for the same reason the upsert is: deleting the global
-    policy must not take a user's override with it, and deleting an override must
-    leave the global one serving everyone else.
+    Scoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:
+    deleting one workspace's policy must not touch another's, deleting the
+    workspace-wide policy must not take a user's override with it, and deleting an
+    override must leave the workspace-wide one serving everyone else.
     """
+    target_workspace_id = await resolve_managed_workspace_id(db, workspace_id)
     policy = (
         await db.execute(
-            select(RoutingPolicy).where(RoutingPolicy.name == name, RoutingPolicy.user_id == user_id)
+            select(RoutingPolicy).where(
+                RoutingPolicy.workspace_id == target_workspace_id,
+                RoutingPolicy.name == name,
+                RoutingPolicy.user_id == user_id,
+            )
         )
     ).scalar_one_or_none()
     if policy is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=_missing_policy_detail(config, name, user_id, "deleted"),
+            detail=_missing_policy_detail(config, name, user_id, "deleted", target_workspace_id),
         )
 
     await db.delete(policy)
@@ -572,7 +615,7 @@ async def explain_policy(
     else:
         assert request.name is not None
         name = request.name
-        resolved = resolve_effective_policy(config, name, request.user_id)
+        resolved = resolve_effective_policy(config, name, request.user_id, workspace_id=request.workspace_id)
         if resolved is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail=f"Routing policy '{name}' not found"
@@ -597,6 +640,7 @@ async def explain_policy(
                 used_pct=request.budget_used_pct, remaining_usd=request.budget_remaining_usd
             ),
             router_ordering=weighted_ordering,
+            workspace_id=request.workspace_id,
         )
     except NoEligibleCandidatesError as exc:
         return ExplainResponse(

--- a/src/gateway/api/routes/routing.py
+++ b/src/gateway/api/routes/routing.py
@@ -81,7 +81,8 @@ class PolicyRequest(BaseModel):
     rename_from: str | None = Field(
         default=None,
         description=(
-            "Current name of the policy to rename, in the same scope. The stored row keeps its id and "
+            "Current name of the policy to rename, in the same scope, meaning the same workspace and "
+            "the same user. A rename never moves a policy between them. The stored row keeps its id and "
             "created_at and takes `name` and `spec`. Sending it asserts that policy exists, so a name with "
             "no stored row is a 404 rather than a create, even when it equals `name`. Omit to create or "
             "update the policy named `name`. Renaming changes what callers must send as `model`; usage "

--- a/src/gateway/api/routes/routing.py
+++ b/src/gateway/api/routes/routing.py
@@ -626,7 +626,11 @@ async def explain_policy(
     # stored examples and no provider call, only the weights the policy declares.
     # Passing it in makes explain show the split rather than the decline path.
     weighted_ordering, weighted_shares = explain_router_ordering(
-        config, spec, user_id=request.user_id, allowlist=request.allowed_models
+        config,
+        spec,
+        user_id=request.user_id,
+        allowlist=request.allowed_models,
+        workspace_id=request.workspace_id,
     )
     try:
         plan = compile_policy(

--- a/src/gateway/api/routes/routing.py
+++ b/src/gateway/api/routes/routing.py
@@ -278,7 +278,9 @@ def _validate_write(config: GatewayConfig, name: str, spec: PolicySpec, user_id:
         )
 
 
-async def _validate_router_pricing(config: GatewayConfig, db: AsyncSession, spec: PolicySpec) -> None:
+async def _validate_router_pricing(
+    config: GatewayConfig, db: AsyncSession, spec: PolicySpec, workspace_id: uuid.UUID
+) -> None:
     """Refuse a learned policy whose candidates are not all priced.
 
     The *learned* router scores by cost, so one unpriced candidate makes it decline
@@ -291,11 +293,15 @@ async def _validate_router_pricing(config: GatewayConfig, db: AsyncSession, spec
 
     Scoped to the backends that actually read a price: the weighted router balances
     on operator-declared capacity, so requiring pricing there would refuse a policy
-    that works.
+    that works. Candidates resolve in the workspace the policy is being stored
+    into, so one naming an alias is validated as it will resolve for the requests
+    this policy will actually serve.
     """
     if not backend_requires_pricing(spec.router_backend):
         return
-    missing = await unpriced_router_candidates(config, db, spec.router_candidates)
+    missing = await unpriced_router_candidates(
+        config, db, spec.router_candidates, workspace_id=workspace_id
+    )
     if missing:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -447,7 +453,7 @@ async def set_policy(
     spec = _validated_spec(request.name, request.spec)
     await refresh_policy_cache(db)
     _validate_write(config, request.name, spec, request.user_id)
-    await _validate_router_pricing(config, db, spec)
+    await _validate_router_pricing(config, db, spec, workspace_id)
 
     # Both scopes are part of the identity: the upsert must not turn one
     # workspace's policy into another's, nor a workspace-wide policy into a

--- a/src/gateway/api/routes/routing_memory.py
+++ b/src/gateway/api/routes/routing_memory.py
@@ -403,7 +403,17 @@ async def rank_candidates(
     # provisioned tenancy, resolving the default workspace *creates* it, and an
     # uncommitted workspace is one the other session's foreign key cannot see. A
     # no-op when the workspace already existed, which is every other case.
-    await db.commit()
+    #
+    # Guarded rather than left bare precisely because it can be a real write: a
+    # failure here would otherwise surface as an unhandled SQLAlchemyError, and
+    # every example in the batch would then fail its foreign key one at a time.
+    try:
+        await db.commit()
+    except SQLAlchemyError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database error"
+        ) from None
     normalized = _validated_scores(config, request.user_id, request.examples, workspace_id)
 
     recorded = 0

--- a/src/gateway/api/routes/routing_memory.py
+++ b/src/gateway/api/routes/routing_memory.py
@@ -21,9 +21,14 @@ Master-key gated, like ``/v1/routing/policies``, with ``user_id`` naming whose
 memory is being taught rather than taking it from the calling key: which model
 serves a caller is an operator decision, exactly as a policy's targets are.
 
-Routing memory is **per user**, even for a global policy: the records hold the
-prompts a user sends, so sharing them across users would let one caller's traffic
-steer another's. A global learned policy therefore warms once per user.
+Routing memory is **per user and per workspace**, even for a workspace-wide
+policy: the records hold the prompts a user sends, so sharing them across users
+would let one caller's traffic steer another's, and sharing them across
+workspaces would do the same across tenants for a user who holds keys in both. A
+workspace-wide learned policy therefore warms once per user in each workspace.
+Both routes take an optional ``workspace_id``; omitting it means the deployment's
+default workspace, which is where a master-key request bills and where every row
+predating workspace scoping was backfilled.
 
 Known gap, tracked on #187: there is no route that lists or deletes recorded
 examples, so a mis-scored example can only be undone in the database. Until that
@@ -33,6 +38,7 @@ accepting anything a typo can produce.
 
 from __future__ import annotations
 
+import uuid
 from typing import Annotated
 
 from any_llm.exceptions import AnyLLMError
@@ -43,6 +49,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, verify_master_key
+from gateway.api.routes._helpers import resolve_managed_workspace_id
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import RouterPreference, RoutingMemory
@@ -119,6 +126,13 @@ class RankRequest(BaseModel):
     """
 
     user_id: str = Field(description="Whose routing memory these examples belong to.")
+    workspace_id: uuid.UUID | None = Field(
+        default=None,
+        description=(
+            "Which workspace's routing memory these examples belong to. Omit for the deployment's "
+            "default workspace. Only requests billing to that workspace vote over them."
+        ),
+    )
     examples: list[ScoredExample] = Field(
         min_length=1,
         max_length=MAX_EXAMPLES_PER_REQUEST,
@@ -171,12 +185,13 @@ class RouterStatus(BaseModel):
 
     Routing memory has no single warmth: it is a set of independent pools.
     ``default_pool`` is what a request with no ``Otari-Router-Task`` header votes
-    over (every record the user has, labeled or not) and ``tasks`` lists each
-    partition, which only requests carrying that label use. Each crosses
-    ``seed_count`` on its own.
+    over (every record the user has in this workspace, labeled or not) and
+    ``tasks`` lists each partition, which only requests carrying that label use.
+    Each crosses ``seed_count`` on its own.
     """
 
     user_id: str
+    workspace_id: uuid.UUID
     embedding_model: str
     seed_count: int
     granularity: str
@@ -215,16 +230,20 @@ async def _require_user(db: AsyncSession, user_id: str) -> None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"User '{user_id}' not found")
 
 
-def _canonical(config: GatewayConfig, selector: str, user_id: str | None = None) -> str | None:
+def _canonical(
+    config: GatewayConfig, selector: str, user_id: str | None = None, *, workspace_id: uuid.UUID | None = None
+) -> str | None:
     """``instance:model`` for a selector, or ``None`` if it resolves to nothing."""
     try:
-        resolved = resolve_provider_selector(config, selector, user_id)
+        resolved = resolve_provider_selector(config, selector, user_id, workspace_id=workspace_id)
     except (ValueError, AnyLLMError):
         return None
     return f"{resolved.instance}:{resolved.model}"
 
 
-def _validated_scores(config: GatewayConfig, user_id: str, examples: list[ScoredExample]) -> dict[str, str]:
+def _validated_scores(
+    config: GatewayConfig, user_id: str, examples: list[ScoredExample], workspace_id: uuid.UUID
+) -> dict[str, str]:
     """Refuse a score key no learned policy could ever ask about, and canonicalize the rest.
 
     The failure this prevents is the worst one the feature has. A mistyped selector
@@ -236,8 +255,9 @@ def _validated_scores(config: GatewayConfig, user_id: str, examples: list[Scored
     Resolution alone is too weak a check: ``openai:gpt-4o-typo`` resolves happily,
     because the prefix names a configured instance and nothing here verifies model
     names. So keys are checked against the union of every learned policy's
-    candidates (plus their default targets) for this user, canonicalized so
-    ``provider/model`` and ``instance:model`` spellings compare equal.
+    candidates (plus their default targets) for this user in this workspace,
+    canonicalized so ``provider/model`` and ``instance:model`` spellings compare
+    equal.
 
     Accepting those spellings is only safe if the stored key is the one the router
     looks up, so the returned map rewrites every accepted key to its canonical
@@ -255,11 +275,11 @@ def _validated_scores(config: GatewayConfig, user_id: str, examples: list[Scored
     would refuse the very examples the learned policy being prepared needs.
     """
     known: dict[str, str] = {}
-    for spec in effective_policies(config, user_id).values():
+    for spec in effective_policies(config, user_id, workspace_id=workspace_id).values():
         if not backend_pool_is_teachable(spec.router_backend):
             continue
         for selector in [*spec.router_candidates, spec.default_target]:
-            canonical = _canonical(config, selector, user_id)
+            canonical = _canonical(config, selector, user_id, workspace_id=workspace_id)
             if canonical is not None:
                 known.setdefault(canonical, selector)
 
@@ -269,7 +289,7 @@ def _validated_scores(config: GatewayConfig, user_id: str, examples: list[Scored
         for selector in example.scores:
             if selector in rejected or selector in normalized:
                 continue
-            canonical = _canonical(config, selector, user_id)
+            canonical = _canonical(config, selector, user_id, workspace_id=workspace_id)
             if canonical is None or (known and canonical not in known):
                 rejected.append(selector)
                 continue
@@ -308,9 +328,11 @@ def _validated_scores(config: GatewayConfig, user_id: str, examples: list[Scored
     return normalized
 
 
-def _learned_policies(config: GatewayConfig, user_id: str | None) -> list[LearnedPolicy]:
+def _learned_policies(
+    config: GatewayConfig, user_id: str | None, workspace_id: uuid.UUID
+) -> list[LearnedPolicy]:
     policies: list[LearnedPolicy] = []
-    for name, spec in effective_policies(config, user_id).items():
+    for name, spec in effective_policies(config, user_id, workspace_id=workspace_id).items():
         backend = spec.router_backend
         if not backend_pool_is_teachable(backend) or backend is None:
             continue
@@ -326,11 +348,17 @@ def _learned_policies(config: GatewayConfig, user_id: str | None) -> list[Learne
 
 
 async def _pool_counts(
-    db: AsyncSession, backend: KnnRoutingMemory, user_id: str
+    db: AsyncSession, backend: KnnRoutingMemory, user_id: str, workspace_id: uuid.UUID
 ) -> tuple[int, list[tuple[str, int]]]:
-    """This user's total record count and per-task counts, for the current embedding model."""
+    """This user's record counts in one workspace, for the current embedding model.
+
+    Filtered by workspace because that is the partition the router reads
+    (``KnnRoutingMemory._load_records``): a total spanning workspaces would report
+    a pool warm that no single request ever votes over.
+    """
     scope = (
         RoutingMemory.user_id == user_id,
+        RoutingMemory.workspace_id == workspace_id,
         RoutingMemory.embedding_model == backend.embedding_model,
     )
     total = int((await db.execute(select(func.count()).select_from(RoutingMemory).where(*scope))).scalar_one())
@@ -369,7 +397,8 @@ async def rank_candidates(
     """
     backend = _knn(config)
     await _require_user(db, request.user_id)
-    normalized = _validated_scores(config, request.user_id, request.examples)
+    workspace_id = await resolve_managed_workspace_id(db, request.workspace_id)
+    normalized = _validated_scores(config, request.user_id, request.examples, workspace_id)
 
     recorded = 0
     touched: set[str | None] = set()
@@ -378,6 +407,7 @@ async def rank_candidates(
         try:
             written = await backend.record_preference(
                 user_id=request.user_id,
+                workspace_id=workspace_id,
                 prompt=example.prompt,
                 scores=scores,
                 task_id=example.task_id,
@@ -414,6 +444,7 @@ async def rank_candidates(
             db.add(
                 RouterPreference(
                     user_id=request.user_id,
+                    workspace_id=workspace_id,
                     prompt=example.prompt,
                     task_id=example.task_id,
                     scores=example.scores,
@@ -429,7 +460,7 @@ async def rank_candidates(
 
     # Warmth of every pool this batch wrote into: each named partition, plus the
     # default pool when any example carried no task label.
-    total, per_task = await _pool_counts(db, backend, request.user_id)
+    total, per_task = await _pool_counts(db, backend, request.user_id, workspace_id)
     counts = dict(per_task)
     pools = [
         RecordedPool(
@@ -447,19 +478,28 @@ async def routing_memory_status(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
     user_id: Annotated[str, Query(description="Whose routing memory to report on.")],
+    workspace_id: Annotated[
+        uuid.UUID | None,
+        Query(description="Which workspace's routing memory to report on. Omit for the default workspace."),
+    ] = None,
 ) -> RouterStatus:
-    """Report how warm one user's routing memory is, per pool.
+    """Report how warm one user's routing memory is in one workspace, per pool.
 
     ``user_id`` is required rather than optional because there is no aggregate
     answer: warmth is per user, and a total across users would describe a pool
-    that no request ever votes over.
+    that no request ever votes over. The same holds across workspaces, which is
+    why ``workspace_id`` narrows rather than aggregating; it merely defaults
+    instead of being required, because a single-workspace deployment has one
+    answer.
     """
     backend = _knn(config)
     await _require_user(db, user_id)
-    total, per_task = await _pool_counts(db, backend, user_id)
+    target_workspace_id = await resolve_managed_workspace_id(db, workspace_id)
+    total, per_task = await _pool_counts(db, backend, user_id, target_workspace_id)
     seed = backend.seed_count
     return RouterStatus(
         user_id=user_id,
+        workspace_id=target_workspace_id,
         embedding_model=backend.embedding_model,
         seed_count=seed,
         granularity=backend.granularity,
@@ -470,7 +510,7 @@ async def routing_memory_status(
         tasks=[
             TaskPool(task_id=task_id, records=count, warm=count >= seed) for task_id, count in per_task
         ],
-        policies=_learned_policies(config, user_id),
+        policies=_learned_policies(config, user_id, target_workspace_id),
     )
 
 

--- a/src/gateway/api/routes/routing_memory.py
+++ b/src/gateway/api/routes/routing_memory.py
@@ -398,6 +398,12 @@ async def rank_candidates(
     backend = _knn(config)
     await _require_user(db, request.user_id)
     workspace_id = await resolve_managed_workspace_id(db, request.workspace_id)
+    # Committed before the loop, because `record_preference` writes its
+    # routing-memory row in a session of its own. On a deployment that has never
+    # provisioned tenancy, resolving the default workspace *creates* it, and an
+    # uncommitted workspace is one the other session's foreign key cannot see. A
+    # no-op when the workspace already existed, which is every other case.
+    await db.commit()
     normalized = _validated_scores(config, request.user_id, request.examples, workspace_id)
 
     recorded = 0

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -254,18 +254,20 @@ class ModelAlias(Base):
     meaning, but writable through the API. Pricing, budgets, and usage all key
     on the resolved target, so nothing here is billed against ``name``.
 
-    ``user_id`` is the scope. ``NULL`` means the alias is global (every caller
-    sees it), which is what every row predating this column is. A non-null
-    ``user_id`` scopes the alias to that user, so two users can point the same
-    display name at different models, and a user-scoped row shadows a global one
-    of the same name for that user only.
+    There are two scopes, and they are independent. ``workspace_id`` says which
+    tenant owns the alias: it resolves only for requests in that workspace, so
+    two workspaces can each point ``fast`` somewhere different. Within a
+    workspace, ``user_id`` narrows it further: ``NULL`` means every caller in
+    that workspace sees it, which is what every row predating the column is, and
+    a non-null ``user_id`` scopes it to that user, shadowing the workspace-wide
+    row of the same name for them alone.
 
     Uniqueness needs two constraints rather than one because SQLite and
     PostgreSQL both treat NULLs as distinct in a unique index: the composite
-    constraint keeps one row per (name, user), and the partial index keeps one
-    global row per name (which the composite one cannot, its ``user_id`` being
-    NULL). The surrogate ``id`` exists only because the natural key contains a
-    nullable column, which a primary key cannot.
+    constraint keeps one row per (workspace, name, user), and the partial index
+    keeps one workspace-wide row per (workspace, name), which the composite one
+    cannot, its ``user_id`` being NULL. The surrogate ``id`` exists only because
+    the natural key contains a nullable column, which a primary key cannot.
     """
 
     __tablename__ = "model_aliases"
@@ -327,11 +329,12 @@ class RoutingPolicy(Base):
     so a row that predates a schema change surfaces as a startup warning rather
     than as a request-time crash.
 
-    Scoping mirrors :class:`ModelAlias` exactly, including the two-constraint
-    uniqueness (SQLite and PostgreSQL both treat NULLs as distinct in a unique
-    index, so the composite constraint cannot keep one *global* row per name).
-    A policy and an alias are the same concept at different complexities, so it
-    would be strange for their scoping rules to differ.
+    Scoping mirrors :class:`ModelAlias` exactly, workspace included, and so does
+    the two-constraint uniqueness (SQLite and PostgreSQL both treat NULLs as
+    distinct in a unique index, so the composite constraint cannot keep one
+    *workspace-wide* row per name). A policy and an alias are the same concept at
+    different complexities, so it would be strange for their scoping rules to
+    differ.
     """
 
     __tablename__ = "routing_policies"

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -270,15 +270,15 @@ class ModelAlias(Base):
 
     __tablename__ = "model_aliases"
     __table_args__ = (
-        # Deliberately not workspace-scoped yet. Widening this to
-        # (workspace_id, name, user_id) would let two workspaces each hold a
-        # "fast" entry, but resolution reads a process-wide cache keyed by name
-        # alone, so the second would silently shadow the first at request time.
-        # The constraint widens in the change that makes that cache
-        # workspace-aware, not before.
-        UniqueConstraint("name", "user_id", name="uq_model_aliases_name_user"),
+        # Workspace-scoped, so two workspaces can each hold a "fast" entry
+        # pointing somewhere different. Safe only because resolution is keyed by
+        # workspace too (``services/alias_service``); while that cache was keyed
+        # on name alone the second workspace's row silently shadowed the first at
+        # request time, which is why this constraint waited for it.
+        UniqueConstraint("workspace_id", "name", "user_id", name="uq_model_aliases_workspace_name_user"),
         Index(
-            "uq_model_aliases_global_name",
+            "uq_model_aliases_workspace_global_name",
+            "workspace_id",
             "name",
             unique=True,
             sqlite_where=text("user_id IS NULL"),
@@ -287,10 +287,10 @@ class ModelAlias(Base):
     )
 
     id: Mapped[str] = mapped_column(primary_key=True, default=lambda: str(uuid.uuid4()))
-    # No index of its own: uq_model_aliases_name_user already leads with `name`,
-    # and uq_model_aliases_global_name indexes it again for the global rows. A
-    # third copy would be paid for on every write to serve reads that mostly do
-    # not happen, since resolution goes through the process-wide alias cache.
+    # No index of its own: both constraints above lead with `workspace_id` and
+    # carry `name` second, and a listing is always workspace-scoped. A third copy
+    # would be paid for on every write to serve reads that mostly do not happen,
+    # since resolution goes through the process-wide alias cache.
     name: Mapped[str] = mapped_column()
     target: Mapped[str] = mapped_column()
     user_id: Mapped[str | None] = mapped_column(ForeignKey("users.user_id", ondelete="CASCADE"), index=True)
@@ -336,15 +336,14 @@ class RoutingPolicy(Base):
 
     __tablename__ = "routing_policies"
     __table_args__ = (
-        # Deliberately not workspace-scoped yet. Widening this to
-        # (workspace_id, name, user_id) would let two workspaces each hold a
-        # "fast" entry, but resolution reads a process-wide cache keyed by name
-        # alone, so the second would silently shadow the first at request time.
-        # The constraint widens in the change that makes that cache
-        # workspace-aware, not before.
-        UniqueConstraint("name", "user_id", name="uq_routing_policies_name_user"),
+        # Workspace-scoped for the same reason, and on the same precondition, as
+        # :class:`ModelAlias`: ``services/policy_store`` keys its cache by
+        # workspace, so two workspaces holding a "fast" policy each resolve their
+        # own rather than one shadowing the other.
+        UniqueConstraint("workspace_id", "name", "user_id", name="uq_routing_policies_workspace_name_user"),
         Index(
-            "uq_routing_policies_global_name",
+            "uq_routing_policies_workspace_global_name",
+            "workspace_id",
             "name",
             unique=True,
             sqlite_where=text("user_id IS NULL"),
@@ -818,7 +817,10 @@ class FileObject(Base):
     The raw bytes live in a pluggable blob backend (see
     gateway.services.file_store); this row holds metadata plus the backend
     ``storage_ref`` used to fetch them. Files are scoped to ``user_id`` for
-    tenant isolation and soft-deleted via ``deleted_at``.
+    tenant isolation and soft-deleted via ``deleted_at``. ``workspace_id`` is a
+    second, independent axis: it says which workspace the upload was made in, so
+    a key confined to one workspace never reaches another's files even when the
+    same user holds keys in both.
     """
 
     __tablename__ = "file_objects"
@@ -827,6 +829,13 @@ class FileObject(Base):
     # Always set to the authenticated user; non-null enforces the user-scoping
     # contract at the schema level. CASCADE removes a user's files on delete.
     user_id: Mapped[str] = mapped_column(ForeignKey("users.user_id", ondelete="CASCADE"), index=True)
+    # The workspace this row belongs to; see `APIKey.workspace_id` for why it is
+    # NOT NULL and RESTRICT rather than nullable and cascading. Existing rows were
+    # backfilled onto the deployment's default workspace, which is also where a
+    # master-key upload lands.
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("workspace.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
     filename: Mapped[str] = mapped_column()
     mime_type: Mapped[str] = mapped_column()
     bytes: Mapped[int] = mapped_column()
@@ -926,20 +935,35 @@ class RoutingMemory(Base):
     Scoped by ``user_id``, which is the identity the request is routed and billed
     under, so one user's examples never steer another's traffic. CASCADE: the
     records are derived training data, worthless once the user is gone.
+    ``workspace_id`` narrows that further: the router reads one (user, workspace)
+    partition, so a user who holds keys in two workspaces does not have one
+    workspace's labels steering the other's traffic.
     """
 
     __tablename__ = "routing_memory"
     __table_args__ = (
-        Index("ix_routing_memory_user_model", "user_id", "embedding_model"),
-        Index("ix_routing_memory_user_created", "user_id", "created_at"),
-        # A task-scoped read filters on all three; without this it walks every
+        # Every read filters on the workspace as well as the user, so the
+        # workspace leads: the same three shapes, one partition narrower.
+        Index("ix_routing_memory_workspace_user_model", "workspace_id", "user_id", "embedding_model"),
+        Index("ix_routing_memory_workspace_user_created", "workspace_id", "user_id", "created_at"),
+        # A task-scoped read filters on all four; without this it walks every
         # record the user has for the embedding model before partitioning.
-        Index("ix_routing_memory_user_model_task", "user_id", "embedding_model", "task_id"),
+        Index(
+            "ix_routing_memory_workspace_user_model_task",
+            "workspace_id",
+            "user_id",
+            "embedding_model",
+            "task_id",
+        ),
     )
 
     id: Mapped[str] = mapped_column(primary_key=True, default=lambda: str(uuid.uuid4()))
     user_id: Mapped[str] = mapped_column(
         ForeignKey("users.user_id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    # The workspace this row belongs to; see `APIKey.workspace_id` for why.
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("workspace.id", ondelete="RESTRICT"), nullable=False, index=True
     )
     embedding_model: Mapped[str] = mapped_column()
     embedding: Mapped[list[float]] = mapped_column(JSON)
@@ -960,6 +984,7 @@ class RoutingMemory(Base):
         return {
             "id": self.id,
             "user_id": self.user_id,
+            "workspace_id": str(self.workspace_id),
             "embedding_model": self.embedding_model,
             "qualities": self.qualities,
             "task_id": self.task_id,
@@ -976,14 +1001,23 @@ class RouterPreference(Base):
     only the embedding, so this is where the prompt text and the raw per-model
     scores live: enough to recompute the memory if the scoring changes, and to
     tell a human label from a judge's.
+
+    ``workspace_id`` matches the :class:`RoutingMemory` row written beside it, so
+    the audit trail partitions exactly the way the training data does.
     """
 
     __tablename__ = "router_preferences"
-    __table_args__ = (Index("ix_router_preferences_user_created", "user_id", "created_at"),)
+    __table_args__ = (
+        Index("ix_router_preferences_workspace_user_created", "workspace_id", "user_id", "created_at"),
+    )
 
     id: Mapped[str] = mapped_column(primary_key=True, default=lambda: str(uuid.uuid4()))
     user_id: Mapped[str] = mapped_column(
         ForeignKey("users.user_id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    # The workspace this row belongs to; see `APIKey.workspace_id` for why.
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("workspace.id", ondelete="RESTRICT"), nullable=False, index=True
     )
     prompt: Mapped[str] = mapped_column()
     task_id: Mapped[str | None] = mapped_column(default=None)
@@ -998,6 +1032,7 @@ class RouterPreference(Base):
         return {
             "id": self.id,
             "user_id": self.user_id,
+            "workspace_id": str(self.workspace_id),
             "prompt": self.prompt,
             "task_id": self.task_id,
             "scores": self.scores,

--- a/src/gateway/services/alias_service.py
+++ b/src/gateway/services/alias_service.py
@@ -77,8 +77,8 @@ def _scope(workspace_id: uuid.UUID | None) -> uuid.UUID | None:
 def cached_aliases(user_id: str | None = None, *, workspace_id: uuid.UUID | None = None) -> dict[str, str]:
     """The stored aliases this worker last loaded. Empty before the first load.
 
-    Returns one workspace's global layer, or ``user_id``'s own layer within it
-    alone when given: the caller-facing merge is :func:`effective_aliases`.
+    Returns one workspace's workspace-wide layer, or ``user_id``'s own layer
+    within it alone when given: the caller-facing merge is :func:`effective_aliases`.
     """
     scope = _scope(workspace_id)
     if scope is None:
@@ -94,7 +94,7 @@ def cache_is_stale(ttl: float = ALIAS_CACHE_TTL_SECONDS) -> bool:
 
 
 async def refresh_alias_cache(db: AsyncSession) -> dict[uuid.UUID, dict[str, str]]:
-    """Reload the alias cache from the database and return the global layers.
+    """Reload the alias cache from the database and return the workspace-wide layers.
 
     Builds fresh dicts and rebinds them, so the swap is atomic from a concurrent
     reader's point of view: the default workspace is resolved with an ``await``
@@ -139,7 +139,7 @@ def effective_aliases(
     """Every alias in force for ``user_id`` in ``workspace_id``.
 
     Layered most-specific-last, so the user's own aliases win over a
-    ``config.yml`` one, which in turn wins over the workspace's global stored
+    ``config.yml`` one, which in turn wins over the workspace's own stored
     layer. A caller with no user (the master key) sees the workspace-wide and
     configured layers only, never another user's aliases. An omitted
     ``workspace_id`` reads the deployment's default workspace, which is where a

--- a/src/gateway/services/alias_service.py
+++ b/src/gateway/services/alias_service.py
@@ -10,14 +10,14 @@ owns it: an alias resolves only for requests in that workspace, which is what
 lets two workspaces each define ``fast`` and get their own target. Within a
 workspace, ``user_id`` scopes it further: ``NULL`` means every caller in that
 workspace sees it, and a non-null ``user_id`` belongs to that user alone,
-shadowing the workspace-global row of the same name for them.
+shadowing the workspace-wide row of the same name for them.
 
 A ``config.yml`` alias has no workspace. It comes from a file the deployment
 owns, so it is in force in every workspace, and it is never listed under one.
 
 Precedence is most-specific-first, so ``user-scoped > config.yml > stored
-workspace-global``. The middle pair is the pre-existing rule (the API refuses to
-store a workspace-global alias shadowing a configured one, so it is a safety
+workspace-wide``. The middle pair is the pre-existing rule (the API refuses to
+store a workspace-wide alias shadowing a configured one, so it is a safety
 net); the user-scoped layer sits on top of both, because overriding a shared name
 for one user is the whole point of scoping it.
 
@@ -56,7 +56,7 @@ from gateway.services.workspace_scope import lookup_default_workspace_id
 # takes at most this long to work on every replica; existing ones are unaffected.
 ALIAS_CACHE_TTL_SECONDS = 30.0
 
-# Workspace-global stored aliases: workspace_id -> {name -> target}.
+# Workspace-wide stored aliases: workspace_id -> {name -> target}.
 _cache: dict[uuid.UUID, dict[str, str]] = {}
 # User-scoped stored aliases: workspace_id -> user_id -> {name -> target}. Kept
 # separate from _cache rather than keyed on (user_id, name) so a resolution for
@@ -140,7 +140,7 @@ def effective_aliases(
 
     Layered most-specific-last, so the user's own aliases win over a
     ``config.yml`` one, which in turn wins over the workspace's global stored
-    layer. A caller with no user (the master key) sees the workspace-global and
+    layer. A caller with no user (the master key) sees the workspace-wide and
     configured layers only, never another user's aliases. An omitted
     ``workspace_id`` reads the deployment's default workspace, which is where a
     deployment-wide write lands.
@@ -218,7 +218,7 @@ async def load_aliases_at_startup(db: AsyncSession) -> None:
     scoped = sum(len(names) for per_user in _user_cache.values() for names in per_user.values())
     if workspace_global or scoped:
         logger.info(
-            "Loaded %d workspace-global and %d user-scoped model alias(es) across %d workspace(s)",
+            "Loaded %d workspace-wide and %d user-scoped model alias(es) across %d workspace(s)",
             workspace_global,
             scoped,
             len(set(_cache) | set(_user_cache)),

--- a/src/gateway/services/alias_service.py
+++ b/src/gateway/services/alias_service.py
@@ -5,14 +5,21 @@ runtime and validated at startup; ``model_aliases`` rows are writable through
 ``/v1/aliases``. Both mean the same thing to a request, so everything that
 resolves or lists aliases reads them merged, via :func:`effective_aliases`.
 
-A stored alias also has a scope. A row with no ``user_id`` is global, which is
-what a ``config.yml`` alias always is. A row with a ``user_id`` belongs to that
-user alone: nobody else resolves it, and it shadows a global alias of the same
-name for that user. Precedence is most-specific-first, so
-``user-scoped > config.yml > global stored``. The middle pair is the pre-existing
-rule (the API refuses to store a global alias shadowing a configured one, so it
-is a safety net); the user-scoped layer sits on top of both, because overriding
-a shared name for one user is the whole point of scoping it.
+A stored alias has two independent scopes. Its **workspace** says which tenant
+owns it: an alias resolves only for requests in that workspace, which is what
+lets two workspaces each define ``fast`` and get their own target. Within a
+workspace, ``user_id`` scopes it further: ``NULL`` means every caller in that
+workspace sees it, and a non-null ``user_id`` belongs to that user alone,
+shadowing the workspace-global row of the same name for them.
+
+A ``config.yml`` alias has no workspace. It comes from a file the deployment
+owns, so it is in force in every workspace, and it is never listed under one.
+
+Precedence is most-specific-first, so ``user-scoped > config.yml > stored
+workspace-global``. The middle pair is the pre-existing rule (the API refuses to
+store a workspace-global alias shadowing a configured one, so it is a safety
+net); the user-scoped layer sits on top of both, because overriding a shared name
+for one user is the whole point of scoping it.
 
 Resolution has to stay synchronous. ``resolve_provider_selector`` is called from
 eleven places, including ``services/vision.py``, which has no database session
@@ -22,10 +29,19 @@ cache, refreshed from the database rather than read per request. A write
 refreshes its own worker immediately; other workers and replicas converge within
 ``ALIAS_CACHE_TTL_SECONDS``, which is the staleness window for a newly created
 alias, not for anything already serving traffic.
+
+The cache is keyed by workspace first, which is what made widening the table's
+uniqueness constraint safe: while it was keyed on name alone, a second
+workspace's ``fast`` silently shadowed the first at request time, so the
+constraint could not allow one. A resolution that names no workspace falls back
+to the deployment's default, matching ``services/workspace_scope``: a caller with
+no workspace of its own (the master key, an operator-configured selector) is
+acting deployment-wide, and the default workspace is where its writes land too.
 """
 
 import asyncio
 import time
+import uuid
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -34,29 +50,42 @@ from gateway.core.config import GatewayConfig
 from gateway.core.database import create_session
 from gateway.log_config import logger
 from gateway.models.entities import ModelAlias
+from gateway.services.workspace_scope import lookup_default_workspace_id
 
 # How long a worker may serve a stale alias map before refreshing. A new alias
 # takes at most this long to work on every replica; existing ones are unaffected.
 ALIAS_CACHE_TTL_SECONDS = 30.0
 
-# Global stored aliases: name -> target.
-_cache: dict[str, str] = {}
-# User-scoped stored aliases: user_id -> {name -> target}. Kept separate from
-# _cache rather than keyed on (user_id, name) so a resolution for one user never
-# has to scan another user's aliases.
-_user_cache: dict[str, dict[str, str]] = {}
+# Workspace-global stored aliases: workspace_id -> {name -> target}.
+_cache: dict[uuid.UUID, dict[str, str]] = {}
+# User-scoped stored aliases: workspace_id -> user_id -> {name -> target}. Kept
+# separate from _cache rather than keyed on (user_id, name) so a resolution for
+# one user never has to scan another user's aliases.
+_user_cache: dict[uuid.UUID, dict[str, dict[str, str]]] = {}
+# Where a resolution that names no workspace looks. Loaded with the rows, so it
+# cannot disagree with them, and ``None`` on a deployment with no workspace at
+# all, where there are no stored aliases to resolve anyway.
+_default_workspace: uuid.UUID | None = None
 _cached_at: float | None = None
 
 
-def cached_aliases(user_id: str | None = None) -> dict[str, str]:
+def _scope(workspace_id: uuid.UUID | None) -> uuid.UUID | None:
+    """The workspace a lookup reads, resolving "none given" to the default."""
+    return workspace_id if workspace_id is not None else _default_workspace
+
+
+def cached_aliases(user_id: str | None = None, *, workspace_id: uuid.UUID | None = None) -> dict[str, str]:
     """The stored aliases this worker last loaded. Empty before the first load.
 
-    Returns the global ones, or ``user_id``'s own layer alone when given: the
-    caller-facing merge is :func:`effective_aliases`.
+    Returns one workspace's global layer, or ``user_id``'s own layer within it
+    alone when given: the caller-facing merge is :func:`effective_aliases`.
     """
+    scope = _scope(workspace_id)
+    if scope is None:
+        return {}
     if user_id is None:
-        return dict(_cache)
-    return dict(_user_cache.get(user_id, {}))
+        return dict(_cache.get(scope, {}))
+    return dict(_user_cache.get(scope, {}).get(user_id, {}))
 
 
 def cache_is_stale(ttl: float = ALIAS_CACHE_TTL_SECONDS) -> bool:
@@ -64,20 +93,30 @@ def cache_is_stale(ttl: float = ALIAS_CACHE_TTL_SECONDS) -> bool:
     return _cached_at is None or (time.monotonic() - _cached_at) >= ttl
 
 
-async def refresh_alias_cache(db: AsyncSession) -> dict[str, str]:
-    """Reload the alias cache from the database and return the global layer."""
-    global _cached_at  # noqa: PLW0603
+async def refresh_alias_cache(db: AsyncSession) -> dict[uuid.UUID, dict[str, str]]:
+    """Reload the alias cache from the database and return the global layers.
+
+    Builds fresh dicts and rebinds them, so the swap is atomic from a concurrent
+    reader's point of view: the default workspace is resolved with an ``await``
+    in the middle, and clearing in place would leave a window where a request
+    resolves against an empty map and 400s on a model that exists.
+    """
+    global _cache, _user_cache, _default_workspace, _cached_at  # noqa: PLW0603
 
     rows = (await db.execute(select(ModelAlias))).scalars().all()
-    _cache.clear()
-    _user_cache.clear()
+    fresh_global: dict[uuid.UUID, dict[str, str]] = {}
+    fresh_scoped: dict[uuid.UUID, dict[str, dict[str, str]]] = {}
     for row in rows:
         if row.user_id is None:
-            _cache[row.name] = row.target
+            fresh_global.setdefault(row.workspace_id, {})[row.name] = row.target
         else:
-            _user_cache.setdefault(row.user_id, {})[row.name] = row.target
+            fresh_scoped.setdefault(row.workspace_id, {}).setdefault(row.user_id, {})[row.name] = row.target
+
+    default_workspace = await lookup_default_workspace_id(db)
+
+    _cache, _user_cache, _default_workspace = fresh_global, fresh_scoped, default_workspace
     _cached_at = time.monotonic()
-    return dict(_cache)
+    return {workspace: dict(names) for workspace, names in _cache.items()}
 
 
 def reset_alias_cache() -> None:
@@ -87,30 +126,38 @@ def reset_alias_cache() -> None:
     process-wide cache, and a worker restarting against a different database
     would answer from the old one until its first refresh.
     """
-    global _cached_at  # noqa: PLW0603
+    global _cache, _user_cache, _default_workspace, _cached_at  # noqa: PLW0603
 
-    _cache.clear()
-    _user_cache.clear()
+    _cache, _user_cache = {}, {}
+    _default_workspace = None
     _cached_at = None
 
 
-def effective_aliases(config: GatewayConfig, user_id: str | None = None) -> dict[str, str]:
-    """Every alias in force for ``user_id``: stored ones plus the configured ones.
+def effective_aliases(
+    config: GatewayConfig, user_id: str | None = None, *, workspace_id: uuid.UUID | None = None
+) -> dict[str, str]:
+    """Every alias in force for ``user_id`` in ``workspace_id``.
 
-    Layered most-specific-last, so ``user_id``'s own aliases win over a
-    ``config.yml`` one, which in turn wins over a global stored one. A caller with
-    no user (the master key) sees the global and configured layers only, never
-    another user's aliases.
+    Layered most-specific-last, so the user's own aliases win over a
+    ``config.yml`` one, which in turn wins over the workspace's global stored
+    layer. A caller with no user (the master key) sees the workspace-global and
+    configured layers only, never another user's aliases. An omitted
+    ``workspace_id`` reads the deployment's default workspace, which is where a
+    deployment-wide write lands.
     """
-    merged = {**_cache, **config.aliases}
-    if user_id is not None:
-        merged.update(_user_cache.get(user_id, {}))
+    scope = _scope(workspace_id)
+    stored = _cache.get(scope, {}) if scope is not None else {}
+    merged = {**stored, **config.aliases}
+    if user_id is not None and scope is not None:
+        merged.update(_user_cache.get(scope, {}).get(user_id, {}))
     return merged
 
 
-def resolve_effective_alias(config: GatewayConfig, name: str, user_id: str | None = None) -> str | None:
-    """The target ``name`` resolves to for ``user_id``, or None when not an alias."""
-    target = effective_aliases(config, user_id).get(name)
+def resolve_effective_alias(
+    config: GatewayConfig, name: str, user_id: str | None = None, *, workspace_id: uuid.UUID | None = None
+) -> str | None:
+    """The target ``name`` resolves to for this caller, or None when not an alias."""
+    target = effective_aliases(config, user_id, workspace_id=workspace_id).get(name)
     return target if isinstance(target, str) and target else None
 
 
@@ -119,12 +166,16 @@ def all_alias_names(config: GatewayConfig) -> set[str]:
 
     For writes that must refuse to treat an alias name as a real model key
     (pricing rows, model allow-list entries). Those checks are scope-blind on
-    purpose: the name means "alias" to at least one caller, so storing it as a
-    model key would be dead data no matter whose request came in.
+    purpose, across workspaces as well as users: the name means "alias" to at
+    least one caller, so storing it as a model key would be dead data no matter
+    whose request came in.
     """
-    names = set(_cache) | set(config.aliases)
-    for scoped in _user_cache.values():
-        names |= set(scoped)
+    names = set(config.aliases)
+    for workspace_names in _cache.values():
+        names |= set(workspace_names)
+    for per_user in _user_cache.values():
+        for scoped in per_user.values():
+            names |= set(scoped)
     return names
 
 
@@ -163,6 +214,12 @@ async def load_aliases_at_startup(db: AsyncSession) -> None:
     except Exception:
         logger.exception("Failed to load model aliases; continuing with config aliases only")
         return
-    scoped = sum(len(names) for names in _user_cache.values())
-    if aliases or scoped:
-        logger.info("Loaded %d global and %d user-scoped model alias(es)", len(aliases), scoped)
+    workspace_global = sum(len(names) for names in aliases.values())
+    scoped = sum(len(names) for per_user in _user_cache.values() for names in per_user.values())
+    if workspace_global or scoped:
+        logger.info(
+            "Loaded %d workspace-global and %d user-scoped model alias(es) across %d workspace(s)",
+            workspace_global,
+            scoped,
+            len(set(_cache) | set(_user_cache)),
+        )

--- a/src/gateway/services/content_normalizer.py
+++ b/src/gateway/services/content_normalizer.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import uuid
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -123,6 +124,7 @@ async def _resolve_from_ref(
     db: AsyncSession | None,
     file_store: FileStore | None,
     user_id: str | None,
+    workspace_id: uuid.UUID | None,
 ) -> tuple[bytes, str, str | None, bool] | None:
     """Resolve a ``{file_data|url|file_id, filename}`` descriptor to bytes.
 
@@ -133,7 +135,7 @@ async def _resolve_from_ref(
     filename = ref.get("filename")
     file_id = ref.get("file_id")
     if file_id and db is not None and file_store is not None:
-        record = await fetch_file(db, str(file_id), user_id)
+        record = await fetch_file(db, str(file_id), user_id, workspace_id=workspace_id)
         if record is None:
             logger.warning("content normalizer: file_id %s not found for user %s", file_id, user_id)
             return None
@@ -155,6 +157,7 @@ async def _classify(
     db: AsyncSession | None,
     file_store: FileStore | None,
     user_id: str | None,
+    workspace_id: uuid.UUID | None,
 ) -> _Source | None:
     """Identify an image/document block and resolve its bytes, or return None."""
     btype = block.get("type")
@@ -169,7 +172,9 @@ async def _classify(
                 data = _decode_data_url(f"data:{src.get('media_type', '')};base64,{src.get('data', '')}")[0]
                 return _Source(_IMAGE, data, src.get("media_type", "image/png"), None, None)
             if src.get("type") == "file":
-                resolved = await _resolve_from_ref(src, db=db, file_store=file_store, user_id=user_id)
+                resolved = await _resolve_from_ref(
+                    src, db=db, file_store=file_store, user_id=user_id, workspace_id=workspace_id
+                )
                 if resolved:
                     return _Source(_IMAGE, resolved[0], resolved[1], resolved[2], None, resolved[3])
             return _Source(_IMAGE, None, "image/png", None, src.get("url"))
@@ -177,7 +182,9 @@ async def _classify(
         image_url = block.get("image_url")
         url = image_url.get("url") if isinstance(image_url, dict) else image_url
         if block.get("file_id"):
-            resolved = await _resolve_from_ref(block, db=db, file_store=file_store, user_id=user_id)
+            resolved = await _resolve_from_ref(
+                block, db=db, file_store=file_store, user_id=user_id, workspace_id=workspace_id
+            )
             if resolved:
                 return _Source(_IMAGE, resolved[0], resolved[1], resolved[2], None, resolved[3])
         if isinstance(url, str):
@@ -197,12 +204,16 @@ async def _classify(
                 data = _decode_data_url(f"data:{src.get('media_type', '')};base64,{src.get('data', '')}")[0]
                 return _Source(_DOCUMENT, data, src.get("media_type", "application/pdf"), None, None)
             if src.get("type") == "file":
-                resolved = await _resolve_from_ref(src, db=db, file_store=file_store, user_id=user_id)
+                resolved = await _resolve_from_ref(
+                    src, db=db, file_store=file_store, user_id=user_id, workspace_id=workspace_id
+                )
                 if resolved:
                     return _Source(_DOCUMENT, resolved[0], resolved[1], resolved[2], None, resolved[3])
             return _Source(_DOCUMENT, None, "application/pdf", None, src.get("url"))
         ref = block.get("file", block) if btype == "file" else block
-        resolved = await _resolve_from_ref(ref, db=db, file_store=file_store, user_id=user_id)
+        resolved = await _resolve_from_ref(
+            ref, db=db, file_store=file_store, user_id=user_id, workspace_id=workspace_id
+        )
         if resolved:
             return _Source(_DOCUMENT, resolved[0], resolved[1], resolved[2], None, resolved[3])
         return None
@@ -302,11 +313,14 @@ async def _normalize_block(
     db: AsyncSession | None,
     file_store: FileStore | None,
     user_id: str | None,
+    workspace_id: uuid.UUID | None,
 ) -> Any:
     if not isinstance(block, dict):
         return block
     try:
-        src = await _classify(block, fmt, db=db, file_store=file_store, user_id=user_id)
+        src = await _classify(
+            block, fmt, db=db, file_store=file_store, user_id=user_id, workspace_id=workspace_id
+        )
     except Exception as exc:  # noqa: BLE001 — never fail the request over a block
         logger.warning("content normalizer: failed to classify block: %s", exc)
         return block
@@ -349,8 +363,13 @@ async def normalize_messages(
     db: AsyncSession | None,
     file_store: FileStore | None,
     user_id: str | None,
+    workspace_id: uuid.UUID | None = None,
 ) -> tuple[list[dict[str, Any]], NormalizationStats]:
     """Return (possibly-rewritten messages, stats).
+
+    ``workspace_id`` confines ``file_id`` resolution to one workspace, and is the
+    workspace of the API key that authenticated the request. ``None`` means "any",
+    which is what a master-key request gets: the operator acting deployment-wide.
 
     Messages whose ``content`` is a plain string are returned untouched (the
     common, zero-overhead path). Only list-content messages are walked.
@@ -370,7 +389,15 @@ async def normalize_messages(
             continue
         new_content = [
             await _normalize_block(
-                block, fmt, caps, config, stats, db=db, file_store=file_store, user_id=user_id
+                block,
+                fmt,
+                caps,
+                config,
+                stats,
+                db=db,
+                file_store=file_store,
+                user_id=user_id,
+                workspace_id=workspace_id,
             )
             for block in content
         ]

--- a/src/gateway/services/file_service.py
+++ b/src/gateway/services/file_service.py
@@ -2,12 +2,13 @@
 
 Used by both the ``/v1/files`` route and the content normalizer, which resolves
 ``file_id`` references in chat messages back to bytes. Centralising the
-user-scoping + soft-delete + expiry rules here keeps the two call sites
-consistent.
+user-scoping, workspace-scoping, soft-delete and expiry rules here keeps the two
+call sites consistent.
 """
 
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, datetime
 
 from sqlalchemy import select
@@ -26,20 +27,28 @@ def _is_expired(record: FileObject) -> bool:
     return expires_at < datetime.now(UTC)
 
 
-async def fetch_file(db: AsyncSession, file_id: str, user_id: str | None) -> FileObject | None:
+async def fetch_file(
+    db: AsyncSession, file_id: str, user_id: str | None, *, workspace_id: uuid.UUID | None = None
+) -> FileObject | None:
     """Return a live, non-deleted, unexpired file owned by ``user_id``.
 
     Returns ``None`` if the file does not exist, belongs to another user, is
-    soft-deleted, or has expired — callers map that to a 404 so cross-user
+    soft-deleted, or has expired: callers map that to a 404 so cross-user
     access is indistinguishable from a missing file.
+
+    ``workspace_id`` narrows that to one workspace, so a key confined to one
+    never reaches a file uploaded through a key in another, even when the same
+    user holds both. Omitted for a master-key request, which is the operator
+    acting deployment-wide and sees every workspace, matching ``GET /v1/keys``.
     """
-    result = await db.execute(
-        select(FileObject).where(
-            FileObject.id == file_id,
-            FileObject.user_id == user_id,
-            FileObject.deleted_at.is_(None),
-        )
-    )
+    conditions = [
+        FileObject.id == file_id,
+        FileObject.user_id == user_id,
+        FileObject.deleted_at.is_(None),
+    ]
+    if workspace_id is not None:
+        conditions.append(FileObject.workspace_id == workspace_id)
+    result = await db.execute(select(FileObject).where(*conditions))
     record = result.scalar_one_or_none()
     if record is None or _is_expired(record):
         return None

--- a/src/gateway/services/policy_store.py
+++ b/src/gateway/services/policy_store.py
@@ -22,6 +22,12 @@ Layering: this sits alongside ``alias_service`` rather than inside
 store inside that package would close an import cycle. Being a leaf peer keeps the
 graph one-directional.
 
+Scoping matches ``alias_service`` exactly, workspace included: a stored policy
+belongs to one workspace and, within it, is either global or scoped to one user.
+A ``config.yml`` policy has no workspace and is in force in all of them. A lookup
+that names no workspace reads the deployment's default, which is where a
+deployment-wide write lands (``services/workspace_scope``).
+
 A stored spec is validated on write and again on load. A row written by
 a newer version whose schema this build does not understand is skipped with a
 warning rather than crashing the loader, so one bad row cannot take routing down
@@ -30,6 +36,7 @@ for every other policy.
 
 import asyncio
 import time
+import uuid
 
 from pydantic import ValidationError
 from sqlalchemy import select
@@ -40,6 +47,7 @@ from gateway.core.database import create_session
 from gateway.log_config import logger
 from gateway.models.entities import RoutingPolicy
 from gateway.models.routing import PolicySpec
+from gateway.services.workspace_scope import lookup_default_workspace_id
 
 __all__ = [
     "POLICY_CACHE_TTL_SECONDS",
@@ -57,19 +65,32 @@ __all__ = [
 # having them converge at different rates would be a surprise nobody benefits from.
 POLICY_CACHE_TTL_SECONDS = 30.0
 
-# Global stored policies: name -> spec.
-_cache: dict[str, PolicySpec] = {}
-# User-scoped stored policies: user_id -> {name -> spec}. Kept separate rather than
-# keyed on (user_id, name) so resolving for one user never scans another's.
-_user_cache: dict[str, dict[str, PolicySpec]] = {}
+# Workspace-global stored policies: workspace_id -> {name -> spec}.
+_cache: dict[uuid.UUID, dict[str, PolicySpec]] = {}
+# User-scoped stored policies: workspace_id -> user_id -> {name -> spec}. Kept
+# separate rather than keyed on (user_id, name) so resolving for one user never
+# scans another's.
+_user_cache: dict[uuid.UUID, dict[str, dict[str, PolicySpec]]] = {}
+# Where a lookup that names no workspace reads; see the module docstring.
+_default_workspace: uuid.UUID | None = None
 _cached_at: float | None = None
 
 
-def cached_policies(user_id: str | None = None) -> dict[str, PolicySpec]:
+def _scope(workspace_id: uuid.UUID | None) -> uuid.UUID | None:
+    """The workspace a lookup reads, resolving "none given" to the default."""
+    return workspace_id if workspace_id is not None else _default_workspace
+
+
+def cached_policies(
+    user_id: str | None = None, *, workspace_id: uuid.UUID | None = None
+) -> dict[str, PolicySpec]:
     """The stored policies this worker last loaded. Empty before the first load."""
+    scope = _scope(workspace_id)
+    if scope is None:
+        return {}
     if user_id is None:
-        return dict(_cache)
-    return dict(_user_cache.get(user_id, {}))
+        return dict(_cache.get(scope, {}))
+    return dict(_user_cache.get(scope, {}).get(user_id, {}))
 
 
 def policy_cache_is_stale(ttl: float = POLICY_CACHE_TTL_SECONDS) -> bool:
@@ -82,60 +103,67 @@ def _parse(row: RoutingPolicy) -> PolicySpec | None:
         return PolicySpec.model_validate(row.spec)
     except ValidationError:
         logger.warning(
-            "Stored routing policy %r (user=%s) does not validate against this build's schema; skipping it. "
-            "Other policies are unaffected.",
+            "Stored routing policy %r (workspace=%s, user=%s) does not validate against this build's schema; "
+            "skipping it. Other policies are unaffected.",
             row.name,
+            row.workspace_id,
             row.user_id,
             exc_info=True,
         )
         return None
 
 
-async def refresh_policy_cache(db: AsyncSession) -> dict[str, PolicySpec]:
-    """Reload the policy cache from the database and return the global layer.
+async def refresh_policy_cache(db: AsyncSession) -> dict[uuid.UUID, dict[str, PolicySpec]]:
+    """Reload the policy cache from the database and return the global layers.
 
     Builds new dicts and rebinds, rather than clearing and refilling in place: the
-    swap is then atomic from a concurrent reader's point of view even if this
-    function later grows an ``await`` in the middle. Clear-then-refill would open a
-    window where a request resolves a policy name against an empty map and 400s on
-    a model that exists.
+    swap is then atomic from a concurrent reader's point of view, which matters
+    now that resolving the default workspace puts an ``await`` in the middle.
+    Clear-then-refill would open a window where a request resolves a policy name
+    against an empty map and 400s on a model that exists.
     """
-    global _cache, _user_cache, _cached_at  # noqa: PLW0603
+    global _cache, _user_cache, _default_workspace, _cached_at  # noqa: PLW0603
 
     rows = (await db.execute(select(RoutingPolicy))).scalars().all()
-    fresh_global: dict[str, PolicySpec] = {}
-    fresh_scoped: dict[str, dict[str, PolicySpec]] = {}
+    fresh_global: dict[uuid.UUID, dict[str, PolicySpec]] = {}
+    fresh_scoped: dict[uuid.UUID, dict[str, dict[str, PolicySpec]]] = {}
     for row in rows:
         spec = _parse(row)
         if spec is None:
             continue
         if row.user_id is None:
-            fresh_global[row.name] = spec
+            fresh_global.setdefault(row.workspace_id, {})[row.name] = spec
         else:
-            fresh_scoped.setdefault(row.user_id, {})[row.name] = spec
+            fresh_scoped.setdefault(row.workspace_id, {}).setdefault(row.user_id, {})[row.name] = spec
 
-    _cache, _user_cache = fresh_global, fresh_scoped
+    default_workspace = await lookup_default_workspace_id(db)
+
+    _cache, _user_cache, _default_workspace = fresh_global, fresh_scoped, default_workspace
     _cached_at = time.monotonic()
-    return dict(_cache)
+    return {workspace: dict(specs) for workspace, specs in _cache.items()}
 
 
 def reset_policy_cache() -> None:
     """Drop the cache so the next load starts clean (startup and tests)."""
-    global _cache, _user_cache, _cached_at  # noqa: PLW0603
+    global _cache, _user_cache, _default_workspace, _cached_at  # noqa: PLW0603
 
     _cache, _user_cache = {}, {}
+    _default_workspace = None
     _cached_at = None
 
 
-def effective_policies(config: GatewayConfig, user_id: str | None = None) -> dict[str, PolicySpec]:
-    """Every policy in force for ``user_id``: stored ones plus configured ones.
+def effective_policies(
+    config: GatewayConfig, user_id: str | None = None, *, workspace_id: uuid.UUID | None = None
+) -> dict[str, PolicySpec]:
+    """Every policy in force for this caller: stored ones plus configured ones.
 
     Precedence is most-specific-last, matching aliases exactly:
-    ``user-scoped stored > config.yml > global stored``. The middle pair is the
-    pre-existing rule for aliases (and the write path refuses to store a global
-    policy that shadows a configured one, so this ordering is a safety net rather
-    than the enforcement); the user-scoped layer sits on top because overriding a
-    shared name for one caller is the entire point of scoping it.
+    ``user-scoped stored > config.yml > workspace-global stored``. The middle pair
+    is the pre-existing rule for aliases (and the write path refuses to store a
+    workspace-global policy that shadows a configured one, so this ordering is a
+    safety net rather than the enforcement); the user-scoped layer sits on top
+    because overriding a shared name for one caller is the entire point of scoping
+    it. An omitted ``workspace_id`` reads the deployment's default workspace.
 
     Returns nothing when routing is disabled, which is what makes
     ``routing.enabled: false`` a true off-switch for stored policies too, not only
@@ -143,32 +171,41 @@ def effective_policies(config: GatewayConfig, user_id: str | None = None) -> dic
     """
     if not config.routing.enabled:
         return {}
-    merged: dict[str, PolicySpec] = {**_cache, **config.routing.policies}
-    if user_id is not None:
-        merged.update(_user_cache.get(user_id, {}))
+    scope = _scope(workspace_id)
+    stored = _cache.get(scope, {}) if scope is not None else {}
+    merged: dict[str, PolicySpec] = {**stored, **config.routing.policies}
+    if user_id is not None and scope is not None:
+        merged.update(_user_cache.get(scope, {}).get(user_id, {}))
     return merged
 
 
 def resolve_effective_policy(
-    config: GatewayConfig, name: str, user_id: str | None = None
+    config: GatewayConfig,
+    name: str,
+    user_id: str | None = None,
+    *,
+    workspace_id: uuid.UUID | None = None,
 ) -> PolicySpec | None:
-    """The policy ``name`` resolves to for ``user_id``, or ``None``."""
-    return effective_policies(config, user_id).get(name)
+    """The policy ``name`` resolves to for this caller, or ``None``."""
+    return effective_policies(config, user_id, workspace_id=workspace_id).get(name)
 
 
 def all_policy_names(config: GatewayConfig) -> set[str]:
     """Every name that is a policy to somebody, in any scope.
 
-    Scope-blind on purpose, like ``all_alias_names``: for writes that must refuse
-    to treat a policy name as a real model key, the name means "policy" to at
-    least one caller, so storing it as a model key would be dead data regardless
-    of whose request arrives.
+    Scope-blind on purpose, like ``all_alias_names``, across workspaces as well
+    as users: for writes that must refuse to treat a policy name as a real model
+    key, the name means "policy" to at least one caller, so storing it as a model
+    key would be dead data regardless of whose request arrives.
     """
     if not config.routing.enabled:
         return set()
-    names = set(_cache) | set(config.routing.policies)
-    for scoped in _user_cache.values():
-        names |= set(scoped)
+    names = set(config.routing.policies)
+    for workspace_names in _cache.values():
+        names |= set(workspace_names)
+    for per_user in _user_cache.values():
+        for scoped in per_user.values():
+            names |= set(scoped)
     return names
 
 
@@ -204,6 +241,12 @@ async def load_policies_at_startup(db: AsyncSession) -> None:
     except Exception:
         logger.exception("Failed to load routing policies; continuing with config policies only")
         return
-    scoped = sum(len(names) for names in _user_cache.values())
-    if policies or scoped:
-        logger.info("Loaded %d global and %d user-scoped routing policy/policies", len(policies), scoped)
+    workspace_global = sum(len(names) for names in policies.values())
+    scoped = sum(len(names) for per_user in _user_cache.values() for names in per_user.values())
+    if workspace_global or scoped:
+        logger.info(
+            "Loaded %d workspace-global and %d user-scoped routing policy/policies across %d workspace(s)",
+            workspace_global,
+            scoped,
+            len(set(_cache) | set(_user_cache)),
+        )

--- a/src/gateway/services/policy_store.py
+++ b/src/gateway/services/policy_store.py
@@ -23,8 +23,8 @@ store inside that package would close an import cycle. Being a leaf peer keeps t
 graph one-directional.
 
 Scoping matches ``alias_service`` exactly, workspace included: a stored policy
-belongs to one workspace and, within it, is either global or scoped to one user.
-A ``config.yml`` policy has no workspace and is in force in all of them. A lookup
+belongs to one workspace and, within it, is either workspace-wide or scoped to
+one user. A ``config.yml`` policy has no workspace and is in force in all of them. A lookup
 that names no workspace reads the deployment's default, which is where a
 deployment-wide write lands (``services/workspace_scope``).
 
@@ -114,7 +114,7 @@ def _parse(row: RoutingPolicy) -> PolicySpec | None:
 
 
 async def refresh_policy_cache(db: AsyncSession) -> dict[uuid.UUID, dict[str, PolicySpec]]:
-    """Reload the policy cache from the database and return the global layers.
+    """Reload the policy cache from the database and return the workspace-wide layers.
 
     Builds new dicts and rebinds, rather than clearing and refilling in place: the
     swap is then atomic from a concurrent reader's point of view, which matters

--- a/src/gateway/services/policy_store.py
+++ b/src/gateway/services/policy_store.py
@@ -65,7 +65,7 @@ __all__ = [
 # having them converge at different rates would be a surprise nobody benefits from.
 POLICY_CACHE_TTL_SECONDS = 30.0
 
-# Workspace-global stored policies: workspace_id -> {name -> spec}.
+# Workspace-wide stored policies: workspace_id -> {name -> spec}.
 _cache: dict[uuid.UUID, dict[str, PolicySpec]] = {}
 # User-scoped stored policies: workspace_id -> user_id -> {name -> spec}. Kept
 # separate rather than keyed on (user_id, name) so resolving for one user never
@@ -158,9 +158,9 @@ def effective_policies(
     """Every policy in force for this caller: stored ones plus configured ones.
 
     Precedence is most-specific-last, matching aliases exactly:
-    ``user-scoped stored > config.yml > workspace-global stored``. The middle pair
+    ``user-scoped stored > config.yml > workspace-wide stored``. The middle pair
     is the pre-existing rule for aliases (and the write path refuses to store a
-    workspace-global policy that shadows a configured one, so this ordering is a
+    workspace-wide policy that shadows a configured one, so this ordering is a
     safety net rather than the enforcement); the user-scoped layer sits on top
     because overriding a shared name for one caller is the entire point of scoping
     it. An omitted ``workspace_id`` reads the deployment's default workspace.
@@ -245,7 +245,7 @@ async def load_policies_at_startup(db: AsyncSession) -> None:
     scoped = sum(len(names) for per_user in _user_cache.values() for names in per_user.values())
     if workspace_global or scoped:
         logger.info(
-            "Loaded %d workspace-global and %d user-scoped routing policy/policies across %d workspace(s)",
+            "Loaded %d workspace-wide and %d user-scoped routing policy/policies across %d workspace(s)",
             workspace_global,
             scoped,
             len(set(_cache) | set(_user_cache)),

--- a/src/gateway/services/provider_kwargs.py
+++ b/src/gateway/services/provider_kwargs.py
@@ -310,12 +310,13 @@ def resolve_provider_selector(
 
     ``user_id`` is the billed user, so a user-scoped alias resolves to that
     user's target. Omit it only for a selector that is not caller input (the
-    operator-configured vision describe model), which is global by definition;
-    omitting it for a request selector would silently ignore the caller's own
-    aliases and resolve the global one instead. ``workspace_id`` is the same
-    kind of omission: pass it for caller input, leave it unset for an
-    operator-configured or otherwise workspace-less resolution, which then reads
-    the deployment's default workspace's aliases and policies.
+    operator-configured vision describe model), which belongs to no user by
+    definition; omitting it for a request selector would silently ignore the
+    caller's own aliases and resolve the workspace-wide one instead.
+    ``workspace_id`` is the same kind of omission: pass it for caller input,
+    leave it unset for an operator-configured or otherwise workspace-less
+    resolution, which then reads the deployment's default workspace's aliases
+    and policies.
 
     Raises ``ValueError`` / ``AnyLLMError`` (from any-llm) for a selector that
     names neither a configured instance nor a known provider, mirroring the

--- a/src/gateway/services/provider_kwargs.py
+++ b/src/gateway/services/provider_kwargs.py
@@ -8,13 +8,17 @@ any-llm is actually dispatched against. When an instance name is itself a real
 any-llm provider (the common case, no ``provider_type`` declared), the two
 coincide and behavior is identical to splitting the selector directly.
 
-**Organization-scoped provider keys** (otari-ai#1748, otari#643) are a second,
-disjoint credential source, consulted only when ``workspace_id`` is passed and
-only for a *bare* ``provider:model``/``provider/model`` selector, i.e. one with
-no matching ``config.providers`` instance. An ``instance:model`` selector
-always resolves through ``config.providers`` exactly as before and never
-touches organization-scoped keys, by construction: the two addressing schemes
-occupy disjoint selector shapes rather than one layering over the other. See
+``workspace_id`` does two unrelated jobs here, and it is worth keeping them
+apart. It selects **which workspace's aliases and routing policies** the
+selector is resolved against (``alias_service``, ``policy_store``), which
+applies to every selector shape. Separately, it selects **whose
+organization-scoped provider keys** may supply credentials (otari-ai#1748,
+otari#643): a second, disjoint credential source, consulted only for a *bare*
+``provider:model``/``provider/model`` selector, i.e. one with no matching
+``config.providers`` instance. An ``instance:model`` selector always draws its
+credentials from ``config.providers`` exactly as before and never touches
+organization-scoped keys, by construction: the two addressing schemes occupy
+disjoint selector shapes rather than one layering over the other. See
 ``services/tenancy/org_provider_key_service.py`` for the overlay this reads.
 
 ``workspace_id`` is per-request, not per-deployment: which organization's keys
@@ -294,9 +298,10 @@ def resolve_provider_selector(
     instance's ``provider_type`` (defaulting to the instance name). Otherwise the
     selector is split by any-llm directly, so unconfigured selectors and the
     legacy ``provider/model`` form keep working exactly as before, and it is
-    this bare-selector branch alone that ``workspace_id`` reaches: an
-    instance-addressed selector never consults organization-scoped keys (see
-    the module docstring).
+    this bare-selector branch alone that hands ``workspace_id`` on to credential
+    resolution: an instance-addressed selector never consults organization-scoped
+    keys (see the module docstring). Alias and policy resolution reads the
+    workspace on both branches.
 
     A selector that names an alias, whether from ``config.yml`` or the
     ``model_aliases`` table, is first substituted with the alias target, then
@@ -309,13 +314,14 @@ def resolve_provider_selector(
     omitting it for a request selector would silently ignore the caller's own
     aliases and resolve the global one instead. ``workspace_id`` is the same
     kind of omission: pass it for caller input, leave it unset for an
-    operator-configured or otherwise workspace-less resolution.
+    operator-configured or otherwise workspace-less resolution, which then reads
+    the deployment's default workspace's aliases and policies.
 
     Raises ``ValueError`` / ``AnyLLMError`` (from any-llm) for a selector that
     names neither a configured instance nor a known provider, mirroring the
     prior ``AnyLLM.split_model_provider`` behavior.
     """
-    alias = resolve_effective_alias(config, model_selector, user_id)
+    alias = resolve_effective_alias(config, model_selector, user_id, workspace_id=workspace_id)
     if alias is None:
         # A *static* routing policy is an alias in everything but spelling: one
         # name, one target. Resolving it here is what makes "an alias is a
@@ -327,7 +333,7 @@ def resolve_provider_selector(
         # honest answer to give; picking its default anyway would silently serve a
         # different model than the policy describes. The completion routes compile
         # it properly; everywhere else it surfaces as an unknown model.
-        alias = resolve_static_policy_target(config, model_selector, user_id)
+        alias = resolve_static_policy_target(config, model_selector, user_id, workspace_id=workspace_id)
     selector = alias if alias is not None else model_selector
 
     split = split_selector(selector)
@@ -356,14 +362,20 @@ def resolve_provider_selector(
     )
 
 
-def resolve_static_policy_target(config: GatewayConfig, model_selector: str, user_id: str | None = None) -> str | None:
+def resolve_static_policy_target(
+    config: GatewayConfig,
+    model_selector: str,
+    user_id: str | None = None,
+    *,
+    workspace_id: uuid.UUID | None = None,
+) -> str | None:
     """The single target of a static routing policy, or ``None``.
 
     ``None`` for a name that is not a policy, for a dynamic policy (whose target
     depends on the request), and when routing is disabled. Scoped like an alias, so
-    a user-scoped policy resolves to that user's target.
+    a user-scoped policy in this workspace resolves to that user's target.
     """
-    spec = resolve_effective_policy(config, model_selector, user_id)
+    spec = resolve_effective_policy(config, model_selector, user_id, workspace_id=workspace_id)
     if spec is None or spec.is_dynamic:
         return None
     return spec.default_target

--- a/src/gateway/services/routing/backends.py
+++ b/src/gateway/services/routing/backends.py
@@ -24,6 +24,7 @@ this build does not have serves its default target and warns once.
 
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
@@ -69,6 +70,12 @@ class RoutingContext:
     safe choice a low-confidence decision leads with."""
     candidate_pool: list[str]
     """The policy's candidates, already filtered to what this caller may use."""
+    workspace_id: uuid.UUID | None = None
+    """The workspace this request bills to, when there is one. A backend that
+    reads stored state partitions on it as well as on ``user_id``, so a user
+    holding keys in two workspaces does not have one steer the other. ``None``
+    only where there is no request (a synchronous surface), which is also where
+    no backend is asked to rank."""
     task_signal: str = ""
     """This turn's prompt text. What ``step`` granularity routes on."""
     trace_signal: str = ""

--- a/src/gateway/services/routing/decide.py
+++ b/src/gateway/services/routing/decide.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from dataclasses import dataclass
 
 from any_llm.exceptions import AnyLLMError
@@ -87,6 +88,7 @@ async def decide_ordering(
     user_id: str | None,
     allowlist: list[str] | None,
     signal: RoutingSignal | None,
+    workspace_id: uuid.UUID | None = None,
 ) -> RouterOrdering | None:
     """Ask the policy's router to rank its candidates for this request.
 
@@ -136,6 +138,7 @@ async def decide_ordering(
         user_id=user_id or "",
         default_model=default_model,
         candidate_pool=pool,
+        workspace_id=workspace_id,
         task_signal=signal.task_signal,
         trace_signal=signal.trace_signal,
         trace_anchor=signal.trace_anchor,

--- a/src/gateway/services/routing/decide.py
+++ b/src/gateway/services/routing/decide.py
@@ -129,7 +129,9 @@ async def decide_ordering(
             )
         return None
 
-    pool = usable_candidates(config, spec.router_candidates, user_id=user_id, allowlist=allowlist)
+    pool = usable_candidates(
+        config, spec.router_candidates, user_id=user_id, allowlist=allowlist, workspace_id=workspace_id
+    )
     default_model = spec.default_target
     if not pool:
         return RouterOrdering([], rationale="no candidate in the pool is usable by this caller")
@@ -210,6 +212,7 @@ def explain_router_ordering(
     *,
     user_id: str | None = None,
     allowlist: list[str] | None = None,
+    workspace_id: uuid.UUID | None = None,
 ) -> tuple[RouterOrdering | None, list[WeightedShare]]:
     """The ordering to show on a surface that has no request to route.
 
@@ -241,13 +244,15 @@ def explain_router_ordering(
     if not backend_is_weighted(spec.router_backend):
         return None, []
     declared = spec.router_candidates
-    usable = usable_candidates(config, declared, user_id=user_id, allowlist=allowlist)
+    usable = usable_candidates(
+        config, declared, user_id=user_id, allowlist=allowlist, workspace_id=workspace_id
+    )
     weights = spec.router_weights
     shares = declared_shares(weights, usable)
     displayed: list[WeightedShare] = []
     for selector in explain_ordering(usable, weights):
         try:
-            resolved = resolve_provider_selector(config, selector, user_id)
+            resolved = resolve_provider_selector(config, selector, user_id, workspace_id=workspace_id)
         except (ValueError, AnyLLMError):  # pragma: no cover - usable_candidates already resolved these
             continue
         displayed.append(
@@ -275,12 +280,18 @@ def usable_candidates(
     *,
     user_id: str | None,
     allowlist: list[str] | None,
+    workspace_id: uuid.UUID | None = None,
 ) -> list[str]:
     """The candidates this caller may actually be served, in declared order.
 
     Selectors are kept in the form the policy wrote them (the compiler resolves
     them again for dispatch); resolution here is only to test the allow-list,
     which matches on the canonical ``instance:model``.
+
+    ``workspace_id`` is passed for the same reason the compiler takes one: a
+    candidate selector can itself name an alias, and resolving it in a different
+    workspace than dispatch will would filter the pool against a canonical key
+    the request never sees.
 
     Public because ``explain`` needs the same pool: a weighted policy's shares are
     normalized over what survived filtering, so computing them from the declared
@@ -289,7 +300,7 @@ def usable_candidates(
     usable: list[str] = []
     for selector in candidates:
         try:
-            resolved = resolve_provider_selector(config, selector, user_id)
+            resolved = resolve_provider_selector(config, selector, user_id, workspace_id=workspace_id)
         except (ValueError, AnyLLMError):
             # The compiler records this as a dropped candidate with a reason; here
             # it just means the router should not rank it.

--- a/src/gateway/services/routing/decide.py
+++ b/src/gateway/services/routing/decide.py
@@ -289,9 +289,9 @@ def usable_candidates(
     which matches on the canonical ``instance:model``.
 
     ``workspace_id`` is passed for the same reason the compiler takes one: a
-    candidate selector can itself name an alias, and resolving it in a different
-    workspace than dispatch will would filter the pool against a canonical key
-    the request never sees.
+    candidate selector can itself name an alias, so resolving it in a workspace
+    other than the one dispatch uses would filter the pool against a canonical
+    key the request never sees.
 
     Public because ``explain`` needs the same pool: a weighted policy's shares are
     normalized over what survived filtering, so computing them from the declared

--- a/src/gateway/services/routing/knn.py
+++ b/src/gateway/services/routing/knn.py
@@ -14,11 +14,13 @@ sub-floor confidence, tool-bearing request, unpriced candidate), and a decline
 serves the policy's default target, so a learned policy is never worse than the
 plain failover policy it was written from.
 
-The store is a linear cosine scan over the user's records held in the gateway DB
+The store is a linear cosine scan over the records the requesting user has in the
+requesting workspace, held in the gateway DB
 (:class:`gateway.models.entities.RoutingMemory`). That holds into the low
-thousands of records per user (the ``router_max_records_per_user`` cap); pgvector
-or an ANN index is the next step past that, and the reasoning is in
-`docs/routing-scaling.md`. Records carry an ``embedding_model`` tag so changing
+thousands of records per partition (the ``router_max_records_per_user`` cap,
+which bounds one user's records in one workspace, since that is what a decision
+loads); pgvector or an ANN index is the next step past that, and the reasoning is
+in `docs/routing-scaling.md`. Records carry an ``embedding_model`` tag so changing
 the embedding model invalidates stale vectors rather than mixing incomparable
 spaces.
 
@@ -33,6 +35,7 @@ from __future__ import annotations
 
 import hashlib
 import math
+import uuid
 from collections import OrderedDict
 from typing import TYPE_CHECKING
 
@@ -142,7 +145,7 @@ class KnnRoutingMemory:
             logger.warning("Router embedding failed (%s); serving the policy default", type(exc).__name__)
             return RoutingDecision.decline(f"embedding error ({type(exc).__name__})")
 
-        records = await self._load_records(ctx.user_id, ctx.task_id)
+        records = await self._load_records(ctx.user_id, ctx.task_id, ctx.workspace_id)
         if len(records) < self.seed_count:
             partition = f" and task '{ctx.task_id}'" if ctx.task_id else ""
             return RoutingDecision.decline(
@@ -173,6 +176,7 @@ class KnnRoutingMemory:
         self,
         *,
         user_id: str,
+        workspace_id: uuid.UUID,
         prompt: str,
         scores: dict[str, float],
         task_id: str | None,
@@ -195,6 +199,7 @@ class KnnRoutingMemory:
             db.add(
                 RoutingMemory(
                     user_id=user_id,
+                    workspace_id=workspace_id,
                     embedding_model=self.embedding_model,
                     embedding=embedding,
                     qualities={model: float(score) for model, score in scores.items()},
@@ -207,7 +212,7 @@ class KnnRoutingMemory:
             except SQLAlchemyError:
                 await db.rollback()
                 raise
-        await self._evict_if_needed(user_id)
+        await self._evict_if_needed(user_id, workspace_id)
         return 1
 
     # -- scoring -----------------------------------------------------------
@@ -347,23 +352,32 @@ class KnnRoutingMemory:
 
     # -- storage / retrieval ------------------------------------------------
 
-    async def _load_records(self, user_id: str, task_id: str | None) -> list[RoutingMemory]:
-        """Load a user's records for the current embedding model.
+    async def _load_records(
+        self, user_id: str, task_id: str | None, workspace_id: uuid.UUID | None = None
+    ) -> list[RoutingMemory]:
+        """Load a user's records for the current embedding model, in one workspace.
 
         A ``task_id`` is a hard partition: only records carrying that label load,
         so the cold-start gate counts that partition alone and a request stays on
         the default target until its own task is warm. Records from other tasks
         never influence it. With no task, every record the user has is in play.
+
+        ``workspace_id`` is a hard partition too: examples labeled in one
+        workspace never steer another's traffic, even for a user who holds keys in
+        both. Omitted only where there is no request to route (no backend is asked
+        to rank there), which reads every workspace the user has records in.
         """
         async with create_session() as db:
             stmt = select(RoutingMemory).where(
                 RoutingMemory.user_id == user_id,
                 RoutingMemory.embedding_model == self.embedding_model,
             )
+            if workspace_id is not None:
+                stmt = stmt.where(RoutingMemory.workspace_id == workspace_id)
             if task_id is not None:
                 stmt = stmt.where(RoutingMemory.task_id == task_id)
             # Newest first, and bounded. Eviction is enforced lazily on write, and
-            # only for the user's whole set rather than per partition, so nothing
+            # only for the (user, workspace) set rather than per task, so nothing
             # else stops this select from growing without limit: a request would
             # then load and cosine-score every row it finds. The cap is what the
             # operator already configured as "how many records this router uses",
@@ -376,15 +390,21 @@ class KnnRoutingMemory:
         sims.sort(key=lambda pair: pair[0], reverse=True)
         return sims[: self.k]
 
-    async def _evict_if_needed(self, user_id: str) -> None:
-        """Keep at most ``max_records`` of the newest records per user."""
+    async def _evict_if_needed(self, user_id: str, workspace_id: uuid.UUID) -> None:
+        """Keep at most ``max_records`` of the newest records per user and workspace.
+
+        Applied within the partition the router reads, not across every workspace
+        the user has records in. ``router_max_records_per_user`` bounds what one
+        decision loads and scores, and a decision only ever loads one workspace,
+        so evicting across them would have a busy workspace delete labels another
+        one is still routing on.
+        """
         if self.max_records <= 0:
             return
+        partition = (RoutingMemory.user_id == user_id, RoutingMemory.workspace_id == workspace_id)
         async with create_session() as db:
             count = (
-                await db.execute(
-                    select(func.count()).select_from(RoutingMemory).where(RoutingMemory.user_id == user_id)
-                )
+                await db.execute(select(func.count()).select_from(RoutingMemory).where(*partition))
             ).scalar_one()
             if count <= self.max_records:
                 return
@@ -395,7 +415,7 @@ class KnnRoutingMemory:
             cutoff = (
                 await db.execute(
                     select(RoutingMemory.created_at)
-                    .where(RoutingMemory.user_id == user_id)
+                    .where(*partition)
                     .order_by(RoutingMemory.created_at.desc())
                     .offset(self.max_records - 1)
                     .limit(1)
@@ -408,7 +428,7 @@ class KnnRoutingMemory:
             # evicted; the count can sit slightly above the cap until the next write.
             await db.execute(
                 delete(RoutingMemory).where(
-                    RoutingMemory.user_id == user_id,
+                    *partition,
                     RoutingMemory.created_at < cutoff,
                 )
             )

--- a/src/gateway/services/routing/knn.py
+++ b/src/gateway/services/routing/knn.py
@@ -486,15 +486,22 @@ class KnnRoutingMemory:
     # -- trace memory ------------------------------------------------------
 
     def _trace_key(self, ctx: RoutingContext) -> str:
-        """Per-(user, task) trace identity for trace-sticky reuse.
+        """Per-(workspace, user, task) trace identity for trace-sticky reuse.
 
         The client-supplied conversation id when present, otherwise a hash of the
-        conversation's opening text. Both are namespaced by user and task, so one
-        conversation id never collides across users or across partitions.
+        conversation's opening text. Both are namespaced by workspace, user and
+        task, so one conversation id never collides across any of the three.
+
+        The workspace belongs here for the same reason it is on
+        :meth:`_load_records`, and is load-bearing rather than tidy: this cache is
+        consulted *before* any record loads, so without it a user sending one
+        conversation id in two workspaces would have workspace A's decision
+        replayed in workspace B, out of process memory, having never read
+        workspace B's examples at all.
         """
         explicit = ctx.trace_key.strip() if ctx.trace_key else ""
         anchor = explicit or ctx.trace_anchor
-        raw = f"{ctx.user_id}\x00{ctx.task_id or ''}\x00{anchor}"
+        raw = f"{ctx.workspace_id or ''}\x00{ctx.user_id}\x00{ctx.task_id or ''}\x00{anchor}"
         return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
     def _remember_trace(self, trace_key: str, model: str) -> None:

--- a/src/gateway/services/routing/knn.py
+++ b/src/gateway/services/routing/knn.py
@@ -157,7 +157,7 @@ class KnnRoutingMemory:
             return RoutingDecision.decline(f"sparse neighborhood: {len(neighbors)}/{self.k} comparable records")
 
         try:
-            prices = await self._candidate_prices(pool)
+            prices = await self._candidate_prices(pool, workspace_id=ctx.workspace_id)
         except RouterPricingError as exc:
             # Startup and write-time validation should have caught this, so getting
             # here means pricing was removed under a running gateway. Declining
@@ -237,8 +237,13 @@ class KnnRoutingMemory:
         # still match: a miss is silent, and leaves the cheap candidate scoreless
         # while the pool reports warm.
         cache: dict[str, str] = {}
-        key_of = {model: self._canonical(model, ctx.user_id, cache) for model in pool}
-        recorded = [self._canonical_qualities(record.qualities, ctx.user_id, cache) for _, record in neighbors]
+        key_of = {
+            model: self._canonical(model, ctx.user_id, cache, workspace_id=ctx.workspace_id) for model in pool
+        }
+        recorded = [
+            self._canonical_qualities(record.qualities, ctx.user_id, cache, workspace_id=ctx.workspace_id)
+            for _, record in neighbors
+        ]
 
         scores: dict[str, float] = {}
         for model in pool:
@@ -286,21 +291,38 @@ class KnnRoutingMemory:
 
     # -- model identity ------------------------------------------------------
 
-    def _canonical(self, selector: str, user_id: str | None, cache: dict[str, str]) -> str:
+    def _canonical(
+        self,
+        selector: str,
+        user_id: str | None,
+        cache: dict[str, str],
+        *,
+        workspace_id: uuid.UUID | None = None,
+    ) -> str:
         """``instance:model`` for a selector, or the selector unchanged if it resolves to nothing.
 
         An unresolvable selector keeps its own spelling rather than dropping out, so
         it can still match a stored key spelled the same way; scoring is not the
         place to decide a candidate is invalid.
 
+        ``workspace_id`` is the request's, and has to be: a candidate selector can
+        name an alias, and this workspace's alias may point somewhere the default
+        workspace's does not. ``usable_candidates`` filtered the pool in this
+        workspace and ``/rank`` canonicalized the stored keys in it, so resolving
+        here in another one produces a key that matches neither, and the candidate
+        drops out of scoring with no score and no error.
+
         ``cache`` is per decision: the pool and the neighbors' stored keys repeat the
         same handful of selectors, and each resolution walks the alias and
-        static-policy tables.
+        static-policy tables. Keying it on the selector alone is safe because one
+        decision has one workspace.
         """
         canonical = cache.get(selector)
         if canonical is None:
             try:
-                resolved = resolve_provider_selector(self.config, selector, user_id)
+                resolved = resolve_provider_selector(
+                    self.config, selector, user_id, workspace_id=workspace_id
+                )
                 canonical = f"{resolved.instance}:{resolved.model}"
             except (ValueError, AnyLLMError):
                 canonical = selector
@@ -308,7 +330,12 @@ class KnnRoutingMemory:
         return canonical
 
     def _canonical_qualities(
-        self, qualities: dict[str, float], user_id: str | None, cache: dict[str, str]
+        self,
+        qualities: dict[str, float],
+        user_id: str | None,
+        cache: dict[str, str],
+        *,
+        workspace_id: uuid.UUID | None = None,
     ) -> dict[str, float]:
         """One record's scores, rekeyed on canonical model identity.
 
@@ -320,7 +347,7 @@ class KnnRoutingMemory:
         """
         canonical: dict[str, float] = {}
         for model, quality in qualities.items():
-            canonical.setdefault(self._canonical(model, user_id, cache), quality)
+            canonical.setdefault(self._canonical(model, user_id, cache, workspace_id=workspace_id), quality)
         return canonical
 
     # -- candidate pool / ordering ------------------------------------------
@@ -440,17 +467,28 @@ class KnnRoutingMemory:
 
     # -- pricing -----------------------------------------------------------
 
-    async def _candidate_prices(self, pool: list[str]) -> dict[str, float]:
+    async def _candidate_prices(
+        self, pool: list[str], *, workspace_id: uuid.UUID | None = None
+    ) -> dict[str, float]:
         async with create_session() as db:
-            return {model: await self._input_price(db, model) for model in pool}
+            return {model: await self._input_price(db, model, workspace_id=workspace_id) for model in pool}
 
-    async def _input_price(self, db: AsyncSession, selector: str) -> float:
+    async def _input_price(
+        self, db: AsyncSession, selector: str, *, workspace_id: uuid.UUID | None = None
+    ) -> float:
         """Input price per million tokens for one candidate.
 
         Resolved through ``resolve_provider_selector`` rather than split by hand so
         the lookup keys on the same ``instance:model`` the request will be billed
         under. A candidate naming a provider *instance* would otherwise be priced
         against its implementation name and look unpriced.
+
+        ``workspace_id`` decides *which model* the selector names, for the same
+        reason it does in :meth:`_canonical`: an alias can point somewhere
+        different per workspace, and pricing the default workspace's target while
+        scoring this workspace's would rank on a price the request never pays.
+        That is separate from *whose rates* apply, which the next paragraph is
+        about and which this deliberately leaves alone.
 
         Deliberately reads the *deployment* price list, not an organization's rate
         overrides, so a router's ranking can differ from what the chosen request
@@ -465,7 +503,7 @@ class KnnRoutingMemory:
         candidate priced only by an override never becomes a stored policy.
         """
         try:
-            resolved = resolve_provider_selector(self.config, selector)
+            resolved = resolve_provider_selector(self.config, selector, workspace_id=workspace_id)
         except (ValueError, AnyLLMError) as exc:
             raise RouterPricingError(f"Router candidate '{selector}' does not resolve to a provider.") from exc
         pricing = await find_model_pricing(db, resolved.instance, resolved.model)
@@ -476,6 +514,18 @@ class KnnRoutingMemory:
     # -- embedding ---------------------------------------------------------
 
     async def _embed(self, text: str) -> list[float]:
+        """Embed ``text`` with the deployment's configured embedding model.
+
+        Resolved with no workspace, and deliberately, unlike every other selector
+        this class resolves. ``router_embedding_model`` is operator configuration
+        rather than caller input, which is the case ``resolve_provider_selector``
+        documents as workspace-less. More than a convention here: every stored
+        vector is tagged with this model name and compared against others carrying
+        the same tag, so if two workspaces resolved that one name to different
+        providers, their vectors would be silently incomparable while claiming to
+        be the same space. Scoping this would create the bug that scoping the
+        others fixes.
+        """
         resolved = resolve_provider_selector(self.config, self.embedding_model)
         result = await aembedding(
             model=resolved.model, inputs=text, provider=resolved.provider, **resolved.kwargs
@@ -516,7 +566,11 @@ class KnnRoutingMemory:
 
 
 async def unpriced_router_candidates(
-    config: GatewayConfig, db: AsyncSession, candidates: list[str]
+    config: GatewayConfig,
+    db: AsyncSession,
+    candidates: list[str],
+    *,
+    workspace_id: uuid.UUID | None = None,
 ) -> list[str]:
     """Which of ``candidates`` have no configured pricing.
 
@@ -524,11 +578,17 @@ async def unpriced_router_candidates(
     validation over the config policies, and the write path for a stored one. The
     router scores by cost, so a candidate with no price could never be compared,
     and a policy that silently never routes is worse than one that fails to load.
+
+    ``workspace_id`` is the workspace the policy is being stored into, so a
+    candidate naming an alias is validated as it will resolve for the requests
+    that policy will serve. Omitted by startup validation, which reads the
+    ``config.yml`` policies: those are deployment-wide, so the default workspace
+    is the only workspace-shaped answer there is.
     """
     missing: list[str] = []
     for selector in candidates:
         try:
-            resolved = resolve_provider_selector(config, selector)
+            resolved = resolve_provider_selector(config, selector, workspace_id=workspace_id)
         except (ValueError, AnyLLMError):
             # An unresolvable selector is refused elsewhere, with a clearer message.
             continue

--- a/src/gateway/services/workspace_scope.py
+++ b/src/gateway/services/workspace_scope.py
@@ -1,7 +1,8 @@
 """Which workspace a request-plane row belongs to.
 
-Every row in ``api_keys``, ``usage_logs``, ``model_aliases`` and
-``routing_policies`` carries a workspace, so every writer needs one. There are
+Every row in ``api_keys``, ``usage_logs``, ``model_aliases``,
+``routing_policies``, ``routing_memory``, ``router_preferences`` and
+``file_objects`` carries a workspace, so every writer needs one. There are
 only two sources:
 
 - **An API key request.** The workspace comes off the key that authenticated it,
@@ -71,11 +72,13 @@ def reset_key_workspace_cache() -> None:
     _workspace_organization.clear()
 
 
-async def default_workspace_id(db: AsyncSession) -> uuid.UUID:
-    """The workspace a deployment-wide write lands in.
+async def lookup_default_workspace_id(db: AsyncSession) -> uuid.UUID | None:
+    """The default workspace, or ``None`` when the deployment has none yet.
 
-    Seeded by the migration that added the columns, and adopted by first-boot
-    provisioning rather than duplicated, so it exists on every migrated database.
+    The read-only half of :func:`default_workspace_id`, for a caller that must
+    not write: the alias and policy cache refreshers run on a timer in every
+    worker, and creating a workspace as a side effect of reloading a cache would
+    turn a read path into a writer racing three replicas.
     """
     resolved = (
         await db.execute(
@@ -84,17 +87,27 @@ async def default_workspace_id(db: AsyncSession) -> uuid.UUID:
             .where(col(Organization.slug) == DEFAULT_ORGANIZATION_SLUG, col(Workspace.name) == DEFAULT_WORKSPACE_NAME)
         )
     ).scalar_one_or_none()
-    if resolved is None:
-        # Fall back to the oldest workspace before creating one: an operator may
-        # have renamed the default, and minting a second beside it would be worse
-        # than billing to the one that exists. The id breaks a ``created_at``
-        # tie, which one transaction creating two workspaces produces, so every
-        # process picks the same one rather than each picking its own.
-        resolved = (
-            await db.execute(
-                select(col(Workspace.id)).order_by(col(Workspace.created_at), col(Workspace.id)).limit(1)
-            )
-        ).scalar_one_or_none()
+    if resolved is not None:
+        return resolved
+    # Fall back to the oldest workspace before reporting none: an operator may
+    # have renamed the default, and a caller that then minted a second beside it
+    # would be worse than using the one that exists. The id breaks a
+    # ``created_at`` tie, which one transaction creating two workspaces produces,
+    # so every process picks the same one rather than each picking its own.
+    return (
+        await db.execute(
+            select(col(Workspace.id)).order_by(col(Workspace.created_at), col(Workspace.id)).limit(1)
+        )
+    ).scalar_one_or_none()
+
+
+async def default_workspace_id(db: AsyncSession) -> uuid.UUID:
+    """The workspace a deployment-wide write lands in.
+
+    Seeded by the migration that added the columns, and adopted by first-boot
+    provisioning rather than duplicated, so it exists on every migrated database.
+    """
+    resolved = await lookup_default_workspace_id(db)
     if resolved is None:
         return await _create_default_workspace(db)
 
@@ -213,6 +226,7 @@ async def organization_for_key_id(db: AsyncSession, api_key_id: str | None) -> u
 
 __all__ = [
     "default_workspace_id",
+    "lookup_default_workspace_id",
     "organization_for_key_id",
     "organization_for_workspace_id",
     "reset_key_workspace_cache",

--- a/tests/integration/test_alias_api.py
+++ b/tests/integration/test_alias_api.py
@@ -144,11 +144,16 @@ def test_create_and_list(client: TestClient) -> None:
         "target": "anthropic:claude-haiku-4",
         "source": "stored",
         "user_id": None,
+        # A write that named no workspace landed in the deployment's default one.
+        "workspace_id": by_name["fast"]["workspace_id"],
         "created_at": by_name["fast"]["created_at"],
         "updated_at": by_name["fast"]["updated_at"],
     }
+    assert by_name["fast"]["workspace_id"] is not None
     assert by_name["configalias"]["source"] == "config"
     assert by_name["configalias"]["target"] == "anthropic:claude-opus-4"
+    # A config.yml alias is deployment-wide, so it belongs to no workspace.
+    assert by_name["configalias"]["workspace_id"] is None
 
 
 def test_create_is_idempotent_and_retargets(client: TestClient) -> None:

--- a/tests/integration/test_workspace_scope_survivals.py
+++ b/tests/integration/test_workspace_scope_survivals.py
@@ -24,7 +24,6 @@ from fastapi.testclient import TestClient
 
 from gateway.services.file_store import LocalDirFileStore
 
-MASTER = "master"
 ALIASES = "/v1/aliases"
 POLICIES = "/v1/routing/policies"
 NOWHERE = "00000000-0000-0000-0000-000000000000"

--- a/tests/integration/test_workspace_scope_survivals.py
+++ b/tests/integration/test_workspace_scope_survivals.py
@@ -1,0 +1,407 @@
+"""The gateway survivals are scoped to a workspace (otari-ai#1643).
+
+Aliases, routing policies, routing memory, router preferences, files and batches
+stay in the gateway rather than moving to the platform, and each is now managed
+and resolved inside one workspace. ``user_id`` is untouched on every one of
+them: the workspace is a second axis, so a user who holds keys in two workspaces
+keeps their per-user scoping within each and reaches neither from the other.
+
+Two properties recur and are what most of these tests are about. A write that
+names no workspace lands in the deployment's default one, which is what keeps a
+single-workspace deployment working with nothing to change. And the same name in
+two workspaces resolves to each workspace's own row, which is the behavior the
+widened uniqueness constraint exists for.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from gateway.services.file_store import LocalDirFileStore
+
+MASTER = "master"
+ALIASES = "/v1/aliases"
+POLICIES = "/v1/routing/policies"
+NOWHERE = "00000000-0000-0000-0000-000000000000"
+
+
+@pytest.fixture
+def tmp_file_store(client: TestClient, tmp_path: Path) -> None:
+    """Point the app's blob store at a temp dir (default writes to cwd)."""
+    cast(Any, client.app).state.file_store = LocalDirFileStore(str(tmp_path))
+
+
+def _default_workspace(client: TestClient, headers: dict[str, str]) -> str:
+    context = client.get("/v1/organizations/me", headers=headers).json()
+    return str(context["workspace_memberships"][0]["workspace_id"])
+
+
+def _make_workspace(client: TestClient, headers: dict[str, str], name: str) -> str:
+    created = client.post("/v1/workspaces", json={"name": name}, headers=headers)
+    assert created.status_code == status.HTTP_201_CREATED, created.text
+    return str(created.json()["id"])
+
+
+def _key_header(
+    client: TestClient, master: dict[str, str], template: dict[str, str], **body: Any
+) -> dict[str, str]:
+    """Mint a key and return an auth header for it.
+
+    The gateway requires a "Bearer " prefix on every header form, so the header
+    name is taken from the fixture's own rather than hardcoded.
+    """
+    created = client.post("/v1/keys", json={"key_name": "k", **body}, headers=master)
+    assert created.status_code == status.HTTP_200_OK, created.text
+    return {next(iter(template)): f"Bearer {created.json()['key']}"}
+
+
+# ---------------------------------------------------------------------------
+# Aliases
+# ---------------------------------------------------------------------------
+
+
+def test_two_workspaces_can_each_define_the_same_alias(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
+    """The row the pre-widening constraint refused outright.
+
+    Storing both was a 409 while the resolution cache was keyed on name alone,
+    because the second would have silently shadowed the first at request time.
+    """
+    default = _default_workspace(client, master_key_header)
+    platform = _make_workspace(client, master_key_header, "Platform team")
+
+    for workspace, target in ((default, "anthropic:claude-haiku-4"), (platform, "openai:gpt-4o-mini")):
+        created = client.post(
+            ALIASES,
+            json={"name": "fast", "target": target, "workspace_id": workspace},
+            headers=master_key_header,
+        )
+        assert created.status_code == status.HTTP_200_OK, created.text
+        assert created.json()["workspace_id"] == workspace
+
+    listed = client.get(f"{ALIASES}?workspace_id={platform}", headers=master_key_header).json()
+    stored = [row for row in listed if row["source"] == "stored"]
+    assert [(row["name"], row["target"]) for row in stored] == [("fast", "openai:gpt-4o-mini")]
+
+
+def test_an_alias_resolves_only_for_a_key_in_its_own_workspace(
+    client: TestClient, master_key_header: dict[str, str], api_key_header: dict[str, str]
+) -> None:
+    """Resolution, not just listing: the catalog reads the caller's workspace.
+
+    ``owned_by`` is the observable. An alias resolves to an otari-owned entry;
+    a name that is not an alias in the caller's workspace is not a model either,
+    so it 404s exactly as an unknown one does.
+    """
+    platform = _make_workspace(client, master_key_header, "Platform team")
+    client.post(
+        ALIASES,
+        json={"name": "fast", "target": "anthropic:claude-haiku-4", "workspace_id": platform},
+        headers=master_key_header,
+    )
+    in_platform = _key_header(client, master_key_header, api_key_header, workspace_id=platform)
+    in_default = _key_header(client, master_key_header, api_key_header, key_name="elsewhere")
+
+    resolved = client.get("/v1/models/fast", headers=in_platform)
+    assert resolved.status_code == status.HTTP_200_OK, resolved.text
+    assert resolved.json()["owned_by"] == "otari"
+
+    unresolved = client.get("/v1/models/fast", headers=in_default)
+    assert unresolved.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_an_alias_written_without_a_workspace_lands_in_the_default_one(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
+    """What a single-workspace deployment does, unchanged by any of this."""
+    default = _default_workspace(client, master_key_header)
+
+    created = client.post(
+        ALIASES, json={"name": "fast", "target": "anthropic:claude-haiku-4"}, headers=master_key_header
+    )
+
+    assert created.json()["workspace_id"] == default
+
+
+def test_deleting_an_alias_leaves_the_other_workspaces_copy(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
+    default = _default_workspace(client, master_key_header)
+    platform = _make_workspace(client, master_key_header, "Platform team")
+    for workspace in (default, platform):
+        client.post(
+            ALIASES,
+            json={"name": "fast", "target": "anthropic:claude-haiku-4", "workspace_id": workspace},
+            headers=master_key_header,
+        )
+
+    removed = client.delete(f"{ALIASES}/fast?workspace_id={platform}", headers=master_key_header)
+    assert removed.status_code == status.HTTP_204_NO_CONTENT
+
+    remaining = client.get(ALIASES, headers=master_key_header).json()
+    assert [row["workspace_id"] for row in remaining if row["source"] == "stored"] == [default]
+
+
+def test_deleting_an_alias_in_the_wrong_workspace_is_a_404(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
+    """The error path of the scoped delete: right name, wrong tenant."""
+    platform = _make_workspace(client, master_key_header, "Platform team")
+    client.post(
+        ALIASES, json={"name": "fast", "target": "anthropic:claude-haiku-4"}, headers=master_key_header
+    )
+
+    missing = client.delete(f"{ALIASES}/fast?workspace_id={platform}", headers=master_key_header)
+
+    assert missing.status_code == status.HTTP_404_NOT_FOUND
+    assert platform in missing.json()["detail"]
+
+
+def test_an_alias_cannot_be_written_into_a_workspace_that_does_not_exist(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
+    """Checked rather than left to the foreign key, matching POST /v1/keys.
+
+    The id comes from the caller, so an unknown one is a bad request; reaching
+    the constraint would answer 500 "Database error" for a value they can fix.
+    """
+    refused = client.post(
+        ALIASES,
+        json={"name": "fast", "target": "anthropic:claude-haiku-4", "workspace_id": NOWHERE},
+        headers=master_key_header,
+    )
+
+    assert refused.status_code == status.HTTP_404_NOT_FOUND
+    assert "not found" in refused.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Routing policies
+# ---------------------------------------------------------------------------
+
+
+def _policy(target: str) -> dict[str, Any]:
+    return {"select": [{"default": target}]}
+
+
+def test_two_workspaces_can_each_define_the_same_policy(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
+    default = _default_workspace(client, master_key_header)
+    platform = _make_workspace(client, master_key_header, "Platform team")
+
+    for workspace, target in ((default, "anthropic:claude-haiku-4"), (platform, "openai:gpt-4o-mini")):
+        created = client.post(
+            POLICIES,
+            json={"name": "cheap", "spec": _policy(target), "workspace_id": workspace},
+            headers=master_key_header,
+        )
+        assert created.status_code == status.HTTP_200_OK, created.text
+        assert created.json()["workspace_id"] == workspace
+
+    scoped = client.get(f"{POLICIES}?workspace_id={platform}", headers=master_key_header).json()
+    stored = [row for row in scoped if row["source"] == "stored"]
+    assert [row["spec"]["select"][0]["default"] for row in stored] == ["openai:gpt-4o-mini"]
+
+
+def test_one_workspace_still_cannot_hold_two_policies_of_a_name(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
+    """Widening admits the cross-workspace row, not the duplicate within one.
+
+    Sent as a rename onto a taken name, which is the path that checks rather
+    than upserting; a plain second POST of the same name is an edit by design.
+    """
+    client.post(POLICIES, json={"name": "cheap", "spec": _policy("openai:gpt-4o-mini")}, headers=master_key_header)
+    client.post(POLICIES, json={"name": "fast", "spec": _policy("openai:gpt-4o")}, headers=master_key_header)
+
+    clash = client.post(
+        POLICIES,
+        json={"name": "cheap", "spec": _policy("openai:gpt-4o"), "rename_from": "fast"},
+        headers=master_key_header,
+    )
+
+    assert clash.status_code == status.HTTP_409_CONFLICT
+
+
+def test_explain_resolves_the_policy_in_the_workspace_it_is_asked_about(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
+    """Resolution again, on the surface that reports what a policy would do."""
+    platform = _make_workspace(client, master_key_header, "Platform team")
+    client.post(
+        POLICIES,
+        json={"name": "cheap", "spec": _policy("openai:gpt-4o-mini"), "workspace_id": platform},
+        headers=master_key_header,
+    )
+
+    there = client.post(
+        f"{POLICIES}/explain", json={"name": "cheap", "workspace_id": platform}, headers=master_key_header
+    )
+    assert there.status_code == status.HTTP_200_OK, there.text
+    assert [c["model"] for c in there.json()["candidates"]] == ["gpt-4o-mini"]
+
+    # The default workspace holds no such policy, so there is nothing to explain.
+    here = client.post(f"{POLICIES}/explain", json={"name": "cheap"}, headers=master_key_header)
+    assert here.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_deleting_a_policy_in_the_wrong_workspace_is_a_404(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
+    platform = _make_workspace(client, master_key_header, "Platform team")
+    client.post(POLICIES, json={"name": "cheap", "spec": _policy("openai:gpt-4o")}, headers=master_key_header)
+
+    missing = client.delete(f"{POLICIES}/cheap?workspace_id={platform}", headers=master_key_header)
+
+    assert missing.status_code == status.HTTP_404_NOT_FOUND
+    assert platform in missing.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Files
+# ---------------------------------------------------------------------------
+
+
+def test_a_file_is_stamped_with_the_uploading_keys_workspace(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    tmp_file_store: None,
+) -> None:
+    """Read off the key, never a header: the caller controls one and not the other."""
+    platform = _make_workspace(client, master_key_header, "Platform team")
+    scoped = _key_header(
+        client, master_key_header, api_key_header, workspace_id=platform, user_id="ada"
+    )
+
+    uploaded = client.post("/v1/files", headers=scoped, files={"file": ("a.txt", b"hi", "text/plain")})
+    assert uploaded.status_code == status.HTTP_200_OK, uploaded.text
+
+    listed = client.get(f"/v1/files?user=ada&workspace_id={platform}", headers=master_key_header).json()
+    assert [row["id"] for row in listed["data"]] == [uploaded.json()["id"]]
+
+
+def test_the_same_user_cannot_reach_their_file_from_another_workspace(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    tmp_file_store: None,
+) -> None:
+    """The isolation the user check alone does not give.
+
+    Both keys belong to Ada, so per-user scoping says yes; the workspace is what
+    says no. 404 rather than 403, matching the cross-user answer, so the two are
+    indistinguishable from a missing file.
+    """
+    platform = _make_workspace(client, master_key_header, "Platform team")
+    there = _key_header(client, master_key_header, api_key_header, workspace_id=platform, user_id="ada")
+    here = _key_header(client, master_key_header, api_key_header, user_id="ada", key_name="here")
+
+    file_id = client.post(
+        "/v1/files", headers=there, files={"file": ("a.txt", b"hi", "text/plain")}
+    ).json()["id"]
+
+    assert client.get(f"/v1/files/{file_id}", headers=here).status_code == status.HTTP_404_NOT_FOUND
+    assert client.get(f"/v1/files/{file_id}/content", headers=here).status_code == status.HTTP_404_NOT_FOUND
+    assert client.delete(f"/v1/files/{file_id}", headers=here).status_code == status.HTTP_404_NOT_FOUND
+    assert client.get("/v1/files", headers=here).json()["data"] == []
+    # The owning workspace still has it, so nothing was lost, only partitioned.
+    assert client.get(f"/v1/files/{file_id}", headers=there).status_code == status.HTTP_200_OK
+
+
+def test_the_master_key_still_sees_every_workspaces_files(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    api_key_header: dict[str, str],
+    tmp_file_store: None,
+) -> None:
+    """The operator acting deployment-wide, which is what keeps their tooling working.
+
+    Narrowable with ``workspace_id`` rather than narrowed by default, matching
+    ``GET /v1/keys``.
+    """
+    platform = _make_workspace(client, master_key_header, "Platform team")
+    there = _key_header(client, master_key_header, api_key_header, workspace_id=platform, user_id="ada")
+    here = _key_header(client, master_key_header, api_key_header, user_id="ada", key_name="here")
+    for header in (there, here):
+        client.post("/v1/files", headers=header, files={"file": ("a.txt", b"hi", "text/plain")})
+
+    everything = client.get("/v1/files?user=ada", headers=master_key_header).json()
+    assert len(everything["data"]) == 2
+
+    narrowed = client.get(f"/v1/files?user=ada&workspace_id={platform}", headers=master_key_header).json()
+    assert len(narrowed["data"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Routing memory and router preferences
+# ---------------------------------------------------------------------------
+
+
+def _rank(client: TestClient, headers: dict[str, str], **body: Any) -> Any:
+    return client.post("/v1/routing/preferences/rank", json=body, headers=headers)
+
+
+def test_routing_memory_is_counted_per_workspace(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Warmth is per partition, and the partition now includes the workspace.
+
+    A total spanning workspaces would report a pool warm that no single request
+    ever votes over, because a decision loads one workspace's records.
+    """
+    from gateway.services.routing import knn
+
+    async def _embed(self: Any, text: str) -> list[float]:
+        return [1.0, 0.0]
+
+    monkeypatch.setattr(knn.KnnRoutingMemory, "_embed", _embed)
+
+    client.post("/v1/users", json={"user_id": "ada"}, headers=master_key_header)
+    platform = _make_workspace(client, master_key_header, "Platform team")
+
+    written = _rank(
+        client,
+        master_key_header,
+        user_id="ada",
+        workspace_id=platform,
+        examples=[{"prompt": "sum this", "scores": {"openai:gpt-4o-mini": 1.0}}],
+    )
+    assert written.status_code == status.HTTP_200_OK, written.text
+
+    there = client.get(
+        f"/v1/routing/status?user_id=ada&workspace_id={platform}", headers=master_key_header
+    ).json()
+    assert there["workspace_id"] == platform
+    assert there["default_pool"]["records"] == 1
+
+    # The default workspace was taught nothing, so its pool is empty even though
+    # the same user has an example elsewhere.
+    here = client.get("/v1/routing/status?user_id=ada", headers=master_key_header).json()
+    assert here["default_pool"]["records"] == 0
+
+
+def test_teaching_a_workspace_that_does_not_exist_is_a_404(
+    client: TestClient, master_key_header: dict[str, str]
+) -> None:
+    client.post("/v1/users", json={"user_id": "ada"}, headers=master_key_header)
+
+    refused = _rank(
+        client,
+        master_key_header,
+        user_id="ada",
+        workspace_id=NOWHERE,
+        examples=[{"prompt": "sum this", "scores": {"openai:gpt-4o-mini": 1.0}}],
+    )
+
+    assert refused.status_code == status.HTTP_404_NOT_FOUND
+    assert "not found" in refused.json()["detail"]

--- a/tests/unit/test_alias_service.py
+++ b/tests/unit/test_alias_service.py
@@ -1,6 +1,7 @@
 """Unit tests for the alias cache that keeps resolution synchronous."""
 
 import time
+import uuid
 from collections.abc import Iterator
 
 import pytest
@@ -21,6 +22,11 @@ CONFIG = GatewayConfig(
     aliases={"configalias": "anthropic:claude-opus-4"},
 )
 
+# The workspace an omitted ``workspace_id`` falls back to, which is what every
+# pre-existing row was backfilled onto and where a deployment-wide write lands.
+DEFAULT = uuid.UUID("00000000-0000-4000-8000-00000000d3fa")
+OTHER = uuid.UUID("00000000-0000-4000-8000-0000000007e5")
+
 
 @pytest.fixture(autouse=True)
 def _clean_cache() -> Iterator[None]:
@@ -29,16 +35,23 @@ def _clean_cache() -> Iterator[None]:
     reset_alias_cache()
 
 
-def _prime(aliases: dict[str, str], per_user: dict[str, dict[str, str]] | None = None) -> None:
+def _prime(
+    aliases: dict[str, str],
+    per_user: dict[str, dict[str, str]] | None = None,
+    *,
+    workspace_id: uuid.UUID = DEFAULT,
+    default_workspace: uuid.UUID | None = DEFAULT,
+) -> None:
     """Stand in for a database load without needing a session.
 
-    Stamped with monotonic(), which is process uptime rather than an epoch: a
-    literal 0.0 would read as loaded-at-boot and so already ancient.
+    Adds one workspace's layers, so calling it twice builds a two-workspace
+    cache. Stamped with monotonic(), which is process uptime rather than an
+    epoch: a literal 0.0 would read as loaded-at-boot and so already ancient.
     """
-    alias_service._cache.clear()
-    alias_service._cache.update(aliases)
-    alias_service._user_cache.clear()
-    alias_service._user_cache.update(per_user or {})
+    alias_service._cache.setdefault(workspace_id, {}).update(aliases)
+    for user_id, names in (per_user or {}).items():
+        alias_service._user_cache.setdefault(workspace_id, {}).setdefault(user_id, {}).update(names)
+    alias_service._default_workspace = default_workspace
     alias_service._cached_at = time.monotonic()
 
 
@@ -48,17 +61,17 @@ def test_config_aliases_resolve_without_any_stored_ones() -> None:
 
 def test_stored_aliases_resolve() -> None:
     _prime({"fast": "anthropic:claude-haiku-4"})
-    assert resolve_effective_alias(CONFIG, "fast") == "anthropic:claude-haiku-4"
+    assert resolve_effective_alias(CONFIG, "fast", workspace_id=DEFAULT) == "anthropic:claude-haiku-4"
 
 
 def test_unknown_name_is_not_an_alias() -> None:
     _prime({"fast": "anthropic:claude-haiku-4"})
-    assert resolve_effective_alias(CONFIG, "openai:gpt-4o") is None
+    assert resolve_effective_alias(CONFIG, "openai:gpt-4o", workspace_id=DEFAULT) is None
 
 
 def test_both_kinds_are_merged() -> None:
     _prime({"fast": "anthropic:claude-haiku-4"})
-    assert effective_aliases(CONFIG) == {
+    assert effective_aliases(CONFIG, workspace_id=DEFAULT) == {
         "fast": "anthropic:claude-haiku-4",
         "configalias": "anthropic:claude-opus-4",
     }
@@ -68,12 +81,12 @@ def test_config_wins_over_a_stored_alias_of_the_same_name() -> None:
     # The API refuses to create this, so it is a safety net: if a row somehow
     # exists, the config alias is what resolves, matching what the listing says.
     _prime({"configalias": "home_lab:qwen3"})
-    assert resolve_effective_alias(CONFIG, "configalias") == "anthropic:claude-opus-4"
+    assert resolve_effective_alias(CONFIG, "configalias", workspace_id=DEFAULT) == "anthropic:claude-opus-4"
 
 
 def test_empty_target_is_not_an_alias() -> None:
     _prime({"broken": ""})
-    assert resolve_effective_alias(CONFIG, "broken") is None
+    assert resolve_effective_alias(CONFIG, "broken", workspace_id=DEFAULT) is None
 
 
 def test_cache_starts_stale_and_is_fresh_after_priming() -> None:
@@ -88,58 +101,117 @@ def test_cache_starts_stale_and_is_fresh_after_priming() -> None:
 def test_reset_clears_the_cache() -> None:
     _prime({"fast": "anthropic:claude-haiku-4"})
     reset_alias_cache()
-    assert cached_aliases() == {}
+    assert cached_aliases(workspace_id=DEFAULT) == {}
     assert cache_is_stale()
 
 
 def test_cached_aliases_is_a_copy() -> None:
     _prime({"fast": "anthropic:claude-haiku-4"})
-    cached_aliases()["fast"] = "tampered"
-    assert resolve_effective_alias(CONFIG, "fast") == "anthropic:claude-haiku-4"
+    cached_aliases(workspace_id=DEFAULT)["fast"] = "tampered"
+    assert resolve_effective_alias(CONFIG, "fast", workspace_id=DEFAULT) == "anthropic:claude-haiku-4"
 
 
 # ---------------------------------------------------------------------------
-# Scoping
+# Workspace scoping
+# ---------------------------------------------------------------------------
+
+
+def test_two_workspaces_each_resolve_their_own_alias() -> None:
+    """The whole point of widening the uniqueness constraint.
+
+    While the cache was keyed on name alone the second row loaded would have
+    shadowed the first for every caller, which is why the constraint could not
+    allow both until this cache could tell them apart.
+    """
+    _prime({"fast": "anthropic:claude-haiku-4"}, workspace_id=DEFAULT)
+    _prime({"fast": "home_lab:qwen3"}, workspace_id=OTHER)
+
+    assert resolve_effective_alias(CONFIG, "fast", workspace_id=DEFAULT) == "anthropic:claude-haiku-4"
+    assert resolve_effective_alias(CONFIG, "fast", workspace_id=OTHER) == "home_lab:qwen3"
+
+
+def test_an_alias_does_not_leak_into_another_workspace() -> None:
+    _prime({"mine": "home_lab:qwen3"}, workspace_id=OTHER)
+    assert resolve_effective_alias(CONFIG, "mine", workspace_id=DEFAULT) is None
+
+
+def test_a_user_scoped_alias_does_not_cross_workspaces() -> None:
+    """Same user, two workspaces: the alias belongs to one of them, not to them."""
+    _prime({}, {"alice": {"fast": "home_lab:qwen3"}}, workspace_id=OTHER)
+    assert resolve_effective_alias(CONFIG, "fast", "alice", workspace_id=OTHER) == "home_lab:qwen3"
+    assert resolve_effective_alias(CONFIG, "fast", "alice", workspace_id=DEFAULT) is None
+
+
+def test_omitting_the_workspace_reads_the_default_one() -> None:
+    """What a master-key request and an operator-configured selector get.
+
+    They act deployment-wide, and the default workspace is where their own
+    writes land, so it is what they resolve against.
+    """
+    _prime({"fast": "anthropic:claude-haiku-4"}, workspace_id=DEFAULT)
+    _prime({"fast": "home_lab:qwen3"}, workspace_id=OTHER)
+    assert resolve_effective_alias(CONFIG, "fast") == "anthropic:claude-haiku-4"
+
+
+def test_a_config_alias_is_in_force_in_every_workspace() -> None:
+    """It comes from a file the deployment owns, so it has no workspace."""
+    _prime({}, workspace_id=OTHER)
+    assert resolve_effective_alias(CONFIG, "configalias", workspace_id=OTHER) == "anthropic:claude-opus-4"
+
+
+def test_no_default_workspace_leaves_only_the_config_layer() -> None:
+    """A deployment with no workspace at all has no stored aliases to resolve."""
+    _prime({"fast": "anthropic:claude-haiku-4"}, default_workspace=None)
+    assert resolve_effective_alias(CONFIG, "fast") is None
+    assert resolve_effective_alias(CONFIG, "configalias") == "anthropic:claude-opus-4"
+    assert cached_aliases() == {}
+
+
+# ---------------------------------------------------------------------------
+# User scoping
 # ---------------------------------------------------------------------------
 
 
 def test_a_user_scoped_alias_resolves_only_for_that_user() -> None:
     _prime({}, {"alice": {"fast": "home_lab:qwen3"}})
-    assert resolve_effective_alias(CONFIG, "fast", "alice") == "home_lab:qwen3"
-    assert resolve_effective_alias(CONFIG, "fast", "bob") is None
+    assert resolve_effective_alias(CONFIG, "fast", "alice", workspace_id=DEFAULT) == "home_lab:qwen3"
+    assert resolve_effective_alias(CONFIG, "fast", "bob", workspace_id=DEFAULT) is None
     # A caller with no user (the master key) is not an implicit member of anyone.
-    assert resolve_effective_alias(CONFIG, "fast") is None
+    assert resolve_effective_alias(CONFIG, "fast", workspace_id=DEFAULT) is None
 
 
-def test_a_user_scoped_alias_beats_the_global_one() -> None:
+def test_a_user_scoped_alias_beats_the_workspace_wide_one() -> None:
     _prime({"fast": "anthropic:claude-haiku-4"}, {"alice": {"fast": "home_lab:qwen3"}})
-    assert resolve_effective_alias(CONFIG, "fast", "alice") == "home_lab:qwen3"
-    assert resolve_effective_alias(CONFIG, "fast", "bob") == "anthropic:claude-haiku-4"
+    assert resolve_effective_alias(CONFIG, "fast", "alice", workspace_id=DEFAULT) == "home_lab:qwen3"
+    assert resolve_effective_alias(CONFIG, "fast", "bob", workspace_id=DEFAULT) == "anthropic:claude-haiku-4"
 
 
 def test_a_user_scoped_alias_beats_a_config_alias() -> None:
-    # Most-specific-wins. The reverse holds for a *global* stored alias (see
-    # above), which is why the API refuses to create one shadowing config.
+    # Most-specific-wins. The reverse holds for a *workspace-wide* stored alias
+    # (see above), which is why the API refuses to create one shadowing config.
     _prime({}, {"alice": {"configalias": "home_lab:qwen3"}})
-    assert resolve_effective_alias(CONFIG, "configalias", "alice") == "home_lab:qwen3"
-    assert resolve_effective_alias(CONFIG, "configalias", "bob") == "anthropic:claude-opus-4"
+    assert resolve_effective_alias(CONFIG, "configalias", "alice", workspace_id=DEFAULT) == "home_lab:qwen3"
+    assert (
+        resolve_effective_alias(CONFIG, "configalias", "bob", workspace_id=DEFAULT)
+        == "anthropic:claude-opus-4"
+    )
 
 
 def test_effective_aliases_layers_all_three_scopes() -> None:
     _prime({"fast": "anthropic:claude-haiku-4"}, {"alice": {"mine": "home_lab:qwen3"}})
-    assert effective_aliases(CONFIG, "alice") == {
+    assert effective_aliases(CONFIG, "alice", workspace_id=DEFAULT) == {
         "fast": "anthropic:claude-haiku-4",
         "configalias": "anthropic:claude-opus-4",
         "mine": "home_lab:qwen3",
     }
-    assert "mine" not in effective_aliases(CONFIG, "bob")
+    assert "mine" not in effective_aliases(CONFIG, "bob", workspace_id=DEFAULT)
 
 
 def test_cached_aliases_returns_one_scope_at_a_time() -> None:
     _prime({"fast": "anthropic:claude-haiku-4"}, {"alice": {"mine": "home_lab:qwen3"}})
-    assert cached_aliases() == {"fast": "anthropic:claude-haiku-4"}
-    assert cached_aliases("alice") == {"mine": "home_lab:qwen3"}
-    assert cached_aliases("bob") == {}
+    assert cached_aliases(workspace_id=DEFAULT) == {"fast": "anthropic:claude-haiku-4"}
+    assert cached_aliases("alice", workspace_id=DEFAULT) == {"mine": "home_lab:qwen3"}
+    assert cached_aliases("bob", workspace_id=DEFAULT) == {}
 
 
 def test_overriding_a_config_alias_drops_its_target_from_that_users_map() -> None:
@@ -151,19 +223,23 @@ def test_overriding_a_config_alias_drops_its_target_from_that_users_map() -> Non
     worth pinning, and it inverts the usual "an alias hides its target" rule.
     """
     _prime({}, {"alice": {"configalias": "home_lab:qwen3"}})
-    assert "anthropic:claude-opus-4" in set(effective_aliases(CONFIG, "bob").values())
-    assert "anthropic:claude-opus-4" not in set(effective_aliases(CONFIG, "alice").values())
+    assert "anthropic:claude-opus-4" in set(effective_aliases(CONFIG, "bob", workspace_id=DEFAULT).values())
+    assert "anthropic:claude-opus-4" not in set(
+        effective_aliases(CONFIG, "alice", workspace_id=DEFAULT).values()
+    )
 
 
 def test_all_alias_names_spans_every_scope() -> None:
     # Scope-blind, for the writes that must never store an alias name as a model
-    # key (pricing rows, allow-list entries).
+    # key (pricing rows, allow-list entries). Blind to the workspace too: the
+    # name means "alias" to somebody wherever the row lives.
     _prime({"fast": "anthropic:claude-haiku-4"}, {"alice": {"mine": "home_lab:qwen3"}})
-    assert all_alias_names(CONFIG) == {"fast", "configalias", "mine"}
+    _prime({"elsewhere": "home_lab:qwen3"}, {"bob": {"theirs": "home_lab:qwen3"}}, workspace_id=OTHER)
+    assert all_alias_names(CONFIG) == {"fast", "configalias", "mine", "elsewhere", "theirs"}
 
 
 def test_reset_clears_the_user_layer_too() -> None:
     _prime({}, {"alice": {"mine": "home_lab:qwen3"}})
     reset_alias_cache()
-    assert cached_aliases("alice") == {}
-    assert resolve_effective_alias(CONFIG, "mine", "alice") is None
+    assert cached_aliases("alice", workspace_id=DEFAULT) == {}
+    assert resolve_effective_alias(CONFIG, "mine", "alice", workspace_id=DEFAULT) is None

--- a/tests/unit/test_batches_route.py
+++ b/tests/unit/test_batches_route.py
@@ -128,6 +128,9 @@ class TestLifecycleWorkspaceId:
         assert resolved == caller_workspace_id
 
 
+_WORKSPACE = uuid.UUID("00000000-0000-4000-8000-00000000d3fa")
+_OTHER_WORKSPACE = uuid.UUID("00000000-0000-4000-8000-0000000007e5")
+
 class TestAuthorizeRecord:
     """`_authorize_record` runs *before* the batch's originating-organization
     credential is used to call the provider (see `_lifecycle_workspace_id`),
@@ -137,27 +140,54 @@ class TestAuthorizeRecord:
     dispatch to happen first."""
 
     def test_master_key_is_always_authorized(self) -> None:
-        record = SimpleNamespace(user_id="someone-else")
+        record = SimpleNamespace(user_id="someone-else", workspace_id=_WORKSPACE)
         _authorize_record(record, "batch-1", api_key=None, is_master_key=True)  # type: ignore[arg-type]
 
-    def test_the_records_own_user_is_authorized(self) -> None:
-        record = SimpleNamespace(user_id="user-1")
-        api_key = SimpleNamespace(user_id="user-1")
+    def test_the_records_own_user_in_its_own_workspace_is_authorized(self) -> None:
+        record = SimpleNamespace(user_id="user-1", workspace_id=_WORKSPACE)
+        api_key = SimpleNamespace(user_id="user-1", workspace_id=_WORKSPACE)
         _authorize_record(record, "batch-1", api_key=api_key, is_master_key=False)  # type: ignore[arg-type]
 
     def test_a_different_user_is_refused_with_404_not_403(self) -> None:
         """404, not 403: a foreign key must not be able to probe which batch
         ids exist by distinguishing "not yours" from "no such batch"."""
-        record = SimpleNamespace(user_id="the-owner")
-        api_key = SimpleNamespace(user_id="someone-else")
+        record = SimpleNamespace(user_id="the-owner", workspace_id=_WORKSPACE)
+        api_key = SimpleNamespace(user_id="someone-else", workspace_id=_WORKSPACE)
 
         with pytest.raises(HTTPException) as exc_info:
             _authorize_record(record, "batch-1", api_key=api_key, is_master_key=False)  # type: ignore[arg-type]
 
         assert exc_info.value.status_code == 404
 
+    def test_the_same_user_in_another_workspace_is_refused(self) -> None:
+        """The half the user check alone cannot see (otari-ai#1643).
+
+        A key confined to one workspace reaching a batch created in another
+        would dispatch the lifecycle call against the *creating* workspace's
+        organization credential, which is exactly what running this check before
+        the dispatch exists to prevent.
+        """
+        record = SimpleNamespace(user_id="user-1", workspace_id=_WORKSPACE)
+        api_key = SimpleNamespace(user_id="user-1", workspace_id=_OTHER_WORKSPACE)
+
+        with pytest.raises(HTTPException) as exc_info:
+            _authorize_record(record, "batch-1", api_key=api_key, is_master_key=False)  # type: ignore[arg-type]
+
+        assert exc_info.value.status_code == 404
+
+    def test_a_batch_predating_the_workspace_column_falls_back_to_the_user_check(self) -> None:
+        """NULL workspace is an unmigrated batch, not a foreign one.
+
+        The same tolerance the metadata-anchored fallback already extends a
+        record-less batch: there is nothing to compare against, so the owner
+        check is the whole check.
+        """
+        record = SimpleNamespace(user_id="user-1", workspace_id=None)
+        api_key = SimpleNamespace(user_id="user-1", workspace_id=_OTHER_WORKSPACE)
+        _authorize_record(record, "batch-1", api_key=api_key, is_master_key=False)  # type: ignore[arg-type]
+
     def test_no_api_key_is_refused(self) -> None:
-        record = SimpleNamespace(user_id="the-owner")
+        record = SimpleNamespace(user_id="the-owner", workspace_id=_WORKSPACE)
 
         with pytest.raises(HTTPException) as exc_info:
             _authorize_record(record, "batch-1", api_key=None, is_master_key=False)  # type: ignore[arg-type]

--- a/tests/unit/test_content_normalizer.py
+++ b/tests/unit/test_content_normalizer.py
@@ -193,7 +193,7 @@ async def test_file_id_resolved_and_inlined_for_native(monkeypatch: pytest.Monke
         storage_ref="x/file-x",
     )
 
-    async def fake_fetch(db, file_id, user_id):  # type: ignore[no-untyped-def]
+    async def fake_fetch(db, file_id, user_id, *, workspace_id=None):  # type: ignore[no-untyped-def]
         assert file_id == "file-x"
         return record
 

--- a/tests/unit/test_knn_router.py
+++ b/tests/unit/test_knn_router.py
@@ -17,14 +17,20 @@ Each routing-memory record is one example: a prompt embedding plus a
 
 from __future__ import annotations
 
+import time
 import uuid
-from typing import Any
+from collections.abc import Iterator
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
 from gateway.api.routes._helpers import conversation_opening_text, first_user_text, latest_user_text
 from gateway.core.config import GatewayConfig
 from gateway.models.entities import RoutingMemory
+from gateway.services import alias_service
+from gateway.services.routing import knn
 from gateway.services.routing.backends import RoutingContext
 from gateway.services.routing.knn import KnnRoutingMemory
 
@@ -97,7 +103,7 @@ def _wire(
         padding = [] if total is None else [_both_good()] * max(0, total - len(records))
         return [*records, *padding]
 
-    async def _prices(pool: list[str]) -> dict[str, float]:
+    async def _prices(pool: list[str], *, workspace_id: uuid.UUID | None = None) -> dict[str, float]:
         return prices or dict.fromkeys(pool, 1.0)
 
     backend._embed = _embed  # type: ignore[method-assign]
@@ -178,7 +184,7 @@ async def test_unpriced_candidate_declines_rather_than_failing() -> None:
     backend = _backend()
     _wire(backend, [_both_good(), _both_good()])
 
-    async def _prices(pool: list[str]) -> dict[str, float]:
+    async def _prices(pool: list[str], *, workspace_id: uuid.UUID | None = None) -> dict[str, float]:
         raise RouterPricingError(f"Router candidate '{CHEAP}' has no configured pricing.")
 
     backend._candidate_prices = _prices  # type: ignore[method-assign]
@@ -531,3 +537,90 @@ def test_ordered_with_fallthrough_appends_the_default_last() -> None:
     assert backend._ordered_with_fallthrough([CHEAP, STRONG], STRONG, [CHEAP, STRONG]) == [CHEAP, STRONG]
     # Chosen == default: it must NOT be demoted; it stays first.
     assert backend._ordered_with_fallthrough([STRONG, CHEAP], STRONG, [CHEAP, STRONG]) == [STRONG, CHEAP]
+
+
+# ---------------------------------------------------------------------------
+# Workspace-scoped aliases (otari-ai#1643)
+#
+# A candidate selector can name an alias, and this PR is what makes an alias
+# point somewhere different per workspace. Every reader of one inside a decision
+# therefore has to resolve it in the *request's* workspace: the pool filter, the
+# score keys and the price all key on the resolved target, so a reader that used
+# the default workspace instead would disagree with the others and the candidate
+# would drop out of scoring with no score and no error.
+# ---------------------------------------------------------------------------
+
+_WORKSPACE = uuid.UUID("00000000-0000-4000-8000-0000000000ab")
+_DEFAULT_WORKSPACE = uuid.UUID("00000000-0000-4000-8000-00000000d3fa")
+_ALIAS = "fast-alias"
+
+
+@pytest.fixture
+def _aliased_workspaces() -> Iterator[None]:
+    """``fast-alias`` points at the cheap model in one workspace, the strong one by default."""
+    alias_service.reset_alias_cache()
+    alias_service._cache[_WORKSPACE] = {_ALIAS: CHEAP}
+    alias_service._cache[_DEFAULT_WORKSPACE] = {_ALIAS: STRONG}
+    alias_service._default_workspace = _DEFAULT_WORKSPACE
+    alias_service._cached_at = time.monotonic()
+    yield
+    alias_service.reset_alias_cache()
+
+
+def test_scoring_canonicalizes_an_alias_in_the_requests_workspace(_aliased_workspaces: None) -> None:
+    """The score-key half. Resolving in the default workspace names the wrong model."""
+    backend = _backend()
+
+    assert backend._canonical(_ALIAS, "u", {}, workspace_id=_WORKSPACE) == "openai:gpt-3.5-turbo"
+    # The same name, the deployment-wide reading: a different model entirely.
+    assert backend._canonical(_ALIAS, "u", {}, workspace_id=None) == "openai:gpt-4o"
+
+
+@pytest.mark.asyncio
+async def test_pricing_follows_the_same_workspaces_alias_as_scoring(
+    _aliased_workspaces: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The price half, which has to name the same model the score key does.
+
+    Pricing the default workspace's target while scoring this workspace's would
+    rank the candidate on a price the request never pays. Separate from *whose*
+    rates apply, which stays the deployment list either way.
+    """
+    asked: list[tuple[str, str]] = []
+
+    async def _pricing(db: Any, instance: str, model: str) -> Any:
+        asked.append((instance, model))
+        return SimpleNamespace(input_price_per_million=Decimal("1"))
+
+    monkeypatch.setattr(knn, "find_model_pricing", _pricing)
+    backend = _backend()
+
+    await backend._input_price(cast(Any, object()), _ALIAS, workspace_id=_WORKSPACE)
+    await backend._input_price(cast(Any, object()), _ALIAS, workspace_id=None)
+
+    assert asked == [("openai", "gpt-3.5-turbo"), ("openai", "gpt-4o")]
+
+
+@pytest.mark.asyncio
+async def test_an_aliased_candidate_matches_the_scores_taught_in_its_workspace(
+    _aliased_workspaces: None,
+) -> None:
+    """End to end: the decline this bug produced, and the routing it should produce.
+
+    ``/rank`` canonicalizes a stored score key in the workspace it was taught in,
+    so these records are keyed on the cheap model alone, which is what teaching
+    ``fast-alias`` in this workspace produces. Resolving the candidate in the
+    default workspace instead looks up ``openai:gpt-4o``, which no record scores,
+    so every candidate is skipped and the router declines while the pool reports
+    warm. That silent decline is the whole failure mode.
+    """
+    backend = _backend(router_alpha=0.0, router_confidence_floor=0.0)
+    records = [_mem({"openai:gpt-3.5-turbo": 1.0}), _mem({"openai:gpt-3.5-turbo": 1.0})]
+    _wire(backend, records, prices={_ALIAS: 1.0, STRONG: 10.0})
+
+    decision = await backend.rank(
+        _ctx(candidates=(_ALIAS, STRONG), default=STRONG, workspace_id=_WORKSPACE)
+    )
+
+    assert decision.ordered_models[0] == _ALIAS
+    assert "no neighbor scored any candidate" not in decision.rationale

--- a/tests/unit/test_knn_router.py
+++ b/tests/unit/test_knn_router.py
@@ -428,6 +428,42 @@ async def test_conversation_id_is_namespaced_per_user() -> None:
 
 
 @pytest.mark.asyncio
+async def test_conversation_id_is_namespaced_per_workspace() -> None:
+    """The same user, the same conversation id, two workspaces: no shared decision.
+
+    The trace cache is consulted before any record loads, so a key that omitted
+    the workspace would replay workspace A's pick in workspace B without ever
+    reading workspace B's examples. That is the cross-workspace leak the rest of
+    the scoping closes at the query, and this closes in process memory.
+    """
+    workspace_a = uuid.UUID("00000000-0000-4000-8000-00000000000a")
+    workspace_b = uuid.UUID("00000000-0000-4000-8000-00000000000b")
+    backend = _backend(router_alpha=0.3, router_granularity="trace_sticky")
+
+    _wire(backend, [_both_good(), _both_good()], prices=PRICES)
+    first = await backend.rank(_ctx(user_id="ada", workspace_id=workspace_a, trace_key="conv-1"))
+    assert first.ordered_models[0] == CHEAP
+
+    # Workspace B has no decision under its own namespace, so it routes fresh on
+    # its own neighbors (here cheap fails) rather than reusing A's.
+    _wire(backend, [_cheap_fails(), _cheap_fails()], prices=PRICES)
+    decision = await backend.rank(
+        _ctx(user_id="ada", workspace_id=workspace_b, trace_key="conv-1", is_trace_continuation=True)
+    )
+    assert decision.ordered_models[0] == STRONG
+    assert "trace-sticky" not in decision.rationale
+
+    # And workspace A still has its own, so the namespacing partitions rather
+    # than simply defeating stickiness.
+    _wire(backend, [_cheap_fails(), _cheap_fails()], prices=PRICES)
+    reused = await backend.rank(
+        _ctx(user_id="ada", workspace_id=workspace_a, trace_key="conv-1", is_trace_continuation=True)
+    )
+    assert reused.ordered_models[0] == CHEAP
+    assert "trace-sticky" in reused.rationale
+
+
+@pytest.mark.asyncio
 async def test_distinct_system_preamble_separates_traces_without_a_conversation_id() -> None:
     # Without a conversation id, the opener anchor includes the system turn, so two
     # conversations that share a first user message but differ in system preamble

--- a/tests/unit/test_knn_router.py
+++ b/tests/unit/test_knn_router.py
@@ -17,6 +17,7 @@ Each routing-memory record is one example: a prompt embedding plus a
 
 from __future__ import annotations
 
+import uuid
 from typing import Any
 
 import pytest
@@ -88,7 +89,9 @@ def _wire(
     async def _embed(text: str) -> list[float]:
         return list(query)
 
-    async def _load(user_id: str, task_id: str | None) -> list[RoutingMemory]:
+    async def _load(
+        user_id: str, task_id: str | None, workspace_id: uuid.UUID | None = None
+    ) -> list[RoutingMemory]:
         # `total` pads the record count without inventing neighbors, which is how
         # the seed gate and the sparse-neighborhood gate are tested separately.
         padding = [] if total is None else [_both_good()] * max(0, total - len(records))

--- a/tests/unit/test_pipeline_vision_billing.py
+++ b/tests/unit/test_pipeline_vision_billing.py
@@ -97,7 +97,11 @@ class _Recorder:
 
 
 async def _normalize_with_vision(
-    user_id: str, provider: LLMProvider | None, model: str, instance: str | None
+    user_id: str,
+    provider: LLMProvider | None,
+    model: str,
+    instance: str | None,
+    workspace_id: uuid.UUID | None,
 ) -> tuple[int, CompletionUsage | None]:
     return 5000, _VISION_USAGE
 

--- a/tests/unit/test_tenancy_schema_chain.py
+++ b/tests/unit/test_tenancy_schema_chain.py
@@ -64,7 +64,7 @@ _CREDENTIAL_COLUMNS = {
 _TOKEN_INDEX = "ix_user_email_verification_token"
 
 _ALIAS_WIDEN_REVISION = "c1e4a7b9d3f6"
-_BEFORE_ALIAS_WIDEN = "a7f3c9e2b481"
+_BEFORE_ALIAS_WIDEN = "c7a1e4d8f3b6"
 _SURVIVALS_REVISION = "d2f5b8c0e4a7"
 _SURVIVAL_TABLES = ("routing_memory", "router_preferences", "file_objects")
 

--- a/tests/unit/test_tenancy_schema_chain.py
+++ b/tests/unit/test_tenancy_schema_chain.py
@@ -64,7 +64,7 @@ _CREDENTIAL_COLUMNS = {
 _TOKEN_INDEX = "ix_user_email_verification_token"
 
 _ALIAS_WIDEN_REVISION = "c1e4a7b9d3f6"
-_BEFORE_ALIAS_WIDEN = "a9c4e2b6d8f1"
+_BEFORE_ALIAS_WIDEN = "a7f3c9e2b481"
 _SURVIVALS_REVISION = "d2f5b8c0e4a7"
 _SURVIVAL_TABLES = ("routing_memory", "router_preferences", "file_objects")
 

--- a/tests/unit/test_tenancy_schema_chain.py
+++ b/tests/unit/test_tenancy_schema_chain.py
@@ -15,9 +15,12 @@ than in-memory because batch mode's rebuild is what is under test.
 The later revisions that reshape the same tables are exercised here too, for the
 same reason: the workspace scoping that rebuilds four request-plane tables, the
 credential columns added to ``user``, whose downgrade depends on SQLite's refusal
-to drop an indexed column, and the identity column added to
-``dashboard_sessions``, which rebuilds that table to tighten a column to NOT NULL
-and point it at ``user``.
+to drop an indexed column, the identity column added to ``dashboard_sessions``,
+which rebuilds that table to tighten a column to NOT NULL and point it at
+``user``, and the two revisions that finish scoping the gateway survivals: one
+swaps the alias and policy uniqueness constraints (a batch rebuild with the
+partial indexes taken out and put back around it), the other adds
+``workspace_id`` to three more tables.
 """
 
 import json
@@ -59,6 +62,11 @@ _CREDENTIAL_COLUMNS = {
     "email_verified_at",
 }
 _TOKEN_INDEX = "ix_user_email_verification_token"
+
+_ALIAS_WIDEN_REVISION = "c1e4a7b9d3f6"
+_BEFORE_ALIAS_WIDEN = "a9c4e2b6d8f1"
+_SURVIVALS_REVISION = "d2f5b8c0e4a7"
+_SURVIVAL_TABLES = ("routing_memory", "router_preferences", "file_objects")
 
 _TOKEN_REVISION = "db8fbf901ee0"
 _BEFORE_TOKENS = "c8e2a4f6b0d3"
@@ -243,6 +251,10 @@ def test_workspace_scope_keeps_the_partial_indexes_it_rebuilds_around(
     foreign key needs it, so this is what proves the indexes survive it rather
     than what proves it was avoided (the migration's own docstring retracts that
     earlier rationale).
+
+    The names are the workspace-scoped ones because ``c1e4a7b9d3f6`` widened both
+    indexes to lead with ``workspace_id``; what is under test here is unchanged,
+    that a partial index survives a batch rebuild of its table.
     """
     _, engine = sqlite_at_head
     with engine.begin() as connection:
@@ -252,7 +264,10 @@ def test_workspace_scope_keeps_the_partial_indexes_it_rebuilds_around(
                 text("SELECT name FROM sqlite_master WHERE type='index' AND sql LIKE '%WHERE%'")
             )
         }
-    assert {"uq_model_aliases_global_name", "uq_routing_policies_global_name"} <= partial
+    assert {
+        "uq_model_aliases_workspace_global_name",
+        "uq_routing_policies_workspace_global_name",
+    } <= partial
 
 
 def _insert_identity(connection: Connection, *, email: str | None = None, token: str | None = None) -> str:
@@ -623,3 +638,308 @@ def test_the_migrated_session_table_matches_the_model(sqlite_at_head: tuple[Conf
 
     assert set(migrated) == set(declared.columns.keys())
     assert migrated["user_id"]["nullable"] is False
+
+
+# ---------------------------------------------------------------------------
+# Workspace-scoped survivals (otari-ai#1643): the two revisions that finish
+# scoping what stays in the gateway. Both reshape existing tables, so SQLite's
+# batch rebuild is the risk, and this module is its only coverage.
+# ---------------------------------------------------------------------------
+
+
+def _two_workspaces(connection: Connection) -> tuple[str, str]:
+    """The migrated default workspace plus a second one beside it, as stored ids.
+
+    A UUID is CHAR(32) hex on SQLite, which is the engine every test here drives,
+    so the returned ids are what the ``workspace_id`` columns actually hold.
+    """
+    default = connection.execute(
+        text(
+            "SELECT w.id FROM workspace w JOIN organization o ON o.id = w.organization_id "
+            "WHERE o.slug = 'default'"
+        )
+    ).scalar_one()
+    organization_id = connection.execute(
+        text("SELECT organization_id FROM workspace WHERE id = :id"), {"id": default}
+    ).scalar_one()
+    second = uuid.uuid4().hex
+    connection.execute(
+        text(
+            "INSERT INTO workspace "
+            "(id, organization_id, name, description, created_by_user_id, "
+            " activation_classification, created_at) "
+            "VALUES (:id, :org, 'Second workspace', NULL, NULL, 'eligible', CURRENT_TIMESTAMP)"
+        ),
+        {"id": second, "org": organization_id},
+    )
+    return str(default), second
+
+
+def test_alias_and_policy_uniqueness_leads_with_the_workspace(
+    sqlite_at_head: tuple[Config, Engine],
+) -> None:
+    """The composite constraint and the partial index both gain ``workspace_id``.
+
+    The pair is what the widening is: the constraint keeps one row per
+    (workspace, name, user), and the partial index keeps one workspace-wide row
+    per (workspace, name), which the constraint cannot, both engines treating a
+    NULL ``user_id`` as distinct.
+    """
+    _, engine = sqlite_at_head
+    inspector = inspect(engine)
+
+    for table, constraint, index in (
+        ("model_aliases", "uq_model_aliases_workspace_name_user", "uq_model_aliases_workspace_global_name"),
+        (
+            "routing_policies",
+            "uq_routing_policies_workspace_name_user",
+            "uq_routing_policies_workspace_global_name",
+        ),
+    ):
+        unique = {c["name"]: c["column_names"] for c in inspector.get_unique_constraints(table)}
+        assert unique[constraint] == ["workspace_id", "name", "user_id"]
+        partial = {i["name"]: i["column_names"] for i in inspector.get_indexes(table)}
+        assert partial[index] == ["workspace_id", "name"]
+
+
+def test_the_widening_keeps_the_plain_indexes_the_rebuild_would_drop(
+    sqlite_at_head: tuple[Config, Engine],
+) -> None:
+    """``copy_from`` replaces reflection, so an index left out of it is lost.
+
+    Both tables carry a ``user_id`` and a ``workspace_id`` index that predate this
+    revision and that nothing else would notice going missing: a dropped index is
+    a slow query, not a failure.
+    """
+    _, engine = sqlite_at_head
+    inspector = inspect(engine)
+
+    for table in ("model_aliases", "routing_policies"):
+        names = {index["name"] for index in inspector.get_indexes(table)}
+        assert {f"ix_{table}_user_id", f"ix_{table}_workspace_id"} <= names
+
+
+def test_two_workspaces_can_hold_the_same_alias_name(tmp_path: Path) -> None:
+    """The row the narrower constraint refused and the widened one admits.
+
+    Written against the migrated schema rather than the models, so it is the
+    revision under test rather than the metadata that produced it.
+    """
+    url = f"sqlite:///{tmp_path / 'widen.db'}"
+    config = _alembic_config(url)
+    command.upgrade(config, "head")
+    engine = create_engine(url)
+
+    with engine.begin() as connection:
+        first, second = _two_workspaces(connection)
+        for index, workspace in enumerate((first, second)):
+            connection.execute(
+                text(
+                    "INSERT INTO model_aliases (id, name, target, user_id, workspace_id, created_at, updated_at) "
+                    "VALUES (:id, 'fast', :target, NULL, :ws, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+                ),
+                {"id": f"alias-{index}", "target": f"anthropic:model-{index}", "ws": workspace},
+            )
+        stored = connection.execute(text("SELECT COUNT(*) FROM model_aliases WHERE name = 'fast'")).scalar_one()
+
+    assert stored == 2
+    engine.dispose()
+
+
+def test_one_workspace_still_cannot_hold_two_of_a_name(tmp_path: Path) -> None:
+    """Widening admits rows; it does not stop admitting the duplicate it existed for."""
+    url = f"sqlite:///{tmp_path / 'widen-dup.db'}"
+    config = _alembic_config(url)
+    command.upgrade(config, "head")
+    engine = create_engine(url)
+
+    with engine.begin() as connection:
+        workspace, _second = _two_workspaces(connection)
+        connection.execute(
+            text(
+                "INSERT INTO model_aliases (id, name, target, user_id, workspace_id, created_at, updated_at) "
+                "VALUES ('a1', 'fast', 'anthropic:one', NULL, :ws, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            ),
+            {"ws": workspace},
+        )
+
+    with pytest.raises(IntegrityError), engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO model_aliases (id, name, target, user_id, workspace_id, created_at, updated_at) "
+                "VALUES ('a2', 'fast', 'anthropic:two', NULL, :ws, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            ),
+            {"ws": workspace},
+        )
+    engine.dispose()
+
+
+def test_the_widening_round_trips(sqlite_at_head: tuple[Config, Engine]) -> None:
+    """Down narrows both constraints back; up widens them again.
+
+    The partial indexes are dropped before each batch rebuild and recreated
+    after, so this is what proves neither direction leaves one behind under a
+    stale name.
+    """
+    config, engine = sqlite_at_head
+
+    command.downgrade(config, _BEFORE_ALIAS_WIDEN)
+
+    inspector = inspect(engine)
+    for table in ("model_aliases", "routing_policies"):
+        assert {c["name"] for c in inspector.get_unique_constraints(table)} == {f"uq_{table}_name_user"}
+        names = {index["name"] for index in inspector.get_indexes(table)}
+        assert f"uq_{table}_global_name" in names
+        assert f"uq_{table}_workspace_global_name" not in names
+
+    command.upgrade(config, "head")
+
+    inspector = inspect(engine)
+    for table in ("model_aliases", "routing_policies"):
+        assert {c["name"] for c in inspector.get_unique_constraints(table)} == {
+            f"uq_{table}_workspace_name_user"
+        }
+
+
+def test_the_survivals_carry_a_restricting_workspace_foreign_key(
+    sqlite_at_head: tuple[Config, Engine],
+) -> None:
+    """NOT NULL and RESTRICT on all three, matching ``api_keys.workspace_id``.
+
+    RESTRICT rather than cascade because deleting a workspace must not silently
+    take a user's uploads or a router's training data with it.
+    """
+    _, engine = sqlite_at_head
+    inspector = inspect(engine)
+
+    for table in _SURVIVAL_TABLES:
+        column = next(c for c in inspector.get_columns(table) if c["name"] == "workspace_id")
+        assert column["nullable"] is False
+        workspace_fk = [fk for fk in inspector.get_foreign_keys(table) if fk["referred_table"] == "workspace"]
+        assert [tuple(fk["constrained_columns"]) for fk in workspace_fk] == [("workspace_id",)]
+        assert workspace_fk[0]["options"].get("ondelete") == "RESTRICT"
+        # The user foreign key is untouched: the workspace is a second axis, not
+        # a re-parenting (otari-ai#1643).
+        user_fk = [fk for fk in inspector.get_foreign_keys(table) if fk["referred_table"] == "users"]
+        assert [tuple(fk["constrained_columns"]) for fk in user_fk] == [("user_id",)]
+        assert user_fk[0]["options"].get("ondelete") == "CASCADE"
+
+
+def test_the_router_indexes_are_rebuilt_leading_with_the_workspace(
+    sqlite_at_head: tuple[Config, Engine],
+) -> None:
+    """Every read filters on the workspace, so it leads each composite index."""
+    _, engine = sqlite_at_head
+    inspector = inspect(engine)
+
+    memory = {index["name"]: index["column_names"] for index in inspector.get_indexes("routing_memory")}
+    assert memory["ix_routing_memory_workspace_user_model"] == ["workspace_id", "user_id", "embedding_model"]
+    assert memory["ix_routing_memory_workspace_user_created"] == ["workspace_id", "user_id", "created_at"]
+    assert memory["ix_routing_memory_workspace_user_model_task"] == [
+        "workspace_id",
+        "user_id",
+        "embedding_model",
+        "task_id",
+    ]
+    assert "ix_routing_memory_user_model" not in memory
+
+    preferences = {i["name"]: i["column_names"] for i in inspector.get_indexes("router_preferences")}
+    assert preferences["ix_router_preferences_workspace_user_created"] == [
+        "workspace_id",
+        "user_id",
+        "created_at",
+    ]
+
+
+def test_existing_survival_rows_are_backfilled_onto_the_default_workspace(tmp_path: Path) -> None:
+    """The upgrade an operator with uploaded files and a taught router runs.
+
+    NOT NULL means the migration has to supply a value, and the only right one is
+    the workspace every other request-plane row was already backfilled onto: no
+    data moves and nothing is re-issued.
+    """
+    url = f"sqlite:///{tmp_path / 'survivals.db'}"
+    config = _alembic_config(url)
+    command.upgrade(config, _ALIAS_WIDEN_REVISION)
+    engine = create_engine(url)
+
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO users (user_id, spend, reserved, blocked, created_at, updated_at, metadata) "
+                "VALUES ('alice', 0, 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '{}')"
+            )
+        )
+        connection.execute(
+            text(
+                "INSERT INTO file_objects "
+                "(id, user_id, filename, mime_type, bytes, purpose, storage_ref, created_at, metadata) "
+                "VALUES ('file-1', 'alice', 'notes.txt', 'text/plain', 4, 'user_data', 'ref-1', "
+                " CURRENT_TIMESTAMP, '{}')"
+            )
+        )
+        connection.execute(
+            text(
+                "INSERT INTO routing_memory "
+                "(id, user_id, embedding_model, embedding, qualities, task_id, label_source, created_at) "
+                "VALUES ('m1', 'alice', 'openai:text-embedding-3-small', '[0.1]', '{}', NULL, 'human', "
+                " CURRENT_TIMESTAMP)"
+            )
+        )
+        connection.execute(
+            text(
+                "INSERT INTO router_preferences "
+                "(id, user_id, prompt, task_id, scores, label_source, created_at) "
+                "VALUES ('p1', 'alice', 'hello', NULL, '{}', 'human', CURRENT_TIMESTAMP)"
+            )
+        )
+
+    command.upgrade(config, _SURVIVALS_REVISION)
+
+    with engine.begin() as connection:
+        default = connection.execute(
+            text(
+                "SELECT w.id FROM workspace w "
+                "JOIN organization o ON o.id = w.organization_id WHERE o.slug = 'default'"
+            )
+        ).scalar_one()
+        for table in _SURVIVAL_TABLES:
+            landed = connection.execute(text(f"SELECT workspace_id FROM {table}")).scalar_one()  # noqa: S608
+            assert landed == default, table
+    engine.dispose()
+
+
+def test_the_survivals_revision_round_trips(sqlite_at_head: tuple[Config, Engine]) -> None:
+    """Down drops the column, its index and the renamed ones; up puts them back.
+
+    The downgrade drops the workspace index before its column on purpose: SQLite
+    refuses ``DROP COLUMN`` while an index covers it, the same ordering the
+    credential revision needed.
+    """
+    config, engine = sqlite_at_head
+
+    command.downgrade(config, _ALIAS_WIDEN_REVISION)
+
+    inspector = inspect(engine)
+    for table in _SURVIVAL_TABLES:
+        assert "workspace_id" not in {column["name"] for column in inspector.get_columns(table)}
+        assert f"ix_{table}_workspace_id" not in {index["name"] for index in inspector.get_indexes(table)}
+    memory = {index["name"] for index in inspector.get_indexes("routing_memory")}
+    assert "ix_routing_memory_user_model" in memory
+    assert "ix_routing_memory_workspace_user_model" not in memory
+
+    command.upgrade(config, "head")
+
+    inspector = inspect(engine)
+    for table in _SURVIVAL_TABLES:
+        assert "workspace_id" in {column["name"] for column in inspector.get_columns(table)}
+
+
+def test_the_migrated_survival_tables_match_their_models(sqlite_at_head: tuple[Config, Engine]) -> None:
+    """Hand-written revisions, so nothing else would notice the two drifting apart."""
+    _, engine = sqlite_at_head
+
+    for table in _SURVIVAL_TABLES:
+        declared = SQLModel.metadata.tables[table]
+        migrated = {column["name"] for column in inspect(engine).get_columns(table)}
+        assert migrated == set(declared.columns.keys()), table

--- a/tests/unit/test_tenancy_schema_chain.py
+++ b/tests/unit/test_tenancy_schema_chain.py
@@ -64,9 +64,24 @@ _CREDENTIAL_COLUMNS = {
 _TOKEN_INDEX = "ix_user_email_verification_token"
 
 _ALIAS_WIDEN_REVISION = "c1e4a7b9d3f6"
-_BEFORE_ALIAS_WIDEN = "c7a1e4d8f3b6"
 _SURVIVALS_REVISION = "d2f5b8c0e4a7"
 _SURVIVAL_TABLES = ("routing_memory", "router_preferences", "file_objects")
+
+
+def _parent_of(revision: str) -> str:
+    """The revision immediately below ``revision``, read from the chain itself.
+
+    Deliberately derived rather than written down. This pair of revisions sits at
+    the end of the chain, so every migration that lands on ``main`` while the
+    branch is open re-points the lower one's ``down_revision``, and a hardcoded
+    constant here is a second place to remember. Reading it back means the
+    downgrade targets below follow the re-point on their own, and the test keeps
+    asserting what it means ("roll back to just before this revision") rather
+    than a literal that goes stale.
+    """
+    parent = ScriptDirectory.from_config(_alembic_config("sqlite://")).get_revision(revision).down_revision
+    assert isinstance(parent, str), f"{revision} should have exactly one parent, got {parent!r}"
+    return parent
 
 _TOKEN_REVISION = "db8fbf901ee0"
 _BEFORE_TOKENS = "c8e2a4f6b0d3"
@@ -783,7 +798,7 @@ def test_the_widening_round_trips(sqlite_at_head: tuple[Config, Engine]) -> None
     """
     config, engine = sqlite_at_head
 
-    command.downgrade(config, _BEFORE_ALIAS_WIDEN)
+    command.downgrade(config, _parent_of(_ALIAS_WIDEN_REVISION))
 
     inspector = inspect(engine)
     for table in ("model_aliases", "routing_policies"):

--- a/tests/unit/test_weighted_router.py
+++ b/tests/unit/test_weighted_router.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import random
+import uuid
 from collections import Counter
 
 import pytest
@@ -56,6 +57,11 @@ def config() -> GatewayConfig:
             "mistral": {"api_key": "sk-mistral"},
         },
     )
+
+
+# The routing-memory surfaces are workspace-scoped; these tests are about which
+# backends read a pool at all, so any one workspace stands for all of them.
+_WORKSPACE = uuid.UUID("00000000-0000-4000-8000-00000000d3fa")
 
 
 def _spec(
@@ -313,9 +319,9 @@ def test_a_weighted_policy_is_not_a_consumer_of_routing_memory() -> None:
     )
     assert not backend_pool_is_teachable(WEIGHTED_BACKEND)
     assert not backend_pool_is_teachable(" Weighted ")
-    assert _learned_policies(weighted_config, "alice") == []
+    assert _learned_policies(weighted_config, "alice", _WORKSPACE) == []
     assert _validated_scores(
-        weighted_config, "alice", [ScoredExample(prompt="hi", scores={"openai:gpt-5-mini": 1.0})]
+        weighted_config, "alice", [ScoredExample(prompt="hi", scores={"openai:gpt-5-mini": 1.0})], _WORKSPACE
     ) == {"openai:gpt-5-mini": "openai:gpt-5-mini"}
 
 
@@ -342,12 +348,14 @@ def test_a_noop_placeholder_pool_is_still_teachable() -> None:
     )
     assert backend_pool_is_teachable("noop")
     assert backend_pool_is_teachable("some-future-backend")
-    assert [policy.name for policy in _learned_policies(cfg, "alice")] == ["warming"]
+    assert [policy.name for policy in _learned_policies(cfg, "alice", _WORKSPACE)] == ["warming"]
     assert _validated_scores(
-        cfg, "alice", [ScoredExample(prompt="hi", scores={"openai:gpt-5-mini": 1.0})]
+        cfg, "alice", [ScoredExample(prompt="hi", scores={"openai:gpt-5-mini": 1.0})], _WORKSPACE
     ) == {"openai:gpt-5-mini": "openai:gpt-5-mini"}
     with pytest.raises(HTTPException, match="do not name a model"):
-        _validated_scores(cfg, "alice", [ScoredExample(prompt="hi", scores={"openai:gpt-4o": 1.0})])
+        _validated_scores(
+            cfg, "alice", [ScoredExample(prompt="hi", scores={"openai:gpt-4o": 1.0})], _WORKSPACE
+        )
 
 
 def test_the_backend_is_registered_and_needs_no_pricing(config: GatewayConfig) -> None:

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -213,14 +213,14 @@ export interface paths {
          * List Aliases
          * @description List every alias in force, from config.yml and from storage.
          *
-         *     Every scope at once, global and user-scoped alike: this is the master-key
-         *     management view, not what any one caller resolves.
+         *     Every scope at once, workspace-wide and user-scoped alike: this is the
+         *     master-key management view, not what any one caller resolves.
          */
         get: operations["list_aliases_v1_aliases_get"];
         put?: never;
         /**
          * Set Alias
-         * @description Create or update a stored alias, global or scoped to one user.
+         * @description Create or update a stored alias in one workspace, optionally for one user.
          */
         post: operations["set_alias_v1_aliases_post"];
         delete?: never;
@@ -243,9 +243,10 @@ export interface paths {
          * Delete Alias
          * @description Delete a stored alias in one scope.
          *
-         *     Scoped by ``user_id`` for the same reason the upsert is: deleting the global
-         *     alias must not take a user's override with it, and deleting an override must
-         *     leave the global one serving everyone else.
+         *     Scoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:
+         *     deleting one workspace's alias must not touch another's, deleting the
+         *     workspace-wide alias must not take a user's override with it, and deleting an
+         *     override must leave the workspace-wide one serving everyone else.
          */
         delete: operations["delete_alias_v1_aliases__name__delete"];
         options?: never;
@@ -735,9 +736,10 @@ export interface paths {
          * List Batches
          * @description List batches for a provider.
          *
-         *     Non-master keys only see batches they own (plus legacy batches without an
-         *     ownership marker); the page is filtered after the provider call, so a page
-         *     may contain fewer than ``limit`` items.
+         *     Non-master keys only see batches they own in their own workspace (plus
+         *     legacy batches without an ownership marker, or without a recorded
+         *     workspace); the page is filtered after the provider call, so a page may
+         *     contain fewer than ``limit`` items.
          */
         get: operations["list_batches_v1_batches_get"];
         put?: never;
@@ -987,7 +989,10 @@ export interface paths {
         };
         /**
          * List Files
-         * @description List the authenticated user's uploaded files.
+         * @description List the authenticated user's uploaded files in the request's workspace.
+         *
+         *     ``workspace_id`` narrows a master-key listing to one workspace; a keyed
+         *     request is already confined to its key's own and cannot widen or move it.
          */
         get: operations["list_files_v1_files_get"];
         put?: never;
@@ -2327,14 +2332,14 @@ export interface paths {
          * List Policies
          * @description List every routing policy in force, from config.yml and from storage.
          *
-         *     Every scope at once, global and user-scoped alike: this is the master-key
-         *     management view, not what any one caller resolves.
+         *     Every scope at once, workspace-wide and user-scoped alike: this is the
+         *     master-key management view, not what any one caller resolves.
          */
         get: operations["list_policies_v1_routing_policies_get"];
         put?: never;
         /**
          * Set Policy
-         * @description Create or update a stored policy, global or scoped to one user.
+         * @description Create or update a stored policy in one workspace, optionally for one user.
          *
          *     The spec is validated here and stored as given, so a row can never contain a
          *     body this build would refuse at load. The cache is refreshed twice: once before
@@ -2398,9 +2403,10 @@ export interface paths {
          * Delete Policy
          * @description Delete a stored policy in one scope.
          *
-         *     Scoped by ``user_id`` for the same reason the upsert is: deleting the global
-         *     policy must not take a user's override with it, and deleting an override must
-         *     leave the global one serving everyone else.
+         *     Scoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:
+         *     deleting one workspace's policy must not touch another's, deleting the
+         *     workspace-wide policy must not take a user's override with it, and deleting an
+         *     override must leave the workspace-wide one serving everyone else.
          */
         delete: operations["delete_policy_v1_routing_policies__name__delete"];
         options?: never;
@@ -2451,11 +2457,14 @@ export interface paths {
         };
         /**
          * Routing Memory Status
-         * @description Report how warm one user's routing memory is, per pool.
+         * @description Report how warm one user's routing memory is in one workspace, per pool.
          *
          *     ``user_id`` is required rather than optional because there is no aggregate
          *     answer: warmth is per user, and a total across users would describe a pool
-         *     that no request ever votes over.
+         *     that no request ever votes over. The same holds across workspaces, which is
+         *     why ``workspace_id`` narrows rather than aggregating; it merely defaults
+         *     instead of being required, because a single-workspace deployment has one
+         *     answer.
          */
         get: operations["routing_memory_status_v1_routing_status_get"];
         put?: never;
@@ -4249,9 +4258,14 @@ export interface components {
             target: string;
             /**
              * User Id
-             * @description User this alias belongs to. Omit for a global alias every caller sees. A user-scoped alias resolves only for that user and shadows a global one of the same name.
+             * @description User this alias belongs to. Omit for an alias every caller in the workspace sees. A user-scoped alias resolves only for that user and shadows the workspace-wide one of the same name.
              */
             user_id?: string | null;
+            /**
+             * Workspace Id
+             * @description Workspace this alias belongs to. Omit for the deployment's default workspace. The alias resolves only for requests in that workspace, so two workspaces can each point the same name at a different model.
+             */
+            workspace_id?: string | null;
         };
         /**
          * AliasResponse
@@ -4270,6 +4284,8 @@ export interface components {
             updated_at?: string | null;
             /** User Id */
             user_id?: string | null;
+            /** Workspace Id */
+            workspace_id?: string | null;
         };
         /**
          * AudioSpeechRequest
@@ -5240,6 +5256,11 @@ export interface components {
              * @description Evaluate conditions as this user.
              */
             user_id?: string | null;
+            /**
+             * Workspace Id
+             * @description Resolve `name` and the policy's candidate selectors in this workspace. Omit for the deployment's default workspace.
+             */
+            workspace_id?: string | null;
         };
         /**
          * ExplainResponse
@@ -6756,9 +6777,14 @@ export interface components {
             };
             /**
              * User Id
-             * @description User this policy belongs to. Omit for a global policy every caller sees. A user-scoped policy resolves only for that user and shadows a global one of the same name.
+             * @description User this policy belongs to. Omit for a policy every caller in the workspace sees. A user-scoped policy resolves only for that user and shadows the workspace-wide one of the same name.
              */
             user_id?: string | null;
+            /**
+             * Workspace Id
+             * @description Workspace this policy belongs to. Omit for the deployment's default workspace. The policy resolves only for requests in that workspace, so two workspaces can each define their own 'fast'.
+             */
+            workspace_id?: string | null;
         };
         /**
          * PolicyResponse
@@ -6784,6 +6810,8 @@ export interface components {
             updated_at?: string | null;
             /** User Id */
             user_id?: string | null;
+            /** Workspace Id */
+            workspace_id?: string | null;
         };
         /** PoolStatus */
         PoolStatus: {
@@ -7036,6 +7064,11 @@ export interface components {
              * @description Whose routing memory these examples belong to.
              */
             user_id: string;
+            /**
+             * Workspace Id
+             * @description Which workspace's routing memory these examples belong to. Omit for the deployment's default workspace. Only requests billing to that workspace vote over them.
+             */
+            workspace_id?: string | null;
         };
         /** RankResponse */
         RankResponse: {
@@ -7318,9 +7351,9 @@ export interface components {
          *
          *     Routing memory has no single warmth: it is a set of independent pools.
          *     ``default_pool`` is what a request with no ``Otari-Router-Task`` header votes
-         *     over (every record the user has, labeled or not) and ``tasks`` lists each
-         *     partition, which only requests carrying that label use. Each crosses
-         *     ``seed_count`` on its own.
+         *     over (every record the user has in this workspace, labeled or not) and
+         *     ``tasks`` lists each partition, which only requests carrying that label use.
+         *     Each crosses ``seed_count`` on its own.
          */
         RouterStatus: {
             /** Alpha */
@@ -7342,6 +7375,11 @@ export interface components {
             tasks: components["schemas"]["TaskPool"][];
             /** User Id */
             user_id: string;
+            /**
+             * Workspace Id
+             * Format: uuid
+             */
+            workspace_id: string;
         };
         /**
          * ScopedBudgetResponse
@@ -9531,7 +9569,7 @@ export interface operations {
     list_aliases_v1_aliases_get: {
         parameters: {
             query?: {
-                /** @description Only stored entries in this workspace. Config-file entries are always included. Every stored entry is in the deployment's default workspace today, because name uniqueness and the resolution cache are both deployment-wide, so this narrows to one workspace and finds the rest empty until those are scoped (otari-ai#1643). */
+                /** @description Only stored entries in this workspace. Config-file entries are always included, being deployment-wide. Omit to list the stored entries of every workspace. */
                 workspace_id?: string | null;
             };
             header?: never;
@@ -9596,8 +9634,10 @@ export interface operations {
     delete_alias_v1_aliases__name__delete: {
         parameters: {
             query?: {
-                /** @description Delete the alias scoped to this user. Omit to delete the global alias of that name. */
+                /** @description Delete the alias scoped to this user. Omit to delete the workspace-wide alias of that name. */
                 user_id?: string | null;
+                /** @description Delete the alias in this workspace. Omit for the deployment's default workspace. */
+                workspace_id?: string | null;
             };
             header?: never;
             path: {
@@ -10666,6 +10706,7 @@ export interface operations {
             query?: {
                 user?: string | null;
                 purpose?: string | null;
+                workspace_id?: string | null;
             };
             header?: never;
             path?: never;
@@ -12815,7 +12856,7 @@ export interface operations {
     list_policies_v1_routing_policies_get: {
         parameters: {
             query?: {
-                /** @description Only stored policies in this workspace. Config-file policies are always included. Every stored policy is in the deployment's default workspace today, because name uniqueness and the resolution cache are both deployment-wide, so this narrows to one workspace and finds the rest empty until those are scoped (otari-ai#1643). */
+                /** @description Only stored policies in this workspace. Config-file policies are always included, being deployment-wide. Omit to list the stored policies of every workspace. */
                 workspace_id?: string | null;
             };
             header?: never;
@@ -12913,8 +12954,10 @@ export interface operations {
     delete_policy_v1_routing_policies__name__delete: {
         parameters: {
             query?: {
-                /** @description Delete the policy scoped to this user. Omit to delete the global one. */
+                /** @description Delete the policy scoped to this user. Omit to delete the workspace-wide one. */
                 user_id?: string | null;
+                /** @description Delete the policy in this workspace. Omit for the deployment's default workspace. */
+                workspace_id?: string | null;
             };
             header?: never;
             path: {
@@ -12980,6 +13023,8 @@ export interface operations {
             query: {
                 /** @description Whose routing memory to report on. */
                 user_id: string;
+                /** @description Which workspace's routing memory to report on. Omit for the default workspace. */
+                workspace_id?: string | null;
             };
             header?: never;
             path?: never;

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -6765,7 +6765,7 @@ export interface components {
             name: string;
             /**
              * Rename From
-             * @description Current name of the policy to rename, in the same scope. The stored row keeps its id and created_at and takes `name` and `spec`. Sending it asserts that policy exists, so a name with no stored row is a 404 rather than a create, even when it equals `name`. Omit to create or update the policy named `name`. Renaming changes what callers must send as `model`; usage already recorded keeps the old name.
+             * @description Current name of the policy to rename, in the same scope, meaning the same workspace and the same user. A rename never moves a policy between them. The stored row keeps its id and created_at and takes `name` and `spec`. Sending it asserts that policy exists, so a name with no stored row is a 404 rather than a create, even when it equals `name`. Omit to create or update the policy named `name`. Renaming changes what callers must send as `model`; usage already recorded keeps the old name.
              */
             rename_from?: string | null;
             /**


### PR DESCRIPTION
## Description

The six concepts that stay in the gateway rather than moving to the platform become tenancy-aware on otari's own schema. Aliases, routing policies and batches already carried a `workspace_id`; routing memory, router preferences and file objects get one here.

The heart of it is the resolution cache. `alias_service` and `policy_store` were keyed on name alone, which is why the alias and policy uniqueness constraints could not be widened: a second workspace's `fast` would have been accepted by the schema and then silently shadowed the first at request time. Both caches are now keyed by workspace first, so the constraints widen to `(workspace_id, name, user_id)`.

`user_id` is untouched on all six. The workspace is a second axis, not a re-parenting, and nothing here depends on the identity bridge.

An existing standalone deployment is unaffected: every scope is optional, omitting it means the deployment's default workspace, and existing rows are backfilled onto it. No credential is re-issued and no data moves.

Fixes mozilla-ai/otari-ai#1643

## PR Type

- [x] New Feature

## Relevant issues

Fixes mozilla-ai/otari-ai#1643

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Both migrations were round-tripped (upgrade, downgrade, upgrade) on SQLite and on PostgreSQL, with rows in place to check the backfill. The OSS-edition smoke gate passes, as do `pnpm --dir web run lint`, `typecheck` and `test` after regenerating the dashboard client.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

Written end to end by the agent, including the migrations and tests. The one design decision worth a human eye is where a lookup with no workspace lands: it reads the deployment's default, matching what `services/workspace_scope` already says a deployment-wide write does.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added workspace awareness to aliases, routing policies, routing memory, router preferences, files, and batches.
- Scoped resolution, authorization, caching, listing, and deletion by workspace.
- Backfilled existing records to the default workspace without moving data or reissuing credentials.
- Updated database migrations, API schemas, generated clients, documentation, and Postman examples.
- Added migration round-trip, unit, and integration tests for workspace isolation and compatibility.

These changes prevent cross-workspace data overlap and provide consistent workspace-based access control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->