### PR TITLE
fix(mcp): reject duplicate MCP server names before they collapse silently

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -115,7 +115,8 @@ are managed there.
 
 - `mcp_servers` and `mcp_server_ids` cannot be combined with `otari_code_execution` or `otari_web_search` in the same request yet
 - `max_tool_iterations` optionally caps the loop; default is `10`, max is `25`
-- `mcp_server_ids` accepts at most 50 ids, which is also the most servers a workspace can have
+- `mcp_server_ids` accepts at most 50 ids, which is also the most servers a workspace can have; a repeated id resolves once
+- Server names must be unique across everything one request uses, because Otari routes each tool call to its server by name. Two `mcp_servers` entries sharing a name are refused with a `400` naming it, the way a bad request-body URL is. An `mcp_servers` name colliding with one of your workspace's stored servers is a `400` too, but a fixed one that repeats neither name, since a stored server is not yours to read. Two stored servers sharing a name is a `500` with the names in the log, on the same grounds as a stored URL that fails its safety check
 - MCP URLs are validated to reduce SSRF risk; by default, private and reserved addresses are blocked, loopback is allowed, and `http://` is rejected when `authorization_token` is present
 - `OTARI_MCP_ALLOW_LOOPBACK=false` disables loopback; `OTARI_MCP_ALLOW_PRIVATE_HOSTS=true` relaxes the private-host restriction
 

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -38,6 +38,7 @@ import hashlib
 import json
 import time
 import uuid
