### PR TITLE
fix(web-search): keep result numbering continuous across a turn

### DIFF
--- a/src/gateway/services/web_search_backend.py
+++ b/src/gateway/services/web_search_backend.py
@@ -243,6 +243,11 @@ class WebSearchBackend:
         # already flattened them. Safe as single-slot state because every tool loop
         # awaits its calls one at a time.
         self._last_results: list[dict[str, Any]] = []
+        # Running result count across every call this instance has served, so
+        # numbering stays continuous ([1], [2], …) across multiple searches in
+        # one turn instead of resetting to [1] on each call — see
+        # `_format_results_for_model`.
+        self._result_count = 0
 
     async def __aenter__(self) -> WebSearchBackend:
         # The search call has its own short timeout; per-page fetches use a
@@ -338,7 +343,9 @@ class WebSearchBackend:
 
             span.set_attribute("web_search.result_count", len(filtered))
             self._last_results = filtered
-            return _format_results_for_model(query, filtered)
+            start = self._result_count + 1
+            self._result_count += len(filtered)
+            return _format_results_for_model(query, filtered, start=start)
 
     # ----- internals -----
 
@@ -517,18 +524,20 @@ class WebSearchBackend:
         return None
 
 
-def _format_results_for_model(query: str, results: list[dict[str, Any]]) -> str:
+def _format_results_for_model(query: str, results: list[dict[str, Any]], *, start: int = 1) -> str:
     """Render results as compact Markdown for tool-message consumption.
 
     Numbered so the model can refer to ``[1]``, ``[2]`` in its answer — gives
     us a clean v2 path to extract structured citations later without changing
-    the v1 wire format.
+    the v1 wire format. ``start`` lets a caller continue the numbering across
+    several searches in one turn, so ``[4]`` always names exactly one result
+    for the whole turn rather than restarting at ``[1]`` on every call.
     """
     if not results:
         return f"No results for query: {query!r}"
 
     parts: list[str] = []
-    for i, r in enumerate(results, start=1):
+    for i, r in enumerate(results, start=start):
         title = str(r.get("title") or "(untitled)").strip()
         url = str(r.get("url") or "").strip()
         snippet = str(r.get("content") or "").strip()

--- a/tests/unit/test_web_search_backend.py
+++ b/tests/unit/test_web_search_backend.py
@@ -112,6 +112,25 @@ async def test_call_tool_returns_formatted_results_without_extraction(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_result_numbering_is_continuous_across_calls_in_one_turn(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patched_async_client(
+        {("searxng", "/search"): httpx.Response(200, json=SEARXNG_OK_BODY)},
+        monkeypatch,
+    )
+
+    async with WebSearchBackend(base_url="http://searxng:8080", extract_content=False) as backend:
+        first = await backend.call_tool(WEB_SEARCH_TOOL_NAME, {"query": "claude code"})
+        second = await backend.call_tool(WEB_SEARCH_TOOL_NAME, {"query": "claude code follow-up"})
+
+    # First search numbers from [1], as before.
+    assert "[1] Post A" in first
+    assert "[2] Post B" in first
+    # Second search in the same turn continues the count instead of resetting.
+    assert "[3] Post A" in second
+    assert "[4] Post B" in second
+
+
+@pytest.mark.asyncio
 async def test_published_date_is_rendered_when_backend_supplies_it(monkeypatch: pytest.MonkeyPatch) -> None:
     # A recency-aware adapter (e.g. Brave with time_range) may set
     # published_date; a plain SearXNG backend never does. Both must render


### PR DESCRIPTION
## Summary
`_format_results_for_model` in `src/gateway/services/web_search_backend.py` numbered results with `enumerate(results, start=1)` on every call. When a model runs two searches in one turn, the tool messages it sees both begin at `[1]`, so a citation like "as reported in [2]" cannot be mapped back to a URL: there are two candidate `[2]`s and no way to tell which search it came from.

`WebSearchBackend` is instantiated once per turn (used as `async with WebSearchBackend(...) as backend:` for the whole tool loop), so this adds a running result count on the instance and threads it through as the starting offset for each call's render. The wire format is unchanged, only the starting index advances, so `[4]` now always names exactly one result for the whole turn.

Fixes #595

## Test plan
- [x] Added `test_result_numbering_is_continuous_across_calls_in_one_turn`, asserting a second search in the same turn continues from `[3]`/`[4]` instead of resetting to `[1]`/`[2]`
- [ ] CI (`make lint`, `pytest`) — could not run the suite locally (repo lockfile targets Linux/macOS only; not runnable from this Windows environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Keep web-search result numbers continuous across searches in the same turn.
- Add a regression test for numbering that continues with `[3]` and `[4]`.
- Preserve the existing wire format and improve citation mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->