### PR TITLE
feat(dashboard): add a trend chip for period-over-period change

### DIFF
--- a/web/src/shared/components/TrendChip.test.tsx
+++ b/web/src/shared/components/TrendChip.test.tsx
@@ -77,10 +77,22 @@ describe("TrendChip", () => {
     expect(hasArrow(container)).toBe(false)
   })
 
-  it("says the direction in a word, since hue carries good vs bad", () => {
-    render(<TrendChip fraction={-0.021} polarity="down-is-good" />)
-    // A fall that is good and a fall that is bad render the same text and the
-    // same arrow, so the word is all a screen reader has to go on.
+  it("says the judgment, not just the direction, when there is one to make", () => {
+    // The same fall under each polarity: identical text, identical arrow, and
+    // the color is the only visible difference, so the announced phrase is all a
+    // screen reader has to tell the two apart.
+    const good = render(
+      <TrendChip fraction={-0.021} polarity="down-is-good" />,
+    ).container
+    expect(good).toHaveTextContent("down, better")
+    const bad = render(
+      <TrendChip fraction={-0.021} polarity="up-is-good" />,
+    ).container
+    expect(bad).toHaveTextContent("down, worse")
+  })
+
+  it("says the direction alone when the metric has no good direction", () => {
+    render(<TrendChip fraction={-0.021} polarity="neutral" />)
     expect(screen.getByText("down")).toBeInTheDocument()
   })
 
@@ -118,7 +130,7 @@ describe("TrendChip", () => {
     const { container } = render(
       <TrendChip fraction={0.033} className="ml-auto" />,
     )
-    expect(container.querySelector(".chip")?.className).toContain("ml-auto")
+    expect(container.firstElementChild).toHaveClass("ml-auto")
   })
 
   it("hides the arrow from the accessibility tree", () => {

--- a/web/src/shared/components/TrendChip.test.tsx
+++ b/web/src/shared/components/TrendChip.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { TrendChip, trendState } from "./TrendChip"
+
+// The arrow is aria-hidden decoration and which hue HeroUI paints is what the
+// stories and the screenshot matrix are for, so the rendered assertions here
+// stay on text, sign, and whether an arrow is there at all. The mapping from a
+// fraction to a direction and a status color is tested as a function instead.
+function hasArrow(container: HTMLElement): boolean {
+  return container.querySelector("svg") !== null
+}
+
+describe("trendState", () => {
+  it("reads the sign as the direction", () => {
+    expect(trendState(0.033, "neutral").direction).toBe("up")
+    expect(trendState(-0.021, "neutral").direction).toBe("down")
+  })
+
+  it("calls a change too small to print flat rather than a fall", () => {
+    // -0.0004 rounds to "0.0%", and a down arrow beside that reads as a bug.
+    expect(trendState(-0.0004, "neutral").direction).toBe("flat")
+    expect(trendState(0, "neutral").direction).toBe("flat")
+    expect(trendState(-0, "neutral").direction).toBe("flat")
+  })
+
+  it("treats NaN as flat rather than falling through to a fall", () => {
+    expect(trendState(Number.NaN, "up-is-good")).toEqual({
+      direction: "flat",
+      color: "default",
+    })
+  })
+
+  it("passes no judgment when the metric has no good direction", () => {
+    expect(trendState(0.12, "neutral").color).toBe("default")
+    expect(trendState(-0.12, "neutral").color).toBe("default")
+  })
+
+  it("colors by the metric's own axis, not the number's", () => {
+    expect(trendState(0.033, "up-is-good").color).toBe("success")
+    expect(trendState(-0.021, "up-is-good").color).toBe("danger")
+    expect(trendState(-0.059, "down-is-good").color).toBe("success")
+    expect(trendState(0.12, "down-is-good").color).toBe("danger")
+  })
+
+  it("leaves a flat change uncolored whatever the polarity", () => {
+    expect(trendState(0, "up-is-good").color).toBe("default")
+    expect(trendState(0, "down-is-good").color).toBe("default")
+  })
+})
+
+describe("TrendChip", () => {
+  it("renders nothing when there is no comparable previous value", () => {
+    expect(
+      render(<TrendChip fraction={null} />).container,
+    ).toBeEmptyDOMElement()
+    expect(
+      render(<TrendChip fraction={undefined} />).container,
+    ).toBeEmptyDOMElement()
+  })
+
+  it("signs a rise and shows an arrow", () => {
+    const { container } = render(<TrendChip fraction={0.033} />)
+    expect(screen.getByText("+3.3%")).toBeInTheDocument()
+    expect(hasArrow(container)).toBe(true)
+  })
+
+  it("keeps the minus sign on a fall", () => {
+    const { container } = render(<TrendChip fraction={-0.021} />)
+    expect(screen.getByText("-2.1%")).toBeInTheDocument()
+    expect(hasArrow(container)).toBe(true)
+  })
+
+  it("drops the arrow and prints a bare zero when nothing moved", () => {
+    const { container } = render(<TrendChip fraction={-0.0004} />)
+    expect(screen.getByText("0.0%")).toBeInTheDocument()
+    expect(hasArrow(container)).toBe(false)
+  })
+
+  it("says the direction in a word, since hue carries good vs bad", () => {
+    render(<TrendChip fraction={-0.021} polarity="down-is-good" />)
+    // A fall that is good and a fall that is bad render the same text and the
+    // same arrow, so the word is all a screen reader has to go on.
+    expect(screen.getByText("down")).toBeInTheDocument()
+  })
+
+  it("names a flat change rather than leaving a bare number", () => {
+    render(<TrendChip fraction={0} />)
+    expect(screen.getByText("no change")).toBeInTheDocument()
+  })
+
+  it("takes an absolute value as its text and still reads the sign", () => {
+    const { container } = render(<TrendChip fraction={0.184} text="+$1,234" />)
+    expect(screen.getByText("+$1,234")).toBeInTheDocument()
+    expect(hasArrow(container)).toBe(true)
+  })
+
+  it("reads the caption out with the number", () => {
+    render(<TrendChip fraction={-0.059} caption="vs last month" />)
+    expect(screen.getByText("-5.9% vs last month")).toBeInTheDocument()
+  })
+
+  it("sets figures tabular so a ticking chip keeps its width", () => {
+    render(<TrendChip fraction={0.033} />)
+    expect(screen.getByText("+3.3%").className).toContain("tabular-nums")
+  })
+
+  it("scales the arrow with the chip", () => {
+    const { container } = render(<TrendChip fraction={0.033} size="lg" />)
+    expect(container.querySelector("svg")?.getAttribute("class")).toContain(
+      "size-4",
+    )
+  })
+
+  it("passes a call site's layout classes through to the chip", () => {
+    // Position, not restyling: a chip is placed by the row it sits in, and
+    // without this the call site needs a wrapper element to do it.
+    const { container } = render(
+      <TrendChip fraction={0.033} className="ml-auto" />,
+    )
+    expect(container.querySelector(".chip")?.className).toContain("ml-auto")
+  })
+
+  it("hides the arrow from the accessibility tree", () => {
+    const { container } = render(<TrendChip fraction={0.033} />)
+    expect(container.querySelector("svg")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    )
+  })
+})

--- a/web/src/shared/components/TrendChip.tsx
+++ b/web/src/shared/components/TrendChip.tsx
@@ -52,10 +52,23 @@ const ARROW_SIZE: Record<TrendSize, string> = {
 // what stops a chip from claiming a fall while reading "-0.0%".
 const FLAT_THRESHOLD = 0.0005
 
-const DIRECTION_LABEL: Record<TrendDirection, string> = {
+const DIRECTION_WORD: Record<TrendDirection, string> = {
   up: "up",
   down: "down",
   flat: "no change",
+}
+
+const JUDGMENT_WORD = { success: "better", danger: "worse" } as const
+
+// What the chip says to a reader who sees neither the arrow nor the hue.
+// Direction alone will not do it: the sign already carries direction, while
+// `polarity` puts good and bad in color, so a fall that is an improvement and a
+// fall that is a regression would otherwise announce identically. The judgment
+// is appended only where there is one to make, which is why a `neutral` metric
+// still says just the direction.
+function announce({ direction, color }: TrendState): string {
+  if (color === "default") return DIRECTION_WORD[direction]
+  return `${DIRECTION_WORD[direction]}, ${JUDGMENT_WORD[color]}`
 }
 
 /**
@@ -89,8 +102,10 @@ export function TrendChip({
   variant = "soft",
   size = "sm",
   // Replaces the formatted percentage when the change reads better as an
-  // absolute ("+$1,234"). `fraction` still decides the arrow and the color, so
-  // pass the signed value even when its text is not what is shown. Named `text`
+  // absolute ("+$1,234"). `fraction` still decides the arrow, the color and the
+  // announced phrase, so it has to be the same change this string describes: a
+  // fraction inside the flat threshold announces "no change" whatever the string
+  // beside it says, so agreeing on the sign alone is not enough. Named `text`
   // rather than `value` because `value` on a component means the datum it is
   // about, and this is only what gets printed.
   text,
@@ -114,7 +129,8 @@ export function TrendChip({
   className?: string
 }) {
   if (fraction == null) return null
-  const { direction, color } = trendState(fraction, polarity)
+  const state = trendState(fraction, polarity)
+  const { direction, color } = state
   const Arrow = direction === "up" ? FiArrowUp : FiArrowDown
   // A flat chip prints a bare zero: the sign of a change too small to render is
   // noise ("-0.0%"), and it would contradict the missing arrow beside it.
@@ -127,13 +143,14 @@ export function TrendChip({
         <Arrow className={`${ARROW_SIZE[size]} shrink-0`} aria-hidden="true" />
       )}
       {/* The arrow is decoration a screen reader never sees, and `polarity`
-          puts the good/bad distinction in hue alone, which no reader of the text
-          can recover: a -2.1% that is good and a -2.1% that is bad differ only
-          in green vs red. So direction is also said in a word. It sits outside
+          puts the good/bad distinction in hue alone: a -2.1% that is an
+          improvement and a -2.1% that is a regression print the same text and
+          draw the same arrow, and differ only in green vs red. So `announce`
+          says the judgment as well as the direction. It sits outside
           `Chip.Label` so it does not join the visible label's text, and
           `sr-only` is rendered (clipped) rather than hidden, so `select-none`
           keeps it out of a drag selection over the chip, as in ModelsPage. */}
-      <span className="sr-only select-none">{DIRECTION_LABEL[direction]}</span>
+      <span className="sr-only select-none">{announce(state)}</span>
       <Chip.Label className="tabular-nums">
         {caption ? `${printed} ${caption}` : printed}
       </Chip.Label>

--- a/web/src/shared/components/TrendChip.tsx
+++ b/web/src/shared/components/TrendChip.tsx
@@ -1,0 +1,142 @@
+import { Chip } from "@heroui/react"
+import { FiArrowDown, FiArrowUp } from "react-icons/fi"
+
+import { formatPct } from "@/shared/helpers/format"
+
+// Period-over-period change as a pill, from the "Trend chips" design canvas.
+//
+// It is built on HeroUI's own Chip rather than a hand-rolled <span>: v3 already
+// ships the shape, the four fill treatments (primary/secondary/tertiary/soft),
+// and the three sizes the canvas draws. `globals.css` aliases the status bases
+// the chip's CSS reads (`--success`, `--danger`, `--default`) onto our tokens;
+// the `-soft` fills and inks on top of those are HeroUI's own derivations from
+// `themes/default/variables.css`, so a HeroUI bump can move them without a
+// token change here. Either way nothing below names a color, which is what
+// makes this theme-aware for free. What this adds is the part a generic chip
+// cannot know: which way the arrow points, which direction is the *good* one
+// for the metric, and tabular figures that keep a column of chips from
+// changing width as it ticks.
+
+// Which way is up for the metric being described. Spend, latency, and error rate
+// improve by falling, so a rise on those reads as danger even though it is a
+// rise. The default is `neutral` rather than a guess: most of this dashboard's
+// numbers are cost and error rate, and a forgotten prop that painted rising
+// spend green would be worse than no color at all.
+export type TrendPolarity = "up-is-good" | "down-is-good" | "neutral"
+
+// The canvas' four treatments, loudest first: `primary` is a solid status fill,
+// `secondary` status ink on the neutral chrome fill, `tertiary` ink alone, and
+// `soft` status ink on a tint of itself. `soft` is the default because a trend
+// is a supporting detail beside a headline number, not the headline.
+export type TrendVariant = "primary" | "secondary" | "tertiary" | "soft"
+
+export type TrendSize = "sm" | "md" | "lg"
+
+export type TrendDirection = "up" | "down" | "flat"
+
+export type TrendState = {
+  direction: TrendDirection
+  color: "success" | "danger" | "default"
+}
+
+// Sized to the text beside it rather than to the chip's box, which is what keeps
+// the arrow reading as a glyph in the line and not as an icon parked next to it.
+const ARROW_SIZE: Record<TrendSize, string> = {
+  sm: "size-3",
+  md: "size-3.5",
+  lg: "size-4",
+}
+
+// `formatPct` prints one decimal place of a percent, so anything under half of
+// one of those rounds to "0.0%". Calling that flat rather than a direction is
+// what stops a chip from claiming a fall while reading "-0.0%".
+const FLAT_THRESHOLD = 0.0005
+
+const DIRECTION_LABEL: Record<TrendDirection, string> = {
+  up: "up",
+  down: "down",
+  flat: "no change",
+}
+
+/**
+ * Which way the number went, and whether that is good for this metric. Exported
+ * so the mapping can be tested as a function rather than through the rendered
+ * chip's classes.
+ */
+export function trendState(
+  fraction: number,
+  polarity: TrendPolarity,
+): TrendState {
+  const direction: TrendDirection =
+    Number.isNaN(fraction) || Math.abs(fraction) < FLAT_THRESHOLD
+      ? "flat"
+      : fraction > 0
+        ? "up"
+        : "down"
+  if (direction === "flat" || polarity === "neutral") {
+    return { direction, color: "default" }
+  }
+  const good = polarity === "up-is-good" ? "up" : "down"
+  return { direction, color: direction === good ? "success" : "danger" }
+}
+
+export function TrendChip({
+  // null (or undefined) when there is nothing to compare against, the shape
+  // `deltaFraction` returns for an unbounded range or a previous value of zero.
+  // Nothing renders, so a call site can hand the value straight over.
+  fraction,
+  polarity = "neutral",
+  variant = "soft",
+  size = "sm",
+  // Replaces the formatted percentage when the change reads better as an
+  // absolute ("+$1,234"). `fraction` still decides the arrow and the color, so
+  // pass the signed value even when its text is not what is shown. Named `text`
+  // rather than `value` because `value` on a component means the datum it is
+  // about, and this is only what gets printed.
+  text,
+  // Trailing context inside the chip, e.g. "vs last month". Part of the chip's
+  // text rather than a tooltip, so it is read out with the number. A string and
+  // not a node: it shares one line inside a pill, which arbitrary JSX would
+  // break.
+  caption,
+  // Layout and position at the call site (`ml-auto` in a tile's value row,
+  // `justify-self-end` in a grid cell), which is what className is for here. Not
+  // for restyling the chip: the fill and the ink come from `variant` and the
+  // metric's own polarity.
+  className,
+}: {
+  fraction: number | null | undefined
+  polarity?: TrendPolarity
+  variant?: TrendVariant
+  size?: TrendSize
+  text?: string
+  caption?: string
+  className?: string
+}) {
+  if (fraction == null) return null
+  const { direction, color } = trendState(fraction, polarity)
+  const Arrow = direction === "up" ? FiArrowUp : FiArrowDown
+  // A flat chip prints a bare zero: the sign of a change too small to render is
+  // noise ("-0.0%"), and it would contradict the missing arrow beside it.
+  const printed =
+    text ??
+    `${direction === "up" ? "+" : ""}${formatPct(direction === "flat" ? 0 : fraction)}`
+  return (
+    <Chip variant={variant} color={color} size={size} className={className}>
+      {direction === "flat" ? null : (
+        <Arrow className={`${ARROW_SIZE[size]} shrink-0`} aria-hidden="true" />
+      )}
+      {/* The arrow is decoration a screen reader never sees, and `polarity`
+          puts the good/bad distinction in hue alone, which no reader of the text
+          can recover: a -2.1% that is good and a -2.1% that is bad differ only
+          in green vs red. So direction is also said in a word. It sits outside
+          `Chip.Label` so it does not join the visible label's text, and
+          `sr-only` is rendered (clipped) rather than hidden, so `select-none`
+          keeps it out of a drag selection over the chip, as in ModelsPage. */}
+      <span className="sr-only select-none">{DIRECTION_LABEL[direction]}</span>
+      <Chip.Label className="tabular-nums">
+        {caption ? `${printed} ${caption}` : printed}
+      </Chip.Label>
+    </Chip>
+  )
+}


### PR DESCRIPTION
## Description

Adds `TrendChip`, a pill that pairs an arrow with a signed percentage, replicating the trend chip drawn on the "Trend chips" design canvas.

It is built on HeroUI v3's own `Chip` rather than a hand-rolled `<span>`. v3 already ships the shape, the four fill treatments (primary/secondary/tertiary/soft) and the three sizes the canvas draws, and `globals.css` already aliases the status bases its CSS reads (`--success`, `--danger`, `--default`) onto our tokens. Nothing in the component names a color, so light and dark both follow the foundation with no work at the call site.

What the wrapper adds is the part a generic chip cannot know:

- **Direction** from the sign of the fraction. The arrow and the sign both carry it, so it survives without hue.
- **Polarity**, the metric's own axis. Spend and error rate improve by falling, so `down-is-good` paints a fall green while the arrow keeps telling the truth about which way it went. It defaults to `neutral`: most numbers on this dashboard are cost and error rate, and a forgotten prop that painted rising spend green would be worse than no color at all.
- **Tabular figures**, so a chip on a live tile does not change width as its digits tick.
- **A flat state** below half of the smallest printable percent, which stops a chip reading `-0.0%` beside no arrow.
- **A screen-reader word for the direction**, since polarity puts good and bad in hue alone: a `-2.1%` that is good and a `-2.1%` that is bad render the same text and the same arrow, and a reader of the text cannot recover the difference.

`trendState` is exported so the mapping from a fraction to a direction and a status color is tested as a function, rather than by asserting HeroUI's class names on the rendered chip.

```tsx
<TrendChip fraction={0.033} polarity="up-is-good" />
<TrendChip fraction={0.12} polarity="down-is-good" />
<TrendChip fraction={0.184} text="+$1,234" />
<TrendChip fraction={-0.059} caption="vs last month" className="ml-auto" />
```

**No call sites yet, on purpose.** `DeltaHint` in `shared/components/ui.tsx` renders the same idea as plain text and has six call sites across `UsagePage` and `OverviewPage`. Migrating them is a behavior change to two pages and belongs in its own PR, so this one lands the primitive and its tests only.

Verified in Storybook across all four variants, three sizes and both themes against the design artboards. The story file is not in the diff because `web/src/**/*.stories.tsx` is excluded in `.git/info/exclude`: the catalog is deliberately local-only.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None. This came from the design canvas rather than a filed issue.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Dashboard-only change, so the checks that apply are the dashboard's: `pnpm --dir web run lint`, `pnpm --dir web run typecheck` and `pnpm --dir web test` all pass on a clean checkout of this branch. No API contract changed, so the OpenAPI spec and the Postman collection are untouched. No page was added, so no screenshot entry is owed.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

The component, its tests and its Storybook stories were written by the agent from the Paper design canvas, then reviewed against a component-API design rubric, which is where the `text` prop name (it was `value`, which reads as the datum rather than the printed string) and the `className` passthrough came from.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added the `TrendChip` dashboard component for period-over-period changes.
- Displays signed percentages with directional arrows in a pill.
- Supports polarity-aware colors, captions, custom text, sizes, variants, and accessible labels.
- Treats very small or invalid values as flat.
- Added tests for formatting, states, accessibility, styling, and empty values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->