### PR TITLE
feat(api): expose managed MCP activity in Messages streams

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -24,6 +24,24 @@ When the model emits an MCP tool call, Otari:
 The loop stops when the model returns a normal assistant response or hits
 `max_tool_iterations`.
 
+## Messages streaming activity
+
+A streaming `/v1/messages` client receives live server-owned activity around
+each gateway-run MCP call. Otari emits a `content_block_start` /
+`content_block_stop` pair containing `mcp_tool_use` immediately before the call,
+then another pair containing the matching `mcp_tool_result` immediately after it.
+The blocks carry an opaque call id, tool and server names, parsed input, result
+content, and an explicit `is_error` value.
+
+These blocks report execution; they do not transfer it. Otari still owns the MCP
+call, feeds the result into the internal model loop, and returns one logical
+Messages stream. The server URL, authorization token, and headers are never
+included. If a client echoes the accumulated assistant message on a later turn,
+Otari removes its activity pairs before forwarding the history upstream.
+
+Chat Completions and Responses streams continue to hide gateway-run MCP activity
+because those formats have no equivalent server-owned MCP vocabulary.
+
 ## Inline MCP servers
 
 ```json

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -26,12 +26,14 @@ The loop stops when the model returns a normal assistant response or hits
 
 ## Messages streaming activity
 
-A streaming `/v1/messages` client receives live server-owned activity around
+A streaming `/v1/messages` client that includes
+`betas: ["mcp-client-2025-04-04"]` receives live server-owned activity around
 each gateway-run MCP call. Otari emits a `content_block_start` /
 `content_block_stop` pair containing `mcp_tool_use` immediately before the call,
 then another pair containing the matching `mcp_tool_result` immediately after it.
 The blocks carry an opaque call id, tool and server names, parsed input, result
-content, and an explicit `is_error` value.
+content, and an explicit `is_error` value. Without that beta declaration, Otari
+still runs the MCP call but returns a stable stream without those activity blocks.
 
 These blocks report execution; they do not transfer it. Otari still owns the MCP
 call, feeds the result into the internal model loop, and returns one logical

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -26,13 +26,15 @@ The loop stops when the model returns a normal assistant response or hits
 
 ## Messages streaming activity
 
-For streaming `/v1/messages` requests with
-`betas: ["mcp-client-2025-04-04"]`, Otari emits server-owned activity around
-each gateway-run MCP call. An `mcp_tool_use` block starts immediately before
-execution with an opaque call id, tool and server names, and parsed input. A
-matching `mcp_tool_result` block follows with the result content and `is_error`
-value. Each block uses a `content_block_start` / `content_block_stop` pair.
-Without the beta, Otari still runs the call but omits these activity blocks.
+For streaming `/v1/messages` requests with the standard Anthropic header
+`anthropic-beta: mcp-client-2025-11-20`, Otari emits server-owned activity
+around each gateway-run MCP call. The legacy `mcp-client-2025-04-04` beta and
+the body form `betas: ["mcp-client-2025-04-04"]` remain supported for existing
+callers. An `mcp_tool_use` block starts immediately before execution with an
+opaque call id, tool and server names, and parsed input. A matching
+`mcp_tool_result` block follows with the result content and `is_error` value.
+Each block uses a `content_block_start` / `content_block_stop` pair. Without an
+MCP client beta, Otari still runs the call but omits these activity blocks.
 
 The blocks report execution without transferring it: Otari runs the call, feeds
 the result back to the model, and returns one logical Messages stream. It strips

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -28,10 +28,10 @@ The loop stops when the model returns a normal assistant response or hits
 
 For streaming `/v1/messages` requests with the standard Anthropic header
 `anthropic-beta: mcp-client-2025-11-20`, Otari emits server-owned activity
-around each gateway-run MCP call. The legacy `mcp-client-2025-04-04` beta and
-the body form `betas: ["mcp-client-2025-04-04"]` remain supported for existing
-callers. An `mcp_tool_use` block starts immediately before execution with an
-opaque call id, tool and server names, and parsed input. A matching
+around each gateway-run MCP call. The body form
+`betas: ["mcp-client-2025-11-20"]` is also accepted. An `mcp_tool_use` block
+starts immediately before execution with an opaque call id, tool and server
+names, and parsed input. A matching
 `mcp_tool_result` block follows with the result content and `is_error` value.
 Each block uses a `content_block_start` / `content_block_stop` pair. Without an
 MCP client beta, Otari still runs the call but omits these activity blocks.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -26,23 +26,19 @@ The loop stops when the model returns a normal assistant response or hits
 
 ## Messages streaming activity
 
-A streaming `/v1/messages` client that includes
-`betas: ["mcp-client-2025-04-04"]` receives live server-owned activity around
-each gateway-run MCP call. Otari emits a `content_block_start` /
-`content_block_stop` pair containing `mcp_tool_use` immediately before the call,
-then another pair containing the matching `mcp_tool_result` immediately after it.
-The blocks carry an opaque call id, tool and server names, parsed input, result
-content, and an explicit `is_error` value. Without that beta declaration, Otari
-still runs the MCP call but returns a stable stream without those activity blocks.
+For streaming `/v1/messages` requests with
+`betas: ["mcp-client-2025-04-04"]`, Otari emits server-owned activity around
+each gateway-run MCP call. An `mcp_tool_use` block starts immediately before
+execution with an opaque call id, tool and server names, and parsed input. A
+matching `mcp_tool_result` block follows with the result content and `is_error`
+value. Each block uses a `content_block_start` / `content_block_stop` pair.
+Without the beta, Otari still runs the call but omits these activity blocks.
 
-These blocks report execution; they do not transfer it. Otari still owns the MCP
-call, feeds the result into the internal model loop, and returns one logical
-Messages stream. The server URL, authorization token, and headers are never
-included. If a client echoes the accumulated assistant message on a later turn,
-Otari removes its activity pairs before forwarding the history upstream.
-
-Chat Completions and Responses streams continue to hide gateway-run MCP activity
-because those formats have no equivalent server-owned MCP vocabulary.
+The blocks report execution without transferring it: Otari runs the call, feeds
+the result back to the model, and returns one logical Messages stream. It strips
+the blocks from history echoed on later turns and never includes the server URL,
+authorization token, or headers. Chat Completions and Responses streams continue
+to hide this activity because they have no equivalent server-owned MCP vocabulary.
 
 ## Inline MCP servers
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -73,6 +73,9 @@ Responses and Messages can expose native server-tool result blocks when their
 wire format expects them. Chat Completions returns only the final assistant
 message. Calls for tools the client must execute are preserved.
 
+For gateway-run MCP activity in Messages streams, see
+[Messages streaming activity](mcp.md#messages-streaming-activity).
+
 ## Code execution
 
 Start the bundled sandbox:

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -167,26 +167,7 @@ def _is_gateway_minted_mcp_block(block: Any) -> bool:
     return str(activity_id or "").startswith(MCP_ACTIVITY_ID_PREFIX)
 
 
-def _has_gateway_minted_mcp_blocks(messages: Any) -> bool:
-    """Whether an inbound transcript contains Otari-provenance MCP activity."""
-    if not isinstance(messages, list):
-        return False
-    for message in messages:
-        if not isinstance(message, dict):
-            continue
-        content = message.get("content")
-        if not isinstance(content, list):
-            continue
-        if any(_is_gateway_minted_mcp_block(block) for block in content):
-            return True
-    return False
-
-
-def _strip_gateway_minted_blocks(
-    messages: Any,
-    *,
-    strip_web_search: bool = True,
-) -> Any:
+def _strip_gateway_minted_blocks(messages: Any) -> Any:
     """Drop this gateway's own server-tool blocks from inbound ``messages``.
 
     Continuing an Anthropic conversation means echoing the previous assistant turn.
@@ -214,11 +195,9 @@ def _strip_gateway_minted_blocks(
             continue
         # Two passes: identify our web-search results and our provenance-prefixed
         # MCP uses, then drop each complete pair. A provider's pair matches neither.
-        minted_web_ids = (
-            {block.get("tool_use_id") for block in content if _is_gateway_minted_result(block)}
-            if strip_web_search
-            else set()
-        )
+        minted_web_ids = {
+            block.get("tool_use_id") for block in content if _is_gateway_minted_result(block)
+        }
         minted_mcp_ids = {
             block.get("id") if block.get("type") == "mcp_tool_use" else block.get("tool_use_id")
             for block in content
@@ -593,16 +572,12 @@ async def create_message(
     """
     user_from_metadata = request.metadata.get("user_id") if request.metadata else None
 
-    # Remove replayed gateway-owned MCP activity before admission derives prompt
+    # Remove replayed gateway-owned activity before admission derives prompt
     # size. Waiting until request_fields are built below would reserve against
     # result content that never reaches the provider and can falsely reject or
-    # overcharge the request. Web-search stripping remains gated later because
-    # its provenance depends on the resolved interception configuration.
-    if _has_gateway_minted_mcp_blocks(request.messages):
-        request.messages = _strip_gateway_minted_blocks(
-            request.messages,
-            strip_web_search=False,
-        )
+    # overcharge the request. Provenance comes from each block, so this is
+    # independent of whether the current request enables the same tool again.
+    request.messages = _strip_gateway_minted_blocks(request.messages)
 
     async def _normalize(
         user_id: str,
@@ -693,9 +668,6 @@ async def create_message(
     scope_prompt_cache_key(request_fields, ctx)
     if request_fields.get("tools"):
         request_fields["tools"] = openai_to_anthropic_tools(request_fields["tools"])
-    inbound_messages = request_fields.get("messages")
-    if inbound_messages and tool_ctx.intercepts_web_search:
-        request_fields["messages"] = _strip_gateway_minted_blocks(inbound_messages)
     if tool_ctx.use_sandbox:
         # ``container`` addresses Anthropic's own code-execution container, and
         # the gateway sandbox owns execution for this request, so the provider

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -153,8 +153,22 @@ def _is_gateway_minted_result(block: Any) -> bool:
     return all(isinstance(hit, dict) and not hit.get("encrypted_content") for hit in hits)
 
 
+def _is_gateway_minted_mcp_block(block: Any) -> bool:
+    """Whether ``block`` carries this gateway's reserved MCP activity prefix."""
+    if not isinstance(block, dict):
+        return False
+    block_type = block.get("type")
+    if block_type == "mcp_tool_use":
+        activity_id = block.get("id")
+    elif block_type == "mcp_tool_result":
+        activity_id = block.get("tool_use_id")
+    else:
+        return False
+    return str(activity_id or "").startswith(MCP_ACTIVITY_ID_PREFIX)
+
+
 def _has_gateway_minted_mcp_blocks(messages: Any) -> bool:
-    """Whether an inbound transcript contains an Otari-provenance MCP use block."""
+    """Whether an inbound transcript contains Otari-provenance MCP activity."""
     if not isinstance(messages, list):
         return False
     for message in messages:
@@ -163,12 +177,7 @@ def _has_gateway_minted_mcp_blocks(messages: Any) -> bool:
         content = message.get("content")
         if not isinstance(content, list):
             continue
-        if any(
-            isinstance(block, dict)
-            and block.get("type") == "mcp_tool_use"
-            and str(block.get("id") or "").startswith(MCP_ACTIVITY_ID_PREFIX)
-            for block in content
-        ):
+        if any(_is_gateway_minted_mcp_block(block) for block in content):
             return True
     return False
 
@@ -211,11 +220,9 @@ def _strip_gateway_minted_blocks(
             else set()
         )
         minted_mcp_ids = {
-            block.get("id")
+            block.get("id") if block.get("type") == "mcp_tool_use" else block.get("tool_use_id")
             for block in content
-            if isinstance(block, dict)
-            and block.get("type") == "mcp_tool_use"
-            and str(block.get("id") or "").startswith(MCP_ACTIVITY_ID_PREFIX)
+            if _is_gateway_minted_mcp_block(block)
         }
         kept_blocks = [block for block in content if not _is_minted_pair_member(block, minted_web_ids, minted_mcp_ids)]
         if len(kept_blocks) == len(content):
@@ -687,11 +694,7 @@ async def create_message(
     if request_fields.get("tools"):
         request_fields["tools"] = openai_to_anthropic_tools(request_fields["tools"])
     inbound_messages = request_fields.get("messages")
-    if inbound_messages and (
-        tool_ctx.intercepts_web_search
-        or tool_ctx.mcp_server_configs
-        or _has_gateway_minted_mcp_blocks(inbound_messages)
-    ):
+    if inbound_messages and tool_ctx.intercepts_web_search:
         request_fields["messages"] = _strip_gateway_minted_blocks(inbound_messages)
     if tool_ctx.use_sandbox:
         # ``container`` addresses Anthropic's own code-execution container, and

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -72,6 +72,14 @@ from gateway.types.attempt import Attempt
 router = APIRouter(prefix="/v1", tags=["messages"])
 
 
+def _merge_anthropic_betas(body_betas: list[str] | None, raw_request: Request) -> list[str] | None:
+    """Combine legacy body betas with Anthropic's standard beta header."""
+    betas = list(body_betas or [])
+    for header_value in raw_request.headers.getlist("anthropic-beta"):
+        betas.extend(beta.strip() for beta in header_value.split(",") if beta.strip())
+    return list(dict.fromkeys(betas)) or None
+
+
 class MessagesRequest(derive_request_base(MessagesParams)):  # type: ignore[misc]
     """Anthropic Messages API-compatible request.
 
@@ -571,6 +579,9 @@ async def create_message(
     applies up to the pre-lock-in point, same as chat).
     """
     user_from_metadata = request.metadata.get("user_id") if request.metadata else None
+    merged_betas = _merge_anthropic_betas(request.betas, raw_request)
+    if merged_betas is not None:
+        request.betas = merged_betas
 
     # Remove replayed gateway-owned activity before admission derives prompt
     # size. Waiting until request_fields are built below would reserve against

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -62,6 +62,7 @@ from gateway.services.mcp_loop import ToolBackend
 from gateway.services.mcp_loop_messages import (
     MAX_TOOL_ITERATIONS_CAP,
     MCP_ACTIVITY_ID_PREFIX,
+    MCP_CLIENT_BETA,
     anthropic_tool_loop,
     anthropic_tool_loop_stream,
 )
@@ -78,6 +79,21 @@ def _merge_anthropic_betas(body_betas: list[str] | None, raw_request: Request) -
     for header_value in raw_request.headers.getlist("anthropic-beta"):
         betas.extend(beta.strip() for beta in header_value.split(",") if beta.strip())
     return list(dict.fromkeys(betas)) or None
+
+
+def _split_mcp_client_beta(kwargs: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    """Consume the client capability without forwarding it to the model provider."""
+    betas = kwargs.get("betas")
+    if not isinstance(betas, list) or MCP_CLIENT_BETA not in betas:
+        return kwargs, False
+
+    provider_kwargs = {**kwargs}
+    provider_betas = [beta for beta in betas if beta != MCP_CLIENT_BETA]
+    if provider_betas:
+        provider_kwargs["betas"] = provider_betas
+    else:
+        provider_kwargs.pop("betas")
+    return provider_kwargs, True
 
 
 class MessagesRequest(derive_request_base(MessagesParams)):  # type: ignore[misc]
@@ -437,10 +453,12 @@ class _MessagesAdapter:
         return isinstance(chunk, MessageDeltaEvent)
 
     async def call_provider(self, kwargs: dict[str, Any]) -> MessageResponse:
-        return await amessages(**kwargs)  # type: ignore[return-value]
+        provider_kwargs, _ = _split_mcp_client_beta(kwargs)
+        return await amessages(**provider_kwargs)  # type: ignore[return-value]
 
     async def open_provider_stream(self, kwargs: dict[str, Any]) -> AsyncIterator[MessageStreamEvent]:
-        return await amessages(**kwargs)  # type: ignore[return-value]
+        provider_kwargs, _ = _split_mcp_client_beta(kwargs)
+        return await amessages(**provider_kwargs)  # type: ignore[return-value]
 
     def prepare_stream_kwargs(
         self,
@@ -466,8 +484,9 @@ class _MessagesAdapter:
         extra: dict[str, Any] = {}
         if on_first_response is not None:
             extra["on_first_response"] = on_first_response
+        provider_kwargs, _ = _split_mcp_client_beta(kwargs)
         return await anthropic_tool_loop(
-            completion_kwargs=kwargs,
+            completion_kwargs=provider_kwargs,
             pool=pool,
             max_iterations=max_iterations,
             emit_native_web_search=emit_native_web_search,
@@ -482,11 +501,16 @@ class _MessagesAdapter:
         *,
         emit_native_web_search: bool = False,
     ) -> AsyncIterator[MessageStreamEvent]:
+        provider_kwargs, emit_native_mcp = _split_mcp_client_beta(kwargs)
+        extra: dict[str, Any] = {}
+        if emit_native_mcp:
+            extra["emit_native_mcp"] = True
         return anthropic_tool_loop_stream(
-            completion_kwargs=kwargs,
+            completion_kwargs=provider_kwargs,
             pool=pool,
             max_iterations=max_iterations,
             emit_native_web_search=emit_native_web_search,
+            **extra,
         )
 
     def inject_hints(

--- a/src/gateway/api/routes/messages.py
+++ b/src/gateway/api/routes/messages.py
@@ -61,6 +61,7 @@ from gateway.services.log_writer import LogWriter
 from gateway.services.mcp_loop import ToolBackend
 from gateway.services.mcp_loop_messages import (
     MAX_TOOL_ITERATIONS_CAP,
+    MCP_ACTIVITY_ID_PREFIX,
     anthropic_tool_loop,
     anthropic_tool_loop_stream,
 )
@@ -152,22 +153,43 @@ def _is_gateway_minted_result(block: Any) -> bool:
     return all(isinstance(hit, dict) and not hit.get("encrypted_content") for hit in hits)
 
 
-def _strip_gateway_minted_blocks(messages: Any) -> Any:
+def _has_gateway_minted_mcp_blocks(messages: Any) -> bool:
+    """Whether an inbound transcript contains an Otari-provenance MCP use block."""
+    if not isinstance(messages, list):
+        return False
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        if any(
+            isinstance(block, dict)
+            and block.get("type") == "mcp_tool_use"
+            and str(block.get("id") or "").startswith(MCP_ACTIVITY_ID_PREFIX)
+            for block in content
+        ):
+            return True
+    return False
+
+
+def _strip_gateway_minted_blocks(
+    messages: Any,
+    *,
+    strip_web_search: bool = True,
+) -> Any:
     """Drop this gateway's own server-tool blocks from inbound ``messages``.
 
-    Continuing an Anthropic conversation means echoing the previous assistant turn,
-    and a gateway-minted ``web_search_tool_result`` carries an ``encrypted_content``
-    the gateway cannot sign, so an echoed turn would ship an unsignable block to a
-    provider. Mirrors ``responses._strip_gateway_minted_items``, but where Responses
-    has no way to tell its own minted items from a provider's, here it can: only
-    blocks with gateway provenance are removed (see
-    :func:`_is_gateway_minted_result`), so a genuine provider-run search's signed
-    blocks round-trip untouched even with interception on. A `server_tool_use` is
-    removed only alongside the gateway-minted result that answers it, matched by
-    ``tool_use_id``, so a provider's pair is never split.
-
-    Only called when interception is active (opted in, with a backend configured),
-    which is the only way one of our blocks can be in a transcript at all.
+    Continuing an Anthropic conversation means echoing the previous assistant turn.
+    A gateway-minted ``web_search_tool_result`` carries an ``encrypted_content`` the
+    gateway cannot sign, while a gateway-minted MCP pair describes execution the
+    internal loop already consumed. Neither should be shipped to a provider on the
+    next request. Mirrors ``responses._strip_gateway_minted_items``, but where
+    Responses has no way to tell its own minted items from a provider's, here it can:
+    web search uses the empty signed-content field and MCP uses an Otari-prefixed call
+    id. Genuine provider-run pairs therefore round-trip untouched. Each use is removed
+    only alongside the result that answers it, matched by ``tool_use_id``, so a
+    provider's pair is never split.
 
     A message left with no content is dropped: an empty ``content`` array is rejected
     by the API, and a turn that held nothing but our pair has nothing left to say.
@@ -181,12 +203,21 @@ def _strip_gateway_minted_blocks(messages: Any) -> Any:
         if not isinstance(content, list):
             kept_messages.append(message)
             continue
-        # Two passes: identify our result blocks, then drop them along with the
-        # server_tool_use each one answers. A provider's pair matches neither.
-        minted_ids = {
-            block.get("tool_use_id") for block in content if _is_gateway_minted_result(block)
+        # Two passes: identify our web-search results and our provenance-prefixed
+        # MCP uses, then drop each complete pair. A provider's pair matches neither.
+        minted_web_ids = (
+            {block.get("tool_use_id") for block in content if _is_gateway_minted_result(block)}
+            if strip_web_search
+            else set()
+        )
+        minted_mcp_ids = {
+            block.get("id")
+            for block in content
+            if isinstance(block, dict)
+            and block.get("type") == "mcp_tool_use"
+            and str(block.get("id") or "").startswith(MCP_ACTIVITY_ID_PREFIX)
         }
-        kept_blocks = [block for block in content if not _is_minted_pair_member(block, minted_ids)]
+        kept_blocks = [block for block in content if not _is_minted_pair_member(block, minted_web_ids, minted_mcp_ids)]
         if len(kept_blocks) == len(content):
             kept_messages.append(message)
             continue
@@ -198,13 +229,22 @@ def _strip_gateway_minted_blocks(messages: Any) -> Any:
     return kept_messages
 
 
-def _is_minted_pair_member(block: Any, minted_ids: set[Any]) -> bool:
+def _is_minted_pair_member(
+    block: Any,
+    minted_web_ids: set[Any],
+    minted_mcp_ids: set[Any],
+) -> bool:
     """Whether ``block`` is one half of a gateway-minted server-tool pair."""
     if not isinstance(block, dict):
         return False
     if _is_gateway_minted_result(block):
-        return True
-    return block.get("type") == "server_tool_use" and block.get("id") in minted_ids
+        return block.get("tool_use_id") in minted_web_ids
+    block_type = block.get("type")
+    if block_type == "server_tool_use":
+        return block.get("id") in minted_web_ids
+    if block_type == "mcp_tool_use":
+        return block.get("id") in minted_mcp_ids
+    return block_type == "mcp_tool_result" and block.get("tool_use_id") in minted_mcp_ids
 
 
 def _anthropic_error(error_type: str, message: str, status_code: int) -> HTTPException:
@@ -546,6 +586,17 @@ async def create_message(
     """
     user_from_metadata = request.metadata.get("user_id") if request.metadata else None
 
+    # Remove replayed gateway-owned MCP activity before admission derives prompt
+    # size. Waiting until request_fields are built below would reserve against
+    # result content that never reaches the provider and can falsely reject or
+    # overcharge the request. Web-search stripping remains gated later because
+    # its provenance depends on the resolved interception configuration.
+    if _has_gateway_minted_mcp_blocks(request.messages):
+        request.messages = _strip_gateway_minted_blocks(
+            request.messages,
+            strip_web_search=False,
+        )
+
     async def _normalize(
         user_id: str,
         provider: LLMProvider | None,
@@ -635,8 +686,13 @@ async def create_message(
     scope_prompt_cache_key(request_fields, ctx)
     if request_fields.get("tools"):
         request_fields["tools"] = openai_to_anthropic_tools(request_fields["tools"])
-    if tool_ctx.intercepts_web_search and request_fields.get("messages"):
-        request_fields["messages"] = _strip_gateway_minted_blocks(request_fields["messages"])
+    inbound_messages = request_fields.get("messages")
+    if inbound_messages and (
+        tool_ctx.intercepts_web_search
+        or tool_ctx.mcp_server_configs
+        or _has_gateway_minted_mcp_blocks(inbound_messages)
+    ):
+        request_fields["messages"] = _strip_gateway_minted_blocks(inbound_messages)
     if tool_ctx.use_sandbox:
         # ``container`` addresses Anthropic's own code-execution container, and
         # the gateway sandbox owns execution for this request, so the provider

--- a/src/gateway/services/_tool_loop.py
+++ b/src/gateway/services/_tool_loop.py
@@ -148,16 +148,17 @@ class StreamToolLoopStrategy(Protocol, Generic[ChunkT, StateT, AccT]):
 
     def accumulate_stream_usage(self, acc: AccT, state: StateT) -> None: ...
 
-    async def advance_stream_transcript(
+    def advance_stream_transcript(
         self,
         transcript: list[Any],
         state: StateT,
         pool: ToolBackend,
-    ) -> None: ...
+        acc: AccT,
+    ) -> AsyncIterator[ChunkT]: ...
 
     def synthetic_events(self, state: StateT, acc: AccT) -> list[ChunkT]: ...
 
-    async def finalize_exit(self, state: StateT, pool: ToolBackend) -> None: ...
+    def finalize_exit(self, state: StateT, pool: ToolBackend, acc: AccT) -> AsyncIterator[ChunkT]: ...
 
 
 def _prepare(
@@ -293,6 +294,9 @@ async def run_tool_loop_stream(
     events are forwarded, with cumulative usage folded in where the format
     supports it) and continuing (the terminal events are dropped, their usage
     accumulated, the owned calls executed, and the next round dispatched).
+    Execution hooks are async iterators so a format can yield truthful server-tool
+    start and completion events around the awaited call without transferring
+    execution ownership to the client.
 
     The upstream stream is closed when the loop stops consuming it early;
     see :func:`_stream_scope`.
@@ -331,13 +335,15 @@ async def run_tool_loop_stream(
             # search and would get silence. Executing them for their side effects is
             # what the non-streaming loop already does before returning a mixed
             # result (see ``run_tool_loop``), so the two agree.
-            await strategy.finalize_exit(state, pool)
+            async for activity in strategy.finalize_exit(state, pool, acc):
+                yield activity
             for terminal in strategy.terminal_events(state, acc):
                 yield terminal
             return
 
         strategy.accumulate_stream_usage(acc, state)
-        await strategy.advance_stream_transcript(transcript, state, pool)
+        async for activity in strategy.advance_stream_transcript(transcript, state, pool, acc):
+            yield activity
         # A format with a native vocabulary for server-side tool calls announces
         # the calls the gateway just ran, in place of the raw tool-call events that
         # were swallowed. Formats without one return nothing.

--- a/src/gateway/services/mcp_client.py
+++ b/src/gateway/services/mcp_client.py
@@ -44,10 +44,12 @@ def mcp_tool_to_openai(tool: MCPTool) -> dict[str, Any]:
 
 @dataclass(frozen=True)
 class MCPToolCallOutcome:
-    """Rendered MCP result plus the server's explicit error classification."""
+    """Model-facing and client-facing renderings of one MCP result."""
 
     content: str
+    activity_content: str
     is_error: bool
+    transport_error: bool = False
 
 
 @dataclass
@@ -138,23 +140,35 @@ class MCPClientPool:
 
         The Messages stream uses this richer form for server-owned activity
         events. Other API formats keep using :meth:`call_tool`, which returns the
-        same model-facing text as before.
+        model-facing text. Transport failures are converted here so their URLs,
+        headers, or credentials cannot reach logs or a model provider through any
+        API format.
         """
         owner = self._tool_owner.get(name)
         if owner is None:
             raise KeyError(f"No MCP server owns tool {name!r}")
         try:
             result = await self._servers[owner].session.call_tool(name, arguments)
-        except Exception:
+        except Exception as exc:
             if self._tally is not None:
                 self._tally.record_failure(name)
-            raise
+            logger.warning("MCP tool %s execution failed: %s", name, type(exc).__name__)
+            return MCPToolCallOutcome(
+                content="[tool error] MCP tool execution failed",
+                activity_content="MCP tool execution failed",
+                is_error=True,
+                transport_error=True,
+            )
         parts = [_render_content_block(block) for block in result.content]
         flattened = "\n".join(p for p in parts if p)
         rendered = f"[tool error] {flattened}" if result.isError else flattened
         if self._tally is not None:
             self._tally.record_result(name, rendered)
-        return MCPToolCallOutcome(content=rendered, is_error=bool(result.isError))
+        return MCPToolCallOutcome(
+            content=rendered,
+            activity_content=flattened,
+            is_error=bool(result.isError),
+        )
 
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
         """Execute a tool call against its owning MCP server and flatten the result to text.

--- a/src/gateway/services/mcp_client.py
+++ b/src/gateway/services/mcp_client.py
@@ -42,6 +42,14 @@ def mcp_tool_to_openai(tool: MCPTool) -> dict[str, Any]:
     }
 
 
+@dataclass(frozen=True)
+class MCPToolCallOutcome:
+    """Rendered MCP result plus the server's explicit error classification."""
+
+    content: str
+    is_error: bool
+
+
 @dataclass
 class _ConnectedServer:
     name: str
@@ -121,19 +129,16 @@ class MCPClientPool:
     def purpose_hints(self) -> list[tuple[str, str]]:
         return [(s.name, s.purpose_hint) for s in self._servers.values() if s.purpose_hint]
 
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
-        """Execute a tool call against its owning MCP server and flatten the result to text.
+    def server_name_for_tool(self, name: str) -> str | None:
+        """Return the configured server that owns ``name``, if connected."""
+        return self._tool_owner.get(name)
 
-        MCP supports rich content blocks (image, embedded resource, structured data). This
-        flattener concatenates text blocks verbatim and renders non-text blocks as a brief
-        ``[type=…]`` placeholder so the model can at least see that *something* came back.
-        For tools that return images or large embedded resources, this is intentionally
-        lossy — fine for the current text-tool use case, but a future improvement is to
-        pass image content through as multimodal message blocks when the model supports it.
+    async def call_tool_outcome(self, name: str, arguments: dict[str, Any]) -> MCPToolCallOutcome:
+        """Execute an MCP call and preserve its explicit ``isError`` status.
 
-        The call is recorded on the request's tally (see
-        :class:`gateway.services.tool_usage.ToolUsageTally`); an ``isError`` result
-        is counted and never billed.
+        The Messages stream uses this richer form for server-owned activity
+        events. Other API formats keep using :meth:`call_tool`, which returns the
+        same model-facing text as before.
         """
         owner = self._tool_owner.get(name)
         if owner is None:
@@ -149,7 +154,23 @@ class MCPClientPool:
         rendered = f"[tool error] {flattened}" if result.isError else flattened
         if self._tally is not None:
             self._tally.record_result(name, rendered)
-        return rendered
+        return MCPToolCallOutcome(content=rendered, is_error=bool(result.isError))
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str:
+        """Execute a tool call against its owning MCP server and flatten the result to text.
+
+        MCP supports rich content blocks (image, embedded resource, structured data). This
+        flattener concatenates text blocks verbatim and renders non-text blocks as a brief
+        ``[type=…]`` placeholder so the model can at least see that *something* came back.
+        For tools that return images or large embedded resources, this is intentionally
+        lossy — fine for the current text-tool use case, but a future improvement is to
+        pass image content through as multimodal message blocks when the model supports it.
+
+        The call is recorded on the request's tally (see
+        :class:`gateway.services.tool_usage.ToolUsageTally`); an ``isError`` result
+        is counted and never billed.
+        """
+        return (await self.call_tool_outcome(name, arguments)).content
 
 
 def _render_content_block(block: Any) -> str:

--- a/src/gateway/services/mcp_loop.py
+++ b/src/gateway/services/mcp_loop.py
@@ -456,9 +456,14 @@ class _ChatToolLoopStrategy:
         # the foreign calls" contract the non-streaming loop applies.
         return has_foreign or not state.mcp_calls
 
-    async def finalize_exit(self, state: _ChatStreamState, pool: ToolBackend) -> None:
+    async def finalize_exit(
+        self, state: _ChatStreamState, pool: ToolBackend, acc: None
+    ) -> AsyncIterator[ChatCompletionChunk]:
+        del acc
         if state.mcp_calls:
             await _execute_mcp_calls(pool, state.mcp_calls)
+        return
+        yield  # pragma: no cover - makes this a no-event async iterator
 
     def terminal_events(self, state: _ChatStreamState, acc: None) -> list[ChatCompletionChunk]:
         return [state.pending_terminal] if state.pending_terminal is not None else []
@@ -476,11 +481,15 @@ class _ChatToolLoopStrategy:
         transcript: list[Any],
         state: _ChatStreamState,
         pool: ToolBackend,
-    ) -> None:
+        acc: None,
+    ) -> AsyncIterator[ChatCompletionChunk]:
+        del acc
         # All-MCP: the terminal chunk was silently dropped so the client
         # doesn't think this iteration's response was the final answer.
         transcript.append({"role": "assistant", "tool_calls": state.mcp_calls})
         transcript.extend(await _execute_mcp_calls(pool, state.mcp_calls))
+        return
+        yield  # pragma: no cover - makes this a no-event async iterator
 
 
 _CHAT_STRATEGY = _ChatToolLoopStrategy()

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -366,10 +366,10 @@ async def _call_stream_tool(
             return outcome.content, outcome.is_error, False
         text = await pool.call_tool(name, arguments)
         return text, is_tool_error(text), False
-    except Exception:  # noqa: BLE001 - recoverable tool failure is model input
+    except Exception as exc:  # noqa: BLE001 - recoverable tool failure is model input
         # Transport exceptions may include URLs, headers, or credentials. Neither
         # logs, client events, nor the model-facing result may receive that detail.
-        logger.warning("Gateway tool %s execution failed", name)
+        logger.warning("Gateway tool %s execution failed: %s", name, type(exc).__name__)
         detail = "MCP tool execution failed" if mcp_backend is not None else "Gateway tool execution failed"
         return f"[tool error] {detail}", True, True
 

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -66,6 +66,7 @@ __all__ = [
     "MaxToolIterationsExceeded",
     "MCP_ACTIVITY_ID_PREFIX",
     "MCP_CLIENT_BETA",
+    "MCP_CLIENT_BETA_LEGACY",
     "anthropic_tool_loop",
     "anthropic_tool_loop_stream",
 ]
@@ -83,9 +84,11 @@ _PAGE_AGE_MAX_CHARS = 128
 # provider-native MCP blocks.
 MCP_ACTIVITY_ID_PREFIX = "otari_mcptoolu_"
 
-# Anthropic beta capability a caller must declare before the Messages stream
+# Anthropic beta capabilities a caller may declare before the Messages stream
 # includes the beta-only MCP activity block vocabulary.
-MCP_CLIENT_BETA = "mcp-client-2025-04-04"
+MCP_CLIENT_BETA = "mcp-client-2025-11-20"
+MCP_CLIENT_BETA_LEGACY = "mcp-client-2025-04-04"
+_MCP_CLIENT_BETAS = frozenset({MCP_CLIENT_BETA, MCP_CLIENT_BETA_LEGACY})
 
 
 def _native_web_search_blocks(query: str, results: list[dict[str, Any]]) -> list[Any]:
@@ -892,7 +895,7 @@ async def anthropic_tool_loop_stream(
     natural ``message_start`` arrives downstream as if nothing had happened.
     """
     betas = completion_kwargs.get("betas")
-    emit_native_mcp = isinstance(betas, list) and MCP_CLIENT_BETA in betas
+    emit_native_mcp = isinstance(betas, list) and not _MCP_CLIENT_BETAS.isdisjoint(betas)
 
     # aclosing makes downstream closes (client disconnect) propagate to the
     # engine generator, and through it to the upstream provider stream,

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -65,6 +65,7 @@ __all__ = [
     "MAX_TOOL_ITERATIONS_CAP",
     "MaxToolIterationsExceeded",
     "MCP_ACTIVITY_ID_PREFIX",
+    "MCP_CLIENT_BETA",
     "anthropic_tool_loop",
     "anthropic_tool_loop_stream",
 ]
@@ -81,6 +82,10 @@ _PAGE_AGE_MAX_CHARS = 128
 # route uses this prefix to remove only our synthetic pair while preserving
 # provider-native MCP blocks.
 MCP_ACTIVITY_ID_PREFIX = "otari_mcptoolu_"
+
+# Anthropic beta capability a caller must declare before the Messages stream
+# includes the beta-only MCP activity block vocabulary.
+MCP_CLIENT_BETA = "mcp-client-2025-04-04"
 
 
 def _native_web_search_blocks(query: str, results: list[dict[str, Any]]) -> list[Any]:
@@ -390,16 +395,17 @@ async def _execute_stream_owned_events(
     acc: _MessagesStreamAccumulator,
     results: list[dict[str, Any]],
     *,
+    emit_mcp_activity: bool,
     native_blocks: list[Any] | None = None,
 ) -> AsyncGenerator[MessageStreamEvent, None]:
-    """Execute owned calls and yield live MCP start/completion representations."""
+    """Execute owned calls and optionally yield MCP activity representations."""
     for spec in state.owned_specs:
         name = str(spec["name"])
         parsed_input = _parsed_stream_input(state, spec)
         mcp_backend = _as_mcp_tool_backend(pool)
         server_name = _mcp_server_name(mcp_backend, name)
         activity_id: str | None = None
-        if server_name is not None:
+        if emit_mcp_activity and server_name is not None:
             activity_id = f"{MCP_ACTIVITY_ID_PREFIX}{uuid.uuid4().hex}"
             start = BetaMCPToolUseBlock(
                 type="mcp_tool_use",
@@ -441,15 +447,21 @@ class _MessagesToolLoopStrategy:
     ``amessages`` is resolved as a module global at call time so tests can
     monkeypatch ``gateway.services.mcp_loop_messages.amessages``.
 
-    ``emit_native_web_search`` is per-request (it depends on how the caller
-    declared the tool), so a request that wants native blocks gets its own
-    strategy instance rather than sharing the module-level default one.
+    Native web-search and MCP activity emission are per-request capabilities,
+    so a request that wants either gets its own strategy instance rather than
+    sharing the module-level default one.
     """
 
     transcript_key = "messages"
 
-    def __init__(self, *, emit_native_web_search: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        emit_native_web_search: bool = False,
+        emit_native_mcp: bool = False,
+    ) -> None:
         self._emit_native_web_search = emit_native_web_search
+        self._emit_native_mcp = emit_native_mcp
 
     def _native_sink(self, sink: list[Any]) -> list[Any] | None:
         """``sink`` when native emission is on, else ``None`` (collect nothing)."""
@@ -695,6 +707,7 @@ class _MessagesToolLoopStrategy:
                 pool,
                 acc,
                 discarded,
+                emit_mcp_activity=self._emit_native_mcp,
                 native_blocks=self._native_sink(state.native_blocks),
             ):
                 yield event
@@ -779,6 +792,7 @@ class _MessagesToolLoopStrategy:
             pool,
             acc,
             tool_results,
+            emit_mcp_activity=self._emit_native_mcp,
             native_blocks=self._native_sink(state.native_blocks),
         ):
             yield event
@@ -788,13 +802,18 @@ class _MessagesToolLoopStrategy:
 _MESSAGES_STRATEGY = _MessagesToolLoopStrategy()
 
 
-def _strategy_for(emit_native_web_search: bool) -> _MessagesToolLoopStrategy:
-    """The shared strategy, or a per-request one when native emission is on.
-
-    Strategies are stateless apart from that flag, so the common case keeps reusing
-    the single module-level instance.
-    """
-    return _MessagesToolLoopStrategy(emit_native_web_search=True) if emit_native_web_search else _MESSAGES_STRATEGY
+def _strategy_for(
+    emit_native_web_search: bool,
+    *,
+    emit_native_mcp: bool = False,
+) -> _MessagesToolLoopStrategy:
+    """The shared strategy, or a per-request one when native emission is on."""
+    if not emit_native_web_search and not emit_native_mcp:
+        return _MESSAGES_STRATEGY
+    return _MessagesToolLoopStrategy(
+        emit_native_web_search=emit_native_web_search,
+        emit_native_mcp=emit_native_mcp,
+    )
 
 
 async def anthropic_tool_loop(
@@ -861,20 +880,27 @@ async def anthropic_tool_loop_stream(
          the logical message will continue.
       4. On ``message_stop``: if all buffered tool uses are gateway-owned, execute
          them, append the hidden call and result to the internal transcript, and
-         continue. MCP execution is represented live as server-owned
-         ``mcp_tool_use`` / ``mcp_tool_result`` blocks. If foreign blocks exist or
-         no owned blocks were buffered, forward the terminal events and exit.
+         continue. For a caller that declared :data:`MCP_CLIENT_BETA`, MCP
+         execution is represented live as server-owned ``mcp_tool_use`` /
+         ``mcp_tool_result`` blocks. If foreign blocks exist or no owned blocks
+         were buffered, forward the terminal events and exit.
 
     Re-emitting a synthetic ``message_start`` for the next iteration is not
     needed because ``amessages`` produces a fresh stream; the next call's
     natural ``message_start`` arrives downstream as if nothing had happened.
     """
+    betas = completion_kwargs.get("betas")
+    emit_native_mcp = isinstance(betas, list) and MCP_CLIENT_BETA in betas
+
     # aclosing makes downstream closes (client disconnect) propagate to the
     # engine generator, and through it to the upstream provider stream,
     # instead of waiting for event-loop async-generator finalization.
     async with aclosing(
         run_tool_loop_stream(
-            strategy=_strategy_for(emit_native_web_search),
+            strategy=_strategy_for(
+                emit_native_web_search,
+                emit_native_mcp=emit_native_mcp,
+            ),
             completion_kwargs=completion_kwargs,
             pool=pool,
             max_iterations=max_iterations,

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -363,20 +363,25 @@ async def _call_stream_tool(
     arguments: dict[str, Any],
     *,
     mcp_backend: MCPToolBackend | None,
-) -> tuple[str, bool, bool]:
-    """Return ``(content, is_error, raised)`` for one gateway-owned call."""
+) -> tuple[str, str, bool, bool]:
+    """Return model content, activity content, error status, and transport status."""
     try:
         if mcp_backend is not None:
             outcome = await mcp_backend.call_tool_outcome(name, arguments)
-            return outcome.content, outcome.is_error, False
+            return (
+                outcome.content,
+                outcome.activity_content,
+                outcome.is_error,
+                outcome.transport_error,
+            )
         text = await pool.call_tool(name, arguments)
-        return text, is_tool_error(text), False
+        return text, text, is_tool_error(text), False
     except Exception as exc:  # noqa: BLE001 - recoverable tool failure is model input
-        # Transport exceptions may include URLs, headers, or credentials. Neither
-        # logs, client events, nor the model-facing result may receive that detail.
+        # An unexpected backend exception may include URLs, headers, or credentials.
+        # Neither logs, client events, nor the model-facing result receives its detail.
         logger.warning("Gateway tool %s execution failed: %s", name, type(exc).__name__)
         detail = "MCP tool execution failed" if mcp_backend is not None else "Gateway tool execution failed"
-        return f"[tool error] {detail}", True, True
+        return f"[tool error] {detail}", detail, True, True
 
 
 def _content_block_events(block: Any, acc: _MessagesStreamAccumulator) -> list[Any]:
@@ -417,20 +422,17 @@ async def _execute_stream_owned_events(
             for event in _content_block_events(start, acc):
                 yield event
 
-        text, is_error, raised = await _call_stream_tool(
+        text, activity_content, is_error, transport_error = await _call_stream_tool(
             pool,
             name,
             parsed_input,
             mcp_backend=mcp_backend if server_name is not None else None,
         )
-        if not raised and native_blocks is not None:
+        if not transport_error and native_blocks is not None:
             native_blocks.extend(_native_blocks_for_call(pool, name, parsed_input))
         results.append({"type": "tool_result", "tool_use_id": spec["id"], "content": text})
 
         if activity_id is not None:
-            # A transport exception may embed URLs or headers. Expose only the
-            # truthful failure state and the same fixed message sent to the model.
-            activity_content = "[tool error] MCP tool execution failed" if raised else text
             completion = BetaMCPToolResultBlock(
                 type="mcp_tool_result",
                 tool_use_id=activity_id,

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -21,6 +21,7 @@ from contextlib import aclosing
 from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 
 from anthropic.types import ServerToolUseBlock, WebSearchResultBlock, WebSearchToolResultBlock
+from anthropic.types.beta import BetaMCPToolResultBlock, BetaMCPToolUseBlock
 from any_llm import amessages
 from any_llm.types.messages import (
     BetaContextManagementResponse,
@@ -37,6 +38,7 @@ from gateway.services.mcp_loop import (
     ToolBackend,
 )
 from gateway.services.tool_format import openai_to_anthropic_tools
+from gateway.services.tool_usage import is_tool_error
 from gateway.services.web_search_backend import WEB_SEARCH_TOOL_NAME
 
 if TYPE_CHECKING:
@@ -51,6 +53,7 @@ __all__ = [
     "DEFAULT_MAX_TOOL_ITERATIONS",
     "MAX_TOOL_ITERATIONS_CAP",
     "MaxToolIterationsExceeded",
+    "MCP_ACTIVITY_ID_PREFIX",
     "anthropic_tool_loop",
     "anthropic_tool_loop_stream",
 ]
@@ -61,6 +64,12 @@ __all__ = [
 # value is whatever a search-API-fronting adapter forwarded, so one overlong or
 # multiline entry shouldn't be what makes a citations panel unreadable.
 _PAGE_AGE_MAX_CHARS = 128
+
+# Provenance marker for MCP activity blocks minted by this gateway. Clients may
+# echo the accumulated assistant message on their next request; the Messages
+# route uses this prefix to remove only our synthetic pair while preserving
+# provider-native MCP blocks.
+MCP_ACTIVITY_ID_PREFIX = "otari_mcptoolu_"
 
 
 def _native_web_search_blocks(query: str, results: list[dict[str, Any]]) -> list[Any]:
@@ -280,37 +289,6 @@ def _reindexed(event: Any, visible_index: int) -> Any:
     return event.model_copy(update={"index": visible_index})
 
 
-async def _execute_stream_owned(
-    state: "_MessagesStreamState",
-    pool: ToolBackend,
-    *,
-    native_blocks: list[Any] | None = None,
-) -> list[dict[str, Any]]:
-    """Run the stream's gateway-owned tool_use blocks, returning tool_result blocks.
-
-    Shared by the continue path (which feeds the results back to the model) and the
-    mixed-batch exit (which runs them for their side effects only), so both parse the
-    buffered JSON arguments the same way. ``native_blocks`` collects per-call native
-    server-tool blocks exactly as in :func:`_execute_tool_uses`.
-    """
-    results: list[dict[str, Any]] = []
-    for spec in state.owned_specs:
-        try:
-            parsed_input = json.loads(state.tool_use_json_bufs.get(spec["index"], "") or "{}")
-        except json.JSONDecodeError:
-            parsed_input = {}
-        try:
-            text = await pool.call_tool(spec["name"], parsed_input)
-        except Exception as exc:  # noqa: BLE001 (same tool-error-as-message idiom as the non-stream loop)
-            logger.warning("MCP tool %s execution failed: %s", spec["name"], exc)
-            text = f"[tool error] {exc}"
-        else:
-            if native_blocks is not None:
-                native_blocks.extend(_native_blocks_for_call(pool, spec["name"], parsed_input))
-        results.append({"type": "tool_result", "tool_use_id": spec["id"], "content": text})
-    return results
-
-
 class _MessagesStreamState:
     """Per-iteration bookkeeping for the Anthropic streaming loop.
 
@@ -331,14 +309,116 @@ class _MessagesStreamState:
         self.stop_reason: str | None = None
         self.deferred_terminal: list[MessageStreamEvent] = []
         self.owned_specs: list[dict[str, Any]] = []
-        # Blocks the gateway runs itself. Their events are swallowed rather than
-        # forwarded: a client shown a ``tool_use`` for ``web_search`` can never be
-        # sent the matching ``tool_result``, because the gateway consumes it.
+        # Blocks the gateway runs itself. Their caller-owned ``tool_use`` events are
+        # swallowed because the gateway consumes them. MCP calls may instead get a
+        # server-owned ``mcp_tool_use`` / ``mcp_tool_result`` representation.
         self.hidden_indices: set[int] = set()
         # Upstream block index -> the index the client sees. Each iteration's
         # blocks start again at 0 upstream, but the client is being shown one
         # single message, so forwarded blocks are renumbered.
         self.visible_index: dict[int, int] = {}
+
+
+def _parsed_stream_input(state: _MessagesStreamState, spec: dict[str, Any]) -> dict[str, Any]:
+    """Parse one buffered tool input, falling back to the loop's historical empty object."""
+    try:
+        value = json.loads(state.tool_use_json_bufs.get(spec["index"], "") or "{}")
+    except json.JSONDecodeError:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _mcp_server_name(pool: ToolBackend, tool_name: str) -> str | None:
+    """Return MCP ownership metadata when ``pool`` is an MCP client pool."""
+    resolver = getattr(pool, "server_name_for_tool", None)
+    if not callable(resolver):
+        return None
+    value = resolver(tool_name)
+    return value if isinstance(value, str) and value else None
+
+
+async def _call_stream_tool(
+    pool: ToolBackend,
+    name: str,
+    arguments: dict[str, Any],
+    *,
+    preserve_mcp_error: bool,
+) -> tuple[str, bool, bool]:
+    """Return ``(content, is_error, raised)`` for one gateway-owned call."""
+    try:
+        call_outcome = getattr(pool, "call_tool_outcome", None)
+        if preserve_mcp_error and callable(call_outcome):
+            outcome = await call_outcome(name, arguments)
+            return str(outcome.content), bool(outcome.is_error), False
+        text = await pool.call_tool(name, arguments)
+        return text, is_tool_error(text), False
+    except Exception as exc:  # noqa: BLE001 - recoverable tool failure is model input
+        # Do not put exception details in logs: transports may include URLs or
+        # headers in them. The internal model result keeps the detail for recovery;
+        # the client-facing activity event receives a fixed error below.
+        logger.warning("Gateway tool %s execution failed", name)
+        return f"[tool error] {exc}", True, True
+
+
+def _content_block_events(block: Any, acc: _MessagesStreamAccumulator) -> list[Any]:
+    """A complete synthetic content block at the next client-visible index."""
+    index = acc["next_index"]
+    acc["next_index"] += 1
+    return [
+        ContentBlockStartEvent(content_block=block, index=index, type="content_block_start"),
+        ContentBlockStopEvent(index=index, type="content_block_stop"),
+    ]
+
+
+async def _execute_stream_owned_events(
+    state: _MessagesStreamState,
+    pool: ToolBackend,
+    acc: _MessagesStreamAccumulator,
+    results: list[dict[str, Any]],
+    *,
+    native_blocks: list[Any] | None = None,
+) -> AsyncGenerator[MessageStreamEvent, None]:
+    """Execute owned calls and yield live MCP start/completion representations."""
+    for spec in state.owned_specs:
+        name = str(spec["name"])
+        parsed_input = _parsed_stream_input(state, spec)
+        server_name = _mcp_server_name(pool, name)
+        activity_id: str | None = None
+        if server_name is not None:
+            activity_id = f"{MCP_ACTIVITY_ID_PREFIX}{uuid.uuid4().hex}"
+            start = BetaMCPToolUseBlock(
+                type="mcp_tool_use",
+                id=activity_id,
+                name=name,
+                server_name=server_name,
+                input=parsed_input,
+            )
+            for event in _content_block_events(start, acc):
+                yield event
+
+        text, is_error, raised = await _call_stream_tool(
+            pool,
+            name,
+            parsed_input,
+            preserve_mcp_error=server_name is not None,
+        )
+        if not raised and native_blocks is not None:
+            native_blocks.extend(_native_blocks_for_call(pool, name, parsed_input))
+        results.append({"type": "tool_result", "tool_use_id": spec["id"], "content": text})
+
+        if activity_id is not None:
+            # A transport exception may embed URLs or headers. Keep its detail in
+            # the model-facing internal result for recovery, but expose only the
+            # truthful failure state and a fixed message to the streaming client.
+            activity_content = "[tool error] MCP tool execution failed" if raised else text
+            completion = BetaMCPToolResultBlock(
+                type="mcp_tool_result",
+                tool_use_id=activity_id,
+                content=activity_content,
+                is_error=is_error,
+            )
+            for event in _content_block_events(completion, acc):
+                yield event
 
 
 class _MessagesToolLoopStrategy:
@@ -580,7 +660,12 @@ class _MessagesToolLoopStrategy:
         # dropped iterations).
         return not owned_specs or has_foreign or state.stop_reason != "tool_use"
 
-    async def finalize_exit(self, state: _MessagesStreamState, pool: ToolBackend) -> None:
+    async def finalize_exit(
+        self,
+        state: _MessagesStreamState,
+        pool: ToolBackend,
+        acc: _MessagesStreamAccumulator,
+    ) -> AsyncIterator[MessageStreamEvent]:
         # Mixed batch: the gateway's tool_use blocks were withheld from the stream, so
         # run them for their side effects rather than dropping the model's request.
         # Matches the non-streaming loop, which executes the owned subset and filters
@@ -588,8 +673,17 @@ class _MessagesToolLoopStrategy:
         if state.stop_reason == "tool_use" and state.owned_specs:
             # Collected, not discarded: the search ran, so a native client is owed the
             # pair describing it even though this round exits for the caller to
-            # dispatch its own tool. ``terminal_events`` emits them.
-            await _execute_stream_owned(state, pool, native_blocks=self._native_sink(state.native_blocks))
+            # dispatch its own tool. ``terminal_events`` emits them. MCP activity is
+            # yielded around the call itself so the start signal is truthful.
+            discarded: list[dict[str, Any]] = []
+            async for event in _execute_stream_owned_events(
+                state,
+                pool,
+                acc,
+                discarded,
+                native_blocks=self._native_sink(state.native_blocks),
+            ):
+                yield event
 
     def terminal_events(
         self,
@@ -626,22 +720,17 @@ class _MessagesToolLoopStrategy:
         appends the start event's block wholesale and only overwrites ``input`` when a
         delta actually arrives, so a start/stop pair preserves the query.
         """
-        events: list[Any] = []
-        for block in blocks:
-            index = acc["next_index"]
-            acc["next_index"] += 1
-            events.append(ContentBlockStartEvent(content_block=block, index=index, type="content_block_start"))
-            events.append(ContentBlockStopEvent(index=index, type="content_block_stop"))
-        return events
+        return [event for block in blocks for event in _content_block_events(block, acc)]
 
-    def synthetic_events(self, state: _MessagesStreamState, acc: _MessagesStreamAccumulator) -> list[Any]:
+    def synthetic_events(
+        self, state: _MessagesStreamState, acc: _MessagesStreamAccumulator
+    ) -> list[Any]:
         """Announce this iteration's gateway-run searches as native content blocks.
 
-        The model's own ``tool_use`` events were swallowed (the client can never be
-        sent the matching ``tool_result``), so a ``server_tool_use`` /
-        ``web_search_tool_result`` pair takes their place for a caller that declared
-        the tool natively. Empty for every other caller, which is what keeps the
-        gateway's calls invisible on the wire as they have always been.
+        The model's own ``tool_use`` events were swallowed, so a
+        ``server_tool_use`` / ``web_search_tool_result`` pair takes their place for a
+        caller that declared the tool natively. MCP activity is yielded directly
+        around execution and therefore does not pass through this deferred hook.
 
         Each block gets a ``content_block_start`` carrying the complete block plus a
         ``content_block_stop``, and no ``input_json_delta``: the SDK accumulator
@@ -656,7 +745,8 @@ class _MessagesToolLoopStrategy:
         transcript: list[Any],
         state: _MessagesStreamState,
         pool: ToolBackend,
-    ) -> None:
+        acc: _MessagesStreamAccumulator,
+    ) -> AsyncIterator[MessageStreamEvent]:
         # Assistant message for the next round; preserve original block
         # ordering. tool_use blocks pick up the parsed input from their
         # JSON buffer.
@@ -664,18 +754,20 @@ class _MessagesToolLoopStrategy:
         for idx in sorted(state.blocks_by_index):
             block_dict = state.blocks_by_index[idx]
             if block_dict.get("type") == "tool_use":
-                try:
-                    parsed_input = json.loads(state.tool_use_json_bufs.get(idx, "") or "{}")
-                except json.JSONDecodeError:
-                    parsed_input = {}
-                block_dict = {**block_dict, "input": parsed_input}
+                spec = {"index": idx}
+                block_dict = {**block_dict, "input": _parsed_stream_input(state, spec)}
             assistant_content.append(block_dict)
 
-        tool_results = await _execute_stream_owned(
-            state, pool, native_blocks=self._native_sink(state.native_blocks)
-        )
-
         transcript.append({"role": "assistant", "content": assistant_content})
+        tool_results: list[dict[str, Any]] = []
+        async for event in _execute_stream_owned_events(
+            state,
+            pool,
+            acc,
+            tool_results,
+            native_blocks=self._native_sink(state.native_blocks),
+        ):
+            yield event
         transcript.append({"role": "user", "content": tool_results})
 
 
@@ -750,14 +842,14 @@ async def anthropic_tool_loop_stream(
       2. Track tool_use content blocks by ``index`` from ``content_block_start``
          (when ``content_block.type == "tool_use"``). Buffer their
          ``input_json_delta`` chunks until ``content_block_stop``.
-      3. Yield every event as it arrives (including the tool_use events, so the
-         client sees the model's tool intent even mid-loop). Defer
-         ``message_delta`` and ``message_stop`` until we know whether the loop
-         will continue.
-      4. On ``message_stop``: if any buffered tool_use blocks exist AND all
-         owned by the pool, execute them, append messages, drop the terminal
-         events, and continue. If foreign blocks exist OR no tool_use blocks
-         were buffered, forward the terminal events and exit.
+      3. Forward caller-owned blocks, but hide gateway-owned ``tool_use`` events.
+         Defer ``message_delta`` and ``message_stop`` until the loop knows whether
+         the logical message will continue.
+      4. On ``message_stop``: if all buffered tool uses are gateway-owned, execute
+         them, append the hidden call and result to the internal transcript, and
+         continue. MCP execution is represented live as server-owned
+         ``mcp_tool_use`` / ``mcp_tool_result`` blocks. If foreign blocks exist or
+         no owned blocks were buffered, forward the terminal events and exit.
 
     Re-emitting a synthetic ``message_start`` for the next iteration is not
     needed because ``amessages`` produces a fresh stream; the next call's

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -864,6 +864,7 @@ async def anthropic_tool_loop_stream(
     pool: ToolBackend,
     max_iterations: int,
     emit_native_web_search: bool = False,
+    emit_native_mcp: bool = False,
 ) -> AsyncGenerator[MessageStreamEvent, None]:
     """Streaming Anthropic Messages tool-use loop.
 
@@ -891,9 +892,6 @@ async def anthropic_tool_loop_stream(
     needed because ``amessages`` produces a fresh stream; the next call's
     natural ``message_start`` arrives downstream as if nothing had happened.
     """
-    betas = completion_kwargs.get("betas")
-    emit_native_mcp = isinstance(betas, list) and MCP_CLIENT_BETA in betas
-
     # aclosing makes downstream closes (client disconnect) propagate to the
     # engine generator, and through it to the upstream provider stream,
     # instead of waiting for event-loop async-generator finalization.

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -18,7 +18,7 @@ import json
 import uuid
 from collections.abc import AsyncGenerator, AsyncIterator, Callable
 from contextlib import aclosing
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict, cast, runtime_checkable
 
 from anthropic.types import ServerToolUseBlock, WebSearchResultBlock, WebSearchToolResultBlock
 from anthropic.types.beta import BetaMCPToolResultBlock, BetaMCPToolUseBlock
@@ -46,6 +46,17 @@ if TYPE_CHECKING:
         MessageResponse,
         MessageStreamEvent,
     )
+
+    from gateway.services.mcp_client import MCPToolCallOutcome
+
+
+@runtime_checkable
+class MCPToolBackend(Protocol):
+    """MCP-specific capabilities used to emit streaming activity blocks."""
+
+    def server_name_for_tool(self, name: str) -> str | None: ...
+
+    async def call_tool_outcome(self, name: str, arguments: dict[str, Any]) -> MCPToolCallOutcome: ...
 
 
 # Re-export so callers in routes/messages.py have a single import surface.
@@ -328,13 +339,17 @@ def _parsed_stream_input(state: _MessagesStreamState, spec: dict[str, Any]) -> d
     return value if isinstance(value, dict) else {}
 
 
-def _mcp_server_name(pool: ToolBackend, tool_name: str) -> str | None:
+def _as_mcp_tool_backend(pool: ToolBackend) -> MCPToolBackend | None:
+    """Narrow ``pool`` when it exposes the MCP streaming activity surface."""
+    return pool if isinstance(pool, MCPToolBackend) else None
+
+
+def _mcp_server_name(pool: MCPToolBackend | None, tool_name: str) -> str | None:
     """Return MCP ownership metadata when ``pool`` is an MCP client pool."""
-    resolver = getattr(pool, "server_name_for_tool", None)
-    if not callable(resolver):
+    if pool is None:
         return None
-    value = resolver(tool_name)
-    return value if isinstance(value, str) and value else None
+    value = pool.server_name_for_tool(tool_name)
+    return value if value else None
 
 
 async def _call_stream_tool(
@@ -342,22 +357,21 @@ async def _call_stream_tool(
     name: str,
     arguments: dict[str, Any],
     *,
-    preserve_mcp_error: bool,
+    mcp_backend: MCPToolBackend | None,
 ) -> tuple[str, bool, bool]:
     """Return ``(content, is_error, raised)`` for one gateway-owned call."""
     try:
-        call_outcome = getattr(pool, "call_tool_outcome", None)
-        if preserve_mcp_error and callable(call_outcome):
-            outcome = await call_outcome(name, arguments)
-            return str(outcome.content), bool(outcome.is_error), False
+        if mcp_backend is not None:
+            outcome = await mcp_backend.call_tool_outcome(name, arguments)
+            return outcome.content, outcome.is_error, False
         text = await pool.call_tool(name, arguments)
         return text, is_tool_error(text), False
-    except Exception as exc:  # noqa: BLE001 - recoverable tool failure is model input
-        # Do not put exception details in logs: transports may include URLs or
-        # headers in them. The internal model result keeps the detail for recovery;
-        # the client-facing activity event receives a fixed error below.
+    except Exception:  # noqa: BLE001 - recoverable tool failure is model input
+        # Transport exceptions may include URLs, headers, or credentials. Neither
+        # logs, client events, nor the model-facing result may receive that detail.
         logger.warning("Gateway tool %s execution failed", name)
-        return f"[tool error] {exc}", True, True
+        detail = "MCP tool execution failed" if mcp_backend is not None else "Gateway tool execution failed"
+        return f"[tool error] {detail}", True, True
 
 
 def _content_block_events(block: Any, acc: _MessagesStreamAccumulator) -> list[Any]:
@@ -382,7 +396,8 @@ async def _execute_stream_owned_events(
     for spec in state.owned_specs:
         name = str(spec["name"])
         parsed_input = _parsed_stream_input(state, spec)
-        server_name = _mcp_server_name(pool, name)
+        mcp_backend = _as_mcp_tool_backend(pool)
+        server_name = _mcp_server_name(mcp_backend, name)
         activity_id: str | None = None
         if server_name is not None:
             activity_id = f"{MCP_ACTIVITY_ID_PREFIX}{uuid.uuid4().hex}"
@@ -400,16 +415,15 @@ async def _execute_stream_owned_events(
             pool,
             name,
             parsed_input,
-            preserve_mcp_error=server_name is not None,
+            mcp_backend=mcp_backend if server_name is not None else None,
         )
         if not raised and native_blocks is not None:
             native_blocks.extend(_native_blocks_for_call(pool, name, parsed_input))
         results.append({"type": "tool_result", "tool_use_id": spec["id"], "content": text})
 
         if activity_id is not None:
-            # A transport exception may embed URLs or headers. Keep its detail in
-            # the model-facing internal result for recovery, but expose only the
-            # truthful failure state and a fixed message to the streaming client.
+            # A transport exception may embed URLs or headers. Expose only the
+            # truthful failure state and the same fixed message sent to the model.
             activity_content = "[tool error] MCP tool execution failed" if raised else text
             completion = BetaMCPToolResultBlock(
                 type="mcp_tool_result",

--- a/src/gateway/services/mcp_loop_messages.py
+++ b/src/gateway/services/mcp_loop_messages.py
@@ -66,7 +66,6 @@ __all__ = [
     "MaxToolIterationsExceeded",
     "MCP_ACTIVITY_ID_PREFIX",
     "MCP_CLIENT_BETA",
-    "MCP_CLIENT_BETA_LEGACY",
     "anthropic_tool_loop",
     "anthropic_tool_loop_stream",
 ]
@@ -84,11 +83,9 @@ _PAGE_AGE_MAX_CHARS = 128
 # provider-native MCP blocks.
 MCP_ACTIVITY_ID_PREFIX = "otari_mcptoolu_"
 
-# Anthropic beta capabilities a caller may declare before the Messages stream
+# Anthropic beta capability a caller must declare before the Messages stream
 # includes the beta-only MCP activity block vocabulary.
 MCP_CLIENT_BETA = "mcp-client-2025-11-20"
-MCP_CLIENT_BETA_LEGACY = "mcp-client-2025-04-04"
-_MCP_CLIENT_BETAS = frozenset({MCP_CLIENT_BETA, MCP_CLIENT_BETA_LEGACY})
 
 
 def _native_web_search_blocks(query: str, results: list[dict[str, Any]]) -> list[Any]:
@@ -895,7 +892,7 @@ async def anthropic_tool_loop_stream(
     natural ``message_start`` arrives downstream as if nothing had happened.
     """
     betas = completion_kwargs.get("betas")
-    emit_native_mcp = isinstance(betas, list) and not _MCP_CLIENT_BETAS.isdisjoint(betas)
+    emit_native_mcp = isinstance(betas, list) and MCP_CLIENT_BETA in betas
 
     # aclosing makes downstream closes (client disconnect) propagate to the
     # engine generator, and through it to the upstream provider stream,

--- a/src/gateway/services/mcp_loop_responses.py
+++ b/src/gateway/services/mcp_loop_responses.py
@@ -560,12 +560,20 @@ class _ResponsesToolLoopStrategy:
         # trade-off as the Anthropic streaming variant.
         return has_foreign or not owned_specs
 
-    async def finalize_exit(self, state: _ResponsesStreamState, pool: ToolBackend) -> None:
+    async def finalize_exit(
+        self,
+        state: _ResponsesStreamState,
+        pool: ToolBackend,
+        acc: dict[str, Any],
+    ) -> AsyncIterator[ResponseStreamEvent]:
+        del acc
         # Mixed batch: the gateway's function_call items were withheld from the
         # stream, so run them for their side effects rather than dropping the model's
         # request. Matches the non-streaming loop's mixed-batch handling.
         if state.owned_specs:
             await _execute_stream_owned(state, pool)
+        return
+        yield  # pragma: no cover - makes this a no-event async iterator
 
     def terminal_events(self, state: _ResponsesStreamState, acc: dict[str, Any]) -> list[ResponseStreamEvent]:
         if state.deferred_completed is None:
@@ -637,7 +645,9 @@ class _ResponsesToolLoopStrategy:
         transcript: list[Any],
         state: _ResponsesStreamState,
         pool: ToolBackend,
-    ) -> None:
+        acc: dict[str, Any],
+    ) -> AsyncIterator[ResponseStreamEvent]:
+        del acc
         replay_items: list[Any] = []
         for output_index in sorted(set(state.compaction_items) | set(state.function_calls)):
             if output_index in state.compaction_items:
@@ -654,6 +664,8 @@ class _ResponsesToolLoopStrategy:
                 )
         transcript.extend(_items_to_dicts(replay_items))
         transcript.extend(await _execute_stream_owned(state, pool))
+        return
+        yield  # pragma: no cover - makes this a no-event async iterator
 
 
 _RESPONSES_STRATEGY = _ResponsesToolLoopStrategy()

--- a/tests/integration/test_messages_route_dispatch.py
+++ b/tests/integration/test_messages_route_dispatch.py
@@ -530,6 +530,60 @@ def test_mcp_servers_dispatches_through_anthropic_tool_loop(
     assert plain_amessages_called is False
 
 
+def test_mcp_servers_do_not_widen_web_search_replay_stripping(
+    client: TestClient,
+    api_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MCP configuration must not strip web-search blocks when interception is off."""
+    monkeypatch.delenv("OTARI_WEB_SEARCH_INTERCEPT", raising=False)
+    replayed_messages = [
+        {"role": "user", "content": "search"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "server_tool_use", "id": "srvtoolu_echoed", "name": "web_search", "input": {}},
+                {
+                    "type": "web_search_tool_result",
+                    "tool_use_id": "srvtoolu_echoed",
+                    "content": [],
+                },
+                {"type": "text", "text": "answer"},
+            ],
+        },
+        {"role": "user", "content": "continue"},
+    ]
+    captured: dict[str, Any] = {}
+
+    async def fake_loop(
+        *, completion_kwargs: Any, pool: Any, max_iterations: int, emit_native_web_search: bool = False
+    ) -> MessageResponse:
+        captured.update(completion_kwargs)
+        return _text_response("ok")
+
+    with (
+        patch("gateway.api.routes.messages.anthropic_tool_loop", new=fake_loop),
+        patch(
+            "gateway.services.mcp_client.MCPClientPool.__aenter__",
+            new=AsyncMock(return_value=AsyncMock(purpose_hints=lambda: [])),
+        ),
+        patch("gateway.services.mcp_client.MCPClientPool.__aexit__", new=AsyncMock(return_value=None)),
+    ):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "anthropic:claude-3-5-sonnet-20241022",
+                "messages": replayed_messages,
+                "max_tokens": 100,
+                "mcp_servers": [{"name": "test", "url": "http://127.0.0.1:9999/mcp"}],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert captured["messages"] == replayed_messages
+
+
 def test_code_execution_dispatches_through_sandbox_backend(
     client: TestClient,
     api_key_header: dict[str, str],

--- a/tests/integration/test_messages_route_dispatch.py
+++ b/tests/integration/test_messages_route_dispatch.py
@@ -1426,7 +1426,11 @@ def test_stream_mcp_activity_requires_beta(
             assert name == "lookup"
             assert arguments == {"issue": 755}
             calls.append((name, arguments))
-            return MCPToolCallOutcome(content="issue result", is_error=False)
+            return MCPToolCallOutcome(
+                content="issue result",
+                activity_content="issue result",
+                is_error=False,
+            )
 
     with (
         patch("gateway.services.mcp_loop_messages.amessages", new=fake_amessages),

--- a/tests/integration/test_messages_route_dispatch.py
+++ b/tests/integration/test_messages_route_dispatch.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import AsyncIterator
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
@@ -19,6 +20,7 @@ import pytest
 from any_llm.types.messages import (
     ContentBlockDeltaEvent,
     ContentBlockStartEvent,
+    ContentBlockStopEvent,
     MessageDelta,
     MessageDeltaEvent,
     MessageDeltaUsage,
@@ -30,11 +32,13 @@ from any_llm.types.messages import (
     TextBlock,
     TextDelta,
 )
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
-_CONTEXT_MANAGEMENT = {
-    "edits": [{"type": "compact_20260112", "trigger": {"type": "input_tokens", "value": 50_000}}]
-}
+from gateway.services.mcp_client import MCPToolCallOutcome
+from gateway.services.mcp_loop_messages import MCP_ACTIVITY_ID_PREFIX
+
+_CONTEXT_MANAGEMENT = {"edits": [{"type": "compact_20260112", "trigger": {"type": "input_tokens", "value": 50_000}}]}
 _BETAS = ["compact-2026-01-12"]
 _AUTOMATIC_CACHE_CONTROL = {"type": "ephemeral", "ttl": "1h"}
 
@@ -976,6 +980,75 @@ async def _stream_iter(*events: MessageStreamEvent) -> AsyncIterator[MessageStre
         yield event
 
 
+def test_echoed_mcp_activity_is_removed_before_prompt_estimation(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """Gateway-owned result content must not consume budget headroom before being stripped."""
+    messages = [
+        {"role": "user", "content": "first turn"},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "mcp_tool_use",
+                    "id": f"{MCP_ACTIVITY_ID_PREFIX}echoed",
+                    "name": "lookup",
+                    "server_name": "fixture",
+                    "input": {"id": 755},
+                },
+                {
+                    "type": "mcp_tool_result",
+                    "tool_use_id": f"{MCP_ACTIVITY_ID_PREFIX}echoed",
+                    "content": "large-result" * 10_000,
+                    "is_error": False,
+                },
+                {"type": "text", "text": "prior answer"},
+            ],
+        },
+        {"role": "user", "content": "continue"},
+    ]
+    sanitized = [
+        messages[0],
+        {"role": "assistant", "content": [{"type": "text", "text": "prior answer"}]},
+        messages[2],
+    ]
+    captured: dict[str, Any] = {}
+
+    async def fake_normalize_messages(input_messages: Any, **kwargs: Any) -> Any:
+        captured["normalized_messages"] = input_messages
+        return input_messages, SimpleNamespace(vision_usage=lambda: None)
+
+    async def fake_resolve_request_context(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        await kwargs["normalize_messages"]("user", None, "model", None)
+        raise HTTPException(status_code=418, detail="stop after admission inputs")
+
+    with (
+        patch(
+            "gateway.api.routes.messages.resolve_request_context",
+            new=fake_resolve_request_context,
+        ),
+        patch(
+            "gateway.api.routes.messages.normalize_request_messages",
+            new=fake_normalize_messages,
+        ),
+    ):
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": "anthropic:claude-3-5-sonnet-20241022",
+                "messages": messages,
+                "max_tokens": 100,
+            },
+            headers=api_key_header,
+        )
+
+    assert response.status_code == 418
+    assert captured["estimate_prompt_chars"] == len(str(sanitized))
+    assert captured["normalized_messages"] == sanitized
+
+
 def test_stream_no_tools_returns_sse_response(
     client: TestClient,
     api_key_header: dict[str, str],
@@ -1204,6 +1277,132 @@ def test_stream_mcp_servers_dispatches_through_tool_loop_stream(
     assert resp.headers["content-type"].startswith("text/event-stream")
     assert seen.get("pool") is not None, "anthropic_tool_loop_stream was not invoked"
     assert plain_amessages_called is False
+
+
+def test_stream_mcp_activity_reaches_the_sse_client(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    streams = iter(
+        [
+            _stream_iter(
+                _stream_message_start(),
+                ContentBlockStartEvent.model_validate(
+                    {
+                        "type": "content_block_start",
+                        "index": 0,
+                        "content_block": {
+                            "type": "tool_use",
+                            "id": "toolu_internal",
+                            "name": "lookup",
+                            "input": {},
+                        },
+                    }
+                ),
+                ContentBlockDeltaEvent.model_validate(
+                    {
+                        "type": "content_block_delta",
+                        "index": 0,
+                        "delta": {
+                            "type": "input_json_delta",
+                            "partial_json": '{"issue": 755}',
+                        },
+                    }
+                ),
+                ContentBlockStopEvent(type="content_block_stop", index=0),
+                MessageDeltaEvent.model_validate(
+                    {
+                        "type": "message_delta",
+                        "delta": {"stop_reason": "tool_use", "stop_sequence": None},
+                        "usage": {"output_tokens": 1},
+                    }
+                ),
+                _stream_message_stop(),
+            ),
+            _stream_iter(
+                _stream_message_start(),
+                ContentBlockStartEvent.model_validate(
+                    {
+                        "type": "content_block_start",
+                        "index": 0,
+                        "content_block": {"type": "text", "text": ""},
+                    }
+                ),
+                _stream_text_delta("done"),
+                ContentBlockStopEvent(type="content_block_stop", index=0),
+                _stream_message_delta(),
+                _stream_message_stop(),
+            ),
+        ]
+    )
+
+    async def fake_amessages(**_kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        return next(streams)
+
+    class ActivityPool:
+        @property
+        def openai_tools(self) -> list[dict[str, Any]]:
+            return [
+                {
+                    "type": "function",
+                    "function": {"name": "lookup", "description": "", "parameters": {}},
+                }
+            ]
+
+        def purpose_hints(self) -> list[tuple[str, str]]:
+            return []
+
+        def owns_tool(self, name: str) -> bool:
+            return name == "lookup"
+
+        def server_name_for_tool(self, name: str) -> str | None:
+            return "fixture" if self.owns_tool(name) else None
+
+        async def call_tool_outcome(self, name: str, arguments: dict[str, Any]) -> MCPToolCallOutcome:
+            assert name == "lookup"
+            assert arguments == {"issue": 755}
+            return MCPToolCallOutcome(content="issue result", is_error=False)
+
+    with (
+        patch("gateway.services.mcp_loop_messages.amessages", new=fake_amessages),
+        patch(
+            "gateway.services.mcp_client.MCPClientPool.__aenter__",
+            new=AsyncMock(return_value=ActivityPool()),
+        ),
+        patch(
+            "gateway.services.mcp_client.MCPClientPool.__aexit__",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        resp = client.post(
+            "/v1/messages",
+            json={
+                "model": "anthropic:claude-3-5-sonnet-20241022",
+                "messages": [{"role": "user", "content": "look it up"}],
+                "max_tokens": 100,
+                "stream": True,
+                "mcp_servers": [{"name": "fixture", "url": "http://127.0.0.1:9999/mcp"}],
+            },
+            headers=api_key_header,
+        )
+
+    assert resp.status_code == 200, resp.text
+    payloads = [json.loads(line.removeprefix("data: ")) for line in resp.text.splitlines() if line.startswith("data: ")]
+    blocks = [payload["content_block"] for payload in payloads if payload.get("type") == "content_block_start"]
+    assert [block["type"] for block in blocks] == [
+        "mcp_tool_use",
+        "mcp_tool_result",
+        "text",
+    ]
+    assert blocks[0]["name"] == "lookup"
+    assert blocks[0]["server_name"] == "fixture"
+    assert blocks[0]["input"] == {"issue": 755}
+    assert blocks[1] == {
+        "type": "mcp_tool_result",
+        "tool_use_id": blocks[0]["id"],
+        "content": "issue result",
+        "is_error": False,
+    }
 
 
 def test_stream_code_execution_dispatches_through_sandbox(

--- a/tests/integration/test_messages_route_dispatch.py
+++ b/tests/integration/test_messages_route_dispatch.py
@@ -36,7 +36,11 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from gateway.services.mcp_client import MCPToolCallOutcome
-from gateway.services.mcp_loop_messages import MCP_ACTIVITY_ID_PREFIX, MCP_CLIENT_BETA
+from gateway.services.mcp_loop_messages import (
+    MCP_ACTIVITY_ID_PREFIX,
+    MCP_CLIENT_BETA,
+    MCP_CLIENT_BETA_LEGACY,
+)
 
 _CONTEXT_MANAGEMENT = {"edits": [{"type": "compact_20260112", "trigger": {"type": "input_tokens", "value": 50_000}}]}
 _BETAS = ["compact-2026-01-12"]
@@ -326,6 +330,36 @@ def test_context_management_non_stream_contract(
     assert body["content"] == [{"type": "compaction", "content": "Conversation summary"}]
     assert body["context_management"]["applied_edits"][0]["cleared_input_tokens"] == 42
     assert body["usage"]["iterations"][0]["type"] == "compaction"
+
+
+def test_anthropic_beta_header_reaches_provider(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    """The Anthropic SDK's beta header is normalized into any-llm kwargs."""
+    captured: dict[str, Any] = {}
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        captured.update(kwargs)
+        return _text_response()
+
+    with patch("gateway.api.routes.messages.amessages", new=fake_amessages):
+        resp = client.post(
+            "/v1/messages?beta=true",
+            json={
+                "model": "anthropic:claude-opus-5",
+                "messages": [{"role": "user", "content": "Use the beta"}],
+                "max_tokens": 100,
+                "betas": _BETAS,
+            },
+            headers={
+                **api_key_header,
+                "anthropic-beta": f"{MCP_CLIENT_BETA},files-api-2025-04-14,{MCP_CLIENT_BETA}",
+            },
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert captured["betas"] == [*_BETAS, MCP_CLIENT_BETA, "files-api-2025-04-14"]
 
 
 def test_gateway_internal_fields_are_stripped_from_upstream_kwargs(
@@ -1365,16 +1399,17 @@ def test_stream_mcp_servers_dispatches_through_tool_loop_stream(
 
 
 @pytest.mark.parametrize(
-    ("betas", "expected_block_types"),
+    ("beta_header", "expected_block_types"),
     [
         (None, ["text"]),
-        ([MCP_CLIENT_BETA], ["mcp_tool_use", "mcp_tool_result", "text"]),
+        (MCP_CLIENT_BETA, ["mcp_tool_use", "mcp_tool_result", "text"]),
+        (MCP_CLIENT_BETA_LEGACY, ["mcp_tool_use", "mcp_tool_result", "text"]),
     ],
 )
 def test_stream_mcp_activity_requires_beta(
     client: TestClient,
     api_key_header: dict[str, str],
-    betas: list[str] | None,
+    beta_header: str | None,
     expected_block_types: list[str],
 ) -> None:
     calls: list[tuple[str, dict[str, Any]]] = []
@@ -1482,9 +1517,11 @@ def test_stream_mcp_activity_requires_beta(
                 "max_tokens": 100,
                 "stream": True,
                 "mcp_servers": [{"name": "fixture", "url": "http://127.0.0.1:9999/mcp"}],
-                **({"betas": betas} if betas is not None else {}),
             },
-            headers=api_key_header,
+            headers={
+                **api_key_header,
+                **({"anthropic-beta": beta_header} if beta_header is not None else {}),
+            },
         )
 
     assert resp.status_code == 200, resp.text
@@ -1492,7 +1529,7 @@ def test_stream_mcp_activity_requires_beta(
     blocks = [payload["content_block"] for payload in payloads if payload.get("type") == "content_block_start"]
     assert [block["type"] for block in blocks] == expected_block_types
     assert calls == [("lookup", {"issue": 755})]
-    if betas is not None:
+    if beta_header is not None:
         assert blocks[0]["name"] == "lookup"
         assert blocks[0]["server_name"] == "fixture"
         assert blocks[0]["input"] == {"issue": 755}

--- a/tests/integration/test_messages_route_dispatch.py
+++ b/tests/integration/test_messages_route_dispatch.py
@@ -328,11 +328,11 @@ def test_context_management_non_stream_contract(
     assert body["usage"]["iterations"][0]["type"] == "compaction"
 
 
-def test_anthropic_beta_header_reaches_provider(
+def test_mcp_client_beta_is_not_forwarded_to_provider(
     client: TestClient,
     api_key_header: dict[str, str],
 ) -> None:
-    """The Anthropic SDK's beta header is normalized into any-llm kwargs."""
+    """The MCP client capability is consumed while other betas reach any-llm."""
     captured: dict[str, Any] = {}
 
     async def fake_amessages(**kwargs: Any) -> MessageResponse:
@@ -355,7 +355,32 @@ def test_anthropic_beta_header_reaches_provider(
         )
 
     assert resp.status_code == 200, resp.text
-    assert captured["betas"] == [*_BETAS, MCP_CLIENT_BETA, "files-api-2025-04-14"]
+    assert captured["betas"] == [*_BETAS, "files-api-2025-04-14"]
+
+
+def test_mcp_client_beta_is_removed_for_translated_provider(
+    client: TestClient,
+    api_key_header: dict[str, str],
+) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        captured.update(kwargs)
+        return _text_response()
+
+    with patch("gateway.api.routes.messages.amessages", new=fake_amessages):
+        resp = client.post(
+            "/v1/messages?beta=true",
+            json={
+                "model": "openai:gpt-4o",
+                "messages": [{"role": "user", "content": "Use the MCP beta"}],
+                "max_tokens": 100,
+            },
+            headers={**api_key_header, "anthropic-beta": MCP_CLIENT_BETA},
+        )
+
+    assert resp.status_code == 200, resp.text
+    assert "betas" not in captured
 
 
 def test_gateway_internal_fields_are_stripped_from_upstream_kwargs(
@@ -1408,6 +1433,7 @@ def test_stream_mcp_activity_requires_beta(
     expected_block_types: list[str],
 ) -> None:
     calls: list[tuple[str, dict[str, Any]]] = []
+    provider_calls: list[dict[str, Any]] = []
     streams = iter(
         [
             _stream_iter(
@@ -1461,7 +1487,8 @@ def test_stream_mcp_activity_requires_beta(
         ]
     )
 
-    async def fake_amessages(**_kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+    async def fake_amessages(**kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        provider_calls.append(kwargs)
         return next(streams)
 
     class ActivityPool:
@@ -1524,6 +1551,7 @@ def test_stream_mcp_activity_requires_beta(
     blocks = [payload["content_block"] for payload in payloads if payload.get("type") == "content_block_start"]
     assert [block["type"] for block in blocks] == expected_block_types
     assert calls == [("lookup", {"issue": 755})]
+    assert all(MCP_CLIENT_BETA not in call.get("betas", []) for call in provider_calls)
     if beta_header is not None:
         assert blocks[0]["name"] == "lookup"
         assert blocks[0]["server_name"] == "fixture"

--- a/tests/integration/test_messages_route_dispatch.py
+++ b/tests/integration/test_messages_route_dispatch.py
@@ -36,7 +36,7 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from gateway.services.mcp_client import MCPToolCallOutcome
-from gateway.services.mcp_loop_messages import MCP_ACTIVITY_ID_PREFIX
+from gateway.services.mcp_loop_messages import MCP_ACTIVITY_ID_PREFIX, MCP_CLIENT_BETA
 
 _CONTEXT_MANAGEMENT = {"edits": [{"type": "compact_20260112", "trigger": {"type": "input_tokens", "value": 50_000}}]}
 _BETAS = ["compact-2026-01-12"]
@@ -1333,10 +1333,20 @@ def test_stream_mcp_servers_dispatches_through_tool_loop_stream(
     assert plain_amessages_called is False
 
 
-def test_stream_mcp_activity_reaches_the_sse_client(
+@pytest.mark.parametrize(
+    ("betas", "expected_block_types"),
+    [
+        (None, ["text"]),
+        ([MCP_CLIENT_BETA], ["mcp_tool_use", "mcp_tool_result", "text"]),
+    ],
+)
+def test_stream_mcp_activity_requires_beta(
     client: TestClient,
     api_key_header: dict[str, str],
+    betas: list[str] | None,
+    expected_block_types: list[str],
 ) -> None:
+    calls: list[tuple[str, dict[str, Any]]] = []
     streams = iter(
         [
             _stream_iter(
@@ -1415,6 +1425,7 @@ def test_stream_mcp_activity_reaches_the_sse_client(
         async def call_tool_outcome(self, name: str, arguments: dict[str, Any]) -> MCPToolCallOutcome:
             assert name == "lookup"
             assert arguments == {"issue": 755}
+            calls.append((name, arguments))
             return MCPToolCallOutcome(content="issue result", is_error=False)
 
     with (
@@ -1436,6 +1447,7 @@ def test_stream_mcp_activity_reaches_the_sse_client(
                 "max_tokens": 100,
                 "stream": True,
                 "mcp_servers": [{"name": "fixture", "url": "http://127.0.0.1:9999/mcp"}],
+                **({"betas": betas} if betas is not None else {}),
             },
             headers=api_key_header,
         )
@@ -1443,20 +1455,18 @@ def test_stream_mcp_activity_reaches_the_sse_client(
     assert resp.status_code == 200, resp.text
     payloads = [json.loads(line.removeprefix("data: ")) for line in resp.text.splitlines() if line.startswith("data: ")]
     blocks = [payload["content_block"] for payload in payloads if payload.get("type") == "content_block_start"]
-    assert [block["type"] for block in blocks] == [
-        "mcp_tool_use",
-        "mcp_tool_result",
-        "text",
-    ]
-    assert blocks[0]["name"] == "lookup"
-    assert blocks[0]["server_name"] == "fixture"
-    assert blocks[0]["input"] == {"issue": 755}
-    assert blocks[1] == {
-        "type": "mcp_tool_result",
-        "tool_use_id": blocks[0]["id"],
-        "content": "issue result",
-        "is_error": False,
-    }
+    assert [block["type"] for block in blocks] == expected_block_types
+    assert calls == [("lookup", {"issue": 755})]
+    if betas is not None:
+        assert blocks[0]["name"] == "lookup"
+        assert blocks[0]["server_name"] == "fixture"
+        assert blocks[0]["input"] == {"issue": 755}
+        assert blocks[1] == {
+            "type": "mcp_tool_result",
+            "tool_use_id": blocks[0]["id"],
+            "content": "issue result",
+            "is_error": False,
+        }
 
 
 def test_stream_code_execution_dispatches_through_sandbox(

--- a/tests/integration/test_messages_route_dispatch.py
+++ b/tests/integration/test_messages_route_dispatch.py
@@ -1021,7 +1021,7 @@ def test_echoed_mcp_activity_is_removed_before_prompt_estimation(
 
     async def fake_resolve_request_context(**kwargs: Any) -> Any:
         captured.update(kwargs)
-        await kwargs["normalize_messages"]("user", None, "model", None)
+        await kwargs["normalize_messages"]("user", None, "model", None, None)
         raise HTTPException(status_code=418, detail="stop after admission inputs")
 
     with (

--- a/tests/integration/test_messages_route_dispatch.py
+++ b/tests/integration/test_messages_route_dispatch.py
@@ -36,11 +36,7 @@ from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from gateway.services.mcp_client import MCPToolCallOutcome
-from gateway.services.mcp_loop_messages import (
-    MCP_ACTIVITY_ID_PREFIX,
-    MCP_CLIENT_BETA,
-    MCP_CLIENT_BETA_LEGACY,
-)
+from gateway.services.mcp_loop_messages import MCP_ACTIVITY_ID_PREFIX, MCP_CLIENT_BETA
 
 _CONTEXT_MANAGEMENT = {"edits": [{"type": "compact_20260112", "trigger": {"type": "input_tokens", "value": 50_000}}]}
 _BETAS = ["compact-2026-01-12"]
@@ -1403,7 +1399,6 @@ def test_stream_mcp_servers_dispatches_through_tool_loop_stream(
     [
         (None, ["text"]),
         (MCP_CLIENT_BETA, ["mcp_tool_use", "mcp_tool_result", "text"]),
-        (MCP_CLIENT_BETA_LEGACY, ["mcp_tool_use", "mcp_tool_result", "text"]),
     ],
 )
 def test_stream_mcp_activity_requires_beta(

--- a/tests/integration/test_messages_route_dispatch.py
+++ b/tests/integration/test_messages_route_dispatch.py
@@ -530,12 +530,12 @@ def test_mcp_servers_dispatches_through_anthropic_tool_loop(
     assert plain_amessages_called is False
 
 
-def test_mcp_servers_do_not_widen_web_search_replay_stripping(
+def test_web_search_replay_is_stripped_when_interception_is_off(
     client: TestClient,
     api_key_header: dict[str, str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """MCP configuration must not strip web-search blocks when interception is off."""
+    """Gateway provenance, not the current interception setting, controls replay stripping."""
     monkeypatch.delenv("OTARI_WEB_SEARCH_INTERCEPT", raising=False)
     replayed_messages = [
         {"role": "user", "content": "search"},
@@ -581,7 +581,11 @@ def test_mcp_servers_do_not_widen_web_search_replay_stripping(
         )
 
     assert resp.status_code == 200, resp.text
-    assert captured["messages"] == replayed_messages
+    assert captured["messages"] == [
+        replayed_messages[0],
+        {"role": "assistant", "content": [{"type": "text", "text": "answer"}]},
+        replayed_messages[2],
+    ]
 
 
 def test_code_execution_dispatches_through_sandbox_backend(
@@ -1034,31 +1038,58 @@ async def _stream_iter(*events: MessageStreamEvent) -> AsyncIterator[MessageStre
         yield event
 
 
-def test_echoed_mcp_activity_is_removed_before_prompt_estimation(
+@pytest.mark.parametrize(
+    "activity_blocks",
+    [
+        [
+            {
+                "type": "mcp_tool_use",
+                "id": f"{MCP_ACTIVITY_ID_PREFIX}echoed",
+                "name": "lookup",
+                "server_name": "fixture",
+                "input": {"id": 755},
+            },
+            {
+                "type": "mcp_tool_result",
+                "tool_use_id": f"{MCP_ACTIVITY_ID_PREFIX}echoed",
+                "content": "large-result" * 10_000,
+                "is_error": False,
+            },
+        ],
+        [
+            {
+                "type": "server_tool_use",
+                "id": "srvtoolu_echoed",
+                "name": "web_search",
+                "input": {"query": "otari"},
+            },
+            {
+                "type": "web_search_tool_result",
+                "tool_use_id": "srvtoolu_echoed",
+                "content": [
+                    {
+                        "type": "web_search_result",
+                        "url": "https://example.test",
+                        "title": "large-result" * 10_000,
+                        "encrypted_content": "",
+                    }
+                ],
+            },
+        ],
+    ],
+    ids=["mcp", "web-search"],
+)
+def test_echoed_gateway_activity_is_removed_before_prompt_estimation(
     client: TestClient,
     api_key_header: dict[str, str],
+    activity_blocks: list[dict[str, Any]],
 ) -> None:
     """Gateway-owned result content must not consume budget headroom before being stripped."""
     messages = [
         {"role": "user", "content": "first turn"},
         {
             "role": "assistant",
-            "content": [
-                {
-                    "type": "mcp_tool_use",
-                    "id": f"{MCP_ACTIVITY_ID_PREFIX}echoed",
-                    "name": "lookup",
-                    "server_name": "fixture",
-                    "input": {"id": 755},
-                },
-                {
-                    "type": "mcp_tool_result",
-                    "tool_use_id": f"{MCP_ACTIVITY_ID_PREFIX}echoed",
-                    "content": "large-result" * 10_000,
-                    "is_error": False,
-                },
-                {"type": "text", "text": "prior answer"},
-            ],
+            "content": [*activity_blocks, {"type": "text", "text": "prior answer"}],
         },
         {"role": "user", "content": "continue"},
     ]

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -74,4 +74,33 @@ async def test_call_tool_outcome_preserves_server_error_status(is_error: bool) -
     assert pool.server_name_for_tool("lookup") == "fixture"
     assert outcome.is_error is is_error
     assert outcome.content == ("[tool error] fixture result" if is_error else "fixture result")
+    assert outcome.activity_content == "fixture result"
+    assert outcome.transport_error is False
     session.call_tool.assert_awaited_once_with("lookup", {"id": 755})
+
+
+@pytest.mark.asyncio
+async def test_call_tool_sanitizes_transport_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = SimpleNamespace(
+        call_tool=AsyncMock(side_effect=RuntimeError("https://internal.test/?token=secret"))
+    )
+    pool = MCPClientPool([])
+    pool._servers["fixture"] = _ConnectedServer(
+        name="fixture",
+        session=cast(Any, session),
+    )
+    pool._tool_owner["lookup"] = "fixture"
+    warnings: list[tuple[Any, ...]] = []
+    monkeypatch.setattr(
+        "gateway.services.mcp_client.logger.warning",
+        lambda message, *args: warnings.append((message, *args)),
+    )
+
+    content = await pool.call_tool("lookup", {"id": 755})
+
+    assert content == "[tool error] MCP tool execution failed"
+    assert warnings == [("MCP tool %s execution failed: %s", "lookup", "RuntimeError")]
+    assert "internal.test" not in str(warnings)
+    assert "secret" not in str(warnings)

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -1,14 +1,10 @@
-"""Unit tests for MCPClientPool's own duplicate-name guard.
-
-prepare_gateway_tools (routes/_pipeline.py) rejects a duplicate server name at
-request-admission time, before any pool is built. That covers every current
-production caller, but the pool's own module docstring advertises
-``async with MCPClientPool(configs) as pool`` as a supported direct entry
-point, so the invariant belongs here too for a caller that reaches it another
-way (otari#792 review).
-"""
+"""Unit coverage for MCPClientPool behavior."""
 
 from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -53,3 +49,29 @@ async def test_aenter_connects_distinct_names(monkeypatch: pytest.MonkeyPatch) -
     async with MCPClientPool(configs) as pool:
         assert set(pool._servers) == {"a", "b"}
     assert connected == ["a", "b"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_error", [False, True])
+async def test_call_tool_outcome_preserves_server_error_status(is_error: bool) -> None:
+    session = SimpleNamespace(
+        call_tool=AsyncMock(
+            return_value=SimpleNamespace(
+                content=[SimpleNamespace(type="text", text="fixture result")],
+                isError=is_error,
+            )
+        )
+    )
+    pool = MCPClientPool([])
+    pool._servers["fixture"] = _ConnectedServer(
+        name="fixture",
+        session=cast(Any, session),
+    )
+    pool._tool_owner["lookup"] = "fixture"
+
+    outcome = await pool.call_tool_outcome("lookup", {"id": 755})
+
+    assert pool.server_name_for_tool("lookup") == "fixture"
+    assert outcome.is_error is is_error
+    assert outcome.content == ("[tool error] fixture result" if is_error else "fixture result")
+    session.call_tool.assert_awaited_once_with("lookup", {"id": 755})

--- a/tests/unit/test_mcp_loop_messages.py
+++ b/tests/unit/test_mcp_loop_messages.py
@@ -873,7 +873,6 @@ async def test_stream_emits_live_mcp_activity_around_execution(
 @pytest.mark.asyncio
 async def test_stream_mcp_exception_emits_error_without_logging_detail(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     iter_streams = iter(
         [
@@ -907,7 +906,13 @@ async def test_stream_mcp_exception_emits_error_without_logging_detail(
             self.calls.append((name, arguments))
             raise RuntimeError("credential-detail-do-not-log")
 
+    logged_warnings: list[tuple[Any, ...]] = []
+
+    def capture_warning(message: str, *args: Any) -> None:
+        logged_warnings.append((message, *args))
+
     monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+    monkeypatch.setattr(messages_loop_module.logger, "warning", capture_warning)
     pool = FailingActivityPool()
     events = [
         event
@@ -930,8 +935,11 @@ async def test_stream_mcp_exception_emits_error_without_logging_detail(
     model_result = provider_calls[1]["messages"][-1]["content"][0]
     assert model_result["content"] == "[tool error] MCP tool execution failed"
     assert "credential-detail-do-not-log" not in str(provider_calls[1]["messages"])
-    assert "credential-detail-do-not-log" not in caplog.text
-    assert "do-not-log" not in caplog.text
+    assert logged_warnings == [
+        ("Gateway tool %s execution failed: %s", "fetch_url", "RuntimeError")
+    ]
+    assert "credential-detail-do-not-log" not in str(logged_warnings)
+    assert "do-not-log" not in str(logged_warnings)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mcp_loop_messages.py
+++ b/tests/unit/test_mcp_loop_messages.py
@@ -33,7 +33,6 @@ from gateway.log_config import logger
 from gateway.services import mcp_loop_messages as messages_loop_module
 from gateway.services.mcp_client import MCPToolCallOutcome
 from gateway.services.mcp_loop_messages import (
-    MCP_CLIENT_BETA,
     MaxToolIterationsExceeded,
     anthropic_tool_loop,
     anthropic_tool_loop_stream,
@@ -856,10 +855,10 @@ async def test_stream_emits_live_mcp_activity_around_execution(
         completion_kwargs={
             "model": "fake",
             "messages": [{"role": "user", "content": "go"}],
-            "betas": [MCP_CLIENT_BETA],
         },
         pool=cast(Any, pool),
         max_iterations=5,
+        emit_native_mcp=True,
     )
 
     assert (await anext(stream)).type == "message_start"
@@ -1001,10 +1000,10 @@ async def test_stream_mcp_exception_emits_error_without_logging_detail(
             completion_kwargs={
                 "model": "fake",
                 "messages": [{"role": "user", "content": "go"}],
-                "betas": [MCP_CLIENT_BETA],
             },
             pool=cast(Any, pool),
             max_iterations=5,
+            emit_native_mcp=True,
         )
     ]
 
@@ -1318,10 +1317,10 @@ async def test_stream_mixed_batch_hides_and_still_runs_the_gateway_tool(
                 "model": "fake",
                 "messages": [{"role": "user", "content": "go"}],
                 "max_tokens": 100,
-                "betas": [MCP_CLIENT_BETA],
             },
             pool=cast(Any, pool),
             max_iterations=5,
+            emit_native_mcp=True,
         )
     ]
 

--- a/tests/unit/test_mcp_loop_messages.py
+++ b/tests/unit/test_mcp_loop_messages.py
@@ -6,6 +6,7 @@ in Anthropic content-block / streaming-event shape.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator
 from typing import Any, cast
 
@@ -29,6 +30,7 @@ from any_llm.types.messages import (
 )
 
 from gateway.services import mcp_loop_messages as messages_loop_module
+from gateway.services.mcp_client import MCPToolCallOutcome
 from gateway.services.mcp_loop_messages import (
     MaxToolIterationsExceeded,
     anthropic_tool_loop,
@@ -76,6 +78,26 @@ class _FakePool:
         if name not in self._results:
             return f"ran {name}"
         return self._results[name]
+
+
+class _ActivityPool(_FakePool):
+    """MCP pool stand-in with server metadata and controllable execution."""
+
+    def __init__(self, *, content: str = "ok", is_error: bool = False) -> None:
+        super().__init__(["fetch_url"])
+        self.content = content
+        self.is_error = is_error
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    def server_name_for_tool(self, name: str) -> str | None:
+        return "fixture-server" if self.owns_tool(name) else None
+
+    async def call_tool_outcome(self, name: str, arguments: dict[str, Any]) -> MCPToolCallOutcome:
+        self.calls.append((name, arguments))
+        self.started.set()
+        await self.release.wait()
+        return MCPToolCallOutcome(content=self.content, is_error=self.is_error)
 
 
 def _text_block(text: str) -> TextBlock:
@@ -235,9 +257,7 @@ async def test_loop_executes_owned_tool_and_completes(monkeypatch: pytest.Monkey
 async def test_loop_replays_compaction_block_with_context_management(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    context_management = {
-        "edits": [{"type": "compact_20260112", "trigger": {"type": "input_tokens", "value": 50_000}}]
-    }
+    context_management = {"edits": [{"type": "compact_20260112", "trigger": {"type": "input_tokens", "value": 50_000}}]}
     responses = iter(
         [
             MessageResponse.model_validate(
@@ -772,12 +792,146 @@ async def test_stream_runs_owned_tool_and_continues(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(("content", "is_error"), [("fixture result", False), ("fixture error", True)])
+async def test_stream_emits_live_mcp_activity_around_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    content: str,
+    is_error: bool,
+) -> None:
+    """The MCP start reaches the client before execution, then a paired completion follows."""
+    iter_streams = iter(
+        [
+            _async_iter(
+                _msg_start_event(),
+                _tool_use_block_start(0, "tu_internal", "fetch_url"),
+                _input_json_delta(0, '{"url": "https://example.test"}'),
+                _content_block_stop(0),
+                _msg_delta_event("tool_use"),
+                _msg_stop_event(),
+            ),
+            _async_iter(
+                _msg_start_event(),
+                _text_block_start(0),
+                _text_delta(0, "done"),
+                _content_block_stop(0),
+                _msg_delta_event("end_turn"),
+                _msg_stop_event(),
+            ),
+        ]
+    )
+
+    async def fake_amessages(**kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        return next(iter_streams)
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+    pool = _ActivityPool(content=content, is_error=is_error)
+    stream = anthropic_tool_loop_stream(
+        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+        pool=cast(Any, pool),
+        max_iterations=5,
+    )
+
+    assert (await anext(stream)).type == "message_start"
+    activity_start = await anext(stream)
+    assert activity_start.type == "content_block_start"
+    use = cast(Any, activity_start).content_block
+    assert use.type == "mcp_tool_use"
+    assert use.id.startswith("otari_mcptoolu_")
+    assert use.name == "fetch_url"
+    assert use.server_name == "fixture-server"
+    assert use.input == {"url": "https://example.test"}
+    assert not pool.started.is_set(), "execution must not precede the client-visible start"
+
+    assert (await anext(stream)).type == "content_block_stop"
+    pending_completion = asyncio.create_task(anext(stream))
+    await asyncio.wait_for(pool.started.wait(), timeout=1)
+    assert not pending_completion.done(), "the completion must wait for the MCP call"
+    pool.release.set()
+
+    completion_start = await pending_completion
+    assert completion_start.type == "content_block_start"
+    result = cast(Any, completion_start).content_block
+    assert result.type == "mcp_tool_result"
+    assert result.tool_use_id == use.id
+    assert result.content == content
+    assert result.is_error is is_error
+    assert cast(Any, completion_start).index == cast(Any, activity_start).index + 1
+
+    remaining = [event async for event in stream]
+    assert [event.type for event in remaining] == [
+        "content_block_stop",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+    assert cast(Any, remaining[1]).index == cast(Any, completion_start).index + 1
+    assert pool.calls == [("fetch_url", {"url": "https://example.test"})]
+
+
+@pytest.mark.asyncio
+async def test_stream_mcp_exception_emits_error_without_logging_detail(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    iter_streams = iter(
+        [
+            _async_iter(
+                _msg_start_event(),
+                _tool_use_block_start(0, "tu_internal", "fetch_url"),
+                _input_json_delta(0, '{"secret_input": "do-not-log"}'),
+                _content_block_stop(0),
+                _msg_delta_event("tool_use"),
+                _msg_stop_event(),
+            ),
+            _async_iter(
+                _msg_start_event(),
+                _text_block_start(0),
+                _text_delta(0, "recovered"),
+                _content_block_stop(0),
+                _msg_delta_event("end_turn"),
+                _msg_stop_event(),
+            ),
+        ]
+    )
+
+    async def fake_amessages(**kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        return next(iter_streams)
+
+    class FailingActivityPool(_ActivityPool):
+        async def call_tool_outcome(self, name: str, arguments: dict[str, Any]) -> MCPToolCallOutcome:
+            self.calls.append((name, arguments))
+            raise RuntimeError("credential-detail-do-not-log")
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+    pool = FailingActivityPool()
+    events = [
+        event
+        async for event in anthropic_tool_loop_stream(
+            completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+            pool=cast(Any, pool),
+            max_iterations=5,
+        )
+    ]
+
+    result = next(
+        cast(Any, event).content_block
+        for event in events
+        if event.type == "content_block_start"
+        and getattr(cast(Any, event).content_block, "type", None) == "mcp_tool_result"
+    )
+    assert result.is_error is True
+    assert result.content == "[tool error] MCP tool execution failed"
+    assert "credential-detail-do-not-log" not in caplog.text
+    assert "do-not-log" not in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_stream_replays_compaction_content_when_tool_loop_continues(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    context_management = {
-        "edits": [{"type": "compact_20260112", "trigger": {"type": "input_tokens", "value": 50_000}}]
-    }
+    context_management = {"edits": [{"type": "compact_20260112", "trigger": {"type": "input_tokens", "value": 50_000}}]}
     iter_streams = iter(
         [
             _async_iter(
@@ -1030,9 +1184,9 @@ async def test_stream_mixed_batch_hides_and_still_runs_the_gateway_tool(
 ) -> None:
     """A mixed batch shows only the caller's tool, and still runs the gateway's.
 
-    The loop exits so the caller can dispatch its own tool. The gateway's block was
-    withheld from the stream (the client can never be sent its result), so it has to
-    be executed anyway or the model's search silently vanishes.
+    The loop exits so the caller can dispatch its own tool. The gateway's ordinary
+    tool block is withheld, but the client receives the server-owned MCP activity
+    pair while Otari executes it.
     """
     iter_streams = iter(
         [
@@ -1055,7 +1209,8 @@ async def test_stream_mixed_batch_hides_and_still_runs_the_gateway_tool(
 
     monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
 
-    pool = _FakePool(tool_names=["fetch_url"], results={"fetch_url": "ok"})
+    pool = _ActivityPool(content="ok")
+    pool.release.set()
     events = [
         event
         async for event in anthropic_tool_loop_stream(
@@ -1071,9 +1226,14 @@ async def test_stream_mixed_batch_hides_and_still_runs_the_gateway_tool(
         if getattr(getattr(e, "content_block", None), "type", None) == "tool_use"
     ]
     assert shown == ["user_tool"]
-    # Renumbered so the caller's block is index 0, with no hole where the hidden one was.
+    # Renumbered so the caller's block is index 0, with no hole where the hidden
+    # raw call was. Server-owned MCP activity follows at indices 1 and 2.
     starts = [getattr(e, "index") for e in events if e.type == "content_block_start"]
-    assert starts == [0]
+    assert starts == [0, 1, 2]
+    activity_types = [
+        getattr(getattr(e, "content_block", None), "type", None) for e in events if e.type == "content_block_start"
+    ]
+    assert activity_types == ["tool_use", "mcp_tool_use", "mcp_tool_result"]
     assert pool.calls == [("fetch_url", {"u": "x"})]
 
 

--- a/tests/unit/test_mcp_loop_messages.py
+++ b/tests/unit/test_mcp_loop_messages.py
@@ -32,6 +32,7 @@ from any_llm.types.messages import (
 from gateway.services import mcp_loop_messages as messages_loop_module
 from gateway.services.mcp_client import MCPToolCallOutcome
 from gateway.services.mcp_loop_messages import (
+    MCP_CLIENT_BETA,
     MaxToolIterationsExceeded,
     anthropic_tool_loop,
     anthropic_tool_loop_stream,
@@ -826,7 +827,11 @@ async def test_stream_emits_live_mcp_activity_around_execution(
     monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
     pool = _ActivityPool(content=content, is_error=is_error)
     stream = anthropic_tool_loop_stream(
-        completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+        completion_kwargs={
+            "model": "fake",
+            "messages": [{"role": "user", "content": "go"}],
+            "betas": [MCP_CLIENT_BETA],
+        },
         pool=cast(Any, pool),
         max_iterations=5,
     )
@@ -867,6 +872,55 @@ async def test_stream_emits_live_mcp_activity_around_execution(
         "message_stop",
     ]
     assert cast(Any, remaining[1]).index == cast(Any, completion_start).index + 1
+    assert pool.calls == [("fetch_url", {"url": "https://example.test"})]
+
+
+@pytest.mark.asyncio
+async def test_stream_hides_mcp_activity_without_beta_but_still_executes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    iter_streams = iter(
+        [
+            _async_iter(
+                _msg_start_event(),
+                _tool_use_block_start(0, "tu_internal", "fetch_url"),
+                _input_json_delta(0, '{"url": "https://example.test"}'),
+                _content_block_stop(0),
+                _msg_delta_event("tool_use"),
+                _msg_stop_event(),
+            ),
+            _async_iter(
+                _msg_start_event(),
+                _text_block_start(0),
+                _text_delta(0, "done"),
+                _content_block_stop(0),
+                _msg_delta_event("end_turn"),
+                _msg_stop_event(),
+            ),
+        ]
+    )
+
+    async def fake_amessages(**kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        return next(iter_streams)
+
+    monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
+    pool = _ActivityPool()
+    pool.release.set()
+    events = [
+        event
+        async for event in anthropic_tool_loop_stream(
+            completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+            pool=cast(Any, pool),
+            max_iterations=5,
+        )
+    ]
+
+    starts = [
+        cast(Any, event).content_block
+        for event in events
+        if event.type == "content_block_start"
+    ]
+    assert [block.type for block in starts] == ["text"]
     assert pool.calls == [("fetch_url", {"url": "https://example.test"})]
 
 
@@ -917,7 +971,11 @@ async def test_stream_mcp_exception_emits_error_without_logging_detail(
     events = [
         event
         async for event in anthropic_tool_loop_stream(
-            completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}]},
+            completion_kwargs={
+                "model": "fake",
+                "messages": [{"role": "user", "content": "go"}],
+                "betas": [MCP_CLIENT_BETA],
+            },
             pool=cast(Any, pool),
             max_iterations=5,
         )
@@ -1229,7 +1287,12 @@ async def test_stream_mixed_batch_hides_and_still_runs_the_gateway_tool(
     events = [
         event
         async for event in anthropic_tool_loop_stream(
-            completion_kwargs={"model": "fake", "messages": [{"role": "user", "content": "go"}], "max_tokens": 100},
+            completion_kwargs={
+                "model": "fake",
+                "messages": [{"role": "user", "content": "go"}],
+                "max_tokens": 100,
+                "betas": [MCP_CLIENT_BETA],
+            },
             pool=cast(Any, pool),
             max_iterations=5,
         )

--- a/tests/unit/test_mcp_loop_messages.py
+++ b/tests/unit/test_mcp_loop_messages.py
@@ -29,6 +29,7 @@ from any_llm.types.messages import (
     ToolUseBlock,
 )
 
+from gateway.log_config import logger
 from gateway.services import mcp_loop_messages as messages_loop_module
 from gateway.services.mcp_client import MCPToolCallOutcome
 from gateway.services.mcp_loop_messages import (
@@ -966,7 +967,7 @@ async def test_stream_mcp_exception_emits_error_without_logging_detail(
         logged_warnings.append((message, *args))
 
     monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
-    monkeypatch.setattr(messages_loop_module.logger, "warning", capture_warning)
+    monkeypatch.setattr(logger, "warning", capture_warning)
     pool = FailingActivityPool()
     events = [
         event

--- a/tests/unit/test_mcp_loop_messages.py
+++ b/tests/unit/test_mcp_loop_messages.py
@@ -896,7 +896,10 @@ async def test_stream_mcp_exception_emits_error_without_logging_detail(
         ]
     )
 
+    provider_calls: list[dict[str, Any]] = []
+
     async def fake_amessages(**kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        provider_calls.append(kwargs)
         return next(iter_streams)
 
     class FailingActivityPool(_ActivityPool):
@@ -923,6 +926,10 @@ async def test_stream_mcp_exception_emits_error_without_logging_detail(
     )
     assert result.is_error is True
     assert result.content == "[tool error] MCP tool execution failed"
+    assert len(provider_calls) == 2
+    model_result = provider_calls[1]["messages"][-1]["content"][0]
+    assert model_result["content"] == "[tool error] MCP tool execution failed"
+    assert "credential-detail-do-not-log" not in str(provider_calls[1]["messages"])
     assert "credential-detail-do-not-log" not in caplog.text
     assert "do-not-log" not in caplog.text
 

--- a/tests/unit/test_mcp_loop_messages.py
+++ b/tests/unit/test_mcp_loop_messages.py
@@ -85,9 +85,16 @@ class _FakePool:
 class _ActivityPool(_FakePool):
     """MCP pool stand-in with server metadata and controllable execution."""
 
-    def __init__(self, *, content: str = "ok", is_error: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        content: str = "ok",
+        activity_content: str | None = None,
+        is_error: bool = False,
+    ) -> None:
         super().__init__(["fetch_url"])
         self.content = content
+        self.activity_content = activity_content if activity_content is not None else content
         self.is_error = is_error
         self.started = asyncio.Event()
         self.release = asyncio.Event()
@@ -99,7 +106,11 @@ class _ActivityPool(_FakePool):
         self.calls.append((name, arguments))
         self.started.set()
         await self.release.wait()
-        return MCPToolCallOutcome(content=self.content, is_error=self.is_error)
+        return MCPToolCallOutcome(
+            content=self.content,
+            activity_content=self.activity_content,
+            is_error=self.is_error,
+        )
 
 
 def _text_block(text: str) -> TextBlock:
@@ -794,10 +805,17 @@ async def test_stream_runs_owned_tool_and_continues(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(("content", "is_error"), [("fixture result", False), ("fixture error", True)])
+@pytest.mark.parametrize(
+    ("content", "activity_content", "is_error"),
+    [
+        ("fixture result", "fixture result", False),
+        ("[tool error] fixture error", "fixture error", True),
+    ],
+)
 async def test_stream_emits_live_mcp_activity_around_execution(
     monkeypatch: pytest.MonkeyPatch,
     content: str,
+    activity_content: str,
     is_error: bool,
 ) -> None:
     """The MCP start reaches the client before execution, then a paired completion follows."""
@@ -822,11 +840,18 @@ async def test_stream_emits_live_mcp_activity_around_execution(
         ]
     )
 
+    provider_calls: list[dict[str, Any]] = []
+
     async def fake_amessages(**kwargs: Any) -> AsyncIterator[MessageStreamEvent]:
+        provider_calls.append(kwargs)
         return next(iter_streams)
 
     monkeypatch.setattr(messages_loop_module, "amessages", fake_amessages)
-    pool = _ActivityPool(content=content, is_error=is_error)
+    pool = _ActivityPool(
+        content=content,
+        activity_content=activity_content,
+        is_error=is_error,
+    )
     stream = anthropic_tool_loop_stream(
         completion_kwargs={
             "model": "fake",
@@ -859,7 +884,7 @@ async def test_stream_emits_live_mcp_activity_around_execution(
     result = cast(Any, completion_start).content_block
     assert result.type == "mcp_tool_result"
     assert result.tool_use_id == use.id
-    assert result.content == content
+    assert result.content == activity_content
     assert result.is_error is is_error
     assert cast(Any, completion_start).index == cast(Any, activity_start).index + 1
 
@@ -873,6 +898,7 @@ async def test_stream_emits_live_mcp_activity_around_execution(
         "message_stop",
     ]
     assert cast(Any, remaining[1]).index == cast(Any, completion_start).index + 1
+    assert provider_calls[1]["messages"][-1]["content"][0]["content"] == content
     assert pool.calls == [("fetch_url", {"url": "https://example.test"})]
 
 
@@ -989,7 +1015,7 @@ async def test_stream_mcp_exception_emits_error_without_logging_detail(
         and getattr(cast(Any, event).content_block, "type", None) == "mcp_tool_result"
     )
     assert result.is_error is True
-    assert result.content == "[tool error] MCP tool execution failed"
+    assert result.content == "MCP tool execution failed"
     assert len(provider_calls) == 2
     model_result = provider_calls[1]["messages"][-1]["content"][0]
     assert model_result["content"] == "[tool error] MCP tool execution failed"

--- a/tests/unit/test_messages_minted_block_stripping.py
+++ b/tests/unit/test_messages_minted_block_stripping.py
@@ -1,8 +1,8 @@
 """Inbound stripping of the server-tool blocks the gateway mints itself.
 
 Continuing an Anthropic conversation means echoing the previous assistant turn
-back. A gateway-minted ``web_search_tool_result`` carries an
-``encrypted_content`` the gateway cannot sign, so it must not reach a provider.
+back. Gateway-minted web-search and MCP activity blocks describe work Otari
+already consumed, so they must not reach the provider on the next request.
 Mirrors ``responses._strip_gateway_minted_items``.
 """
 
@@ -13,8 +13,12 @@ from typing import Any
 import pytest
 
 from gateway.api.routes._pipeline import ToolContext
-from gateway.api.routes.messages import _strip_gateway_minted_blocks
+from gateway.api.routes.messages import (
+    _has_gateway_minted_mcp_blocks,
+    _strip_gateway_minted_blocks,
+)
 from gateway.core.config import GatewayConfig
+from gateway.services.mcp_loop_messages import MCP_ACTIVITY_ID_PREFIX
 
 
 def test_strips_the_minted_pair_but_keeps_the_text() -> None:
@@ -164,6 +168,71 @@ def _gateway_pair(tool_use_id: str = "srvtoolu_gw") -> list[dict[str, Any]]:
     ]
 
 
+def _mcp_pair(tool_use_id: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "mcp_tool_use",
+            "id": tool_use_id,
+            "name": "lookup",
+            "server_name": "fixture",
+            "input": {"id": 755},
+        },
+        {
+            "type": "mcp_tool_result",
+            "tool_use_id": tool_use_id,
+            "content": "result",
+            "is_error": False,
+        },
+    ]
+
+
+def test_gateway_mcp_activity_pair_is_stripped() -> None:
+    gateway_pair = _mcp_pair(f"{MCP_ACTIVITY_ID_PREFIX}abc")
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "content": [*gateway_pair, {"type": "text", "text": "answer"}],
+        }
+    ]
+
+    kept = _strip_gateway_minted_blocks(messages)[0]["content"]
+
+    assert _has_gateway_minted_mcp_blocks(messages) is True
+    assert kept == [{"type": "text", "text": "answer"}]
+
+
+def test_early_mcp_strip_preserves_web_search_blocks() -> None:
+    gateway_mcp_pair = _mcp_pair(f"{MCP_ACTIVITY_ID_PREFIX}abc")
+    web_pair = _gateway_pair()
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "content": [*web_pair, *gateway_mcp_pair, {"type": "text", "text": "answer"}],
+        }
+    ]
+
+    kept = _strip_gateway_minted_blocks(messages, strip_web_search=False)[0]["content"]
+
+    assert kept == [*web_pair, {"type": "text", "text": "answer"}]
+
+
+def test_provider_mcp_activity_pair_survives() -> None:
+    messages: list[dict[str, Any]] = [{"role": "assistant", "content": _mcp_pair("mcptoolu_provider")}]
+
+    assert _has_gateway_minted_mcp_blocks(messages) is False
+    assert _strip_gateway_minted_blocks(messages) == messages
+
+
+def test_mcp_result_is_removed_only_with_its_gateway_use() -> None:
+    provider_pair = _mcp_pair("mcptoolu_provider")
+    gateway_pair = _mcp_pair(f"{MCP_ACTIVITY_ID_PREFIX}abc")
+    messages: list[dict[str, Any]] = [{"role": "assistant", "content": [*provider_pair, *gateway_pair]}]
+
+    kept = _strip_gateway_minted_blocks(messages)[0]["content"]
+
+    assert kept == provider_pair
+
+
 def test_provider_signed_blocks_survive() -> None:
     """A search Anthropic ran and signed must round-trip untouched, even with
     interception on: stripping it would break the citations chain Anthropic owns."""
@@ -192,9 +261,7 @@ def test_gateway_pair_is_stripped_and_provider_pair_kept_in_one_turn() -> None:
 def test_a_providers_server_tool_use_is_never_orphaned() -> None:
     """The server_tool_use dropped is the one our result answers, matched by id, so a
     provider's pair is never split into an orphan the API would reject."""
-    messages: list[dict[str, Any]] = [
-        {"role": "assistant", "content": [*_provider_pair(), *_gateway_pair()]}
-    ]
+    messages: list[dict[str, Any]] = [{"role": "assistant", "content": [*_provider_pair(), *_gateway_pair()]}]
 
     kept = _strip_gateway_minted_blocks(messages)[0]["content"]
 

--- a/tests/unit/test_messages_minted_block_stripping.py
+++ b/tests/unit/test_messages_minted_block_stripping.py
@@ -233,6 +233,28 @@ def test_mcp_result_is_removed_only_with_its_gateway_use() -> None:
     assert kept == provider_pair
 
 
+def test_orphaned_gateway_mcp_result_is_stripped() -> None:
+    messages: list[dict[str, Any]] = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "mcp_tool_result",
+                    "tool_use_id": f"{MCP_ACTIVITY_ID_PREFIX}orphaned",
+                    "content": "result",
+                    "is_error": False,
+                },
+                {"type": "text", "text": "answer"},
+            ],
+        }
+    ]
+
+    assert _has_gateway_minted_mcp_blocks(messages) is True
+    assert _strip_gateway_minted_blocks(messages)[0]["content"] == [
+        {"type": "text", "text": "answer"}
+    ]
+
+
 def test_provider_signed_blocks_survive() -> None:
     """A search Anthropic ran and signed must round-trip untouched, even with
     interception on: stripping it would break the citations chain Anthropic owns."""

--- a/tests/unit/test_messages_minted_block_stripping.py
+++ b/tests/unit/test_messages_minted_block_stripping.py
@@ -13,10 +13,7 @@ from typing import Any
 import pytest
 
 from gateway.api.routes._pipeline import ToolContext
-from gateway.api.routes.messages import (
-    _has_gateway_minted_mcp_blocks,
-    _strip_gateway_minted_blocks,
-)
+from gateway.api.routes.messages import _strip_gateway_minted_blocks
 from gateway.core.config import GatewayConfig
 from gateway.services.mcp_loop_messages import MCP_ACTIVITY_ID_PREFIX
 
@@ -90,11 +87,11 @@ def test_non_list_input_passes_through() -> None:
     assert _strip_gateway_minted_blocks("not a list") == "not a list"
 
 
-# --- the gate that decides whether stripping runs at all ----------------------
+# --- web-search interception capability ---------------------------------------
 
 
 def _tool_ctx(config: GatewayConfig) -> ToolContext:
-    """A ToolContext carrying nothing but the two inputs the gate reads."""
+    """A ToolContext carrying nothing but the two inputs the property reads."""
     return ToolContext(
         config=config,
         mcp_server_configs=None,
@@ -125,9 +122,7 @@ def test_gate_is_on_when_opted_in_with_a_backend(monkeypatch: pytest.MonkeyPatch
 
 
 def test_gate_is_off_when_opted_in_without_a_backend(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With nothing to intercept to, the keyword was forwarded and the provider ran
-    the search, so the blocks in the transcript are its own signed ones. Stripping
-    them would break the citations round-trip Anthropic itself established."""
+    """With nothing to intercept to, the provider remains the search owner."""
     monkeypatch.delenv("OTARI_WEB_SEARCH_INTERCEPT", raising=False)
     config = GatewayConfig(web_search_intercept=True)
     assert config.web_search_url is None
@@ -197,11 +192,10 @@ def test_gateway_mcp_activity_pair_is_stripped() -> None:
 
     kept = _strip_gateway_minted_blocks(messages)[0]["content"]
 
-    assert _has_gateway_minted_mcp_blocks(messages) is True
     assert kept == [{"type": "text", "text": "answer"}]
 
 
-def test_early_mcp_strip_preserves_web_search_blocks() -> None:
+def test_mcp_and_web_search_activity_are_stripped_together() -> None:
     gateway_mcp_pair = _mcp_pair(f"{MCP_ACTIVITY_ID_PREFIX}abc")
     web_pair = _gateway_pair()
     messages: list[dict[str, Any]] = [
@@ -211,15 +205,14 @@ def test_early_mcp_strip_preserves_web_search_blocks() -> None:
         }
     ]
 
-    kept = _strip_gateway_minted_blocks(messages, strip_web_search=False)[0]["content"]
+    kept = _strip_gateway_minted_blocks(messages)[0]["content"]
 
-    assert kept == [*web_pair, {"type": "text", "text": "answer"}]
+    assert kept == [{"type": "text", "text": "answer"}]
 
 
 def test_provider_mcp_activity_pair_survives() -> None:
     messages: list[dict[str, Any]] = [{"role": "assistant", "content": _mcp_pair("mcptoolu_provider")}]
 
-    assert _has_gateway_minted_mcp_blocks(messages) is False
     assert _strip_gateway_minted_blocks(messages) == messages
 
 
@@ -249,7 +242,6 @@ def test_orphaned_gateway_mcp_result_is_stripped() -> None:
         }
     ]
 
-    assert _has_gateway_minted_mcp_blocks(messages) is True
     assert _strip_gateway_minted_blocks(messages)[0]["content"] == [
         {"type": "text", "text": "answer"}
     ]


### PR DESCRIPTION
## Description

## Why

Gateway-owned MCP calls were hidden from Messages streaming clients, so activity UIs could not show tool execution or its result. Echoed activity also needed to be removed before budget admission so hidden result content could not cause false budget rejection or estimate-based charging.

## What changed

Messages streams now emit paired server-owned `mcp_tool_use` and `mcp_tool_result` blocks while Otari retains execution ownership. The gateway preserves explicit MCP errors, avoids exposing transport details, strips replayed activity before prompt estimation, and keeps provider-native blocks intact.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #755

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Targeted verification: `make lint`, `make typecheck`, 171 relevant unit and integration tests, and the OSS-edition smoke gate. The streaming response is not represented by the OpenAPI response model, so generated artifacts are unchanged.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** GPT-5.6 Sol via pi

**Any additional AI details you'd like to share:** The agent implemented the change, added tests and documentation, investigated a budget-estimation review finding, and ran the listed checks.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added gateway-managed MCP activity events to `/v1/messages` streams.
- Included call IDs, tool and server names, inputs, results, and errors.
- Kept MCP execution within the gateway and preserved one logical stream.
- Removed replayed gateway activity before prompt estimation and provider dispatch.
- Protected credentials and transport details.
- Added documentation and tests for streaming, errors, replay handling, and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->