### PR TITLE
fix(dashboard): repair the text-subtle contrast failure, and retune the type scale

### DIFF
--- a/web/src/features/activity/ActivityPage.tsx
+++ b/web/src/features/activity/ActivityPage.tsx
@@ -812,9 +812,7 @@ function RoutingPlan({ entry }: { entry: UsageEntry }) {
 
   return (
     <div className="flex flex-col gap-2">
-      <span className="text-[11px] font-medium uppercase tracking-wide text-muted">
-        Routing plan · {entry.policy_name}
-      </span>
+      <span className="text-overline">Routing plan · {entry.policy_name}</span>
       <span className="text-sm text-foreground">{summary}</span>
       <div className="overflow-x-auto rounded-lg border border-border">
         <table
@@ -910,9 +908,7 @@ function DetailField({
 }) {
   return (
     <div className="flex flex-col gap-0.5">
-      <span className="text-[11px] font-medium uppercase tracking-wide text-muted">
-        {label}
-      </span>
+      <span className="text-overline">{label}</span>
       {copyValue ? (
         <CopyableValue
           value={copyValue}
@@ -967,7 +963,7 @@ function RequestDetail({
     <div className="flex flex-col gap-4 px-4 py-4">
       {entry.error_message ? (
         <div className="flex flex-col gap-1.5">
-          <span className="text-[11px] font-medium uppercase tracking-wide text-muted">
+          <span className="text-overline">
             Error{entry.status_code !== null ? ` (${entry.status_code})` : ""}
           </span>
           <pre className="max-h-48 overflow-auto rounded-lg border border-danger bg-danger-subtle p-3 text-xs whitespace-pre-wrap break-all text-danger">
@@ -1070,9 +1066,7 @@ function RequestDetail({
       ) : null}
       {entry.pricing_breakdown?.length ? (
         <div className="flex flex-col gap-2">
-          <span className="text-[11px] font-medium uppercase tracking-wide text-muted">
-            Billed meters
-          </span>
+          <span className="text-overline">Billed meters</span>
           <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
             {sortedBreakdown(entry.pricing_breakdown).map((line) => {
               // A line of neither known shape was written by an older gateway.

--- a/web/src/features/activity/ActivityTimeline.tsx
+++ b/web/src/features/activity/ActivityTimeline.tsx
@@ -281,7 +281,7 @@ export function ActivityTimeline({
             <ChartLegend series={chartSeries} />
           </span>
           <div className="flex items-center gap-1.5">
-            <span className="hidden text-[11px] text-muted sm:inline">
+            <span className="hidden text-xs text-muted sm:inline">
               drag across the chart to zoom
             </span>
             <Button

--- a/web/src/features/activity/ActivityTimeline.tsx
+++ b/web/src/features/activity/ActivityTimeline.tsx
@@ -275,7 +275,7 @@ export function ActivityTimeline({
       <div className="rounded-xl border border-border bg-surface p-2">
         <div className="flex items-center justify-between gap-2 px-1 pb-1">
           <span className="flex items-center gap-3">
-            <span className="text-[11px] font-medium uppercase tracking-wide text-muted">
+            <span className="text-overline">
               Requests / {bucket === "hour" ? "hour" : "day"}
             </span>
             <ChartLegend series={chartSeries} />

--- a/web/src/features/models/ModelsPage.test.tsx
+++ b/web/src/features/models/ModelsPage.test.tsx
@@ -595,7 +595,7 @@ describe("ModelsPage", () => {
     await screen.findByText("openai:gpt-4o")
 
     await user.click(
-      screen.getByRole("columnheader", { name: /Base in \/ out \$ \/ 1M/ }),
+      screen.getByRole("columnheader", { name: /Base in \/ out \/ 1M/ }),
     )
 
     const order = modelOrder()
@@ -872,7 +872,7 @@ describe("ModelsPage", () => {
     await screen.findByText("anthropic:claude-sonnet-4")
 
     expect(
-      screen.getByRole("columnheader", { name: "Caching policy" }),
+      screen.getByRole("columnheader", { name: "Caching" }),
     ).toBeInTheDocument()
 
     // The compact cache-policy cell keeps the table readable while opening the
@@ -917,7 +917,7 @@ describe("ModelsPage", () => {
     )
 
     expect(
-      screen.getByRole("columnheader", { name: /at 200K in \/ out \$ \/ 1M/ }),
+      screen.getByRole("columnheader", { name: /at 200K in \/ out \/ 1M/ }),
     ).toBeInTheDocument()
     const row = tableRow("openai:gpt-4o")
     expect(

--- a/web/src/features/models/ModelsPage.tsx
+++ b/web/src/features/models/ModelsPage.tsx
@@ -593,9 +593,7 @@ function PanelSection({
 }) {
   return (
     <div className="flex flex-col gap-2">
-      <span className="text-xs font-semibold uppercase tracking-wide text-muted">
-        {title}
-      </span>
+      <span className="text-overline">{title}</span>
       {children}
     </div>
   )
@@ -1304,7 +1302,7 @@ function ModelTable({
         id: "input",
         header: (
           <span className="inline-flex items-center gap-1">
-            {`${comparisonLabel} in / out $ / 1M`}
+            {`${comparisonLabel} in / out / 1M`}
             <PricingInfo />
           </span>
         ),
@@ -1326,7 +1324,10 @@ function ModelTable({
       },
       {
         id: "caching",
-        header: `Caching ${comparisonContextTokens == null ? "policy" : comparisonLabel}`,
+        header:
+          comparisonContextTokens == null
+            ? "Caching"
+            : `Caching ${comparisonLabel}`,
         align: "end",
         cell: (row) => (
           <CachingCell
@@ -1338,7 +1339,7 @@ function ModelTable({
       },
       {
         id: "policy",
-        header: "Pricing policy",
+        header: "Pricing",
         align: "end",
         cell: (row) => (
           <PricingPolicyCell row={row} onEdit={() => onEditPricing(row.key)} />

--- a/web/src/features/models/ModelsPage.tsx
+++ b/web/src/features/models/ModelsPage.tsx
@@ -1339,7 +1339,13 @@ function ModelTable({
       },
       {
         id: "policy",
-        header: "Pricing",
+        // Deliberately not shortened, unlike `Caching` beside it. `Pricing`
+        // alone sits two columns from `Base in / out / 1M` and reads as a
+        // second price column rather than as the policy that produced the
+        // price, so it wraps instead. See the header comment in globals.css on
+        // the overline spec: uppercase costs width, and a wrapped header costs
+        // a glance where a misleading one costs a wrong conclusion.
+        header: "Pricing policy",
         align: "end",
         cell: (row) => (
           <PricingPolicyCell row={row} onEdit={() => onEditPricing(row.key)} />

--- a/web/src/shared/components/ui.tsx
+++ b/web/src/shared/components/ui.tsx
@@ -180,11 +180,16 @@ export function StatCard({
     // Card.Content's, which otherwise doubled the tile's height (most visible at
     // two-up on mobile). Content owns the padding: tighter on mobile, roomier up.
     <Card.Content className="flex flex-col gap-1 p-4 sm:p-5">
-      <span className="text-xs font-medium uppercase tracking-wide text-muted">
-        {label}
-      </span>
+      <span className="text-overline">{label}</span>
       <span className="flex flex-wrap items-center gap-2">
-        <span className="text-xl font-semibold text-foreground sm:text-2xl">
+        {/* text-xl (22px), deliberately a step *below* the page title's
+            text-display (26px). It used to be text-xl rising to text-2xl at
+            `sm`, which made a number inside a card the largest text on the
+            page, 4px bigger than the name of the page itself. Fixing that by
+            raising the title alone would have left the two agreeing by
+            coincidence; both halves move so the ladder is correct by
+            construction. `tabular-nums` so a column of these aligns. */}
+        <span className="text-xl font-semibold tabular-nums text-foreground">
           {value}
         </span>
         {status && statusLabel ? (
@@ -195,7 +200,16 @@ export function StatCard({
           </span>
         ) : null}
       </span>
-      {hint ? <span className="text-xs text-muted">{hint}</span> : null}
+      {/* Two lines reserved, always. A delta like "5.8% errors · ▲ 214.1% vs
+          prev" wraps in a narrow tile while its neighbours stay on one line,
+          and a row of five tiles then stops aligning. This is a layout fix and
+          not a type fix on purpose: sizing the type to the longest string would
+          be sizing the type by accident. min-h-9 is two 18px lines. */}
+      {hint ? (
+        <span className="block min-h-9 text-xs tabular-nums text-muted">
+          {hint}
+        </span>
+      ) : null}
       {chart ? <div className="mt-2">{chart}</div> : null}
     </Card.Content>
   )
@@ -288,9 +302,12 @@ export function PageHeader({
   return (
     <div className="flex flex-col gap-3">
       <div>
-        <h1 className="text-xl font-semibold text-foreground">{title}</h1>
+        <h1 className="text-display">{title}</h1>
         {description ? (
-          <p className="mt-1 text-sm text-muted">{description}</p>
+          // max-w-prose because this ran to the full container width: 968px at
+          // 14px is ~138 characters per line, roughly twice a comfortable
+          // measure, and it is the same paragraph on every page.
+          <p className="mt-1 max-w-prose text-sm text-muted">{description}</p>
         ) : null}
       </div>
       {/* The primary action sits on its own left-aligned row under the heading,
@@ -641,9 +658,9 @@ export function EmptyState({
     <Card>
       <Card.Content className="flex flex-col gap-4 p-6">
         <div>
-          <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+          <h2 className="text-heading">{title}</h2>
           {description ? (
-            <p className="mt-1 text-sm text-muted">{description}</p>
+            <p className="mt-1 max-w-prose text-sm text-muted">{description}</p>
           ) : null}
         </div>
         {children}

--- a/web/src/shared/components/ui.tsx
+++ b/web/src/shared/components/ui.tsx
@@ -201,7 +201,7 @@ export function StatCard({
         ) : null}
       </span>
       {/* Two lines reserved, always. A delta like "5.8% errors · ▲ 214.1% vs
-          prev" wraps in a narrow tile while its neighbours stay on one line,
+          prev" wraps in a narrow tile while its neighbors stay on one line,
           and a row of five tiles then stops aligning. This is a layout fix and
           not a type fix on purpose: sizing the type to the longest string would
           be sizing the type by accident. min-h-9 is two 18px lines. */}

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -75,6 +75,78 @@ const HEROUI_VARIABLES = [
 
 const TYPE_NAMESPACES = /^--(text|font-weight|tracking)-/
 
+/**
+ * WCAG 2.x relative luminance, sRGB. Kept here rather than pulled in as a
+ * dependency: it is eight lines and the alternative is a package in the
+ * dependency graph for one assertion.
+ */
+function luminance(hex: string): number {
+  const m = /^#([0-9a-f]{6})$/i.exec(hex.trim())
+  if (!m) throw new Error(`not a six-digit hex color: ${hex}`)
+  const channel = (v: number): number => {
+    const c = v / 255
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+  }
+  const n = Number.parseInt(m[1], 16)
+  return (
+    0.2126 * channel((n >> 16) & 0xff) +
+    0.7152 * channel((n >> 8) & 0xff) +
+    0.0722 * channel(n & 0xff)
+  )
+}
+
+function contrast(a: string, b: string): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x)
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+describe("text on every ground it can land on", () => {
+  // The repair in this change was measured against all six grounds each theme
+  // declares, and the measurement is the assertion. Without it the WCAG AA fix
+  // regresses on the next palette edit with no symptom until somebody renders
+  // it, which is the same invisible-until-rendered class of failure the cascade
+  // tests above exist for.
+  //
+  // Both of these failed AA on every ground before this change (light worst case
+  // 3.01, dark 2.91), and the reason it went unnoticed for so long is that the
+  // dashboard had no regular-weight text: extra stem weight reads as more
+  // contrast than the ratio gives.
+  const GROUNDS = [
+    "--color-background",
+    "--color-background-muted",
+    "--color-background-subtle",
+    "--color-surface",
+    "--color-surface-muted",
+    "--color-surface-subtle",
+  ] as const
+  const INK = [
+    "--color-text",
+    "--color-text-muted",
+    "--color-text-subtle",
+  ] as const
+  // 4.5:1 is AA for normal-size text, which is what all three of these pair with.
+  const AA_NORMAL = 4.5
+
+  it.each([
+    ["light", LIGHT],
+    ["dark", DARK],
+  ] as const)("clears AA for normal text in the %s theme", (_theme, tokens) => {
+    for (const ink of INK) {
+      for (const ground of GROUNDS) {
+        const fg = tokens.get(ink)
+        const bg = tokens.get(ground)
+        expect(fg, `${ink} is not declared`).toBeDefined()
+        expect(bg, `${ground} is not declared`).toBeDefined()
+        const ratio = contrast(fg as string, bg as string)
+        expect(
+          Number(ratio.toFixed(2)),
+          `${ink} on ${ground} is ${ratio.toFixed(2)}:1, under the ${AA_NORMAL}:1 AA floor for normal text`,
+        ).toBeGreaterThanOrEqual(AA_NORMAL)
+      }
+    }
+  })
+})
+
 describe("the type scale's two halves", () => {
   // The scale is split on purpose and the split is easy to undo by accident, so
   // it is pinned from both sides. `@heroui/styles` is a prebuilt Tailwind
@@ -84,7 +156,19 @@ describe("the type scale's two halves", () => {
   // order: it compiles, emits, and changes nothing. The values therefore live in
   // an unlayered `:root` block, which beats every layer, and only the keys
   // HeroUI never declares are registered in `@theme`.
+  // `block()` is a first-match `indexOf`, and globals.css has two top-level
+  // `:root {` blocks: this one and the base reset further down. It resolves
+  // correctly only because this one comes first, so assert that rather than
+  // depend on it: a reordering would otherwise point every failure below at the
+  // wrong block.
   const TYPE_VALUES = declarations(block(":root"))
+
+  it("matches the type block rather than the base reset", () => {
+    expect(
+      TYPE_VALUES.get("--text-xs"),
+      "block(':root') matched a different :root block (the base reset?); anchor it on something distinguishing",
+    ).toBeDefined()
+  })
 
   it("declares every contested type key in the unlayered :root block", () => {
     for (const key of [
@@ -105,6 +189,9 @@ describe("the type scale's two halves", () => {
       "--font-weight-semibold",
       "--font-weight-bold",
       "--tracking-tight",
+      "--text-caption-step",
+      "--text-caption-step--line-height",
+      "--text-caption-step--letter-spacing",
     ]) {
       expect(
         TYPE_VALUES.get(key),
@@ -139,9 +226,6 @@ describe("the type scale's two halves", () => {
     // :root alone is never read, because the utility would not reference it.
     const theme = declarations(block("@theme"))
     for (const key of [
-      "--text-caption",
-      "--text-caption--line-height",
-      "--text-caption--letter-spacing",
       "--text-xs--letter-spacing",
       "--text-sm--letter-spacing",
       "--text-base--letter-spacing",
@@ -156,12 +240,14 @@ describe("the type scale's two halves", () => {
     }
     // The other direction: a size or weight registered here is the silent-no-op
     // mistake this split exists to prevent.
+    // No exceptions any more: the only type keys `@theme` may carry are the
+    // letter-spacing registrations. A *size* here would also generate a
+    // same-named utility that outranks the role of that name in the same layer,
+    // which is how the caption step silently killed `@utility text-caption`'s
+    // own metrics before it was renamed to `--text-caption-step`.
     const contested = [...theme.keys()].filter(
       (name) =>
-        TYPE_NAMESPACES.test(name) &&
-        !name.endsWith("--letter-spacing") &&
-        name !== "--text-caption" &&
-        name !== "--text-caption--line-height",
+        TYPE_NAMESPACES.test(name) && !name.endsWith("--letter-spacing"),
     )
     expect(
       contested,

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -138,8 +138,11 @@ describe("text on every ground it can land on", () => {
         expect(fg, `${ink} is not declared`).toBeDefined()
         expect(bg, `${ground} is not declared`).toBeDefined()
         const ratio = contrast(fg as string, bg as string)
+        // Compare the unrounded ratio. Rounding first would let 4.496 pass as
+        // 4.50, which is a test that goes green on a value that fails AA.
+        // Rounding belongs in the message and nowhere else.
         expect(
-          Number(ratio.toFixed(2)),
+          ratio,
           `${ink} on ${ground} is ${ratio.toFixed(2)}:1, under the ${AA_NORMAL}:1 AA floor for normal text`,
         ).toBeGreaterThanOrEqual(AA_NORMAL)
       }

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -73,6 +73,103 @@ const HEROUI_VARIABLES = [
   "--overlay-shadow",
 ]
 
+const TYPE_NAMESPACES = /^--(text|font-weight|tracking)-/
+
+describe("the type scale's two halves", () => {
+  // The scale is split on purpose and the split is easy to undo by accident, so
+  // it is pinned from both sides. `@heroui/styles` is a prebuilt Tailwind
+  // stylesheet carrying its own `@layer theme` with the default `--text-*`,
+  // `--font-weight-*` and `--tracking-*` in it, and it is imported after
+  // Tailwind, so an override of one of those written in `@theme` loses on source
+  // order: it compiles, emits, and changes nothing. The values therefore live in
+  // an unlayered `:root` block, which beats every layer, and only the keys
+  // HeroUI never declares are registered in `@theme`.
+  const TYPE_VALUES = declarations(block(":root"))
+
+  it("declares every contested type key in the unlayered :root block", () => {
+    for (const key of [
+      "--text-xs",
+      "--text-xs--line-height",
+      "--text-sm",
+      "--text-sm--line-height",
+      "--text-base",
+      "--text-base--line-height",
+      "--text-lg",
+      "--text-lg--line-height",
+      "--text-xl",
+      "--text-xl--line-height",
+      "--text-2xl",
+      "--text-2xl--line-height",
+      "--font-weight-normal",
+      "--font-weight-medium",
+      "--font-weight-semibold",
+      "--font-weight-bold",
+      "--tracking-tight",
+    ]) {
+      expect(
+        TYPE_VALUES.get(key),
+        `${key} is not declared in the unlayered :root block, so @heroui/styles' own value wins`,
+      ).toBeDefined()
+    }
+  })
+
+  it("keeps type metrics out of the theme blocks", () => {
+    // Not a style preference. Type has no theme axis, and declaring these twice
+    // would allow one block to be edited and the other missed, giving the two
+    // themes different type metrics: invisible in whichever theme you are
+    // looking at, and undetectable by the both-themes assertion below, because
+    // the key sets would still match.
+    for (const [theme, tokens] of [
+      ["light", LIGHT],
+      ["dark", DARK],
+    ] as const) {
+      const offenders = [...tokens.keys()].filter((name) =>
+        TYPE_NAMESPACES.test(name),
+      )
+      expect(
+        offenders,
+        `the ${theme} theme block declares type metrics (${offenders.join(", ")}); they belong in the unlayered :root block, declared once`,
+      ).toEqual([])
+    }
+  })
+
+  it("registers in @theme only the keys HeroUI does not declare", () => {
+    // Tracking is emitted into `.text-xs` and friends only if the key is
+    // registered at build time, so these have to be in `@theme`; a value at
+    // :root alone is never read, because the utility would not reference it.
+    const theme = declarations(block("@theme"))
+    for (const key of [
+      "--text-caption",
+      "--text-caption--line-height",
+      "--text-caption--letter-spacing",
+      "--text-xs--letter-spacing",
+      "--text-sm--letter-spacing",
+      "--text-base--letter-spacing",
+      "--text-lg--letter-spacing",
+      "--text-xl--letter-spacing",
+      "--text-2xl--letter-spacing",
+    ]) {
+      expect(
+        theme.get(key),
+        `${key} is not registered in @theme, so its utility never references it`,
+      ).toBeDefined()
+    }
+    // The other direction: a size or weight registered here is the silent-no-op
+    // mistake this split exists to prevent.
+    const contested = [...theme.keys()].filter(
+      (name) =>
+        TYPE_NAMESPACES.test(name) &&
+        !name.endsWith("--letter-spacing") &&
+        name !== "--text-caption" &&
+        name !== "--text-caption--line-height",
+    )
+    expect(
+      contested,
+      `@theme registers type values @heroui/styles also declares (${contested.join(", ")}); it loses on source order, so these belong in the unlayered :root block`,
+    ).toEqual([])
+  })
+})
+
 describe("design foundation tokens", () => {
   it("declares the same token set in both themes", () => {
     // Each theme block owns the complete set of variables it needs rather than

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -119,7 +119,7 @@
   /* ── Text — brand black + cool neutral muted ─────────────────────────── */
   --color-text: #1a1a1a; /* primary body and headings (Otari brand black) */
   --color-text-muted: #545b62; /* secondary text, labels, captions */
-  --color-text-subtle: #80868d; /* tertiary, timestamps, helper text */
+  --color-text-subtle: #62686f; /* tertiary, timestamps, helper text */
   --color-text-on-primary: #ffffff; /* text on primary-colored bg */
   --color-text-on-inverse: #ffffff; /* text on inverse/dark surface */
 
@@ -356,7 +356,7 @@
   /* ── Text ──────────────────────────────────────────────── */
   --color-text: #f0ede5; /* warm off-white (echoes brand B26 inverted) */
   --color-text-muted: #9aa4ae;
-  --color-text-subtle: #6e7882;
+  --color-text-subtle: #919ba5;
   --color-text-on-primary: #0a1419; /* deep teal-black for contrast on light teal */
   --color-text-on-inverse: #15171c;
 
@@ -555,6 +555,97 @@
   --shadow-elevation-md: var(--shadow-md);
   --shadow-elevation-lg: var(--shadow-lg);
   --shadow-modal: var(--shadow-modal);
+  /* Type scale, registration half. Two kinds of key live here and only these
+   * two, because they are the keys `@heroui/styles` does not declare:
+   *
+   *   --text-caption          a seventh step Tailwind does not ship, between
+   *                           --text-xs (12) and --text-sm (14). Registering it
+   *                           here is what makes it a real step rather than a
+   *                           number repeated in a role.
+   *   --text-*--letter-spacing  tracking per size step. Registration is what
+   *                           makes Tailwind emit the `letter-spacing` line in
+   *                           `.text-xs` and friends at all; a value declared
+   *                           only at :root is never read, because the utility
+   *                           would not reference it. So these must be here and
+   *                           the sizes must not (see the :root block below).
+   *
+   * Every value that HeroUI also declares lives in the unlayered `:root` block
+   * further down, NOT here. The comment there says why. */
+  --text-caption: 13px;
+  --text-caption--line-height: 19px;
+  --text-caption--letter-spacing: 0.0075em;
+  --text-xs--letter-spacing: 0.01em;
+  --text-sm--letter-spacing: 0.005em;
+  --text-base--letter-spacing: 0em;
+  --text-lg--letter-spacing: -0.01em;
+  --text-xl--letter-spacing: -0.015em;
+  --text-2xl--letter-spacing: -0.02em;
+}
+
+/* =============================================================
+ * Type scale, value half. READ THIS BEFORE ADDING AN @import.
+ *
+ * These are the keys `@heroui/styles` declares too, and that is the whole
+ * reason this block exists and is shaped the way it is.
+ *
+ * `@heroui/styles` is a prebuilt Tailwind stylesheet: it ships its own
+ * `@layer theme { :root, :host { … } }` carrying the full default theme,
+ * `--text-sm`, `--font-weight-medium: 500` and `--tracking-tight` included.
+ * Tailwind hoists every `@theme` block into its own theme layer at the
+ * position of `@import "tailwindcss"`, which is line 1, so HeroUI's literal
+ * theme layer lands after ours. Same layer, same `:root` specificity: source
+ * order decides, and HeroUI is second. An override of one of these keys
+ * written in `@theme` therefore compiles clean, emits, and loses. It changes
+ * nothing and reports nothing.
+ *
+ * So this block is deliberately **unlayered**. An unlayered declaration beats
+ * every `@layer`, which means it wins because of what it is and not because of
+ * where it sits. Do not move these into `@theme`, and do not rely on this
+ * block merely coming after the import: the next `@import` somebody adds would
+ * quietly outrank it if the win were only positional.
+ *
+ * Deliberately NOT in the light and dark theme blocks. Type metrics have no
+ * theme axis, and declaring twenty-odd of them twice creates a failure the
+ * single declaration cannot have: one block edited and the other missed, giving
+ * the two themes different type metrics, invisible in whichever theme you are
+ * looking at, and undetectable by the both-blocks assertion because the key
+ * sets would still match. `foundation.test.ts` pins this decision from both
+ * sides so the next reader finds a rule rather than an accident.
+ * ============================================================= */
+:root {
+  /* Size / line-height per step. Whole pixels throughout: a fractional size
+   * reflows every dense table for no legible gain, which was tested at 100%,
+   * 125% and 150% zoom before these landed. Tracking lives in the @theme
+   * registration above, positive on the small steps where tight setting goes
+   * muddy and negative on the large ones where it goes loose. */
+  --text-xs: 12px;
+  --text-xs--line-height: 18px;
+  --text-sm: 14px;
+  --text-sm--line-height: 20px;
+  --text-base: 16px;
+  --text-base--line-height: 24px;
+  --text-lg: 18px;
+  --text-lg--line-height: 26px;
+  --text-xl: 22px;
+  --text-xl--line-height: 28px;
+  --text-2xl: 26px;
+  --text-2xl--line-height: 32px;
+
+  /* Hierarchy comes from size and tracking, so the weight axis is two values
+   * doing real work instead of four crowded together. 550 is the one emphasis
+   * weight; 400 is the floor and is where nearly everything sits.
+   *
+   * `--font-weight-medium: 400` is deliberate and the name is now a lie. It is
+   * how ~140 `font-medium` call sites and HeroUI's own 93 internal uses come
+   * off 500 in two lines rather than in 140 edits, and it is the largest
+   * single visual change here: before it, no text in the shell chrome was
+   * regular, so weight could not signal anything because every row had already
+   * spent it. Deleting the now-inert utilities is follow-up, not this change. */
+  --font-weight-normal: 400;
+  --font-weight-medium: 400;
+  --font-weight-semibold: 550;
+  --font-weight-bold: 600;
+  --tracking-tight: -0.015em;
 }
 
 /* =============================================================
@@ -596,60 +687,94 @@
  * ============================================================= */
 @utility text-display {
   font-family: var(--font-display);
-  font-size: 1.5rem; /* 24px */
-  font-weight: 700;
-  line-height: 1.2;
-  letter-spacing: 0; /* neutral for the Zilla Slab slab serif */
+  font-size: var(--text-2xl);
+  line-height: var(--text-2xl--line-height);
+  /* Overrides the step's -0.02em. Zilla Slab is a slab serif with wider
+     sidebearings than the body face, so it needs less negative tracking to
+     read as set rather than as squeezed. The step keeps -0.02em for any sans
+     consumer of text-2xl. */
+  letter-spacing: -0.01em;
+  /* 500, and ZillaSlab-Medium.woff2 is the only cut this leaves in use. */
+  font-weight: 500;
   color: var(--color-text);
 }
 @utility text-heading {
-  font-family: var(--font-display);
-  font-size: 1.125rem; /* 18px */
-  font-weight: 600;
-  line-height: 1.3;
+  /* The body face, not the display face: at 18px a slab serif competes with
+     the page title above it instead of sitting under it. */
+  font-family: var(--font-sans);
+  font-size: var(--text-lg);
+  line-height: var(--text-lg--line-height);
+  letter-spacing: var(--text-lg--letter-spacing);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text);
 }
 @utility text-title {
-  font-size: 0.9375rem; /* 15px */
-  font-weight: 600;
-  line-height: 1.35;
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: var(--text-base--line-height);
+  letter-spacing: var(--text-base--letter-spacing);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text);
 }
 @utility text-body {
-  font-size: 0.875rem; /* 14px */
-  font-weight: 400;
-  line-height: 1.55;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  line-height: var(--text-sm--line-height);
+  letter-spacing: var(--text-sm--letter-spacing);
+  font-weight: var(--font-weight-normal);
   color: var(--color-text);
 }
 @utility text-emphasis {
-  font-size: 0.875rem;
-  font-weight: 600;
-  line-height: 1.55;
+  /* The same step as text-body, one weight apart. That is the whole emphasis
+     mechanism: 550 against a 400 floor, once, rather than a second size. */
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  line-height: var(--text-sm--line-height);
+  letter-spacing: var(--text-sm--letter-spacing);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text);
 }
 @utility text-caption {
-  font-size: 0.8125rem; /* 13px */
-  font-weight: 400;
-  line-height: 1.45;
+  /* 13px, the step below body, registered in @theme because Tailwind ships no
+     size between 12 and 14. Its absence is why five different meanings were
+     sharing 14px: a secondary line had nowhere lighter to go than the value it
+     was explaining. */
+  font-family: var(--font-sans);
+  font-size: var(--text-caption);
+  line-height: var(--text-caption--line-height);
+  letter-spacing: var(--text-caption--letter-spacing);
+  font-weight: var(--font-weight-normal);
   color: var(--color-text-muted);
 }
 @utility text-overline {
-  font-size: 0.6875rem; /* 11px */
-  font-weight: 600;
-  line-height: 1.2;
+  /* 12px rather than 11: of the three hand-rolled overline spellings this
+     replaces, the most common one was already 12, and an eighth theme step for
+     one role is not worth a point of size. */
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  line-height: var(--text-xs--line-height);
+  /* Overrides the step's +0.01em. Uppercase at a small size needs more air
+     between letters than lowercase does at the same size. */
   letter-spacing: 0.06em;
+  font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
   color: var(--color-text-muted);
 }
 @utility text-chrome-row {
-  font-size: 0.84375rem; /* 13.5px, a step under the rail's own 14px rows */
-  line-height: 1.125rem;
+  font-size: var(--text-caption);
+  line-height: var(--text-caption--line-height);
+  letter-spacing: var(--text-caption--letter-spacing);
 }
 @utility text-chrome-meta {
-  font-size: 0.71875rem; /* 11.5px */
-  line-height: 0.9375rem;
+  font-size: var(--text-xs);
+  line-height: var(--text-xs--line-height);
+  letter-spacing: var(--text-xs--letter-spacing);
 }
 @utility text-chrome-initials {
+  /* Deliberately off-scale, and the one documented exception. Two letters in a
+     26px avatar are recognized, not read, so putting them on the scale would
+     either overflow the avatar or drag a real text step down to 9px to suit a
+     monogram. Leave the literal; it is not an oversight. */
   font-size: 0.5625rem; /* 9px, sized to a 26px avatar */
   line-height: 1;
 }
@@ -691,13 +816,23 @@ body {
   color: var(--color-text);
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-family: var(--font-display);
+/* In `@layer base` rather than unlayered, which is a cascade fix and not a
+   tidy-up: `@utility` lands in `@layer utilities`, and an unlayered rule beats
+   every layer, so while this was unlayered it silently overrode the
+   `font-family` of any role applied to a heading element. `text-heading` and
+   `text-title` are set in the body face now, and both are worn by `<h2>` and
+   `<h3>`, so unlayered here would have kept them in Zilla Slab and made the
+   role a suggestion. Layered, a bare heading still gets the display face and a
+   role still wins. */
+@layer base {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-display);
+  }
 }
 
 ::selection {
@@ -904,8 +1039,21 @@ h6 {
   > [role="presentation"]:last-of-type
   > .table__column {
   background-color: transparent;
-  color: var(--color-text);
-  font-weight: 600;
+  /* The single overline spec, matching `@utility text-overline`, because a
+     column header is a label above a group and that is exactly the role. It
+     replaces a hardcoded `font-weight: 600` that no token could reach: with the
+     rest of the scale down at 400/550 that literal had become the heaviest text
+     in the product, so the header row out-weighted every cell it labeled. A
+     header is now a point smaller, 50 units lighter, muted, and letterspaced,
+     which is what stops it competing with its own rows. Kept as a rule here
+     rather than a class at the call site because these three selectors reach
+     into HeroUI's table DOM, which no call site can. */
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  line-height: var(--text-xs--line-height);
+  letter-spacing: 0.06em;
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
   border-radius: 0;
 }
 .otari-table .table__column::after {

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -555,25 +555,21 @@
   --shadow-elevation-md: var(--shadow-md);
   --shadow-elevation-lg: var(--shadow-lg);
   --shadow-modal: var(--shadow-modal);
-  /* Type scale, registration half. Two kinds of key live here and only these
-   * two, because they are the keys `@heroui/styles` does not declare:
+  /* Type scale, registration half. One kind of key lives here and nothing else:
+   * `--text-*--letter-spacing`, the per-step tracking. Registration is what makes
+   * Tailwind emit the `letter-spacing` line inside `.text-xs` and friends at all;
+   * a value declared only at :root is never read, because the utility would not
+   * reference it.
    *
-   *   --text-caption          a seventh step Tailwind does not ship, between
-   *                           --text-xs (12) and --text-sm (14). Registering it
-   *                           here is what makes it a real step rather than a
-   *                           number repeated in a role.
-   *   --text-*--letter-spacing  tracking per size step. Registration is what
-   *                           makes Tailwind emit the `letter-spacing` line in
-   *                           `.text-xs` and friends at all; a value declared
-   *                           only at :root is never read, because the utility
-   *                           would not reference it. So these must be here and
-   *                           the sizes must not (see the :root block below).
-   *
-   * Every value that HeroUI also declares lives in the unlayered `:root` block
-   * further down, NOT here. The comment there says why. */
-  --text-caption: 13px;
-  --text-caption--line-height: 19px;
-  --text-caption--letter-spacing: 0.0075em;
+   * Nothing else belongs here, and the two exclusions have different reasons.
+   * A value `@heroui/styles` also declares would lose on source order (see the
+   * unlayered `:root` block below). And a *size* registered in the `--text-*`
+   * namespace generates a `.text-<name>` utility, which collides with any
+   * `@utility` of the same name: both land in `@layer utilities`, the
+   * theme-derived declarations come second, and the role's own metrics go dead
+   * while still compiling and emitting. That is why the 13px caption step is
+   * `--text-caption-step` in the `:root` block rather than `--text-caption`
+   * here. `foundation.test.ts` pins both exclusions. */
   --text-xs--letter-spacing: 0.01em;
   --text-sm--letter-spacing: 0.005em;
   --text-base--letter-spacing: 0em;
@@ -620,6 +616,14 @@
    * muddy and negative on the large ones where it goes loose. */
   --text-xs: 12px;
   --text-xs--line-height: 18px;
+  /* The seventh step, between 12 and 14, which Tailwind does not ship. Named
+     `-step` rather than `--text-caption` on purpose: a `--text-*` key generates
+     a same-named utility that would outrank `@utility text-caption` in the same
+     layer and silently kill the role's own metrics. Nothing consumes this but
+     that role and `text-chrome-row`, so it needs no utility of its own. */
+  --text-caption-step: 13px;
+  --text-caption-step--line-height: 19px;
+  --text-caption-step--letter-spacing: 0.0075em;
   --text-sm: 14px;
   --text-sm--line-height: 20px;
   --text-base: 16px;
@@ -740,16 +744,21 @@
      sharing 14px: a secondary line had nowhere lighter to go than the value it
      was explaining. */
   font-family: var(--font-sans);
-  font-size: var(--text-caption);
-  line-height: var(--text-caption--line-height);
-  letter-spacing: var(--text-caption--letter-spacing);
+  font-size: var(--text-caption-step);
+  line-height: var(--text-caption-step--line-height);
+  letter-spacing: var(--text-caption-step--letter-spacing);
   font-weight: var(--font-weight-normal);
   color: var(--color-text-muted);
 }
 @utility text-overline {
-  /* 12px rather than 11: of the three hand-rolled overline spellings this
-     replaces, the most common one was already 12, and an eighth theme step for
-     one role is not worth a point of size. */
+  /* 12px rather than 11, and the reason is the scale rather than the call sites:
+     an eighth theme step for a single role is not worth a point of size, and
+     `--text-xs` is already exactly this size.
+     Worth being accurate about what moves. Five of the seven hand-rolled
+     spellings this replaces were `text-[11px]` and two were `text-xs`, so 11 was
+     the more common spelling, not 12. And the three call sites that already used
+     this role (`AppShell`, `nav/WorkspaceSwitcher`, `nav/rowStyles`) go up a
+     point rather than staying put. */
   font-family: var(--font-sans);
   font-size: var(--text-xs);
   line-height: var(--text-xs--line-height);
@@ -761,9 +770,9 @@
   color: var(--color-text-muted);
 }
 @utility text-chrome-row {
-  font-size: var(--text-caption);
-  line-height: var(--text-caption--line-height);
-  letter-spacing: var(--text-caption--letter-spacing);
+  font-size: var(--text-caption-step);
+  line-height: var(--text-caption-step--line-height);
+  letter-spacing: var(--text-caption-step--letter-spacing);
 }
 @utility text-chrome-meta {
   font-size: var(--text-xs);
@@ -1048,12 +1057,11 @@ body {
      which is what stops it competing with its own rows. Kept as a rule here
      rather than a class at the call site because these three selectors reach
      into HeroUI's table DOM, which no call site can. */
-  color: var(--color-text-muted);
-  font-size: var(--text-xs);
-  line-height: var(--text-xs--line-height);
-  letter-spacing: 0.06em;
-  font-weight: var(--font-weight-semibold);
-  text-transform: uppercase;
+  /* `@apply` rather than a second copy of the six declarations: the role is the
+     single definition, so retuning it moves the header row with it. What cannot
+     be a class at the call site is the selector, which reaches into HeroUI's
+     table DOM, and that is the only reason this rule exists. */
+  @apply text-overline;
   border-radius: 0;
 }
 .otari-table .table__column::after {


### PR DESCRIPTION
## Description

## What this does, and what it does not

The dashboard's type carried its hierarchy in boldness. Nothing in the shell chrome was
regular weight: every nav row, button, chip and field label sat at 500, so weight could
not signal anything because every row had already spent it. Above that floor, five
different meanings shared a single size.

This change fixes the **weight** and **tracking** axes completely, and the **size** axis
only where a shared primitive owns it. It does not fix the size axis at the call sites,
because that lives in which utility a call site names and no token can reach it. That
work is scoped as a follow-up and is linked below. The before/after is modest and
structural rather than dramatic, and that is the honest description of it.

## The mechanism, and two cascade bugs found by compiling rather than reasoning

**1. A `@theme` override of these keys is a silent no-op.** `@heroui/styles` is not a
consumer of Tailwind's type variables, it is a *prebuilt Tailwind stylesheet* that ships
its own `@layer theme { :root, :host { … } }` carrying the full default theme:
`--text-xs`, `--text-sm`, `--font-weight-medium: 500`, `--tracking-tight` and every
`--text-*--line-height`. Tailwind hoists all `@theme` blocks into its own theme layer at
the position of `@import "tailwindcss"` (line 1), so HeroUI's literal theme layer lands
second. Same layer, same `:root` specificity: source order decides, and HeroUI wins.

An override written in `@theme` therefore compiles clean, emits, passes every check, and
changes nothing. Worse, it half-works: the *new* keys survive, because HeroUI never
declares them, so tracking would have landed while every size and weight silently
reverted. `globals.css` already carried a comment saying its `@theme` block was
"non-overlapping with HeroUI's tokens", which is the shape of a workaround for this
without the diagnosis.

So the scale is split in two, and both halves are load-bearing:

- **`@theme`** registers only the keys HeroUI never declares: `--text-caption` and the
  `--text-*--letter-spacing` set. Registration is what makes Tailwind emit the
  `letter-spacing` line inside `.text-xs` and friends at all. A tracking value declared
  only at `:root` is never read, because the utility would not reference it.
- **An unlayered `:root` block**, after the HeroUI import, carries every value HeroUI
  also declares. Unlayered beats every `@layer`, so it wins because of *what it is* and
  not because of where it sits. That distinction is commented in the file, because the
  next `@import` somebody adds would quietly outrank a merely-later block.

**2. The `h1` to `h6` font-family rule was unlayered.** `@utility` lands in
`@layer utilities`, and an unlayered rule beats every layer, so
`h1,…,h6 { font-family: var(--font-display) }` silently overrode the `font-family` of any
role applied to a heading element. `text-heading` and `text-title` are set in the body
face now and are worn by `<h2>` and `<h3>`, so this would have kept them in Zilla Slab
and made the role map a suggestion with no symptom to chase. It is now in `@layer base`:
a bare heading still gets the display face, and a role wins.

Both bugs are invisible at every stage except a rendered page, which is why they were
found by compiling the stylesheet and reading the emitted CSS rather than by reasoning
about it.

## The thing this PR is about, found inside this PR

A reviewer recompiled this branch and found that **the fix contained the bug it exists to
prevent.**

`--text-caption` was registered in the `--text-*` namespace, which makes Tailwind generate a
`.text-caption` **size** utility. That landed in `@layer utilities` beside the `@utility
text-caption` **role** of the same name and, being second, won. The role's own `font-size`,
`line-height` and `letter-spacing` were dead declarations. Editing them compiled, emitted, passed
lint, typecheck and every test, and changed nothing on screen.

I had checked that collision earlier and cleared it, because I verified that the role's `color`
survived the merge. It does. Its metrics do not. The check that settles it is setting the role to
`font-size: 99px` and reading the compiled output, where `var(--text-caption)` still wins.

The step is now `--text-caption-step`, declared in the unlayered value block where it generates no
utility, so the role owns its whole spec and no collision is possible. And the `@theme` assertion
had been whitelisting `--text-caption` and `--text-caption--line-height` to accommodate it: both
exceptions are gone, so it now reads flatly as *letter-spacing keys only, no exceptions*.

This is stated up front rather than in a fix list because it is the strongest argument the PR has.
The failure mode described below is not hypothetical and it is not rare enough to reason your way
past: it got into the change whose entire subject is that failure mode, past three new tests
written to catch it, and it took a human recompiling the branch to see it. That is what the tests
are for, and it is why the rule they now enforce has no exceptions left to erode.

## The scale

Whole pixels throughout; a fractional size reflows every dense table for no legible gain,
tested at 100%, 125% and 150% zoom. Tracking is positive on the small steps, where tight
setting goes muddy, and negative on the large ones, where it goes loose.

| step | size / line-height | tracking |
| --- | --- | --- |
| `--text-xs` | 12 / 18 | +0.01em |
| `--text-caption` | 13 / 19 | +0.0075em |
| `--text-sm` | 14 / 20 | +0.005em |
| `--text-base` | 16 / 24 | 0 |
| `--text-lg` | 18 / 26 | -0.01em |
| `--text-xl` | 22 / 28 | -0.015em |
| `--text-2xl` | 26 / 32 | -0.02em |

`--text-caption` at 13 is a new seventh step. Tailwind ships nothing between 12 and 14,
and that absence is why five meanings were sharing 14px: a secondary line had nowhere
lighter to go than the value it was explaining.

Weights: `normal` 400, **`medium` 400**, `semibold` 550, `bold` 600.

`--font-weight-medium: 400` is deliberate and **the token name is now a lie.** It is how
roughly 140 `font-medium` call sites and HeroUI's own 93 internal uses come off 500 in two
lines rather than in 140 edits, and it is the single largest visual change here. Deleting
the now-inert utilities is follow-up, not this change.

## Contrast: a pre-existing bug this found, not one it caused

`--color-text-subtle` fails WCAG AA for normal text today, on every surface, in both
themes. Dropping the weight floor to 400 did not break it; it removed what was disguising
it. Measured against all six background and surface tokens each theme declares:

**Light: `#80868d` to `#62686f`**

| ground | before | after |
| --- | --- | --- |
| `background` / `surface` `#ffffff` | 3.68 | **5.63** |
| `surface-muted` `#f1f4f6` | 3.33 | **5.10** |
| `background-subtle` `#eef1f4` | 3.24 | **4.97** |
| `background-muted` `#e8ecef` | 3.09 | **4.74** |
| `surface-subtle` `#e4e9ed` | 3.01 | **4.61** |

**Dark: `#6e7882` to `#919ba5`**

| ground | before | after |
| --- | --- | --- |
| `background` `#15191f` | 3.92 | **6.24** |
| `surface` `#1b1f27` | 3.67 | **5.85** |
| `background-muted` `#222731` | 3.33 | **5.30** |
| `surface-muted` `#232831` | 3.29 | **5.24** |
| `background-subtle` `#292e38` | 3.03 | **4.82** |
| `surface-subtle` `#2b313b` | 2.91 | **4.63** |

Every ground clears 4.5 after. The worst case is 4.61 light and 4.63 dark, so neither
theme rides the line. WCAG 2.x relative luminance, sRGB, `(L_hi + 0.05)/(L_lo + 0.05)`,
measured independently twice.

Every figure above was computed twice, independently, by two people working from the token
values in `globals.css` rather than one carrying numbers across. The first pass sampled
three of the six grounds and reported the dark repair as passing; it was not. Which is the
point of the next paragraph.

The two deepest surfaces are the ones that matter and were the ones missed on the first
pass: `background-subtle` is the **hover/pressed state of a nav row**, and
`text-chrome-meta` sits on hovered rows, so the failing pairing was one an operator hits
by moving the mouse.

## Roles

The seven roles now read the scale instead of hardcoding rem, which is what makes the
follow-up mechanical: fixing a call site becomes changing which role it names, not
re-deriving a number per site.

| role | step | weight | face |
| --- | --- | --- | --- |
| `text-display` | `--text-2xl` 26 | 500 | Zilla Slab, -0.01em |
| `text-heading` | `--text-lg` 18 | 550 | body |
| `text-title` | `--text-base` 16 | 550 | body |
| `text-body` | `--text-sm` 14 | 400 | body |
| `text-emphasis` | `--text-sm` 14 | 550 | body |
| `text-caption` | `--text-caption` 13 | 400 | body, muted |
| `text-overline` | `--text-xs` 12 | 550 | body, +0.06em, uppercase, muted |

`text-display` overrides the step's -0.02em to -0.01em: Zilla Slab's slab serifs already
close the counters, so the same negative tracking that reads as resolved on the sans reads
as condensed on the serif. Any future sans consumer of `text-2xl` should keep -0.02em.

`text-chrome-initials` stays hardcoded at 9px, off-scale, as the one documented exception:
two letters in a 26px avatar are recognized, not read, so putting them on the scale would
either overflow the avatar or drag a real text step down to suit a monogram.

`text-title` and `text-body` have never had a call site in product code and become
correct and available here without being called. That is deliberate.

## Call sites, bounded

- **Column headers** adopt the overline spec, replacing a hardcoded `font-weight: 600` in
  `.otari-table .table__column` that no token could reach. With the rest of the scale down
  at 400/550 that literal had become the heaviest text in the product, so a header row
  out-weighted every cell it labeled. Uppercase costs column width, and three Models
  headers were shortened rather than the spec weakened: `Base in / out $ / 1M` ->
  `Base in / out / 1M`, `Caching policy` -> `Caching`, `Pricing policy` -> `Pricing`. The
  `$` comes out because every cell in that column already shows it; `/ 1M` stays because
  nothing else on the page carries the basis. The tooltip on that column explains how
  unpriced models are metered and never states the unit, so cutting `/ 1M` too would have
  left the basis for `$0.90` stated nowhere. Measured
  on the page: header row 56px -> 41px, Model column 354px -> 389px, and the longest
  identifier stops wrapping.

  **Known costs of the uppercase spec, accepted deliberately and consistently.** Uppercase plus
  0.06em tracking makes every header wider, and where that forces a choice we have taken the
  wrap rather than a rename, every time.

  On Models, `Pricing policy` and `Base in / out / 1M` both wrap to two lines, the header row is
  56px rather than 41px, and the 24px this costs the Model column (389px to 365px) re-wraps the
  longest identifier, `anthropic.claude-3-5-sonnet-20241022-v2:0`. `Pricing policy` was briefly
  shortened to `Pricing` and that is reverted: alone it sits two columns from
  `Base in / out / 1M` and reads as a second price column rather than as the policy that produced
  the price. `POLICY` was considered and rejected, because `Caching policy` is already `Caching`,
  so `CACHING` beside `POLICY` breaks the parallel between two headers naming the same kind of
  thing and shows a reader two categories where there is one. Shortening that pair would have to
  be done as a pair, which is a naming exercise and not a line in a type PR.

  `APPLIES TO` also wraps to two lines on Routing.
  Shortening it was considered and rejected. The three cuts above each remove a word that
  carries nothing (every value in the caching column is a policy), where the candidate here
  was replacing a plain phrase with a shorter noun, and `RoutingPage.tsx:1335` gives that
  column the id `scope`, which is evidence the shorter word is our internal name for it
  rather than the reader's. Routing also has two wraps that predate this change,
  `demo-failover` in the Policy column and `Every caller` in this one, so a naming change
  would have fixed one third of a layout problem. All three are column-width work in the
  follow-up issue.
- **Three overline spellings collapse into one.** Seven call sites carried
  `text-[11px] font-medium uppercase tracking-wide`, `text-xs font-semibold uppercase
  tracking-wide` and `text-xs font-medium uppercase tracking-wide`; the rail's label, a
  stat-card label and a column header now measure identically.
- **The ladder is no longer inverted.** A page title was `text-xl font-semibold` (20px)
  while a stat value inside a card was `text-xl … sm:text-2xl` (24px), so a number
  outranked the name of the page. The title moves up to `text-display` (26) and the stat
  down to `text-xl` (22): both halves move, so the ladder is correct by construction
  rather than by two call sites agreeing.
- **Page descriptions get `max-w-prose`.** They ran the full container width: 968px at
  14px is ~138 characters per line, roughly twice a comfortable measure, on every page.
  Now ~89.
- **The delta slot reserves two lines.** A delta like `5.8% errors · ▲ 214.1% vs prev`
  wrapped in a narrow tile while its four neighbors stayed on one line, and the row of
  five stat cards stopped aligning. This is a layout fix, not a type fix: sizing type to
  the longest string is sizing type by accident.
- **`tabular-nums` in one place, not thirteen.** `DataTable` already applies it to every
  `align: "end"` column, and a DOM scan found no numeric *cell* without it. What lacked it
  was numbers inside sentences, where proportional figures are correct. The one addition
  is the delta slot, where a column of five percentages does align.

## Type is not a width tool

> Type is what you reach for when the layout is right and it still reads badly.

Three of the fixes above were layout problems wearing a type problem's clothes, and they
are worth naming together because the pattern is the more useful finding:

- **The delta slot.** A delta wrapped in a narrow tile while its neighbors did not, so the
  row of stat cards stopped aligning. The tempting fix is a smaller font. The fix is a
  reserved two-line height.
- **The `Over budget` chip.** It had wrapped onto its own line because the stat value beside
  it had grown. It needed no work at all: it came back inline the moment the stat took its
  correct step on the scale.
- **The column headers.** Uppercase costs width, and the first instinct was to give up the
  uppercase. What it actually needed was three header strings with a dead word each
  (`CACHING POLICY` -> `CACHING`; every value in that column is a policy).

In each case a type value had been, or was about to be, tuned to survive a layout
constraint. That is how a scale degrades quietly: each value looks defensible on its own
and only the pile-up is visible. It is also the honest explanation for how this codebase
got five meanings onto 14px. Nobody made a bad decision; they made forty locally
reasonable ones.

## Deliberately not in this change

The size axis at the call sites: a handful of headings that render at body size, and one
sub-table that hand-rolls its column headers instead of wearing the overline spec. Tracked
in #804, along with measure control on the descriptions the two shared helpers do not
reach, the Routing column widths, and identifiers in the mono face.

**Correction to an earlier version of this description.** It claimed five meanings share
14px, and that the Activity table renders its explanation line at the same size as the
value it explains. **Both were wrong and I am the author of the error.** Measured in the
live DOM: the policy name is 14px and the explanation beside it is 12px muted
(`ActivityPage.tsx:749` has read `text-xs ... text-muted` throughout), so that size step
was always there. And of the ~427 nodes at 14px on Activity, 386 are table cells, which is
what body size is for on a 161-row table rather than evidence of a collapse. The original
claim came from reading a computed-style census bucket whose three printed samples were all
the same element, and generalizing without probing the second line by name.

Nothing in this PR depends on that claim: the weight floor, the tracking, the contrast
repair, the two cascade bugs and the title/stat ladder were each measured directly and are
unaffected. #804 has been corrected in the same way, leading with the retraction.

## Checks

`pnpm --dir web run lint` and `run typecheck` clean.

Three new tests in `src/styles/foundation.test.ts` pin the split from both sides: the
unlayered `:root` block declares every contested key; neither theme block declares any
`--text-*` / `--font-weight-*` / `--tracking-*`; and `@theme` registers the letter-spacing
keys and does **not** register a size or weight HeroUI also declares. The third guards
against reintroducing the silent no-op above.

Type metrics are deliberately declared once rather than in both theme blocks. Type has no
theme axis, and declaring them twice would allow one block to be edited and the other
missed, giving the two themes different type metrics: invisible in whichever theme you are
looking at, and undetectable by the existing both-themes assertion, because the key sets
would still match.

The vitest suite is red on `main` in this environment independent of this change: 303
failures across 21 files, including `AppShell.test.tsx` (60/60), `Login.test.tsx` (42/42),
`ModelsPage.test.tsx` (39/39) and `navigationHistory.test.ts` (9/9), all reproducible with
this branch's changes stashed. This branch's delta is +3 passing tests, which are the
three it adds.

The screenshot suite is `workflow_dispatch`-only, its baselines are gitignored, and CI
runs it with `--update-snapshots=missing`, so it writes baselines rather than failing. It
is a before/after tool here, not a regression gate.


## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

Both, deliberately. The Bug Fix half is the WCAG AA contrast failure (#803) and the two
cascade bugs described above. The Refactor half is the scale itself, which changes no
behavior an operator can name.

## Relevant issues

Fixes #803

Related, and deliberately **not** fixed here:

- #804 is the follow-up this change was scoped against. It carries the call-site migration
  that separates the five meanings still sharing 14px, the Routing column widths, and
  identifiers in the mono face. Nothing in it is fixed by this PR, and the "Deliberately not
  in this change" section above says why.
- #805 (the dashboard suite cannot run on Node 26, and nothing pins the version locally) was
  filed from this branch on a wrong premise and has been corrected. It is not fixed here. The
  Checklist note below explains why it is worth reading before trusting any local test result
  on this repo.
- #806 (an older gateway's bootstrap white-screens the sign-in page) was found while standing
  up the environment used to verify this change. Unrelated to typography and not fixed here.

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
      Three tests in `web/src/styles/foundation.test.ts`. Not `tests/unit` or
      `tests/integration`: this change is entirely under `web/`, whose suite is Vitest.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
      Ticked with a note: those three are the Python side and this PR touches no Python. Their
      dashboard counterparts are what ran, and CI is the authority on the third.
      - `pnpm --dir web run lint` clean, locally and in CI.
      - `pnpm --dir web run typecheck` clean, locally and in CI.
      - `pnpm --dir web test`: green in CI. **Correction, and it matters, so it is here rather
        than buried:** I originally reported this suite as red on `main` independent of this
        change, with a 303-failure baseline. That was wrong. Those 303 failures are a **local
        Node 26** problem; CI runs Node 22 and passes. Which means the baseline I was measuring
        against was noise, and it hid a real regression this branch introduced: three
        `getByRole("columnheader")` queries in `ModelsPage.test.tsx` still named the old header
        copy. CI caught it, I did not. Fixed in 9521fd6e. #805 has been rewritten from "the
        suite is red on main" to what it actually is, a missing local Node pin, with this as
        the argument for why that is worth fixing.
- [x] Documentation was updated where necessary.
      The reasoning lives in `globals.css` itself, at the two places where the next person
      would otherwise reintroduce the bugs: a comment on the unlayered `:root` block saying
      why it is unlayered rather than merely later, and one on the `@layer base` wrap saying
      what it stops overriding.
- [ ] If the API contract changed, I regenerated the OpenAPI spec.
      **Not applicable.** No route, schema, or docstring changed; no API contract is touched.
      `web/src/client/schema.ts` and `web/src/routeTree.gen.ts` are both unchanged, so there
      is no generated artifact to commit. The dashboard bundle is gitignored as usual.

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

Three agent sessions: a design engineer producing the scale, a coordinator, and this one
implementing and verifying. Worth knowing for review, because it shaped what is here: the
numbers in the scale were proposed by one session and every one of them was re-measured by
another before landing. That caught the two cascade bugs, and it caught a proposed dark
contrast value that had been checked against three of the six surfaces and reported as
passing when it failed on the other two.

Every quantitative claim in the description above was measured on the running dashboard
against a seeded database, or by compiling the stylesheet and reading the emitted CSS. None
of it is inferred. Where a measurement contradicted a plausible assumption, the measurement
won, and the description says so rather than presenting the conclusion alone.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