+from collections import Counter
 from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Iterable, Sequence
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, replace
@@ -2254,7 +2255,7 @@ async def prepare_gateway_tools(
             await _validate_mcp_server_urls(
                 adapter, stored_servers, stored=True, workspace_id=ctx.workspace_id
             )
-            stored_names = [server.name for server in stored_servers]
+            stored_name_counts = Counter(server.name for server in stored_servers)
             # Standalone cannot reach this: `uq_workspace_mcp_servers_workspace_name`
             # makes stored names unique per workspace and `resolve_workspace_mcp_servers`
             # de-duplicates the ids. Hybrid can, because `_resolve_platform_mcp_servers`
@@ -2263,11 +2264,11 @@ async def prepare_gateway_tools(
             # URL does, since a stored duplicate is workspace configuration the caller
             # can neither see nor fix: a fixed 500 detail, with the names and the
             # workspace in the log.
-            if len(set(stored_names)) != len(stored_names):
+            if len(stored_name_counts) != len(stored_servers):
                 logger.error(
                     "Stored MCP servers do not have unique names for workspace %s: %s",
                     ctx.workspace_id,
-                    sorted({name for name in stored_names if stored_names.count(name) > 1}),
+                    sorted(name for name, count in stored_name_counts.items() if count > 1),
                 )
                 raise adapter.error(500, MCP_SERVER_NAMES_NOT_UNIQUE_DETAIL, ErrorKind.API)
             # Fixed detail rather than the name: a stored name is not the caller's to
@@ -2275,7 +2276,7 @@ async def prepare_gateway_tools(
             # key), so the rejection does not repeat one back. It does not pretend to
             # close the oracle: the probe name is caller-supplied, so a caller holding a
             # stored id still learns a name by guessing it here and reading the 400.
-            if inline_names & set(stored_names):
+            if inline_names & stored_name_counts.keys():
                 raise adapter.error(400, MCP_SERVER_NAME_COLLIDES_WITH_STORED_DETAIL, ErrorKind.INVALID_REQUEST)
             mcp_servers = (mcp_servers or []) + stored_servers
 

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -218,6 +218,7 @@ MCP_SERVER_URL_UNSAFE_DETAIL = "A configured MCP server's URL failed its safety 
 MCP_SERVER_NAME_COLLIDES_WITH_STORED_DETAIL = (
     "A request-supplied MCP server name collides with one of this workspace's stored servers"
 )
+MCP_SERVER_NAMES_NOT_UNIQUE_DETAIL = "Configured MCP servers do not have unique names"
 NO_RESOLVABLE_PROVIDER_DETAIL = "Authorization service returned no resolvable provider"
 PROVIDER_ERROR_DETAIL = "LLM provider error"
 PROVIDER_TIMEOUT_DETAIL = "LLM provider timeout"
@@ -2235,31 +2236,46 @@ async def prepare_gateway_tools(
 
         # Checked per source, not over the merged list: see
         # `_validate_mcp_server_urls` for why a stored server's rejection cannot
-        # carry the same body a caller's own does. The duplicate-name check below
-        # follows the same split. Inline-vs-inline is the caller's own request, so
-        # the 400 names the duplicate. Inline-vs-stored gets a fixed detail instead:
-        # echoing the name there would let any key holder learn a stored server's
-        # name by guessing it inline and reading the error, the same existence
-        # oracle `_validate_mcp_server_urls` withholds for a stored host.
+        # carry the same body a caller's own does. `MCPClientPool` keys sessions by
+        # `name`, so a duplicate silently collapses two servers into one and
+        # misroutes tool calls (otari#591); each source refuses one the way it
+        # refuses an unsafe URL.
         inline_names: set[str] = set()
         if mcp_servers:
-            await _validate_mcp_server_urls(adapter, mcp_servers)
-            # MCPClientPool keys sessions by `name`; a duplicate silently collapses two
-            # servers into one and misroutes tool calls (otari#591). Reject it here.
+            # Before the URL check, which spends a DNS lookup per server: a repeat
+            # inside the caller's own list is knowable without any of them.
             for server in mcp_servers:
                 if server.name in inline_names:
                     raise adapter.error(400, duplicate_mcp_server_name_detail(server.name), ErrorKind.INVALID_REQUEST)
                 inline_names.add(server.name)
+            await _validate_mcp_server_urls(adapter, mcp_servers)
         if mcp_server_ids:
             stored_servers = await _resolve_mcp_server_ids(adapter, ctx, mcp_server_ids)
             await _validate_mcp_server_urls(
                 adapter, stored_servers, stored=True, workspace_id=ctx.workspace_id
             )
-            # Stored names are already unique within a workspace
-            # (uq_workspace_mcp_servers_workspace_name) and mcp_server_ids is
-            # de-duplicated by resolve_workspace_mcp_servers, so the only
-            # remaining collision to check is inline vs. stored.
-            if inline_names & {server.name for server in stored_servers}:
+            stored_names = [server.name for server in stored_servers]
+            # Standalone cannot reach this: `uq_workspace_mcp_servers_workspace_name`
+            # makes stored names unique per workspace and `resolve_workspace_mcp_servers`
+            # de-duplicates the ids. Hybrid can, because `_resolve_platform_mcp_servers`
+            # returns the platform's payload verbatim, so that uniqueness is a remote
+            # promise rather than a local invariant. It answers the way an unsafe stored
+            # URL does, since a stored duplicate is workspace configuration the caller
+            # can neither see nor fix: a fixed 500 detail, with the names and the
+            # workspace in the log.
+            if len(set(stored_names)) != len(stored_names):
+                logger.error(
+                    "Stored MCP servers do not have unique names for workspace %s: %s",
+                    ctx.workspace_id,
+                    sorted({name for name in stored_names if stored_names.count(name) > 1}),
+                )
+                raise adapter.error(500, MCP_SERVER_NAMES_NOT_UNIQUE_DETAIL, ErrorKind.API)
+            # Fixed detail rather than the name: a stored name is not the caller's to
+            # read (`routes/workspace_mcp_servers` gates even the read behind the master
+            # key), so the rejection does not repeat one back. It does not pretend to
+            # close the oracle: the probe name is caller-supplied, so a caller holding a
+            # stored id still learns a name by guessing it here and reading the 400.
+            if inline_names & set(stored_names):
                 raise adapter.error(400, MCP_SERVER_NAME_COLLIDES_WITH_STORED_DETAIL, ErrorKind.INVALID_REQUEST)
             mcp_servers = (mcp_servers or []) + stored_servers
 

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -215,6 +215,9 @@ API_KEY_NO_USER_DETAIL = "API key has no associated user"
 MCP_SERVER_IDS_UNAVAILABLE_DETAIL = "mcp_server_ids is unavailable for this request"
 MCP_SERVER_TOKEN_UNREADABLE_DETAIL = "A configured MCP server's authorization token could not be read"
 MCP_SERVER_URL_UNSAFE_DETAIL = "A configured MCP server's URL failed its safety check"
+MCP_SERVER_NAME_COLLIDES_WITH_STORED_DETAIL = (
+    "A request-supplied MCP server name collides with one of this workspace's stored servers"
+)
 NO_RESOLVABLE_PROVIDER_DETAIL = "Authorization service returned no resolvable provider"
 PROVIDER_ERROR_DETAIL = "LLM provider error"
 PROVIDER_TIMEOUT_DETAIL = "LLM provider timeout"
@@ -1262,12 +1265,8 @@ def policy_in_hybrid_mode_detail(model_selector: str) -> str:
 
 
 def duplicate_mcp_server_name_detail(name: str) -> str:
-    """400 detail for two mcp_servers entries sharing a name."""
-    return (
-        f"Duplicate MCP server name {name!r}. mcp_servers entries (including a workspace's stored "
-        "servers) must have unique names: MCPClientPool keys its connected sessions by name, so a "
-        "duplicate silently drops one server's tools and routes its tool calls to the other server."
-    )
+    """400 detail for two entries in the caller's own ``mcp_servers`` list sharing a name."""
+    return f"Duplicate MCP server name {name!r}. mcp_servers entries must have unique names."
 
 
 async def _compile_request_plan(
@@ -2236,23 +2235,33 @@ async def prepare_gateway_tools(
 
         # Checked per source, not over the merged list: see
         # `_validate_mcp_server_urls` for why a stored server's rejection cannot
-        # carry the same body a caller's own does.
+        # carry the same body a caller's own does. The duplicate-name check below
+        # follows the same split. Inline-vs-inline is the caller's own request, so
+        # the 400 names the duplicate. Inline-vs-stored gets a fixed detail instead:
+        # echoing the name there would let any key holder learn a stored server's
+        # name by guessing it inline and reading the error, the same existence
+        # oracle `_validate_mcp_server_urls` withholds for a stored host.
+        inline_names: set[str] = set()
         if mcp_servers:
             await _validate_mcp_server_urls(adapter, mcp_servers)
+            # MCPClientPool keys sessions by `name`; a duplicate silently collapses two
+            # servers into one and misroutes tool calls (otari#591). Reject it here.
+            for server in mcp_servers:
+                if server.name in inline_names:
+                    raise adapter.error(400, duplicate_mcp_server_name_detail(server.name), ErrorKind.INVALID_REQUEST)
+                inline_names.add(server.name)
         if mcp_server_ids:
             stored_servers = await _resolve_mcp_server_ids(adapter, ctx, mcp_server_ids)
             await _validate_mcp_server_urls(
                 adapter, stored_servers, stored=True, workspace_id=ctx.workspace_id
             )
+            # Stored names are already unique within a workspace
+            # (uq_workspace_mcp_servers_workspace_name) and mcp_server_ids is
+            # de-duplicated by resolve_workspace_mcp_servers, so the only
+            # remaining collision to check is inline vs. stored.
+            if inline_names & {server.name for server in stored_servers}:
+                raise adapter.error(400, MCP_SERVER_NAME_COLLIDES_WITH_STORED_DETAIL, ErrorKind.INVALID_REQUEST)
             mcp_servers = (mcp_servers or []) + stored_servers
-        if mcp_servers:
-            # MCPClientPool keys sessions by `name`; a duplicate silently collapses two
-            # servers into one and misroutes tool calls (otari#591). Reject it here.
-            seen_names: set[str] = set()
-            for server in mcp_servers:
-                if server.name in seen_names:
-                    raise adapter.error(400, duplicate_mcp_server_name_detail(server.name), ErrorKind.INVALID_REQUEST)
-                seen_names.add(server.name)
 
         sandbox_tool_entry, tools_after_sandbox = _extract_code_execution_tool(tools)
         # Read the effective config value (dashboard override / env / YAML), falling

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -1261,6 +1261,15 @@ def policy_in_hybrid_mode_detail(model_selector: str) -> str:
     )
 
 
+def duplicate_mcp_server_name_detail(name: str) -> str:
+    """400 detail for two mcp_servers entries sharing a name."""
+    return (
+        f"Duplicate MCP server name {name!r}. mcp_servers entries (including a workspace's stored "
+        "servers) must have unique names: MCPClientPool keys its connected sessions by name, so a "
+        "duplicate silently drops one server's tools and routes its tool calls to the other server."
+    )
+
+
 async def _compile_request_plan(
     *,
     adapter: FormatAdapter[Any, Any],
@@ -2236,6 +2245,14 @@ async def prepare_gateway_tools(
                 adapter, stored_servers, stored=True, workspace_id=ctx.workspace_id
             )
             mcp_servers = (mcp_servers or []) + stored_servers
+        if mcp_servers:
+            # MCPClientPool keys sessions by `name`; a duplicate silently collapses two
+            # servers into one and misroutes tool calls (otari#591). Reject it here.
+            seen_names: set[str] = set()
+            for server in mcp_servers:
+                if server.name in seen_names:
+                    raise adapter.error(400, duplicate_mcp_server_name_detail(server.name), ErrorKind.INVALID_REQUEST)
+                seen_names.add(server.name)
 
         sandbox_tool_entry, tools_after_sandbox = _extract_code_execution_tool(tools)
         # Read the effective config value (dashboard override / env / YAML), falling

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -906,12 +906,20 @@ async def _resolve_platform_mcp_servers(
     user_token: str,
     mcp_server_ids: list[uuid.UUID],
 ) -> list[McpServerConfig]:
-    """Swap workspace-scoped MCP server ids for inline configs by calling the platform."""
+    """Swap workspace-scoped MCP server ids for inline configs by calling the platform.
+
+    Ids are de-duplicated with their order preserved, which is the contract
+    `resolve_workspace_mcp_servers` states the two modes share. It matters more
+    than a saved round trip now that two resolved servers sharing a name are a
+    500 (`prepare_gateway_tools`): the protocol does not say what the platform
+    answers for a repeated id, so sending one twice must not be able to make a
+    request fail on a duplicate the caller never really asked for.
+    """
     payload = await _post_resolve(
         config,
         user_token=user_token,
         path="/gateway/mcp-servers/resolve",
-        body={"mcp_server_ids": [str(uid) for uid in mcp_server_ids]},
+        body={"mcp_server_ids": [str(uid) for uid in dict.fromkeys(mcp_server_ids)]},
         client_error_detail="MCP server resolution failed",
     )
     return [

--- a/src/gateway/services/mcp_client.py
+++ b/src/gateway/services/mcp_client.py
@@ -65,6 +65,8 @@ class MCPClientPool:
     async def __aenter__(self) -> MCPClientPool:
         try:
             for cfg in self._configs:
+                if cfg.name in self._servers:
+                    raise ValueError(f"Duplicate MCP server name {cfg.name!r}")
                 self._servers[cfg.name] = await self._connect(cfg)
         except BaseException:
             await self._stack.aclose()

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -1,0 +1,55 @@
+"""Unit tests for MCPClientPool's own duplicate-name guard.
+
+prepare_gateway_tools (routes/_pipeline.py) rejects a duplicate server name at
+request-admission time, before any pool is built. That covers every current
+production caller, but the pool's own module docstring advertises
+``async with MCPClientPool(configs) as pool`` as a supported direct entry
+point, so the invariant belongs here too for a caller that reaches it another
+way (otari#792 review).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.models.mcp import McpServerConfig
+from gateway.services.mcp_client import MCPClientPool, _ConnectedServer
+
+
+@pytest.mark.asyncio
+async def test_aenter_rejects_duplicate_server_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two configs sharing a name raise instead of the second silently overwriting the first."""
+
+    async def fake_connect(self: MCPClientPool, cfg: McpServerConfig) -> _ConnectedServer:
+        return _ConnectedServer(name=cfg.name, session=object())  # type: ignore[arg-type]
+
+    monkeypatch.setattr(MCPClientPool, "_connect", fake_connect)
+
+    configs = [
+        McpServerConfig(name="tools", url="https://93.184.216.34/mcp"),
+        McpServerConfig(name="tools", url="https://93.184.216.35/mcp"),
+    ]
+    pool = MCPClientPool(configs)
+    with pytest.raises(ValueError, match="tools"):
+        await pool.__aenter__()
+
+
+@pytest.mark.asyncio
+async def test_aenter_connects_distinct_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Distinct names still connect normally; the guard only fires on a repeat."""
+
+    connected: list[str] = []
+
+    async def fake_connect(self: MCPClientPool, cfg: McpServerConfig) -> _ConnectedServer:
+        connected.append(cfg.name)
+        return _ConnectedServer(name=cfg.name, session=object())  # type: ignore[arg-type]
+
+    monkeypatch.setattr(MCPClientPool, "_connect", fake_connect)
+
+    configs = [
+        McpServerConfig(name="a", url="https://93.184.216.34/mcp"),
+        McpServerConfig(name="b", url="https://93.184.216.35/mcp"),
+    ]
+    async with MCPClientPool(configs) as pool:
+        assert set(pool._servers) == {"a", "b"}
+    assert connected == ["a", "b"]

--- a/tests/unit/test_mcp_server_id_resolve.py
+++ b/tests/unit/test_mcp_server_id_resolve.py
@@ -27,6 +27,32 @@ def _ok_response(servers: list[dict[str, Any]]) -> httpx.Response:
 
 
 @pytest.mark.asyncio
+async def test_repeated_ids_are_sent_once_in_request_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Hybrid de-duplicates ids like the standalone path, so a repeat cannot resolve twice.
+
+    Two resolved servers sharing a name are a 500 in `prepare_gateway_tools`,
+    and the protocol does not say what the platform answers for a repeated id,
+    so a caller naming one twice must not be able to trip that (otari#792
+    review).
+    """
+    captured: dict[str, Any] = {}
+
+    async def fake_post(
+        *, url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float
+    ) -> httpx.Response:
+        captured["body"] = body
+        return _ok_response([])
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+
+    first = uuid.UUID("11111111-1111-1111-1111-111111111111")
+    second = uuid.UUID("22222222-2222-2222-2222-222222222222")
+    await _resolve_platform_mcp_servers(_config(), "tk_user", [first, second, first])
+
+    assert captured["body"]["mcp_server_ids"] == [str(first), str(second)]
+
+
+@pytest.mark.asyncio
 async def test_resolve_returns_configs(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 

--- a/tests/unit/test_pipeline_settlement.py
+++ b/tests/unit/test_pipeline_settlement.py
@@ -1152,7 +1152,8 @@ async def test_duplicate_inline_mcp_server_name_releases_reservation(monkeypatch
 async def test_duplicate_mcp_server_name_against_a_stored_server_releases_reservation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An inline server whose name matches a workspace's stored server is refused, not silently dropped."""
+    """An inline server whose name matches a workspace's stored server is refused with a fixed
+    detail that does not echo the stored server's name back to the caller (otari#792 review)."""
     settlement = _Settlement()
     settlement.install(monkeypatch)
 
@@ -1170,6 +1171,11 @@ async def test_duplicate_mcp_server_name_against_a_stored_server_releases_reserv
         )
 
     assert exc_info.value.status_code == 400
+    # Deliberately not asserting the stored server's name is IN the detail: it
+    # must not be, since an inline caller would otherwise learn a stored
+    # server's name by guessing it and reading the error (otari#792 review).
+    assert exc_info.value.detail == pipeline.MCP_SERVER_NAME_COLLIDES_WITH_STORED_DETAIL
+    assert "tools" not in str(exc_info.value.detail)
     assert settlement.refunded == 1
 
 

--- a/tests/unit/test_pipeline_settlement.py
+++ b/tests/unit/test_pipeline_settlement.py
@@ -1180,6 +1180,68 @@ async def test_duplicate_mcp_server_name_against_a_stored_server_releases_reserv
 
 
 @pytest.mark.asyncio
+async def test_an_inline_duplicate_is_refused_before_the_url_safety_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The name check runs first, so a doomed request does not spend a DNS lookup per server."""
+    settlement = _Settlement()
+    settlement.install(monkeypatch)
+    monkeypatch.delenv("OTARI_MCP_ALLOW_PRIVATE_HOSTS", raising=False)
+
+    ctx = _ctx(GatewayConfig(), db=cast(Any, object()), reservation=_reservation(), workspace_id=uuid.uuid4())
+    # Loopback: both URLs would fail `validate_mcp_url`, so the detail says which
+    # of the two gates answered.
+    dupes = [
+        McpServerConfig(name="tools", url="https://127.0.0.1/mcp"),
+        McpServerConfig(name="tools", url="https://127.0.0.1/other"),
+    ]
+    with pytest.raises(HTTPException) as exc_info:
+        await _call_prepare_gateway_tools(ctx, mcp_servers=dupes)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == pipeline.duplicate_mcp_server_name_detail("tools")
+    assert settlement.refunded == 1
+
+
+@pytest.mark.asyncio
+async def test_stored_mcp_servers_sharing_a_name_are_an_operator_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two *stored* servers sharing a name is broken workspace config, not a bad request.
+
+    Unreachable in standalone (`uq_workspace_mcp_servers_workspace_name`, plus
+    `resolve_workspace_mcp_servers` de-duplicates the ids), so the resolve is
+    stubbed to produce what hybrid can: `_resolve_platform_mcp_servers` returns
+    the platform's payload verbatim, and that uniqueness is the platform's
+    promise rather than a local invariant (otari#792 review).
+    """
+    settlement = _Settlement()
+    settlement.install(monkeypatch)
+
+    async def stored(*args: Any, **kwargs: Any) -> list[McpServerConfig]:
+        return [
+            McpServerConfig(name="tools", url="https://93.184.216.34/mcp"),
+            McpServerConfig(name="tools", url="https://93.184.216.35/mcp"),
+        ]
+
+    monkeypatch.setattr(pipeline, "resolve_workspace_mcp_servers", stored)
+
+    ctx = _ctx(GatewayConfig(), db=cast(Any, object()), reservation=_reservation(), workspace_id=uuid.uuid4())
+    with pytest.raises(HTTPException) as exc_info:
+        await _call_prepare_gateway_tools(
+            ctx,
+            mcp_server_ids=[cast(Any, "11111111-1111-1111-1111-111111111111")],
+        )
+
+    assert exc_info.value.status_code == 500
+    # The caller can neither see nor fix a stored server, so the name stays in
+    # the log, as it does for a stored URL that fails its safety check.
+    assert exc_info.value.detail == pipeline.MCP_SERVER_NAMES_NOT_UNIQUE_DETAIL
+    assert "tools" not in str(exc_info.value.detail)
+    assert settlement.refunded == 1
+
+
+@pytest.mark.asyncio
 async def test_a_database_failure_releases_the_reservation(monkeypatch: pytest.MonkeyPatch) -> None:
     """A `SQLAlchemyError` is not an `HTTPException`, and must still not leave the hold behind.
 

--- a/tests/unit/test_pipeline_settlement.py
+++ b/tests/unit/test_pipeline_settlement.py
@@ -1179,21 +1179,56 @@ async def test_duplicate_mcp_server_name_against_a_stored_server_releases_reserv
     assert settlement.refunded == 1
 
 
+# RFC 1918, deliberately not loopback: `MCP_ALLOW_LOOPBACK` defaults to *true*,
+# so `127.0.0.1` passes `validate_mcp_url` and would make the ordering test below
+# vacuous. `MCP_ALLOW_PRIVATE_HOSTS` defaults to false, so these are rejected with
+# only that variable cleared.
+_UNSAFE_URL = "https://10.0.0.1/mcp"
+_OTHER_UNSAFE_URL = "https://10.0.0.2/mcp"
+
+
 @pytest.mark.asyncio
-async def test_an_inline_duplicate_is_refused_before_the_url_safety_check(
+async def test_an_unsafe_inline_url_is_refused_when_the_names_are_distinct(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The name check runs first, so a doomed request does not spend a DNS lookup per server."""
+    """Negative control for the ordering test below: these URLs really do fail the safety check."""
     settlement = _Settlement()
     settlement.install(monkeypatch)
     monkeypatch.delenv("OTARI_MCP_ALLOW_PRIVATE_HOSTS", raising=False)
 
     ctx = _ctx(GatewayConfig(), db=cast(Any, object()), reservation=_reservation(), workspace_id=uuid.uuid4())
-    # Loopback: both URLs would fail `validate_mcp_url`, so the detail says which
-    # of the two gates answered.
+    with pytest.raises(HTTPException) as exc_info:
+        await _call_prepare_gateway_tools(
+            ctx,
+            mcp_servers=[
+                McpServerConfig(name="tools", url=_UNSAFE_URL),
+                McpServerConfig(name="other", url=_OTHER_UNSAFE_URL),
+            ],
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "private range" in str(exc_info.value.detail)
+    assert settlement.refunded == 1
+
+
+@pytest.mark.asyncio
+async def test_an_inline_duplicate_is_refused_before_the_url_safety_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The name check runs first, so a doomed request does not spend a DNS lookup per server.
+
+    Same URLs as the test above, which reports the unsafe URL when the names
+    differ; only the repeated name changes the answer, so this pins the order
+    rather than passing for either reason.
+    """
+    settlement = _Settlement()
+    settlement.install(monkeypatch)
+    monkeypatch.delenv("OTARI_MCP_ALLOW_PRIVATE_HOSTS", raising=False)
+
+    ctx = _ctx(GatewayConfig(), db=cast(Any, object()), reservation=_reservation(), workspace_id=uuid.uuid4())
     dupes = [
-        McpServerConfig(name="tools", url="https://127.0.0.1/mcp"),
-        McpServerConfig(name="tools", url="https://127.0.0.1/other"),
+        McpServerConfig(name="tools", url=_UNSAFE_URL),
+        McpServerConfig(name="tools", url=_OTHER_UNSAFE_URL),
     ]
     with pytest.raises(HTTPException) as exc_info:
         await _call_prepare_gateway_tools(ctx, mcp_servers=dupes)

--- a/tests/unit/test_pipeline_settlement.py
+++ b/tests/unit/test_pipeline_settlement.py
@@ -53,6 +53,7 @@ from gateway.api.routes._pipeline import (
 )
 from gateway.api.routes._platform import ResolvedAttempt, ResolvedRoute, SettledCost
 from gateway.core.config import GatewayConfig
+from gateway.models.mcp import McpServerConfig
 from gateway.rate_limit import RateLimitInfo
 from gateway.services.budget_service import ReservationHandle
 from gateway.services.tenancy.errors import WorkspaceMcpServerNotFoundError
@@ -1125,6 +1126,50 @@ async def test_unknown_mcp_server_id_releases_reservation(monkeypatch: pytest.Mo
         )
 
     assert exc_info.value.status_code == 404
+    assert settlement.refunded == 1
+
+
+@pytest.mark.asyncio
+async def test_duplicate_inline_mcp_server_name_releases_reservation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two request-body servers sharing a name are refused, not silently collapsed (otari#591)."""
+    settlement = _Settlement()
+    settlement.install(monkeypatch)
+
+    ctx = _ctx(GatewayConfig(), db=cast(Any, object()), reservation=_reservation(), workspace_id=uuid.uuid4())
+    dupes = [
+        McpServerConfig(name="tools", url="https://93.184.216.34/mcp"),
+        McpServerConfig(name="tools", url="https://93.184.216.35/mcp"),
+    ]
+    with pytest.raises(HTTPException) as exc_info:
+        await _call_prepare_gateway_tools(ctx, mcp_servers=dupes)
+
+    assert exc_info.value.status_code == 400
+    assert "tools" in str(exc_info.value.detail)
+    assert settlement.refunded == 1
+
+
+@pytest.mark.asyncio
+async def test_duplicate_mcp_server_name_against_a_stored_server_releases_reservation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An inline server whose name matches a workspace's stored server is refused, not silently dropped."""
+    settlement = _Settlement()
+    settlement.install(monkeypatch)
+
+    async def stored(*args: Any, **kwargs: Any) -> list[McpServerConfig]:
+        return [McpServerConfig(name="tools", url="https://93.184.216.35/mcp")]
+
+    monkeypatch.setattr(pipeline, "resolve_workspace_mcp_servers", stored)
+
+    ctx = _ctx(GatewayConfig(), db=cast(Any, object()), reservation=_reservation(), workspace_id=uuid.uuid4())
+    with pytest.raises(HTTPException) as exc_info:
+        await _call_prepare_gateway_tools(
+            ctx,
+            mcp_servers=[McpServerConfig(name="tools", url="https://93.184.216.34/mcp")],
+            mcp_server_ids=[cast(Any, "11111111-1111-1111-1111-111111111111")],
+        )
+
+    assert exc_info.value.status_code == 400
     assert settlement.refunded == 1
 
 


### PR DESCRIPTION
## Description

`MCPClientPool.__aenter__` builds `self._servers` keyed by `cfg.name` with no
uniqueness check:

```python
for cfg in self._configs:
    self._servers[cfg.name] = await self._connect(cfg)
```

Two servers sharing a name collapse into one dict slot: the earlier server's
tools disappear from `openai_tools` (so the model never picks them
spontaneously), but `_tool_owner` still maps its tool names to the shared
`cfg.name` key, and that entry is never revisited. If a caller's own
`tools` list happens to name one of those stale tools, `call_tool` resolves
`_tool_owner[name]` and dispatches to whichever server survived, sending the
caller's tool arguments (and the surviving server's `Authorization` header)
to a server the call was never meant for.

This can happen within a single request's inline `mcp_servers`, or between
an inline server and a workspace's stored one (the hybrid case): the
platform enforces name uniqueness per workspace, but nothing checks an
inline name against a resolved platform name before the two lists merge.

`prepare_gateway_tools` already validates `mcp_servers` for URL safety at
this same merge point (`_validate_mcp_server_urls`); this adds the matching
uniqueness check, rejecting a duplicate with a 400 naming the repeated
server before the pool is ever constructed. Every production caller of
`MCPClientPool` gets its configs from this one merged list, so a single
check here covers the non-streaming, streaming, and eager-open paths.

Verification:
- New regression tests fail on unmodified `main` (`DID NOT RAISE
  HTTPException`) and pass on this branch, exercising the real
  `prepare_gateway_tools` entry point rather than the pool directly: two
  inline servers sharing a name, and an inline server colliding with a
  mocked stored one.
- Full `tests/unit` suite green (2487 passed, 8 pre-existing skips).
- `make lint`, `make typecheck`, `make openapi-check` all clean; no API
  contract changed, so no OpenAPI regen was needed.
- Not verified: `tests/integration` (needs Testcontainers Postgres, not
  exercised for this change since it touches no database code) and a live
  MCP session; the fix and its tests operate on the pure validation path.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #591

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [ ] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** Claude (Anthropic)

**Any additional AI details you'd like to share:** Root cause, fix, and tests drafted with an AI coding agent operating autonomously, with the verification described above run in a clean container against this repo's own gates.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Rejects duplicate MCP server names before they can hide tools or route calls to the wrong server.

## Changes

- Added validation for duplicate inline names and inline/stored name collisions.
- Added a defensive duplicate-name check in `MCPClientPool`.
- Added tests for HTTP 400 responses, reservation refunds, and pool behavior.
- Prevented stored server names from appearing in collision error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->