### PR TITLE
feat(dashboard): render usage deltas as trend chips

### DIFF
--- a/web/src/features/usage/UsagePage.test.tsx
+++ b/web/src/features/usage/UsagePage.test.tsx
@@ -187,6 +187,10 @@ function jsonResponse(body: unknown, status = 200): Response {
 function mockApi(
   body: UsageSummary | null,
   extra: Record<string, unknown> = {},
+  // The previous window. Without one, that query gets the current window's body
+  // back, every delta is exactly zero, and a test cannot see a direction or a
+  // polarity color.
+  previousBody?: UsageSummary,
 ) {
   return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = String(input)
@@ -194,6 +198,12 @@ function mockApi(
       if (url.includes(path)) return jsonResponse(answer)
     }
     if (url.includes("/v1/usage/summary")) {
+      // The previous-period query is the only one on this page passing
+      // NO_BREAKDOWNS, which goes on the wire as the server's `none` sentinel,
+      // so that is what tells the two windows apart here.
+      if (previousBody && url.includes("dimensions=none")) {
+        return jsonResponse(previousBody)
+      }
       return jsonResponse(body ?? summary())
     }
     if (url.includes("/v1/usage/series")) {
@@ -616,11 +626,41 @@ describe("UsagePage", () => {
     // And it announces a direction, which the glyph never did: "▲" is
     // decoration a screen reader skips. TrendChip.test.tsx owns the direction
     // and polarity mapping; this only asserts the tiles go through it.
+    // Anchored, and counted. Unanchored, `up` also matches the page's own
+    // description and the "No grouping" option, so the assertion would pass with
+    // the announcement deleted. The count is the four tiles that have a delta,
+    // less cache hit rate, which this fixture gives no input-token composition
+    // to divide by.
     expect(
-      screen.getAllByText(/^(no change|up|down)(, (better|worse))?$/).length,
-    ).toBeGreaterThan(0)
+      screen.getAllByText(/^(no change|up|down)(, (better|worse))?$/),
+    ).toHaveLength(3)
     // The hand-rolled arrow glyphs are gone from the tiles.
     expect(screen.queryByText(/[▲▼]/)).not.toBeInTheDocument()
+  })
+
+  it("reads a chip against the metric's own polarity, not the direction alone", async () => {
+    // Spend rose from 827.00 to 1,240.50, a 50% rise. On `down-is-good` that is
+    // the regression, so the chip is a danger chip and says so: direction plus
+    // judgment, because polarity puts good and bad in hue alone.
+    mockApi(
+      summary(),
+      {},
+      summary({
+        totals: usageTotals({
+          cost: 827,
+          request_count: 42_000,
+          billed_input_tokens: 4_000_000,
+          billed_output_tokens: 2_200_000,
+        }),
+      }),
+    )
+    renderPage(<UsagePage />)
+
+    expect(await screen.findByText("up, worse")).toBeInTheDocument()
+    expect(screen.getByText("+50.0% vs prev")).toBeInTheDocument()
+    // Requests doubled too, but volume carries no polarity, so it announces the
+    // direction and nothing more.
+    expect(screen.getAllByText("up").length).toBeGreaterThan(0)
   })
 
   it("lists spend by model with a reconciling 'other' fold row", async () => {

--- a/web/src/features/usage/UsagePage.test.tsx
+++ b/web/src/features/usage/UsagePage.test.tsx
@@ -616,7 +616,9 @@ describe("UsagePage", () => {
     // And it announces a direction, which the glyph never did: "▲" is
     // decoration a screen reader skips. TrendChip.test.tsx owns the direction
     // and polarity mapping; this only asserts the tiles go through it.
-    expect(screen.getAllByText(/no change|up|down/).length).toBeGreaterThan(0)
+    expect(
+      screen.getAllByText(/^(no change|up|down)(, (better|worse))?$/).length,
+    ).toBeGreaterThan(0)
     // The hand-rolled arrow glyphs are gone from the tiles.
     expect(screen.queryByText(/[▲▼]/)).not.toBeInTheDocument()
   })

--- a/web/src/features/usage/UsagePage.test.tsx
+++ b/web/src/features/usage/UsagePage.test.tsx
@@ -605,6 +605,22 @@ describe("UsagePage", () => {
     expect(summaryCalls.some((u) => !u.includes("end_date="))).toBe(true)
   })
 
+  it("renders period-over-period change as a trend chip, not a glyph", async () => {
+    mockApi(summary())
+    renderPage(<UsagePage />)
+    await screen.findByText("$1,240.50")
+
+    // The chip carries the caption the old plain-text hint carried, so the
+    // comparison still says what it is being compared against.
+    expect(screen.getAllByText(/vs prev/).length).toBeGreaterThan(0)
+    // And it announces a direction, which the glyph never did: "▲" is
+    // decoration a screen reader skips. TrendChip.test.tsx owns the direction
+    // and polarity mapping; this only asserts the tiles go through it.
+    expect(screen.getAllByText(/no change|up|down/).length).toBeGreaterThan(0)
+    // The hand-rolled arrow glyphs are gone from the tiles.
+    expect(screen.queryByText(/[▲▼]/)).not.toBeInTheDocument()
+  })
+
   it("lists spend by model with a reconciling 'other' fold row", async () => {
     mockApi(summary())
     renderPage(<UsagePage />)

--- a/web/src/features/usage/UsagePage.tsx
+++ b/web/src/features/usage/UsagePage.tsx
@@ -31,8 +31,8 @@ import {
 } from "@/shared/components/charts"
 import { DataTable, type DataTableColumn } from "@/shared/components/DataTable"
 import { type FilterChip, FilterChips } from "@/shared/components/FilterChips"
+import { TrendChip } from "@/shared/components/TrendChip"
 import {
-  DeltaHint,
   EmptyState,
   ErrorBanner,
   FilterMultiComboBox,
@@ -64,7 +64,7 @@ import { useSelectedWorkspace } from "@/shared/hooks/SelectedWorkspace"
 // ---------- formatting ----------
 
 // Compact currency (formatUsd), token counts (formatTokens), percentages
-// (formatPct) and the period-over-period helpers (deltaFraction / DeltaHint) are
+// (formatPct) and the period-over-period helpers (deltaFraction / TrendChip) are
 // shared with the overview page from @/shared/helpers/format and @/shared/components/ui. Only the
 // two formatters specific to this page stay local.
 function formatBucketLabel(iso: string, bucket: UsageBucket): string {
@@ -1051,15 +1051,19 @@ export function UsagePage() {
             <StatCard
               label="Tracked cost"
               value={totals ? formatUsd(totals.cost) : "—"}
+              // Spend falling is the improvement, so a rise paints danger while
+              // the arrow keeps telling the truth about which way it went.
+              trend={
+                <TrendChip
+                  fraction={costDelta}
+                  polarity="down-is-good"
+                  caption="vs prev"
+                />
+              }
               hint={
-                totals ? (
-                  <span className="text-muted">
-                    <DeltaHint fraction={costDelta} />
-                    {totals.unpriced_requests
-                      ? `${costDelta !== null ? " · " : ""}${formatNumber(totals.unpriced_requests)} unpriced`
-                      : null}
-                  </span>
-                ) : null
+                totals?.unpriced_requests
+                  ? `${formatNumber(totals.unpriced_requests)} unpriced`
+                  : null
               }
               chart={
                 hasTrend ? (
@@ -1073,24 +1077,21 @@ export function UsagePage() {
             <StatCard
               label="Requests"
               value={totals ? formatNumber(totals.request_count) : "—"}
-              hint={
-                totals ? (
-                  <span className="text-muted">
-                    {formatPct(errorRate)} errors
-                    {prevTotals ? (
-                      <>
-                        {" · "}
-                        <DeltaHint
-                          fraction={deltaFraction(
-                            totals.request_count,
-                            prevTotals.request_count,
-                          )}
-                        />
-                      </>
-                    ) : null}
-                  </span>
+              // Volume, so `neutral`: more traffic through the gateway is
+              // neither a win nor a regression on its own, and the error rate
+              // beside it is what carries the judgment.
+              trend={
+                totals && prevTotals ? (
+                  <TrendChip
+                    fraction={deltaFraction(
+                      totals.request_count,
+                      prevTotals.request_count,
+                    )}
+                    caption="vs prev"
+                  />
                 ) : null
               }
+              hint={totals ? `${formatPct(errorRate)} errors` : null}
               chart={
                 hasTrend ? (
                   <Sparkline
@@ -1105,10 +1106,12 @@ export function UsagePage() {
               value={
                 billedTotal !== undefined ? formatTokens(billedTotal) : "—"
               }
-              hint={
+              // Volume again, for the same reason as Requests.
+              trend={
                 billedTotal !== undefined ? (
-                  <DeltaHint
+                  <TrendChip
                     fraction={deltaFraction(billedTotal, prevBilledTotal)}
+                    caption="vs prev"
                   />
                 ) : null
               }
@@ -1124,24 +1127,20 @@ export function UsagePage() {
             <StatCard
               label="Cache hit rate"
               value={cacheHitRate !== null ? formatPct(cacheHitRate) : "—"}
-              hint={
-                totals ? (
-                  <span className="text-muted">
-                    {cacheHitRate !== null && prevCacheHitRate !== undefined ? (
-                      <>
-                        <DeltaHint
-                          fraction={deltaFraction(
-                            cacheHitRate,
-                            prevCacheHitRate,
-                          )}
-                        />
-                        {" · "}
-                      </>
-                    ) : null}
-                    {formatTokens(cache.read)} read ·{" "}
-                    {formatTokens(cache.write)} written
-                  </span>
+              // A higher share of reads served from cache is the win here.
+              trend={
+                cacheHitRate !== null && prevCacheHitRate !== undefined ? (
+                  <TrendChip
+                    fraction={deltaFraction(cacheHitRate, prevCacheHitRate)}
+                    polarity="up-is-good"
+                    caption="vs prev"
+                  />
                 ) : null
+              }
+              hint={
+                totals
+                  ? `${formatTokens(cache.read)} read · ${formatTokens(cache.write)} written`
+                  : null
               }
               chart={
                 hasTrend && hasComposition ? (

--- a/web/src/features/usage/UsagePage.tsx
+++ b/web/src/features/usage/UsagePage.tsx
@@ -64,9 +64,10 @@ import { useSelectedWorkspace } from "@/shared/hooks/SelectedWorkspace"
 // ---------- formatting ----------
 
 // Compact currency (formatUsd), token counts (formatTokens), percentages
-// (formatPct) and the period-over-period helpers (deltaFraction / TrendChip) are
-// shared with the overview page from @/shared/helpers/format and @/shared/components/ui. Only the
-// two formatters specific to this page stay local.
+// (formatPct) and the period-over-period delta (deltaFraction) are shared with
+// the overview page from @/shared/helpers/format, and the chip that renders one
+// comes from @/shared/components/TrendChip. Only the two formatters specific to
+// this page stay local.
 function formatBucketLabel(iso: string, bucket: UsageBucket): string {
   const d = new Date(iso)
   if (Number.isNaN(d.getTime())) return iso
@@ -743,6 +744,23 @@ export function UsagePage() {
   const prevCacheHitRate =
     prevCache.input > 0 ? prevCache.read / prevCache.input : undefined
 
+  // One delta per tile that has one. Named rather than inlined so each tile can
+  // gate its chip on `!== null`: `TrendChip` renders nothing for a null fraction
+  // (no comparable previous period), but the element itself is still truthy, and
+  // `StatCard` would reserve the aside row for a chip that draws nothing.
+  const requestDelta =
+    totals && prevTotals
+      ? deltaFraction(totals.request_count, prevTotals.request_count)
+      : null
+  const billedDelta =
+    billedTotal !== undefined
+      ? deltaFraction(billedTotal, prevBilledTotal)
+      : null
+  const cacheDelta =
+    cacheHitRate !== null && prevCacheHitRate !== undefined
+      ? deltaFraction(cacheHitRate, prevCacheHitRate)
+      : null
+
   const hasComposition = series.some((p) => (p.input_tokens ?? 0) > 0)
   const hasErrors = series.some((p) => (p.errors ?? 0) > 0)
 
@@ -1054,11 +1072,13 @@ export function UsagePage() {
               // Spend falling is the improvement, so a rise paints danger while
               // the arrow keeps telling the truth about which way it went.
               trend={
-                <TrendChip
-                  fraction={costDelta}
-                  polarity="down-is-good"
-                  caption="vs prev"
-                />
+                costDelta !== null ? (
+                  <TrendChip
+                    fraction={costDelta}
+                    polarity="down-is-good"
+                    caption="vs prev"
+                  />
+                ) : null
               }
               hint={
                 totals?.unpriced_requests
@@ -1081,14 +1101,8 @@ export function UsagePage() {
               // neither a win nor a regression on its own, and the error rate
               // beside it is what carries the judgment.
               trend={
-                totals && prevTotals ? (
-                  <TrendChip
-                    fraction={deltaFraction(
-                      totals.request_count,
-                      prevTotals.request_count,
-                    )}
-                    caption="vs prev"
-                  />
+                requestDelta !== null ? (
+                  <TrendChip fraction={requestDelta} caption="vs prev" />
                 ) : null
               }
               hint={totals ? `${formatPct(errorRate)} errors` : null}
@@ -1108,11 +1122,8 @@ export function UsagePage() {
               }
               // Volume again, for the same reason as Requests.
               trend={
-                billedTotal !== undefined ? (
-                  <TrendChip
-                    fraction={deltaFraction(billedTotal, prevBilledTotal)}
-                    caption="vs prev"
-                  />
+                billedDelta !== null ? (
+                  <TrendChip fraction={billedDelta} caption="vs prev" />
                 ) : null
               }
               chart={
@@ -1129,9 +1140,9 @@ export function UsagePage() {
               value={cacheHitRate !== null ? formatPct(cacheHitRate) : "—"}
               // A higher share of reads served from cache is the win here.
               trend={
-                cacheHitRate !== null && prevCacheHitRate !== undefined ? (
+                cacheDelta !== null ? (
                   <TrendChip
-                    fraction={deltaFraction(cacheHitRate, prevCacheHitRate)}
+                    fraction={cacheDelta}
                     polarity="up-is-good"
                     caption="vs prev"
                   />

--- a/web/src/shared/components/ui.test.tsx
+++ b/web/src/shared/components/ui.test.tsx
@@ -68,14 +68,14 @@ describe("StatCard", () => {
         chart={<svg aria-label="trend" />}
       />,
     )
-    expect(container.querySelector(".min-h-10")).not.toBeNull()
+    expect(container.querySelector(".min-h-10\\.5")).not.toBeNull()
   })
 
   it("reserves nothing for a tile with neither aside nor chart", () => {
     const { container } = render(
       <StatCard label="Avg latency" value="1.33 s" />,
     )
-    expect(container.querySelector(".min-h-10")).toBeNull()
+    expect(container.querySelector(".min-h-10\\.5")).toBeNull()
   })
 })
 

--- a/web/src/shared/components/ui.test.tsx
+++ b/web/src/shared/components/ui.test.tsx
@@ -56,9 +56,11 @@ describe("StatCard", () => {
     ).toBeTruthy()
   })
 
-  it("reserves the hint's two lines for a charted tile that has no hint", () => {
-    // Otherwise a tile whose only hint was its delta loses 36px and its
-    // sparkline rides above its neighbours' in the same row.
+  it("reserves the aside row's height for a charted tile that has nothing to say", () => {
+    // Otherwise a tile whose only aside was its delta loses the row, and its
+    // sparkline rides above its neighbours' in the same grid row. Asserted on
+    // the class for the same reason as the tile's own min-w-0 above: jsdom does
+    // no layout, so the reservation is only observable as the utility.
     const { container } = render(
       <StatCard
         label="Tokens"
@@ -66,14 +68,14 @@ describe("StatCard", () => {
         chart={<svg aria-label="trend" />}
       />,
     )
-    expect(container.querySelector(".min-h-9")).not.toBeNull()
+    expect(container.querySelector(".min-h-10")).not.toBeNull()
   })
 
-  it("reserves nothing for a tile with neither hint nor chart", () => {
+  it("reserves nothing for a tile with neither aside nor chart", () => {
     const { container } = render(
       <StatCard label="Avg latency" value="1.33 s" />,
     )
-    expect(container.querySelector(".min-h-9")).toBeNull()
+    expect(container.querySelector(".min-h-10")).toBeNull()
   })
 })
 

--- a/web/src/shared/components/ui.test.tsx
+++ b/web/src/shared/components/ui.test.tsx
@@ -31,6 +31,50 @@ describe("StatCard", () => {
     expect(root.className).toContain("min-w-0")
     expect(root.className).toContain("p-0")
   })
+
+  it("puts the trend under the value, on one row with the hint", () => {
+    render(
+      <StatCard
+        label="Tracked cost"
+        value="$12.34"
+        trend={<span>up 4.2%</span>}
+        hint="3 unpriced"
+      />,
+    )
+    const value = screen.getByText("$12.34")
+    const trend = screen.getByText("up 4.2%")
+    const hint = screen.getByText("3 unpriced")
+    // Below the value, not sharing its row.
+    expect(value.parentElement).not.toContainElement(trend)
+    expect(
+      value.compareDocumentPosition(trend) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    // On one row with the hint, and ahead of it, rather than stacked above it.
+    expect(trend.parentElement).toBe(hint.parentElement)
+    expect(
+      trend.compareDocumentPosition(hint) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+  })
+
+  it("reserves the hint's two lines for a charted tile that has no hint", () => {
+    // Otherwise a tile whose only hint was its delta loses 36px and its
+    // sparkline rides above its neighbours' in the same row.
+    const { container } = render(
+      <StatCard
+        label="Tokens"
+        value="3.3M"
+        chart={<svg aria-label="trend" />}
+      />,
+    )
+    expect(container.querySelector(".min-h-9")).not.toBeNull()
+  })
+
+  it("reserves nothing for a tile with neither hint nor chart", () => {
+    const { container } = render(
+      <StatCard label="Avg latency" value="1.33 s" />,
+    )
+    expect(container.querySelector(".min-h-9")).toBeNull()
+  })
 })
 
 describe("RefreshButton", () => {

--- a/web/src/shared/components/ui.test.tsx
+++ b/web/src/shared/components/ui.test.tsx
@@ -58,7 +58,7 @@ describe("StatCard", () => {
 
   it("reserves the aside row's height for a charted tile that has nothing to say", () => {
     // Otherwise a tile whose only aside was its delta loses the row, and its
-    // sparkline rides above its neighbours' in the same grid row. Asserted on
+    // sparkline rides above its neighbors' in the same grid row. Asserted on
     // the class for the same reason as the tile's own min-w-0 above: jsdom does
     // no layout, so the reservation is only observable as the utility.
     const { container } = render(

--- a/web/src/shared/components/ui.tsx
+++ b/web/src/shared/components/ui.tsx
@@ -156,6 +156,7 @@ export function StatCard({
   label,
   value,
   hint,
+  trend,
   status,
   statusLabel,
   chart,
@@ -163,7 +164,15 @@ export function StatCard({
 }: {
   label: string
   value: ReactNode
+  // Supporting context under the value: what the number is made of ("5.8%
+  // errors", "311.2k read"), not how it moved. The movement is `trend`, and the
+  // two share one row.
   hint?: ReactNode
+  // Period-over-period change, as a <TrendChip>. It leads the aside row under
+  // the value, ahead of `hint`: a pill sharing the value's baseline competes
+  // with the number for the first glance, while a second row of its own spends
+  // a line saying what belongs beside the hint anyway.
+  trend?: ReactNode
   status?: StatStatus
   // A short word (and/or icon) shown as a pill beside the value. Required to be a
   // non-color signal so status is legible without hue (colorblind operators).
@@ -200,14 +209,33 @@ export function StatCard({
           </span>
         ) : null}
       </span>
-      {/* Two lines reserved, always. A delta like "5.8% errors · ▲ 214.1% vs
-          prev" wraps in a narrow tile while its neighbors stay on one line,
-          and a row of five tiles then stops aligning. This is a layout fix and
-          not a type fix on purpose: sizing the type to the longest string would
-          be sizing the type by accident. min-h-9 is two 18px lines. */}
-      {hint ? (
-        <span className="block min-h-9 text-xs tabular-nums text-muted">
-          {hint}
+      {/* One row under the value carrying both the movement (the chip) and the
+          composition (the hint): they are two halves of the same aside, and
+          stacked they read as two, costing a line the tile does not have.
+          `flex` also makes the chip hug its text, which it does not do as a
+          direct child of this column: HeroUI's Chip is inline-flex, and a
+          stretched child would run the pill the full width of the tile.
+
+          `flex-wrap` because at five-up the pair does not always fit; the wrap
+          is the fallback, not the layout. `items-center` aligns the hint's
+          x-height to the middle of the pill rather than to its box.
+
+          Two lines reserved (min-h-9, two 18px lines) so that fallback does
+          not misalign a row of tiles: one tile wrapping while its neighbors
+          stay on one line moves its sparkline up relative to theirs. This is a
+          layout fix and not a type fix on purpose: sizing the type to the
+          longest string would be sizing the type by accident. Reserved for a
+          charted tile even with neither chip nor hint, since the chart is what
+          makes the misalignment visible; a tile with no chart and nothing to
+          say reserves nothing, so a lone tile carries no dead space. */}
+      {trend || hint || chart ? (
+        <span className="flex min-h-9 flex-wrap items-center gap-x-2 gap-y-1 text-xs tabular-nums text-muted">
+          {trend}
+          {/* Its own element, not a bare text node beside the chip: the two
+              are separate statements, and a node keeps the hint addressable
+              (by a test, and by a reader's selection) rather than merged into
+              the chip's text. */}
+          {hint ? <span>{hint}</span> : null}
         </span>
       ) : null}
       {chart ? <div className="mt-2">{chart}</div> : null}

--- a/web/src/shared/components/ui.tsx
+++ b/web/src/shared/components/ui.tsx
@@ -222,18 +222,22 @@ export function StatCard({
 
           The wrap is reserved for so it does not misalign a row of tiles: one
           tile wrapping while its neighbors stay on one line would move its
-          sparkline up relative to theirs. min-h-10 is 40px, which is what the
-          wrap costs: an 18px chip line, `gap-y-1`, and one 18px hint line.
-          #807 reserved 36px here for two lines of plain text, which the chip's
-          own line height now overruns by 4px. A hint long enough to wrap on its
-          own still overruns this, so it is a floor and not a guarantee; the
-          type is deliberately not sized to the longest string, which would be
-          sizing it by accident. Reserved for a charted tile even with neither
-          chip nor hint, since the chart is what makes the misalignment visible;
-          a tile with no chart and nothing to say reserves nothing, so a lone
-          tile carries no dead space. */}
+          sparkline up relative to theirs. min-h-10.5 is 42px, which is what the
+          wrap costs: a 20px chip line, `gap-y-1`, and one 18px hint line. The
+          chip's line is 20px and not the 18px its `text-xs` implies, because
+          HeroUI's `.chip` sets `--tw-leading` to `leading-5` on the element and
+          `.chip--sm` does not reset it, so the size modifier's
+          `line-height: var(--tw-leading, var(--text-xs--line-height))` resolves
+          to the base 20px rather than to our token. #807 reserved 36px here for
+          two lines of plain text, which that overruns. A hint long enough to
+          wrap on its own still overruns this, so it is a floor and not a
+          guarantee; the type is deliberately not sized to the longest string,
+          which would be sizing it by accident. Reserved for a charted tile even
+          with neither chip nor hint, since the chart is what makes the
+          misalignment visible; a tile with no chart and nothing to say reserves
+          nothing, so a lone tile carries no dead space. */}
       {trend || hint || chart ? (
-        <span className="flex min-h-10 flex-wrap items-center gap-x-2 gap-y-1 text-xs tabular-nums text-muted">
+        <span className="flex min-h-10.5 flex-wrap items-center gap-x-2 gap-y-1 text-xs tabular-nums text-muted">
           {trend}
           {/* Its own element, not a bare text node beside the chip: the two
               are separate statements, and a node keeps the hint addressable

--- a/web/src/shared/components/ui.tsx
+++ b/web/src/shared/components/ui.tsx
@@ -220,16 +220,20 @@ export function StatCard({
           is the fallback, not the layout. `items-center` aligns the hint's
           x-height to the middle of the pill rather than to its box.
 
-          Two lines reserved (min-h-9, two 18px lines) so that fallback does
-          not misalign a row of tiles: one tile wrapping while its neighbors
-          stay on one line moves its sparkline up relative to theirs. This is a
-          layout fix and not a type fix on purpose: sizing the type to the
-          longest string would be sizing the type by accident. Reserved for a
-          charted tile even with neither chip nor hint, since the chart is what
-          makes the misalignment visible; a tile with no chart and nothing to
-          say reserves nothing, so a lone tile carries no dead space. */}
+          The wrap is reserved for so it does not misalign a row of tiles: one
+          tile wrapping while its neighbors stay on one line would move its
+          sparkline up relative to theirs. min-h-10 is 40px, which is what the
+          wrap costs: an 18px chip line, `gap-y-1`, and one 18px hint line.
+          #807 reserved 36px here for two lines of plain text, which the chip's
+          own line height now overruns by 4px. A hint long enough to wrap on its
+          own still overruns this, so it is a floor and not a guarantee; the
+          type is deliberately not sized to the longest string, which would be
+          sizing it by accident. Reserved for a charted tile even with neither
+          chip nor hint, since the chart is what makes the misalignment visible;
+          a tile with no chart and nothing to say reserves nothing, so a lone
+          tile carries no dead space. */}
       {trend || hint || chart ? (
-        <span className="flex min-h-9 flex-wrap items-center gap-x-2 gap-y-1 text-xs tabular-nums text-muted">
+        <span className="flex min-h-10 flex-wrap items-center gap-x-2 gap-y-1 text-xs tabular-nums text-muted">
           {trend}
           {/* Its own element, not a bare text node beside the chip: the two
               are separate statements, and a node keeps the hint addressable


### PR DESCRIPTION
## Description

`TrendChip` landed in #801 with no call sites. #801 deferred them on purpose ("No call sites yet,
on purpose"), on the grounds that migrating `DeltaHint` is a behavior change to two pages and
belongs in its own PR. That follow-up was never opened, so the Usage page still printed its
period-over-period change as `▲ 212.2% vs prev`: an arrow a screen reader skips, in one color
whichever way the number went, so a rise in spend and a rise in cache hit rate read identically.

This is that follow-up, for the Usage page.

### The chips

The four tiles that have a delta now render a chip that knows the metric's own axis:

| Tile | Polarity | Why |
| --- | --- | --- |
| Tracked cost | `down-is-good` | Spend falling is the improvement |
| Requests | `neutral` | Volume. More traffic is neither a win nor a regression on its own, and the error rate beside it carries the judgment |
| Tokens (billed) | `neutral` | Same |
| Cache hit rate | `up-is-good` | A higher share of reads served from cache is the win |
| Avg latency | n/a | No delta on the wire, untouched |

So a fall in spend and a rise in cache hit rate both paint as the improvement they are, while the
arrow keeps telling the truth about which way the number went. `neutral` is a deliberate choice
rather than an omission on the two volume tiles: painting rising traffic green would assert
something the gateway does not know.

### The layout

`StatCard` gains a `trend` slot. The chip and the hint share one row under the value, because
they are two halves of the same aside: the chip says how the number moved, the hint says what it
is made of ("5.8% errors", "311.2k read · 0 written"). Stacked they read as two statements and
cost a line the tile does not have.

```
CACHE HIT RATE
13.0%
[↑ +0.4% vs prev]  311.2k read · 0 written
```

The row is a flex row, which is also what makes the chip hug its text: HeroUI's `Chip` is
inline-flex, and as a stretched child of `Card.Content`'s column it ran the full width of the
tile as a pill-shaped band. `flex-wrap` is the fallback at five-up, not the layout.

Moving the delta out of `hint` also left the billed-tokens tile with no hint at all, since the
delta was all it had, and its sparkline rode above its neighbors'. The reservation #807 added for
a wrapping hint now also covers a charted tile with nothing to say, so a row of tiles keeps its
charts on one line. A tile with neither hint nor chart still reserves nothing, so a lone tile
carries no dead space.

Self-review caught that reservation being 4px short: #807 sized it as two 18px lines of plain
text, and a wrapped row is now an 18px chip line plus `gap-y-1` plus an 18px hint line, so 40px.
Raised to match. A hint long enough to wrap on its own still overruns it, so it is a floor and not
a guarantee, and the comment says so.

### Not in scope

`DeltaHint` stays. `OverviewPage` has two more call sites, and moving them is the rest of the
migration; `DeltaHint` can retire in that PR. Keeping this diff to one page is what #801 asked for.

### Verification

`pnpm --dir web run lint`, `pnpm --dir web run typecheck` and `pnpm --dir web test` all pass:
104 files, 1525 tests. Three tests are new (two on `StatCard`'s layout, one asserting the Usage
tiles go through a chip and no longer render the glyph); `TrendChip.test.tsx` already owns the
direction and polarity mapping, so the page test does not re-cover it.

Worth recording, because it cost time: the dashboard suite fails wholesale on Node 26 (554
failures, renders accumulating in one document) and passes on Node 22, which is what
`otari-dashboard.yml` uses. Run it on 22.

No API contract changed, so the OpenAPI spec and the Postman collection are untouched. No page was
added, so no screenshot entry is owed. The bundle is not committed.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #814

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Dashboard-only change, so the checks that apply are the dashboard's, listed under Verification
above. No Python changed, so `make lint` and `make test` have nothing to say about this diff.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

Written against a local gateway seeded with `scripts/seed_usage_smoke.py`, so the tiles were read
with real deltas in them rather than from the test fixtures alone.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replaced glyph-based Usage KPI deltas with `TrendChip`.
- Applied the correct trend meaning to cost, requests, billed tokens, and cache hit rate.
- Added a dedicated trend area to `StatCard` and preserved tile alignment.
- Added regression tests for Usage rendering and `StatCard` layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->