### PR TITLE
refactor(dashboard): put headings that render at body size onto the type roles

### DIFF
--- a/web/src/app/HybridLanding.tsx
+++ b/web/src/app/HybridLanding.tsx
@@ -78,9 +78,7 @@ export function HybridLanding() {
           </div>
 
           <div className="flex flex-col gap-2">
-            <h2 className="text-sm font-semibold text-foreground">
-              Point a client here
-            </h2>
+            <h2 className="text-title">Point a client here</h2>
             <CopyableValue
               value={baseUrl}
               label="gateway base URL"

--- a/web/src/features/account/PasskeysCard.tsx
+++ b/web/src/features/account/PasskeysCard.tsx
@@ -230,7 +230,7 @@ export function PasskeysCard() {
 
   return (
     <section className="flex flex-col gap-2">
-      <h2 className="text-sm font-semibold text-foreground">Passkeys</h2>
+      <h2 className="text-title">Passkeys</h2>
       <Card>
         <Card.Content className="flex flex-col gap-4 px-5 py-5">
           <p className="max-w-3xl text-sm text-muted">

--- a/web/src/features/account/PasswordCard.tsx
+++ b/web/src/features/account/PasswordCard.tsx
@@ -174,7 +174,7 @@ export function PasswordCard() {
 
   return (
     <section className="flex flex-col gap-2">
-      <h2 className="text-sm font-semibold text-foreground">
+      <h2 className="text-title">
         {isClaimed ? "Dashboard password" : "Claim this deployment"}
       </h2>
       <Card>

--- a/web/src/features/activity/ActivityPage.tsx
+++ b/web/src/features/activity/ActivityPage.tsx
@@ -224,9 +224,7 @@ function InFlightControl({
       <Popover.Content placement="bottom end">
         <Popover.Dialog>
           <div className="flex w-80 flex-col gap-2">
-            <Popover.Heading className="text-sm font-medium">
-              In flight
-            </Popover.Heading>
+            <Popover.Heading className="text-title">In flight</Popover.Heading>
             <p className="text-xs text-muted">
               Running right now, across the whole gateway; longest-running
               first. Not narrowed by the filters above.
@@ -821,25 +819,25 @@ function RoutingPlan({ entry }: { entry: UsageEntry }) {
         >
           <thead className="text-muted">
             <tr className="border-b border-border">
-              <th scope="col" className="px-3 py-2 text-left font-medium">
+              <th scope="col" className="px-3 py-2 text-left text-overline">
                 #
               </th>
-              <th scope="col" className="px-3 py-2 text-left font-medium">
+              <th scope="col" className="px-3 py-2 text-left text-overline">
                 Target
               </th>
-              <th scope="col" className="px-3 py-2 text-left font-medium">
+              <th scope="col" className="px-3 py-2 text-left text-overline">
                 Selected as
               </th>
-              <th scope="col" className="px-3 py-2 text-left font-medium">
+              <th scope="col" className="px-3 py-2 text-left text-overline">
                 Outcome
               </th>
               {/* Every attempt's `latency_ms` is measured from the start of the
                   request, not from the start of that attempt, so this is the same
                   "Total time" the row column shows, not a per-candidate duration. */}
-              <th scope="col" className="px-3 py-2 text-right font-medium">
+              <th scope="col" className="px-3 py-2 text-right text-overline">
                 Total time
               </th>
-              <th scope="col" className="px-3 py-2 text-right font-medium">
+              <th scope="col" className="px-3 py-2 text-right text-overline">
                 Cost
               </th>
             </tr>

--- a/web/src/features/activity/ActivityPage.tsx
+++ b/web/src/features/activity/ActivityPage.tsx
@@ -817,7 +817,10 @@ function RoutingPlan({ entry }: { entry: UsageEntry }) {
           className="w-full text-xs"
           aria-label={`Routing plan for policy ${entry.policy_name}`}
         >
-          <thead className="text-muted">
+          {/* No `text-muted` here: `text-overline` on each `<th>` sets the color
+              itself, so a second declaration on the parent is one more place to
+              keep in step for no effect. */}
+          <thead>
             <tr className="border-b border-border">
               <th scope="col" className="px-3 py-2 text-left text-overline">
                 #

--- a/web/src/features/budgets/BudgetsPage.tsx
+++ b/web/src/features/budgets/BudgetsPage.tsx
@@ -256,7 +256,7 @@ function BudgetForm({
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-sm font-semibold text-foreground">{title}</div>
+        <div className="text-title">{title}</div>
         <ErrorBanner error={error} />
         <Field
           label="Name (optional)"

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -418,9 +418,7 @@ function CreateKeyForm({
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-sm font-semibold text-foreground">
-          Create API key
-        </div>
+        <div className="text-title">Create API key</div>
         <ErrorBanner error={create.error} />
         <div className="grid gap-4 sm:grid-cols-2">
           <Field
@@ -548,7 +546,7 @@ function EditKeyForm({
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-sm font-semibold text-foreground">
+        <div className="text-title">
           Edit <code>{apiKey.key_name ?? apiKey.id}</code>
         </div>
         <ErrorBanner error={update.error} />

--- a/web/src/features/models/ModelsPage.tsx
+++ b/web/src/features/models/ModelsPage.tsx
@@ -824,9 +824,7 @@ function ModelDetailPanel({
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <h2 className="text-base font-semibold break-all text-foreground">
-                {row.model}
-              </h2>
+              <h2 className="text-title break-all">{row.model}</h2>
               {metadata?.deprecated ? (
                 <Chip size="sm" color="danger">
                   deprecated

--- a/web/src/features/organization/CreateOrganizationForm.tsx
+++ b/web/src/features/organization/CreateOrganizationForm.tsx
@@ -22,9 +22,7 @@ export function CreateOrganizationForm({ onClose }: { onClose: () => void }) {
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-sm font-semibold text-foreground">
-          Create organization
-        </div>
+        <div className="text-title">Create organization</div>
         <ErrorBanner error={create.error ?? switchTo.error} />
         <Field
           label="Name"

--- a/web/src/features/organization/OrganizationGeneralPage.tsx
+++ b/web/src/features/organization/OrganizationGeneralPage.tsx
@@ -42,7 +42,7 @@ function OrganizationDetails({
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-sm font-semibold text-foreground">Details</div>
+        <div className="text-title">Details</div>
         <ErrorBanner error={update.error} />
         <Field
           label="Organization name"

--- a/web/src/features/organization/OrganizationMembersPage.tsx
+++ b/web/src/features/organization/OrganizationMembersPage.tsx
@@ -197,7 +197,7 @@ function AddMemberForm({ onClose }: { onClose: () => void }) {
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-sm font-semibold text-foreground">Add member</div>
+        <div className="text-title">Add member</div>
         <ErrorBanner error={add.error} />
         <div className="grid gap-4 sm:grid-cols-2">
           <Field
@@ -319,9 +319,7 @@ function InviteMemberForm({ onClose }: { onClose: () => void }) {
     return (
       <Card>
         <Card.Content className="flex flex-col gap-4 p-5">
-          <div className="text-sm font-semibold text-foreground">
-            Invitation sent
-          </div>
+          <div className="text-title">Invitation sent</div>
           {result.mail_sent ? (
             <InfoBanner>
               An email with an accept link was sent to{" "}
@@ -357,9 +355,7 @@ function InviteMemberForm({ onClose }: { onClose: () => void }) {
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-sm font-semibold text-foreground">
-          Invite member
-        </div>
+        <div className="text-title">Invite member</div>
         <ErrorBanner error={invite.error} />
         <div className="grid gap-4 sm:grid-cols-2">
           <Field
@@ -606,9 +602,7 @@ function MemberEditor({
   return (
     <Card>
       <Card.Content className="flex flex-col gap-5 p-5">
-        <div className="text-sm font-semibold text-foreground">
-          Edit {memberLabel(member)}
-        </div>
+        <div className="text-title">Edit {memberLabel(member)}</div>
         <ErrorBanner error={error} />
 
         {spendRow ? (

--- a/web/src/features/organization/RateOverridesCard.tsx
+++ b/web/src/features/organization/RateOverridesCard.tsx
@@ -188,9 +188,7 @@ export function RateOverridesCard() {
   return (
     <section className="flex flex-col gap-2">
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <h2 className="text-sm font-semibold text-foreground">
-          Rate overrides
-        </h2>
+        <h2 className="text-title">Rate overrides</h2>
         <Button
           size="sm"
           variant="primary"

--- a/web/src/features/overview/OverviewPage.tsx
+++ b/web/src/features/overview/OverviewPage.tsx
@@ -614,9 +614,7 @@ function RecentActivity({
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold text-foreground">
-          Recent activity
-        </h2>
+        <h2 className="text-title">Recent activity</h2>
         <Link
           to="/activity"
           className="text-sm text-link hover:text-link-hover hover:underline"

--- a/web/src/features/pricing/ModelPricingPage.tsx
+++ b/web/src/features/pricing/ModelPricingPage.tsx
@@ -117,9 +117,7 @@ function PricingRefreshSection() {
 
   return (
     <section className="flex flex-col gap-2">
-      <h2 className="text-sm font-semibold text-foreground">
-        Default pricing catalog
-      </h2>
+      <h2 className="text-title">Default pricing catalog</h2>
       <Card>
         <Card.Content className="flex flex-col gap-4 p-5">
           <div className="flex flex-wrap items-start justify-between gap-3">
@@ -282,7 +280,7 @@ function PriceTable() {
 
   return (
     <section className="flex flex-col gap-2">
-      <h2 className="text-sm font-semibold text-foreground">Model prices</h2>
+      <h2 className="text-title">Model prices</h2>
       <ErrorBanner error={pricing.error} />
       <Card>
         <Card.Content className="p-0">

--- a/web/src/features/providers/ProvidersPage.tsx
+++ b/web/src/features/providers/ProvidersPage.tsx
@@ -649,7 +649,7 @@ function EditProviderForm({
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-sm font-semibold text-foreground">
+        <div className="text-title">
           Edit <code>{provider.instance}</code>
         </div>
         <ErrorBanner error={update.error} />

--- a/web/src/features/routing/RoutingPage.tsx
+++ b/web/src/features/routing/RoutingPage.tsx
@@ -620,7 +620,7 @@ function PolicyForm({
     <div className="flex flex-col gap-4">
       <Card>
         <Card.Content className="flex flex-col gap-5 p-5">
-          <div className="text-sm font-semibold text-foreground">
+          <div className="text-title">
             {editing ? (
               <>
                 Edit {existing.kind === "alias" ? "alias" : "policy"}{" "}

--- a/web/src/features/settings/MailDeliveryCard.tsx
+++ b/web/src/features/settings/MailDeliveryCard.tsx
@@ -61,7 +61,7 @@ export function MailDeliveryCard() {
 
   return (
     <section className="flex flex-col gap-2">
-      <h2 className="text-sm font-semibold text-foreground">Email delivery</h2>
+      <h2 className="text-title">Email delivery</h2>
       <Card>
         <Card.Content className="flex flex-col divide-y divide-border px-5 py-1">
           <div className="flex flex-col gap-4 py-4">

--- a/web/src/features/settings/MaintenanceModeCard.tsx
+++ b/web/src/features/settings/MaintenanceModeCard.tsx
@@ -28,9 +28,7 @@ export function MaintenanceModeCard() {
 
   return (
     <section className="flex flex-col gap-2">
-      <h2 className="text-sm font-semibold text-foreground">
-        Maintenance mode
-      </h2>
+      <h2 className="text-title">Maintenance mode</h2>
       <Card>
         <Card.Content className="flex flex-col divide-y divide-border px-5 py-1">
           <div className="flex flex-col gap-4 py-4">

--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -564,7 +564,7 @@ function SecurityKeysSection({
 }) {
   return (
     <section className="flex flex-col gap-2">
-      <h2 className="text-sm font-semibold text-foreground">
+      <h2 className="text-heading">
         Credential security <span className="font-normal text-muted">(2)</span>
       </h2>
       <Card>
@@ -683,7 +683,7 @@ export function SettingsPage() {
 
       {groups.map((group) => (
         <section key={group.name} className="flex flex-col gap-2">
-          <h2 className="text-sm font-semibold text-foreground">
+          <h2 className="text-heading">
             {group.name}{" "}
             <span className="font-normal text-muted">
               ({group.fields.length})

--- a/web/src/features/tools/OrganizationGuardrailsCard.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.tsx
@@ -460,9 +460,7 @@ export function OrganizationGuardrailsCard({
 
   return (
     <section className="flex flex-col gap-2">
-      <h2 className="text-sm font-semibold text-foreground">
-        Organization guardrails
-      </h2>
+      <h2 className="text-title">Organization guardrails</h2>
       <p className="text-sm text-muted">
         Guardrails that run on every request from the workspaces below, whether
         the caller asked for them or not. They compose with the deployment

--- a/web/src/features/tools/SearchToolsCard.tsx
+++ b/web/src/features/tools/SearchToolsCard.tsx
@@ -307,7 +307,7 @@ export function SearchToolsCard({
 
   return (
     <section className="flex flex-col gap-2">
-      <h2 className="text-sm font-semibold text-foreground">Search tools</h2>
+      <h2 className="text-title">Search tools</h2>
       <p className="text-sm text-muted">
         The tools <code className="font-mono">POST /v1/search</code> dispatches
         against. A searxng tool that declares no backend URL uses the web-search

--- a/web/src/features/tools/ToolsGuardrailsPage.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.tsx
@@ -736,11 +736,7 @@ export function ToolsGuardrailsPage({ only }: { only?: ToolServiceName } = {}) {
                 {/* Dropped when the page is narrowed to this one service: the
                     page title already says it, and repeating it reads as two
                     headings for the same thing. */}
-                {only ? null : (
-                  <h2 className="text-sm font-semibold text-foreground">
-                    {service.label}
-                  </h2>
-                )}
+                {only ? null : <h2 className="text-title">{service.label}</h2>}
                 <p className="text-sm text-muted">{service.blurb}</p>
                 <Card>
                   <Card.Content className="flex flex-col divide-y divide-border px-5 py-1">

--- a/web/src/features/tools/WorkspaceCodeExecutionPolicyCard.tsx
+++ b/web/src/features/tools/WorkspaceCodeExecutionPolicyCard.tsx
@@ -233,9 +233,7 @@ export function WorkspaceCodeExecutionPolicyCard({
 
   return (
     <section className="flex flex-col gap-2">
-      <h2 className="text-sm font-semibold text-foreground">
-        This workspace ({selected.name})
-      </h2>
+      <h2 className="text-title">This workspace ({selected.name})</h2>
       <p className="text-sm text-muted">
         Whether requests billed to this workspace may use otari_code_execution,
         and the limits they run under. A workspace policy can only narrow what

--- a/web/src/features/tools/WorkspaceMcpServersCard.tsx
+++ b/web/src/features/tools/WorkspaceMcpServersCard.tsx
@@ -73,7 +73,7 @@ export function WorkspaceMcpServersCard({
   const [pendingDelete, setPendingDelete] = useState<WorkspaceMcpServer>()
 
   const heading = showHeading ? (
-    <h2 className="text-sm font-semibold text-foreground">MCP servers</h2>
+    <h2 className="text-title">MCP servers</h2>
   ) : null
 
   if (!selected) {

--- a/web/src/features/tools/WorkspaceWebSearchCard.tsx
+++ b/web/src/features/tools/WorkspaceWebSearchCard.tsx
@@ -209,9 +209,7 @@ export function WorkspaceWebSearchCard({
 
   return (
     <section className="flex flex-col gap-2">
-      <h2 className="text-sm font-semibold text-foreground">
-        This workspace ({selected.name})
-      </h2>
+      <h2 className="text-title">This workspace ({selected.name})</h2>
       <p className="text-sm text-muted">
         Whether requests billed to this workspace may search the web, and how
         far a search may reach. Blocking covers both doors: the otari_web_search

--- a/web/src/features/usage/UsagePage.tsx
+++ b/web/src/features/usage/UsagePage.tsx
@@ -1315,7 +1315,7 @@ export function UsagePage() {
           <div className="grid gap-6 xl:grid-cols-2">
             <div className="flex flex-col gap-3">
               <div className="flex flex-wrap items-center justify-between gap-3">
-                <h2 className="text-sm font-semibold text-foreground">
+                <h2 className="text-title">
                   Spend by {activePrimary.label.toLowerCase()}
                 </h2>
                 <div className="inline-flex gap-1.5">
@@ -1348,7 +1348,7 @@ export function UsagePage() {
             </div>
             <div className="flex flex-col gap-3">
               <div className="flex flex-wrap items-center justify-between gap-3">
-                <h2 className="text-sm font-semibold text-foreground">
+                <h2 className="text-title">
                   Spend by {activeSecondary.label.toLowerCase()}
                 </h2>
                 <div className="inline-flex gap-1.5">
@@ -1388,9 +1388,7 @@ export function UsagePage() {
           {toolRows.length ? (
             <div className="rounded-2xl border border-border bg-surface p-4">
               <div className="mb-3 flex flex-col gap-1">
-                <h2 className="text-sm font-semibold text-foreground">
-                  Gateway-run tools
-                </h2>
+                <h2 className="text-title">Gateway-run tools</h2>
                 <p className="text-xs text-muted">
                   Tools Otari ran itself, billed per call. MCP tools are not
                   listed here: their names come from your own server, so they

--- a/web/src/features/workspaces/WorkspaceMembersPanel.tsx
+++ b/web/src/features/workspaces/WorkspaceMembersPanel.tsx
@@ -146,9 +146,7 @@ export function WorkspaceMembersPanel({
 
   return (
     <div className="flex flex-col gap-4 p-4">
-      <div className="text-sm font-semibold text-foreground">
-        Members of {workspaceName}
-      </div>
+      <div className="text-title">Members of {workspaceName}</div>
       <ErrorBanner
         error={members.error ?? updateRole.error ?? removeMember.error}
       />

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -316,9 +316,7 @@ export function CreateWorkspaceForm({
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-sm font-semibold text-foreground">
-          Create workspace
-        </div>
+        <div className="text-title">Create workspace</div>
         {/* A refusal about the name is carried by the name, not by a block above
             the form that resizes whatever frames it. What is left here is what
             no field state can honestly say: a failure the operator cannot
@@ -522,7 +520,7 @@ function EditWorkspaceForm({
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-sm font-semibold text-foreground">
+        <div className="text-title">
           Edit <code>{workspace.name}</code>
         </div>
         <ErrorBanner

--- a/web/src/shared/components/ui/SettingsSection.tsx
+++ b/web/src/shared/components/ui/SettingsSection.tsx
@@ -23,7 +23,7 @@ export const SettingsSection = ({
     <section className="flex flex-col gap-3">
       <div className="flex items-start justify-between gap-4">
         <div className="flex flex-col gap-1">
-          <h2 className="text-base font-semibold">{title}</h2>
+          <h2 className="text-title">{title}</h2>
           {description && <p className="text-sm text-muted">{description}</p>}
         </div>
         {actions && <div className="shrink-0">{actions}</div>}


### PR DESCRIPTION
## Description

### The collapse was real. We had it in the wrong place, twice.

#807 and an earlier version of #804 both claimed the dashboard had "five meanings sharing 14px"
and named the Activity table's secondary explanation line as the headline instance. **Both
claims were wrong**, they are retracted in those two places, and this PR is what the finding
actually was.

The explanation line was never 14px. It is 12px muted and `ActivityPage.tsx:749` has read
`text-xs break-words text-muted` throughout. And classifying every 14px node on Activity by
structure: 386 of ~427 are table cells, which is what body size is *for* on a 161-row table.

The real collapse was in the **headings**, and it was uniform:

    text-sm font-semibold text-foreground     35 sites, 26 files

That is the card-and-section-heading idiom of the whole dashboard, and `text-sm` is 14px. So
every card title and every section heading rendered at the same size as the body text inside
it, distinguished from its own content by weight alone. `text-title` (16) existed for exactly
this and had **zero consumers**.

Settings is the clearest before and after. Its document outline was:

    H1  26px/500   Settings
    H2  14px/550   Server & database (9)
    H2  14px/550   Metering & budgets (6)
    ... ten more, every one at body size

A 12px jump from the page title to the first heading, then nothing at all between a heading and
the rows it labels. It now reads:

    H1  26px/500   Settings
    H2  18px/550   Server & database (9)        <- section, heads a group of cards
    H2  16px/550   Email delivery               <- a card's own title
    body 14px/400

Four levels where there were two.

One limit on that, raised in review: **roughly fifteen of the 33 `text-title` sites are `<div>`s
rather than heading elements**, so the document-outline improvement the Settings example
describes reaches the `<h2>` subset and not all of them. They look right either way; the outline
only improves where the element was already a heading. The Settings example happens to be all
`<h2>`, which is what made the claim look general. Turning those `<div>`s into headings is a
separate change, and #808 covers the outline question.

### The split, and the rule behind it

35 sites, one substitution, two destinations. The rule is what the heading *heads*, not where it
sits in the file:

- **`text-title` (16/550), 33 sites.** A card's own title: it lives inside a bordered surface
  and titles that surface's contents.
- **`text-heading` (18/550), 2 sites.** An `<h2>` in a `<section>` that *contains* a `Card`. It
  heads a group of cards rather than titling one, which is the distinction the role names. Both
  are on Settings, where every section heading was previously the same size as the settings rows
  beneath it.

One corroboration worth noting: `shared/components/ui/SettingsSection.tsx` was already at
`text-base font-semibold`, which is 16/550, the exact metrics `text-title` names. Somebody had
reached for that size by hand in the one place the role map independently says 16. It now names
the role instead of restating the numbers.

### Two more from the same pass

- **Activity's per-attempt plan sub-table hand-rolled its column headers** as
  `<th className="px-3 py-2 text-left font-medium">`, so it missed the single overline spec
  `.otari-table .table__column` gives every other table on that page. Two tables on one screen
  labelling their columns differently. Six headers, now `text-overline`.
- **A `Popover.Heading` was at body size.** It is a dialog title; it takes `text-title`.

### Activity barely moved, and that is expected

Six sub-table headers and one popover title. **Its row heights are unchanged**, and they were
never going to change here: the rows are 79px median because the Routing column's explanation
renders into a 117px column, so a sentence of that length wraps three ways at any size in the
scale. Simulated before deciding: moving those lines to `text-caption` (13px) makes rows
*taller*, 79 to 81px median, and the wrap does not resolve.

So Activity's problem is column width, tracked in #804 along with the deliberate-wrapping
comment at `ActivityPage.tsx:748` that whoever picks it up should read first. Please do not
reopen Activity as a type question.

`text-caption` is therefore still unconsumed, deliberately. The sites that would want it are
already at 12px and moving them up a step costs wrapping. A step that exists and is not yet
needed is fine; manufacturing a consumer to justify it is not.

### Retargeted to `main`, and why the diff is bigger than the change

This PR was opened against `fix/type-scale` (#807) to keep the diff to its own single commit.
**I have retargeted it to `main`, because stacking turned out to cost far more than the clean
diff was worth.** A PR based on a topic branch in this repo gets:

- **no dashboard CI.** `otari-dashboard.yml`, `otari-lint.yml`, `otari-typecheck.yml`,
  `otari-tests.yml` and the rest all declare `pull_request: branches: [main]`, so **none of them
  ran.** No lint, no typecheck, no vitest, no build. Only the three repo-wide meta checks fired,
  and a green tick on those looks like a green PR.
- **no CodeRabbit review.** `.coderabbit.yaml` sets `base_branches: ["main"]`, so it posted
  "Review skipped" rather than reviewing.
- **no `protect-main`.** The ruleset covers the default branch only, so this reported
  `mergeStateStatus: CLEAN` and could have been merged into `fix/type-scale` with no approval and
  no thread resolution, folding two reviews into one.

CI is the check that caught the only real regression in #807, so trading three checks for a
tidier diff was the wrong trade and I made it. Documented in #811 so the next person does not.

**What this costs a reviewer, and how to work around it:** until #807 merges, the diff below
shows **four commits and 33 files**, three of which belong to #807. **This PR's change is the
single commit `5574e601`**, 27 files, all of them a one-line class substitution. Reviewing that
commit alone is reviewing this PR. Once #807 merges the diff collapses to just it.

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

`refactor` rather than `feat` or `fix`: nothing became newly possible and no defect is repaired
here. One note on the consequence, since it is a real one: `cliff.toml` has `refactor` as
`skip = true`, so this will not appear in the changelog even though it changes what every card
title in the product looks like. That is the right call given #807 carries the user-visible
claim and these two will land together, but it is worth knowing rather than discovering.

## Relevant issues

Part of #804. Deliberately not `Fixes`, because #804 also carries the column widths, the
descriptions the shared helpers do not reach, and identifiers in the mono face, none of which
are here.

Filed while doing this work and **not** fixed here: #808 (sidebar disclosure groups are `<h3>`,
so they sit in every page's document outline) and #809 (a long `database_url` overflows its
Settings row). Neither is caused by this change; both were visible because of it.

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
      No new tests, and that is the honest answer rather than a skipped box: this changes which
      utility class a heading carries. It changes no element, no text, no behavior, and no
      query. The suite queries headings by role and text, so it covers this change as-is, and
      the two `toHaveClass` assertions in the whole suite are both on `md:hidden`. Adding a test
      that asserts a class name would pin the implementation rather than the behavior and would
      have to be rewritten by the next retune. `web/src/styles/foundation.test.ts` already
      guards the scale these roles read.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
      Those three are the Python side and this PR touches no Python. Their dashboard
      counterparts:
      - `pnpm --dir web run lint` clean.
      - `pnpm --dir web run typecheck` clean.
      - `pnpm --dir web test`: I compared the **failing-file sets** against this branch's base
        rather than comparing counts, because a count can hide a swap. **Zero newly failing,
        zero newly passing**, sets byte-identical. The 303 failures in both are the Node 26
        problem in #805, and CI on Node 22 is the real check.
- [x] Documentation was updated where necessary.
      No doc change owed: the roles and their reasoning already live in `globals.css`, and this
      only adds consumers. The role-to-step map is in #804.
- [ ] If the API contract changed, I regenerated the OpenAPI spec.
      **Not applicable.** No route, schema, or docstring changed. `web/src/client/schema.ts` and
      `web/src/routeTree.gen.ts` are unchanged.

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

Same three-session arrangement as #807, and the same rule: a claim does not ship until it has
been measured by someone other than whoever proposed it.

That rule is why this PR exists in this shape. The migration this started as was a twelve-page
sweep based on the "five meanings on 14px" claim. Measuring the first page before editing it
showed the claim was false, that the sweep as specified would have made Activity's rows taller,
and that the real finding was a different one with 35 instances. The scope came out larger than
what was agreed (35 sites rather than 3) and that was a judgment call: a uniform idiom
half-migrated reads as a bug where all-14 read as a choice. It is one commit and revertible
whole.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
