### PR TITLE
feat(mcp): replace inline MCP execution with stored-server endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,21 @@ The per-request flow (auth → budget → dispatch → reconciliation) spans sev
   file to commit and never leaves a bundle to commit. Screenshot baselines are a fourth
   artifact that is deliberately neither: the suite runs on demand and its PNGs are gitignored
   while the dashboard is mid-migration.
+- Raising the `mcp` ceiling is an API change, not just a dependency bump.
+  `POST /v1/mcp/execute` answers with mcp's own `CallToolResult`, so ten
+  mcp-owned schemas (`CallToolResult`, `TextContent`, `ImageContent`,
+  `AudioContent`, `ResourceLink`, `EmbeddedResource`, `Annotations`,
+  `BlobResourceContents`, `TextResourceContents`, `Icon`) live in
+  `docs/public/openapi.json` and travel from there into the Postman collection
+  and `web/src/client/schema.ts`. An mcp release that touches any of those
+  shapes therefore changes three committed files with drift checks over them.
+  That is why `pyproject.toml` pins mcp to one minor line: left open, a
+  `uv lock` run for an unrelated dependency would move those artifacts as a
+  side effect and fail CI on a diff that explained none of it. So a bump means
+  raising the ceiling *and* regenerating both public artifacts and the
+  dashboard client in the same change. The native result is deliberate (a
+  gateway-owned mirror model would silently drop any content block type a
+  future mcp adds), so the cost is paid here rather than in the response shape.
 
 ## Repository Conventions
 - Prefer minimal, targeted edits over broad refactors, and match the import order and typing style of the file you are in (`TYPE_CHECKING` for type-only imports where it helps, as in `routes/_helpers.py`).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -28,8 +28,8 @@ operations, a separately scoped endpoint serves it to the caller's own
 organization: `/v1/organizations/me/usage` for usage, and
 `/v1/organizations/me/keys` for a member's own API keys.
 
-In hybrid mode, the generation APIs and `/v1/mcp/execute` accept an otari.ai
-user token through `Authorization: Bearer <token>`. Local API keys and
+In hybrid mode, the generation APIs and the `/v1/mcp` endpoints accept an
+otari.ai user token through `Authorization: Bearer <token>`. Local API keys and
 management APIs are not used.
 
 ## Availability by mode
@@ -38,7 +38,7 @@ management APIs are not used.
 | --- | --- | --- | --- |
 | Health and `/v1/bootstrap` | Yes | Yes | Yes |
 | Chat, Messages, and Responses | Yes | No | Yes |
-| Stateless MCP execution | Yes | No | Yes |
+| Caller-orchestrated MCP | Yes | No | Yes |
 | Other inference APIs | Yes | No | No |
 | `/v1/models` | Yes | Yes | No |
 | Management APIs | Yes | Yes | No |
@@ -86,12 +86,25 @@ Gateway-side failures use fixed public messages. Diagnose them with protected
 logs and safe metadata such as request ID, provider, model, and status. Do not
 log provider keys, prompts, responses, or raw upstream bodies.
 
-## Stateless MCP execution
+## Caller-orchestrated MCP
 
-`POST /v1/mcp/execute` executes one caller-approved tool against one inline MCP
-server and returns its native typed result. The endpoint checks the server URL,
-its configured allowlist, and live tool discovery before execution. See
-[MCP](mcp.md#stateless-tool-execution) for the request shape and error behavior.
+Two stored-server endpoints let an application own its own MCP tool loop, as an
+alternative to sending `mcp_servers` with a completion and letting Otari own it.
+`GET /v1/mcp/servers/{mcp_server_id}/tools` returns the tool definitions a stored
+MCP server exposes to the authenticated workspace, and `POST /v1/mcp/execute`
+runs one exact caller-authorized call and returns the remote server's native MCP
+result.
+
+Otari executes a caller-authorized call; it does not verify a user approval and
+does not claim to. The calling application is the authorization boundary and owns
+any human approval, argument editing, cancellation, and action history. Otari
+enforces authentication, stored-server access, the stored tool allowlist, URL
+safety, and its own execution bounds.
+
+`POST /v1/mcp/execute` must never be retried automatically, including by a
+reverse proxy or service mesh: an `outcome_unknown` response means the tool may
+already have run. See [MCP](mcp.md#caller-orchestrated-mcp) for the request
+shapes, the error and execution-state contract, and the limits.
 
 ## Keeping generated clients current
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -28,8 +28,9 @@ operations, a separately scoped endpoint serves it to the caller's own
 organization: `/v1/organizations/me/usage` for usage, and
 `/v1/organizations/me/keys` for a member's own API keys.
 
-In hybrid mode, the completion APIs accept an otari.ai user token through
-`Authorization: Bearer <token>`. Local API keys and management APIs are not used.
+In hybrid mode, the generation APIs and `/v1/mcp/execute` accept an otari.ai
+user token through `Authorization: Bearer <token>`. Local API keys and
+management APIs are not used.
 
 ## Availability by mode
 
@@ -37,6 +38,7 @@ In hybrid mode, the completion APIs accept an otari.ai user token through
 | --- | --- | --- | --- |
 | Health and `/v1/bootstrap` | Yes | Yes | Yes |
 | Chat, Messages, and Responses | Yes | No | Yes |
+| Stateless MCP execution | Yes | No | Yes |
 | Other inference APIs | Yes | No | No |
 | `/v1/models` | Yes | Yes | No |
 | Management APIs | Yes | Yes | No |
@@ -83,6 +85,13 @@ removed.
 Gateway-side failures use fixed public messages. Diagnose them with protected
 logs and safe metadata such as request ID, provider, model, and status. Do not
 log provider keys, prompts, responses, or raw upstream bodies.
+
+## Stateless MCP execution
+
+`POST /v1/mcp/execute` executes one caller-approved tool against one inline MCP
+server and returns its native typed result. The endpoint checks the server URL,
+its configured allowlist, and live tool discovery before execution. See
+[MCP](mcp.md#stateless-tool-execution) for the request shape and error behavior.
 
 ## Keeping generated clients current
 

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -16,7 +16,7 @@ Otari calls these endpoints, all rooted at the configured platform base URL:
 |---|---|
 | `POST {base}/gateway/provider-keys/resolve` | Authorize a request and return one or more provider credentials to try |
 | `POST {base}/gateway/usage`                 | Report the outcome of an attempt back to the platform |
-| `POST {base}/gateway/mcp-servers/resolve`   | Swap workspace-scoped MCP server ids for inline server configs (called only when a request references MCP server ids) |
+| `POST {base}/gateway/mcp-servers/resolve`   | Authorize MCP access and swap workspace-scoped MCP server ids for inline server configs |
 | `POST {base}/gateway/web-search/resolve`    | Resolve the workspace's web-search policy (called only when a request uses the `otari_web_search` tool) |
 
 `{base}` means Otari platform `base_url` setting. Otari concatenates literally. The peer service is responsible for including any API-version prefix it exposes its own routes under. For the reference otari deployment that prefix is `/api/v1`, so the base URL is `http://backend:8000/api/v1` and Otari ends up POSTing to `http://backend:8000/api/v1/gateway/provider-keys/resolve`.
@@ -219,9 +219,11 @@ its own tenant.
 
 ## MCP server resolution
 
-Called only when a request references one or more workspace-scoped MCP server
-ids (a hybrid-only feature). Otari swaps those ids for the inline server
-configs it needs to open the connections.
+Called when a request references workspace-scoped MCP server ids (a
+hybrid-only feature). Otari swaps those ids for the inline server configs it
+needs to open the connections. `POST /v1/mcp/execute` also calls this endpoint
+with an empty `mcp_server_ids` list to authenticate and authorize its inline,
+stateless MCP call through the same platform boundary.
 
 ### Request
 
@@ -235,6 +237,9 @@ Content-Type: application/json
   "mcp_server_ids": ["01HX1...", "01HX2..."]
 }
 ```
+
+For stateless execution the body is `{"mcp_server_ids": []}`. A successful
+peer returns `{"servers": []}`.
 
 ### Response
 

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -223,9 +223,10 @@ Called when a request references workspace-scoped MCP server ids (a
 hybrid-only feature). Otari swaps those ids for the inline server configs it
 needs to open the connections. The caller-orchestrated endpoints,
 `GET /v1/mcp/servers/{mcp_server_id}/tools` and `POST /v1/mcp/execute`, call the
-same endpoint with the one id they were asked about, and read the answer more
-strictly than the tool loop does: exactly one entry, whose `id` is the id that
-was requested.
+same endpoint with the one id they were asked about. They accept the legacy
+response shape, which returns one enabled connection config without `id` or
+`enabled` and omits disabled servers, while validating either field when a newer
+peer supplies it.
 
 ### Request
 
@@ -262,22 +263,30 @@ The caller-orchestrated endpoints send exactly one id:
 ```
 
 Otari reads `name`, `url`, `authorization_token`, `purpose_hint`, and
-`allowed_tools` off each entry in `servers`; a missing `servers` key is treated
-as an empty list. The same URL-safety rules as inline MCP configs apply once the
-configs are resolved (SSRF guard, no bearer token over cleartext `http://`).
+`allowed_tools` off each entry in `servers`; for the tool loop, a missing
+`servers` key is treated as an empty list. The same URL-safety rules as inline
+MCP configs apply once the configs are resolved (SSRF guard, no bearer token
+over cleartext `http://`).
 
-`id` and `enabled` are required by the caller-orchestrated endpoints and unused
-by the tool loop. `id` is what lets those endpoints confirm they resolved the
-server the caller named, and `enabled` is what turns a decommissioned server
-into their `404` rather than a live connection. A peer that omits either answers
-those two endpoints with `502 mcp_resolution_failed`; the tool loop keeps
-working, since it reads neither.
+For a caller-orchestrated request, exactly one returned entry is bound to the
+one id Otari requested. A legacy entry may omit `id` and `enabled`; Otari uses
+the requested id and treats a returned config as enabled. An empty `servers`
+list is the legacy representation of a disabled server and becomes
+`404 mcp_server_not_found`, the same public result as any inaccessible server.
+A missing or malformed `servers` list, multiple entries, malformed recognized
+fields, or an explicit id that does not match remain
+`502 mcp_resolution_failed`.
+
+New peers should return `id` and `enabled`. When present, `id` must match the
+request and `enabled` must be a JSON boolean; `enabled: false` becomes the same
+404 without opening an MCP connection. These fields remain unused by the
+managed tool loop.
 
 Otari derives the `server_revision` those endpoints publish from the resolved
-URL, a digest of the resolved credential, `enabled`, and the sorted
-`allowed_tools`. `name` and `purpose_hint` are excluded, so retitling a server
-does not invalidate an authorization an application is still holding. Nothing
-platform-side stores or returns a revision.
+URL, a digest of the resolved credential, the effective enabled state, and the
+sorted `allowed_tools`. `name` and `purpose_hint` are excluded, so retitling a
+server does not invalidate an authorization an application is still holding.
+Nothing platform-side stores or returns a revision.
 
 ### Failure
 

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -297,10 +297,11 @@ Nothing platform-side stores or returns a revision.
 | Network/timeout                    | Mapped to `502 Bad Gateway`. |
 
 The caller-orchestrated endpoints publish their own error contract instead of
-forwarding any of this, because a platform `detail` may name a workspace, a plan,
-or a stored server. A `401`, `402` or `403` becomes `401 authentication_failed`,
-a `404` becomes `404 mcp_server_not_found`, a `429` keeps its status and
-`Retry-After` as `rate_limit_exceeded`, and everything else becomes
+forwarding any detail, because a platform `detail` may name a workspace, a plan,
+or a stored server. Statuses remain meaningful: `401` becomes
+`authentication_failed`, `402` becomes `payment_required`, `403` becomes
+`forbidden`, `404` becomes `mcp_server_not_found`, and `429` keeps its status and
+`Retry-After` as `rate_limit_exceeded`. Other platform resolution failures become
 `502 mcp_resolution_failed`. See [MCP](mcp.md#caller-orchestrated-mcp).
 
 ## Web search resolution

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -221,9 +221,11 @@ its own tenant.
 
 Called when a request references workspace-scoped MCP server ids (a
 hybrid-only feature). Otari swaps those ids for the inline server configs it
-needs to open the connections. `POST /v1/mcp/execute` also calls this endpoint
-with an empty `mcp_server_ids` list to authenticate and authorize its inline,
-stateless MCP call through the same platform boundary.
+needs to open the connections. The caller-orchestrated endpoints,
+`GET /v1/mcp/servers/{mcp_server_id}/tools` and `POST /v1/mcp/execute`, call the
+same endpoint with the one id they were asked about, and read the answer more
+strictly than the tool loop does: exactly one entry, whose `id` is the id that
+was requested.
 
 ### Request
 
@@ -238,8 +240,8 @@ Content-Type: application/json
 }
 ```
 
-For stateless execution the body is `{"mcp_server_ids": []}`. A successful
-peer returns `{"servers": []}`.
+The caller-orchestrated endpoints send exactly one id:
+`{"mcp_server_ids": ["2c948a61-dc96-4cd8-96bb-8e1434bf424e"]}`.
 
 ### Response
 
@@ -247,8 +249,10 @@ peer returns `{"servers": []}`.
 {
   "servers": [
     {
+      "id": "2c948a61-dc96-4cd8-96bb-8e1434bf424e",
       "name": "github",
       "url": "https://mcp.example.com/github",
+      "enabled": true,
       "authorization_token": "ghp_...",   // optional
       "purpose_hint": "Repo and issue lookups",   // optional
       "allowed_tools": ["list_issues", "get_file"] // optional
@@ -262,6 +266,19 @@ Otari reads `name`, `url`, `authorization_token`, `purpose_hint`, and
 as an empty list. The same URL-safety rules as inline MCP configs apply once the
 configs are resolved (SSRF guard, no bearer token over cleartext `http://`).
 
+`id` and `enabled` are required by the caller-orchestrated endpoints and unused
+by the tool loop. `id` is what lets those endpoints confirm they resolved the
+server the caller named, and `enabled` is what turns a decommissioned server
+into their `404` rather than a live connection. A peer that omits either answers
+those two endpoints with `502 mcp_resolution_failed`; the tool loop keeps
+working, since it reads neither.
+
+Otari derives the `server_revision` those endpoints publish from the resolved
+URL, a digest of the resolved credential, `enabled`, and the sorted
+`allowed_tools`. `name` and `purpose_hint` are excluded, so retitling a server
+does not invalidate an authorization an application is still holding. Nothing
+platform-side stores or returns a revision.
+
 ### Failure
 
 | Status | Behavior |
@@ -269,6 +286,13 @@ configs are resolved (SSRF guard, no bearer token over cleartext `http://`).
 | `400`, `401`, `402`, `403`, `404`, `429` | Status code is forwarded to the client; `429`'s `Retry-After` header is preserved. The `detail` is the platform's JSON `detail` string when present, otherwise the fallback `"MCP server resolution failed"`. |
 | `422`, `5xx`                      | Mapped to `502 Bad Gateway` with `detail = "Authorization service unavailable"`. |
 | Network/timeout                    | Mapped to `502 Bad Gateway`. |
+
+The caller-orchestrated endpoints publish their own error contract instead of
+forwarding any of this, because a platform `detail` may name a workspace, a plan,
+or a stored server. A `401`, `402` or `403` becomes `401 authentication_failed`,
+a `404` becomes `404 mcp_server_not_found`, a `429` keeps its status and
+`Retry-After` as `rate_limit_exceeded`, and everything else becomes
+`502 mcp_resolution_failed`. See [MCP](mcp.md#caller-orchestrated-mcp).
 
 ## Web search resolution
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,8 @@ Calling the gateway from your own code.
 
 - [API reference](api-reference.md): authentication, mode availability, and links to generated schemas.
 - [Built-in tools](tools.md): sandboxed code execution and web search Otari runs itself.
-- [MCP](mcp.md): connect MCP servers to chat, messages, and responses requests.
+- [MCP](mcp.md): connect MCP servers to chat, messages, and responses requests,
+  or drive them from your own application through the caller-orchestrated endpoints.
 - [Files](files.md): file uploads and document understanding for local models.
 - [Guardrails](guardrails.md): request-level checks like prompt-injection detection.
 - [Use with Claude Code](use-with-claude-code.md): point the Claude Code CLI at Otari.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -168,9 +168,11 @@ an approval credential.
 It detects Otari-side and platform-side configuration changes only. A remote
 server that changes its own catalog, or a tool's behavior, behind an unchanged
 URL will not move it; catching that would need another live `tools/list` at
-execution time, which this version does not do. What the revision binds is the
-stored server id, its stored configuration, the remote tool name, and the exact
-arguments, not an immutable remote implementation.
+execution time, which this version does not do. The revision binds the request
+only to the stored server configuration returned by discovery. The calling
+application is responsible for binding the server id,
+revision, remote tool name, and final arguments to its authorization or approval
+record. Neither mechanism binds the call to an immutable remote implementation.
 
 `client_execution_id` is a canonical UUID you generate, for correlation across
 your service and Otari. It is not proof of approval and **not an idempotency

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -270,13 +270,12 @@ Gateway-owned ceilings, not caller-controlled request fields:
 Discovery and execution hold separate concurrency ceilings, so slow or hostile
 discovery cannot starve calls an application has already authorized.
 
-The 1 MiB transport ceiling is enforced at two points: a `Content-Length`
-pre-check that refuses an oversized response before its body is read, and a
-measurement of the decoded result. It is **not** a streaming bound. A chunked or
-SSE response carries no `Content-Length`, and the MCP SDK's Streamable HTTP
-transport buffers a JSON response before returning a result, so that case is
-bounded by the call and total deadlines and by your deployment's HTTP timeouts
-until a streaming-bounded transport lands.
+The 1 MiB transport ceiling is enforced while each response stream is read, so
+chunked JSON and SSE responses cannot bypass it by omitting `Content-Length`.
+Otari requests identity encoding and refuses compressed responses before
+reading their bodies, preventing a small encoded response from expanding past
+the ceiling during decompression. The decoded MCP result is measured again
+before it is returned.
 
 Redirects are disabled. Otari returns a redirect response rather than following
 it, so no credential and no call data is ever sent to a redirect destination.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -24,6 +24,29 @@ When the model emits an MCP tool call, Otari:
 The loop stops when the model returns a normal assistant response or hits
 `max_tool_iterations`.
 
+## Stateless tool execution
+
+`POST /v1/mcp/execute` runs one caller-approved tool against one inline MCP
+server, without calling a model or retaining a session:
+
+```json
+{
+  "server": {
+    "name": "github",
+    "url": "https://mcp.example.com/github",
+    "allowed_tools": ["create_issue"]
+  },
+  "tool_name": "create_issue",
+  "arguments": {"repository": "mozilla-ai/otari", "title": "Approved issue"}
+}
+```
+
+Otari checks URL safety, `allowed_tools`, and live tool discovery before
+execution. It returns the native MCP result, including `isError`; transport and
+protocol failures become a sanitized `502`. The endpoint accepts the usual API
+key or master key in standalone mode, and an otari.ai bearer token in hybrid
+mode.
+
 ## Messages streaming activity
 
 For streaming `/v1/messages` requests with the standard Anthropic header

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -114,6 +114,10 @@ one with a `$ref` pointing outside itself:
 {"tool_name": "create_issue", "code": "mcp_tool_schema_unsupported"}
 ```
 
+A tool name outside the 1–256-character execution limit is omitted with
+`mcp_tool_name_unsupported`, so every tool returned by discovery can be sent
+back to the execution endpoint.
+
 Otari does not validate an `inputSchema` against a JSON Schema dialect, and never
 truncates, rewrites, or drops a keyword. It bounds the size, depth and property
 count it will carry, and it refuses a schema that would have to be fetched over

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -413,7 +413,7 @@ are managed there.
 - `mcp_server_ids` accepts at most 50 ids, which is also the most servers a workspace can have; a repeated id resolves once
 - Server names must be unique across everything one request uses, because Otari routes each tool call to its server by name. Two `mcp_servers` entries sharing a name are refused with a `400` naming it, the way a bad request-body URL is. An `mcp_servers` name colliding with one of your workspace's stored servers is a `400` too, but a fixed one that repeats neither name, since a stored server is not yours to read. Two stored servers sharing a name is a `500` with the names in the log, on the same grounds as a stored URL that fails its safety check
 - MCP URLs are validated to reduce SSRF risk; by default, private and reserved addresses are blocked, loopback is allowed, and `http://` is rejected when `authorization_token` is present
-- Redirects are followed only when the scheme, host, and port stay the same, or when a default-port `http://` URL upgrades to `https://` on the same host; configure the final URL when a redirect changes host or port
+- The managed MCP loop follows redirects only when the scheme, host, and port stay the same, or when a default-port `http://` URL upgrades to `https://` on the same host. Caller-orchestrated discovery and execution do not follow redirects. Configure the final URL when a managed-loop redirect changes host or port
 - `OTARI_MCP_ALLOW_LOOPBACK=false` disables loopback; `OTARI_MCP_ALLOW_PRIVATE_HOSTS=true` relaxes the private-host restriction
 
 For the hybrid platform contract behind `mcp_server_ids`, see

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -234,6 +234,8 @@ exception text.
 |---|---:|---|---|
 | Invalid request body | 422 | `invalid_request` | `not_started` |
 | Authentication failure | 401 | `authentication_failed` | `not_started` |
+| Payment required or insufficient funds | 402 | `payment_required` | `not_started` |
+| Platform authorization refused | 403 | `forbidden` | `not_started` |
 | Authenticated request rate exceeded | 429 | `rate_limit_exceeded` | `not_started` |
 | Server inaccessible to caller, or disabled | 404 | `mcp_server_not_found` | `not_started` |
 | Stored server revision changed | 409 | `mcp_server_changed` | `not_started` |
@@ -244,6 +246,7 @@ exception text.
 | Discovery bound or pagination failure | 502 | `mcp_discovery_limit_exceeded` | `not_started` |
 | Discovery admission deadline exceeded | 503 | `mcp_discovery_capacity_unavailable` | `not_started` |
 | Execution admission deadline exceeded | 503 | `mcp_capacity_unavailable` | `not_started` |
+| Local service temporarily unavailable | 503 | `service_unavailable` | `not_started` |
 | Connection or initialization failure | 502 | `mcp_connection_failed` | `not_started` |
 | Tool-call deadline exceeded after dispatch | 504 | `mcp_outcome_unknown` | `outcome_unknown` |
 | Transport, cancellation, protocol or parse failure after dispatch | 502 | `mcp_outcome_unknown` | `outcome_unknown` |
@@ -281,8 +284,10 @@ reading their bodies, preventing a small encoded response from expanding past
 the ceiling during decompression. The decoded MCP result is measured again
 before it is returned.
 
-Redirects are disabled. Otari returns a redirect response rather than following
-it, so no credential and no call data is ever sent to a redirect destination.
+Redirects are disabled and never forwarded to the caller. A redirect during
+connection or initialization becomes `502 mcp_connection_failed`; after tool
+dispatch it becomes `502 mcp_outcome_unknown`. No credential or call data is
+sent to the redirect destination.
 
 ### Availability
 
@@ -333,7 +338,7 @@ to hide this activity because they have no equivalent server-owned MCP vocabular
 - `url`: streamable HTTP MCP endpoint, reachable from the gateway
 - `authorization_token`: optional bearer token; when set, the `url` must use `https://`
 - `purpose_hint`: optional hint Otari prepends to the system message to help the model choose the tool
-- `allowed_tools`: optional allow-list; only these tools are exposed from that server
+- `allowed_tools`: optional allow-list with three states: omit it or send `null` to expose every listed tool, send `[]` to expose none, or send a non-empty list to expose only those named tools
 
 ## Workspace-scoped servers
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -24,28 +24,269 @@ When the model emits an MCP tool call, Otari:
 The loop stops when the model returns a normal assistant response or hits
 `max_tool_iterations`.
 
-## Stateless tool execution
+## Caller-orchestrated MCP
 
-`POST /v1/mcp/execute` runs one caller-approved tool against one inline MCP
-server, without calling a model or retaining a session:
+Otari supports two MCP integration modes, and they are alternatives rather than
+layers.
+
+**Managed MCP** is the loop above: you send `mcp_servers` or `mcp_server_ids`
+with a completion, and Otari owns the model/tool loop.
+
+**Caller-orchestrated MCP** hands the loop back to your application. Otari
+provides two stored-server endpoints, and your application decides whether a
+proposed call may run:
+
+1. `GET /v1/mcp/servers/{mcp_server_id}/tools` returns the tool definitions a
+   stored MCP server exposes to the authenticated workspace.
+2. Your application exposes those tools to its model or workflow, and applies
+   its own authorization policy to whatever gets proposed. That may be a user
+   approval prompt, an administrator rule, or trusted read-only
+   auto-authorization.
+3. `POST /v1/mcp/execute` runs one exact authorized call and returns the remote
+   server's native MCP result.
+
+**Otari executes a caller-authorized call. It does not verify a user approval
+and does not claim to.** The calling application is the authorization boundary
+and owns any human approval, argument editing, cancellation, and action history.
+What Otari enforces independently is authentication, that the stored server is
+one the authenticated workspace may reach, the stored tool allowlist, URL
+safety, and its own execution bounds.
+
+Between the two requests Otari holds nothing open: no model stream, no MCP
+session, no database session, no worker-local state. That is why your
+application can pause for a person for as long as it needs to.
+
+Both endpoints refer to a server by the id it was registered under. There is no
+inline server field: registering a remote MCP server through the control plane
+once, rather than transmitting a URL and a credential per request, is what keeps
+authorization, credential storage, revocation, and allowlist policy on Otari's
+side of the boundary. Local `stdio` servers stay outside this: a hosted Otari
+deployment cannot reach a machine-local process.
+
+### Discovery
+
+```http
+GET /v1/mcp/servers/2c948a61-dc96-4cd8-96bb-8e1434bf424e/tools
+Authorization: Bearer <token>
+```
 
 ```json
 {
-  "server": {
-    "name": "github",
-    "url": "https://mcp.example.com/github",
-    "allowed_tools": ["create_issue"]
-  },
-  "tool_name": "create_issue",
-  "arguments": {"repository": "mozilla-ai/otari", "title": "Approved issue"}
+  "server_id": "2c948a61-dc96-4cd8-96bb-8e1434bf424e",
+  "server_revision": "9f2c41ae7b0d4e5c8a13d6f0b27e5c91",
+  "tools": [
+    {
+      "name": "create_issue",
+      "description": "Create an issue",
+      "input_schema": {"type": "object", "properties": {"title": {"type": "string"}}},
+      "annotations": {"readOnlyHint": false}
+    }
+  ],
+  "warnings": []
 }
 ```
 
-Otari checks URL safety, `allowed_tools`, and live tool discovery before
-execution. It returns the native MCP result, including `isError`; transport and
-protocol failures become a sanitized `502`. The endpoint accepts the usual API
-key or master key in standalone mode, and an otari.ai bearer token in hybrid
-mode.
+Call this once per server when you prepare a run, and reuse the answer for every
+tool from that server for the length of the run. There is no cross-run cache, so
+a later run rediscovers.
+
+Where the stored server has an allowlist, `tools` is its intersection with the
+live catalog, so a tool the server added later is not exposed just because it
+was listed. Where it has none, the whole live catalog is returned, the same
+meaning the column already carries in the managed loop. An explicit empty
+allowlist is a deny-all: `tools` is empty and Otari opens no connection.
+
+The response never contains the server URL, its credential, or an allowlist entry
+the live catalog did not return.
+
+`annotations` is the server's own metadata, passed through as untrusted data.
+Otari never turns `readOnlyHint` into an authorization decision, and never infers
+safety from a tool's name or description. Your risk policy is yours.
+
+`tools` is either the complete authorized catalog or absent: a pagination
+failure or a discovery ceiling returns `502 mcp_discovery_limit_exceeded` with no
+tools at all, because a short catalog would be read as the complete input to
+your authorization policy. The one exception is `warnings`, which names a tool
+whose descriptor Otari could not carry, for example a schema that is too large or
+one with a `$ref` pointing outside itself:
+
+```json
+{"tool_name": "create_issue", "code": "mcp_tool_schema_unsupported"}
+```
+
+Otari does not validate an `inputSchema` against a JSON Schema dialect, and never
+truncates, rewrites, or drops a keyword. It bounds the size, depth and property
+count it will carry, and it refuses a schema that would have to be fetched over
+the network to be understood at all. An unknown dialect or vendor keyword survives
+the round trip unchanged.
+
+### Execution
+
+```http
+POST /v1/mcp/execute
+Authorization: Bearer <token>
+Content-Type: application/json
+```
+
+```json
+{
+  "mcp_server_id": "2c948a61-dc96-4cd8-96bb-8e1434bf424e",
+  "tool_name": "create_issue",
+  "arguments": {"title": "Approved title", "body": "Approved body"},
+  "server_revision": "9f2c41ae7b0d4e5c8a13d6f0b27e5c91",
+  "client_execution_id": "6e51b3bc-6f48-4c68-a61e-0786bc80cd67"
+}
+```
+
+Otari resolves the stored server, applies its allowlist to `tool_name`, compares
+`server_revision`, validates the resolved URL, and then calls that one tool
+directly. It never calls `tools/list` here: MCP permits calling a known tool, and
+what authorizes the call is the stored allowlist and the authenticated workspace,
+not a live catalog.
+
+The successful body is the native MCP result:
+
+```json
+{
+  "content": [{"type": "text", "text": "Created issue #42"}],
+  "structuredContent": {"issue_number": 42},
+  "isError": false
+}
+```
+
+`isError: true` is still an HTTP 200. The server handled the call and classified
+the outcome itself, so it is a definitive result rather than a transport failure,
+and it is not a retry signal.
+
+`server_revision` is the value discovery returned. Persist it with the proposed
+call and send it back. It is an opaque revision of the stored server's URL,
+credential, enabled state and allowlist, so a configuration change between your
+authorization decision and this request is refused with
+`409 mcp_server_changed` rather than executed against something else. It is not
+an approval credential.
+
+It detects Otari-side and platform-side configuration changes only. A remote
+server that changes its own catalog, or a tool's behavior, behind an unchanged
+URL will not move it; catching that would need another live `tools/list` at
+execution time, which this version does not do. What the revision binds is the
+stored server id, its stored configuration, the remote tool name, and the exact
+arguments, not an immutable remote implementation.
+
+`client_execution_id` is a canonical UUID you generate, for correlation across
+your service and Otari. It is not proof of approval and **not an idempotency
+key.**
+
+### Never retry an execution automatically
+
+Repeating a request with the same `client_execution_id` may execute the tool
+again. Otari implements no deduplication, because a worker-local one would not
+survive a second process or a restart.
+
+Send exactly one HTTP attempt for `POST /v1/mcp/execute`, and make sure nothing
+on the path adds attempts of its own: your SDK, your own retry policy, and the
+reverse proxies, service meshes and ingress controllers in front of Otari, on
+connection resets and 5xx responses alike.
+
+`execution_state` on every error tells you what a retry would mean:
+
+- `not_started`: Otari knows the call was not dispatched. Retrying is as safe as
+  your own execution claim allows.
+- `outcome_unknown`: dispatch began and no definitive result came back, so the
+  tool may have mutated external state. Surface this as indeterminate. Do not
+  turn it into an ordinary failure, and do not fall back to executing the call
+  yourself.
+
+The boundary is deliberately conservative. Once the transport has begun writing
+the `tools/call` request, every timeout, cancellation, protocol error, parse
+error, size-limit breach and dropped connection is `outcome_unknown`, even where
+the client cannot prove the server received the whole request.
+
+A caller-side network failure that produces no typed Otari response at all is
+always indeterminate.
+
+### Errors
+
+Both endpoints share one error body:
+
+```json
+{
+  "detail": "MCP execution outcome is unknown",
+  "code": "mcp_outcome_unknown",
+  "execution_state": "outcome_unknown",
+  "request_id": "req_..."
+}
+```
+
+`detail` is a fixed safe message per category; `code` and `execution_state` are
+stable enums. `request_id` is an opaque Otari request id, present in every error
+body and returned in `X-Otari-Request-ID` on success and failure alike, which is
+why a successful body stays the plain MCP result. No error carries a server URL,
+a credential, a header, your arguments, a result, a platform detail, or raw
+exception text.
+
+| Condition | Status | Code | Execution state |
+|---|---:|---|---|
+| Invalid request body | 422 | `invalid_request` | `not_started` |
+| Authentication failure | 401 | `authentication_failed` | `not_started` |
+| Authenticated request rate exceeded | 429 | `rate_limit_exceeded` | `not_started` |
+| Server inaccessible to caller, or disabled | 404 | `mcp_server_not_found` | `not_started` |
+| Stored server revision changed | 409 | `mcp_server_changed` | `not_started` |
+| Tool absent from stored allowlist | 403 | `mcp_tool_not_allowed` | `not_started` |
+| Unsafe resolved URL | 400 | `unsafe_mcp_url` | `not_started` |
+| Stored-server resolution unavailable | 502 | `mcp_resolution_failed` | `not_started` |
+| Stored credential unavailable | 500 | `mcp_credentials_unavailable` | `not_started` |
+| Discovery bound or pagination failure | 502 | `mcp_discovery_limit_exceeded` | `not_started` |
+| Discovery admission deadline exceeded | 503 | `mcp_discovery_capacity_unavailable` | `not_started` |
+| Execution admission deadline exceeded | 503 | `mcp_capacity_unavailable` | `not_started` |
+| Connection or initialization failure | 502 | `mcp_connection_failed` | `not_started` |
+| Tool-call deadline exceeded after dispatch | 504 | `mcp_outcome_unknown` | `outcome_unknown` |
+| Transport, cancellation, protocol or parse failure after dispatch | 502 | `mcp_outcome_unknown` | `outcome_unknown` |
+| Result exceeds the response bound | 502 | `mcp_result_too_large` | `outcome_unknown` |
+
+Only the two capacity codes and `rate_limit_exceeded` carry `Retry-After`. No
+other failure advertises an automatic retry.
+
+### Limits
+
+Gateway-owned ceilings, not caller-controlled request fields:
+
+| Scope | Limit | Value |
+|---|---|---|
+| Request | `tool_name` length | 1 to 256 characters |
+| Request | `arguments` encoded size, nesting depth | 256 KiB, depth 32 |
+| Discovery | `tools/list` pages followed | 20 |
+| Discovery | live descriptors examined | 1,000 |
+| Discovery | returned tools | 200 |
+| Discovery | per description / schema / annotations | 4 KiB / 64 KiB at depth 32 / 16 KiB |
+| Discovery | serialized response | 1 MiB |
+| Discovery | total request, concurrency, admission wait | 15 s, 4 per process, 5 s |
+| Both | connection plus initialization | 5 s |
+| Execution | tool call, from dispatch | 30 s |
+| Execution | serialized result | 1 MiB |
+| Execution | concurrency, admission wait, total request | 8 per process, 5 s, 45 s |
+
+Discovery and execution hold separate concurrency ceilings, so slow or hostile
+discovery cannot starve calls an application has already authorized.
+
+The 1 MiB transport ceiling is enforced at two points: a `Content-Length`
+pre-check that refuses an oversized response before its body is read, and a
+measurement of the decoded result. It is **not** a streaming bound. A chunked or
+SSE response carries no `Content-Length`, and the MCP SDK's Streamable HTTP
+transport buffers a JSON response before returning a result, so that case is
+bounded by the call and total deadlines and by your deployment's HTTP timeouts
+until a streaming-bounded transport lands.
+
+Redirects are disabled. Otari returns a redirect response rather than following
+it, so no credential and no call data is ever sent to a redirect destination.
+
+### Availability
+
+Both endpoints are data-plane surfaces. Standalone resolves stored servers from
+the authenticated API key's workspace; a master-key request holds no workspace of
+its own and reaches no stored server, so it gets the `404`. Hybrid resolves them
+through otari.ai using the authenticated user token. Hosted mode is a control
+plane and serves neither: both paths return the standard hosted-mode `404`
+naming the configured data-plane URL.
 
 ## Messages streaming activity
 
@@ -106,6 +347,13 @@ The workspace is the one your API key belongs to; it is never read from a
 header. An id that names no server in that workspace returns `404`, and a
 server that is configured but disabled is skipped rather than refusing the
 request.
+
+The same stored servers are what
+[caller-orchestrated MCP](#caller-orchestrated-mcp) refers to by id, so a server
+registered once serves both integration modes. The two read a disabled server
+differently, and deliberately: the loop above resolves a list and skips one
+entry, while an endpoint asked about exactly that server answers `404` rather
+than returning nothing.
 
 ### Configuring them (standalone)
 

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -3995,6 +3995,16 @@
         "title": "EmbeddingRequest",
         "type": "object"
       },
+      "ExecutionState": {
+        "description": "Whether the remote tool may have run (R-ERR-2).\n\nA retry-safety classification, not a description of how the HTTP request\nwent. ``NOT_STARTED`` is Otari saying it knows the tool did not run;\n``OUTCOME_UNKNOWN`` is Otari saying it cannot know, which is the only honest\nanswer once the transport has begun writing ``tools/call``.",
+        "enum": [
+          "not_started",
+          "outcome_unknown",
+          "completed"
+        ],
+        "title": "ExecutionState",
+        "type": "string"
+      },
       "ExplainRequest": {
         "description": "Ask what a policy would do, without dispatching anything.\n\nEither name a stored/configured policy (``name``) or pass a draft ``spec`` that\nhas not been saved. The draft form is what makes authoring-time validation\npossible: the compiler filters candidates, so a chain can compile down to one\nattempt, and an author needs to see that before saving rather than during an\noutage.",
         "properties": {
@@ -5334,20 +5344,64 @@
         "title": "ManagedTool",
         "type": "object"
       },
+      "McpErrorBody": {
+        "description": "The one error shape both stored-server endpoints return (R-ERR-1).",
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "execution_state": {
+            "$ref": "#/components/schemas/ExecutionState"
+          },
+          "request_id": {
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "detail",
+          "code",
+          "execution_state",
+          "request_id"
+        ],
+        "title": "McpErrorBody",
+        "type": "object"
+      },
       "McpExecuteRequest": {
-        "description": "One MCP server and the exact tool call the client approved.",
+        "additionalProperties": false,
+        "description": "One stored server, and the exact call the application authorized.\n\nNo inline server fields (R-REQ-4): a caller registers a remote MCP server\nthrough the control plane once and refers to it by id afterwards, which\nkeeps URLs, credentials, revocation and allowlist policy on Otari's side of\nthe boundary instead of in every request.\n\nExtras are forbidden rather than ignored, so a caller still sending the old\ninline ``server`` block is told its configuration was not used instead of\nwatching Otari quietly execute against a different server than the one it\nnamed.",
         "properties": {
           "arguments": {
             "additionalProperties": true,
-            "description": "The JSON-object arguments to pass to the approved tool.",
+            "description": "The exact caller-authorized JSON-object arguments.",
             "title": "Arguments",
             "type": "object"
           },
-          "server": {
-            "$ref": "#/components/schemas/McpServerConfig"
+          "client_execution_id": {
+            "description": "A caller-generated UUID, for correlation only. It is not proof of approval and not an idempotency key: repeating a request with the same value may execute the tool again, so this request must never be retried automatically.",
+            "format": "uuid",
+            "title": "Client Execution Id",
+            "type": "string"
+          },
+          "mcp_server_id": {
+            "description": "The stored MCP server to execute against.",
+            "format": "uuid",
+            "title": "Mcp Server Id",
+            "type": "string"
+          },
+          "server_revision": {
+            "description": "The stored-server revision returned by tool discovery. Required, and compared against the current one so a configuration change since the caller authorized this call is refused rather than executed. Not an approval credential.",
+            "pattern": "^[A-Za-z0-9._:\\-]{1,128}$",
+            "title": "Server Revision",
+            "type": "string"
           },
           "tool_name": {
-            "description": "The MCP tool the caller has approved for this one execution.",
+            "description": "The remote MCP tool name the caller authorized for this one execution.",
             "maxLength": 256,
             "minLength": 1,
             "title": "Tool Name",
@@ -5355,8 +5409,10 @@
           }
         },
         "required": [
-          "server",
-          "tool_name"
+          "mcp_server_id",
+          "tool_name",
+          "server_revision",
+          "client_execution_id"
         ],
         "title": "McpExecuteRequest",
         "type": "object"
@@ -5418,6 +5474,110 @@
           "url"
         ],
         "title": "McpServerConfig",
+        "type": "object"
+      },
+      "McpToolDefinition": {
+        "description": "One live tool a caller-orchestrated application may expose to its model.\n\n``annotations`` is the remote server's own metadata, passed through as\nuntrusted data. Otari never turns ``readOnlyHint`` into an authorization\ndecision (R-RISK-1); each application owns its risk policy, and a server\ncannot waive an application's approval gate by labeling itself read-only.",
+        "properties": {
+          "annotations": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The server's MCP annotations, untrusted metadata rather than policy.",
+            "title": "Annotations"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The server's own description, untrusted.",
+            "title": "Description"
+          },
+          "input_schema": {
+            "additionalProperties": true,
+            "description": "The tool's MCP inputSchema, unmodified.",
+            "title": "Input Schema",
+            "type": "object"
+          },
+          "name": {
+            "description": "The remote MCP tool name to send back to /v1/mcp/execute.",
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "input_schema"
+        ],
+        "title": "McpToolDefinition",
+        "type": "object"
+      },
+      "McpToolWarning": {
+        "description": "One tool that was omitted, and the code that omitted it (R-SCHEMA-3).",
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "tool_name": {
+            "title": "Tool Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tool_name",
+          "code"
+        ],
+        "title": "McpToolWarning",
+        "type": "object"
+      },
+      "McpToolsResponse": {
+        "description": "The authorized catalog for one stored server.\n\nCarries no server URL, no credential, and no allowlist entry that the live\ncatalog did not return (R-DISC-2). ``server_revision`` is what an\napplication persists with a proposed call and sends back to\n``/v1/mcp/execute``, so a stored-configuration change between the two is\nrefused rather than executed.",
+        "properties": {
+          "server_id": {
+            "format": "uuid",
+            "title": "Server Id",
+            "type": "string"
+          },
+          "server_revision": {
+            "description": "An opaque revision of the stored server's URL, credential, enabled state and allowlist. It detects Otari-side and platform-side configuration changes only: a remote server that changes its own catalog or a tool's behavior behind an unchanged URL will not move it.",
+            "title": "Server Revision",
+            "type": "string"
+          },
+          "tools": {
+            "items": {
+              "$ref": "#/components/schemas/McpToolDefinition"
+            },
+            "maxItems": 200,
+            "title": "Tools",
+            "type": "array"
+          },
+          "warnings": {
+            "items": {
+              "$ref": "#/components/schemas/McpToolWarning"
+            },
+            "title": "Warnings",
+            "type": "array"
+          }
+        },
+        "required": [
+          "server_id",
+          "server_revision",
+          "tools",
+          "warnings"
+        ],
+        "title": "McpToolsResponse",
         "type": "object"
       },
       "Message": {
@@ -18528,7 +18688,7 @@
     },
     "/v1/mcp/execute": {
       "post": {
-        "description": "Execute one caller-approved tool against one inline MCP server.\n\nThe server is connected only for this request. Otari validates its URL,\napplies its configured tool allowlist, confirms the tool through live MCP\ndiscovery, and then executes exactly the named call. A server-returned\n``isError`` remains a typed MCP result; transport and protocol failures are\nreturned as a sanitized gateway error.",
+        "description": "Execute one caller-authorized tool call against a stored MCP server.\n\nThe calling application owns any user approval, argument editing,\ncancellation and action history; Otari executes exactly the tool name and\narguments it is given, once, and returns the remote server's native result.\nA result with ``isError: true`` is a definitive outcome and comes back as an\nHTTP 200.\n\n**This request must never be retried automatically.** ``client_execution_id``\nis correlation, not idempotency: once the call has been dispatched Otari\ncannot know whether the tool ran, and an ``outcome_unknown`` response means\nexactly that. Proxies, service meshes and SDKs on this path have to disable\nretries for it, including on connection resets and 5xx responses.",
         "operationId": "execute_mcp_tool_v1_mcp_execute_post",
         "requestBody": {
           "content": {
@@ -18551,15 +18711,115 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
           "422": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/McpErrorBody"
                 }
               }
             },
-            "description": "Validation Error"
+            "description": "Unprocessable Content"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Gateway Timeout"
           }
         },
         "security": [
@@ -18571,6 +18831,128 @@
           }
         ],
         "summary": "Execute Mcp Tool",
+        "tags": [
+          "mcp"
+        ]
+      }
+    },
+    "/v1/mcp/servers/{mcp_server_id}/tools": {
+      "get": {
+        "description": "List the tools a stored MCP server exposes to the authenticated workspace.\n\nCall this once per server when preparing a model or workflow run, and reuse\nthe answer for every tool from that server for the length of the run: there\nis no cross-run cache in this version, so a later run rediscovers and\nstaleness stays bounded without any invalidation state to keep.\n\nThe response is the whole authorized catalog or an error. It is never\npartial, because a caller would read a short catalog as the complete input\nto its own authorization and risk policy. The single exception is\n``warnings``, which names a tool whose descriptor Otari could not carry.\n\nA tool the server removes after discovery may still be proposed from the\nrun's snapshot; execution then returns the remote server's own typed error.",
+        "operationId": "list_mcp_tools_v1_mcp_servers__mcp_server_id__tools_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "mcp_server_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Mcp Server Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpToolsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Unprocessable Content"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "List Mcp Tools",
         "tags": [
           "mcp"
         ]

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -5418,7 +5418,7 @@
         "type": "object"
       },
       "McpServerConfig": {
-        "description": "Inline MCP server configuration accepted by generation and execution requests.\n\nStreamable HTTP transport. The `url` must be reachable from the gateway process.\n\nURL safety (SSRF guard against private/link-local/reserved IP ranges, plus\nrejecting plain ``http://`` when ``authorization_token`` is set) is\nenforced by :func:`gateway.services.url_safety.validate_mcp_url`, called\nfrom the async request pipeline (``prepare_gateway_tools``) rather than\nhere at parse time: the safety check does a DNS lookup, which must be\nawaited so it can't block the event loop, and Pydantic validators run\nsynchronously during request-body parsing.",
+        "description": "Inline MCP server configuration accepted by generation requests.\n\nStreamable HTTP transport. The `url` must be reachable from the gateway process.\n\nURL safety (SSRF guard against private/link-local/reserved IP ranges, plus\nrejecting plain ``http://`` when ``authorization_token`` is set) is\nenforced by :func:`gateway.services.url_safety.validate_mcp_url`, called\nfrom the async request pipeline (``prepare_gateway_tools``) rather than\nhere at parse time: the safety check does a DNS lookup, which must be\nawaited so it can't block the event loop, and Pydantic validators run\nsynchronously during request-body parsing.",
         "properties": {
           "allowed_tools": {
             "anyOf": [

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -18731,6 +18731,16 @@
             },
             "description": "Unauthorized"
           },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
           "403": {
             "content": {
               "application/json": {
@@ -18882,6 +18892,26 @@
               }
             },
             "description": "Unauthorized"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Payment Required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpErrorBody"
+                }
+              }
+            },
+            "description": "Forbidden"
           },
           "404": {
             "content": {

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1191,6 +1191,92 @@
         "title": "AliasResponse",
         "type": "object"
       },
+      "Annotations": {
+        "additionalProperties": true,
+        "properties": {
+          "audience": {
+            "anyOf": [
+              {
+                "items": {
+                  "enum": [
+                    "user",
+                    "assistant"
+                  ],
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Audience"
+          },
+          "priority": {
+            "anyOf": [
+              {
+                "maximum": 1.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Priority"
+          }
+        },
+        "title": "Annotations",
+        "type": "object"
+      },
+      "AudioContent": {
+        "additionalProperties": true,
+        "description": "Audio content for a message.",
+        "properties": {
+          "_meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          },
+          "annotations": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Annotations"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "data": {
+            "title": "Data",
+            "type": "string"
+          },
+          "mimeType": {
+            "title": "Mimetype",
+            "type": "string"
+          },
+          "type": {
+            "const": "audio",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "data",
+          "mimeType"
+        ],
+        "title": "AudioContent",
+        "type": "object"
+      },
       "AudioSpeechRequest": {
         "description": "OpenAI-compatible audio speech (TTS) request.\n\nThe speech fields are derived from any-llm's ``AudioSpeechParams`` (see\n``_schema_derive``) so the schema cannot silently drop a param any-llm\nforwards. ``user`` is gateway-only (billing / auth scoping); it is not an\nany-llm param and is stripped before the request is forwarded.",
         "properties": {
@@ -1328,6 +1414,51 @@
           }
         },
         "title": "BillingMeters",
+        "type": "object"
+      },
+      "BlobResourceContents": {
+        "additionalProperties": true,
+        "description": "Binary contents of a resource.",
+        "properties": {
+          "_meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          },
+          "blob": {
+            "title": "Blob",
+            "type": "string"
+          },
+          "mimeType": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mimetype"
+          },
+          "uri": {
+            "format": "uri",
+            "minLength": 1,
+            "title": "Uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uri",
+          "blob"
+        ],
+        "title": "BlobResourceContents",
         "type": "object"
       },
       "Body_create_file_v1_files_post": {
@@ -1609,6 +1740,69 @@
           "updated_at"
         ],
         "title": "BudgetResponse",
+        "type": "object"
+      },
+      "CallToolResult": {
+        "additionalProperties": true,
+        "description": "The server's response to a tool call.",
+        "properties": {
+          "_meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          },
+          "content": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/TextContent"
+                },
+                {
+                  "$ref": "#/components/schemas/ImageContent"
+                },
+                {
+                  "$ref": "#/components/schemas/AudioContent"
+                },
+                {
+                  "$ref": "#/components/schemas/ResourceLink"
+                },
+                {
+                  "$ref": "#/components/schemas/EmbeddedResource"
+                }
+              ]
+            },
+            "title": "Content",
+            "type": "array"
+          },
+          "isError": {
+            "default": false,
+            "title": "Iserror",
+            "type": "boolean"
+          },
+          "structuredContent": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Structuredcontent"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "title": "CallToolResult",
         "type": "object"
       },
       "CallerIdentityPublic": {
@@ -3688,6 +3882,56 @@
         "title": "DroppedResponse",
         "type": "object"
       },
+      "EmbeddedResource": {
+        "additionalProperties": true,
+        "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
+        "properties": {
+          "_meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          },
+          "annotations": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Annotations"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "resource": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TextResourceContents"
+              },
+              {
+                "$ref": "#/components/schemas/BlobResourceContents"
+              }
+            ],
+            "title": "Resource"
+          },
+          "type": {
+            "const": "resource",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "resource"
+        ],
+        "title": "EmbeddedResource",
+        "type": "object"
+      },
       "EmbeddingRequest": {
         "description": "OpenAI-compatible embedding request.",
         "properties": {
@@ -4289,6 +4533,94 @@
           }
         },
         "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "Icon": {
+        "additionalProperties": true,
+        "description": "An icon for display in user interfaces.",
+        "properties": {
+          "mimeType": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mimetype"
+          },
+          "sizes": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sizes"
+          },
+          "src": {
+            "title": "Src",
+            "type": "string"
+          }
+        },
+        "required": [
+          "src"
+        ],
+        "title": "Icon",
+        "type": "object"
+      },
+      "ImageContent": {
+        "additionalProperties": true,
+        "description": "Image content for a message.",
+        "properties": {
+          "_meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          },
+          "annotations": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Annotations"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "data": {
+            "title": "Data",
+            "type": "string"
+          },
+          "mimeType": {
+            "title": "Mimetype",
+            "type": "string"
+          },
+          "type": {
+            "const": "image",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "data",
+          "mimeType"
+        ],
+        "title": "ImageContent",
         "type": "object"
       },
       "ImageGenerationRequest": {
@@ -5002,8 +5334,35 @@
         "title": "ManagedTool",
         "type": "object"
       },
+      "McpExecuteRequest": {
+        "description": "One MCP server and the exact tool call the client approved.",
+        "properties": {
+          "arguments": {
+            "additionalProperties": true,
+            "description": "The JSON-object arguments to pass to the approved tool.",
+            "title": "Arguments",
+            "type": "object"
+          },
+          "server": {
+            "$ref": "#/components/schemas/McpServerConfig"
+          },
+          "tool_name": {
+            "description": "The MCP tool the caller has approved for this one execution.",
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "Tool Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "server",
+          "tool_name"
+        ],
+        "title": "McpExecuteRequest",
+        "type": "object"
+      },
       "McpServerConfig": {
-        "description": "Inline MCP server configuration accepted on the chat completions request.\n\nStreamable HTTP transport. The `url` must be reachable from the gateway process.\n\nURL safety (SSRF guard against private/link-local/reserved IP ranges, plus\nrejecting plain ``http://`` when ``authorization_token`` is set) is\nenforced by :func:`gateway.services.url_safety.validate_mcp_url`, called\nfrom the async request pipeline (``prepare_gateway_tools``) rather than\nhere at parse time: the safety check does a DNS lookup, which must be\nawaited so it can't block the event loop, and Pydantic validators run\nsynchronously during request-body parsing.",
+        "description": "Inline MCP server configuration accepted by generation and execution requests.\n\nStreamable HTTP transport. The `url` must be reachable from the gateway process.\n\nURL safety (SSRF guard against private/link-local/reserved IP ranges, plus\nrejecting plain ``http://`` when ``authorization_token`` is set) is\nenforced by :func:`gateway.services.url_safety.validate_mcp_url`, called\nfrom the async request pipeline (``prepare_gateway_tools``) rather than\nhere at parse time: the safety check does a DNS lookup, which must be\nawaited so it can't block the event loop, and Pydantic validators run\nsynchronously during request-body parsing.",
         "properties": {
           "allowed_tools": {
             "anyOf": [
@@ -8811,6 +9170,114 @@
         "title": "ResetPasswordRequest",
         "type": "object"
       },
+      "ResourceLink": {
+        "additionalProperties": true,
+        "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of `resources/list` requests.",
+        "properties": {
+          "_meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          },
+          "annotations": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Annotations"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "icons": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Icon"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Icons"
+          },
+          "mimeType": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mimetype"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "type": {
+            "const": "resource_link",
+            "title": "Type",
+            "type": "string"
+          },
+          "uri": {
+            "format": "uri",
+            "minLength": 1,
+            "title": "Uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "uri",
+          "type"
+        ],
+        "title": "ResourceLink",
+        "type": "object"
+      },
       "ResponsesRequest": {
         "additionalProperties": true,
         "description": "OpenAI Responses API-compatible request.\n\nThe wire fields are derived from any-llm's ``ResponsesParams`` (see\n``_schema_derive``) so the schema cannot silently drop a param any-llm\nforwards. Gateway-internal fields (``mcp_servers``, ``mcp_server_ids``,\n``guardrails``, ``tools_header``, ``max_tool_iterations``) opt the request\ninto gateway-managed MCP / sandbox / web_search / guardrails without\nchanging the upstream wire shape. They're stripped before the request is\nforwarded.",
@@ -10412,6 +10879,94 @@
           "reason"
         ],
         "title": "TestServiceResponse",
+        "type": "object"
+      },
+      "TextContent": {
+        "additionalProperties": true,
+        "description": "Text content for a message.",
+        "properties": {
+          "_meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          },
+          "annotations": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Annotations"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          },
+          "type": {
+            "const": "text",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "title": "TextContent",
+        "type": "object"
+      },
+      "TextResourceContents": {
+        "additionalProperties": true,
+        "description": "Text contents of a resource.",
+        "properties": {
+          "_meta": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Meta"
+          },
+          "mimeType": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mimetype"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          },
+          "uri": {
+            "format": "uri",
+            "minLength": 1,
+            "title": "Uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "uri",
+          "text"
+        ],
+        "title": "TextResourceContents",
         "type": "object"
       },
       "TokenChargeLine": {
@@ -17968,6 +18523,56 @@
         "summary": "Receive Logs",
         "tags": [
           "otel"
+        ]
+      }
+    },
+    "/v1/mcp/execute": {
+      "post": {
+        "description": "Execute one caller-approved tool against one inline MCP server.\n\nThe server is connected only for this request. Otari validates its URL,\napplies its configured tool allowlist, confirms the tool through live MCP\ndiscovery, and then executes exactly the named call. A server-returned\n``isError`` remains a typed MCP result; transport and protocol failures are\nreturned as a sanitized gateway error.",
+        "operationId": "execute_mcp_tool_v1_mcp_execute_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/McpExecuteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallToolResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Execute Mcp Tool",
+        "tags": [
+          "mcp"
         ]
       }
     },

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -2159,6 +2159,44 @@
     {
       "item": [
         {
+          "name": "Execute Mcp Tool",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"server\": {\n    \"name\": \"string\",\n    \"url\": \"string\"\n  },\n  \"tool_name\": \"string\"\n}"
+            },
+            "description": "Execute one caller-approved tool against one inline MCP server.\n\nThe server is connected only for this request. Otari validates its URL,\napplies its configured tool allowlist, confirms the tool through live MCP\ndiscovery, and then executes exactly the named call. A server-returned\n``isError`` remains a typed MCP result; transport and protocol failures are\nreturned as a sanitized gateway error.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "mcp",
+                "execute"
+              ],
+              "raw": "{{baseUrl}}/v1/mcp/execute"
+            }
+          }
+        }
+      ],
+      "name": "mcp"
+    },
+    {
+      "item": [
+        {
           "name": "Create Message",
           "request": {
             "body": {

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -2168,9 +2168,9 @@
                   "language": "json"
                 }
               },
-              "raw": "{\n  \"server\": {\n    \"name\": \"string\",\n    \"url\": \"string\"\n  },\n  \"tool_name\": \"string\"\n}"
+              "raw": "{\n  \"mcp_server_id\": \"00000000-0000-0000-0000-000000000000\",\n  \"tool_name\": \"string\",\n  \"server_revision\": \"string\",\n  \"client_execution_id\": \"00000000-0000-0000-0000-000000000000\"\n}"
             },
-            "description": "Execute one caller-approved tool against one inline MCP server.\n\nThe server is connected only for this request. Otari validates its URL,\napplies its configured tool allowlist, confirms the tool through live MCP\ndiscovery, and then executes exactly the named call. A server-returned\n``isError`` remains a typed MCP result; transport and protocol failures are\nreturned as a sanitized gateway error.",
+            "description": "Execute one caller-authorized tool call against a stored MCP server.\n\nThe calling application owns any user approval, argument editing,\ncancellation and action history; Otari executes exactly the tool name and\narguments it is given, once, and returns the remote server's native result.\nA result with ``isError: true`` is a definitive outcome and comes back as an\nHTTP 200.\n\n**This request must never be retried automatically.** ``client_execution_id``\nis correlation, not idempotency: once the call has been dispatched Otari\ncannot know whether the tool ran, and an ``outcome_unknown`` response means\nexactly that. Proxies, service meshes and SDKs on this path have to disable\nretries for it, including on connection resets and 5xx responses.",
             "header": [
               {
                 "key": "Content-Type",
@@ -2188,6 +2188,34 @@
                 "execute"
               ],
               "raw": "{{baseUrl}}/v1/mcp/execute"
+            }
+          }
+        },
+        {
+          "name": "List Mcp Tools",
+          "request": {
+            "description": "List the tools a stored MCP server exposes to the authenticated workspace.\n\nCall this once per server when preparing a model or workflow run, and reuse\nthe answer for every tool from that server for the length of the run: there\nis no cross-run cache in this version, so a later run rediscovers and\nstaleness stays bounded without any invalidation state to keep.\n\nThe response is the whole authorized catalog or an error. It is never\npartial, because a caller would read a short catalog as the complete input\nto its own authorization and risk policy. The single exception is\n``warnings``, which names a tool whose descriptor Otari could not carry.\n\nA tool the server removes after discovery may still be proposed from the\nrun's snapshot; execution then returns the remote server's own typed error.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "mcp",
+                "servers",
+                ":mcp_server_id",
+                "tools"
+              ],
+              "raw": "{{baseUrl}}/v1/mcp/servers/:mcp_server_id/tools",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "mcp_server_id",
+                  "value": ""
+                }
+              ]
             }
           }
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,23 @@ dependencies = [
     "fastapi>=0.115.0",
     "genai-prices>=0.1.0",
     "markitdown[docx,pptx,xlsx,pdf]>=0.1.0",
-    "mcp>=1.28.1,<2.0.0",
+    # Pinned to one minor line, not just below the next major. The major
+    # ceiling is #689: mcp 2.0 removed
+    # `mcp.client.streamable_http.streamablehttp_client`, which
+    # `services/mcp_client.py` and `services/mcp_stateless.py` import at module
+    # scope, so a fresh resolution picking it up kills every gateway command.
+    # The minor ceiling is a second, separate coupling: `/v1/mcp/execute`
+    # answers with mcp's own `CallToolResult`, so ten mcp-owned schemas are
+    # written into `docs/public/openapi.json` and from there into the Postman
+    # collection and `web/src/client/schema.ts`, all three committed with drift
+    # checks. An mcp release that touches any of those shapes therefore changes
+    # three generated files here. Left open to `<2.0.0`, a `uv lock` run for an
+    # unrelated dependency would move mcp and those artifacts as a side effect,
+    # and the drift checks would fail on a PR whose diff explained none of it.
+    # Bumping this is deliberate work: raise the ceiling, then regenerate both
+    # public artifacts and the dashboard client (see AGENTS.md, "Generated
+    # Artifacts").
+    "mcp>=1.28.1,<1.29.0",
     "opentelemetry-api>=1.39.1",
     "pillow>=12.3.0",
     "pypdfium2>=4.30.0",

--- a/scripts/sdk_codegen/sdk-endpoints.txt
+++ b/scripts/sdk_codegen/sdk-endpoints.txt
@@ -70,6 +70,8 @@ POST /v1/audio/transcriptions
 
 [excluded]
 GET /v1/models/{model_id}      # redundant, list_models covers discovery
+# Stateless MCP execution is public, but no SDK shell wraps it yet.
+POST /v1/mcp/execute                 # not yet wrapped
 # Files API: added to the gateway spec, not yet wrapped by any SDK shell.
 POST /v1/files                       # not yet wrapped
 GET /v1/files                        # not yet wrapped

--- a/scripts/sdk_codegen/sdk-endpoints.txt
+++ b/scripts/sdk_codegen/sdk-endpoints.txt
@@ -70,7 +70,11 @@ POST /v1/audio/transcriptions
 
 [excluded]
 GET /v1/models/{model_id}      # redundant, list_models covers discovery
-# Stateless MCP execution is public, but no SDK shell wraps it yet.
+# Caller-orchestrated MCP is public, but no SDK shell wraps it yet. Typed
+# mcp.list_tools and mcp.execute methods are the next step for the SDKs, and
+# execution needs one deliberate property no generated wrapper gives it for
+# free: exactly one HTTP attempt, never a retry.
+GET /v1/mcp/servers/{mcp_server_id}/tools    # not yet wrapped
 POST /v1/mcp/execute                 # not yet wrapped
 # Files API: added to the gateway spec, not yet wrapped by any SDK shell.
 POST /v1/files                       # not yet wrapped

--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -26,6 +26,7 @@ from gateway.api.routes import (
     keys,
     mail,
     maintenance_mode,
+    mcp,
     messages,
     models,
     moderations,
@@ -132,6 +133,10 @@ def _register_core_routers(api: APIRouter, config: GatewayConfig) -> None:
     if serves_data_plane:
         api.include_router(messages.router)
         api.include_router(responses.router)
+        # Stateless MCP execution is a data-plane route. In hybrid mode it
+        # authenticates through the platform's MCP resolver without opening a local
+        # database; standalone uses the ordinary API/master-key path.
+        api.include_router(mcp.router)
 
     if config.is_hybrid_mode:
         # The hybrid stub router is mounted by register_routers, after the

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -40,6 +40,7 @@ from gateway.services.bedrock_gateway_auth import build_bedrock_client_args
 from gateway.services.mcp_loop import MaxToolIterationsExceeded
 from gateway.services.mcp_stateless import (
     CODE_RESOLUTION_FAILED,
+    CODE_SERVER_NOT_FOUND,
     ExecutionState,
     McpExecutionError,
 )
@@ -955,19 +956,21 @@ async def _resolve_platform_mcp_server(
 ) -> ResolvedMcpServer:
     """Resolve one stored MCP server for the stored-server endpoints.
 
-    The same platform resolver `_resolve_platform_mcp_servers` calls, read
-    strictly instead of leniently. The tool-loop caller resolves a list and can
-    reasonably work with whatever came back; here the answer authorizes one
-    caller-authorized call, so exactly one entry whose id matches the requested id
-    is the only acceptable shape (R-RES-1). Zero, several, a different id, or a
-    field Otari cannot read is a resolution failure.
+    The same platform resolver `_resolve_platform_mcp_servers` calls, with a
+    one-id request. A current peer may echo ``id`` and ``enabled``; an older peer
+    returns only the connection config and omits a disabled server. Exactly one
+    legacy entry is therefore bound to the only id requested and treated as
+    enabled. An explicit id must still match, and an explicit enabled value must
+    still be a strict boolean (R-RES-1).
 
-    ``enabled`` is returned rather than acted on: the disabled-server 404 is one
-    row of an outcome ladder both modes share, and it belongs in the route that
-    owns that ladder.
+    An empty list is the legacy disabled-server answer and is indistinguishable
+    here from an inaccessible server, which is also the public 404 contract.
+    Several entries, a mismatched id, a missing ``servers`` list, or a field
+    Otari cannot read remain resolution failures.
 
     Raises:
-        McpExecutionError: the answer was not one matching, well-formed entry.
+        McpExecutionError: the server was inaccessible, or the answer was not a
+            matching, well-formed entry.
         HTTPException: the platform itself refused, for the route to classify.
     """
     payload = await _post_resolve(
@@ -978,10 +981,20 @@ async def _resolve_platform_mcp_server(
         client_error_detail="MCP server resolution failed",
     )
     servers = payload.get("servers") if isinstance(payload, dict) else None
-    if not isinstance(servers, list) or len(servers) != 1:
+    if not isinstance(servers, list):
         raise McpExecutionError(CODE_RESOLUTION_FAILED, ExecutionState.NOT_STARTED, 502)
+    if not servers:
+        raise McpExecutionError(CODE_SERVER_NOT_FOUND, ExecutionState.NOT_STARTED, 404)
+    if len(servers) != 1:
+        raise McpExecutionError(CODE_RESOLUTION_FAILED, ExecutionState.NOT_STARTED, 502)
+
+    entry = servers[0]
+    if isinstance(entry, dict):
+        entry = dict(entry)
+        entry.setdefault("id", mcp_server_id)
+        entry.setdefault("enabled", True)
     try:
-        resolved = ResolvedMcpServer.model_validate(servers[0])
+        resolved = ResolvedMcpServer.model_validate(entry)
     except ValidationError:
         # No detail from the validator travels: it would quote the resolver's
         # own payload, which carries the stored URL and credential.

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -556,7 +556,13 @@ async def _post_resolve(
         ) from None
 
     if response.status_code == 200:
-        return response.json()
+        try:
+            return response.json()
+        except ValueError:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Authorization service unavailable",
+            ) from None
 
     if response.status_code in {400, 401, 402, 403, 404, 429}:
         detail = _safe_detail_from_platform(response, client_error_detail)

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -35,9 +35,14 @@ from gateway.core.usage import (
 )
 from gateway.log_config import logger
 from gateway.metrics import record_abandoned_attempt
-from gateway.models.mcp import McpServerConfig
+from gateway.models.mcp import McpServerConfig, ResolvedMcpServer
 from gateway.services.bedrock_gateway_auth import build_bedrock_client_args
 from gateway.services.mcp_loop import MaxToolIterationsExceeded
+from gateway.services.mcp_stateless import (
+    CODE_RESOLUTION_FAILED,
+    ExecutionState,
+    McpExecutionError,
+)
 from gateway.services.sandbox_backend import SandboxNotReachableError
 from gateway.services.web_search_backend import WebSearchNotReachableError
 
@@ -941,6 +946,49 @@ async def _resolve_platform_mcp_servers(
         )
         for s in payload.get("servers", [])
     ]
+
+
+async def _resolve_platform_mcp_server(
+    config: GatewayConfig,
+    user_token: str,
+    mcp_server_id: uuid.UUID,
+) -> ResolvedMcpServer:
+    """Resolve one stored MCP server for the stored-server endpoints.
+
+    The same platform resolver `_resolve_platform_mcp_servers` calls, read
+    strictly instead of leniently. The tool-loop caller resolves a list and can
+    reasonably work with whatever came back; here the answer authorizes one
+    caller-authorized call, so exactly one entry whose id matches the requested id
+    is the only acceptable shape (R-RES-1). Zero, several, a different id, or a
+    field Otari cannot read is a resolution failure.
+
+    ``enabled`` is returned rather than acted on: the disabled-server 404 is one
+    row of an outcome ladder both modes share, and it belongs in the route that
+    owns that ladder.
+
+    Raises:
+        McpExecutionError: the answer was not one matching, well-formed entry.
+        HTTPException: the platform itself refused, for the route to classify.
+    """
+    payload = await _post_resolve(
+        config,
+        user_token=user_token,
+        path="/gateway/mcp-servers/resolve",
+        body={"mcp_server_ids": [str(mcp_server_id)]},
+        client_error_detail="MCP server resolution failed",
+    )
+    servers = payload.get("servers") if isinstance(payload, dict) else None
+    if not isinstance(servers, list) or len(servers) != 1:
+        raise McpExecutionError(CODE_RESOLUTION_FAILED, ExecutionState.NOT_STARTED, 502)
+    try:
+        resolved = ResolvedMcpServer.model_validate(servers[0])
+    except ValidationError:
+        # No detail from the validator travels: it would quote the resolver's
+        # own payload, which carries the stored URL and credential.
+        raise McpExecutionError(CODE_RESOLUTION_FAILED, ExecutionState.NOT_STARTED, 502) from None
+    if resolved.id != mcp_server_id:
+        raise McpExecutionError(CODE_RESOLUTION_FAILED, ExecutionState.NOT_STARTED, 502)
+    return resolved
 
 
 async def _resolve_platform_web_search(

--- a/src/gateway/api/routes/hosted_mode.py
+++ b/src/gateway/api/routes/hosted_mode.py
@@ -88,6 +88,13 @@ DATA_PLANE_PREFIXES: tuple[tuple[str, str], ...] = (
     ),
     ("/v1/batches", "queues completions, so it is dispatch deferred rather than avoided"),
     (
+        "/v1/mcp",
+        "caller-orchestrated MCP discovery and execution. Neither dispatches to a "
+        "model, and execution bills nothing here, but both open an outbound MCP "
+        "session on behalf of a tenant, which belongs on the data-plane gateway "
+        "that holds that tenant's request context",
+    ),
+    (
         "/v1/files",
         "dispatches to no provider and costs nothing to serve, so not the leak "
         "itself. It exists only to be referenced from a completion or a batch, and "

--- a/src/gateway/api/routes/mcp.py
+++ b/src/gateway/api/routes/mcp.py
@@ -494,24 +494,58 @@ async def list_mcp_tools(
     A tool the server removes after discovery may still be proposed from the
     run's snapshot; execution then returns the remote server's own typed error.
     """
-    principal = await _authenticate(raw_request, db, config)
-    server = await _resolve_server(principal, db, config, mcp_server_id)
-
-    if server.allowed_tools == []:
-        # An operator's explicit deny-all is a complete answer already, so this
-        # opens no connection at all (R-RES-4).
-        response = McpToolsResponse(server_id=server.id, server_revision=server.revision, tools=[], warnings=[])
-        if discovery_response_exceeds_bound(response):  # pragma: no cover - fixed-size response
-            raise McpExecutionError(CODE_DISCOVERY_LIMIT_EXCEEDED, ExecutionState.NOT_STARTED, 502)
-        return response
-
-    await release_session(db)
-    await _require_safe_url(server)
-    track_request(raw_request, endpoint=TOOLS_ENDPOINT, model=TOOLS_LABEL)
-
     started = time.monotonic()
     try:
-        catalog = await discover_stored_tools(server)
+        async with asyncio.timeout(mcp_stateless.DISCOVERY_TOTAL_TIMEOUT_S):
+            principal = await _authenticate(raw_request, db, config)
+            server = await _resolve_server(principal, db, config, mcp_server_id)
+
+            if server.allowed_tools == []:
+                # An operator's explicit deny-all is a complete answer already,
+                # so this opens no connection at all (R-RES-4).
+                response = McpToolsResponse(
+                    server_id=server.id,
+                    server_revision=server.revision,
+                    tools=[],
+                    warnings=[],
+                )
+                if discovery_response_exceeds_bound(response):  # pragma: no cover - fixed-size response
+                    raise McpExecutionError(CODE_DISCOVERY_LIMIT_EXCEEDED, ExecutionState.NOT_STARTED, 502)
+                return response
+
+            await release_session(db)
+            await _require_safe_url(server)
+            track_request(raw_request, endpoint=TOOLS_ENDPOINT, model=TOOLS_LABEL)
+            catalog = await discover_stored_tools(server)
+
+            response = McpToolsResponse(
+                server_id=server.id,
+                server_revision=server.revision,
+                tools=[
+                    McpToolDefinition(
+                        name=tool.name,
+                        description=tool.description,
+                        input_schema=tool.inputSchema,
+                        annotations=tool.annotations.model_dump(mode="json", exclude_none=True)
+                        if tool.annotations is not None
+                        else None,
+                    )
+                    for tool in catalog.tools
+                ],
+                warnings=[McpToolWarning(tool_name=name, code=code) for name, code in catalog.warnings],
+            )
+            if discovery_response_exceeds_bound(response):
+                raise McpExecutionError(CODE_DISCOVERY_LIMIT_EXCEEDED, ExecutionState.NOT_STARTED, 502)
+    except TimeoutError:
+        exc = McpExecutionError(CODE_DISCOVERY_LIMIT_EXCEEDED, ExecutionState.NOT_STARTED, 502)
+        logger.info(
+            "Stateless MCP discovery request_id=%s server_id=%s outcome=%s duration_ms=%.2f",
+            getattr(raw_request.state, "otari_request_id", "-"),
+            mcp_server_id,
+            exc.code,
+            (time.monotonic() - started) * 1000,
+        )
+        raise exc from None
     except McpExecutionError as exc:
         logger.info(
             "Stateless MCP discovery request_id=%s server_id=%s outcome=%s duration_ms=%.2f",
@@ -522,24 +556,6 @@ async def list_mcp_tools(
         )
         raise
 
-    response = McpToolsResponse(
-        server_id=server.id,
-        server_revision=server.revision,
-        tools=[
-            McpToolDefinition(
-                name=tool.name,
-                description=tool.description,
-                input_schema=tool.inputSchema,
-                annotations=tool.annotations.model_dump(mode="json", exclude_none=True)
-                if tool.annotations is not None
-                else None,
-            )
-            for tool in catalog.tools
-        ],
-        warnings=[McpToolWarning(tool_name=name, code=code) for name, code in catalog.warnings],
-    )
-    if discovery_response_exceeds_bound(response):
-        raise McpExecutionError(CODE_DISCOVERY_LIMIT_EXCEEDED, ExecutionState.NOT_STARTED, 502)
     logger.info(
         "Stateless MCP discovery request_id=%s server_id=%s outcome=ok tools=%d omitted=%d duration_ms=%.2f",
         getattr(raw_request.state, "otari_request_id", "-"),

--- a/src/gateway/api/routes/mcp.py
+++ b/src/gateway/api/routes/mcp.py
@@ -101,6 +101,7 @@ async def execute_mcp_tool(
             detail=str(exc),
         ) from exc
 
+    result: CallToolResult | None = None
     try:
         async with MCPClientPool([server]) as pool:
             if not pool.owns_tool(request.tool_name):
@@ -108,12 +109,21 @@ async def execute_mcp_tool(
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail=MCP_TOOL_NOT_FOUND_DETAIL,
                 )
-            return await pool.call_tool_result(request.tool_name, request.arguments)
+            result = await pool.call_tool_result(request.tool_name, request.arguments)
     except HTTPException:
         raise
     except Exception as exc:
-        logger.warning("Stateless MCP request failed error_class=%s", type(exc).__name__)
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=MCP_EXECUTION_FAILED_DETAIL,
-        ) from exc
+        if result is not None:
+            # The tool already returned a definitive result. A transport close
+            # failure must not invite the caller to retry a mutating operation.
+            logger.warning("Stateless MCP cleanup failed error_class=%s", type(exc).__name__)
+        else:
+            logger.warning("Stateless MCP request failed error_class=%s", type(exc).__name__)
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=MCP_EXECUTION_FAILED_DETAIL,
+            ) from exc
+
+    if result is None:
+        raise RuntimeError("MCP tool call completed without a result")
+    return result

--- a/src/gateway/api/routes/mcp.py
+++ b/src/gateway/api/routes/mcp.py
@@ -53,7 +53,9 @@ from gateway.core.config import GatewayConfig
 from gateway.core.database import release_session
 from gateway.inflight import track_request
 from gateway.log_config import logger
+from gateway.models.entities import APIKey
 from gateway.rate_limit import check_rate_limit
+from gateway.repositories.users_repository import get_active_user
 
 # The module as well as the names below, so the whole-request deadline is read
 # off it at call time and stays tunable in the one place that owns the ceilings.
@@ -306,6 +308,12 @@ async def _authenticate(
     workspace, which would let operator credentials reach one tenant's
     configured servers. No stored server is accessible to it, and that is what
     the 404 says.
+
+    A blocked user is refused too, and has to be refused here. ``users.blocked``
+    is read in ``budget_service.reserve_budget``, which is the only place any
+    request plane consults it, and these routes never reach it because they
+    reserve nothing. Without this, blocking someone would stop their completions
+    and leave them driving mutating MCP tools through the gateway.
     """
     if config.is_hybrid_mode:
         return _Principal(user_token=_extract_platform_user_token(raw_request), workspace_id=None)
@@ -318,8 +326,31 @@ async def _authenticate(
     api_key, _is_master = await verify_api_key_or_master_key(raw_request, db, config)
     if api_key is None:
         raise McpExecutionError(CODE_SERVER_NOT_FOUND, ExecutionState.NOT_STARTED, 404)
-    check_rate_limit(raw_request, str(api_key.user_id))
+    # The key's own bucket, falling back to the key when it names no user, so
+    # every user-less key does not share one bucket keyed on ``"None"``.
+    check_rate_limit(raw_request, api_key.user_id or api_key.id)
+    await _refuse_blocked_user(db, api_key)
     return _Principal(user_token=None, workspace_id=await resolve_workspace_id(db, api_key))
+
+
+async def _refuse_blocked_user(db: AsyncSession, api_key: APIKey) -> None:
+    """Refuse a key whose user an operator has blocked.
+
+    Reported as an authentication failure rather than a code of its own: the
+    caller's credential no longer authorizes anything, which is what the caller
+    needs to know, and the alternative would tell an unauthenticated probe that
+    a given key names a real but blocked user. Why it was refused goes to the
+    log instead.
+
+    A key with no user has no block to check, which is the bootstrap and
+    convenience path (``users_repository.DEFAULT_USER_ID``).
+    """
+    if api_key.user_id is None:
+        return
+    user = await get_active_user(db, api_key.user_id)
+    if user is not None and user.blocked:
+        logger.warning("Stateless MCP request refused reason=user_blocked api_key_id=%s", api_key.id)
+        raise McpExecutionError(CODE_AUTHENTICATION_FAILED, ExecutionState.NOT_STARTED, 401)
 
 
 async def _resolve_server(

--- a/src/gateway/api/routes/mcp.py
+++ b/src/gateway/api/routes/mcp.py
@@ -1,0 +1,119 @@
+"""Stateless execution of one caller-approved MCP tool call."""
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from mcp.types import CallToolResult
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.api.deps import get_config, get_db_if_needed, verify_api_key_or_master_key
+from gateway.api.routes._platform import (
+    _extract_platform_user_token,
+    _resolve_platform_mcp_servers,
+)
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger
+from gateway.models.mcp import McpServerConfig
+from gateway.services.mcp_client import MCPClientPool
+from gateway.services.url_safety import UnsafeURLError, validate_mcp_url
+
+router = APIRouter(prefix="/v1/mcp", tags=["mcp"])
+
+MCP_TOOL_NOT_ALLOWED_DETAIL = "The requested tool is not allowed by the MCP server configuration"
+MCP_TOOL_NOT_FOUND_DETAIL = "The requested tool was not found on the MCP server"
+MCP_EXECUTION_FAILED_DETAIL = "MCP server request failed"
+
+
+class McpExecuteRequest(BaseModel):
+    """One MCP server and the exact tool call the client approved."""
+
+    server: McpServerConfig
+    tool_name: str = Field(
+        min_length=1,
+        max_length=256,
+        description="The MCP tool the caller has approved for this one execution.",
+    )
+    arguments: dict[str, Any] = Field(
+        default_factory=dict,
+        description="The JSON-object arguments to pass to the approved tool.",
+    )
+
+
+async def _authenticate(
+    raw_request: Request,
+    db: AsyncSession | None,
+    config: GatewayConfig,
+) -> None:
+    """Authenticate through the mode's existing data-plane path."""
+    if config.is_hybrid_mode:
+        user_token = _extract_platform_user_token(raw_request)
+        # Stateless execution has no stored ids to resolve. The empty resolve
+        # deliberately reuses the platform's MCP authorization boundary rather
+        # than inventing a second authentication call for this endpoint.
+        await _resolve_platform_mcp_servers(config, user_token, [])
+        return
+
+    if db is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication temporarily unavailable, please retry",
+        )
+    await verify_api_key_or_master_key(raw_request, db, config)
+
+
+@router.post(
+    "/execute",
+    response_model=CallToolResult,
+    response_model_exclude_none=True,
+)
+async def execute_mcp_tool(
+    raw_request: Request,
+    request: McpExecuteRequest,
+    db: Annotated[AsyncSession | None, Depends(get_db_if_needed)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+) -> CallToolResult:
+    """Execute one caller-approved tool against one inline MCP server.
+
+    The server is connected only for this request. Otari validates its URL,
+    applies its configured tool allowlist, confirms the tool through live MCP
+    discovery, and then executes exactly the named call. A server-returned
+    ``isError`` remains a typed MCP result; transport and protocol failures are
+    returned as a sanitized gateway error.
+    """
+    await _authenticate(raw_request, db, config)
+
+    server = request.server
+    if server.allowed_tools is not None and request.tool_name not in server.allowed_tools:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=MCP_TOOL_NOT_ALLOWED_DETAIL,
+        )
+
+    try:
+        await validate_mcp_url(
+            server.url,
+            has_authorization_token=bool(server.authorization_token),
+        )
+    except UnsafeURLError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    try:
+        async with MCPClientPool([server]) as pool:
+            if not pool.owns_tool(request.tool_name):
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=MCP_TOOL_NOT_FOUND_DETAIL,
+                )
+            return await pool.call_tool_result(request.tool_name, request.arguments)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.warning("Stateless MCP request failed error_class=%s", type(exc).__name__)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=MCP_EXECUTION_FAILED_DETAIL,
+        ) from exc

--- a/src/gateway/api/routes/mcp.py
+++ b/src/gateway/api/routes/mcp.py
@@ -1,71 +1,535 @@
-"""Stateless execution of one caller-approved MCP tool call."""
+"""Caller-orchestrated MCP: stored-server tool discovery and one-shot execution.
 
-from typing import Annotated, Any
+For an application that uses Otari as its routing layer and owns its own
+authorization policy. It asks Otari for the tool definitions a stored MCP server
+exposes, lets a model, a person, or a workflow propose a call, applies whatever
+policy it has (a human approval prompt, an administrator rule, trusted
+read-only auto-authorization), and then asks Otari to execute that one exact
+call.
+
+**Otari does not verify a human approval and does not claim to** (R-AUTH-4).
+The calling application is the authorization boundary. What Otari enforces
+independently is authentication, that the stored server is one the authenticated
+workspace may reach, the stored tool allowlist, URL safety, and its own
+execution bounds.
+
+Nothing is held open across a caller's decision: no model stream, no MCP
+session, no database session, no worker-local state. That is the whole reason
+these are two separate requests rather than a pause inside the managed tool
+loop.
+
+The managed loop in ``services/mcp_loop.py`` remains a separate supported
+integration mode, for a client that wants Otari to own the model/tool loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from fastapi.routing import APIRoute
 from mcp.types import CallToolResult
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db_if_needed, verify_api_key_or_master_key
 from gateway.api.routes._platform import (
     _extract_platform_user_token,
-    _resolve_platform_mcp_servers,
+    _resolve_platform_mcp_server,
 )
+
+# ``GatewayConfig`` and ``AsyncSession`` are imported at runtime rather than
+# under ``TYPE_CHECKING``: this module uses postponed annotations, and FastAPI
+# resolves a route signature at import time to decide what each parameter is.
+# Left as strings it cannot resolve, it reads both dependencies as query
+# parameters and every request fails validation before the handler runs.
 from gateway.core.config import GatewayConfig
+from gateway.core.database import release_session
+from gateway.inflight import track_request
 from gateway.log_config import logger
-from gateway.models.mcp import McpServerConfig
-from gateway.services.mcp_client import MCPClientPool
+from gateway.rate_limit import check_rate_limit
+
+# The module as well as the names below, so the whole-request deadline is read
+# off it at call time and stays tunable in the one place that owns the ceilings.
+from gateway.services import mcp_stateless
+from gateway.services.mcp_stateless import (
+    ARGUMENTS_MAX_DEPTH,
+    CODE_AUTHENTICATION_FAILED,
+    CODE_CAPACITY_UNAVAILABLE,
+    CODE_CONNECTION_FAILED,
+    CODE_CREDENTIALS_UNAVAILABLE,
+    CODE_DISCOVERY_CAPACITY_UNAVAILABLE,
+    CODE_DISCOVERY_LIMIT_EXCEEDED,
+    CODE_INVALID_REQUEST,
+    CODE_OUTCOME_UNKNOWN,
+    CODE_RATE_LIMIT_EXCEEDED,
+    CODE_RESOLUTION_FAILED,
+    CODE_RESULT_TOO_LARGE,
+    CODE_SERVER_CHANGED,
+    CODE_SERVER_NOT_FOUND,
+    CODE_TOOL_NOT_ALLOWED,
+    CODE_UNSAFE_URL,
+    DISCOVERY_MAX_TOOLS,
+    REVISION_PATTERN,
+    TOOL_NAME_MAX_LENGTH,
+    ExecutionState,
+    McpExecutionError,
+    arguments_within_bounds,
+    discover_stored_tools,
+    execute_stored_tool,
+)
+from gateway.services.secret_box import SecretBoxUnavailableError, SecretDecryptionError
+from gateway.services.tenancy.workspace_mcp_server_service import resolve_workspace_mcp_server
 from gateway.services.url_safety import UnsafeURLError, validate_mcp_url
+from gateway.services.workspace_scope import resolve_workspace_id
 
-router = APIRouter(prefix="/v1/mcp", tags=["mcp"])
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
 
-MCP_TOOL_NOT_ALLOWED_DETAIL = "The requested tool is not allowed by the MCP server configuration"
-MCP_TOOL_NOT_FOUND_DETAIL = "The requested tool was not found on the MCP server"
-MCP_EXECUTION_FAILED_DETAIL = "MCP server request failed"
+    from fastapi import Response
+
+    from gateway.models.mcp import ResolvedMcpServer
+
+EXECUTE_ENDPOINT = "/v1/mcp/execute"
+TOOLS_ENDPOINT = "/v1/mcp/servers/{mcp_server_id}/tools"
+
+# The in-flight registry describes work by model, and these endpoints run no
+# model. The label names what is actually being done instead, so an operator
+# watching /v1/usage/in-flight sees a stateless MCP call rather than a blank.
+EXECUTE_LABEL = "mcp.execute"
+TOOLS_LABEL = "mcp.list_tools"
+
+# One fixed safe message per error code (R-ERR-1). Nothing here varies with the
+# request, the resolver answer, or the remote server: a message that varied
+# would be the leak the whole error contract exists to prevent.
+SAFE_DETAILS: dict[str, str] = {
+    CODE_INVALID_REQUEST: "MCP request is invalid",
+    CODE_AUTHENTICATION_FAILED: "Authentication failed",
+    CODE_RATE_LIMIT_EXCEEDED: "Rate limit exceeded",
+    CODE_SERVER_NOT_FOUND: "MCP server not found",
+    CODE_SERVER_CHANGED: "MCP server configuration changed, rediscover its tools",
+    CODE_TOOL_NOT_ALLOWED: "The requested tool is not allowed for this MCP server",
+    CODE_UNSAFE_URL: "MCP server URL is unsafe",
+    CODE_RESOLUTION_FAILED: "MCP server resolution failed",
+    CODE_CREDENTIALS_UNAVAILABLE: "MCP server credentials are unavailable",
+    CODE_DISCOVERY_LIMIT_EXCEEDED: "MCP discovery exceeded its limits",
+    CODE_DISCOVERY_CAPACITY_UNAVAILABLE: "MCP discovery capacity is unavailable",
+    CODE_CAPACITY_UNAVAILABLE: "MCP execution capacity is unavailable",
+    CODE_CONNECTION_FAILED: "MCP server connection failed",
+    CODE_OUTCOME_UNKNOWN: "MCP execution outcome is unknown",
+    CODE_RESULT_TOO_LARGE: "MCP result exceeds the response limit",
+}
+
+
+# The two failures that are transient by construction: a per-process slot did
+# not free up inside the admission deadline. Everything else this contract
+# returns is a decision, a bound, or an outcome Otari cannot know, and none of
+# those get better by being sent again (R-ERR-4). The one other status carrying
+# this header is the 429, which keeps the limiter's own value.
+_RETRYABLE_CAPACITY_CODES = frozenset({CODE_CAPACITY_UNAVAILABLE, CODE_DISCOVERY_CAPACITY_UNAVAILABLE})
+RETRY_AFTER_ONE = {"Retry-After": "1"}
+
+
+class McpErrorBody(BaseModel):
+    """The one error shape both stored-server endpoints return (R-ERR-1)."""
+
+    detail: str
+    code: str
+    execution_state: ExecutionState
+    request_id: str
+
+
+class _McpRoute(APIRoute):
+    """Gives every route on this router the shared error contract and request id.
+
+    A route class rather than an application exception handler, for two reasons.
+    The 422 has to be normalized too, and a ``RequestValidationError`` is raised
+    inside the route handler where only this wrapper can see it; and the
+    contract is deliberately local to ``/v1/mcp``, so nothing else on the
+    deployment picks up an error shape it never published.
+    """
+
+    def get_route_handler(self) -> Callable[[Request], Awaitable[Response]]:
+        original = super().get_route_handler()
+
+        async def handler(request: Request) -> Response:
+            request_id = f"req_{uuid.uuid4().hex}"
+            request.state.otari_request_id = request_id
+            try:
+                response = await original(request)
+            except RequestValidationError:
+                # Normalized rather than forwarded: FastAPI's body echoes the
+                # rejected value, which here is the caller's own arguments.
+                return _error_response(CODE_INVALID_REQUEST, ExecutionState.NOT_STARTED, 422, request_id)
+            except McpExecutionError as exc:
+                return _error_response(
+                    exc.code,
+                    exc.execution_state,
+                    exc.status_code,
+                    request_id,
+                    headers=RETRY_AFTER_ONE if exc.code in _RETRYABLE_CAPACITY_CODES else None,
+                )
+            except HTTPException as exc:
+                code, execution_state, status_code = _classify(exc)
+                retry_after = (exc.headers or {}).get("Retry-After")
+                return _error_response(
+                    code,
+                    execution_state,
+                    status_code,
+                    request_id,
+                    headers={"Retry-After": retry_after} if retry_after else None,
+                )
+            response.headers["X-Otari-Request-ID"] = request_id
+            return response
+
+        return handler
+
+
+def _error_response(
+    code: str,
+    execution_state: ExecutionState,
+    status_code: int,
+    request_id: str,
+    *,
+    headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    body = McpErrorBody(
+        detail=SAFE_DETAILS.get(code, "MCP request failed"),
+        code=code,
+        execution_state=execution_state,
+        request_id=request_id,
+    )
+    response_headers = {"X-Otari-Request-ID": request_id}
+    if headers:
+        response_headers.update(headers)
+    return JSONResponse(status_code=status_code, content=body.model_dump(mode="json"), headers=response_headers)
+
+
+def _classify(exc: HTTPException) -> tuple[str, ExecutionState, int]:
+    """Map an authentication or platform refusal onto this contract's enums.
+
+    Every one of these is raised before dispatch, so all of them are
+    ``not_started``. The platform's own detail is dropped rather than forwarded:
+    it may describe a workspace, a plan, or a stored server, and R-ERR-1 lets
+    nothing platform-side through.
+    """
+    if exc.status_code in {401, 402, 403}:
+        return CODE_AUTHENTICATION_FAILED, ExecutionState.NOT_STARTED, 401
+    if exc.status_code == 404:
+        return CODE_SERVER_NOT_FOUND, ExecutionState.NOT_STARTED, 404
+    if exc.status_code == 429:
+        return CODE_RATE_LIMIT_EXCEEDED, ExecutionState.NOT_STARTED, 429
+    return CODE_RESOLUTION_FAILED, ExecutionState.NOT_STARTED, 502
+
+
+router = APIRouter(prefix="/v1/mcp", tags=["mcp"], route_class=_McpRoute)
 
 
 class McpExecuteRequest(BaseModel):
-    """One MCP server and the exact tool call the client approved."""
+    """One stored server, and the exact call the application authorized.
 
-    server: McpServerConfig
+    No inline server fields (R-REQ-4): a caller registers a remote MCP server
+    through the control plane once and refers to it by id afterwards, which
+    keeps URLs, credentials, revocation and allowlist policy on Otari's side of
+    the boundary instead of in every request.
+
+    Extras are forbidden rather than ignored, so a caller still sending the old
+    inline ``server`` block is told its configuration was not used instead of
+    watching Otari quietly execute against a different server than the one it
+    named.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    mcp_server_id: uuid.UUID = Field(description="The stored MCP server to execute against.")
     tool_name: str = Field(
         min_length=1,
-        max_length=256,
-        description="The MCP tool the caller has approved for this one execution.",
+        max_length=TOOL_NAME_MAX_LENGTH,
+        description="The remote MCP tool name the caller authorized for this one execution.",
     )
     arguments: dict[str, Any] = Field(
         default_factory=dict,
-        description="The JSON-object arguments to pass to the approved tool.",
+        description="The exact caller-authorized JSON-object arguments.",
     )
+    server_revision: str = Field(
+        pattern=REVISION_PATTERN,
+        description=(
+            "The stored-server revision returned by tool discovery. Required, and compared "
+            "against the current one so a configuration change since the caller authorized "
+            "this call is refused rather than executed. Not an approval credential."
+        ),
+    )
+    client_execution_id: uuid.UUID = Field(
+        description=(
+            "A caller-generated UUID, for correlation only. It is not proof of approval and "
+            "not an idempotency key: repeating a request with the same value may execute the "
+            "tool again, so this request must never be retried automatically."
+        ),
+    )
+
+    @field_validator("arguments")
+    @classmethod
+    def _bounded_arguments(cls, value: dict[str, Any]) -> dict[str, Any]:
+        if not arguments_within_bounds(value):
+            raise ValueError(f"arguments exceed the size or depth limit (depth {ARGUMENTS_MAX_DEPTH})")
+        return value
+
+
+@dataclass(frozen=True, slots=True)
+class _Principal:
+    """Who the request authenticated as, in whichever mode answered it."""
+
+    user_token: str | None
+    workspace_id: uuid.UUID | None
 
 
 async def _authenticate(
     raw_request: Request,
     db: AsyncSession | None,
     config: GatewayConfig,
-) -> None:
-    """Authenticate through the mode's existing data-plane path."""
+) -> _Principal:
+    """Authenticate, and rate-limit the principal before any outbound access.
+
+    Hybrid mode carries the user token through to the platform resolver, which
+    is both the authorization and the rate-limit boundary there (R-ADM-2); Otari
+    preserves whatever 429 it returns. Standalone authenticates the key and
+    charges the request to that key's own bucket here.
+
+    A master-key request is refused. It holds no workspace of its own, so it can
+    only ever resolve a stored server through the deployment's default
+    workspace, which would let operator credentials reach one tenant's
+    configured servers. No stored server is accessible to it, and that is what
+    the 404 says.
+    """
     if config.is_hybrid_mode:
-        user_token = _extract_platform_user_token(raw_request)
-        # Stateless execution has no stored ids to resolve. The empty resolve
-        # deliberately reuses the platform's MCP authorization boundary rather
-        # than inventing a second authentication call for this endpoint.
-        await _resolve_platform_mcp_servers(config, user_token, [])
-        return
+        return _Principal(user_token=_extract_platform_user_token(raw_request), workspace_id=None)
 
     if db is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Authentication temporarily unavailable, please retry",
         )
-    await verify_api_key_or_master_key(raw_request, db, config)
+    api_key, _is_master = await verify_api_key_or_master_key(raw_request, db, config)
+    if api_key is None:
+        raise McpExecutionError(CODE_SERVER_NOT_FOUND, ExecutionState.NOT_STARTED, 404)
+    check_rate_limit(raw_request, str(api_key.user_id))
+    return _Principal(user_token=None, workspace_id=await resolve_workspace_id(db, api_key))
+
+
+async def _resolve_server(
+    principal: _Principal,
+    db: AsyncSession | None,
+    config: GatewayConfig,
+    mcp_server_id: uuid.UUID,
+) -> ResolvedMcpServer:
+    """Resolve the stored server, applying the outcome ladder both modes share (R-RES-1).
+
+    No MCP network access happens here or in anything it raises, so a refusal on
+    these grounds never reaches the remote server.
+    """
+    if config.is_hybrid_mode:
+        server = await _resolve_platform_mcp_server(config, principal.user_token or "", mcp_server_id)
+    else:
+        if db is None or principal.workspace_id is None:  # pragma: no cover - _authenticate settles both
+            raise McpExecutionError(CODE_RESOLUTION_FAILED, ExecutionState.NOT_STARTED, 502)
+        try:
+            resolved = await resolve_workspace_mcp_server(
+                db,
+                workspace_id=principal.workspace_id,
+                server_id=mcp_server_id,
+            )
+        except (SecretDecryptionError, SecretBoxUnavailableError):
+            # Connecting without the credential the workspace configured would
+            # send an unauthenticated request to a server that expects one.
+            logger.warning("Stateless MCP stored credential unavailable server_id=%s", mcp_server_id)
+            raise McpExecutionError(CODE_CREDENTIALS_UNAVAILABLE, ExecutionState.NOT_STARTED, 500) from None
+        if resolved is None:
+            raise McpExecutionError(CODE_SERVER_NOT_FOUND, ExecutionState.NOT_STARTED, 404)
+        server = resolved
+
+    if not server.enabled:
+        # Indistinguishable from an id naming no server, on purpose: a caller
+        # learns that it cannot reach this server, not why.
+        raise McpExecutionError(CODE_SERVER_NOT_FOUND, ExecutionState.NOT_STARTED, 404)
+    return server
+
+
+def _require_allowed(server: ResolvedMcpServer, tool_name: str) -> None:
+    """Apply the stored allowlist to one tool name (R-RES-4).
+
+    ``None`` admits every live tool, the meaning the column already carries in
+    the managed loop; an explicit empty list is a deny-all, so it refuses here
+    as well.
+    """
+    if server.allowed_tools is not None and tool_name not in server.allowed_tools:
+        raise McpExecutionError(CODE_TOOL_NOT_ALLOWED, ExecutionState.NOT_STARTED, 403)
+
+
+async def _require_safe_url(server: ResolvedMcpServer) -> None:
+    """Run the existing MCP SSRF policy over the resolved URL (R-TRANSPORT-3)."""
+    try:
+        await validate_mcp_url(server.url, has_authorization_token=bool(server.authorization_token))
+    except UnsafeURLError:
+        raise McpExecutionError(CODE_UNSAFE_URL, ExecutionState.NOT_STARTED, 400) from None
+
+
+class McpToolDefinition(BaseModel):
+    """One live tool a caller-orchestrated application may expose to its model.
+
+    ``annotations`` is the remote server's own metadata, passed through as
+    untrusted data. Otari never turns ``readOnlyHint`` into an authorization
+    decision (R-RISK-1); each application owns its risk policy, and a server
+    cannot waive an application's approval gate by labeling itself read-only.
+    """
+
+    name: str = Field(description="The remote MCP tool name to send back to /v1/mcp/execute.")
+    description: str | None = Field(default=None, description="The server's own description, untrusted.")
+    input_schema: dict[str, Any] = Field(description="The tool's MCP inputSchema, unmodified.")
+    annotations: dict[str, Any] | None = Field(
+        default=None,
+        description="The server's MCP annotations, untrusted metadata rather than policy.",
+    )
+
+
+class McpToolWarning(BaseModel):
+    """One tool that was omitted, and the code that omitted it (R-SCHEMA-3)."""
+
+    tool_name: str
+    code: str
+
+
+class McpToolsResponse(BaseModel):
+    """The authorized catalog for one stored server.
+
+    Carries no server URL, no credential, and no allowlist entry that the live
+    catalog did not return (R-DISC-2). ``server_revision`` is what an
+    application persists with a proposed call and sends back to
+    ``/v1/mcp/execute``, so a stored-configuration change between the two is
+    refused rather than executed.
+    """
+
+    server_id: uuid.UUID
+    server_revision: str = Field(
+        description=(
+            "An opaque revision of the stored server's URL, credential, enabled state and "
+            "allowlist. It detects Otari-side and platform-side configuration changes only: "
+            "a remote server that changes its own catalog or a tool's behavior behind an "
+            "unchanged URL will not move it."
+        ),
+    )
+    tools: list[McpToolDefinition] = Field(max_length=DISCOVERY_MAX_TOOLS)
+    warnings: list[McpToolWarning]
+
+
+@router.get(
+    "/servers/{mcp_server_id}/tools",
+    response_model=McpToolsResponse,
+    responses={
+        400: {"model": McpErrorBody},
+        401: {"model": McpErrorBody},
+        404: {"model": McpErrorBody},
+        422: {"model": McpErrorBody},
+        429: {"model": McpErrorBody},
+        500: {"model": McpErrorBody},
+        502: {"model": McpErrorBody},
+        503: {"model": McpErrorBody},
+    },
+)
+async def list_mcp_tools(
+    raw_request: Request,
+    mcp_server_id: uuid.UUID,
+    db: Annotated[AsyncSession | None, Depends(get_db_if_needed)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+) -> McpToolsResponse:
+    """List the tools a stored MCP server exposes to the authenticated workspace.
+
+    Call this once per server when preparing a model or workflow run, and reuse
+    the answer for every tool from that server for the length of the run: there
+    is no cross-run cache in this version, so a later run rediscovers and
+    staleness stays bounded without any invalidation state to keep.
+
+    The response is the whole authorized catalog or an error. It is never
+    partial, because a caller would read a short catalog as the complete input
+    to its own authorization and risk policy. The single exception is
+    ``warnings``, which names a tool whose descriptor Otari could not carry.
+
+    A tool the server removes after discovery may still be proposed from the
+    run's snapshot; execution then returns the remote server's own typed error.
+    """
+    principal = await _authenticate(raw_request, db, config)
+    server = await _resolve_server(principal, db, config, mcp_server_id)
+
+    if server.allowed_tools == []:
+        # An operator's explicit deny-all is a complete answer already, so this
+        # opens no connection at all (R-RES-4).
+        return McpToolsResponse(server_id=server.id, server_revision=server.revision, tools=[], warnings=[])
+
+    await release_session(db)
+    await _require_safe_url(server)
+    track_request(raw_request, endpoint=TOOLS_ENDPOINT, model=TOOLS_LABEL)
+
+    started = time.monotonic()
+    try:
+        catalog = await discover_stored_tools(server)
+    except McpExecutionError as exc:
+        logger.info(
+            "Stateless MCP discovery request_id=%s server_id=%s outcome=%s duration_ms=%.2f",
+            getattr(raw_request.state, "otari_request_id", "-"),
+            mcp_server_id,
+            exc.code,
+            (time.monotonic() - started) * 1000,
+        )
+        raise
+
+    logger.info(
+        "Stateless MCP discovery request_id=%s server_id=%s outcome=ok tools=%d omitted=%d duration_ms=%.2f",
+        getattr(raw_request.state, "otari_request_id", "-"),
+        mcp_server_id,
+        len(catalog.tools),
+        len(catalog.warnings),
+        (time.monotonic() - started) * 1000,
+    )
+    return McpToolsResponse(
+        server_id=server.id,
+        server_revision=server.revision,
+        tools=[
+            McpToolDefinition(
+                name=tool.name,
+                description=tool.description,
+                input_schema=tool.inputSchema,
+                annotations=tool.annotations.model_dump(mode="json", exclude_none=True)
+                if tool.annotations is not None
+                else None,
+            )
+            for tool in catalog.tools
+        ],
+        warnings=[McpToolWarning(tool_name=name, code=code) for name, code in catalog.warnings],
+    )
 
 
 @router.post(
     "/execute",
     response_model=CallToolResult,
     response_model_exclude_none=True,
+    responses={
+        400: {"model": McpErrorBody},
+        401: {"model": McpErrorBody},
+        403: {"model": McpErrorBody},
+        404: {"model": McpErrorBody},
+        409: {"model": McpErrorBody},
+        422: {"model": McpErrorBody},
+        429: {"model": McpErrorBody},
+        500: {"model": McpErrorBody},
+        502: {"model": McpErrorBody},
+        503: {"model": McpErrorBody},
+        504: {"model": McpErrorBody},
+    },
 )
 async def execute_mcp_tool(
     raw_request: Request,
@@ -73,57 +537,92 @@ async def execute_mcp_tool(
     db: Annotated[AsyncSession | None, Depends(get_db_if_needed)],
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> CallToolResult:
-    """Execute one caller-approved tool against one inline MCP server.
+    """Execute one caller-authorized tool call against a stored MCP server.
 
-    The server is connected only for this request. Otari validates its URL,
-    applies its configured tool allowlist, confirms the tool through live MCP
-    discovery, and then executes exactly the named call. A server-returned
-    ``isError`` remains a typed MCP result; transport and protocol failures are
-    returned as a sanitized gateway error.
+    The calling application owns any user approval, argument editing,
+    cancellation and action history; Otari executes exactly the tool name and
+    arguments it is given, once, and returns the remote server's native result.
+    A result with ``isError: true`` is a definitive outcome and comes back as an
+    HTTP 200.
+
+    **This request must never be retried automatically.** ``client_execution_id``
+    is correlation, not idempotency: once the call has been dispatched Otari
+    cannot know whether the tool ran, and an ``outcome_unknown`` response means
+    exactly that. Proxies, service meshes and SDKs on this path have to disable
+    retries for it, including on connection resets and 5xx responses.
     """
-    await _authenticate(raw_request, db, config)
+    principal = await _authenticate(raw_request, db, config)
+    server = await _resolve_server(principal, db, config, request.mcp_server_id)
+    _require_allowed(server, request.tool_name)
+    if request.server_revision != server.revision:
+        # In memory, over the resolution both modes already needed, so this
+        # costs no database, platform or MCP round trip (R-RES-2).
+        raise McpExecutionError(CODE_SERVER_CHANGED, ExecutionState.NOT_STARTED, 409)
 
-    server = request.server
-    if server.allowed_tools is not None and request.tool_name not in server.allowed_tools:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=MCP_TOOL_NOT_ALLOWED_DETAIL,
-        )
+    # Before DNS, before the concurrency wait, and before any MCP network I/O:
+    # a pooled connection must not be pinned for the length of a remote call.
+    await release_session(db)
+    await _require_safe_url(server)
+    track_request(raw_request, endpoint=EXECUTE_ENDPOINT, model=EXECUTE_LABEL)
+
+    dispatched = False
+    started = time.monotonic()
+    timings: dict[str, float] = {"resolve_ms": (time.monotonic() - started) * 1000}
+
+    def mark_dispatched() -> None:
+        nonlocal dispatched
+        dispatched = True
 
     try:
-        await validate_mcp_url(
-            server.url,
-            has_authorization_token=bool(server.authorization_token),
-        )
-    except UnsafeURLError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
-        ) from exc
-
-    result: CallToolResult | None = None
-    try:
-        async with MCPClientPool([server]) as pool:
-            if not pool.owns_tool(request.tool_name):
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=MCP_TOOL_NOT_FOUND_DETAIL,
-                )
-            result = await pool.call_tool_result(request.tool_name, request.arguments)
-    except HTTPException:
+        async with asyncio.timeout(mcp_stateless.EXECUTION_TOTAL_TIMEOUT_S):
+            result = await execute_stored_tool(
+                server,
+                request.tool_name,
+                request.arguments,
+                on_dispatch=mark_dispatched,
+                timings=timings,
+            )
+    except TimeoutError:
+        # The total deadline can only be reached before dispatch here: past it,
+        # the call's own deadline is the shorter of the two and classifies the
+        # failure itself.
+        raise McpExecutionError(
+            CODE_OUTCOME_UNKNOWN if dispatched else CODE_CONNECTION_FAILED,
+            ExecutionState.OUTCOME_UNKNOWN if dispatched else ExecutionState.NOT_STARTED,
+            504 if dispatched else 502,
+        ) from None
+    except McpExecutionError as exc:
+        _log_outcome(raw_request, request, exc.execution_state, exc.code, started, timings)
         raise
-    except Exception as exc:
-        if result is not None:
-            # The tool already returned a definitive result. A transport close
-            # failure must not invite the caller to retry a mutating operation.
-            logger.warning("Stateless MCP cleanup failed error_class=%s", type(exc).__name__)
-        else:
-            logger.warning("Stateless MCP request failed error_class=%s", type(exc).__name__)
-            raise HTTPException(
-                status_code=status.HTTP_502_BAD_GATEWAY,
-                detail=MCP_EXECUTION_FAILED_DETAIL,
-            ) from exc
 
-    if result is None:
-        raise RuntimeError("MCP tool call completed without a result")
+    _log_outcome(raw_request, request, ExecutionState.COMPLETED, "ok", started, timings)
     return result
+
+
+def _log_outcome(
+    raw_request: Request,
+    request: McpExecuteRequest,
+    execution_state: ExecutionState,
+    outcome: str,
+    started: float,
+    timings: dict[str, float],
+) -> None:
+    """Record timings, outcome and correlation ids, and nothing else (R-OBS-1, R-OBS-2).
+
+    Both ids are opaque: the caller's ``client_execution_id`` is a canonical
+    UUID validated at parse time, and the Otari request id is generated here.
+    Neither carries user content, approval content, arguments or credentials.
+    """
+    logger.info(
+        "Stateless MCP execution request_id=%s client_execution_id=%s server_id=%s "
+        "outcome=%s execution_state=%s duration_ms=%.2f phases=%s",
+        getattr(raw_request.state, "otari_request_id", "-"),
+        request.client_execution_id,
+        request.mcp_server_id,
+        outcome,
+        execution_state.value,
+        (time.monotonic() - started) * 1000,
+        # Durations and one byte count. The tool name, the arguments and the
+        # result are deliberately absent from every field above and here.
+        " ".join(f"{phase}={value:.2f}" for phase, value in sorted(timings.items())),
+    )

--- a/src/gateway/api/routes/mcp.py
+++ b/src/gateway/api/routes/mcp.py
@@ -92,7 +92,7 @@ from gateway.services.url_safety import UnsafeURLError, validate_mcp_url
 from gateway.services.workspace_scope import resolve_workspace_id
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Callable, Coroutine
 
     from fastapi import Response
 
@@ -157,7 +157,7 @@ class _McpRoute(APIRoute):
     deployment picks up an error shape it never published.
     """
 
-    def get_route_handler(self) -> Callable[[Request], Awaitable[Response]]:
+    def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
         original = super().get_route_handler()
 
         async def handler(request: Request) -> Response:

--- a/src/gateway/api/routes/mcp.py
+++ b/src/gateway/api/routes/mcp.py
@@ -37,6 +37,7 @@ from fastapi.routing import APIRoute
 from mcp.types import CallToolResult
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from gateway.api.deps import get_config, get_db_if_needed, verify_api_key_or_master_key
 from gateway.api.routes._platform import (
@@ -68,13 +69,16 @@ from gateway.services.mcp_stateless import (
     CODE_CREDENTIALS_UNAVAILABLE,
     CODE_DISCOVERY_CAPACITY_UNAVAILABLE,
     CODE_DISCOVERY_LIMIT_EXCEEDED,
+    CODE_FORBIDDEN,
     CODE_INVALID_REQUEST,
     CODE_OUTCOME_UNKNOWN,
+    CODE_PAYMENT_REQUIRED,
     CODE_RATE_LIMIT_EXCEEDED,
     CODE_RESOLUTION_FAILED,
     CODE_RESULT_TOO_LARGE,
     CODE_SERVER_CHANGED,
     CODE_SERVER_NOT_FOUND,
+    CODE_SERVICE_UNAVAILABLE,
     CODE_TOOL_NOT_ALLOWED,
     CODE_UNSAFE_URL,
     DISCOVERY_MAX_TOOLS,
@@ -114,7 +118,10 @@ TOOLS_LABEL = "mcp.list_tools"
 SAFE_DETAILS: dict[str, str] = {
     CODE_INVALID_REQUEST: "MCP request is invalid",
     CODE_AUTHENTICATION_FAILED: "Authentication failed",
+    CODE_PAYMENT_REQUIRED: "Payment required",
+    CODE_FORBIDDEN: "Request forbidden",
     CODE_RATE_LIMIT_EXCEEDED: "Rate limit exceeded",
+    CODE_SERVICE_UNAVAILABLE: "MCP service is unavailable",
     CODE_SERVER_NOT_FOUND: "MCP server not found",
     CODE_SERVER_CHANGED: "MCP server configuration changed, rediscover its tools",
     CODE_TOOL_NOT_ALLOWED: "The requested tool is not allowed for this MCP server",
@@ -178,7 +185,7 @@ class _McpRoute(APIRoute):
                     request_id,
                     headers=RETRY_AFTER_ONE if exc.code in _RETRYABLE_CAPACITY_CODES else None,
                 )
-            except HTTPException as exc:
+            except StarletteHTTPException as exc:
                 code, execution_state, status_code = _classify(exc)
                 retry_after = (exc.headers or {}).get("Retry-After")
                 return _error_response(
@@ -214,7 +221,7 @@ def _error_response(
     return JSONResponse(status_code=status_code, content=body.model_dump(mode="json"), headers=response_headers)
 
 
-def _classify(exc: HTTPException) -> tuple[str, ExecutionState, int]:
+def _classify(exc: StarletteHTTPException) -> tuple[str, ExecutionState, int]:
     """Map an authentication or platform refusal onto this contract's enums.
 
     Every one of these is raised before dispatch, so all of them are
@@ -222,12 +229,20 @@ def _classify(exc: HTTPException) -> tuple[str, ExecutionState, int]:
     it may describe a workspace, a plan, or a stored server, and R-ERR-1 lets
     nothing platform-side through.
     """
-    if exc.status_code in {401, 402, 403}:
+    if exc.status_code in {400, 422}:
+        return CODE_INVALID_REQUEST, ExecutionState.NOT_STARTED, 422
+    if exc.status_code == 401:
         return CODE_AUTHENTICATION_FAILED, ExecutionState.NOT_STARTED, 401
+    if exc.status_code == 402:
+        return CODE_PAYMENT_REQUIRED, ExecutionState.NOT_STARTED, 402
+    if exc.status_code == 403:
+        return CODE_FORBIDDEN, ExecutionState.NOT_STARTED, 403
     if exc.status_code == 404:
         return CODE_SERVER_NOT_FOUND, ExecutionState.NOT_STARTED, 404
     if exc.status_code == 429:
         return CODE_RATE_LIMIT_EXCEEDED, ExecutionState.NOT_STARTED, 429
+    if exc.status_code == 503:
+        return CODE_SERVICE_UNAVAILABLE, ExecutionState.NOT_STARTED, 503
     return CODE_RESOLUTION_FAILED, ExecutionState.NOT_STARTED, 502
 
 
@@ -465,6 +480,8 @@ class McpToolsResponse(BaseModel):
     responses={
         400: {"model": McpErrorBody},
         401: {"model": McpErrorBody},
+        402: {"model": McpErrorBody},
+        403: {"model": McpErrorBody},
         404: {"model": McpErrorBody},
         422: {"model": McpErrorBody},
         429: {"model": McpErrorBody},
@@ -574,6 +591,7 @@ async def list_mcp_tools(
     responses={
         400: {"model": McpErrorBody},
         401: {"model": McpErrorBody},
+        402: {"model": McpErrorBody},
         403: {"model": McpErrorBody},
         404: {"model": McpErrorBody},
         409: {"model": McpErrorBody},
@@ -641,11 +659,13 @@ async def execute_mcp_tool(
         # The total deadline can only be reached before dispatch here: past it,
         # the call's own deadline is the shorter of the two and classifies the
         # failure itself.
-        raise McpExecutionError(
+        exc = McpExecutionError(
             CODE_OUTCOME_UNKNOWN if dispatched else CODE_CONNECTION_FAILED,
             ExecutionState.OUTCOME_UNKNOWN if dispatched else ExecutionState.NOT_STARTED,
             504 if dispatched else 502,
-        ) from None
+        )
+        _log_outcome(raw_request, request, exc.execution_state, exc.code, started, timings)
+        raise exc from None
     except McpExecutionError as exc:
         _log_outcome(raw_request, request, exc.execution_state, exc.code, started, timings)
         raise

--- a/src/gateway/api/routes/mcp.py
+++ b/src/gateway/api/routes/mcp.py
@@ -582,6 +582,7 @@ async def execute_mcp_tool(
     exactly that. Proxies, service meshes and SDKs on this path have to disable
     retries for it, including on connection resets and 5xx responses.
     """
+    started = time.monotonic()
     principal = await _authenticate(raw_request, db, config)
     server = await _resolve_server(principal, db, config, request.mcp_server_id)
     _require_allowed(server, request.tool_name)
@@ -597,7 +598,6 @@ async def execute_mcp_tool(
     track_request(raw_request, endpoint=EXECUTE_ENDPOINT, model=EXECUTE_LABEL)
 
     dispatched = False
-    started = time.monotonic()
     timings: dict[str, float] = {"resolve_ms": (time.monotonic() - started) * 1000}
 
     def mark_dispatched() -> None:

--- a/src/gateway/api/routes/mcp.py
+++ b/src/gateway/api/routes/mcp.py
@@ -84,6 +84,7 @@ from gateway.services.mcp_stateless import (
     McpExecutionError,
     arguments_within_bounds,
     discover_stored_tools,
+    discovery_response_exceeds_bound,
     execute_stored_tool,
 )
 from gateway.services.secret_box import SecretBoxUnavailableError, SecretDecryptionError
@@ -499,7 +500,10 @@ async def list_mcp_tools(
     if server.allowed_tools == []:
         # An operator's explicit deny-all is a complete answer already, so this
         # opens no connection at all (R-RES-4).
-        return McpToolsResponse(server_id=server.id, server_revision=server.revision, tools=[], warnings=[])
+        response = McpToolsResponse(server_id=server.id, server_revision=server.revision, tools=[], warnings=[])
+        if discovery_response_exceeds_bound(response):  # pragma: no cover - fixed-size response
+            raise McpExecutionError(CODE_DISCOVERY_LIMIT_EXCEEDED, ExecutionState.NOT_STARTED, 502)
+        return response
 
     await release_session(db)
     await _require_safe_url(server)
@@ -518,15 +522,7 @@ async def list_mcp_tools(
         )
         raise
 
-    logger.info(
-        "Stateless MCP discovery request_id=%s server_id=%s outcome=ok tools=%d omitted=%d duration_ms=%.2f",
-        getattr(raw_request.state, "otari_request_id", "-"),
-        mcp_server_id,
-        len(catalog.tools),
-        len(catalog.warnings),
-        (time.monotonic() - started) * 1000,
-    )
-    return McpToolsResponse(
+    response = McpToolsResponse(
         server_id=server.id,
         server_revision=server.revision,
         tools=[
@@ -542,6 +538,17 @@ async def list_mcp_tools(
         ],
         warnings=[McpToolWarning(tool_name=name, code=code) for name, code in catalog.warnings],
     )
+    if discovery_response_exceeds_bound(response):
+        raise McpExecutionError(CODE_DISCOVERY_LIMIT_EXCEEDED, ExecutionState.NOT_STARTED, 502)
+    logger.info(
+        "Stateless MCP discovery request_id=%s server_id=%s outcome=ok tools=%d omitted=%d duration_ms=%.2f",
+        getattr(raw_request.state, "otari_request_id", "-"),
+        mcp_server_id,
+        len(catalog.tools),
+        len(catalog.warnings),
+        (time.monotonic() - started) * 1000,
+    )
+    return response
 
 
 @router.post(
@@ -583,22 +590,8 @@ async def execute_mcp_tool(
     retries for it, including on connection resets and 5xx responses.
     """
     started = time.monotonic()
-    principal = await _authenticate(raw_request, db, config)
-    server = await _resolve_server(principal, db, config, request.mcp_server_id)
-    _require_allowed(server, request.tool_name)
-    if request.server_revision != server.revision:
-        # In memory, over the resolution both modes already needed, so this
-        # costs no database, platform or MCP round trip (R-RES-2).
-        raise McpExecutionError(CODE_SERVER_CHANGED, ExecutionState.NOT_STARTED, 409)
-
-    # Before DNS, before the concurrency wait, and before any MCP network I/O:
-    # a pooled connection must not be pinned for the length of a remote call.
-    await release_session(db)
-    await _require_safe_url(server)
-    track_request(raw_request, endpoint=EXECUTE_ENDPOINT, model=EXECUTE_LABEL)
-
     dispatched = False
-    timings: dict[str, float] = {"resolve_ms": (time.monotonic() - started) * 1000}
+    timings: dict[str, float] = {}
 
     def mark_dispatched() -> None:
         nonlocal dispatched
@@ -606,6 +599,21 @@ async def execute_mcp_tool(
 
     try:
         async with asyncio.timeout(mcp_stateless.EXECUTION_TOTAL_TIMEOUT_S):
+            principal = await _authenticate(raw_request, db, config)
+            server = await _resolve_server(principal, db, config, request.mcp_server_id)
+            _require_allowed(server, request.tool_name)
+            if request.server_revision != server.revision:
+                # In memory, over the resolution both modes already needed, so this
+                # costs no database, platform or MCP round trip (R-RES-2).
+                raise McpExecutionError(CODE_SERVER_CHANGED, ExecutionState.NOT_STARTED, 409)
+
+            # Before DNS, before the concurrency wait, and before any MCP network I/O:
+            # a pooled connection must not be pinned for the length of a remote call.
+            await release_session(db)
+            await _require_safe_url(server)
+            timings["resolve_ms"] = (time.monotonic() - started) * 1000
+            track_request(raw_request, endpoint=EXECUTE_ENDPOINT, model=EXECUTE_LABEL)
+
             result = await execute_stored_tool(
                 server,
                 request.tool_name,

--- a/src/gateway/models/mcp.py
+++ b/src/gateway/models/mcp.py
@@ -1,4 +1,4 @@
-"""Request-body models for inline MCP server configuration on /v1/chat/completions."""
+"""Request-body models for inline MCP server configuration."""
 
 from __future__ import annotations
 
@@ -18,7 +18,7 @@ MAX_MCP_SERVER_IDS = 50
 
 
 class McpServerConfig(BaseModel):
-    """Inline MCP server configuration accepted on the chat completions request.
+    """Inline MCP server configuration accepted by generation and execution requests.
 
     Streamable HTTP transport. The `url` must be reachable from the gateway process.
 

--- a/src/gateway/models/mcp.py
+++ b/src/gateway/models/mcp.py
@@ -1,8 +1,12 @@
-"""Request-body models for inline MCP server configuration."""
+"""Wire and internal models for MCP server configuration."""
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+import hashlib
+import json
+import uuid
+
+from pydantic import BaseModel, ConfigDict, Field, StrictBool
 
 # Ceiling on ``mcp_server_ids`` in one request. A workspace can hold at most 50
 # configured servers, in standalone (``MAX_MCP_SERVERS_PER_WORKSPACE`` in
@@ -15,6 +19,11 @@ from pydantic import BaseModel, Field
 # unbounded ``IN`` list, which is why the usage filters carry the same kind of
 # ceiling (``core/sql.MAX_FILTER_VALUES``).
 MAX_MCP_SERVER_IDS = 50
+
+# Hex characters kept from the revision digest. 32 leaves collision risk far
+# below the chance of a stored-server change going unnoticed for any other
+# reason, and stays well inside the 1-to-128-character wire format (R-DISC-3).
+REVISION_LENGTH = 32
 
 
 class McpServerConfig(BaseModel):
@@ -36,3 +45,66 @@ class McpServerConfig(BaseModel):
     authorization_token: str | None = None
     purpose_hint: str | None = Field(default=None, max_length=2000)
     allowed_tools: list[str] | None = None
+
+
+class ResolvedMcpServer(BaseModel):
+    """One stored MCP server, resolved for the authenticated workspace.
+
+    The internal counterpart of :class:`McpServerConfig`: the same connection
+    details, plus the two fields the stored-server endpoints need and an inline
+    request body cannot carry. ``id`` is what the exactly-one-matching-entry
+    check compares, and ``enabled`` is what separates the disabled-server 404
+    from a server the caller cannot see at all.
+
+    Lives here rather than beside either resolver because both modes produce it:
+    ``_platform._resolve_platform_mcp_server`` in hybrid mode and
+    ``workspace_mcp_server_service.resolve_workspace_mcp_server`` in standalone,
+    and a service may not import the API layer.
+    """
+
+    # Extra keys are ignored so a platform that grows a field does not break a
+    # gateway that has not learned about it, but ``enabled`` is strict: lax
+    # coercion would read a resolver that answered ``"no"`` as enabled, and this
+    # flag is what stands between a decommissioned server and a live execution.
+    model_config = ConfigDict(extra="ignore")
+
+    id: uuid.UUID
+    name: str = Field(min_length=1, max_length=128)
+    url: str = Field(min_length=1)
+    authorization_token: str | None = None
+    enabled: StrictBool = True
+    purpose_hint: str | None = Field(default=None, max_length=2000)
+    allowed_tools: list[str] | None = None
+
+    @property
+    def revision(self) -> str:
+        """The opaque revision of this server's execution-relevant configuration.
+
+        Derived rather than stored (R-RES-3): a pure function of the four fields
+        that change what an execution does, so every worker and replica agrees
+        by construction and the value moves atomically with the configuration it
+        covers. ``name`` and ``purpose_hint`` are excluded, so retitling a server
+        does not invalidate an authorization an application is still holding.
+
+        The credential contributes only as a digest, and the whole value is a
+        digest, so neither the token nor the URL can be read back out of a
+        revision that travels to a caller.
+        """
+        canonical = json.dumps(
+            {
+                "url": self.url,
+                "credential": _credential_fingerprint(self.authorization_token),
+                "enabled": self.enabled,
+                "allowed_tools": None if self.allowed_tools is None else sorted(self.allowed_tools),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(canonical.encode()).hexdigest()[:REVISION_LENGTH]
+
+
+def _credential_fingerprint(token: str | None) -> str:
+    """Distinguish credentials without carrying one into the revision input."""
+    if token is None:
+        return ""
+    return hashlib.sha256(token.encode()).hexdigest()

--- a/src/gateway/models/mcp.py
+++ b/src/gateway/models/mcp.py
@@ -63,9 +63,9 @@ class ResolvedMcpServer(BaseModel):
     """
 
     # Extra keys are ignored so a platform that grows a field does not break a
-    # gateway that has not learned about it, but ``enabled`` is strict: lax
-    # coercion would read a resolver that answered ``"no"`` as enabled, and this
-    # flag is what stands between a decommissioned server and a live execution.
+    # gateway that has not learned about it. ``enabled`` defaults true for legacy
+    # peers that return only enabled server configs, but an explicit value is
+    # strict: lax coercion would read a resolver that answered ``"no"`` as enabled.
     model_config = ConfigDict(extra="ignore")
 
     id: uuid.UUID

--- a/src/gateway/models/mcp.py
+++ b/src/gateway/models/mcp.py
@@ -27,7 +27,7 @@ REVISION_LENGTH = 32
 
 
 class McpServerConfig(BaseModel):
-    """Inline MCP server configuration accepted by generation and execution requests.
+    """Inline MCP server configuration accepted by generation requests.
 
     Streamable HTTP transport. The `url` must be reachable from the gateway process.
 

--- a/src/gateway/services/mcp_client.py
+++ b/src/gateway/services/mcp_client.py
@@ -187,7 +187,7 @@ class MCPClientPool:
         """Return the configured server that owns ``name``, if connected."""
         return self._tool_owner.get(name)
 
-    async def call_tool_result(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+    async def _call_tool_result(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
         """Execute an MCP call and return the server's native typed result."""
         owner = self._tool_owner.get(name)
         if owner is None:
@@ -211,7 +211,7 @@ class MCPClientPool:
         if name not in self._tool_owner:
             raise KeyError(f"No MCP server owns tool {name!r}")
         try:
-            result = await self.call_tool_result(name, arguments)
+            result = await self._call_tool_result(name, arguments)
         except Exception as exc:
             logger.warning("MCP tool %s execution failed: %s", name, type(exc).__name__)
             return MCPToolCallOutcome(

--- a/src/gateway/services/mcp_client.py
+++ b/src/gateway/services/mcp_client.py
@@ -27,6 +27,7 @@ from gateway.log_config import logger
 from gateway.services.tool_usage import ToolUsageTally
 
 if TYPE_CHECKING:
+    from mcp.types import CallToolResult
     from mcp.types import Tool as MCPTool
 
     from gateway.models.mcp import McpServerConfig
@@ -148,7 +149,7 @@ class MCPClientPool:
         await session.initialize()
 
         listed = await session.list_tools()
-        allowed = set(cfg.allowed_tools) if cfg.allowed_tools else None
+        allowed = set(cfg.allowed_tools) if cfg.allowed_tools is not None else None
         openai_tools: list[dict[str, Any]] = []
         for tool in listed.tools:
             if allowed is not None and tool.name not in allowed:
@@ -186,6 +187,18 @@ class MCPClientPool:
         """Return the configured server that owns ``name``, if connected."""
         return self._tool_owner.get(name)
 
+    async def call_tool_result(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+        """Execute an MCP call and return the server's native typed result."""
+        owner = self._tool_owner.get(name)
+        if owner is None:
+            raise KeyError(f"No MCP server owns tool {name!r}")
+        try:
+            return await self._servers[owner].session.call_tool(name, arguments)
+        except Exception:
+            if self._tally is not None:
+                self._tally.record_failure(name)
+            raise
+
     async def call_tool_outcome(self, name: str, arguments: dict[str, Any]) -> MCPToolCallOutcome:
         """Execute an MCP call and preserve its explicit ``isError`` status.
 
@@ -195,14 +208,11 @@ class MCPClientPool:
         headers, or credentials cannot reach logs or a model provider through any
         API format.
         """
-        owner = self._tool_owner.get(name)
-        if owner is None:
+        if name not in self._tool_owner:
             raise KeyError(f"No MCP server owns tool {name!r}")
         try:
-            result = await self._servers[owner].session.call_tool(name, arguments)
+            result = await self.call_tool_result(name, arguments)
         except Exception as exc:
-            if self._tally is not None:
-                self._tally.record_failure(name)
             logger.warning("MCP tool %s execution failed: %s", name, type(exc).__name__)
             return MCPToolCallOutcome(
                 content="[tool error] MCP tool execution failed",

--- a/src/gateway/services/mcp_stateless.py
+++ b/src/gateway/services/mcp_stateless.py
@@ -110,6 +110,7 @@ EXECUTION_ADMISSION_TIMEOUT_S = 5.0
 # --------------------------------------------------------------------------- #
 
 # Per-tool omission codes, reported in a discovery response's ``warnings``.
+WARN_NAME_UNSUPPORTED = "mcp_tool_name_unsupported"
 WARN_SCHEMA_UNSUPPORTED = "mcp_tool_schema_unsupported"
 WARN_DESCRIPTION_TOO_LARGE = "mcp_tool_description_too_large"
 WARN_ANNOTATIONS_TOO_LARGE = "mcp_tool_annotations_too_large"
@@ -283,10 +284,12 @@ def screen_tool(tool: MCPTool) -> str | None:
 
     Structural and size checks only (R-SCHEMA-1). The schema is untrusted data
     rather than something Otari executes, so an unrecognized dialect or keyword
-    is carried through untouched; what is refused is a schema Otari cannot
-    safely hold in memory, or one that would make it fetch a second schema over
-    the network to be understood at all.
+    is carried through untouched; what is refused is a descriptor Otari cannot
+    safely return or execute, or a schema that would make it fetch another
+    schema over the network to be understood at all.
     """
+    if not tool.name or len(tool.name) > TOOL_NAME_MAX_LENGTH:
+        return WARN_NAME_UNSUPPORTED
     if _oversized(tool.description, TOOL_DESCRIPTION_MAX_BYTES):
         return WARN_DESCRIPTION_TOO_LARGE
     if tool.annotations is not None and _oversized(tool.annotations, TOOL_ANNOTATIONS_MAX_BYTES):
@@ -543,6 +546,8 @@ async def _discover_once(server: ResolvedMcpServer) -> DiscoveredCatalog:
             else:
                 warnings.append((tool.name, code))
 
+        if len(tools) > DISCOVERY_MAX_TOOLS:
+            raise McpExecutionError(CODE_DISCOVERY_LIMIT_EXCEEDED, ExecutionState.NOT_STARTED, 502)
         if _oversized(tools, DISCOVERY_RESPONSE_MAX_BYTES):
             raise McpExecutionError(CODE_DISCOVERY_LIMIT_EXCEEDED, ExecutionState.NOT_STARTED, 502)
         return DiscoveredCatalog(tools=tools, warnings=warnings)
@@ -560,7 +565,8 @@ async def collect_tools(session: Any, *, allowed_tools: list[str] | None) -> lis
 
     Pagination stops early once every allowlisted name has been seen. A server
     with thousands of tools and a three-name allowlist is then one or two pages,
-    not twenty, and the ceiling below stays a defense rather than a routine cost.
+    not twenty. The returned-tool ceiling is applied after descriptor screening,
+    so omitted tools do not take valid siblings away from the caller.
 
     Raises:
         McpDiscoveryRefused: on a pagination validation failure (R-DISC-4) or a
@@ -579,7 +585,7 @@ async def collect_tools(session: Any, *, allowed_tools: list[str] | None) -> lis
             raise McpDiscoveryRefused
         for tool in tools:
             name = getattr(tool, "name", None)
-            if not isinstance(name, str) or not name:
+            if not isinstance(name, str):
                 raise McpDiscoveryRefused
             examined += 1
             if examined > DISCOVERY_MAX_EXAMINED:
@@ -596,8 +602,6 @@ async def collect_tools(session: Any, *, allowed_tools: list[str] | None) -> lis
                     raise McpDiscoveryRefused
                 continue
             collected[name] = tool
-            if len(collected) > DISCOVERY_MAX_TOOLS:
-                raise McpDiscoveryRefused
 
         if allowed is not None and allowed.issubset(collected):
             break

--- a/src/gateway/services/mcp_stateless.py
+++ b/src/gateway/services/mcp_stateless.py
@@ -195,6 +195,29 @@ class McpExecutionError(Exception):
 # --------------------------------------------------------------------------- #
 
 
+# Nesting depth followed when naming a grouped failure. anyio nests one level,
+# so this only exists so a pathological group cannot recurse without end.
+_FAILURE_GROUP_MAX_DEPTH = 4
+
+
+def failure_class(exc: BaseException, _depth: int = 0) -> str:
+    """Name a failure by its leaf types, carrying nothing the exception said.
+
+    The MCP SDK yields inside ``anyio.create_task_group()``, so a transport
+    failure usually arrives wrapped: ``ExceptionGroup('unhandled errors in a
+    TaskGroup', [ConnectError(...)])``. Logging the outer type alone records
+    ``ExceptionGroup`` for nearly every real failure, which is no diagnostic at
+    all, so the leaves are named instead.
+
+    Types only, never a message: an exception's message can hold the server URL,
+    the credential, or the caller's arguments (R-OBS-2).
+    """
+    if isinstance(exc, BaseExceptionGroup) and _depth < _FAILURE_GROUP_MAX_DEPTH:
+        leaves = sorted({failure_class(leaf, _depth + 1) for leaf in exc.exceptions})
+        return "+".join(leaves) if leaves else type(exc).__name__
+    return type(exc).__name__
+
+
 def _oversized(value: Any, ceiling: int) -> bool:
     """Whether ``value`` exceeds ``ceiling`` once encoded.
 
@@ -456,25 +479,29 @@ async def discover_stored_tools(server: ResolvedMcpServer) -> DiscoveredCatalog:
     except McpCapacityUnavailable:
         raise McpExecutionError(CODE_DISCOVERY_CAPACITY_UNAVAILABLE, ExecutionState.NOT_STARTED, 503) from None
     except TimeoutError:
+        # This deadline, converted by ``asyncio.timeout`` on the way out, which
+        # is why the arm below cannot mistake it for the server cancelling us.
         raise McpExecutionError(CODE_DISCOVERY_LIMIT_EXCEEDED, ExecutionState.NOT_STARTED, 502) from None
+    except McpExecutionError:
+        raise
+    except BaseException as exc:
+        # Everything the transport can throw, in the shapes it actually throws
+        # them: a bare ``CancelledError`` when the SDK's task group cancels its
+        # caller, or a group when it collects several. Neither is an
+        # ``Exception``, so a narrower arm here would let the most ordinary
+        # failure of all escape the error contract and answer nothing.
+        logger.warning("Stateless MCP discovery failed error_class=%s", failure_class(exc))
+        raise McpExecutionError(CODE_CONNECTION_FAILED, ExecutionState.NOT_STARTED, 502) from None
 
 
 async def _discover_once(server: ResolvedMcpServer) -> DiscoveredCatalog:
     stack = AsyncExitStack()
     try:
-        try:
-            session = await stack.enter_async_context(open_session(server))
-        except Exception as exc:
-            logger.warning("Stateless MCP discovery connection failed error_class=%s", type(exc).__name__)
-            raise McpExecutionError(CODE_CONNECTION_FAILED, ExecutionState.NOT_STARTED, 502) from None
-
+        session = await stack.enter_async_context(open_session(server))
         try:
             listed = await collect_tools(session, allowed_tools=server.allowed_tools)
         except McpDiscoveryRefused:
             raise McpExecutionError(CODE_DISCOVERY_LIMIT_EXCEEDED, ExecutionState.NOT_STARTED, 502) from None
-        except Exception as exc:
-            logger.warning("Stateless MCP discovery failed error_class=%s", type(exc).__name__)
-            raise McpExecutionError(CODE_CONNECTION_FAILED, ExecutionState.NOT_STARTED, 502) from None
 
         tools: list[MCPTool] = []
         warnings: list[tuple[str, str]] = []
@@ -611,13 +638,19 @@ async def _execute_once(
     try:
         try:
             session = await stack.enter_async_context(open_session(server))
-        except Exception as exc:
+        except BaseException as exc:
+            # ``BaseException``, not ``Exception``, because that is what a dead
+            # server actually raises: the SDK yields inside an anyio task group,
+            # so a closed port surfaces as a bare ``CancelledError`` and a
+            # collected failure as a group, and neither is an ``Exception``. A
+            # narrower arm let the commonest failure of all escape the contract
+            # and return no response at all.
+            #
             # Still ``not_started``: nothing was written, so the caller's own
-            # execution claim is still safe to release or retry (R-ERR-2).
-            # Cancellation is deliberately not caught here and below: it is also
-            # how an enclosing phase deadline arrives, and converting it into a
-            # connection failure would hide which bound was actually reached.
-            logger.warning("Stateless MCP connection failed error_class=%s", type(exc).__name__)
+            # execution claim is safe to release or retry (R-ERR-2). The
+            # enclosing total deadline reaches here as a cancellation too, and
+            # is reported the same way, which is the same status and state.
+            logger.warning("Stateless MCP connection failed error_class=%s", failure_class(exc))
             raise McpExecutionError(CODE_CONNECTION_FAILED, ExecutionState.NOT_STARTED, 502) from None
 
         timings["connect_ms"] = (monotonic() - phase_started) * 1000
@@ -629,11 +662,13 @@ async def _execute_once(
                 result = await session.call_tool(tool_name, arguments)
         except TimeoutError:
             raise McpExecutionError(CODE_OUTCOME_UNKNOWN, ExecutionState.OUTCOME_UNKNOWN, 504) from None
-        except (Exception, asyncio.CancelledError) as exc:
-            # Deliberately conservative (R-ERR-3), cancellation included: a
-            # cancelled local transport says nothing about whether the remote
-            # server ran the tool to completion.
-            logger.warning("Stateless MCP call failed after dispatch error_class=%s", type(exc).__name__)
+        except BaseException as exc:
+            # Deliberately conservative (R-ERR-3), cancellation and grouped
+            # cancellation included: a cancelled local transport says nothing
+            # about whether the remote server ran the tool to completion, and
+            # letting either escape would answer a possibly-completed mutation
+            # with no execution state at all.
+            logger.warning("Stateless MCP call failed after dispatch error_class=%s", failure_class(exc))
             raise McpExecutionError(CODE_OUTCOME_UNKNOWN, ExecutionState.OUTCOME_UNKNOWN, 502) from None
 
         finally:
@@ -667,5 +702,5 @@ async def _close_bounded(stack: AsyncExitStack) -> None:
     try:
         async with asyncio.timeout(CLEANUP_TIMEOUT_S):
             await asyncio.shield(closer)
-    except (Exception, asyncio.CancelledError) as exc:
-        logger.warning("Stateless MCP cleanup failed error_class=%s", type(exc).__name__)
+    except BaseException as exc:
+        logger.warning("Stateless MCP cleanup failed error_class=%s", failure_class(exc))

--- a/src/gateway/services/mcp_stateless.py
+++ b/src/gateway/services/mcp_stateless.py
@@ -82,13 +82,9 @@ DISCOVERY_MAX_EXAMINED = 1000
 DISCOVERY_MAX_TOOLS = 200
 DISCOVERY_RESPONSE_MAX_BYTES = 1024 * 1024
 
-# Transport (L-TRANSPORT-BYTES, L-RESULT-BYTES). One ceiling, enforced at the
-# two points that need no change to the MCP SDK's transport: the
-# ``Content-Length`` a well-behaved server sends, checked before the body is
-# read, and the decoded result, measured after. A chunked or SSE response
-# carries no length and the SDK buffers it before handing back a result, so in
-# the first version that case is bounded by the call and total deadlines rather
-# than mid-stream (R-TRANSPORT-1).
+# Transport (L-TRANSPORT-BYTES, L-RESULT-BYTES). Compressed responses are
+# refused before reading, and uncompressed response streams are counted as
+# they are consumed, including chunked JSON and SSE (R-TRANSPORT-1).
 TRANSPORT_MAX_BYTES = 1024 * 1024
 RESULT_MAX_BYTES = 1024 * 1024
 
@@ -323,25 +319,50 @@ def arguments_within_bounds(arguments: dict[str, Any]) -> bool:
 
 
 async def enforce_content_length(response: httpx.Response) -> None:
-    """Refuse an oversized response before its body is read.
+    """Install the decoded response ceiling before the body is read.
 
     Registered as an httpx response event hook, which runs with the headers
-    available and the body still unread, so a server declaring a gigabyte never
-    gets to send one.
-
-    A response with no ``Content-Length`` passes here and is caught by the
-    post-decode measurement instead; that is the documented shape of this bound
-    (R-TRANSPORT-1), not an oversight.
+    available and the body still unread. Compression is refused because one
+    encoded chunk can expand beyond the ceiling before a decoded-byte counter
+    can inspect it. Identity-encoded streams are wrapped so missing or dishonest
+    ``Content-Length`` values cannot bypass the limit.
     """
-    declared = response.headers.get("content-length")
-    if declared is None:
-        return
-    try:
-        length = int(declared)
-    except ValueError:
-        return
-    if length > TRANSPORT_MAX_BYTES:
+    content_encoding = response.headers.get("content-encoding", "identity").strip().lower()
+    if content_encoding not in {"", "identity"}:
         raise TransportResponseTooLarge
+
+    declared = response.headers.get("content-length")
+    if declared is not None:
+        try:
+            length = int(declared)
+        except ValueError:
+            pass
+        else:
+            if length > TRANSPORT_MAX_BYTES:
+                raise TransportResponseTooLarge
+
+    if not isinstance(response.stream, httpx.AsyncByteStream):  # pragma: no cover - async client invariant
+        raise TypeError("Expected an asynchronous HTTP response stream")
+    response.stream = _BoundedResponseStream(response.stream, TRANSPORT_MAX_BYTES)
+
+
+class _BoundedResponseStream(httpx.AsyncByteStream):
+    """Count response bytes while preserving streaming and close behavior."""
+
+    def __init__(self, stream: httpx.AsyncByteStream, ceiling: int) -> None:
+        self._stream = stream
+        self._ceiling = ceiling
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        consumed = 0
+        async for chunk in self._stream:
+            consumed += len(chunk)
+            if consumed > self._ceiling:
+                raise TransportResponseTooLarge
+            yield chunk
+
+    async def aclose(self) -> None:
+        await self._stream.aclose()
 
 
 def build_http_client_factory() -> Callable[..., httpx.AsyncClient]:
@@ -359,13 +380,14 @@ def build_http_client_factory() -> Callable[..., httpx.AsyncClient]:
         timeout: httpx.Timeout | None = None,
         auth: httpx.Auth | None = None,
     ) -> httpx.AsyncClient:
+        client_headers = dict(headers or {})
+        client_headers["Accept-Encoding"] = "identity"
         kwargs: dict[str, Any] = {
             "follow_redirects": False,
             "timeout": timeout if timeout is not None else httpx.Timeout(CONNECT_TIMEOUT_S, read=CALL_TIMEOUT_S),
             "event_hooks": {"response": [enforce_content_length]},
+            "headers": client_headers,
         }
-        if headers is not None:
-            kwargs["headers"] = headers
         if auth is not None:
             kwargs["auth"] = auth
         return httpx.AsyncClient(**kwargs)
@@ -381,6 +403,15 @@ def result_exceeds_bound(result: CallToolResult) -> bool:
     back.
     """
     return _oversized(result, RESULT_MAX_BYTES)
+
+
+def discovery_response_exceeds_bound(response: Any) -> bool:
+    """Whether the complete serialized discovery response exceeds its ceiling."""
+    try:
+        value = response.model_dump(mode="json") if hasattr(response, "model_dump") else response
+        return len(_encode(value)) > DISCOVERY_RESPONSE_MAX_BYTES
+    except (TypeError, ValueError):
+        return True
 
 
 class ConcurrencyGate:
@@ -473,8 +504,8 @@ async def discover_stored_tools(server: ResolvedMcpServer) -> DiscoveredCatalog:
         McpExecutionError: with the code and status the route returns.
     """
     try:
-        async with DISCOVERY_GATE.slot():
-            async with asyncio.timeout(DISCOVERY_TOTAL_TIMEOUT_S):
+        async with asyncio.timeout(DISCOVERY_TOTAL_TIMEOUT_S):
+            async with DISCOVERY_GATE.slot():
                 return await _discover_once(server)
     except McpCapacityUnavailable:
         raise McpExecutionError(CODE_DISCOVERY_CAPACITY_UNAVAILABLE, ExecutionState.NOT_STARTED, 503) from None

--- a/src/gateway/services/mcp_stateless.py
+++ b/src/gateway/services/mcp_stateless.py
@@ -692,15 +692,17 @@ async def _close_bounded(stack: AsyncExitStack) -> None:
     Shielded and bounded (R-EXEC-1). A definitive result is already in hand by
     the time this runs, so a transport that will not close, or a request whose
     task is being cancelled, must not turn a completed mutation into an error
-    the caller might retry. A close that overruns its deadline is left to finish
-    on its own and reported as a failure class with no content.
+    the caller might retry. A close that overruns its deadline is cancelled and
+    awaited so stalled shutdowns cannot accumulate detached transport tasks.
     """
     closer = asyncio.ensure_future(stack.aclose())
-    # Read the outcome even when the wait below gives up on it, so an abandoned
-    # close cannot surface later as an unretrieved task exception.
-    closer.add_done_callback(lambda task: task.exception() if not task.cancelled() else None)
     try:
         async with asyncio.timeout(CLEANUP_TIMEOUT_S):
             await asyncio.shield(closer)
     except BaseException as exc:
         logger.warning("Stateless MCP cleanup failed error_class=%s", failure_class(exc))
+        closer.cancel()
+        try:
+            await closer
+        except BaseException:
+            pass

--- a/src/gateway/services/mcp_stateless.py
+++ b/src/gateway/services/mcp_stateless.py
@@ -507,18 +507,16 @@ async def discover_stored_tools(server: ResolvedMcpServer) -> DiscoveredCatalog:
         McpExecutionError: with the code and status the route returns.
     """
     try:
-        async with asyncio.timeout(DISCOVERY_TOTAL_TIMEOUT_S):
-            async with DISCOVERY_GATE.slot():
-                return await _discover_once(server)
+        async with DISCOVERY_GATE.slot():
+            return await _discover_once(server)
     except McpCapacityUnavailable:
         raise McpExecutionError(CODE_DISCOVERY_CAPACITY_UNAVAILABLE, ExecutionState.NOT_STARTED, 503) from None
-    except TimeoutError:
-        # This deadline, converted by ``asyncio.timeout`` on the way out, which
-        # is why the arm below cannot mistake it for the server cancelling us.
-        raise McpExecutionError(CODE_DISCOVERY_LIMIT_EXCEEDED, ExecutionState.NOT_STARTED, 502) from None
     except McpExecutionError:
         raise
     except BaseException as exc:
+        task = asyncio.current_task()
+        if isinstance(exc, asyncio.CancelledError) and task is not None and task.cancelling():
+            raise
         # Everything the transport can throw, in the shapes it actually throws
         # them: a bare ``CancelledError`` when the SDK's task group cancels its
         # caller, or a group when it collects several. Neither is an

--- a/src/gateway/services/mcp_stateless.py
+++ b/src/gateway/services/mcp_stateless.py
@@ -22,7 +22,7 @@ from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
 from enum import StrEnum
 from time import monotonic
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import httpx
 from mcp import ClientSession
@@ -31,7 +31,7 @@ from mcp.client.streamable_http import streamablehttp_client
 from gateway.log_config import logger
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable, MutableMapping
+    from collections.abc import AsyncIterator, Callable, Coroutine, MutableMapping
 
     from mcp.types import CallToolResult
     from mcp.types import Tool as MCPTool
@@ -130,13 +130,19 @@ CODE_TOOL_NOT_ALLOWED = "mcp_tool_not_allowed"
 CODE_UNSAFE_URL = "unsafe_mcp_url"
 CODE_CREDENTIALS_UNAVAILABLE = "mcp_credentials_unavailable"
 CODE_AUTHENTICATION_FAILED = "authentication_failed"
+CODE_PAYMENT_REQUIRED = "payment_required"
+CODE_FORBIDDEN = "forbidden"
 CODE_RATE_LIMIT_EXCEEDED = "rate_limit_exceeded"
+CODE_SERVICE_UNAVAILABLE = "service_unavailable"
 CODE_INVALID_REQUEST = "invalid_request"
 
 
 # --------------------------------------------------------------------------- #
 # Failure types
 # --------------------------------------------------------------------------- #
+
+
+T = TypeVar("T")
 
 
 class McpDiscoveryRefused(Exception):
@@ -453,6 +459,16 @@ DISCOVERY_GATE = ConcurrencyGate(limit=DISCOVERY_CONCURRENCY, admission_timeout_
 EXECUTION_GATE = ConcurrencyGate(limit=EXECUTION_CONCURRENCY, admission_timeout_s=EXECUTION_ADMISSION_TIMEOUT_S)
 
 
+async def _run_in_owner_task(operation: Coroutine[Any, Any, T]) -> T:
+    """Run an anyio-backed context entirely in one task and await its cleanup."""
+    owner = asyncio.create_task(operation)
+    try:
+        return await asyncio.shield(owner)
+    except asyncio.CancelledError:
+        owner.cancel()
+        return await owner
+
+
 @asynccontextmanager
 async def open_session(server: ResolvedMcpServer) -> AsyncIterator[ClientSession]:
     """Open one size-bounded, redirect-disabled MCP session on a stored server.
@@ -508,7 +524,7 @@ async def discover_stored_tools(server: ResolvedMcpServer) -> DiscoveredCatalog:
     """
     try:
         async with DISCOVERY_GATE.slot():
-            return await _discover_once(server)
+            return await _run_in_owner_task(_discover_once(server))
     except McpCapacityUnavailable:
         raise McpExecutionError(CODE_DISCOVERY_CAPACITY_UNAVAILABLE, ExecutionState.NOT_STARTED, 503) from None
     except McpExecutionError:
@@ -653,7 +669,7 @@ async def execute_stored_tool(
     try:
         async with EXECUTION_GATE.slot():
             record["admission_ms"] = (monotonic() - admission_started) * 1000
-            return await _execute_once(server, tool_name, arguments, on_dispatch, record)
+            return await _run_in_owner_task(_execute_once(server, tool_name, arguments, on_dispatch, record))
     except McpCapacityUnavailable:
         record["admission_ms"] = (monotonic() - admission_started) * 1000
         raise McpExecutionError(CODE_CAPACITY_UNAVAILABLE, ExecutionState.NOT_STARTED, 503) from None
@@ -722,20 +738,13 @@ async def _execute_once(
 async def _close_bounded(stack: AsyncExitStack) -> None:
     """Close the transport without letting shutdown outlive or replace a result.
 
-    Shielded and bounded (R-EXEC-1). A definitive result is already in hand by
-    the time this runs, so a transport that will not close, or a request whose
-    task is being cancelled, must not turn a completed mutation into an error
-    the caller might retry. A close that overruns its deadline is cancelled and
-    awaited so stalled shutdowns cannot accumulate detached transport tasks.
+    Bounded and run in the same owner task that entered the transport
+    (R-EXEC-1). A definitive result is already in hand by the time this runs, so
+    a transport that will not close must not replace it. The timeout cancels and
+    awaits cleanup in place, so no transport task is detached.
     """
-    closer = asyncio.ensure_future(stack.aclose())
     try:
         async with asyncio.timeout(CLEANUP_TIMEOUT_S):
-            await asyncio.shield(closer)
+            await stack.aclose()
     except BaseException as exc:
         logger.warning("Stateless MCP cleanup failed error_class=%s", failure_class(exc))
-        closer.cancel()
-        try:
-            await closer
-        except BaseException:
-            pass

--- a/src/gateway/services/mcp_stateless.py
+++ b/src/gateway/services/mcp_stateless.py
@@ -1,0 +1,671 @@
+"""Stateless, single-server MCP discovery and execution.
+
+The primitive behind the stored-server endpoints in ``api/routes/mcp.py``, and
+deliberately not :class:`~gateway.services.mcp_client.MCPClientPool`. The pool
+exists to hold several sessions open across a model's whole tool loop and to
+publish the union of their tools; these endpoints connect to exactly one server,
+do exactly one thing, and close. An application pauses for a person between
+discovery and execution, so nothing here may be kept alive across that wait.
+
+The bounds are the point. A caller-orchestrated application hands Otari a tool
+name and arguments a model proposed, and the remote server is untrusted: its
+catalog can be unbounded, its schemas hostile, its response arbitrarily large.
+Every ceiling in the design's limits table is enforced here or in the route, and
+each is named in the constant that carries it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import AsyncExitStack, asynccontextmanager
+from dataclasses import dataclass
+from enum import StrEnum
+from time import monotonic
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+from gateway.log_config import logger
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable, MutableMapping
+
+    from mcp.types import CallToolResult
+    from mcp.types import Tool as MCPTool
+
+    from gateway.models.mcp import ResolvedMcpServer
+
+
+# --------------------------------------------------------------------------- #
+# Limits
+#
+# Every ceiling the design's limits table names, in one block so a deployment
+# tuning one can see what it sits beside. They are gateway-owned, not
+# caller-controlled request fields.
+# --------------------------------------------------------------------------- #
+
+# Request body (L-TOOLNAME, L-ARGS). Enforced at parse time by the request
+# model, so a caller's own text is bounded before resolution, logging or
+# telemetry sees any of it (R-REQ-3).
+TOOL_NAME_MAX_LENGTH = 256
+ARGUMENTS_MAX_BYTES = 256 * 1024
+ARGUMENTS_MAX_DEPTH = 32
+
+# The wire format of a stored-server revision (R-DISC-3).
+REVISION_PATTERN = r"^[A-Za-z0-9._:\-]{1,128}$"
+
+# Per tool (L-DISC-DESC, L-DISC-SCHEMA, L-DISC-ANNOT). A breach of one of these
+# omits the single tool and reports a warning (R-SCHEMA-3), rather than failing
+# the whole catalog: one hostile descriptor must not take a server's other
+# tools away from an application.
+TOOL_DESCRIPTION_MAX_BYTES = 4 * 1024
+SCHEMA_MAX_BYTES = 64 * 1024
+SCHEMA_MAX_DEPTH = 32
+TOOL_ANNOTATIONS_MAX_BYTES = 16 * 1024
+
+# Not in the design's table, and bounded for the same reason the three above
+# are: an object whose size and depth both pass can still hold hundreds of
+# thousands of one-character properties, and everything downstream of discovery
+# (an application's validator, a model's context) pays for each.
+SCHEMA_MAX_PROPERTIES = 1000
+
+# Whole catalog (L-DISC-PAGES, L-DISC-EXAMINED, L-DISC-TOOLS,
+# L-DISC-RESPONSE). A breach of one of these refuses the entire response
+# (R-DISC-5). Returning what was collected so far would hand an application a
+# catalog it would read as complete and then base an authorization decision
+# on.
+DISCOVERY_MAX_PAGES = 20
+DISCOVERY_MAX_EXAMINED = 1000
+DISCOVERY_MAX_TOOLS = 200
+DISCOVERY_RESPONSE_MAX_BYTES = 1024 * 1024
+
+# Transport (L-TRANSPORT-BYTES, L-RESULT-BYTES). One ceiling, enforced at the
+# two points that need no change to the MCP SDK's transport: the
+# ``Content-Length`` a well-behaved server sends, checked before the body is
+# read, and the decoded result, measured after. A chunked or SSE response
+# carries no length and the SDK buffers it before handing back a result, so in
+# the first version that case is bounded by the call and total deadlines rather
+# than mid-stream (R-TRANSPORT-1).
+TRANSPORT_MAX_BYTES = 1024 * 1024
+RESULT_MAX_BYTES = 1024 * 1024
+
+# Phase deadlines (L-CONNECT, L-CALL, L-CLEANUP, L-DISC-TOTAL, L-TOTAL). They
+# are distinct on purpose: the call deadline starts at dispatch and excludes the
+# capacity wait, and the total ones cap the whole operation so repeated slow
+# phases cannot exceed the intended request lifetime.
+CONNECT_TIMEOUT_S = 5.0
+CALL_TIMEOUT_S = 30.0
+CLEANUP_TIMEOUT_S = 2.0
+DISCOVERY_TOTAL_TIMEOUT_S = 15.0
+EXECUTION_TOTAL_TIMEOUT_S = 45.0
+
+# Admission (L-DISC-CONC, L-DISC-ADMIT, L-EXEC-CONC, L-EXEC-ADMIT).
+DISCOVERY_CONCURRENCY = 4
+DISCOVERY_ADMISSION_TIMEOUT_S = 5.0
+EXECUTION_CONCURRENCY = 8
+EXECUTION_ADMISSION_TIMEOUT_S = 5.0
+
+
+# --------------------------------------------------------------------------- #
+# Stable wire codes
+# --------------------------------------------------------------------------- #
+
+# Per-tool omission codes, reported in a discovery response's ``warnings``.
+WARN_SCHEMA_UNSUPPORTED = "mcp_tool_schema_unsupported"
+WARN_DESCRIPTION_TOO_LARGE = "mcp_tool_description_too_large"
+WARN_ANNOTATIONS_TOO_LARGE = "mcp_tool_annotations_too_large"
+
+# Error codes. The route owns the one safe ``detail`` string each maps to; these
+# are the stable enum a caller branches on.
+CODE_CONNECTION_FAILED = "mcp_connection_failed"
+CODE_OUTCOME_UNKNOWN = "mcp_outcome_unknown"
+CODE_RESULT_TOO_LARGE = "mcp_result_too_large"
+CODE_CAPACITY_UNAVAILABLE = "mcp_capacity_unavailable"
+CODE_DISCOVERY_LIMIT_EXCEEDED = "mcp_discovery_limit_exceeded"
+CODE_DISCOVERY_CAPACITY_UNAVAILABLE = "mcp_discovery_capacity_unavailable"
+CODE_RESOLUTION_FAILED = "mcp_resolution_failed"
+CODE_SERVER_NOT_FOUND = "mcp_server_not_found"
+CODE_SERVER_CHANGED = "mcp_server_changed"
+CODE_TOOL_NOT_ALLOWED = "mcp_tool_not_allowed"
+CODE_UNSAFE_URL = "unsafe_mcp_url"
+CODE_CREDENTIALS_UNAVAILABLE = "mcp_credentials_unavailable"
+CODE_AUTHENTICATION_FAILED = "authentication_failed"
+CODE_RATE_LIMIT_EXCEEDED = "rate_limit_exceeded"
+CODE_INVALID_REQUEST = "invalid_request"
+
+
+# --------------------------------------------------------------------------- #
+# Failure types
+# --------------------------------------------------------------------------- #
+
+
+class McpDiscoveryRefused(Exception):
+    """A whole-catalog discovery failure (R-DISC-5).
+
+    Raised for a pagination validation failure or a discovery ceiling breach,
+    both of which refuse the entire response. Carries no message on purpose:
+    every caller answers it with one fixed safe detail, and the only detail
+    worth attaching would describe the remote server's catalog.
+    """
+
+
+class TransportResponseTooLarge(Exception):
+    """A transport response that exceeded the byte ceiling."""
+
+
+class McpCapacityUnavailable(Exception):
+    """A concurrency slot did not free up inside the admission deadline."""
+
+
+class ExecutionState(StrEnum):
+    """Whether the remote tool may have run (R-ERR-2).
+
+    A retry-safety classification, not a description of how the HTTP request
+    went. ``NOT_STARTED`` is Otari saying it knows the tool did not run;
+    ``OUTCOME_UNKNOWN`` is Otari saying it cannot know, which is the only honest
+    answer once the transport has begun writing ``tools/call``.
+    """
+
+    NOT_STARTED = "not_started"
+    OUTCOME_UNKNOWN = "outcome_unknown"
+    COMPLETED = "completed"
+
+
+class McpExecutionError(Exception):
+    """A stateless MCP failure, already classified for the wire.
+
+    Carries the status, the stable error code, and the execution state rather
+    than a message: the detail a caller sees is fixed per category (R-ERR-1),
+    and anything the remote server or the exception said about why is exactly
+    what must not travel.
+    """
+
+    def __init__(self, code: str, execution_state: ExecutionState, status_code: int) -> None:
+        super().__init__(code)
+        self.code = code
+        self.execution_state = execution_state
+        self.status_code = status_code
+
+
+# --------------------------------------------------------------------------- #
+# Measuring untrusted JSON
+# --------------------------------------------------------------------------- #
+
+
+def _oversized(value: Any, ceiling: int) -> bool:
+    """Whether ``value`` exceeds ``ceiling`` once encoded.
+
+    Encoded rather than measured in place, because that is the size the value
+    occupies in the discovery response an application receives, and a value that
+    will not encode at all is oversized by the only definition that matters
+    here: Otari cannot carry it.
+    """
+    if value is None:
+        return False
+    try:
+        encoded = _encode(value)
+    except (TypeError, ValueError):
+        return True
+    return len(encoded) > ceiling
+
+
+def _encode(value: Any) -> bytes:
+    return json.dumps(value, separators=(",", ":"), default=_as_jsonable).encode()
+
+
+def _as_jsonable(value: Any) -> Any:
+    """Render a Pydantic model the way the response would, or refuse to size it."""
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json", exclude_none=True)
+    raise TypeError(type(value).__name__)
+
+
+def _walk(schema: dict[str, Any]) -> tuple[int, int, bool]:
+    """Measure nesting depth and property count, and spot any non-local ``$ref``.
+
+    One traversal for all three, iteratively rather than recursively: the depth
+    ceiling is what makes a deep schema safe, and a recursive walk would have to
+    survive the schema long enough to enforce it.
+
+    A ``$ref`` is local only when it is a fragment of this same schema, so it
+    resolves without a request. Anything else, absolute, protocol-relative, or a
+    sibling file, is refused rather than fetched.
+    """
+    max_depth = 0
+    properties = 0
+    external_ref = False
+    stack: list[tuple[Any, int]] = [(schema, 1)]
+    while stack:
+        node, depth = stack.pop()
+        max_depth = max(max_depth, depth)
+        if isinstance(node, dict):
+            ref = node.get("$ref")
+            if isinstance(ref, str) and not ref.startswith("#"):
+                external_ref = True
+            for key, value in node.items():
+                if key == "properties" and isinstance(value, dict):
+                    properties += len(value)
+                stack.append((value, depth + 1))
+        elif isinstance(node, list):
+            stack.extend((item, depth + 1) for item in node)
+    return max_depth, properties, external_ref
+
+
+# --------------------------------------------------------------------------- #
+# Screening one live tool descriptor, and one call's arguments
+# --------------------------------------------------------------------------- #
+
+
+def screen_tool(tool: MCPTool) -> str | None:
+    """Return the warning code that omits ``tool``, or ``None`` to admit it.
+
+    Structural and size checks only (R-SCHEMA-1). The schema is untrusted data
+    rather than something Otari executes, so an unrecognized dialect or keyword
+    is carried through untouched; what is refused is a schema Otari cannot
+    safely hold in memory, or one that would make it fetch a second schema over
+    the network to be understood at all.
+    """
+    if _oversized(tool.description, TOOL_DESCRIPTION_MAX_BYTES):
+        return WARN_DESCRIPTION_TOO_LARGE
+    if tool.annotations is not None and _oversized(tool.annotations, TOOL_ANNOTATIONS_MAX_BYTES):
+        return WARN_ANNOTATIONS_TOO_LARGE
+    if not _schema_is_supported(tool.inputSchema):
+        return WARN_SCHEMA_UNSUPPORTED
+    return None
+
+
+def _schema_is_supported(schema: Any) -> bool:
+    if not isinstance(schema, dict):
+        return False
+    if _oversized(schema, SCHEMA_MAX_BYTES):
+        return False
+    depth, properties, external_ref = _walk(schema)
+    return depth <= SCHEMA_MAX_DEPTH and properties <= SCHEMA_MAX_PROPERTIES and not external_ref
+
+
+def arguments_within_bounds(arguments: dict[str, Any]) -> bool:
+    """Whether one call's arguments are small and shallow enough to forward."""
+    if _oversized(arguments, ARGUMENTS_MAX_BYTES):
+        return False
+    depth, _, _ = _walk(arguments)
+    return depth <= ARGUMENTS_MAX_DEPTH
+
+
+# --------------------------------------------------------------------------- #
+# Transport and admission
+# --------------------------------------------------------------------------- #
+
+
+async def enforce_content_length(response: httpx.Response) -> None:
+    """Refuse an oversized response before its body is read.
+
+    Registered as an httpx response event hook, which runs with the headers
+    available and the body still unread, so a server declaring a gigabyte never
+    gets to send one.
+
+    A response with no ``Content-Length`` passes here and is caught by the
+    post-decode measurement instead; that is the documented shape of this bound
+    (R-TRANSPORT-1), not an oversight.
+    """
+    declared = response.headers.get("content-length")
+    if declared is None:
+        return
+    try:
+        length = int(declared)
+    except ValueError:
+        return
+    if length > TRANSPORT_MAX_BYTES:
+        raise TransportResponseTooLarge
+
+
+def build_http_client_factory() -> Callable[..., httpx.AsyncClient]:
+    """An MCP HTTP client factory with redirects disabled and a size pre-check.
+
+    The SDK's own factory sets ``follow_redirects=True``, which on a
+    credentialed request means httpx would replay the ``Authorization`` header,
+    and the request body, at whatever host the remote server names. Redirects
+    are excluded from the first version entirely (R-TRANSPORT-2): a later one
+    may follow them by validating each destination before anything is sent.
+    """
+
+    def factory(
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
+    ) -> httpx.AsyncClient:
+        kwargs: dict[str, Any] = {
+            "follow_redirects": False,
+            "timeout": timeout if timeout is not None else httpx.Timeout(CONNECT_TIMEOUT_S, read=CALL_TIMEOUT_S),
+            "event_hooks": {"response": [enforce_content_length]},
+        }
+        if headers is not None:
+            kwargs["headers"] = headers
+        if auth is not None:
+            kwargs["auth"] = auth
+        return httpx.AsyncClient(**kwargs)
+
+    return factory
+
+
+def result_exceeds_bound(result: CallToolResult) -> bool:
+    """Whether a decoded MCP result is too large to return (L-RESULT-BYTES).
+
+    A breach here is ``outcome_unknown`` rather than a clean failure: the tool
+    ran and may have mutated something, and Otari simply cannot carry what came
+    back.
+    """
+    return _oversized(result, RESULT_MAX_BYTES)
+
+
+class ConcurrencyGate:
+    """A per-process slot ceiling with a bounded wait for admission.
+
+    Discovery and execution hold separate gates (R-ADM-1). Discovery talks to a
+    server that has not been authorized for anything yet and can be slow or
+    hostile; execution is running a call a person or a policy already approved.
+    One ceiling shared between them would let the first starve the second.
+    """
+
+    def __init__(self, *, limit: int, admission_timeout_s: float) -> None:
+        self.limit = limit
+        self._admission_timeout_s = admission_timeout_s
+        self._semaphore = asyncio.Semaphore(limit)
+
+    @asynccontextmanager
+    async def slot(self) -> AsyncIterator[None]:
+        """Hold one slot, or raise :class:`McpCapacityUnavailable`.
+
+        Raises:
+            McpCapacityUnavailable: the deadline passed with no slot free.
+        """
+        try:
+            async with asyncio.timeout(self._admission_timeout_s):
+                await self._semaphore.acquire()
+        except TimeoutError:
+            raise McpCapacityUnavailable from None
+        try:
+            yield
+        finally:
+            self._semaphore.release()
+
+
+DISCOVERY_GATE = ConcurrencyGate(limit=DISCOVERY_CONCURRENCY, admission_timeout_s=DISCOVERY_ADMISSION_TIMEOUT_S)
+EXECUTION_GATE = ConcurrencyGate(limit=EXECUTION_CONCURRENCY, admission_timeout_s=EXECUTION_ADMISSION_TIMEOUT_S)
+
+
+@asynccontextmanager
+async def open_session(server: ResolvedMcpServer) -> AsyncIterator[ClientSession]:
+    """Open one size-bounded, redirect-disabled MCP session on a stored server.
+
+    Connection and initialization share one deadline (L-CONNECT), so a server
+    that accepts a socket and then never answers ``initialize`` cannot hold a
+    slot for the length of the call deadline instead.
+    """
+    headers = {"Authorization": f"Bearer {server.authorization_token}"} if server.authorization_token else None
+    async with AsyncExitStack() as stack:
+        async with asyncio.timeout(CONNECT_TIMEOUT_S):
+            read, write, _ = await stack.enter_async_context(
+                streamablehttp_client(
+                    server.url,
+                    headers=headers,
+                    timeout=CONNECT_TIMEOUT_S,
+                    sse_read_timeout=CALL_TIMEOUT_S,
+                    httpx_client_factory=build_http_client_factory(),
+                )
+            )
+            session = await stack.enter_async_context(ClientSession(read, write))
+            await session.initialize()
+        yield session
+
+
+# --------------------------------------------------------------------------- #
+# Discovery
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoveredCatalog:
+    """The tools an application may expose, and what was left out.
+
+    ``warnings`` pairs a tool name with the code that omitted it, and carries no
+    schema fragment or validator text: a warning describes that a descriptor was
+    unusable, never what was in it (R-SCHEMA-3).
+    """
+
+    tools: list[MCPTool]
+    warnings: list[tuple[str, str]]
+
+
+async def discover_stored_tools(server: ResolvedMcpServer) -> DiscoveredCatalog:
+    """List the live tools a stored server's allowlist admits.
+
+    One bounded session, one paginated ``tools/list``, per-tool screening, and
+    a ceiling on the whole serialized answer. Every failure is ``not_started``:
+    discovery runs no tool.
+
+    Raises:
+        McpExecutionError: with the code and status the route returns.
+    """
+    try:
+        async with DISCOVERY_GATE.slot():
+            async with asyncio.timeout(DISCOVERY_TOTAL_TIMEOUT_S):
+                return await _discover_once(server)
+    except McpCapacityUnavailable:
+        raise McpExecutionError(CODE_DISCOVERY_CAPACITY_UNAVAILABLE, ExecutionState.NOT_STARTED, 503) from None
+    except TimeoutError:
+        raise McpExecutionError(CODE_DISCOVERY_LIMIT_EXCEEDED, ExecutionState.NOT_STARTED, 502) from None
+
+
+async def _discover_once(server: ResolvedMcpServer) -> DiscoveredCatalog:
+    stack = AsyncExitStack()
+    try:
+        try:
+            session = await stack.enter_async_context(open_session(server))
+        except Exception as exc:
+            logger.warning("Stateless MCP discovery connection failed error_class=%s", type(exc).__name__)
+            raise McpExecutionError(CODE_CONNECTION_FAILED, ExecutionState.NOT_STARTED, 502) from None
+
+        try:
+            listed = await collect_tools(session, allowed_tools=server.allowed_tools)
+        except McpDiscoveryRefused:
+            raise McpExecutionError(CODE_DISCOVERY_LIMIT_EXCEEDED, ExecutionState.NOT_STARTED, 502) from None
+        except Exception as exc:
+            logger.warning("Stateless MCP discovery failed error_class=%s", type(exc).__name__)
+            raise McpExecutionError(CODE_CONNECTION_FAILED, ExecutionState.NOT_STARTED, 502) from None
+
+        tools: list[MCPTool] = []
+        warnings: list[tuple[str, str]] = []
+        for tool in listed:
+            code = screen_tool(tool)
+            if code is None:
+                tools.append(tool)
+            else:
+                warnings.append((tool.name, code))
+
+        if _oversized(tools, DISCOVERY_RESPONSE_MAX_BYTES):
+            raise McpExecutionError(CODE_DISCOVERY_LIMIT_EXCEEDED, ExecutionState.NOT_STARTED, 502)
+        return DiscoveredCatalog(tools=tools, warnings=warnings)
+    finally:
+        await _close_bounded(stack)
+
+
+async def collect_tools(session: Any, *, allowed_tools: list[str] | None) -> list[MCPTool]:
+    """Page through ``tools/list`` and return the tools the allowlist admits.
+
+    ``allowed_tools`` carries the three-state meaning of the stored column
+    (R-RES-4): ``None`` exposes the whole live catalog, and a list exposes its
+    intersection with it. An empty list is a deny-all the caller settles without
+    connecting at all, so it never reaches here.
+
+    Pagination stops early once every allowlisted name has been seen. A server
+    with thousands of tools and a three-name allowlist is then one or two pages,
+    not twenty, and the ceiling below stays a defense rather than a routine cost.
+
+    Raises:
+        McpDiscoveryRefused: on a pagination validation failure (R-DISC-4) or a
+            discovery ceiling breach.
+    """
+    allowed = None if allowed_tools is None else set(allowed_tools)
+    collected: dict[str, MCPTool] = {}
+    examined = 0
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+
+    for _ in range(DISCOVERY_MAX_PAGES):
+        page = await session.list_tools(cursor)
+        tools = getattr(page, "tools", None)
+        if not isinstance(tools, list):
+            raise McpDiscoveryRefused
+        for tool in tools:
+            name = getattr(tool, "name", None)
+            if not isinstance(name, str) or not name:
+                raise McpDiscoveryRefused
+            examined += 1
+            if examined > DISCOVERY_MAX_EXAMINED:
+                raise McpDiscoveryRefused
+            if allowed is not None and name not in allowed:
+                continue
+            previous = collected.get(name)
+            if previous is not None:
+                # One tool listed twice is harmless; two different tools under
+                # one name are not. An application maps a model's proposal back
+                # to a name, so which descriptor it validated against would
+                # decide what actually ran.
+                if previous != tool:
+                    raise McpDiscoveryRefused
+                continue
+            collected[name] = tool
+            if len(collected) > DISCOVERY_MAX_TOOLS:
+                raise McpDiscoveryRefused
+
+        if allowed is not None and allowed.issubset(collected):
+            break
+        cursor = getattr(page, "nextCursor", None)
+        if cursor is None:
+            break
+        if not isinstance(cursor, str) or cursor in seen_cursors:
+            # A server repeating a cursor is either broken or trying to keep the
+            # session open past every other bound; both are the same refusal.
+            raise McpDiscoveryRefused
+        seen_cursors.add(cursor)
+    else:
+        raise McpDiscoveryRefused
+
+    return list(collected.values())
+
+
+# --------------------------------------------------------------------------- #
+# Execution
+# --------------------------------------------------------------------------- #
+
+
+async def execute_stored_tool(
+    server: ResolvedMcpServer,
+    tool_name: str,
+    arguments: dict[str, Any],
+    *,
+    on_dispatch: Callable[[], None] | None = None,
+    timings: MutableMapping[str, float] | None = None,
+) -> CallToolResult:
+    """Execute exactly one caller-authorized tool call and return its result.
+
+    No ``list_tools``: MCP permits calling a known tool directly, and what
+    authorizes this call is the stored allowlist and the authenticated
+    workspace, not a live catalog (R-DISC-6). The route has already applied
+    both by the time this runs.
+
+    ``on_dispatch`` fires immediately before the transport begins writing, which
+    is the boundary every classification below turns on.
+
+    ``timings``, when given, collects the phase durations and the result size for
+    the caller to log. It carries no tool name, argument, or result content
+    (R-OBS-1, R-OBS-2), and it is filled in as each phase ends, so a failure part
+    way through still leaves the phases that did run.
+
+    Raises:
+        McpExecutionError: with the code, state and status the route returns.
+    """
+    record = timings if timings is not None else {}
+    admission_started = monotonic()
+    try:
+        async with EXECUTION_GATE.slot():
+            record["admission_ms"] = (monotonic() - admission_started) * 1000
+            return await _execute_once(server, tool_name, arguments, on_dispatch, record)
+    except McpCapacityUnavailable:
+        record["admission_ms"] = (monotonic() - admission_started) * 1000
+        raise McpExecutionError(CODE_CAPACITY_UNAVAILABLE, ExecutionState.NOT_STARTED, 503) from None
+
+
+async def _execute_once(
+    server: ResolvedMcpServer,
+    tool_name: str,
+    arguments: dict[str, Any],
+    on_dispatch: Callable[[], None] | None,
+    timings: MutableMapping[str, float],
+) -> CallToolResult:
+    stack = AsyncExitStack()
+    phase_started = monotonic()
+    try:
+        try:
+            session = await stack.enter_async_context(open_session(server))
+        except Exception as exc:
+            # Still ``not_started``: nothing was written, so the caller's own
+            # execution claim is still safe to release or retry (R-ERR-2).
+            # Cancellation is deliberately not caught here and below: it is also
+            # how an enclosing phase deadline arrives, and converting it into a
+            # connection failure would hide which bound was actually reached.
+            logger.warning("Stateless MCP connection failed error_class=%s", type(exc).__name__)
+            raise McpExecutionError(CODE_CONNECTION_FAILED, ExecutionState.NOT_STARTED, 502) from None
+
+        timings["connect_ms"] = (monotonic() - phase_started) * 1000
+        if on_dispatch is not None:
+            on_dispatch()
+        phase_started = monotonic()
+        try:
+            async with asyncio.timeout(CALL_TIMEOUT_S):
+                result = await session.call_tool(tool_name, arguments)
+        except TimeoutError:
+            raise McpExecutionError(CODE_OUTCOME_UNKNOWN, ExecutionState.OUTCOME_UNKNOWN, 504) from None
+        except (Exception, asyncio.CancelledError) as exc:
+            # Deliberately conservative (R-ERR-3), cancellation included: a
+            # cancelled local transport says nothing about whether the remote
+            # server ran the tool to completion.
+            logger.warning("Stateless MCP call failed after dispatch error_class=%s", type(exc).__name__)
+            raise McpExecutionError(CODE_OUTCOME_UNKNOWN, ExecutionState.OUTCOME_UNKNOWN, 502) from None
+
+        finally:
+            timings["call_ms"] = (monotonic() - phase_started) * 1000
+
+        if result_exceeds_bound(result):
+            # The tool ran, so this is not a clean refusal; Otari simply cannot
+            # carry what came back.
+            raise McpExecutionError(CODE_RESULT_TOO_LARGE, ExecutionState.OUTCOME_UNKNOWN, 502)
+        timings["result_bytes"] = len(_encode(result))
+        return result
+    finally:
+        cleanup_started = monotonic()
+        await _close_bounded(stack)
+        timings["cleanup_ms"] = (monotonic() - cleanup_started) * 1000
+
+
+async def _close_bounded(stack: AsyncExitStack) -> None:
+    """Close the transport without letting shutdown outlive or replace a result.
+
+    Shielded and bounded (R-EXEC-1). A definitive result is already in hand by
+    the time this runs, so a transport that will not close, or a request whose
+    task is being cancelled, must not turn a completed mutation into an error
+    the caller might retry. A close that overruns its deadline is left to finish
+    on its own and reported as a failure class with no content.
+    """
+    closer = asyncio.ensure_future(stack.aclose())
+    # Read the outcome even when the wait below gives up on it, so an abandoned
+    # close cannot surface later as an unretrieved task exception.
+    closer.add_done_callback(lambda task: task.exception() if not task.cancelled() else None)
+    try:
+        async with asyncio.timeout(CLEANUP_TIMEOUT_S):
+            await asyncio.shield(closer)
+    except (Exception, asyncio.CancelledError) as exc:
+        logger.warning("Stateless MCP cleanup failed error_class=%s", type(exc).__name__)

--- a/src/gateway/services/tenancy/workspace_mcp_server_service.py
+++ b/src/gateway/services/tenancy/workspace_mcp_server_service.py
@@ -50,7 +50,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.models.entities import WorkspaceMcpServer
-from gateway.models.mcp import McpServerConfig
+from gateway.models.mcp import McpServerConfig, ResolvedMcpServer
 from gateway.models.tenancy import User
 from gateway.repositories.tenancy import WorkspaceRepository
 from gateway.services.secret_box import (
@@ -299,6 +299,52 @@ async def resolve_workspace_mcp_servers(
     return resolved
 
 
+async def resolve_workspace_mcp_server(
+    db: AsyncSession,
+    *,
+    workspace_id: uuid.UUID,
+    server_id: uuid.UUID,
+) -> ResolvedMcpServer | None:
+    """Resolve one stored server for the caller-orchestrated MCP endpoints.
+
+    The standalone counterpart of `_platform._resolve_platform_mcp_server`, and
+    the singular sibling of :func:`resolve_workspace_mcp_servers`. It differs
+    from that one in the two ways the stored-server endpoints need. It reports a
+    disabled server instead of skipping it, because a disabled server is a
+    named 404 here rather than one entry quietly missing from a list; and it
+    returns the id, so a revision can be derived over the configuration that
+    was actually resolved (R-RES-3).
+
+    ``None`` means no such server *in this workspace*, which covers an id
+    belonging to another one: the same non-oracle answer the plural resolver
+    gives, since ``workspace_id`` comes off the authenticating key.
+
+    Raises `secret_box.SecretDecryptionError` when a stored token will not
+    decrypt, for the same reason the plural resolver does: connecting without a
+    credential the workspace configured would send an unauthenticated request
+    to a server that expects one.
+    """
+    row = (
+        await db.execute(
+            select(WorkspaceMcpServer).where(
+                WorkspaceMcpServer.workspace_id == workspace_id,
+                WorkspaceMcpServer.id == server_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+    return ResolvedMcpServer(
+        id=row.id,
+        name=row.name,
+        url=row.url,
+        authorization_token=decrypt_secret(row.encrypted_token) if row.encrypted_token else None,
+        enabled=row.enabled,
+        purpose_hint=row.purpose_hint,
+        allowed_tools=row.allowed_tools,
+    )
+
+
 class WorkspaceMcpServerService:
     """CRUD for a workspace's MCP servers. Writes are management-gated; the list is not."""
 
@@ -504,5 +550,6 @@ __all__ = [
     "WorkspaceMcpServerService",
     "WorkspaceMcpServerUpdate",
     "WorkspaceMcpServersPublic",
+    "resolve_workspace_mcp_server",
     "resolve_workspace_mcp_servers",
 ]

--- a/tests/integration/test_hosted_mode_surface.py
+++ b/tests/integration/test_hosted_mode_surface.py
@@ -39,6 +39,9 @@ INFERENCE_PATHS = (
     "/v1/moderations",
     "/v1/search",
     "/v1/files",
+    # Discovery and execution both belong to the data plane: a hosted control
+    # plane holds no MCP session and runs no tool.
+    "/v1/mcp/execute",
 )
 
 EXPECTED_DETAIL = (

--- a/tests/integration/test_mcp_stored_server_endpoints.py
+++ b/tests/integration/test_mcp_stored_server_endpoints.py
@@ -27,7 +27,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
 from gateway.api.routes import mcp as mcp_route
-from gateway.models.entities import APIKey, WorkspaceMcpServer
+from gateway.models.entities import APIKey, User, WorkspaceMcpServer
 from gateway.models.mcp import ResolvedMcpServer
 from gateway.models.tenancy import Organization, Workspace
 from gateway.services import mcp_stateless
@@ -36,6 +36,9 @@ from gateway.services.secret_box import encrypt_secret, generate_secret_key
 from .conftest import build_test_client
 
 PUBLIC_URL = "https://93.184.216.34/mcp"
+# The same public host over cleartext, for the credential rule rather than the
+# private-address one.
+CLEARTEXT_URL = "http://93.184.216.34/mcp"
 CLIENT_EXECUTION_ID = "6e51b3bc-6f48-4c68-a61e-0786bc80cd67"
 
 RESULT = CallToolResult(content=[TextContent(type="text", text="Created issue #42")])
@@ -299,6 +302,104 @@ def test_the_authenticated_principal_is_rate_limited_before_any_outbound_access(
         assert second.json()["execution_state"] == "not_started"
         assert second.headers["Retry-After"]
         assert len(session.calls) == 1, "the refused request never reached the server"
+
+
+def test_a_blocked_user_cannot_drive_an_outbound_mcp_call(
+    client: TestClient,
+    test_db: Session,
+    api_key_obj: dict[str, Any],
+    api_key_header: dict[str, str],
+    session: _FakeSession,
+) -> None:
+    """The block is a kill switch, and these endpoints are something to kill.
+
+    ``users.blocked`` is read in ``reserve_budget``, which these routes never
+    reach because they reserve nothing. Without a check of their own, blocking
+    someone would stop their completions and leave them driving mutating MCP
+    tools through the gateway.
+    """
+    row = _store_server(test_db, _workspace_id(test_db, api_key_obj["id"]))
+    body = _execute_body(row)
+    user = test_db.get(User, api_key_obj["user_id"])
+    assert user is not None
+    user.blocked = True
+    test_db.add(user)
+    test_db.commit()
+
+    executed = client.post("/v1/mcp/execute", headers=api_key_header, json=body)
+    tools = client.get(f"/v1/mcp/servers/{row.id}/tools", headers=api_key_header)
+
+    for response in (executed, tools):
+        assert response.status_code == 401, response.text
+        assert response.json()["code"] == "authentication_failed"
+        assert response.json()["execution_state"] == "not_started"
+    assert session.calls == []
+    assert session.pages == 0
+
+
+def test_an_unblocked_user_is_unaffected(
+    client: TestClient,
+    test_db: Session,
+    api_key_obj: dict[str, Any],
+    api_key_header: dict[str, str],
+    session: _FakeSession,
+) -> None:
+    """The other half of the block, so the check cannot pass by refusing everyone."""
+    row = _store_server(test_db, _workspace_id(test_db, api_key_obj["id"]))
+    user = test_db.get(User, api_key_obj["user_id"])
+    assert user is not None and user.blocked is False
+
+    response = client.post("/v1/mcp/execute", headers=api_key_header, json=_execute_body(row))
+
+    assert response.status_code == 200, response.text
+
+
+def test_a_stored_token_is_never_sent_over_cleartext_http(
+    client: TestClient,
+    test_db: Session,
+    api_key_obj: dict[str, Any],
+    api_key_header: dict[str, str],
+    session: _FakeSession,
+) -> None:
+    """The URL-safety rule the route's ``has_authorization_token`` argument feeds.
+
+    A public ``http://`` host, so the private-address rule cannot short-circuit
+    this and the cleartext-credential rule is what has to fire. Its pair below
+    is what makes the argument itself tested: the same URL with no stored token
+    has nothing to leak and is allowed through.
+    """
+    row = _store_server(test_db, _workspace_id(test_db, api_key_obj["id"]), url=CLEARTEXT_URL, token="ghp_token")
+
+    response = client.post(
+        "/v1/mcp/execute",
+        headers=api_key_header,
+        json=_execute_body(row, server_revision=_revision(row)),
+    )
+
+    assert response.status_code == 400, response.text
+    assert response.json()["code"] == "unsafe_mcp_url"
+    assert response.json()["execution_state"] == "not_started"
+    assert session.calls == []
+    assert "ghp_token" not in response.text
+
+
+def test_the_same_cleartext_url_is_allowed_when_there_is_no_token_to_leak(
+    client: TestClient,
+    test_db: Session,
+    api_key_obj: dict[str, Any],
+    api_key_header: dict[str, str],
+    session: _FakeSession,
+) -> None:
+    row = _store_server(test_db, _workspace_id(test_db, api_key_obj["id"]), url=CLEARTEXT_URL, token=None)
+
+    response = client.post(
+        "/v1/mcp/execute",
+        headers=api_key_header,
+        json=_execute_body(row, server_revision=_revision(row, token=None)),
+    )
+
+    assert response.status_code == 200, response.text
+    assert session.calls == [("create_issue", {"title": "Approved title"})]
 
 
 def test_a_master_key_cannot_reach_a_workspaces_stored_server(

--- a/tests/integration/test_mcp_stored_server_endpoints.py
+++ b/tests/integration/test_mcp_stored_server_endpoints.py
@@ -27,6 +27,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
 from gateway.api.routes import mcp as mcp_route
+from gateway.core.database import release_session
+from gateway.inflight import InFlightRegistry
 from gateway.models.entities import APIKey, User, WorkspaceMcpServer
 from gateway.models.mcp import ResolvedMcpServer
 from gateway.models.tenancy import Organization, Workspace
@@ -88,7 +90,7 @@ _EVENTS: list[str] = []
 def _events(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[str]]:
     """Record the order of the two steps that must not be interleaved."""
     _EVENTS.clear()
-    original = mcp_route.release_session
+    original = release_session
 
     async def spy(db: Any) -> bool:
         released = await original(db)
@@ -238,7 +240,7 @@ def test_the_call_appears_in_the_in_flight_registry_while_it_runs(
     session: _FakeSession,
 ) -> None:
     """Execution step 7, through the standard middleware lifecycle."""
-    registry = client.app.state.inflight
+    registry: InFlightRegistry = client.app.state.inflight  # type: ignore[attr-defined]
     seen: list[list[str]] = []
     session.on_call = lambda: seen.append([entry.endpoint for entry in registry.snapshot()])
     row = _store_server(test_db, _workspace_id(test_db, api_key_obj["id"]))
@@ -259,7 +261,7 @@ def test_discovery_registers_under_its_own_endpoint_while_it_runs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An operator watching in-flight work sees which of the two endpoints is running."""
-    registry = client.app.state.inflight
+    registry: InFlightRegistry = client.app.state.inflight  # type: ignore[attr-defined]
     seen: list[list[str]] = []
     original = session.list_tools
 

--- a/tests/integration/test_mcp_stored_server_endpoints.py
+++ b/tests/integration/test_mcp_stored_server_endpoints.py
@@ -1,0 +1,440 @@
+"""The standalone half of the caller-orchestrated MCP endpoints.
+
+The hybrid half is unit-tested in ``tests/unit/test_mcp_execute_endpoint.py``
+and ``tests/unit/test_mcp_tools_endpoint.py``, where the platform resolver is
+the only seam. Here the resolution is real: a key authenticates, its workspace
+is derived from the key row, and the stored server, its encrypted credential and
+its allowlist come out of the database. What that buys, and what only this half
+can show, is that the request-scoped database session is handed back before any
+outbound work and that a master key cannot reach a tenant's stored server.
+
+URLs are public IP literals, so ``validate_mcp_url`` never reaches a resolver
+and the suite does not need egress.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from mcp.types import CallToolResult, ListToolsResult, TextContent
+from mcp.types import Tool as MCPTool
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from gateway.api.routes import mcp as mcp_route
+from gateway.models.entities import APIKey, WorkspaceMcpServer
+from gateway.models.mcp import ResolvedMcpServer
+from gateway.models.tenancy import Organization, Workspace
+from gateway.services import mcp_stateless
+from gateway.services.secret_box import encrypt_secret, generate_secret_key
+
+from .conftest import build_test_client
+
+PUBLIC_URL = "https://93.184.216.34/mcp"
+CLIENT_EXECUTION_ID = "6e51b3bc-6f48-4c68-a61e-0786bc80cd67"
+
+RESULT = CallToolResult(content=[TextContent(type="text", text="Created issue #42")])
+
+
+@pytest.fixture(autouse=True)
+def _secret_key(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("OTARI_SECRET_KEY", generate_secret_key())
+    yield
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.tools = [MCPTool(name="create_issue", description="Create an issue", inputSchema={"type": "object"})]
+        self.pages = 0
+        self.on_call: Any = None
+
+    async def list_tools(self, cursor: str | None = None) -> ListToolsResult:
+        self.pages += 1
+        return ListToolsResult(tools=self.tools)
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+        self.calls.append((name, arguments))
+        if self.on_call is not None:
+            self.on_call()
+        return RESULT
+
+
+@pytest.fixture
+def session(monkeypatch: pytest.MonkeyPatch) -> _FakeSession:
+    fake = _FakeSession()
+
+    @asynccontextmanager
+    async def open_session(*args: Any, **kwargs: Any) -> Any:
+        _EVENTS.append("mcp_session_opened")
+        yield fake
+
+    monkeypatch.setattr(mcp_stateless, "open_session", open_session)
+    return fake
+
+
+_EVENTS: list[str] = []
+
+
+@pytest.fixture(autouse=True)
+def _events(monkeypatch: pytest.MonkeyPatch) -> Iterator[list[str]]:
+    """Record the order of the two steps that must not be interleaved."""
+    _EVENTS.clear()
+    original = mcp_route.release_session
+
+    async def spy(db: Any) -> bool:
+        released = await original(db)
+        _EVENTS.append("session_released")
+        return released
+
+    monkeypatch.setattr(mcp_route, "release_session", spy)
+    yield _EVENTS
+
+
+def _workspace_id(test_db: Session, api_key_id: str) -> uuid.UUID:
+    key = test_db.get(APIKey, api_key_id)
+    assert key is not None and key.workspace_id is not None
+    return key.workspace_id
+
+
+def _other_workspace(test_db: Session) -> uuid.UUID:
+    """A second workspace in the deployment, to hold a server this key may not reach."""
+    organization = test_db.query(Organization).first()
+    assert organization is not None
+    workspace = Workspace(name="Other", organization_id=organization.id)
+    test_db.add(workspace)
+    test_db.commit()
+    test_db.refresh(workspace)
+    return workspace.id
+
+
+def _store_server(
+    test_db: Session,
+    workspace_id: uuid.UUID,
+    *,
+    url: str = PUBLIC_URL,
+    token: str | None = "ghp_token",
+    enabled: bool = True,
+    allowed_tools: list[str] | None = None,
+) -> WorkspaceMcpServer:
+    row = WorkspaceMcpServer(
+        workspace_id=workspace_id,
+        name="github",
+        url=url,
+        encrypted_token=encrypt_secret(token) if token else None,
+        enabled=enabled,
+        allowed_tools=allowed_tools,
+    )
+    test_db.add(row)
+    test_db.commit()
+    test_db.refresh(row)
+    return row
+
+
+def _revision(row: WorkspaceMcpServer, *, token: str | None = "ghp_token") -> str:
+    return ResolvedMcpServer(
+        id=row.id,
+        name=row.name,
+        url=row.url,
+        authorization_token=token,
+        enabled=row.enabled,
+        allowed_tools=row.allowed_tools,
+    ).revision
+
+
+def _execute_body(row: WorkspaceMcpServer, **overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "mcp_server_id": str(row.id),
+        "tool_name": "create_issue",
+        "arguments": {"title": "Approved title"},
+        "server_revision": _revision(row),
+        "client_execution_id": CLIENT_EXECUTION_ID,
+    }
+    body.update(overrides)
+    return body
+
+
+def test_a_workspace_key_executes_against_its_own_stored_server(
+    client: TestClient,
+    test_db: Session,
+    api_key_obj: dict[str, Any],
+    api_key_header: dict[str, str],
+    session: _FakeSession,
+) -> None:
+    row = _store_server(test_db, _workspace_id(test_db, api_key_obj["id"]), allowed_tools=["create_issue"])
+
+    response = client.post("/v1/mcp/execute", headers=api_key_header, json=_execute_body(row))
+
+    assert response.status_code == 200, response.text
+    assert response.json()["content"] == [{"type": "text", "text": "Created issue #42"}]
+    assert session.calls == [("create_issue", {"title": "Approved title"})]
+
+
+def test_the_stored_credential_is_decrypted_and_never_returned(
+    client: TestClient,
+    test_db: Session,
+    api_key_obj: dict[str, Any],
+    api_key_header: dict[str, str],
+    session: _FakeSession,
+) -> None:
+    row = _store_server(test_db, _workspace_id(test_db, api_key_obj["id"]))
+
+    tools = client.get(f"/v1/mcp/servers/{row.id}/tools", headers=api_key_header)
+    executed = client.post("/v1/mcp/execute", headers=api_key_header, json=_execute_body(row))
+
+    assert tools.status_code == 200, tools.text
+    assert executed.status_code == 200, executed.text
+    for secret in ("ghp_token", "93.184.216.34"):
+        assert secret not in tools.text, secret
+        assert secret not in executed.text, secret
+
+
+def test_the_database_session_is_released_before_the_mcp_session_opens(
+    client: TestClient,
+    test_db: Session,
+    api_key_obj: dict[str, Any],
+    api_key_header: dict[str, str],
+    session: _FakeSession,
+    _events: list[str],
+) -> None:
+    """Execution step 5: a pooled connection must not be pinned across a remote call."""
+    row = _store_server(test_db, _workspace_id(test_db, api_key_obj["id"]))
+
+    response = client.post("/v1/mcp/execute", headers=api_key_header, json=_execute_body(row))
+
+    assert response.status_code == 200, response.text
+    assert _events == ["session_released", "mcp_session_opened"]
+
+
+def test_discovery_also_releases_the_session_before_connecting(
+    client: TestClient,
+    test_db: Session,
+    api_key_obj: dict[str, Any],
+    api_key_header: dict[str, str],
+    session: _FakeSession,
+    _events: list[str],
+) -> None:
+    row = _store_server(test_db, _workspace_id(test_db, api_key_obj["id"]))
+
+    response = client.get(f"/v1/mcp/servers/{row.id}/tools", headers=api_key_header)
+
+    assert response.status_code == 200, response.text
+    assert _events == ["session_released", "mcp_session_opened"]
+
+
+def test_the_call_appears_in_the_in_flight_registry_while_it_runs(
+    client: TestClient,
+    test_db: Session,
+    api_key_obj: dict[str, Any],
+    api_key_header: dict[str, str],
+    session: _FakeSession,
+) -> None:
+    """Execution step 7, through the standard middleware lifecycle."""
+    registry = client.app.state.inflight
+    seen: list[list[str]] = []
+    session.on_call = lambda: seen.append([entry.endpoint for entry in registry.snapshot()])
+    row = _store_server(test_db, _workspace_id(test_db, api_key_obj["id"]))
+
+    response = client.post("/v1/mcp/execute", headers=api_key_header, json=_execute_body(row))
+
+    assert response.status_code == 200, response.text
+    assert seen == [["/v1/mcp/execute"]]
+    assert registry.snapshot() == [], "the middleware deregisters once the response is sent"
+
+
+def test_discovery_registers_under_its_own_endpoint_while_it_runs(
+    client: TestClient,
+    test_db: Session,
+    api_key_obj: dict[str, Any],
+    api_key_header: dict[str, str],
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An operator watching in-flight work sees which of the two endpoints is running."""
+    registry = client.app.state.inflight
+    seen: list[list[str]] = []
+    original = session.list_tools
+
+    async def watched(cursor: str | None = None) -> ListToolsResult:
+        seen.append([entry.endpoint for entry in registry.snapshot()])
+        return await original(cursor)
+
+    monkeypatch.setattr(session, "list_tools", watched)
+    row = _store_server(test_db, _workspace_id(test_db, api_key_obj["id"]))
+
+    response = client.get(f"/v1/mcp/servers/{row.id}/tools", headers=api_key_header)
+
+    assert response.status_code == 200, response.text
+    assert seen == [["/v1/mcp/servers/{mcp_server_id}/tools"]]
+    assert registry.snapshot() == []
+
+
+def test_the_authenticated_principal_is_rate_limited_before_any_outbound_access(
+    test_config: Any,
+    postgres_url: str,
+    clean_database: None,
+    session: _FakeSession,
+) -> None:
+    """R-ADM-2: the limit is charged to the key's own subject, before the MCP call."""
+    config = test_config.model_copy(update={"rate_limit_rpm": 1})
+    for rate_limited_client in build_test_client(config):
+        master = {"Otari-Key": f"Bearer {config.master_key}"}
+        key = rate_limited_client.post("/v1/keys", json={"key_name": "rl"}, headers=master).json()
+        header = {"Otari-Key": f"Bearer {key['key']}"}
+        with Session(create_engine(postgres_url)) as db:
+            row = _store_server(db, _workspace_id(db, key["id"]))
+            body = _execute_body(row)
+
+        first = rate_limited_client.post("/v1/mcp/execute", headers=header, json=body)
+        second = rate_limited_client.post("/v1/mcp/execute", headers=header, json=body)
+
+        assert first.status_code == 200, first.text
+        assert second.status_code == 429, second.text
+        assert second.json()["code"] == "rate_limit_exceeded"
+        assert second.json()["execution_state"] == "not_started"
+        assert second.headers["Retry-After"]
+        assert len(session.calls) == 1, "the refused request never reached the server"
+
+
+def test_a_master_key_cannot_reach_a_workspaces_stored_server(
+    client: TestClient,
+    test_db: Session,
+    api_key_obj: dict[str, Any],
+    master_key_header: dict[str, str],
+    session: _FakeSession,
+) -> None:
+    """Operator credentials hold no workspace, so no stored server is theirs to run."""
+    row = _store_server(test_db, _workspace_id(test_db, api_key_obj["id"]))
+
+    executed = client.post("/v1/mcp/execute", headers=master_key_header, json=_execute_body(row))
+    tools = client.get(f"/v1/mcp/servers/{row.id}/tools", headers=master_key_header)
+
+    for response in (executed, tools):
+        assert response.status_code == 404, response.text
+        assert response.json()["code"] == "mcp_server_not_found"
+    assert session.calls == []
+    assert session.pages == 0
+
+
+def test_a_server_stored_in_another_workspace_is_not_found(
+    client: TestClient,
+    test_db: Session,
+    api_key_obj: dict[str, Any],
+    api_key_header: dict[str, str],
+    session: _FakeSession,
+) -> None:
+    row = _store_server(test_db, _other_workspace(test_db))
+
+    response = client.post("/v1/mcp/execute", headers=api_key_header, json=_execute_body(row))
+
+    assert response.status_code == 404, response.text
+    assert response.json()["code"] == "mcp_server_not_found"
+    assert session.calls == []
+
+
+def test_a_disabled_stored_server_is_not_found(
+    client: TestClient,
+    test_db: Session,
+    api_key_obj: dict[str, Any],
+    api_key_header: dict[str, str],
+    session: _FakeSession,
+) -> None:
+    row = _store_server(test_db, _workspace_id(test_db, api_key_obj["id"]), enabled=False)
+
+    response = client.post("/v1/mcp/execute", headers=api_key_header, json=_execute_body(row))
+
+    assert response.status_code == 404, response.text
+    assert session.calls == []
+
+
+def test_a_credential_that_will_not_decrypt_is_a_sanitized_five_hundred(
+    client: TestClient,
+    test_db: Session,
+    api_key_obj: dict[str, Any],
+    api_key_header: dict[str, str],
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Connecting without the credential the workspace configured is not an option."""
+    row = _store_server(test_db, _workspace_id(test_db, api_key_obj["id"]))
+    monkeypatch.setenv("OTARI_SECRET_KEY", generate_secret_key())
+
+    response = client.post("/v1/mcp/execute", headers=api_key_header, json=_execute_body(row))
+
+    assert response.status_code == 500, response.text
+    assert response.json()["code"] == "mcp_credentials_unavailable"
+    assert response.json()["execution_state"] == "not_started"
+    assert session.calls == []
+
+
+def test_the_stored_allowlist_narrows_discovery_and_execution_alike(
+    client: TestClient,
+    test_db: Session,
+    api_key_obj: dict[str, Any],
+    api_key_header: dict[str, str],
+    session: _FakeSession,
+) -> None:
+    row = _store_server(test_db, _workspace_id(test_db, api_key_obj["id"]), allowed_tools=["create_issue"])
+    session.tools.append(MCPTool(name="delete_repo", description="danger", inputSchema={"type": "object"}))
+
+    tools = client.get(f"/v1/mcp/servers/{row.id}/tools", headers=api_key_header)
+    refused = client.post(
+        "/v1/mcp/execute",
+        headers=api_key_header,
+        json=_execute_body(row, tool_name="delete_repo"),
+    )
+
+    assert [tool["name"] for tool in tools.json()["tools"]] == ["create_issue"]
+    assert refused.status_code == 403, refused.text
+    assert refused.json()["code"] == "mcp_tool_not_allowed"
+    assert session.calls == []
+
+
+def test_the_discovered_revision_is_what_execution_accepts(
+    client: TestClient,
+    test_db: Session,
+    api_key_obj: dict[str, Any],
+    api_key_header: dict[str, str],
+    session: _FakeSession,
+) -> None:
+    """The two endpoints agree on the revision, which is the whole point of it."""
+    row = _store_server(test_db, _workspace_id(test_db, api_key_obj["id"]))
+
+    discovered = client.get(f"/v1/mcp/servers/{row.id}/tools", headers=api_key_header).json()
+    executed = client.post(
+        "/v1/mcp/execute",
+        headers=api_key_header,
+        json=_execute_body(row, server_revision=discovered["server_revision"]),
+    )
+
+    assert executed.status_code == 200, executed.text
+
+
+def test_a_configuration_change_after_discovery_is_refused_without_contacting_the_server(
+    client: TestClient,
+    test_db: Session,
+    api_key_obj: dict[str, Any],
+    api_key_header: dict[str, str],
+    session: _FakeSession,
+) -> None:
+    row = _store_server(test_db, _workspace_id(test_db, api_key_obj["id"]))
+    discovered = client.get(f"/v1/mcp/servers/{row.id}/tools", headers=api_key_header).json()
+
+    row.url = "https://93.184.216.35/mcp"
+    test_db.add(row)
+    test_db.commit()
+
+    response = client.post(
+        "/v1/mcp/execute",
+        headers=api_key_header,
+        json=_execute_body(row, server_revision=discovered["server_revision"]),
+    )
+
+    assert response.status_code == 409, response.text
+    assert response.json()["code"] == "mcp_server_changed"
+    assert session.calls == []

--- a/tests/integration/test_tenancy_races.py
+++ b/tests/integration/test_tenancy_races.py
@@ -48,6 +48,7 @@ from gateway.services.tenancy.errors import (
     InvitationAlreadyUsedError,
     LastWorkspaceError,
     MembershipUpdateError,
+    NotAuthorizedError,
     OrganizationMemberAlreadyExistsError,
     ResetTokenInvalidError,
     VerificationTokenInvalidError,
@@ -368,7 +369,12 @@ async def test_concurrent_demotions_cannot_strip_the_last_owner(
 
     outcomes = list(await asyncio.gather(*(run_one(attempt) for attempt in attempts)))
 
-    refused = [outcome for outcome in outcomes if isinstance(outcome, MembershipUpdateError)]
+    # Which refusal the loser gets depends on where it was when the winner
+    # committed: still inside its own pre-lock reads, so its actor is an owner
+    # and the last-owner guard turns it away, or not yet started, so its actor
+    # is already a member and the management-role check turns it away first.
+    # Both are the same invariant holding, which is what the owner count asserts.
+    refused = [outcome for outcome in outcomes if isinstance(outcome, MembershipUpdateError | NotAuthorizedError)]
     assert len(refused) == 1
     assert await OrganizationMemberRepository(async_db).count_active_owners(organization.id) == 1
 

--- a/tests/integration/test_workspace_mcp_servers.py
+++ b/tests/integration/test_workspace_mcp_servers.py
@@ -53,6 +53,7 @@ from gateway.services.tenancy.workspace_mcp_server_service import (
     WorkspaceMcpServerCreate,
     WorkspaceMcpServerService,
     WorkspaceMcpServerUpdate,
+    resolve_workspace_mcp_server,
     resolve_workspace_mcp_servers,
 )
 
@@ -881,3 +882,124 @@ async def test_mcp_server_ids_is_bounded_on_the_request() -> None:
             messages=[{"role": "user", "content": "hi"}],
             mcp_server_ids=[uuid.uuid4() for _ in range(MAX_MCP_SERVER_IDS + 1)],
         )
+
+
+# --------------------------------------------------------------------------- #
+# Single stored-server resolution, for the caller-orchestrated endpoints
+# --------------------------------------------------------------------------- #
+
+
+async def test_single_resolution_returns_the_stored_server_and_its_revision(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+    created = await service.create_server(
+        user=owner,
+        workspace_id=workspace.id,
+        request=_create(authorization_token="ghp_token", allowed_tools=["list_issues"], purpose_hint="Issues"),
+    )
+
+    resolved = await resolve_workspace_mcp_server(async_db, workspace_id=workspace.id, server_id=created.id)
+
+    assert resolved is not None
+    assert resolved.id == created.id
+    assert resolved.url == PUBLIC_URL
+    assert resolved.authorization_token == "ghp_token"
+    assert resolved.enabled is True
+    assert resolved.allowed_tools == ["list_issues"]
+    assert resolved.revision
+
+
+async def test_single_resolution_of_an_unchanged_server_is_stable(async_db: AsyncSession) -> None:
+    """R-RES-3: the revision has to survive being derived twice, on any worker."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+    created = await service.create_server(user=owner, workspace_id=workspace.id, request=_create())
+
+    first = await resolve_workspace_mcp_server(async_db, workspace_id=workspace.id, server_id=created.id)
+    second = await resolve_workspace_mcp_server(async_db, workspace_id=workspace.id, server_id=created.id)
+
+    assert first is not None and second is not None
+    assert first.revision == second.revision
+
+
+async def test_single_resolution_revision_moves_when_the_stored_url_changes(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+    created = await service.create_server(user=owner, workspace_id=workspace.id, request=_create())
+    before = await resolve_workspace_mcp_server(async_db, workspace_id=workspace.id, server_id=created.id)
+
+    await service.update_server(
+        user=owner,
+        workspace_id=workspace.id,
+        server_id=created.id,
+        request=WorkspaceMcpServerUpdate(url=OTHER_PUBLIC_URL),
+    )
+    after = await resolve_workspace_mcp_server(async_db, workspace_id=workspace.id, server_id=created.id)
+
+    assert before is not None and after is not None
+    assert before.revision != after.revision
+
+
+async def test_single_resolution_revision_ignores_a_rename(async_db: AsyncSession) -> None:
+    """Retitling a server must not invalidate an authorization already granted."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+    created = await service.create_server(user=owner, workspace_id=workspace.id, request=_create())
+    before = await resolve_workspace_mcp_server(async_db, workspace_id=workspace.id, server_id=created.id)
+
+    await service.update_server(
+        user=owner,
+        workspace_id=workspace.id,
+        server_id=created.id,
+        request=WorkspaceMcpServerUpdate(name="github-enterprise", purpose_hint="Tickets"),
+    )
+    after = await resolve_workspace_mcp_server(async_db, workspace_id=workspace.id, server_id=created.id)
+
+    assert before is not None and after is not None
+    assert before.revision == after.revision
+
+
+async def test_single_resolution_reports_a_disabled_server_rather_than_skipping_it(async_db: AsyncSession) -> None:
+    """The plural resolver drops a disabled server; this one has to name it.
+
+    The stored-server endpoints answer a disabled server with a 404 that both
+    modes share, and a resolver that silently returned nothing would be
+    indistinguishable from an id belonging to another workspace.
+    """
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+    created = await service.create_server(user=owner, workspace_id=workspace.id, request=_create(enabled=False))
+
+    resolved = await resolve_workspace_mcp_server(async_db, workspace_id=workspace.id, server_id=created.id)
+
+    assert resolved is not None
+    assert resolved.enabled is False
+
+
+async def test_single_resolution_of_another_workspaces_server_finds_nothing(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    first = await _workspace(async_db, organization, name="First", owner=owner)
+    second = await _workspace(async_db, organization, name="Second", owner=owner)
+    service = WorkspaceMcpServerService(async_db)
+    created = await service.create_server(user=owner, workspace_id=first.id, request=_create())
+
+    assert await resolve_workspace_mcp_server(async_db, workspace_id=second.id, server_id=created.id) is None
+
+
+async def test_single_resolution_of_an_unknown_id_finds_nothing(async_db: AsyncSession) -> None:
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+
+    assert await resolve_workspace_mcp_server(async_db, workspace_id=workspace.id, server_id=uuid.uuid4()) is None

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import Any, cast
@@ -9,6 +10,7 @@ from unittest.mock import AsyncMock
 
 import httpx
 import pytest
+from mcp.types import CallToolResult, TextContent
 
 from gateway.models.mcp import McpServerConfig
 from gateway.services.mcp_client import MCPClientPool, _ConnectedServer
@@ -51,6 +53,48 @@ async def test_aenter_connects_distinct_names(monkeypatch: pytest.MonkeyPatch) -
     async with MCPClientPool(configs) as pool:
         assert set(pool._servers) == {"a", "b"}
     assert connected == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_empty_allowed_tools_exposes_no_discovered_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit empty allowlist denies every tool; only None means unrestricted."""
+
+    @asynccontextmanager
+    async def fake_transport(*args: Any, **kwargs: Any) -> AsyncIterator[tuple[object, object, object]]:
+        yield object(), object(), object()
+
+    class FakeSession:
+        async def __aenter__(self) -> FakeSession:
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            return None
+
+        async def initialize(self) -> None:
+            return None
+
+        async def list_tools(self) -> SimpleNamespace:
+            return SimpleNamespace(
+                tools=[
+                    SimpleNamespace(
+                        name="list_issues",
+                        description="List issues",
+                        inputSchema={"type": "object"},
+                    )
+                ]
+            )
+
+    monkeypatch.setattr("gateway.services.mcp_client.streamablehttp_client", fake_transport)
+    monkeypatch.setattr("gateway.services.mcp_client.ClientSession", lambda *args: FakeSession())
+
+    config = McpServerConfig(
+        name="tools",
+        url="https://93.184.216.34/mcp",
+        allowed_tools=[],
+    )
+    async with MCPClientPool([config]) as pool:
+        assert pool.openai_tools == []
+        assert pool.owns_tool("list_issues") is False
 
 
 @pytest.mark.asyncio
@@ -106,6 +150,29 @@ async def test_call_tool_sanitizes_transport_failure(
     assert warnings == [("MCP tool %s execution failed: %s", "lookup", "RuntimeError")]
     assert "internal.test" not in str(warnings)
     assert "secret" not in str(warnings)
+
+
+@pytest.mark.asyncio
+async def test_call_tool_result_returns_native_mcp_result() -> None:
+    result = CallToolResult(
+        content=[TextContent(type="text", text="fixture result")],
+        structuredContent={"issue": 791},
+        isError=True,
+    )
+    session = SimpleNamespace(call_tool=AsyncMock(return_value=result))
+    pool = MCPClientPool([])
+    pool._servers["fixture"] = _ConnectedServer(
+        name="fixture",
+        session=cast(Any, session),
+    )
+    pool._tool_owner["lookup"] = "fixture"
+
+    returned = await pool.call_tool_result("lookup", {"id": 791})
+
+    assert returned is result
+    assert returned.structuredContent == {"issue": 791}
+    assert returned.isError is True
+    session.call_tool.assert_awaited_once_with("lookup", {"id": 791})
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -153,7 +153,7 @@ async def test_call_tool_sanitizes_transport_failure(
 
 
 @pytest.mark.asyncio
-async def test_call_tool_result_returns_native_mcp_result() -> None:
+async def test_call_tool_result_extraction_returns_native_mcp_result() -> None:
     result = CallToolResult(
         content=[TextContent(type="text", text="fixture result")],
         structuredContent={"issue": 791},
@@ -167,7 +167,7 @@ async def test_call_tool_result_returns_native_mcp_result() -> None:
     )
     pool._tool_owner["lookup"] = "fixture"
 
-    returned = await pool.call_tool_result("lookup", {"id": 791})
+    returned = await pool._call_tool_result("lookup", {"id": 791})  # noqa: SLF001
 
     assert returned is result
     assert returned.structuredContent == {"issue": 791}

--- a/tests/unit/test_mcp_discovery_pagination.py
+++ b/tests/unit/test_mcp_discovery_pagination.py
@@ -17,7 +17,6 @@ from mcp.types import Tool as MCPTool
 from gateway.services.mcp_stateless import (
     DISCOVERY_MAX_EXAMINED,
     DISCOVERY_MAX_PAGES,
-    DISCOVERY_MAX_TOOLS,
     McpDiscoveryRefused,
     collect_tools,
 )
@@ -126,14 +125,6 @@ async def test_the_examined_descriptor_ceiling_counts_allowlist_removals_too() -
 
     with pytest.raises(McpDiscoveryRefused):
         await collect_tools(session, allowed_tools=["a"])
-
-
-@pytest.mark.asyncio
-async def test_the_returned_tool_ceiling_fails_the_whole_request() -> None:
-    session = _FakeSession([_page([_tool(f"t{i}") for i in range(DISCOVERY_MAX_TOOLS + 1)])])
-
-    with pytest.raises(McpDiscoveryRefused):
-        await collect_tools(session, allowed_tools=None)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mcp_discovery_pagination.py
+++ b/tests/unit/test_mcp_discovery_pagination.py
@@ -1,0 +1,177 @@
+"""Bounded ``tools/list`` collection (R-DISC-1, R-DISC-4, L-DISC-* ceilings).
+
+The live catalog of a remote MCP server is untrusted and paginated. Discovery
+follows the cursor, stops at the first ceiling it reaches, and either returns
+the complete authorized catalog or nothing: a partial page would be read by
+an application as the whole authorization and risk-policy input (R-DISC-5).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from mcp.types import ListToolsResult
+from mcp.types import Tool as MCPTool
+
+from gateway.services.mcp_stateless import (
+    DISCOVERY_MAX_EXAMINED,
+    DISCOVERY_MAX_PAGES,
+    DISCOVERY_MAX_TOOLS,
+    McpDiscoveryRefused,
+    collect_tools,
+)
+
+
+def _tool(name: str, description: str = "a tool") -> MCPTool:
+    return MCPTool(name=name, description=description, inputSchema={"type": "object"})
+
+
+class _FakeSession:
+    """A ``ClientSession`` stand-in that serves prepared ``tools/list`` pages."""
+
+    def __init__(self, pages: list[Any]) -> None:
+        self._pages = pages
+        self.cursors: list[str | None] = []
+
+    async def list_tools(self, cursor: str | None = None) -> Any:
+        self.cursors.append(cursor)
+        return self._pages[len(self.cursors) - 1]
+
+
+def _page(tools: list[MCPTool], next_cursor: str | None = None) -> ListToolsResult:
+    return ListToolsResult(tools=tools, nextCursor=next_cursor)
+
+
+@pytest.mark.asyncio
+async def test_a_single_page_catalog_is_returned_whole() -> None:
+    session = _FakeSession([_page([_tool("a"), _tool("b")])])
+
+    tools = await collect_tools(session, allowed_tools=None)
+
+    assert [t.name for t in tools] == ["a", "b"]
+    assert session.cursors == [None]
+
+
+@pytest.mark.asyncio
+async def test_the_cursor_is_followed_to_the_end() -> None:
+    session = _FakeSession(
+        [
+            _page([_tool("a")], next_cursor="p2"),
+            _page([_tool("b")], next_cursor="p3"),
+            _page([_tool("c")]),
+        ]
+    )
+
+    tools = await collect_tools(session, allowed_tools=None)
+
+    assert [t.name for t in tools] == ["a", "b", "c"]
+    assert session.cursors == [None, "p2", "p3"]
+
+
+@pytest.mark.asyncio
+async def test_only_the_allowlist_intersection_is_returned() -> None:
+    """A tool the server added is not exposed merely because it was listed."""
+    session = _FakeSession([_page([_tool("a"), _tool("newly_added"), _tool("b")])])
+
+    tools = await collect_tools(session, allowed_tools=["b", "a", "never_listed"])
+
+    assert [t.name for t in tools] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_pagination_stops_once_every_allowlisted_name_is_found() -> None:
+    session = _FakeSession(
+        [
+            _page([_tool("a")], next_cursor="p2"),
+            _page([_tool("b")], next_cursor="p3"),
+            _page([_tool("c")]),
+        ]
+    )
+
+    tools = await collect_tools(session, allowed_tools=["a", "b"])
+
+    assert [t.name for t in tools] == ["a", "b"]
+    assert session.cursors == [None, "p2"]
+
+
+@pytest.mark.asyncio
+async def test_a_repeated_cursor_fails_the_whole_request() -> None:
+    session = _FakeSession(
+        [
+            _page([_tool("a")], next_cursor="loop"),
+            _page([_tool("b")], next_cursor="loop"),
+        ]
+    )
+
+    with pytest.raises(McpDiscoveryRefused):
+        await collect_tools(session, allowed_tools=None)
+
+
+@pytest.mark.asyncio
+async def test_the_page_ceiling_fails_the_whole_request() -> None:
+    pages = [_page([_tool(f"t{i}")], next_cursor=f"p{i + 1}") for i in range(DISCOVERY_MAX_PAGES + 1)]
+    session = _FakeSession(pages)
+
+    with pytest.raises(McpDiscoveryRefused):
+        await collect_tools(session, allowed_tools=None)
+
+    assert len(session.cursors) == DISCOVERY_MAX_PAGES
+
+
+@pytest.mark.asyncio
+async def test_the_examined_descriptor_ceiling_counts_allowlist_removals_too() -> None:
+    removed = [_tool(f"denied{i}") for i in range(DISCOVERY_MAX_EXAMINED + 1)]
+    session = _FakeSession([_page(removed)])
+
+    with pytest.raises(McpDiscoveryRefused):
+        await collect_tools(session, allowed_tools=["a"])
+
+
+@pytest.mark.asyncio
+async def test_the_returned_tool_ceiling_fails_the_whole_request() -> None:
+    session = _FakeSession([_page([_tool(f"t{i}") for i in range(DISCOVERY_MAX_TOOLS + 1)])])
+
+    with pytest.raises(McpDiscoveryRefused):
+        await collect_tools(session, allowed_tools=None)
+
+
+@pytest.mark.asyncio
+async def test_a_conflicting_duplicate_tool_name_fails_the_whole_request() -> None:
+    session = _FakeSession(
+        [
+            _page([_tool("a", "one thing")], next_cursor="p2"),
+            _page([_tool("a", "something else")]),
+        ]
+    )
+
+    with pytest.raises(McpDiscoveryRefused):
+        await collect_tools(session, allowed_tools=None)
+
+
+@pytest.mark.asyncio
+async def test_an_identical_repeat_of_one_tool_is_not_a_conflict() -> None:
+    session = _FakeSession(
+        [
+            _page([_tool("a")], next_cursor="p2"),
+            _page([_tool("a")]),
+        ]
+    )
+
+    tools = await collect_tools(session, allowed_tools=None)
+
+    assert [t.name for t in tools] == ["a"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tools", ["not-a-list", [{"name": "a"}], [None]])
+async def test_a_malformed_page_fails_the_whole_request(tools: Any) -> None:
+    class _Page:
+        nextCursor = None
+
+    page = _Page()
+    page.tools = tools  # type: ignore[attr-defined]
+    session = _FakeSession([page])
+
+    with pytest.raises(McpDiscoveryRefused):
+        await collect_tools(session, allowed_tools=None)

--- a/tests/unit/test_mcp_execute_endpoint.py
+++ b/tests/unit/test_mcp_execute_endpoint.py
@@ -1,0 +1,288 @@
+"""Endpoint coverage for stateless MCP tool execution."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import ANY, AsyncMock, Mock
+
+import pytest
+from fastapi.testclient import TestClient
+from mcp.types import CallToolResult, TextContent
+
+from gateway import log_config
+from gateway.api.deps import reset_config
+from gateway.api.routes import mcp as mcp_route
+from gateway.core.config import GatewayConfig
+from gateway.core.database import reset_db
+from gateway.main import create_app
+from gateway.services.url_safety import UnsafeURLError
+
+AUTH = {"Authorization": "Bearer sk-test-master"}
+PUBLIC_URL = "https://93.184.216.34/mcp"
+
+
+@pytest.fixture(autouse=True)
+def _reset_globals() -> Iterator[None]:
+    yield
+    reset_config()
+    reset_db()
+
+
+def _standalone_client(tmp_path: Path) -> TestClient:
+    return TestClient(
+        create_app(
+            GatewayConfig(
+                database_url=f"sqlite:///{tmp_path / 'mcp-execute.db'}",
+                master_key="sk-test-master",
+            )
+        )
+    )
+
+
+def _hybrid_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("OTARI_AI_TOKEN", "gw-test-token")
+    return TestClient(
+        create_app(
+            GatewayConfig(
+                mode="hybrid",
+                platform={"base_url": "http://platform.test/api/v1"},
+            )
+        )
+    )
+
+
+def _body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "server": {
+            "name": "github",
+            "url": PUBLIC_URL,
+            "authorization_token": "server-secret",
+            "allowed_tools": ["list_issues"],
+        },
+        "tool_name": "list_issues",
+        "arguments": {"repository": "mozilla-ai/otari"},
+    }
+    body.update(overrides)
+    return body
+
+
+async def _safe_url(*args: Any, **kwargs: Any) -> None:
+    return None
+
+
+class _FakePool:
+    result = CallToolResult(
+        content=[TextContent(type="text", text="two open issues")],
+        structuredContent={"count": 2},
+        isError=False,
+    )
+    owns = True
+    enter_error: Exception | None = None
+    call_error: Exception | None = None
+    instances: list[_FakePool] = []
+
+    def __init__(self, configs: list[Any]) -> None:
+        self.configs = configs
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        type(self).instances.append(self)
+
+    async def __aenter__(self) -> _FakePool:
+        if self.enter_error is not None:
+            raise self.enter_error
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    def owns_tool(self, name: str) -> bool:
+        return self.owns
+
+    async def call_tool_result(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+        self.calls.append((name, arguments))
+        if self.call_error is not None:
+            raise self.call_error
+        return self.result
+
+
+@pytest.fixture
+def fake_pool(monkeypatch: pytest.MonkeyPatch) -> type[_FakePool]:
+    _FakePool.instances = []
+    _FakePool.owns = True
+    _FakePool.enter_error = None
+    _FakePool.call_error = None
+    _FakePool.result = CallToolResult(
+        content=[TextContent(type="text", text="two open issues")],
+        structuredContent={"count": 2},
+        isError=False,
+    )
+    monkeypatch.setattr(mcp_route, "MCPClientPool", _FakePool)
+    monkeypatch.setattr(mcp_route, "validate_mcp_url", _safe_url)
+    return _FakePool
+
+
+def test_executes_exact_approved_call_and_returns_native_result(
+    tmp_path: Path,
+    fake_pool: type[_FakePool],
+) -> None:
+    with _standalone_client(tmp_path) as client:
+        response = client.post("/v1/mcp/execute", headers=AUTH, json=_body())
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "content": [{"type": "text", "text": "two open issues"}],
+        "structuredContent": {"count": 2},
+        "isError": False,
+    }
+    pool = fake_pool.instances[0]
+    assert len(pool.configs) == 1
+    assert pool.configs[0].name == "github"
+    assert pool.configs[0].authorization_token == "server-secret"
+    assert pool.calls == [("list_issues", {"repository": "mozilla-ai/otari"})]
+
+
+def test_server_reported_error_remains_a_typed_success(
+    tmp_path: Path,
+    fake_pool: type[_FakePool],
+) -> None:
+    fake_pool.result = CallToolResult(
+        content=[TextContent(type="text", text="permission denied")],
+        isError=True,
+    )
+    with _standalone_client(tmp_path) as client:
+        response = client.post("/v1/mcp/execute", headers=AUTH, json=_body())
+
+    assert response.status_code == 200, response.text
+    assert response.json()["isError"] is True
+    assert response.json()["content"] == [{"type": "text", "text": "permission denied"}]
+
+
+def test_requires_authentication_before_contacting_server(
+    tmp_path: Path,
+    fake_pool: type[_FakePool],
+) -> None:
+    with _standalone_client(tmp_path) as client:
+        response = client.post("/v1/mcp/execute", json=_body())
+
+    assert response.status_code == 401
+    assert fake_pool.instances == []
+
+
+@pytest.mark.parametrize("allowed_tools", [[], ["read_issue"]])
+def test_configured_allowlist_is_enforced_before_contacting_server(
+    tmp_path: Path,
+    fake_pool: type[_FakePool],
+    allowed_tools: list[str],
+) -> None:
+    server = _body()["server"]
+    server["allowed_tools"] = allowed_tools
+    with _standalone_client(tmp_path) as client:
+        response = client.post("/v1/mcp/execute", headers=AUTH, json=_body(server=server))
+
+    assert response.status_code == 403, response.text
+    assert response.json() == {"detail": mcp_route.MCP_TOOL_NOT_ALLOWED_DETAIL}
+    assert fake_pool.instances == []
+
+
+def test_unsafe_url_is_rejected_before_contacting_server(
+    tmp_path: Path,
+    fake_pool: type[_FakePool],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def reject(*args: Any, **kwargs: Any) -> None:
+        raise UnsafeURLError("MCP server URL is unsafe")
+
+    monkeypatch.setattr(mcp_route, "validate_mcp_url", reject)
+    with _standalone_client(tmp_path) as client:
+        response = client.post("/v1/mcp/execute", headers=AUTH, json=_body())
+
+    assert response.status_code == 400, response.text
+    assert response.json() == {"detail": "MCP server URL is unsafe"}
+    assert fake_pool.instances == []
+
+
+def test_tool_must_exist_in_live_discovery(
+    tmp_path: Path,
+    fake_pool: type[_FakePool],
+) -> None:
+    fake_pool.owns = False
+    with _standalone_client(tmp_path) as client:
+        response = client.post("/v1/mcp/execute", headers=AUTH, json=_body())
+
+    assert response.status_code == 404, response.text
+    assert response.json() == {"detail": mcp_route.MCP_TOOL_NOT_FOUND_DETAIL}
+    assert fake_pool.instances[0].calls == []
+
+
+@pytest.mark.parametrize("stage", ["connect", "call"])
+def test_transport_and_protocol_failures_are_sanitized(
+    tmp_path: Path,
+    fake_pool: type[_FakePool],
+    monkeypatch: pytest.MonkeyPatch,
+    stage: str,
+) -> None:
+    warning = Mock()
+    monkeypatch.setattr(log_config.logger, "warning", warning)
+    private_message = "server-secret repository=mozilla-ai/otari private-result"
+    if stage == "connect":
+        fake_pool.enter_error = RuntimeError(private_message)
+    else:
+        fake_pool.call_error = RuntimeError(private_message)
+
+    with _standalone_client(tmp_path) as client:
+        # App startup uses the same process-wide logger for configuration
+        # warnings. Isolate the request under test from those lifespan calls.
+        warning.reset_mock()
+        response = client.post("/v1/mcp/execute", headers=AUTH, json=_body())
+
+    assert response.status_code == 502, response.text
+    assert response.json() == {"detail": mcp_route.MCP_EXECUTION_FAILED_DETAIL}
+    assert private_message not in response.text
+    warning.assert_called_once_with(
+        "Stateless MCP request failed error_class=%s",
+        "RuntimeError",
+    )
+
+
+def test_arguments_must_be_a_json_object(tmp_path: Path, fake_pool: type[_FakePool]) -> None:
+    with _standalone_client(tmp_path) as client:
+        response = client.post(
+            "/v1/mcp/execute",
+            headers=AUTH,
+            json=_body(arguments=["not", "an", "object"]),
+        )
+
+    assert response.status_code == 422
+    assert fake_pool.instances == []
+
+
+def test_hybrid_mode_authenticates_through_empty_mcp_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_pool: type[_FakePool],
+) -> None:
+    resolve = AsyncMock(return_value=[])
+    monkeypatch.setattr(mcp_route, "_resolve_platform_mcp_servers", resolve)
+    with _hybrid_client(monkeypatch) as client:
+        response = client.post(
+            "/v1/mcp/execute",
+            headers={"Authorization": "Bearer platform-user-token"},
+            json=_body(),
+        )
+
+    assert response.status_code == 200, response.text
+    resolve.assert_awaited_once_with(ANY, "platform-user-token", [])
+
+
+def test_hybrid_mode_requires_user_token(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_pool: type[_FakePool],
+) -> None:
+    resolve = AsyncMock(return_value=[])
+    monkeypatch.setattr(mcp_route, "_resolve_platform_mcp_servers", resolve)
+    with _hybrid_client(monkeypatch) as client:
+        response = client.post("/v1/mcp/execute", json=_body())
+
+    assert response.status_code == 401
+    resolve.assert_not_awaited()
+    assert fake_pool.instances == []

--- a/tests/unit/test_mcp_execute_endpoint.py
+++ b/tests/unit/test_mcp_execute_endpoint.py
@@ -81,6 +81,7 @@ class _FakePool:
     owns = True
     enter_error: Exception | None = None
     call_error: Exception | None = None
+    exit_error: Exception | None = None
     instances: list[_FakePool] = []
 
     def __init__(self, configs: list[Any]) -> None:
@@ -94,7 +95,8 @@ class _FakePool:
         return self
 
     async def __aexit__(self, *exc: object) -> None:
-        return None
+        if self.exit_error is not None:
+            raise self.exit_error
 
     def owns_tool(self, name: str) -> bool:
         return self.owns
@@ -112,6 +114,7 @@ def fake_pool(monkeypatch: pytest.MonkeyPatch) -> type[_FakePool]:
     _FakePool.owns = True
     _FakePool.enter_error = None
     _FakePool.call_error = None
+    _FakePool.exit_error = None
     _FakePool.result = CallToolResult(
         content=[TextContent(type="text", text="two open issues")],
         structuredContent={"count": 2},
@@ -156,6 +159,30 @@ def test_server_reported_error_remains_a_typed_success(
     assert response.status_code == 200, response.text
     assert response.json()["isError"] is True
     assert response.json()["content"] == [{"type": "text", "text": "permission denied"}]
+
+
+def test_cleanup_failure_does_not_hide_a_successful_mutating_call(
+    tmp_path: Path,
+    fake_pool: type[_FakePool],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warning = Mock()
+    monkeypatch.setattr(log_config.logger, "warning", warning)
+    fake_pool.exit_error = RuntimeError("server-secret cleanup failure")
+
+    with _standalone_client(tmp_path) as client:
+        warning.reset_mock()
+        response = client.post("/v1/mcp/execute", headers=AUTH, json=_body())
+
+    assert response.status_code == 200, response.text
+    assert response.json()["content"] == [{"type": "text", "text": "two open issues"}]
+    assert fake_pool.instances[0].calls == [
+        ("list_issues", {"repository": "mozilla-ai/otari"})
+    ]
+    warning.assert_called_once_with(
+        "Stateless MCP cleanup failed error_class=%s",
+        "RuntimeError",
+    )
 
 
 def test_requires_authentication_before_contacting_server(

--- a/tests/unit/test_mcp_execute_endpoint.py
+++ b/tests/unit/test_mcp_execute_endpoint.py
@@ -93,6 +93,7 @@ class _Platform:
     def __init__(self) -> None:
         self.servers: list[dict[str, Any]] | None = [_stored().model_dump(mode="json")]
         self.status_code = 200
+        self.malformed_json = False
         self.bodies: list[dict[str, Any]] = []
         self.retry_after: str | None = None
         self.delay_s = 0.0
@@ -109,6 +110,8 @@ def platform(monkeypatch: pytest.MonkeyPatch) -> _Platform:
         await asyncio.sleep(fake.delay_s)
         fake.bodies.append(body)
         response_headers = {"Retry-After": fake.retry_after} if fake.retry_after else None
+        if fake.malformed_json:
+            return httpx.Response(fake.status_code, content=b"{")
         return httpx.Response(fake.status_code, json=fake.payload(), headers=response_headers)
 
     monkeypatch.setattr(platform_module, "_post_platform", post)
@@ -372,6 +375,20 @@ def test_multiple_resolver_entries_are_a_resolution_failure(
     assert session.calls == []
 
 
+def test_a_malformed_successful_resolver_response_is_a_resolution_failure(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    platform.malformed_json = True
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
+
+    assert response.status_code == 502, response.text
+    assert _error(response)["code"] == "mcp_resolution_failed"
+    assert session.calls == []
+
+
 def test_the_platforms_rate_limit_is_preserved(
     client: TestClient,
     platform: _Platform,
@@ -534,6 +551,26 @@ def test_a_deadline_after_dispatch_is_an_unknown_outcome(
 
     assert response.status_code == 504, response.text
     assert _error(response)["execution_state"] == "outcome_unknown"
+
+
+def test_the_total_deadline_includes_platform_resolution(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mcp_stateless, "EXECUTION_TOTAL_TIMEOUT_S", 0.01)
+    platform.delay_s = 10
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
+
+    assert response.status_code == 502, response.text
+    assert _error(response) == {
+        "detail": "MCP server connection failed",
+        "code": "mcp_connection_failed",
+        "execution_state": "not_started",
+    }
+    assert session.calls == []
 
 
 def test_an_oversized_result_is_an_unknown_outcome(

--- a/tests/unit/test_mcp_execute_endpoint.py
+++ b/tests/unit/test_mcp_execute_endpoint.py
@@ -145,7 +145,7 @@ def _body(**overrides: Any) -> dict[str, Any]:
     return body
 
 
-def _error(response: httpx.Response) -> dict[str, Any]:
+def _error(response: Any) -> dict[str, Any]:
     payload = dict(response.json())
     assert payload.pop("request_id"), "every error body carries the opaque request id"
     return payload
@@ -534,7 +534,7 @@ def test_a_capacity_refusal_is_the_only_failure_that_invites_a_retry(
     monkeypatch.setattr(mcp_stateless, "EXECUTION_GATE", gate)
     monkeypatch.setattr(mcp_stateless, "DISCOVERY_GATE", gate)
 
-    async def hold_the_only_slot() -> httpx.Response:
+    async def hold_the_only_slot() -> Any:
         async with gate.slot():
             return await asyncio.to_thread(
                 lambda: client.post(path, headers=USER_AUTH, json=_body())

--- a/tests/unit/test_mcp_execute_endpoint.py
+++ b/tests/unit/test_mcp_execute_endpoint.py
@@ -22,6 +22,7 @@ from unittest.mock import Mock
 
 import httpx
 import pytest
+from fastapi import HTTPException, Request
 from fastapi.testclient import TestClient
 from mcp.types import CallToolResult, TextContent
 
@@ -389,6 +390,34 @@ def test_a_malformed_successful_resolver_response_is_a_resolution_failure(
     assert session.calls == []
 
 
+@pytest.mark.parametrize(
+    ("platform_status", "expected_code", "expected_detail"),
+    [
+        (402, "payment_required", "Payment required"),
+        (403, "forbidden", "Request forbidden"),
+    ],
+)
+def test_platform_payment_and_authorization_refusals_keep_their_status(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+    platform_status: int,
+    expected_code: str,
+    expected_detail: str,
+) -> None:
+    platform.status_code = platform_status
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
+
+    assert response.status_code == platform_status, response.text
+    assert _error(response) == {
+        "detail": expected_detail,
+        "code": expected_code,
+        "execution_state": "not_started",
+    }
+    assert session.calls == []
+
+
 def test_the_platforms_rate_limit_is_preserved(
     client: TestClient,
     platform: _Platform,
@@ -456,6 +485,56 @@ def test_an_invalid_request_is_refused_before_resolution_or_logging(
     assert _error(response) == {
         "detail": "MCP request is invalid",
         "code": "invalid_request",
+        "execution_state": "not_started",
+    }
+    assert platform.bodies == []
+    assert session.calls == []
+
+
+def test_a_non_json_parse_failure_uses_the_shared_invalid_request_error(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail_to_parse(_request: Request) -> Any:
+        raise RecursionError
+
+    monkeypatch.setattr(Request, "json", fail_to_parse)
+
+    response = client.post(
+        "/v1/mcp/execute",
+        headers={**USER_AUTH, "Content-Type": "application/json"},
+        content=b"{}",
+    )
+
+    assert response.status_code == 422, response.text
+    assert _error(response) == {
+        "detail": "MCP request is invalid",
+        "code": "invalid_request",
+        "execution_state": "not_started",
+    }
+    assert platform.bodies == []
+    assert session.calls == []
+
+
+def test_a_local_service_unavailability_keeps_its_status(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def unavailable(*args: Any, **kwargs: Any) -> Any:
+        raise HTTPException(status_code=503, detail="internal detail")
+
+    monkeypatch.setattr("gateway.api.routes.mcp._authenticate", unavailable)
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
+
+    assert response.status_code == 503, response.text
+    assert _error(response) == {
+        "detail": "MCP service is unavailable",
+        "code": "service_unavailable",
         "execution_state": "not_started",
     }
     assert platform.bodies == []
@@ -553,12 +632,14 @@ def test_a_deadline_after_dispatch_is_an_unknown_outcome(
     assert _error(response)["execution_state"] == "outcome_unknown"
 
 
-def test_the_total_deadline_includes_platform_resolution(
+def test_the_total_deadline_includes_platform_resolution_and_logs_the_outcome(
     client: TestClient,
     platform: _Platform,
     session: _FakeSession,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    info = Mock()
+    monkeypatch.setattr(log_config.logger, "info", info)
     monkeypatch.setattr(mcp_stateless, "EXECUTION_TOTAL_TIMEOUT_S", 0.01)
     platform.delay_s = 10
 
@@ -570,6 +651,8 @@ def test_the_total_deadline_includes_platform_resolution(
         "code": "mcp_connection_failed",
         "execution_state": "not_started",
     }
+    info.assert_called_once()
+    assert info.call_args.args[4:6] == ("mcp_connection_failed", "not_started")
     assert session.calls == []
 
 

--- a/tests/unit/test_mcp_execute_endpoint.py
+++ b/tests/unit/test_mcp_execute_endpoint.py
@@ -176,6 +176,22 @@ def test_the_exact_authorized_call_runs_and_the_native_result_comes_back(
     assert platform.bodies == [{"mcp_server_ids": [str(SERVER_ID)]}]
 
 
+def test_the_legacy_resolver_shape_executes_the_authorized_call(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    stored = _stored().model_dump(mode="json")
+    del stored["id"]
+    del stored["enabled"]
+    platform.servers = [stored]
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
+
+    assert response.status_code == 200, response.text
+    assert session.calls == [("create_issue", {"title": "Approved title", "body": "Approved body"})]
+
+
 def test_the_request_id_is_returned_on_success_without_touching_the_result(
     client: TestClient,
     platform: _Platform,
@@ -328,14 +344,26 @@ def test_a_server_the_platform_refuses_is_not_found(
     assert session.calls == []
 
 
-@pytest.mark.parametrize("servers", [[], [_stored().model_dump(mode="json")] * 2])
-def test_an_unusable_resolver_answer_is_a_resolution_failure(
+def test_a_legacy_empty_resolver_answer_is_not_found(
     client: TestClient,
     platform: _Platform,
     session: _FakeSession,
-    servers: list[dict[str, Any]],
 ) -> None:
-    platform.servers = servers
+    platform.servers = []
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
+
+    assert response.status_code == 404, response.text
+    assert _error(response)["code"] == "mcp_server_not_found"
+    assert session.calls == []
+
+
+def test_multiple_resolver_entries_are_a_resolution_failure(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    platform.servers = [_stored().model_dump(mode="json")] * 2
 
     response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
 

--- a/tests/unit/test_mcp_execute_endpoint.py
+++ b/tests/unit/test_mcp_execute_endpoint.py
@@ -1,26 +1,50 @@
-"""Endpoint coverage for stateless MCP tool execution."""
+"""``POST /v1/mcp/execute``: the caller-orchestrated execution contract.
+
+Otari executes one exact call an application has already authorized. It proves
+no approval and claims none (R-AUTH-4); what it enforces is authentication,
+stored-server access, the stored allowlist, URL safety, and its own bounds.
+
+Exercised in hybrid mode, where the platform resolver is the only seam that has
+to be substituted, so the route, the resolver parsing, the revision check and
+the bounded execution all run for real. The standalone half of the same ladder,
+which needs a database, a key and a stored row, is in
+``tests/integration/test_mcp_stored_server_endpoints.py``.
+"""
 
 from __future__ import annotations
 
+import asyncio
+import uuid
 from collections.abc import Iterator
-from pathlib import Path
+from contextlib import asynccontextmanager
 from typing import Any
-from unittest.mock import ANY, AsyncMock, Mock
+from unittest.mock import Mock
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 from mcp.types import CallToolResult, TextContent
 
 from gateway import log_config
 from gateway.api.deps import reset_config
-from gateway.api.routes import mcp as mcp_route
+from gateway.api.routes import _platform as platform_module
 from gateway.core.config import GatewayConfig
 from gateway.core.database import reset_db
 from gateway.main import create_app
-from gateway.services.url_safety import UnsafeURLError
+from gateway.models.mcp import ResolvedMcpServer
+from gateway.services import mcp_stateless
 
-AUTH = {"Authorization": "Bearer sk-test-master"}
+SERVER_ID = uuid.UUID("2c948a61-dc96-4cd8-96bb-8e1434bf424e")
+CLIENT_EXECUTION_ID = "6e51b3bc-6f48-4c68-a61e-0786bc80cd67"
+# A public IP literal, so URL safety never reaches a DNS resolver.
 PUBLIC_URL = "https://93.184.216.34/mcp"
+USER_AUTH = {"Authorization": "Bearer platform-user-token"}
+
+RESULT = CallToolResult(
+    content=[TextContent(type="text", text="Created issue #42")],
+    structuredContent={"issue_number": 42},
+    isError=False,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -30,286 +54,510 @@ def _reset_globals() -> Iterator[None]:
     reset_db()
 
 
-def _standalone_client(tmp_path: Path) -> TestClient:
-    return TestClient(
-        create_app(
-            GatewayConfig(
-                database_url=f"sqlite:///{tmp_path / 'mcp-execute.db'}",
-                master_key="sk-test-master",
-            )
-        )
-    )
-
-
-def _hybrid_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
-    monkeypatch.setenv("OTARI_AI_TOKEN", "gw-test-token")
-    return TestClient(
-        create_app(
-            GatewayConfig(
-                mode="hybrid",
-                platform={"base_url": "http://platform.test/api/v1"},
-            )
-        )
-    )
-
-
-def _body(**overrides: Any) -> dict[str, Any]:
-    body: dict[str, Any] = {
-        "server": {
-            "name": "github",
-            "url": PUBLIC_URL,
-            "authorization_token": "server-secret",
-            "allowed_tools": ["list_issues"],
-        },
-        "tool_name": "list_issues",
-        "arguments": {"repository": "mozilla-ai/otari"},
+def _stored(**overrides: Any) -> ResolvedMcpServer:
+    fields: dict[str, Any] = {
+        "id": SERVER_ID,
+        "name": "github",
+        "url": PUBLIC_URL,
+        "authorization_token": "server-secret",
+        "enabled": True,
+        "allowed_tools": ["create_issue"],
     }
-    body.update(overrides)
-    return body
+    fields.update(overrides)
+    return ResolvedMcpServer(**fields)
 
 
-async def _safe_url(*args: Any, **kwargs: Any) -> None:
-    return None
+class _FakeSession:
+    """The remote MCP server, as the route's bounded session sees it."""
 
-
-class _FakePool:
-    result = CallToolResult(
-        content=[TextContent(type="text", text="two open issues")],
-        structuredContent={"count": 2},
-        isError=False,
-    )
-    owns = True
-    enter_error: Exception | None = None
-    call_error: Exception | None = None
-    exit_error: Exception | None = None
-    instances: list[_FakePool] = []
-
-    def __init__(self, configs: list[Any]) -> None:
-        self.configs = configs
+    def __init__(self) -> None:
         self.calls: list[tuple[str, dict[str, Any]]] = []
-        type(self).instances.append(self)
+        self.listed = 0
+        self.result = RESULT
+        self.call_error: BaseException | None = None
 
-    async def __aenter__(self) -> _FakePool:
-        if self.enter_error is not None:
-            raise self.enter_error
-        return self
+    async def list_tools(self, cursor: str | None = None) -> Any:
+        self.listed += 1
+        raise AssertionError("execution must never call list_tools")
 
-    async def __aexit__(self, *exc: object) -> None:
-        if self.exit_error is not None:
-            raise self.exit_error
-
-    def owns_tool(self, name: str) -> bool:
-        return self.owns
-
-    async def call_tool_result(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
         self.calls.append((name, arguments))
         if self.call_error is not None:
             raise self.call_error
         return self.result
 
 
+class _Platform:
+    """The platform MCP resolver, and a record of what was asked of it."""
+
+    def __init__(self) -> None:
+        self.servers: list[dict[str, Any]] | None = [_stored().model_dump(mode="json")]
+        self.status_code = 200
+        self.bodies: list[dict[str, Any]] = []
+        self.retry_after: str | None = None
+
+    def payload(self) -> Any:
+        return {"servers": self.servers} if self.status_code == 200 else {"detail": "refused"}
+
+
 @pytest.fixture
-def fake_pool(monkeypatch: pytest.MonkeyPatch) -> type[_FakePool]:
-    _FakePool.instances = []
-    _FakePool.owns = True
-    _FakePool.enter_error = None
-    _FakePool.call_error = None
-    _FakePool.exit_error = None
-    _FakePool.result = CallToolResult(
-        content=[TextContent(type="text", text="two open issues")],
-        structuredContent={"count": 2},
-        isError=False,
-    )
-    monkeypatch.setattr(mcp_route, "MCPClientPool", _FakePool)
-    monkeypatch.setattr(mcp_route, "validate_mcp_url", _safe_url)
-    return _FakePool
+def platform(monkeypatch: pytest.MonkeyPatch) -> _Platform:
+    fake = _Platform()
+
+    async def post(*, url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float) -> Any:
+        fake.bodies.append(body)
+        response_headers = {"Retry-After": fake.retry_after} if fake.retry_after else None
+        return httpx.Response(fake.status_code, json=fake.payload(), headers=response_headers)
+
+    monkeypatch.setattr(platform_module, "_post_platform", post)
+    return fake
 
 
-def test_executes_exact_approved_call_and_returns_native_result(
-    tmp_path: Path,
-    fake_pool: type[_FakePool],
+@pytest.fixture
+def session(monkeypatch: pytest.MonkeyPatch) -> _FakeSession:
+    fake = _FakeSession()
+
+    @asynccontextmanager
+    async def open_session(*args: Any, **kwargs: Any) -> Any:
+        yield fake
+
+    monkeypatch.setattr(mcp_stateless, "open_session", open_session)
+    return fake
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("OTARI_AI_TOKEN", "gw-test-token")
+    app = create_app(GatewayConfig(mode="hybrid", platform={"base_url": "http://platform.test/api/v1"}))
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def _body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "mcp_server_id": str(SERVER_ID),
+        "tool_name": "create_issue",
+        "arguments": {"title": "Approved title", "body": "Approved body"},
+        "server_revision": _stored().revision,
+        "client_execution_id": CLIENT_EXECUTION_ID,
+    }
+    body.update(overrides)
+    return body
+
+
+def _error(response: httpx.Response) -> dict[str, Any]:
+    payload = dict(response.json())
+    assert payload.pop("request_id"), "every error body carries the opaque request id"
+    return payload
+
+
+# --------------------------------------------------------------------------- #
+# The authorized call
+# --------------------------------------------------------------------------- #
+
+
+def test_the_exact_authorized_call_runs_and_the_native_result_comes_back(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
 ) -> None:
-    with _standalone_client(tmp_path) as client:
-        response = client.post("/v1/mcp/execute", headers=AUTH, json=_body())
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
 
     assert response.status_code == 200, response.text
     assert response.json() == {
-        "content": [{"type": "text", "text": "two open issues"}],
-        "structuredContent": {"count": 2},
+        "content": [{"type": "text", "text": "Created issue #42"}],
+        "structuredContent": {"issue_number": 42},
         "isError": False,
     }
-    pool = fake_pool.instances[0]
-    assert len(pool.configs) == 1
-    assert pool.configs[0].name == "github"
-    assert pool.configs[0].authorization_token == "server-secret"
-    assert pool.calls == [("list_issues", {"repository": "mozilla-ai/otari"})]
+    assert session.calls == [("create_issue", {"title": "Approved title", "body": "Approved body"})]
+    assert session.listed == 0, "authorization comes from the stored allowlist, not live discovery"
+    assert platform.bodies == [{"mcp_server_ids": [str(SERVER_ID)]}]
 
 
-def test_server_reported_error_remains_a_typed_success(
-    tmp_path: Path,
-    fake_pool: type[_FakePool],
+def test_the_request_id_is_returned_on_success_without_touching_the_result(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
 ) -> None:
-    fake_pool.result = CallToolResult(
-        content=[TextContent(type="text", text="permission denied")],
-        isError=True,
-    )
-    with _standalone_client(tmp_path) as client:
-        response = client.post("/v1/mcp/execute", headers=AUTH, json=_body())
+    """The successful body stays the native MCP result, so the id rides a header."""
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
+
+    assert response.headers["X-Otari-Request-ID"]
+    assert "request_id" not in response.json()
+
+
+def test_a_server_reported_error_is_a_definitive_two_hundred(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    session.result = CallToolResult(content=[TextContent(type="text", text="denied")], isError=True)
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
 
     assert response.status_code == 200, response.text
     assert response.json()["isError"] is True
-    assert response.json()["content"] == [{"type": "text", "text": "permission denied"}]
 
 
-def test_cleanup_failure_does_not_hide_a_successful_mutating_call(
-    tmp_path: Path,
-    fake_pool: type[_FakePool],
-    monkeypatch: pytest.MonkeyPatch,
+def test_an_absent_allowlist_admits_any_live_tool(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
 ) -> None:
-    warning = Mock()
-    monkeypatch.setattr(log_config.logger, "warning", warning)
-    fake_pool.exit_error = RuntimeError("server-secret cleanup failure")
+    """R-RES-4: ``null`` carries the same meaning it does in the managed loop."""
+    stored = _stored(allowed_tools=None)
+    platform.servers = [stored.model_dump(mode="json")]
 
-    with _standalone_client(tmp_path) as client:
-        warning.reset_mock()
-        response = client.post("/v1/mcp/execute", headers=AUTH, json=_body())
-
-    assert response.status_code == 200, response.text
-    assert response.json()["content"] == [{"type": "text", "text": "two open issues"}]
-    assert fake_pool.instances[0].calls == [
-        ("list_issues", {"repository": "mozilla-ai/otari"})
-    ]
-    warning.assert_called_once_with(
-        "Stateless MCP cleanup failed error_class=%s",
-        "RuntimeError",
+    response = client.post(
+        "/v1/mcp/execute",
+        headers=USER_AUTH,
+        json=_body(tool_name="anything_at_all", server_revision=stored.revision),
     )
 
+    assert response.status_code == 200, response.text
+    assert session.calls == [("anything_at_all", {"title": "Approved title", "body": "Approved body"})]
 
-def test_requires_authentication_before_contacting_server(
-    tmp_path: Path,
-    fake_pool: type[_FakePool],
+
+# --------------------------------------------------------------------------- #
+# Refusals that open no MCP connection
+# --------------------------------------------------------------------------- #
+
+
+def test_an_unauthenticated_request_reaches_neither_platform_nor_server(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
 ) -> None:
-    with _standalone_client(tmp_path) as client:
-        response = client.post("/v1/mcp/execute", json=_body())
+    response = client.post("/v1/mcp/execute", json=_body())
 
     assert response.status_code == 401
-    assert fake_pool.instances == []
+    assert _error(response) == {
+        "detail": "Authentication failed",
+        "code": "authentication_failed",
+        "execution_state": "not_started",
+    }
+    assert platform.bodies == []
+    assert session.calls == []
 
 
 @pytest.mark.parametrize("allowed_tools", [[], ["read_issue"]])
-def test_configured_allowlist_is_enforced_before_contacting_server(
-    tmp_path: Path,
-    fake_pool: type[_FakePool],
+def test_a_tool_outside_the_stored_allowlist_is_refused_before_connecting(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
     allowed_tools: list[str],
 ) -> None:
-    server = _body()["server"]
-    server["allowed_tools"] = allowed_tools
-    with _standalone_client(tmp_path) as client:
-        response = client.post("/v1/mcp/execute", headers=AUTH, json=_body(server=server))
+    stored = _stored(allowed_tools=allowed_tools)
+    platform.servers = [stored.model_dump(mode="json")]
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body(server_revision=stored.revision))
 
     assert response.status_code == 403, response.text
-    assert response.json() == {"detail": mcp_route.MCP_TOOL_NOT_ALLOWED_DETAIL}
-    assert fake_pool.instances == []
+    assert _error(response)["code"] == "mcp_tool_not_allowed"
+    assert _error(response)["execution_state"] == "not_started"
+    assert session.calls == []
 
 
-def test_unsafe_url_is_rejected_before_contacting_server(
-    tmp_path: Path,
-    fake_pool: type[_FakePool],
-    monkeypatch: pytest.MonkeyPatch,
+def test_a_stale_revision_is_refused_without_a_second_resolver_call(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
 ) -> None:
-    async def reject(*args: Any, **kwargs: Any) -> None:
-        raise UnsafeURLError("MCP server URL is unsafe")
+    """R-RES-2: the comparison is in memory, over the resolution already needed."""
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body(server_revision="stale-revision"))
 
-    monkeypatch.setattr(mcp_route, "validate_mcp_url", reject)
-    with _standalone_client(tmp_path) as client:
-        response = client.post("/v1/mcp/execute", headers=AUTH, json=_body())
-
-    assert response.status_code == 400, response.text
-    assert response.json() == {"detail": "MCP server URL is unsafe"}
-    assert fake_pool.instances == []
+    assert response.status_code == 409, response.text
+    assert _error(response)["code"] == "mcp_server_changed"
+    assert len(platform.bodies) == 1
+    assert session.calls == []
 
 
-def test_tool_must_exist_in_live_discovery(
-    tmp_path: Path,
-    fake_pool: type[_FakePool],
+def test_a_disabled_server_is_not_found(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
 ) -> None:
-    fake_pool.owns = False
-    with _standalone_client(tmp_path) as client:
-        response = client.post("/v1/mcp/execute", headers=AUTH, json=_body())
+    stored = _stored(enabled=False)
+    platform.servers = [stored.model_dump(mode="json")]
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body(server_revision=stored.revision))
 
     assert response.status_code == 404, response.text
-    assert response.json() == {"detail": mcp_route.MCP_TOOL_NOT_FOUND_DETAIL}
-    assert fake_pool.instances[0].calls == []
+    assert _error(response)["code"] == "mcp_server_not_found"
+    assert session.calls == []
 
 
-@pytest.mark.parametrize("stage", ["connect", "call"])
-def test_transport_and_protocol_failures_are_sanitized(
-    tmp_path: Path,
-    fake_pool: type[_FakePool],
-    monkeypatch: pytest.MonkeyPatch,
-    stage: str,
+def test_a_server_the_platform_refuses_is_not_found(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
 ) -> None:
-    warning = Mock()
-    monkeypatch.setattr(log_config.logger, "warning", warning)
-    private_message = "server-secret repository=mozilla-ai/otari private-result"
-    if stage == "connect":
-        fake_pool.enter_error = RuntimeError(private_message)
-    else:
-        fake_pool.call_error = RuntimeError(private_message)
+    platform.status_code = 404
 
-    with _standalone_client(tmp_path) as client:
-        # App startup uses the same process-wide logger for configuration
-        # warnings. Isolate the request under test from those lifespan calls.
-        warning.reset_mock()
-        response = client.post("/v1/mcp/execute", headers=AUTH, json=_body())
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
+
+    assert response.status_code == 404, response.text
+    assert _error(response) == {
+        "detail": "MCP server not found",
+        "code": "mcp_server_not_found",
+        "execution_state": "not_started",
+    }
+    assert session.calls == []
+
+
+@pytest.mark.parametrize("servers", [[], [_stored().model_dump(mode="json")] * 2])
+def test_an_unusable_resolver_answer_is_a_resolution_failure(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+    servers: list[dict[str, Any]],
+) -> None:
+    platform.servers = servers
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
 
     assert response.status_code == 502, response.text
-    assert response.json() == {"detail": mcp_route.MCP_EXECUTION_FAILED_DETAIL}
-    assert private_message not in response.text
-    warning.assert_called_once_with(
-        "Stateless MCP request failed error_class=%s",
-        "RuntimeError",
+    assert _error(response)["code"] == "mcp_resolution_failed"
+    assert session.calls == []
+
+
+def test_the_platforms_rate_limit_is_preserved(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    platform.status_code = 429
+    platform.retry_after = "7"
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
+
+    assert response.status_code == 429, response.text
+    assert response.headers["Retry-After"] == "7"
+    assert _error(response)["code"] == "rate_limit_exceeded"
+    assert session.calls == []
+
+
+def test_an_unsafe_resolved_url_is_refused_before_connecting(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    stored = _stored(url="http://169.254.169.254/mcp")
+    platform.servers = [stored.model_dump(mode="json")]
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body(server_revision=stored.revision))
+
+    assert response.status_code == 400, response.text
+    assert _error(response) == {
+        "detail": "MCP server URL is unsafe",
+        "code": "unsafe_mcp_url",
+        "execution_state": "not_started",
+    }
+    assert session.calls == []
+
+
+# --------------------------------------------------------------------------- #
+# Request validation, normalized into the shared error shape
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"client_execution_id": "not-a-uuid"},
+        {"client_execution_id": None},
+        {"mcp_server_id": "not-a-uuid"},
+        {"tool_name": ""},
+        {"tool_name": "x" * 257},
+        {"arguments": ["not", "an", "object"]},
+        {"server_revision": ""},
+        {"server_revision": "has spaces"},
+        {"server_revision": "x" * 129},
+    ],
+)
+def test_an_invalid_request_is_refused_before_resolution_or_logging(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+    overrides: dict[str, Any],
+) -> None:
+    """R-REQ-3: arbitrary caller text must not reach a resolver, a log, or telemetry."""
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body(**overrides))
+
+    assert response.status_code == 422, response.text
+    assert _error(response) == {
+        "detail": "MCP request is invalid",
+        "code": "invalid_request",
+        "execution_state": "not_started",
+    }
+    assert platform.bodies == []
+    assert session.calls == []
+
+
+def test_an_inline_server_configuration_is_not_accepted(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    """R-REQ-4: a caller never transmits a URL, a credential, or a policy."""
+    body = _body()
+    body["server"] = {"name": "github", "url": "https://attacker.example.com/mcp"}
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=body)
+
+    assert response.status_code == 422, response.text
+    assert _error(response)["code"] == "invalid_request"
+    assert platform.bodies == []
+
+
+def test_oversized_arguments_are_refused(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    response = client.post(
+        "/v1/mcp/execute",
+        headers=USER_AUTH,
+        json=_body(arguments={"body": "x" * (mcp_stateless.ARGUMENTS_MAX_BYTES + 1)}),
     )
 
-
-def test_arguments_must_be_a_json_object(tmp_path: Path, fake_pool: type[_FakePool]) -> None:
-    with _standalone_client(tmp_path) as client:
-        response = client.post(
-            "/v1/mcp/execute",
-            headers=AUTH,
-            json=_body(arguments=["not", "an", "object"]),
-        )
-
-    assert response.status_code == 422
-    assert fake_pool.instances == []
+    assert response.status_code == 422, response.text
+    assert _error(response)["code"] == "invalid_request"
+    assert session.calls == []
 
 
-def test_hybrid_mode_authenticates_through_empty_mcp_resolution(
-    monkeypatch: pytest.MonkeyPatch,
-    fake_pool: type[_FakePool],
+def test_too_deeply_nested_arguments_are_refused(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
 ) -> None:
-    resolve = AsyncMock(return_value=[])
-    monkeypatch.setattr(mcp_route, "_resolve_platform_mcp_servers", resolve)
-    with _hybrid_client(monkeypatch) as client:
-        response = client.post(
-            "/v1/mcp/execute",
-            headers={"Authorization": "Bearer platform-user-token"},
-            json=_body(),
-        )
+    nested: dict[str, Any] = {}
+    for _ in range(mcp_stateless.ARGUMENTS_MAX_DEPTH + 2):
+        nested = {"next": nested}
 
-    assert response.status_code == 200, response.text
-    resolve.assert_awaited_once_with(ANY, "platform-user-token", [])
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body(arguments=nested))
+
+    assert response.status_code == 422, response.text
+    assert _error(response)["code"] == "invalid_request"
+    assert session.calls == []
 
 
-def test_hybrid_mode_requires_user_token(
-    monkeypatch: pytest.MonkeyPatch,
-    fake_pool: type[_FakePool],
+# --------------------------------------------------------------------------- #
+# The dispatch boundary
+# --------------------------------------------------------------------------- #
+
+
+def test_a_failure_after_dispatch_is_an_unknown_outcome(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
 ) -> None:
-    resolve = AsyncMock(return_value=[])
-    monkeypatch.setattr(mcp_route, "_resolve_platform_mcp_servers", resolve)
-    with _hybrid_client(monkeypatch) as client:
-        response = client.post("/v1/mcp/execute", json=_body())
+    session.call_error = RuntimeError("server-secret connection reset")
 
-    assert response.status_code == 401
-    resolve.assert_not_awaited()
-    assert fake_pool.instances == []
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
+
+    assert response.status_code == 502, response.text
+    assert _error(response) == {
+        "detail": "MCP execution outcome is unknown",
+        "code": "mcp_outcome_unknown",
+        "execution_state": "outcome_unknown",
+    }
+    assert "server-secret" not in response.text
+
+
+def test_a_deadline_after_dispatch_is_an_unknown_outcome(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mcp_stateless, "CALL_TIMEOUT_S", 0.01)
+
+    async def never_answer(name: str, arguments: dict[str, Any]) -> CallToolResult:
+        await asyncio.sleep(10)
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(session, "call_tool", never_answer)
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
+
+    assert response.status_code == 504, response.text
+    assert _error(response)["execution_state"] == "outcome_unknown"
+
+
+def test_an_oversized_result_is_an_unknown_outcome(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    session.result = CallToolResult(
+        content=[TextContent(type="text", text="x" * (mcp_stateless.RESULT_MAX_BYTES + 1))]
+    )
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
+
+    assert response.status_code == 502, response.text
+    assert _error(response)["code"] == "mcp_result_too_large"
+    assert _error(response)["execution_state"] == "outcome_unknown"
+
+
+def test_no_error_body_carries_a_url_credential_argument_or_exception_text(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """R-OBS-2, at the one boundary a caller can read."""
+    warning = Mock()
+    monkeypatch.setattr(log_config.logger, "warning", warning)
+    session.call_error = RuntimeError(f"{PUBLIC_URL} server-secret title=Approved title")
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
+
+    for secret in ("93.184.216.34", "server-secret", "Approved title", "RuntimeError"):
+        assert secret not in response.text, secret
+    logged = " ".join(str(call) for call in warning.call_args_list)
+    for secret in ("93.184.216.34", "server-secret", "Approved title"):
+        assert secret not in logged, secret
+
+
+@pytest.mark.parametrize("path", ["/v1/mcp/execute", f"/v1/mcp/servers/{SERVER_ID}/tools"])
+def test_a_capacity_refusal_is_the_only_failure_that_invites_a_retry(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+) -> None:
+    """R-ERR-4: capacity is transient, so it says so; nothing else advertises a retry."""
+    gate = mcp_stateless.ConcurrencyGate(limit=1, admission_timeout_s=0.01)
+    monkeypatch.setattr(mcp_stateless, "EXECUTION_GATE", gate)
+    monkeypatch.setattr(mcp_stateless, "DISCOVERY_GATE", gate)
+
+    async def hold_the_only_slot() -> httpx.Response:
+        async with gate.slot():
+            return await asyncio.to_thread(
+                lambda: client.post(path, headers=USER_AUTH, json=_body())
+                if path.endswith("execute")
+                else client.get(path, headers=USER_AUTH)
+            )
+
+    response = asyncio.run(hold_the_only_slot())
+
+    assert response.status_code == 503, response.text
+    assert response.headers["Retry-After"] == "1"
+    assert _error(response)["code"] in {"mcp_capacity_unavailable", "mcp_discovery_capacity_unavailable"}
+    assert _error(response)["execution_state"] == "not_started"
+
+
+def test_a_failure_after_dispatch_advertises_no_retry(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    session.call_error = RuntimeError("connection reset")
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
+
+    assert response.status_code == 502
+    assert "Retry-After" not in response.headers

--- a/tests/unit/test_mcp_execute_endpoint.py
+++ b/tests/unit/test_mcp_execute_endpoint.py
@@ -95,6 +95,7 @@ class _Platform:
         self.status_code = 200
         self.bodies: list[dict[str, Any]] = []
         self.retry_after: str | None = None
+        self.delay_s = 0.0
 
     def payload(self) -> Any:
         return {"servers": self.servers} if self.status_code == 200 else {"detail": "refused"}
@@ -105,6 +106,7 @@ def platform(monkeypatch: pytest.MonkeyPatch) -> _Platform:
     fake = _Platform()
 
     async def post(*, url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float) -> Any:
+        await asyncio.sleep(fake.delay_s)
         fake.bodies.append(body)
         response_headers = {"Retry-After": fake.retry_after} if fake.retry_after else None
         return httpx.Response(fake.status_code, json=fake.payload(), headers=response_headers)
@@ -184,6 +186,27 @@ def test_the_request_id_is_returned_on_success_without_touching_the_result(
 
     assert response.headers["X-Otari-Request-ID"]
     assert "request_id" not in response.json()
+
+
+def test_execution_timings_include_server_resolution(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    info = Mock()
+    monkeypatch.setattr(log_config.logger, "info", info)
+    platform.delay_s = 0.02
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
+
+    assert response.status_code == 200, response.text
+    info.assert_called_once()
+    duration_ms = info.call_args.args[6]
+    phases = dict(field.split("=", 1) for field in info.call_args.args[7].split())
+    resolve_ms = float(phases["resolve_ms"])
+    assert resolve_ms >= 15
+    assert duration_ms >= resolve_ms
 
 
 def test_a_server_reported_error_is_a_definitive_two_hundred(

--- a/tests/unit/test_mcp_execute_endpoint.py
+++ b/tests/unit/test_mcp_execute_endpoint.py
@@ -561,3 +561,42 @@ def test_a_failure_after_dispatch_advertises_no_retry(
 
     assert response.status_code == 502
     assert "Retry-After" not in response.headers
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        asyncio.CancelledError(),
+        ExceptionGroup("unhandled errors in a TaskGroup", [httpx.ConnectError("all attempts failed")]),
+    ],
+)
+def test_a_real_transport_failure_shape_still_gets_the_error_contract(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: BaseException,
+) -> None:
+    """A dead server must not escape the contract into a bare 500.
+
+    The SDK yields inside an anyio task group, so a closed port surfaces as a
+    bare ``CancelledError`` and a shutdown as an ``ExceptionGroup``. Neither is
+    the tidy ``Exception`` a substituted session raises, and the earlier version
+    of this endpoint only ever saw the tidy one.
+    """
+
+    @asynccontextmanager
+    async def refuse(*args: Any, **kwargs: Any) -> Any:
+        raise failure
+        yield  # pragma: no cover - unreachable, keeps this an async generator
+
+    monkeypatch.setattr(mcp_stateless, "open_session", refuse)
+
+    response = client.post("/v1/mcp/execute", headers=USER_AUTH, json=_body())
+
+    assert response.status_code == 502, response.text
+    assert _error(response) == {
+        "detail": "MCP server connection failed",
+        "code": "mcp_connection_failed",
+        "execution_state": "not_started",
+    }

--- a/tests/unit/test_mcp_server_revision.py
+++ b/tests/unit/test_mcp_server_revision.py
@@ -1,0 +1,76 @@
+"""The derived stored-server revision (R-DISC-3, R-RES-3).
+
+The revision is what binds an application's authorization decision to the
+configuration Otari executed against. It has to be a pure function of the four
+execution-relevant fields so that every worker and replica derives the same
+value, and it has to ignore the two fields an operator may retitle without
+invalidating a pending approval.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+import pytest
+
+from gateway.models.mcp import ResolvedMcpServer
+
+REVISION_FORMAT = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+
+SERVER_ID = uuid.UUID("2c948a61-dc96-4cd8-96bb-8e1434bf424e")
+
+
+def _server(**overrides: object) -> ResolvedMcpServer:
+    fields: dict[str, object] = {
+        "id": SERVER_ID,
+        "name": "github",
+        "url": "https://mcp.example.com/mcp",
+        "authorization_token": "server-secret",
+        "enabled": True,
+        "allowed_tools": ["create_issue", "list_issues"],
+    }
+    fields.update(overrides)
+    return ResolvedMcpServer(**fields)  # type: ignore[arg-type]
+
+
+def test_revision_matches_the_published_format() -> None:
+    assert REVISION_FORMAT.match(_server().revision)
+
+
+def test_repeated_resolution_of_an_unchanged_server_derives_one_revision() -> None:
+    assert _server().revision == _server().revision
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"url": "https://other.example.com/mcp"},
+        {"authorization_token": "rotated-secret"},
+        {"authorization_token": None},
+        {"enabled": False},
+        {"allowed_tools": ["create_issue"]},
+        {"allowed_tools": None},
+        {"allowed_tools": []},
+    ],
+)
+def test_execution_relevant_change_moves_the_revision(change: dict[str, object]) -> None:
+    assert _server(**change).revision != _server().revision
+
+
+def test_allowlist_order_does_not_move_the_revision() -> None:
+    assert _server(allowed_tools=["list_issues", "create_issue"]).revision == _server().revision
+
+
+def test_absent_and_empty_allowlists_are_different_revisions() -> None:
+    """The two are opposite policies (R-RES-4), so they must not collide."""
+    assert _server(allowed_tools=None).revision != _server(allowed_tools=[]).revision
+
+
+@pytest.mark.parametrize("change", [{"name": "github-enterprise"}, {"purpose_hint": "issues"}])
+def test_display_only_change_leaves_the_revision_alone(change: dict[str, object]) -> None:
+    assert _server(**change).revision == _server().revision
+
+
+def test_revision_does_not_disclose_the_credential() -> None:
+    assert "server-secret" not in _server().revision

--- a/tests/unit/test_mcp_stateless_discovery.py
+++ b/tests/unit/test_mcp_stateless_discovery.py
@@ -146,43 +146,6 @@ async def test_an_oversized_serialized_response_refuses_the_whole_response(opene
 
 
 @pytest.mark.asyncio
-async def test_the_total_deadline_refuses_the_whole_response(
-    opened: dict[str, Any],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(mcp_stateless, "DISCOVERY_TOTAL_TIMEOUT_S", 0.01)
-    opened["session"].delay = 5
-
-    with pytest.raises(McpExecutionError) as raised:
-        await discover_stored_tools(SERVER)
-
-    assert raised.value.code == "mcp_discovery_limit_exceeded"
-    assert raised.value.execution_state is ExecutionState.NOT_STARTED
-
-
-@pytest.mark.asyncio
-async def test_the_total_deadline_includes_admission_and_discovery(
-    opened: dict[str, Any],
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    class _DelayedGate:
-        @asynccontextmanager
-        async def slot(self) -> Any:
-            await asyncio.sleep(0.03)
-            yield
-
-    monkeypatch.setattr(mcp_stateless, "DISCOVERY_GATE", _DelayedGate())
-    monkeypatch.setattr(mcp_stateless, "DISCOVERY_TOTAL_TIMEOUT_S", 0.05)
-    opened["session"].delay = 0.03
-
-    with pytest.raises(McpExecutionError) as raised:
-        await discover_stored_tools(SERVER)
-
-    assert raised.value.code == "mcp_discovery_limit_exceeded"
-    assert raised.value.execution_state is ExecutionState.NOT_STARTED
-
-
-@pytest.mark.asyncio
 async def test_a_connection_failure_is_reported_as_one(opened: dict[str, Any]) -> None:
     opened["connect_error"] = RuntimeError("server-secret refused")
 

--- a/tests/unit/test_mcp_stateless_discovery.py
+++ b/tests/unit/test_mcp_stateless_discovery.py
@@ -19,6 +19,7 @@ from mcp.types import Tool as MCPTool
 from gateway.models.mcp import ResolvedMcpServer
 from gateway.services import mcp_stateless
 from gateway.services.mcp_stateless import (
+    DISCOVERY_MAX_TOOLS,
     DISCOVERY_RESPONSE_MAX_BYTES,
     SCHEMA_MAX_BYTES,
     ConcurrencyGate,
@@ -83,6 +84,35 @@ async def test_one_unusable_descriptor_is_omitted_and_labeled(opened: dict[str, 
 
     assert [t.name for t in catalog.tools] == ["create_issue"]
     assert catalog.warnings == [("broken", "mcp_tool_schema_unsupported")]
+
+
+@pytest.mark.asyncio
+async def test_an_omitted_descriptor_does_not_count_toward_the_returned_tool_ceiling(
+    opened: dict[str, Any],
+) -> None:
+    external_schema = {"type": "object", "$ref": "https://example.com/schema"}
+    opened["session"] = _FakeSession(
+        [_tool(f"valid{i}") for i in range(DISCOVERY_MAX_TOOLS)]
+        + [_tool("broken", inputSchema=external_schema)]
+    )
+
+    catalog = await discover_stored_tools(SERVER)
+
+    assert len(catalog.tools) == DISCOVERY_MAX_TOOLS
+    assert catalog.warnings == [("broken", "mcp_tool_schema_unsupported")]
+
+
+@pytest.mark.asyncio
+async def test_more_than_the_returned_tool_ceiling_refuses_the_whole_response(
+    opened: dict[str, Any],
+) -> None:
+    opened["session"] = _FakeSession([_tool(f"tool{i}") for i in range(DISCOVERY_MAX_TOOLS + 1)])
+
+    with pytest.raises(McpExecutionError) as raised:
+        await discover_stored_tools(SERVER)
+
+    assert raised.value.code == "mcp_discovery_limit_exceeded"
+    assert raised.value.execution_state is ExecutionState.NOT_STARTED
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mcp_stateless_discovery.py
+++ b/tests/unit/test_mcp_stateless_discovery.py
@@ -1,0 +1,157 @@
+"""Bounded stored-server discovery (R-DISC-5, R-SCHEMA-3, R-ADM-1).
+
+Discovery either returns the complete authorized catalog or nothing. The one
+permitted partial result is the labeled per-tool omission: a single unusable
+descriptor must not take its siblings with it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+from mcp.types import ListToolsResult
+from mcp.types import Tool as MCPTool
+
+from gateway.models.mcp import ResolvedMcpServer
+from gateway.services import mcp_stateless
+from gateway.services.mcp_stateless import (
+    DISCOVERY_RESPONSE_MAX_BYTES,
+    SCHEMA_MAX_BYTES,
+    ConcurrencyGate,
+    ExecutionState,
+    McpExecutionError,
+    discover_stored_tools,
+)
+
+SERVER = ResolvedMcpServer(
+    id=uuid.UUID("2c948a61-dc96-4cd8-96bb-8e1434bf424e"),
+    name="github",
+    url="https://mcp.example.com/mcp",
+    authorization_token="server-secret",
+)
+
+
+def _tool(name: str, **overrides: Any) -> MCPTool:
+    fields: dict[str, Any] = {"name": name, "description": name, "inputSchema": {"type": "object"}}
+    fields.update(overrides)
+    return MCPTool(**fields)
+
+
+class _FakeSession:
+    def __init__(self, tools: list[MCPTool]) -> None:
+        self._tools = tools
+        self.delay = 0.0
+
+    async def list_tools(self, cursor: str | None = None) -> ListToolsResult:
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        return ListToolsResult(tools=self._tools)
+
+
+@pytest.fixture
+def opened(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    state: dict[str, Any] = {"session": _FakeSession([_tool("create_issue")]), "connect_error": None}
+
+    @asynccontextmanager
+    async def open_session(*args: Any, **kwargs: Any) -> Any:
+        if state["connect_error"] is not None:
+            raise state["connect_error"]
+        yield state["session"]
+
+    monkeypatch.setattr(mcp_stateless, "open_session", open_session)
+    return state
+
+
+@pytest.mark.asyncio
+async def test_the_admitted_catalog_is_returned(opened: dict[str, Any]) -> None:
+    catalog = await discover_stored_tools(SERVER)
+
+    assert [t.name for t in catalog.tools] == ["create_issue"]
+    assert catalog.warnings == []
+
+
+@pytest.mark.asyncio
+async def test_one_unusable_descriptor_is_omitted_and_labeled(opened: dict[str, Any]) -> None:
+    huge = {"type": "object", "properties": {"x": {"description": "y" * (SCHEMA_MAX_BYTES + 1)}}}
+    opened["session"] = _FakeSession([_tool("create_issue"), _tool("broken", inputSchema=huge)])
+
+    catalog = await discover_stored_tools(SERVER)
+
+    assert [t.name for t in catalog.tools] == ["create_issue"]
+    assert catalog.warnings == [("broken", "mcp_tool_schema_unsupported")]
+
+
+@pytest.mark.asyncio
+async def test_a_pagination_failure_refuses_the_whole_response(
+    opened: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def refuse(*args: Any, **kwargs: Any) -> Any:
+        raise mcp_stateless.McpDiscoveryRefused
+
+    monkeypatch.setattr(mcp_stateless, "collect_tools", refuse)
+
+    with pytest.raises(McpExecutionError) as raised:
+        await discover_stored_tools(SERVER)
+
+    assert raised.value.code == "mcp_discovery_limit_exceeded"
+    assert raised.value.execution_state is ExecutionState.NOT_STARTED
+    assert raised.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_an_oversized_serialized_response_refuses_the_whole_response(opened: dict[str, Any]) -> None:
+    filler = "z" * 4000
+    count = DISCOVERY_RESPONSE_MAX_BYTES // len(filler) + 2
+    opened["session"] = _FakeSession([_tool(f"t{i}", description=filler) for i in range(count)])
+
+    with pytest.raises(McpExecutionError) as raised:
+        await discover_stored_tools(SERVER)
+
+    assert raised.value.code == "mcp_discovery_limit_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_the_total_deadline_refuses_the_whole_response(
+    opened: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mcp_stateless, "DISCOVERY_TOTAL_TIMEOUT_S", 0.01)
+    opened["session"].delay = 5
+
+    with pytest.raises(McpExecutionError) as raised:
+        await discover_stored_tools(SERVER)
+
+    assert raised.value.code == "mcp_discovery_limit_exceeded"
+    assert raised.value.execution_state is ExecutionState.NOT_STARTED
+
+
+@pytest.mark.asyncio
+async def test_a_connection_failure_is_reported_as_one(opened: dict[str, Any]) -> None:
+    opened["connect_error"] = RuntimeError("server-secret refused")
+
+    with pytest.raises(McpExecutionError) as raised:
+        await discover_stored_tools(SERVER)
+
+    assert raised.value.code == "mcp_connection_failed"
+    assert raised.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_no_free_discovery_slot_before_the_deadline_is_refused(
+    opened: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gate = ConcurrencyGate(limit=1, admission_timeout_s=0.01)
+    monkeypatch.setattr(mcp_stateless, "DISCOVERY_GATE", gate)
+
+    async with gate.slot():
+        with pytest.raises(McpExecutionError) as raised:
+            await discover_stored_tools(SERVER)
+
+    assert raised.value.code == "mcp_discovery_capacity_unavailable"
+    assert raised.value.status_code == 503

--- a/tests/unit/test_mcp_stateless_discovery.py
+++ b/tests/unit/test_mcp_stateless_discovery.py
@@ -155,3 +155,32 @@ async def test_no_free_discovery_slot_before_the_deadline_is_refused(
 
     assert raised.value.code == "mcp_discovery_capacity_unavailable"
     assert raised.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_a_task_group_cancelling_the_caller_is_a_connection_failure(opened: dict[str, Any]) -> None:
+    """A dead server raises a bare CancelledError, which is not an ``Exception``."""
+    opened["connect_error"] = asyncio.CancelledError()
+
+    with pytest.raises(McpExecutionError) as raised:
+        await discover_stored_tools(SERVER)
+
+    assert raised.value.code == "mcp_connection_failed"
+    assert raised.value.execution_state is ExecutionState.NOT_STARTED
+
+
+@pytest.mark.asyncio
+async def test_a_server_dying_mid_pagination_is_a_connection_failure(
+    opened: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def die(cursor: str | None = None) -> Any:
+        raise BaseExceptionGroup("unhandled errors in a TaskGroup", [asyncio.CancelledError()])
+
+    monkeypatch.setattr(opened["session"], "list_tools", die)
+
+    with pytest.raises(McpExecutionError) as raised:
+        await discover_stored_tools(SERVER)
+
+    assert raised.value.code == "mcp_connection_failed"
+    assert raised.value.status_code == 502

--- a/tests/unit/test_mcp_stateless_discovery.py
+++ b/tests/unit/test_mcp_stateless_discovery.py
@@ -9,10 +9,13 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
 
+import anyio
 import pytest
+from mcp import ClientSession
 from mcp.types import ListToolsResult
 from mcp.types import Tool as MCPTool
 
@@ -73,6 +76,32 @@ async def test_the_admitted_catalog_is_returned(opened: dict[str, Any]) -> None:
 
     assert [t.name for t in catalog.tools] == ["create_issue"]
     assert catalog.warnings == []
+
+
+@pytest.mark.asyncio
+async def test_a_real_client_session_closes_without_cancelling_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def list_tools(_session: ClientSession, cursor: str | None = None) -> ListToolsResult:
+        assert cursor is None
+        return ListToolsResult(tools=[_tool("create_issue")])
+
+    @asynccontextmanager
+    async def open_real_session(*args: Any, **kwargs: Any) -> AsyncIterator[ClientSession]:
+        incoming_writer, incoming_reader = anyio.create_memory_object_stream(1)
+        outgoing_writer, outgoing_reader = anyio.create_memory_object_stream(1)
+        async with incoming_writer, incoming_reader, outgoing_writer, outgoing_reader:
+            async with ClientSession(incoming_reader, outgoing_writer) as real_session:
+                yield real_session
+
+    monkeypatch.setattr(ClientSession, "list_tools", list_tools)
+    monkeypatch.setattr(mcp_stateless, "open_session", open_real_session)
+
+    catalog = await discover_stored_tools(SERVER)
+
+    assert [tool.name for tool in catalog.tools] == ["create_issue"]
+    task = asyncio.current_task()
+    assert task is not None and task.cancelling() == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mcp_stateless_discovery.py
+++ b/tests/unit/test_mcp_stateless_discovery.py
@@ -131,6 +131,28 @@ async def test_the_total_deadline_refuses_the_whole_response(
 
 
 @pytest.mark.asyncio
+async def test_the_total_deadline_includes_admission_and_discovery(
+    opened: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _DelayedGate:
+        @asynccontextmanager
+        async def slot(self) -> Any:
+            await asyncio.sleep(0.03)
+            yield
+
+    monkeypatch.setattr(mcp_stateless, "DISCOVERY_GATE", _DelayedGate())
+    monkeypatch.setattr(mcp_stateless, "DISCOVERY_TOTAL_TIMEOUT_S", 0.05)
+    opened["session"].delay = 0.03
+
+    with pytest.raises(McpExecutionError) as raised:
+        await discover_stored_tools(SERVER)
+
+    assert raised.value.code == "mcp_discovery_limit_exceeded"
+    assert raised.value.execution_state is ExecutionState.NOT_STARTED
+
+
+@pytest.mark.asyncio
 async def test_a_connection_failure_is_reported_as_one(opened: dict[str, Any]) -> None:
     opened["connect_error"] = RuntimeError("server-secret refused")
 

--- a/tests/unit/test_mcp_stateless_execution.py
+++ b/tests/unit/test_mcp_stateless_execution.py
@@ -10,12 +10,15 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from contextlib import AsyncExitStack
+from collections.abc import AsyncIterator
+from contextlib import AsyncExitStack, asynccontextmanager
 from typing import Any
 from unittest.mock import Mock
 
+import anyio
 import pytest
 from httpx import ConnectError
+from mcp import ClientSession
 from mcp.types import CallToolResult, TextContent
 
 from gateway import log_config
@@ -89,6 +92,36 @@ async def test_the_exact_tool_is_called_once_without_live_discovery(session: _Fa
     assert result == RESULT
     assert session.calls == [("create_issue", {"title": "Approved"})]
     assert session.listed == 0
+
+
+@pytest.mark.asyncio
+async def test_a_real_client_session_closes_without_cancelling_its_caller(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def call_tool(
+        _session: ClientSession,
+        name: str,
+        arguments: dict[str, Any],
+    ) -> CallToolResult:
+        assert (name, arguments) == ("create_issue", {"title": "Approved"})
+        return RESULT
+
+    @asynccontextmanager
+    async def open_real_session(*args: Any, **kwargs: Any) -> AsyncIterator[ClientSession]:
+        incoming_writer, incoming_reader = anyio.create_memory_object_stream(1)
+        outgoing_writer, outgoing_reader = anyio.create_memory_object_stream(1)
+        async with incoming_writer, incoming_reader, outgoing_writer, outgoing_reader:
+            async with ClientSession(incoming_reader, outgoing_writer) as real_session:
+                yield real_session
+
+    monkeypatch.setattr(ClientSession, "call_tool", call_tool)
+    monkeypatch.setattr(mcp_stateless, "open_session", open_real_session)
+
+    result = await execute_stored_tool(SERVER, "create_issue", {"title": "Approved"})
+
+    assert result == RESULT
+    task = asyncio.current_task()
+    assert task is not None and task.cancelling() == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mcp_stateless_execution.py
+++ b/tests/unit/test_mcp_stateless_execution.py
@@ -45,6 +45,9 @@ class _FakeSession:
         self.listed = 0
         self.call_error: BaseException | None = None
         self.result = RESULT
+        # Set by the fixture below, so a test can fail the connect or the
+        # cleanup half of the substituted session independently.
+        self.transport: dict[str, BaseException | None] = {}
 
     async def list_tools(self, cursor: str | None = None) -> Any:
         self.listed += 1
@@ -61,8 +64,8 @@ class _FakeSession:
 def session(monkeypatch: pytest.MonkeyPatch) -> _FakeSession:
     """Substitute the real transport with a session that records what it is asked."""
     fake = _FakeSession()
-    state = {"connect_error": None, "cleanup_error": None}
-    fake.transport = state  # type: ignore[attr-defined]
+    state: dict[str, BaseException | None] = {"connect_error": None, "cleanup_error": None}
+    fake.transport = state
 
     from contextlib import asynccontextmanager
 

--- a/tests/unit/test_mcp_stateless_execution.py
+++ b/tests/unit/test_mcp_stateless_execution.py
@@ -11,10 +11,13 @@ from __future__ import annotations
 import asyncio
 import uuid
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
+from httpx import ConnectError
 from mcp.types import CallToolResult, TextContent
 
+from gateway import log_config
 from gateway.models.mcp import ResolvedMcpServer
 from gateway.services import mcp_stateless
 from gateway.services.mcp_stateless import (
@@ -212,3 +215,96 @@ async def test_phase_timings_survive_a_failure_after_dispatch(session: _FakeSess
     assert "connect_ms" in timings
     assert "call_ms" in timings
     assert "result_bytes" not in timings
+
+
+# --------------------------------------------------------------------------- #
+# The shapes a real MCP transport failure actually arrives in
+#
+# The SDK yields inside ``anyio.create_task_group()``, so a dead server does not
+# raise the tidy ``Exception`` a mocked pool does. Against the pinned ``mcp``,
+# ``session.initialize()`` against a closed port raises a bare
+# ``CancelledError``, which is not an ``Exception`` at all, and transport
+# shutdown separately raises an ``ExceptionGroup``. Both have to land inside the
+# error contract rather than escaping it.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_a_task_group_cancelling_the_caller_is_a_connection_failure(session: _FakeSession) -> None:
+    """The shape a closed port actually produces: a bare CancelledError."""
+    session.transport["connect_error"] = asyncio.CancelledError()
+
+    with pytest.raises(McpExecutionError) as raised:
+        await execute_stored_tool(SERVER, "create_issue", {})
+
+    assert raised.value.code == "mcp_connection_failed"
+    assert raised.value.execution_state is ExecutionState.NOT_STARTED
+    assert raised.value.status_code == 502
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_grouped_connection_failure_is_reported_by_its_leaf(
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``ExceptionGroup`` alone says nothing, so the log names what was inside it."""
+    warning = Mock()
+    monkeypatch.setattr(log_config.logger, "warning", warning)
+    session.transport["connect_error"] = ExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [ConnectError("All connection attempts failed")],
+    )
+
+    with pytest.raises(McpExecutionError) as raised:
+        await execute_stored_tool(SERVER, "create_issue", {})
+
+    assert raised.value.code == "mcp_connection_failed"
+    warning.assert_called_once_with("Stateless MCP connection failed error_class=%s", "ConnectError")
+
+
+@pytest.mark.asyncio
+async def test_a_group_holding_a_cancellation_after_dispatch_is_an_unknown_outcome(
+    session: _FakeSession,
+) -> None:
+    """A ``BaseExceptionGroup`` is not an ``Exception``, and must not escape the contract."""
+    session.call_error = BaseExceptionGroup("unhandled errors in a TaskGroup", [asyncio.CancelledError()])
+
+    with pytest.raises(McpExecutionError) as raised:
+        await execute_stored_tool(SERVER, "create_issue", {})
+
+    assert raised.value.code == "mcp_outcome_unknown"
+    assert raised.value.execution_state is ExecutionState.OUTCOME_UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_a_grouped_cleanup_failure_still_preserves_the_result(session: _FakeSession) -> None:
+    """The shape transport shutdown actually produces, over R-EXEC-1."""
+    session.transport["cleanup_error"] = BaseExceptionGroup(
+        "unhandled errors in a TaskGroup",
+        [asyncio.CancelledError()],
+    )
+
+    assert await execute_stored_tool(SERVER, "create_issue", {"title": "Approved"}) == RESULT
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (RuntimeError(), "RuntimeError"),
+        (ExceptionGroup("g", [ConnectError("x")]), "ConnectError"),
+        (BaseExceptionGroup("g", [asyncio.CancelledError()]), "CancelledError"),
+        (
+            ExceptionGroup("g", [ConnectError("x"), ExceptionGroup("inner", [TimeoutError()])]),
+            "ConnectError+TimeoutError",
+        ),
+        (ExceptionGroup("g", [ConnectError("x"), ConnectError("y")]), "ConnectError"),
+    ],
+)
+def test_a_failure_class_names_the_leaves_and_nothing_else(exc: BaseException, expected: str) -> None:
+    assert mcp_stateless.failure_class(exc) == expected
+
+
+def test_a_failure_class_carries_no_message_from_the_exception() -> None:
+    """R-OBS-2: an exception message can hold a URL, a credential, or an argument."""
+    assert "server-secret" not in mcp_stateless.failure_class(RuntimeError("server-secret leaked"))

--- a/tests/unit/test_mcp_stateless_execution.py
+++ b/tests/unit/test_mcp_stateless_execution.py
@@ -1,0 +1,214 @@
+"""One bounded stateless execution (execution steps 9-13, R-EXEC-1, R-ERR-2, R-ERR-3).
+
+The dispatch boundary is what these cover. Before the transport starts writing
+``tools/call``, Otari knows the tool did not run and says ``not_started``. From
+that moment on it cannot know, so every failure is ``outcome_unknown`` and no
+path may invite a retry of a call that may already have mutated something.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+
+import pytest
+from mcp.types import CallToolResult, TextContent
+
+from gateway.models.mcp import ResolvedMcpServer
+from gateway.services import mcp_stateless
+from gateway.services.mcp_stateless import (
+    RESULT_MAX_BYTES,
+    ConcurrencyGate,
+    ExecutionState,
+    McpExecutionError,
+    execute_stored_tool,
+)
+
+SERVER = ResolvedMcpServer(
+    id=uuid.UUID("2c948a61-dc96-4cd8-96bb-8e1434bf424e"),
+    name="github",
+    url="https://mcp.example.com/mcp",
+    authorization_token="server-secret",
+    allowed_tools=["create_issue"],
+)
+
+RESULT = CallToolResult(content=[TextContent(type="text", text="Created issue #42")])
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.listed = 0
+        self.call_error: BaseException | None = None
+        self.result = RESULT
+
+    async def list_tools(self, cursor: str | None = None) -> Any:
+        self.listed += 1
+        raise AssertionError("execution must never call list_tools")
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+        self.calls.append((name, arguments))
+        if self.call_error is not None:
+            raise self.call_error
+        return self.result
+
+
+@pytest.fixture
+def session(monkeypatch: pytest.MonkeyPatch) -> _FakeSession:
+    """Substitute the real transport with a session that records what it is asked."""
+    fake = _FakeSession()
+    state = {"connect_error": None, "cleanup_error": None}
+    fake.transport = state  # type: ignore[attr-defined]
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def open_session(*args: Any, **kwargs: Any) -> Any:
+        if state["connect_error"] is not None:
+            raise state["connect_error"]
+        yield fake
+        if state["cleanup_error"] is not None:
+            raise state["cleanup_error"]
+
+    monkeypatch.setattr(mcp_stateless, "open_session", open_session)
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_the_exact_tool_is_called_once_without_live_discovery(session: _FakeSession) -> None:
+    result = await execute_stored_tool(SERVER, "create_issue", {"title": "Approved"})
+
+    assert result == RESULT
+    assert session.calls == [("create_issue", {"title": "Approved"})]
+    assert session.listed == 0
+
+
+@pytest.mark.asyncio
+async def test_a_connection_failure_is_not_started(session: _FakeSession) -> None:
+    session.transport["connect_error"] = RuntimeError("server-secret refused")
+
+    with pytest.raises(McpExecutionError) as raised:
+        await execute_stored_tool(SERVER, "create_issue", {})
+
+    assert raised.value.code == "mcp_connection_failed"
+    assert raised.value.execution_state is ExecutionState.NOT_STARTED
+    assert raised.value.status_code == 502
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_deadline_after_dispatch_is_an_unknown_outcome(
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mcp_stateless, "CALL_TIMEOUT_S", 0.01)
+
+    async def never_answer(name: str, arguments: dict[str, Any]) -> CallToolResult:
+        session.calls.append((name, arguments))
+        await asyncio.sleep(10)
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(session, "call_tool", never_answer)
+
+    with pytest.raises(McpExecutionError) as raised:
+        await execute_stored_tool(SERVER, "create_issue", {})
+
+    assert raised.value.code == "mcp_outcome_unknown"
+    assert raised.value.execution_state is ExecutionState.OUTCOME_UNKNOWN
+    assert raised.value.status_code == 504
+
+
+@pytest.mark.asyncio
+async def test_a_transport_failure_after_dispatch_is_an_unknown_outcome(session: _FakeSession) -> None:
+    session.call_error = RuntimeError("connection reset")
+
+    with pytest.raises(McpExecutionError) as raised:
+        await execute_stored_tool(SERVER, "create_issue", {})
+
+    assert raised.value.code == "mcp_outcome_unknown"
+    assert raised.value.execution_state is ExecutionState.OUTCOME_UNKNOWN
+    assert raised.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_cancellation_after_dispatch_is_an_unknown_outcome(session: _FakeSession) -> None:
+    """Cancelling local work cannot assert the remote server stopped the tool."""
+    session.call_error = asyncio.CancelledError()
+
+    with pytest.raises(McpExecutionError) as raised:
+        await execute_stored_tool(SERVER, "create_issue", {})
+
+    assert raised.value.execution_state is ExecutionState.OUTCOME_UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_an_oversized_result_is_refused_as_an_unknown_outcome(session: _FakeSession) -> None:
+    session.result = CallToolResult(content=[TextContent(type="text", text="x" * (RESULT_MAX_BYTES + 1))])
+
+    with pytest.raises(McpExecutionError) as raised:
+        await execute_stored_tool(SERVER, "create_issue", {})
+
+    assert raised.value.code == "mcp_result_too_large"
+    assert raised.value.execution_state is ExecutionState.OUTCOME_UNKNOWN
+    assert raised.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_a_definitive_result_survives_a_cleanup_failure(session: _FakeSession) -> None:
+    """R-EXEC-1: transport shutdown must not turn a completed mutation into a retry."""
+    session.transport["cleanup_error"] = RuntimeError("server-secret cleanup failure")
+
+    assert await execute_stored_tool(SERVER, "create_issue", {"title": "Approved"}) == RESULT
+
+
+@pytest.mark.asyncio
+async def test_a_server_reported_error_is_a_definitive_result(session: _FakeSession) -> None:
+    session.result = CallToolResult(content=[TextContent(type="text", text="denied")], isError=True)
+
+    result = await execute_stored_tool(SERVER, "create_issue", {})
+
+    assert result.isError is True
+
+
+@pytest.mark.asyncio
+async def test_no_free_slot_before_the_deadline_is_not_started(
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gate = ConcurrencyGate(limit=1, admission_timeout_s=0.01)
+    monkeypatch.setattr(mcp_stateless, "EXECUTION_GATE", gate)
+
+    async with gate.slot():
+        with pytest.raises(McpExecutionError) as raised:
+            await execute_stored_tool(SERVER, "create_issue", {})
+
+    assert raised.value.code == "mcp_capacity_unavailable"
+    assert raised.value.execution_state is ExecutionState.NOT_STARTED
+    assert raised.value.status_code == 503
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_phase_timings_and_result_size_are_recorded_without_content(session: _FakeSession) -> None:
+    """R-OBS-1: the route logs phases and sizes, and R-OBS-2 leaves out everything else."""
+    timings: dict[str, float] = {}
+
+    await execute_stored_tool(SERVER, "create_issue", {"title": "Approved"}, timings=timings)
+
+    assert set(timings) == {"admission_ms", "connect_ms", "call_ms", "cleanup_ms", "result_bytes"}
+    assert all(value >= 0 for value in timings.values())
+    assert timings["result_bytes"] > 0
+
+
+@pytest.mark.asyncio
+async def test_phase_timings_survive_a_failure_after_dispatch(session: _FakeSession) -> None:
+    session.call_error = RuntimeError("connection reset")
+    timings: dict[str, float] = {}
+
+    with pytest.raises(McpExecutionError):
+        await execute_stored_tool(SERVER, "create_issue", {}, timings=timings)
+
+    assert "connect_ms" in timings
+    assert "call_ms" in timings
+    assert "result_bytes" not in timings

--- a/tests/unit/test_mcp_stateless_execution.py
+++ b/tests/unit/test_mcp_stateless_execution.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from contextlib import AsyncExitStack
 from typing import Any
 from unittest.mock import Mock
 
@@ -289,6 +290,25 @@ async def test_a_grouped_cleanup_failure_still_preserves_the_result(session: _Fa
     )
 
     assert await execute_stored_tool(SERVER, "create_issue", {"title": "Approved"}) == RESULT
+
+
+@pytest.mark.asyncio
+async def test_a_cleanup_timeout_cancels_and_awaits_the_closer(monkeypatch: pytest.MonkeyPatch) -> None:
+    finished = asyncio.Event()
+
+    async def stalled_cleanup() -> None:
+        try:
+            await asyncio.Event().wait()
+        finally:
+            finished.set()
+
+    stack = AsyncExitStack()
+    stack.push_async_callback(stalled_cleanup)
+    monkeypatch.setattr(mcp_stateless, "CLEANUP_TIMEOUT_S", 0.01)
+
+    await mcp_stateless._close_bounded(stack)
+
+    assert finished.is_set(), "the timed-out closer must not remain detached"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_mcp_stateless_transport.py
+++ b/tests/unit/test_mcp_stateless_transport.py
@@ -13,6 +13,7 @@ from mcp.types import CallToolResult, TextContent
 
 from gateway.services.mcp_stateless import (
     RESULT_MAX_BYTES,
+    TRANSPORT_MAX_BYTES,
     ConcurrencyGate,
     McpCapacityUnavailable,
     TransportResponseTooLarge,
@@ -22,12 +23,30 @@ from gateway.services.mcp_stateless import (
 )
 
 
+class _ChunkedStream(httpx.AsyncByteStream):
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self):  # type: ignore[no-untyped-def]
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _UnreadableStream(httpx.AsyncByteStream):
+    """A body that fails the test if anything reads it."""
+
+    async def __aiter__(self):  # type: ignore[no-untyped-def]
+        raise AssertionError("the oversized body was read")
+        yield b""
+
+
 def test_the_transport_client_never_follows_a_redirect() -> None:
     factory = build_http_client_factory()
 
     client = factory({"Authorization": "Bearer server-secret"}, None, None)
 
     assert client.follow_redirects is False
+    assert client.headers["Accept-Encoding"] == "identity"
 
 
 @pytest.mark.asyncio
@@ -51,14 +70,6 @@ async def test_a_redirect_forwards_neither_credentials_nor_call_data() -> None:
     assert seen[0].url.host == "mcp.example.com"
 
 
-class _UnreadableStream(httpx.AsyncByteStream):
-    """A body that fails the test if anything reads it."""
-
-    async def __aiter__(self):  # type: ignore[no-untyped-def]
-        raise AssertionError("the oversized body was read")
-        yield b""
-
-
 @pytest.mark.asyncio
 async def test_an_oversized_content_length_is_refused_before_the_body_is_read() -> None:
     response = httpx.Response(
@@ -73,18 +84,43 @@ async def test_an_oversized_content_length_is_refused_before_the_body_is_read() 
 
 @pytest.mark.asyncio
 async def test_a_response_within_the_ceiling_is_allowed_through() -> None:
-    response = httpx.Response(200, headers={"content-length": "10"})
+    response = httpx.Response(200, headers={"content-length": "2"}, stream=_ChunkedStream([b"ok"]))
 
     # Returning at all is the assertion: the hook refuses by raising.
     await enforce_content_length(response)
+    assert await response.aread() == b"ok"
 
 
 @pytest.mark.asyncio
-async def test_a_missing_content_length_is_left_to_the_post_decode_measurement() -> None:
-    """A chunked or SSE response carries no length, and is bounded after decoding."""
-    response = httpx.Response(200, headers={"transfer-encoding": "chunked"})
+async def test_a_chunked_response_is_refused_while_streaming_past_the_ceiling() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"transfer-encoding": "chunked"},
+            stream=_ChunkedStream([b"x" * TRANSPORT_MAX_BYTES, b"x"]),
+        )
 
-    await enforce_content_length(response)
+    client = build_http_client_factory()()
+    client._transport = httpx.MockTransport(handler)  # noqa: SLF001
+    async with client:
+        with pytest.raises(TransportResponseTooLarge):
+            await client.get("https://mcp.example.com/mcp")
+
+
+@pytest.mark.asyncio
+async def test_a_compressed_response_is_refused_before_the_body_is_read() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-encoding": "gzip", "content-length": "10"},
+            stream=_UnreadableStream(),
+        )
+
+    client = build_http_client_factory()()
+    client._transport = httpx.MockTransport(handler)  # noqa: SLF001
+    async with client:
+        with pytest.raises(TransportResponseTooLarge):
+            await client.get("https://mcp.example.com/mcp")
 
 
 def test_a_result_within_the_ceiling_passes_the_post_decode_measurement() -> None:

--- a/tests/unit/test_mcp_stateless_transport.py
+++ b/tests/unit/test_mcp_stateless_transport.py
@@ -75,7 +75,8 @@ async def test_an_oversized_content_length_is_refused_before_the_body_is_read() 
 async def test_a_response_within_the_ceiling_is_allowed_through() -> None:
     response = httpx.Response(200, headers={"content-length": "10"})
 
-    assert await enforce_content_length(response) is None
+    # Returning at all is the assertion: the hook refuses by raising.
+    await enforce_content_length(response)
 
 
 @pytest.mark.asyncio
@@ -83,7 +84,7 @@ async def test_a_missing_content_length_is_left_to_the_post_decode_measurement()
     """A chunked or SSE response carries no length, and is bounded after decoding."""
     response = httpx.Response(200, headers={"transfer-encoding": "chunked"})
 
-    assert await enforce_content_length(response) is None
+    await enforce_content_length(response)
 
 
 def test_a_result_within_the_ceiling_passes_the_post_decode_measurement() -> None:

--- a/tests/unit/test_mcp_stateless_transport.py
+++ b/tests/unit/test_mcp_stateless_transport.py
@@ -1,0 +1,145 @@
+"""The stateless transport's own bounds (R-TRANSPORT-1, R-TRANSPORT-2, R-ADM-1).
+
+Everything here is defense against the remote MCP server, which is untrusted:
+its response may be arbitrarily large, and it may answer a credentialed request
+with a redirect to somewhere else entirely.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from mcp.types import CallToolResult, TextContent
+
+from gateway.services.mcp_stateless import (
+    RESULT_MAX_BYTES,
+    ConcurrencyGate,
+    McpCapacityUnavailable,
+    TransportResponseTooLarge,
+    build_http_client_factory,
+    enforce_content_length,
+    result_exceeds_bound,
+)
+
+
+def test_the_transport_client_never_follows_a_redirect() -> None:
+    factory = build_http_client_factory()
+
+    client = factory({"Authorization": "Bearer server-secret"}, None, None)
+
+    assert client.follow_redirects is False
+
+
+@pytest.mark.asyncio
+async def test_a_redirect_forwards_neither_credentials_nor_call_data() -> None:
+    """The redirect is returned as-is, so nothing is re-sent to its destination."""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(307, headers={"location": "https://attacker.example.com/collect"})
+
+    factory = build_http_client_factory()
+    client = factory({"Authorization": "Bearer server-secret"}, None, None)
+    client._transport = httpx.MockTransport(handler)  # noqa: SLF001
+
+    async with client:
+        response = await client.post("https://mcp.example.com/mcp", json={"method": "tools/call"})
+
+    assert response.status_code == 307
+    assert len(seen) == 1
+    assert seen[0].url.host == "mcp.example.com"
+
+
+class _UnreadableStream(httpx.AsyncByteStream):
+    """A body that fails the test if anything reads it."""
+
+    async def __aiter__(self):  # type: ignore[no-untyped-def]
+        raise AssertionError("the oversized body was read")
+        yield b""
+
+
+@pytest.mark.asyncio
+async def test_an_oversized_content_length_is_refused_before_the_body_is_read() -> None:
+    response = httpx.Response(
+        200,
+        headers={"content-length": str(RESULT_MAX_BYTES + 1)},
+        stream=_UnreadableStream(),
+    )
+
+    with pytest.raises(TransportResponseTooLarge):
+        await enforce_content_length(response)
+
+
+@pytest.mark.asyncio
+async def test_a_response_within_the_ceiling_is_allowed_through() -> None:
+    response = httpx.Response(200, headers={"content-length": "10"})
+
+    assert await enforce_content_length(response) is None
+
+
+@pytest.mark.asyncio
+async def test_a_missing_content_length_is_left_to_the_post_decode_measurement() -> None:
+    """A chunked or SSE response carries no length, and is bounded after decoding."""
+    response = httpx.Response(200, headers={"transfer-encoding": "chunked"})
+
+    assert await enforce_content_length(response) is None
+
+
+def test_a_result_within_the_ceiling_passes_the_post_decode_measurement() -> None:
+    result = CallToolResult(content=[TextContent(type="text", text="Created issue #42")])
+
+    assert result_exceeds_bound(result) is False
+
+
+def test_an_oversized_result_fails_the_post_decode_measurement() -> None:
+    result = CallToolResult(content=[TextContent(type="text", text="x" * (RESULT_MAX_BYTES + 1))])
+
+    assert result_exceeds_bound(result) is True
+
+
+@pytest.mark.asyncio
+async def test_a_gate_admits_up_to_its_ceiling() -> None:
+    gate = ConcurrencyGate(limit=2, admission_timeout_s=0.01)
+
+    async with gate.slot():
+        async with gate.slot():
+            pass
+
+
+@pytest.mark.asyncio
+async def test_a_gate_refuses_once_its_admission_deadline_passes() -> None:
+    gate = ConcurrencyGate(limit=1, admission_timeout_s=0.01)
+
+    async with gate.slot():
+        with pytest.raises(McpCapacityUnavailable):
+            async with gate.slot():
+                pass
+
+
+@pytest.mark.asyncio
+async def test_a_refused_slot_is_released_for_the_next_caller() -> None:
+    gate = ConcurrencyGate(limit=1, admission_timeout_s=0.01)
+
+    async with gate.slot():
+        with pytest.raises(McpCapacityUnavailable):
+            async with gate.slot():
+                pass
+
+    async with gate.slot():
+        pass
+
+
+@pytest.mark.asyncio
+async def test_discovery_load_cannot_exhaust_execution_capacity() -> None:
+    """Separate gates (R-ADM-1), so hostile discovery cannot starve an approved call."""
+    from gateway.services.mcp_stateless import DISCOVERY_GATE, EXECUTION_GATE
+
+    assert DISCOVERY_GATE is not EXECUTION_GATE
+    held = [await DISCOVERY_GATE._semaphore.acquire() for _ in range(DISCOVERY_GATE.limit)]  # noqa: SLF001
+    try:
+        async with EXECUTION_GATE.slot():
+            pass
+    finally:
+        for _ in held:
+            DISCOVERY_GATE._semaphore.release()  # noqa: SLF001

--- a/tests/unit/test_mcp_stored_server_resolution.py
+++ b/tests/unit/test_mcp_stored_server_resolution.py
@@ -1,10 +1,9 @@
 """Hybrid resolution of one stored MCP server (R-RES-1, R-RES-2, R-RES-3).
 
 The resolver answer is the authorization input for both stored-server
-endpoints, so it is parsed strictly: exactly one entry, whose id is the id that
-was asked for. Anything else is a resolution failure rather than a best guess,
-because the alternative is executing a caller-authorized call against a server
-the caller did not name.
+endpoints. A current peer can echo the requested id and enabled state; a legacy
+peer returns one enabled connection config or an empty list for a disabled
+server. Malformed or ambiguous answers still fail closed.
 """
 
 from __future__ import annotations
@@ -73,6 +72,19 @@ async def test_the_matching_entry_is_resolved(monkeypatch: pytest.MonkeyPatch) -
 
 
 @pytest.mark.asyncio
+async def test_a_legacy_entry_is_bound_to_the_only_requested_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    entry = _entry()
+    del entry["id"]
+    del entry["enabled"]
+    _platform_returns({"servers": [entry]}, monkeypatch)
+
+    server = await _resolve_platform_mcp_server(_config(), "tk_user", SERVER_ID)
+
+    assert server.id == SERVER_ID
+    assert server.enabled is True
+
+
+@pytest.mark.asyncio
 async def test_a_disabled_server_resolves_and_says_so(monkeypatch: pytest.MonkeyPatch) -> None:
     """The 404 belongs to the route's outcome ladder, which both modes share."""
     _platform_returns({"servers": [_entry(enabled=False)]}, monkeypatch)
@@ -80,6 +92,19 @@ async def test_a_disabled_server_resolves_and_says_so(monkeypatch: pytest.Monkey
     server = await _resolve_platform_mcp_server(_config(), "tk_user", SERVER_ID)
 
     assert server.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_a_legacy_empty_answer_is_server_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Legacy peers omit a disabled server, which has the same public outcome."""
+    _platform_returns({"servers": []}, monkeypatch)
+
+    with pytest.raises(McpExecutionError) as raised:
+        await _resolve_platform_mcp_server(_config(), "tk_user", SERVER_ID)
+
+    assert raised.value.code == "mcp_server_not_found"
+    assert raised.value.execution_state is ExecutionState.NOT_STARTED
+    assert raised.value.status_code == 404
 
 
 @pytest.mark.asyncio
@@ -98,7 +123,6 @@ async def test_an_absent_allowlist_stays_absent(monkeypatch: pytest.MonkeyPatch)
 @pytest.mark.parametrize(
     "payload",
     [
-        {"servers": []},
         {"servers": [_entry(), _entry(id=str(OTHER_ID))]},
         {"servers": [_entry(id=str(OTHER_ID))]},
         {"servers": [_entry(id="not-a-uuid")]},

--- a/tests/unit/test_mcp_stored_server_resolution.py
+++ b/tests/unit/test_mcp_stored_server_resolution.py
@@ -1,0 +1,136 @@
+"""Hybrid resolution of one stored MCP server (R-RES-1, R-RES-2, R-RES-3).
+
+The resolver answer is the authorization input for both stored-server
+endpoints, so it is parsed strictly: exactly one entry, whose id is the id that
+was asked for. Anything else is a resolution failure rather than a best guess,
+because the alternative is executing a caller-authorized call against a server
+the caller did not name.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from gateway.api.routes import _platform as platform_module
+from gateway.api.routes._platform import _resolve_platform_mcp_server
+from gateway.services.mcp_stateless import ExecutionState, McpExecutionError
+
+SERVER_ID = uuid.UUID("2c948a61-dc96-4cd8-96bb-8e1434bf424e")
+OTHER_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+
+def _config() -> Any:
+    cfg = MagicMock()
+    cfg.platform = {"base_url": "https://platform.local", "resolve_timeout_ms": 5000}
+    cfg.platform_token = "gw_test_token"
+    return cfg
+
+
+def _entry(**overrides: Any) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "id": str(SERVER_ID),
+        "name": "github",
+        "url": "https://mcp.example.com/mcp",
+        "authorization_token": "server-secret",
+        "enabled": True,
+        "purpose_hint": "issues",
+        "allowed_tools": ["create_issue"],
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _platform_returns(payload: Any, monkeypatch: pytest.MonkeyPatch, status_code: int = 200) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    async def fake_post(*, url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float) -> Any:
+        captured["body"] = body
+        captured["url"] = url
+        return httpx.Response(status_code, json=payload)
+
+    monkeypatch.setattr(platform_module, "_post_platform", fake_post)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_the_matching_entry_is_resolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _platform_returns({"servers": [_entry()]}, monkeypatch)
+
+    server = await _resolve_platform_mcp_server(_config(), "tk_user", SERVER_ID)
+
+    assert server.id == SERVER_ID
+    assert server.url == "https://mcp.example.com/mcp"
+    assert server.authorization_token == "server-secret"
+    assert server.enabled is True
+    assert server.allowed_tools == ["create_issue"]
+    assert captured["body"] == {"mcp_server_ids": [str(SERVER_ID)]}
+
+
+@pytest.mark.asyncio
+async def test_a_disabled_server_resolves_and_says_so(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The 404 belongs to the route's outcome ladder, which both modes share."""
+    _platform_returns({"servers": [_entry(enabled=False)]}, monkeypatch)
+
+    server = await _resolve_platform_mcp_server(_config(), "tk_user", SERVER_ID)
+
+    assert server.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_an_absent_allowlist_stays_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``null`` and a missing key both mean "every live tool" (R-RES-4)."""
+    entry = _entry()
+    del entry["allowed_tools"]
+    _platform_returns({"servers": [entry]}, monkeypatch)
+
+    server = await _resolve_platform_mcp_server(_config(), "tk_user", SERVER_ID)
+
+    assert server.allowed_tools is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"servers": []},
+        {"servers": [_entry(), _entry(id=str(OTHER_ID))]},
+        {"servers": [_entry(id=str(OTHER_ID))]},
+        {"servers": [_entry(id="not-a-uuid")]},
+        {"servers": [_entry(url=None)]},
+        {"servers": [_entry(enabled="yes")]},
+        {"servers": [_entry(allowed_tools="create_issue")]},
+        {"servers": "github"},
+        {},
+        [],
+    ],
+)
+async def test_anything_but_one_matching_entry_is_a_resolution_failure(
+    payload: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _platform_returns(payload, monkeypatch)
+
+    with pytest.raises(McpExecutionError) as raised:
+        await _resolve_platform_mcp_server(_config(), "tk_user", SERVER_ID)
+
+    assert raised.value.code == "mcp_resolution_failed"
+    assert raised.value.execution_state is ExecutionState.NOT_STARTED
+    assert raised.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_the_platforms_own_refusal_is_left_for_the_route_to_classify(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _platform_returns({"detail": "no such server"}, monkeypatch, status_code=404)
+
+    with pytest.raises(HTTPException) as raised:
+        await _resolve_platform_mcp_server(_config(), "tk_user", SERVER_ID)
+
+    assert raised.value.status_code == 404

--- a/tests/unit/test_mcp_tool_screening.py
+++ b/tests/unit/test_mcp_tool_screening.py
@@ -1,0 +1,112 @@
+"""Per-tool admission of a live MCP descriptor (R-SCHEMA-1 to R-SCHEMA-3).
+
+An ``inputSchema`` is untrusted JSON Schema *data*. Otari does not validate it
+against a dialect, rewrite it, or drop keywords it does not recognize; it
+bounds what it will carry and refuses anything that would make Otari fetch a
+schema over the network. A tool that fails screening is omitted from the
+catalog with a labeled warning, and its siblings stay available.
+"""
+
+from __future__ import annotations
+
+import pytest
+from mcp.types import Tool as MCPTool
+
+from gateway.services.mcp_stateless import (
+    SCHEMA_MAX_BYTES,
+    SCHEMA_MAX_DEPTH,
+    TOOL_ANNOTATIONS_MAX_BYTES,
+    TOOL_DESCRIPTION_MAX_BYTES,
+    screen_tool,
+)
+
+
+def _tool(**overrides: object) -> MCPTool:
+    fields: dict[str, object] = {
+        "name": "create_issue",
+        "description": "Create an issue",
+        "inputSchema": {"type": "object", "properties": {"title": {"type": "string"}}},
+    }
+    fields.update(overrides)
+    return MCPTool(**fields)  # type: ignore[arg-type]
+
+
+def test_an_ordinary_tool_is_admitted() -> None:
+    assert screen_tool(_tool()) is None
+
+
+def test_an_unknown_dialect_or_keyword_is_admitted_unchanged() -> None:
+    """Unknown keywords are preserved, not rejected (R-SCHEMA-1, R-SCHEMA-2)."""
+    schema = {
+        "$schema": "https://example.com/draft/2044-01/schema",
+        "type": "object",
+        "properties": {"title": {"type": "string", "x-vendor-widget": "textarea"}},
+        "x-vendor-policy": {"retries": 3},
+    }
+    tool = _tool(inputSchema=schema)
+
+    assert screen_tool(tool) is None
+    assert tool.inputSchema == schema
+
+
+def test_a_local_reference_is_admitted() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"labels": {"$ref": "#/$defs/label"}},
+        "$defs": {"label": {"type": "string"}},
+    }
+
+    assert screen_tool(_tool(inputSchema=schema)) is None
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "https://example.com/schema.json",
+        "//example.com/schema.json",
+        "schema.json#/$defs/label",
+        "file:///etc/passwd",
+    ],
+)
+def test_an_external_reference_is_refused_without_network_access(ref: str) -> None:
+    schema = {"type": "object", "properties": {"labels": {"$ref": ref}}}
+
+    assert screen_tool(_tool(inputSchema=schema)) == "mcp_tool_schema_unsupported"
+
+
+def test_a_non_object_schema_is_refused() -> None:
+    tool = _tool()
+    # MCP's own model types ``inputSchema`` as an object, so a server sending
+    # something else can only reach this through the loosely typed wire form.
+    object.__setattr__(tool, "inputSchema", ["not", "an", "object"])
+
+    assert screen_tool(tool) == "mcp_tool_schema_unsupported"
+
+
+def test_an_oversized_schema_is_refused() -> None:
+    schema = {"type": "object", "properties": {"title": {"description": "x" * (SCHEMA_MAX_BYTES + 1)}}}
+
+    assert screen_tool(_tool(inputSchema=schema)) == "mcp_tool_schema_unsupported"
+
+
+def test_a_too_deeply_nested_schema_is_refused() -> None:
+    nested: dict[str, object] = {"type": "object"}
+    for _ in range(SCHEMA_MAX_DEPTH + 2):
+        nested = {"properties": nested}
+
+    assert screen_tool(_tool(inputSchema=nested)) == "mcp_tool_schema_unsupported"
+
+
+def test_an_oversized_description_is_refused() -> None:
+    assert screen_tool(_tool(description="x" * (TOOL_DESCRIPTION_MAX_BYTES + 1))) == "mcp_tool_description_too_large"
+
+
+def test_an_oversized_annotations_object_is_refused() -> None:
+    tool = _tool()
+    object.__setattr__(tool, "annotations", {"note": "x" * (TOOL_ANNOTATIONS_MAX_BYTES + 1)})
+
+    assert screen_tool(tool) == "mcp_tool_annotations_too_large"
+
+
+def test_a_missing_description_is_admitted() -> None:
+    assert screen_tool(_tool(description=None)) is None

--- a/tests/unit/test_mcp_tool_screening.py
+++ b/tests/unit/test_mcp_tool_screening.py
@@ -17,6 +17,7 @@ from gateway.services.mcp_stateless import (
     SCHEMA_MAX_DEPTH,
     TOOL_ANNOTATIONS_MAX_BYTES,
     TOOL_DESCRIPTION_MAX_BYTES,
+    TOOL_NAME_MAX_LENGTH,
     screen_tool,
 )
 
@@ -33,6 +34,15 @@ def _tool(**overrides: object) -> MCPTool:
 
 def test_an_ordinary_tool_is_admitted() -> None:
     assert screen_tool(_tool()) is None
+
+
+def test_a_tool_name_at_the_execution_limit_is_admitted() -> None:
+    assert screen_tool(_tool(name="x" * TOOL_NAME_MAX_LENGTH)) is None
+
+
+@pytest.mark.parametrize("name", ["", "x" * (TOOL_NAME_MAX_LENGTH + 1)])
+def test_a_tool_name_execution_cannot_accept_is_omitted(name: str) -> None:
+    assert screen_tool(_tool(name=name)) == "mcp_tool_name_unsupported"
 
 
 def test_an_unknown_dialect_or_keyword_is_admitted_unchanged() -> None:

--- a/tests/unit/test_mcp_tools_endpoint.py
+++ b/tests/unit/test_mcp_tools_endpoint.py
@@ -1,0 +1,306 @@
+"""``GET /v1/mcp/servers/{id}/tools``: the stored-server discovery contract.
+
+An application calls this once per server when it prepares a model or workflow
+run, and every proposed call from that server reuses the answer. The response is
+the whole authorized catalog or nothing (R-DISC-5), and it carries neither the
+stored URL, the credential, nor the allowlist itself (R-DISC-2).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+from mcp.types import ListToolsResult, ToolAnnotations
+from mcp.types import Tool as MCPTool
+
+from gateway.api.deps import reset_config
+from gateway.api.routes import _platform as platform_module
+from gateway.core.config import GatewayConfig
+from gateway.core.database import reset_db
+from gateway.main import create_app
+from gateway.models.mcp import ResolvedMcpServer
+from gateway.services import mcp_stateless
+
+SERVER_ID = uuid.UUID("2c948a61-dc96-4cd8-96bb-8e1434bf424e")
+PUBLIC_URL = "https://93.184.216.34/mcp"
+USER_AUTH = {"Authorization": "Bearer platform-user-token"}
+TOOLS_PATH = f"/v1/mcp/servers/{SERVER_ID}/tools"
+
+
+@pytest.fixture(autouse=True)
+def _reset_globals() -> Iterator[None]:
+    yield
+    reset_config()
+    reset_db()
+
+
+def _stored(**overrides: Any) -> ResolvedMcpServer:
+    fields: dict[str, Any] = {
+        "id": SERVER_ID,
+        "name": "github",
+        "url": PUBLIC_URL,
+        "authorization_token": "server-secret",
+        "enabled": True,
+        "allowed_tools": None,
+    }
+    fields.update(overrides)
+    return ResolvedMcpServer(**fields)
+
+
+class _FakeSession:
+    def __init__(self) -> None:
+        self.tools: list[MCPTool] = [
+            MCPTool(
+                name="create_issue",
+                description="Create an issue",
+                inputSchema={"type": "object", "properties": {"title": {"type": "string"}}, "required": ["title"]},
+                annotations=ToolAnnotations(readOnlyHint=False),
+            )
+        ]
+        self.pages = 0
+
+    async def list_tools(self, cursor: str | None = None) -> ListToolsResult:
+        self.pages += 1
+        return ListToolsResult(tools=self.tools)
+
+
+@pytest.fixture
+def session(monkeypatch: pytest.MonkeyPatch) -> _FakeSession:
+    fake = _FakeSession()
+
+    @asynccontextmanager
+    async def open_session(*args: Any, **kwargs: Any) -> Any:
+        yield fake
+
+    monkeypatch.setattr(mcp_stateless, "open_session", open_session)
+    return fake
+
+
+class _Platform:
+    def __init__(self) -> None:
+        self.servers: list[dict[str, Any]] | None = [_stored().model_dump(mode="json")]
+        self.status_code = 200
+        self.bodies: list[dict[str, Any]] = []
+
+
+@pytest.fixture
+def platform(monkeypatch: pytest.MonkeyPatch) -> _Platform:
+    fake = _Platform()
+
+    async def post(*, url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float) -> Any:
+        fake.bodies.append(body)
+        payload = {"servers": fake.servers} if fake.status_code == 200 else {"detail": "refused"}
+        return httpx.Response(fake.status_code, json=payload)
+
+    monkeypatch.setattr(platform_module, "_post_platform", post)
+    return fake
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("OTARI_AI_TOKEN", "gw-test-token")
+    app = create_app(GatewayConfig(mode="hybrid", platform={"base_url": "http://platform.test/api/v1"}))
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_the_live_catalog_is_returned_with_the_stored_server_revision(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    response = client.get(TOOLS_PATH, headers=USER_AUTH)
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "server_id": str(SERVER_ID),
+        "server_revision": _stored().revision,
+        "tools": [
+            {
+                "name": "create_issue",
+                "description": "Create an issue",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"title": {"type": "string"}},
+                    "required": ["title"],
+                },
+                "annotations": {"readOnlyHint": False},
+            }
+        ],
+        "warnings": [],
+    }
+    assert response.headers["X-Otari-Request-ID"]
+
+
+def test_the_response_discloses_no_url_credential_or_allowlist(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    """R-DISC-2, R-CAT-2: the allowlist's effect shows; its contents never do."""
+    platform.servers = [_stored(allowed_tools=["create_issue", "never_listed"]).model_dump(mode="json")]
+
+    response = client.get(TOOLS_PATH, headers=USER_AUTH)
+
+    assert response.status_code == 200, response.text
+    assert [tool["name"] for tool in response.json()["tools"]] == ["create_issue"]
+    for secret in ("93.184.216.34", "server-secret", "never_listed"):
+        assert secret not in response.text, secret
+
+
+def test_a_tool_the_allowlist_excludes_is_not_exposed(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    """R-DISC-1: a server-added tool is not exposed just because it was listed."""
+    session.tools.append(MCPTool(name="delete_repo", description="danger", inputSchema={"type": "object"}))
+    platform.servers = [_stored(allowed_tools=["create_issue"]).model_dump(mode="json")]
+
+    response = client.get(TOOLS_PATH, headers=USER_AUTH)
+
+    assert [tool["name"] for tool in response.json()["tools"]] == ["create_issue"]
+
+
+def test_an_explicit_empty_allowlist_denies_every_tool_without_connecting(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    """R-RES-4: an operator's deny-all is answered without touching the server."""
+    stored = _stored(allowed_tools=[])
+    platform.servers = [stored.model_dump(mode="json")]
+
+    response = client.get(TOOLS_PATH, headers=USER_AUTH)
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "server_id": str(SERVER_ID),
+        "server_revision": stored.revision,
+        "tools": [],
+        "warnings": [],
+    }
+    assert session.pages == 0
+
+
+def test_an_unusable_descriptor_is_omitted_and_labeled(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    """R-SCHEMA-3: the one permitted partial result, and its siblings survive."""
+    session.tools.append(
+        MCPTool(
+            name="broken",
+            description="an external reference",
+            inputSchema={"type": "object", "properties": {"x": {"$ref": "https://attacker.example.com/s.json"}}},
+        )
+    )
+
+    response = client.get(TOOLS_PATH, headers=USER_AUTH)
+
+    assert response.status_code == 200, response.text
+    assert [tool["name"] for tool in response.json()["tools"]] == ["create_issue"]
+    assert response.json()["warnings"] == [{"tool_name": "broken", "code": "mcp_tool_schema_unsupported"}]
+    assert "attacker.example.com" not in response.text
+
+
+def test_an_unknown_schema_keyword_survives_the_round_trip(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    """R-SCHEMA-2: Otari never truncates, rewrites, or drops a keyword."""
+    schema = {
+        "$schema": "https://example.com/draft/2044-01/schema",
+        "type": "object",
+        "properties": {"title": {"type": "string", "x-vendor-widget": "textarea"}},
+        "x-vendor-policy": {"retries": 3},
+    }
+    session.tools = [MCPTool(name="create_issue", description="d", inputSchema=schema)]
+
+    response = client.get(TOOLS_PATH, headers=USER_AUTH)
+
+    assert response.json()["tools"][0]["input_schema"] == schema
+
+
+def test_a_pagination_failure_returns_no_partial_catalog(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cursors = ["loop", "loop"]
+
+    async def looping(cursor: str | None = None) -> ListToolsResult:
+        session.pages += 1
+        return ListToolsResult(tools=session.tools, nextCursor=cursors[min(session.pages - 1, 1)])
+
+    monkeypatch.setattr(session, "list_tools", looping)
+
+    response = client.get(TOOLS_PATH, headers=USER_AUTH)
+
+    assert response.status_code == 502, response.text
+    payload = response.json()
+    assert payload["code"] == "mcp_discovery_limit_exceeded"
+    assert payload["execution_state"] == "not_started"
+    assert "tools" not in payload
+
+
+def test_an_unauthenticated_request_reaches_neither_platform_nor_server(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    response = client.get(TOOLS_PATH)
+
+    assert response.status_code == 401
+    assert response.json()["code"] == "authentication_failed"
+    assert platform.bodies == []
+    assert session.pages == 0
+
+
+def test_a_disabled_server_is_not_found(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    platform.servers = [_stored(enabled=False).model_dump(mode="json")]
+
+    response = client.get(TOOLS_PATH, headers=USER_AUTH)
+
+    assert response.status_code == 404, response.text
+    assert response.json()["code"] == "mcp_server_not_found"
+    assert session.pages == 0
+
+
+def test_an_unsafe_resolved_url_is_refused_before_connecting(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    platform.servers = [_stored(url="http://169.254.169.254/mcp").model_dump(mode="json")]
+
+    response = client.get(TOOLS_PATH, headers=USER_AUTH)
+
+    assert response.status_code == 400, response.text
+    assert response.json()["code"] == "unsafe_mcp_url"
+    assert session.pages == 0
+
+
+def test_a_non_uuid_server_id_is_refused(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    response = client.get("/v1/mcp/servers/not-a-uuid/tools", headers=USER_AUTH)
+
+    assert response.status_code == 422, response.text
+    assert response.json()["code"] == "invalid_request"
+    assert platform.bodies == []

--- a/tests/unit/test_mcp_tools_endpoint.py
+++ b/tests/unit/test_mcp_tools_endpoint.py
@@ -21,6 +21,7 @@ from mcp.types import Tool as MCPTool
 
 from gateway.api.deps import reset_config
 from gateway.api.routes import _platform as platform_module
+from gateway.api.routes import mcp as mcp_route
 from gateway.core.config import GatewayConfig
 from gateway.core.database import reset_db
 from gateway.main import create_app
@@ -209,6 +210,26 @@ def test_an_unusable_descriptor_is_omitted_and_labeled(
     assert [tool["name"] for tool in response.json()["tools"]] == ["create_issue"]
     assert response.json()["warnings"] == [{"tool_name": "broken", "code": "mcp_tool_schema_unsupported"}]
     assert "attacker.example.com" not in response.text
+
+
+def test_the_response_ceiling_includes_warnings_and_envelope(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def oversized_catalog(*args: Any, **kwargs: Any) -> mcp_stateless.DiscoveredCatalog:
+        return mcp_stateless.DiscoveredCatalog(
+            tools=[],
+            warnings=[("x" * mcp_stateless.DISCOVERY_RESPONSE_MAX_BYTES, "mcp_tool_schema_unsupported")],
+        )
+
+    monkeypatch.setattr(mcp_route, "discover_stored_tools", oversized_catalog)
+
+    response = client.get(TOOLS_PATH, headers=USER_AUTH)
+
+    assert response.status_code == 502, response.text
+    assert response.json()["code"] == "mcp_discovery_limit_exceeded"
 
 
 def test_an_unknown_schema_keyword_survives_the_round_trip(

--- a/tests/unit/test_mcp_tools_endpoint.py
+++ b/tests/unit/test_mcp_tools_endpoint.py
@@ -8,6 +8,7 @@ stored URL, the credential, nor the allowlist itself (R-DISC-2).
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from collections.abc import Iterator
 from contextlib import asynccontextmanager
@@ -65,9 +66,11 @@ class _FakeSession:
             )
         ]
         self.pages = 0
+        self.delay_s = 0.0
 
     async def list_tools(self, cursor: str | None = None) -> ListToolsResult:
         self.pages += 1
+        await asyncio.sleep(self.delay_s)
         return ListToolsResult(tools=self.tools)
 
 
@@ -88,6 +91,7 @@ class _Platform:
         self.servers: list[dict[str, Any]] | None = [_stored().model_dump(mode="json")]
         self.status_code = 200
         self.bodies: list[dict[str, Any]] = []
+        self.delay_s = 0.0
 
 
 @pytest.fixture
@@ -96,6 +100,7 @@ def platform(monkeypatch: pytest.MonkeyPatch) -> _Platform:
 
     async def post(*, url: str, headers: dict[str, str], body: dict[str, Any], timeout_seconds: float) -> Any:
         fake.bodies.append(body)
+        await asyncio.sleep(fake.delay_s)
         payload = {"servers": fake.servers} if fake.status_code == 200 else {"detail": "refused"}
         return httpx.Response(fake.status_code, json=payload)
 
@@ -188,6 +193,58 @@ def test_an_explicit_empty_allowlist_denies_every_tool_without_connecting(
         "warnings": [],
     }
     assert session.pages == 0
+
+
+def test_the_total_deadline_includes_authentication(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def slow_authentication(*args: Any, **kwargs: Any) -> Any:
+        await asyncio.sleep(10)
+
+    monkeypatch.setattr(mcp_stateless, "DISCOVERY_TOTAL_TIMEOUT_S", 0.01)
+    monkeypatch.setattr(mcp_route, "_authenticate", slow_authentication)
+
+    response = client.get(TOOLS_PATH, headers=USER_AUTH)
+
+    assert response.status_code == 502, response.text
+    assert response.json()["code"] == "mcp_discovery_limit_exceeded"
+    assert platform.bodies == []
+    assert session.pages == 0
+
+
+def test_the_total_deadline_includes_platform_resolution(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mcp_stateless, "DISCOVERY_TOTAL_TIMEOUT_S", 0.01)
+    platform.delay_s = 10
+
+    response = client.get(TOOLS_PATH, headers=USER_AUTH)
+
+    assert response.status_code == 502, response.text
+    assert response.json()["code"] == "mcp_discovery_limit_exceeded"
+    assert session.pages == 0
+
+
+def test_the_total_deadline_includes_mcp_discovery(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mcp_stateless, "DISCOVERY_TOTAL_TIMEOUT_S", 0.01)
+    session.delay_s = 10
+
+    response = client.get(TOOLS_PATH, headers=USER_AUTH)
+
+    assert response.status_code == 502, response.text
+    assert response.json()["code"] == "mcp_discovery_limit_exceeded"
+    assert session.pages == 1
 
 
 def test_an_unusable_descriptor_is_omitted_and_labeled(

--- a/tests/unit/test_mcp_tools_endpoint.py
+++ b/tests/unit/test_mcp_tools_endpoint.py
@@ -212,6 +212,31 @@ def test_an_unusable_descriptor_is_omitted_and_labeled(
     assert "attacker.example.com" not in response.text
 
 
+def test_an_unexecutable_tool_name_is_omitted_and_labeled(
+    client: TestClient,
+    platform: _Platform,
+    session: _FakeSession,
+) -> None:
+    session.tools.append(
+        MCPTool(
+            name="x" * (mcp_stateless.TOOL_NAME_MAX_LENGTH + 1),
+            description="too long to execute",
+            inputSchema={"type": "object"},
+        )
+    )
+
+    response = client.get(TOOLS_PATH, headers=USER_AUTH)
+
+    assert response.status_code == 200, response.text
+    assert [tool["name"] for tool in response.json()["tools"]] == ["create_issue"]
+    assert response.json()["warnings"] == [
+        {
+            "tool_name": "x" * (mcp_stateless.TOOL_NAME_MAX_LENGTH + 1),
+            "code": "mcp_tool_name_unsupported",
+        }
+    ]
+
+
 def test_the_response_ceiling_includes_warnings_and_envelope(
     client: TestClient,
     platform: _Platform,

--- a/tests/unit/test_operator_gate_declarations.py
+++ b/tests/unit/test_operator_gate_declarations.py
@@ -103,6 +103,7 @@ _UNGATED_ROUTERS: dict[str, str] = {
     "embeddings.router": _DATA_PLANE,
     "files.router": _DATA_PLANE,
     "images.router": _DATA_PLANE,
+    "mcp.router": _DATA_PLANE,
     "messages.router": _DATA_PLANE,
     "moderations.router": _DATA_PLANE,
     "otlp.router": _DATA_PLANE,

--- a/uv.lock
+++ b/uv.lock
@@ -1089,7 +1089,7 @@ requires-dist = [
     { name = "genai-prices", specifier = ">=0.1.0" },
     { name = "idna", specifier = ">=3.7" },
     { name = "markitdown", extras = ["docx", "pptx", "xlsx", "pdf"], specifier = ">=0.1.0" },
-    { name = "mcp", specifier = ">=1.28.1,<2.0.0" },
+    { name = "mcp", specifier = ">=1.28.1,<1.29.0" },
     { name = "numpy", marker = "extra == 'ocr'", specifier = ">=1.26.0" },
     { name = "opentelemetry-api", specifier = ">=1.39.1" },
     { name = "opentelemetry-proto", specifier = ">=1.39.1" },

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -6991,7 +6991,7 @@ export interface components {
         };
         /**
          * McpServerConfig
-         * @description Inline MCP server configuration accepted by generation and execution requests.
+         * @description Inline MCP server configuration accepted by generation requests.
          *
          *     Streamable HTTP transport. The `url` must be reachable from the gateway process.
          *

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -1326,6 +1326,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/mcp/execute": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Execute Mcp Tool
+         * @description Execute one caller-approved tool against one inline MCP server.
+         *
+         *     The server is connected only for this request. Otari validates its URL,
+         *     applies its configured tool allowlist, confirms the tool through live MCP
+         *     discovery, and then executes exactly the named call. A server-returned
+         *     ``isError`` remains a typed MCP result; transport and protocol failures are
+         *     returned as a sanitized gateway error.
+         */
+        post: operations["execute_mcp_tool_v1_mcp_execute_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/messages": {
         parameters: {
             query?: never;
@@ -4947,6 +4973,37 @@ export interface components {
             /** Workspace Id */
             workspace_id?: string | null;
         };
+        /** Annotations */
+        Annotations: {
+            /** Audience */
+            audience?: ("user" | "assistant")[] | null;
+            /** Priority */
+            priority?: number | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * AudioContent
+         * @description Audio content for a message.
+         */
+        AudioContent: {
+            /** Meta */
+            _meta?: {
+                [key: string]: unknown;
+            } | null;
+            annotations?: components["schemas"]["Annotations"] | null;
+            /** Data */
+            data: string;
+            /** Mimetype */
+            mimeType: string;
+            /**
+             * Type
+             * @constant
+             */
+            type: "audio";
+        } & {
+            [key: string]: unknown;
+        };
         /**
          * AudioSpeechRequest
          * @description OpenAI-compatible audio speech (TTS) request.
@@ -5034,6 +5091,27 @@ export interface components {
             tools?: {
                 [key: string]: components["schemas"]["ToolMeter"];
             };
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * BlobResourceContents
+         * @description Binary contents of a resource.
+         */
+        BlobResourceContents: {
+            /** Meta */
+            _meta?: {
+                [key: string]: unknown;
+            } | null;
+            /** Blob */
+            blob: string;
+            /** Mimetype */
+            mimeType?: string | null;
+            /**
+             * Uri
+             * Format: uri
+             */
+            uri: string;
         } & {
             [key: string]: unknown;
         };
@@ -5132,6 +5210,29 @@ export interface components {
              * @default 0
              */
             user_count: number;
+        };
+        /**
+         * CallToolResult
+         * @description The server's response to a tool call.
+         */
+        CallToolResult: {
+            /** Meta */
+            _meta?: {
+                [key: string]: unknown;
+            } | null;
+            /** Content */
+            content: (components["schemas"]["TextContent"] | components["schemas"]["ImageContent"] | components["schemas"]["AudioContent"] | components["schemas"]["ResourceLink"] | components["schemas"]["EmbeddedResource"])[];
+            /**
+             * Iserror
+             * @default false
+             */
+            isError: boolean;
+            /** Structuredcontent */
+            structuredContent?: {
+                [key: string]: unknown;
+            } | null;
+        } & {
+            [key: string]: unknown;
         };
         /**
          * CallerIdentityPublic
@@ -6068,6 +6169,29 @@ export interface components {
             selector: string;
         };
         /**
+         * EmbeddedResource
+         * @description The contents of a resource, embedded into a prompt or tool call result.
+         *
+         *     It is up to the client how best to render embedded resources for the benefit
+         *     of the LLM and/or the user.
+         */
+        EmbeddedResource: {
+            /** Meta */
+            _meta?: {
+                [key: string]: unknown;
+            } | null;
+            annotations?: components["schemas"]["Annotations"] | null;
+            /** Resource */
+            resource: components["schemas"]["TextResourceContents"] | components["schemas"]["BlobResourceContents"];
+            /**
+             * Type
+             * @constant
+             */
+            type: "resource";
+        } & {
+            [key: string]: unknown;
+        };
+        /**
          * EmbeddingRequest
          * @description OpenAI-compatible embedding request.
          */
@@ -6356,6 +6480,42 @@ export interface components {
         HTTPValidationError: {
             /** Detail */
             detail?: components["schemas"]["ValidationError"][];
+        };
+        /**
+         * Icon
+         * @description An icon for display in user interfaces.
+         */
+        Icon: {
+            /** Mimetype */
+            mimeType?: string | null;
+            /** Sizes */
+            sizes?: string[] | null;
+            /** Src */
+            src: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * ImageContent
+         * @description Image content for a message.
+         */
+        ImageContent: {
+            /** Meta */
+            _meta?: {
+                [key: string]: unknown;
+            } | null;
+            annotations?: components["schemas"]["Annotations"] | null;
+            /** Data */
+            data: string;
+            /** Mimetype */
+            mimeType: string;
+            /**
+             * Type
+             * @constant
+             */
+            type: "image";
+        } & {
+            [key: string]: unknown;
         };
         /**
          * ImageGenerationRequest
@@ -6722,8 +6882,27 @@ export interface components {
             object: "tool";
         };
         /**
+         * McpExecuteRequest
+         * @description One MCP server and the exact tool call the client approved.
+         */
+        McpExecuteRequest: {
+            /**
+             * Arguments
+             * @description The JSON-object arguments to pass to the approved tool.
+             */
+            arguments?: {
+                [key: string]: unknown;
+            };
+            server: components["schemas"]["McpServerConfig"];
+            /**
+             * Tool Name
+             * @description The MCP tool the caller has approved for this one execution.
+             */
+            tool_name: string;
+        };
+        /**
          * McpServerConfig
-         * @description Inline MCP server configuration accepted on the chat completions request.
+         * @description Inline MCP server configuration accepted by generation and execution requests.
          *
          *     Streamable HTTP transport. The `url` must be reachable from the gateway process.
          *
@@ -8491,6 +8670,43 @@ export interface components {
             token: string;
         };
         /**
+         * ResourceLink
+         * @description A resource that the server is capable of reading, included in a prompt or tool call result.
+         *
+         *     Note: resource links returned by tools are not guaranteed to appear in the results of `resources/list` requests.
+         */
+        ResourceLink: {
+            /** Meta */
+            _meta?: {
+                [key: string]: unknown;
+            } | null;
+            annotations?: components["schemas"]["Annotations"] | null;
+            /** Description */
+            description?: string | null;
+            /** Icons */
+            icons?: components["schemas"]["Icon"][] | null;
+            /** Mimetype */
+            mimeType?: string | null;
+            /** Name */
+            name: string;
+            /** Size */
+            size?: number | null;
+            /** Title */
+            title?: string | null;
+            /**
+             * Type
+             * @constant
+             */
+            type: "resource_link";
+            /**
+             * Uri
+             * Format: uri
+             */
+            uri: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
          * ResponsesRequest
          * @description OpenAI Responses API-compatible request.
          *
@@ -9157,6 +9373,47 @@ export interface components {
             ok: boolean;
             /** Reason */
             reason: string;
+        };
+        /**
+         * TextContent
+         * @description Text content for a message.
+         */
+        TextContent: {
+            /** Meta */
+            _meta?: {
+                [key: string]: unknown;
+            } | null;
+            annotations?: components["schemas"]["Annotations"] | null;
+            /** Text */
+            text: string;
+            /**
+             * Type
+             * @constant
+             */
+            type: "text";
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * TextResourceContents
+         * @description Text contents of a resource.
+         */
+        TextResourceContents: {
+            /** Meta */
+            _meta?: {
+                [key: string]: unknown;
+            } | null;
+            /** Mimetype */
+            mimeType?: string | null;
+            /** Text */
+            text: string;
+            /**
+             * Uri
+             * Format: uri
+             */
+            uri: string;
+        } & {
+            [key: string]: unknown;
         };
         /**
          * TokenChargeLine
@@ -12641,6 +12898,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    execute_mcp_tool_v1_mcp_execute_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["McpExecuteRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CallToolResult"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -13102,6 +13102,15 @@ export interface operations {
                     "application/json": components["schemas"]["McpErrorBody"];
                 };
             };
+            /** @description Payment Required */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
             /** @description Forbidden */
             403: {
                 headers: {
@@ -13216,6 +13225,24 @@ export interface operations {
             };
             /** @description Unauthorized */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Payment Required */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -1337,15 +1337,54 @@ export interface paths {
         put?: never;
         /**
          * Execute Mcp Tool
-         * @description Execute one caller-approved tool against one inline MCP server.
+         * @description Execute one caller-authorized tool call against a stored MCP server.
          *
-         *     The server is connected only for this request. Otari validates its URL,
-         *     applies its configured tool allowlist, confirms the tool through live MCP
-         *     discovery, and then executes exactly the named call. A server-returned
-         *     ``isError`` remains a typed MCP result; transport and protocol failures are
-         *     returned as a sanitized gateway error.
+         *     The calling application owns any user approval, argument editing,
+         *     cancellation and action history; Otari executes exactly the tool name and
+         *     arguments it is given, once, and returns the remote server's native result.
+         *     A result with ``isError: true`` is a definitive outcome and comes back as an
+         *     HTTP 200.
+         *
+         *     **This request must never be retried automatically.** ``client_execution_id``
+         *     is correlation, not idempotency: once the call has been dispatched Otari
+         *     cannot know whether the tool ran, and an ``outcome_unknown`` response means
+         *     exactly that. Proxies, service meshes and SDKs on this path have to disable
+         *     retries for it, including on connection resets and 5xx responses.
          */
         post: operations["execute_mcp_tool_v1_mcp_execute_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/mcp/servers/{mcp_server_id}/tools": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Mcp Tools
+         * @description List the tools a stored MCP server exposes to the authenticated workspace.
+         *
+         *     Call this once per server when preparing a model or workflow run, and reuse
+         *     the answer for every tool from that server for the length of the run: there
+         *     is no cross-run cache in this version, so a later run rediscovers and
+         *     staleness stays bounded without any invalidation state to keep.
+         *
+         *     The response is the whole authorized catalog or an error. It is never
+         *     partial, because a caller would read a short catalog as the complete input
+         *     to its own authorization and risk policy. The single exception is
+         *     ``warnings``, which names a tool whose descriptor Otari could not carry.
+         *
+         *     A tool the server removes after discovery may still be proposed from the
+         *     run's snapshot; execution then returns the remote server's own typed error.
+         */
+        get: operations["list_mcp_tools_v1_mcp_servers__mcp_server_id__tools_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -6211,6 +6250,17 @@ export interface components {
             user?: string | null;
         };
         /**
+         * ExecutionState
+         * @description Whether the remote tool may have run (R-ERR-2).
+         *
+         *     A retry-safety classification, not a description of how the HTTP request
+         *     went. ``NOT_STARTED`` is Otari saying it knows the tool did not run;
+         *     ``OUTCOME_UNKNOWN`` is Otari saying it cannot know, which is the only honest
+         *     answer once the transport has begun writing ``tools/call``.
+         * @enum {string}
+         */
+        ExecutionState: "not_started" | "outcome_unknown" | "completed";
+        /**
          * ExplainRequest
          * @description Ask what a policy would do, without dispatching anything.
          *
@@ -6882,21 +6932,60 @@ export interface components {
             object: "tool";
         };
         /**
+         * McpErrorBody
+         * @description The one error shape both stored-server endpoints return (R-ERR-1).
+         */
+        McpErrorBody: {
+            /** Code */
+            code: string;
+            /** Detail */
+            detail: string;
+            execution_state: components["schemas"]["ExecutionState"];
+            /** Request Id */
+            request_id: string;
+        };
+        /**
          * McpExecuteRequest
-         * @description One MCP server and the exact tool call the client approved.
+         * @description One stored server, and the exact call the application authorized.
+         *
+         *     No inline server fields (R-REQ-4): a caller registers a remote MCP server
+         *     through the control plane once and refers to it by id afterwards, which
+         *     keeps URLs, credentials, revocation and allowlist policy on Otari's side of
+         *     the boundary instead of in every request.
+         *
+         *     Extras are forbidden rather than ignored, so a caller still sending the old
+         *     inline ``server`` block is told its configuration was not used instead of
+         *     watching Otari quietly execute against a different server than the one it
+         *     named.
          */
         McpExecuteRequest: {
             /**
              * Arguments
-             * @description The JSON-object arguments to pass to the approved tool.
+             * @description The exact caller-authorized JSON-object arguments.
              */
             arguments?: {
                 [key: string]: unknown;
             };
-            server: components["schemas"]["McpServerConfig"];
+            /**
+             * Client Execution Id
+             * Format: uuid
+             * @description A caller-generated UUID, for correlation only. It is not proof of approval and not an idempotency key: repeating a request with the same value may execute the tool again, so this request must never be retried automatically.
+             */
+            client_execution_id: string;
+            /**
+             * Mcp Server Id
+             * Format: uuid
+             * @description The stored MCP server to execute against.
+             */
+            mcp_server_id: string;
+            /**
+             * Server Revision
+             * @description The stored-server revision returned by tool discovery. Required, and compared against the current one so a configuration change since the caller authorized this call is refused rather than executed. Not an approval credential.
+             */
+            server_revision: string;
             /**
              * Tool Name
-             * @description The MCP tool the caller has approved for this one execution.
+             * @description The remote MCP tool name the caller authorized for this one execution.
              */
             tool_name: string;
         };
@@ -6925,6 +7014,77 @@ export interface components {
             purpose_hint?: string | null;
             /** Url */
             url: string;
+        };
+        /**
+         * McpToolDefinition
+         * @description One live tool a caller-orchestrated application may expose to its model.
+         *
+         *     ``annotations`` is the remote server's own metadata, passed through as
+         *     untrusted data. Otari never turns ``readOnlyHint`` into an authorization
+         *     decision (R-RISK-1); each application owns its risk policy, and a server
+         *     cannot waive an application's approval gate by labeling itself read-only.
+         */
+        McpToolDefinition: {
+            /**
+             * Annotations
+             * @description The server's MCP annotations, untrusted metadata rather than policy.
+             */
+            annotations?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Description
+             * @description The server's own description, untrusted.
+             */
+            description?: string | null;
+            /**
+             * Input Schema
+             * @description The tool's MCP inputSchema, unmodified.
+             */
+            input_schema: {
+                [key: string]: unknown;
+            };
+            /**
+             * Name
+             * @description The remote MCP tool name to send back to /v1/mcp/execute.
+             */
+            name: string;
+        };
+        /**
+         * McpToolWarning
+         * @description One tool that was omitted, and the code that omitted it (R-SCHEMA-3).
+         */
+        McpToolWarning: {
+            /** Code */
+            code: string;
+            /** Tool Name */
+            tool_name: string;
+        };
+        /**
+         * McpToolsResponse
+         * @description The authorized catalog for one stored server.
+         *
+         *     Carries no server URL, no credential, and no allowlist entry that the live
+         *     catalog did not return (R-DISC-2). ``server_revision`` is what an
+         *     application persists with a proposed call and sends back to
+         *     ``/v1/mcp/execute``, so a stored-configuration change between the two is
+         *     refused rather than executed.
+         */
+        McpToolsResponse: {
+            /**
+             * Server Id
+             * Format: uuid
+             */
+            server_id: string;
+            /**
+             * Server Revision
+             * @description An opaque revision of the stored server's URL, credential, enabled state and allowlist. It detects Otari-side and platform-side configuration changes only: a remote server that changes its own catalog or a tool's behavior behind an unchanged URL will not move it.
+             */
+            server_revision: string;
+            /** Tools */
+            tools: components["schemas"]["McpToolDefinition"][];
+            /** Warnings */
+            warnings: components["schemas"]["McpToolWarning"][];
         };
         /**
          * Message
@@ -12924,13 +13084,197 @@ export interface operations {
                     "application/json": components["schemas"]["CallToolResult"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Unprocessable Content */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Bad Gateway */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Gateway Timeout */
+            504: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+        };
+    };
+    list_mcp_tools_v1_mcp_servers__mcp_server_id__tools_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                mcp_server_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpToolsResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Unprocessable Content */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Bad Gateway */
+            502: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
+                };
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpErrorBody"];
                 };
             };
         };


### PR DESCRIPTION
## Why

Otari's stateless MCP endpoint took an inline server configuration, so a caller
transmitted a URL and a credential on every request, chose its own outbound
destination, and supplied its own policy. In hybrid mode it authenticated by
resolving an empty id list, which bound the call to no stored server at all.
Nothing tied the tool a caller asked for to a server its workspace was
authorized to reach.

 MCP servers expose tools that an AI application can call. This PR adds a safer, stateless way for 
 an application to use those tools:                                                                
                                                                                                   
 1. The application asks Otari which tools a stored MCP server exposes.                            
 2. The application decides whether to allow a proposed tool call, potentially asking a human.     
 3. The application sends the approved tool name and arguments back to Otari.                      
 4. Otari opens a short-lived MCP connection, runs exactly that call, returns the native MCP       
    result, and closes the connection.                                                             
                                                                                                   
 Nothing remains open while approval is happening. 

## What changed

`POST /v1/mcp/execute` now takes a stored server id, and
`GET /v1/mcp/servers/{mcp_server_id}/tools` is new. Together they let an
application own its own MCP tool loop: discover once per run, apply its own
authorization policy to what a model proposes, then ask Otari to run one exact
authorized call. Otari holds nothing open in between, which is what lets the
application pause for a person.

Otari executes a caller-authorized call and does not verify a human approval.
It enforces authentication, stored-server access, the stored allowlist, URL
safety, and its own bounds.

`server_revision` binds an authorization decision to the configuration it was
made against. It is derived from the resolved URL, a digest of the credential,
the enabled state and the sorted allowlist, so no migration or platform field
is needed and every worker agrees by construction. A stale revision is a 409.

## Notes

- **Legacy resolver compatibility.** New platform peers should return `id` and
  `enabled`. A legacy peer may omit both; Otari binds its one returned entry to
  the requested id and treats it as enabled. An empty list remains the legacy
  disabled-server response. Contract in `docs/hybrid-mode-protocol.md`.
- **`/v1/mcp/execute` must never be retried automatically**, including by a
  proxy or service mesh. `outcome_unknown` means the tool may already have run.
  Verify ingress policy before enabling for anyone real.
- **The inline `server` field is gone**, and now rejected rather than ignored.
- **Empty MCP allowlists now deny all tools.** This changes managed completion behavior. Omit `allowed_tools` or send `null` for unrestricted access; use `[]` for deny-all.
- Execution never calls `tools/list`; the stored allowlist is the authority.
- Errors share one body (`detail`, `code`, `execution_state`, `request_id`) with
  a fixed safe message per code. `docs/mcp.md` has the full table and limits.
- `mcp` is pinned to one minor line. The endpoint answers with mcp's own
  `CallToolResult`, so ten mcp-owned schemas reach three committed artifacts;
  see the constraint comment and AGENTS.md before raising it.

Fixes #791

## PR Type

- [x] New Feature
- [x] Refactor
- [x] Documentation

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [x] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:** GPT-5 Codex for the original inline-server version; Claude Opus 5 for this refactor.

**Any additional AI details you'd like to share:** The refactor was driven test-first against the design doc, and the review findings on the first version were each verified against the new code rather than assumed fixed. Two were reproduced before fixing: a blocked user's call returning 200, and a dead MCP server escaping the error contract entirely.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not an AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Replaced inline MCP server settings with stored-server references.
- Added stored-server tool discovery.
- Added checks for access, revisions, allowlists, URL safety, and execution limits.
- Standardized errors and added safe handling for uncertain execution outcomes.
- Updated documentation, API artifacts, dependency controls, and tests.

These changes support secure, stateless, caller-controlled MCP approvals without open sessions or shared approval state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


