### PR TITLE
fix(streaming): relax final forwarded-tool timeout

### DIFF
--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -487,10 +487,12 @@ The mechanism is a per-attempt **first-chunk gate**. For each attempt:
    so it additionally gets `STREAMING_FALLBACK_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS`
    of grace on top of the budget (default 0). A request that forwards provider
    tools but does not run a gateway-managed tool loop keeps the tight budget on
-   non-final attempts, while its final deadline is floored to the tool-loop
-   budget (default 30000 ms). This gives tool-heavy agents more time only when
-   there is nowhere left to fail over. If the upstream raises before yielding or
-   the bounded wait times out, move to the next attempt.
+   non-final attempts, while its final attempt takes the tool-loop budget
+   (`STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS_TOOL_LOOP`, default 30000 ms) as
+   its base before the grace is added. This gives tool-heavy agents more time
+   only when there is nowhere left to fail over, and the configured grace stays
+   additive in every mode. If the upstream raises before yielding or the bounded
+   wait times out, move to the next attempt.
 3. Once a first chunk is in hand, commit. Stitch it back onto the iterator
    and start flushing SSE chunks to the client.
 
@@ -530,4 +532,5 @@ flag.
 | `PLATFORM_USAGE_INLINE_TIMEOUT_MS` | `1500` | Budget for the one usage report the response path waits on to attach inline cost. Expiry ships the response without cost; the report itself continues. |
 | `PLATFORM_USAGE_MAX_RETRIES` | `3` | Max retries for transient usage-report failures. |
 | `STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS` | `2000` | Per-attempt budget for the streaming first-chunk gate. Forwarded provider-tool requests retain it on non-final attempts. |
-| `STREAMING_FALLBACK_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS` | `0` | Extra first-chunk grace for the sole/final attempt. A final request with forwarded provider tools gets at least the tool-loop budget (`30000` ms by default). |
+| `STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS_TOOL_LOOP` | `30000` | Gate budget for a gateway-managed tool loop, and the final-attempt base for a request that forwards provider tools. |
+| `STREAMING_FALLBACK_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS` | `0` | Extra first-chunk grace for the sole/final attempt, added on top of whichever base budget applies. |

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -485,10 +485,12 @@ The mechanism is a per-attempt **first-chunk gate**. For each attempt:
    per-attempt failover budget (`STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS`,
    default 2000 ms). The sole/final attempt has no next attempt to fall over to,
    so it additionally gets `STREAMING_FALLBACK_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS`
-   of grace on top of the budget (default 0, i.e. unchanged), so a slow-but-valid
-   first token is not turned into a timeout, while the wait stays bounded. If the
-   upstream raises before yielding or the wait times out, move to the next
-   attempt.
+   of grace on top of the budget (default 0). A request that forwards provider
+   tools but does not run a gateway-managed tool loop keeps the tight budget on
+   non-final attempts, while its final deadline is floored to the tool-loop
+   budget (default 30000 ms). This gives tool-heavy agents more time only when
+   there is nowhere left to fail over. If the upstream raises before yielding or
+   the bounded wait times out, move to the next attempt.
 3. Once a first chunk is in hand, commit. Stitch it back onto the iterator
    and start flushing SSE chunks to the client.
 
@@ -527,5 +529,5 @@ flag.
 | `PLATFORM_USAGE_TIMEOUT_MS` | `5000` | Per-usage-report timeout. |
 | `PLATFORM_USAGE_INLINE_TIMEOUT_MS` | `1500` | Budget for the one usage report the response path waits on to attach inline cost. Expiry ships the response without cost; the report itself continues. |
 | `PLATFORM_USAGE_MAX_RETRIES` | `3` | Max retries for transient usage-report failures. |
-| `STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS` | `2000` | Per-attempt budget for the streaming first-chunk gate. |
-| `STREAMING_FALLBACK_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS` | `0` | Extra first-chunk grace for the sole/final attempt, on top of the budget. `0` = unchanged. |
+| `STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS` | `2000` | Per-attempt budget for the streaming first-chunk gate. Forwarded provider-tool requests retain it on non-final attempts. |
+| `STREAMING_FALLBACK_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS` | `0` | Extra first-chunk grace for the sole/final attempt. A final request with forwarded provider tools gets at least the tool-loop budget (`30000` ms by default). |

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -3713,9 +3713,11 @@ def stream_final_attempt_extra_seconds(
     Added on top of the per-attempt failover budget for the terminal attempt,
     which has no next entry in the routing policy to fall over to. A request that
     forwards provider-native tools but does not run a gateway-managed tool loop
-    keeps the plain failover budget for non-final attempts, while its final
-    deadline is floored to the tool-loop budget. Tool-heavy agents therefore get
-    the existing relaxed criterion only when there is nowhere left to fail over.
+    keeps the plain failover budget on non-final attempts, and on the final one
+    is raised to the tool-loop base before the configured grace is added, so
+    tool-heavy agents get the relaxed criterion only where there is nowhere left
+    to fail over. The grace stays additive in every mode: an operator who
+    configures it always buys that much more time.
     """
     configured_extra = (
         int(
@@ -3731,7 +3733,7 @@ def stream_final_attempt_extra_seconds(
 
     plain_budget = stream_first_chunk_timeout_seconds(config, tool_mode=False)
     tool_loop_budget = stream_first_chunk_timeout_seconds(config, tool_mode=True)
-    return max(configured_extra, tool_loop_budget - plain_budget)
+    return configured_extra + max(0.0, tool_loop_budget - plain_budget)
 
 
 # ---------------------------------------------------------------------------

--- a/src/gateway/api/routes/_pipeline.py
+++ b/src/gateway/api/routes/_pipeline.py
@@ -3702,15 +3702,22 @@ def stream_first_chunk_timeout_seconds(config: GatewayConfig, *, tool_mode: bool
     )
 
 
-def stream_final_attempt_extra_seconds(config: GatewayConfig) -> float:
+def stream_final_attempt_extra_seconds(
+    config: GatewayConfig,
+    *,
+    tool_mode: bool = False,
+    has_forwarded_tools: bool = False,
+) -> float:
     """Extra first-chunk grace granted only to the sole/final streaming attempt.
 
     Added on top of the per-attempt failover budget for the terminal attempt,
-    which has no next entry in the routing policy to fall over to. Keeps that
-    attempt's wait bounded while not converting a slow-but-valid first token into
-    a timeout. Mode-agnostic (applies on top of the plain or tool-loop budget).
+    which has no next entry in the routing policy to fall over to. A request that
+    forwards provider-native tools but does not run a gateway-managed tool loop
+    keeps the plain failover budget for non-final attempts, while its final
+    deadline is floored to the tool-loop budget. Tool-heavy agents therefore get
+    the existing relaxed criterion only when there is nowhere left to fail over.
     """
-    return (
+    configured_extra = (
         int(
             config.platform.get(
                 _STREAM_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS_KEY,
@@ -3719,6 +3726,12 @@ def stream_final_attempt_extra_seconds(config: GatewayConfig) -> float:
         )
         / 1000
     )
+    if tool_mode or not has_forwarded_tools:
+        return configured_extra
+
+    plain_budget = stream_first_chunk_timeout_seconds(config, tool_mode=False)
+    tool_loop_budget = stream_first_chunk_timeout_seconds(config, tool_mode=True)
+    return max(configured_extra, tool_loop_budget - plain_budget)
 
 
 # ---------------------------------------------------------------------------
@@ -3935,7 +3948,11 @@ async def run_streaming_with_fallback(
     """
     tool_mode = tool_ctx.use_tool_loop
     first_chunk_timeout = stream_first_chunk_timeout_seconds(config, tool_mode=tool_mode)
-    final_attempt_extra = stream_final_attempt_extra_seconds(config)
+    final_attempt_extra = stream_final_attempt_extra_seconds(
+        config,
+        tool_mode=tool_mode,
+        has_forwarded_tools=bool(tool_ctx.remaining_user_tools),
+    )
 
     backend_stack = AsyncExitStack()
     pool_for_loop: Any = None

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -92,9 +92,10 @@ _STREAM_FIRST_CHUNK_TIMEOUT_MS_TOOL_LOOP_KEY = "streaming_first_chunk_timeout_ms
 # into a 504 with nothing to fall over to. Granting grace keeps the terminal wait
 # bounded (a genuinely hung upstream still times out at budget + grace) while not
 # failing valid slow-to-start responses. Applied on top of whichever base budget
-# is in effect (plain or tool-loop). Defaults to 0 (no grace), so behavior is
-# unchanged unless an operator opts in via ``config.platform`` (v1.2 will move
-# these onto the routing_policy schema).
+# is in effect: the tool-loop one whenever the request runs a gateway-managed
+# tool loop or forwards provider-native tools, the plain one otherwise. Defaults
+# to 0 (no grace), so behavior is unchanged unless an operator opts in via
+# ``config.platform`` (v1.2 will move these onto the routing_policy schema).
 _DEFAULT_STREAM_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS = 0
 _STREAM_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS_KEY = "streaming_final_attempt_extra_first_chunk_timeout_ms"
 

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -2481,6 +2481,13 @@ def _apply_platform_env_overrides(config: dict[str, Any]) -> None:
             "streaming_first_chunk_timeout_ms",
             int,
         ),
+        # The same budget for a request that runs a gateway-managed tool loop or
+        # forwards provider-native tools, which are slow to emit a first token
+        # because the model picks a tool before it says anything.
+        "STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS_TOOL_LOOP": (
+            "streaming_first_chunk_timeout_ms_tool_loop",
+            int,
+        ),
         # Extra first-chunk grace for the sole/final streaming attempt, added on
         # top of the per-attempt budget above. The failover budget exists to move
         # to the next routing-policy entry when an attempt is slow; the final

--- a/tests/integration/test_config_env_loading.py
+++ b/tests/integration/test_config_env_loading.py
@@ -401,6 +401,9 @@ def test_load_config_platform_env_overrides(tmp_path: Path, monkeypatch: pytest.
     monkeypatch.setenv("PLATFORM_USAGE_TIMEOUT_MS", "2345")
     monkeypatch.setenv("PLATFORM_USAGE_INLINE_TIMEOUT_MS", "150")
     monkeypatch.setenv("PLATFORM_USAGE_MAX_RETRIES", "7")
+    monkeypatch.setenv("STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS", "3000")
+    monkeypatch.setenv("STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS_TOOL_LOOP", "12000")
+    monkeypatch.setenv("STREAMING_FALLBACK_FINAL_ATTEMPT_EXTRA_FIRST_CHUNK_TIMEOUT_MS", "4000")
 
     config = load_config(str(config_file))
 
@@ -411,6 +414,9 @@ def test_load_config_platform_env_overrides(tmp_path: Path, monkeypatch: pytest.
     assert config.platform["usage_timeout_ms"] == 2345
     assert config.platform["usage_inline_timeout_ms"] == 150
     assert config.platform["usage_max_retries"] == 7
+    assert config.platform["streaming_first_chunk_timeout_ms"] == 3000
+    assert config.platform["streaming_first_chunk_timeout_ms_tool_loop"] == 12000
+    assert config.platform["streaming_final_attempt_extra_first_chunk_timeout_ms"] == 4000
 
 
 def test_load_config_sets_default_platform_base_url_when_token_is_set(

--- a/tests/unit/test_pipeline_settlement.py
+++ b/tests/unit/test_pipeline_settlement.py
@@ -49,6 +49,7 @@ from gateway.api.routes._pipeline import (
     run_platform_non_stream,
     run_single_attempt_stream,
     run_standalone_non_stream,
+    stream_final_attempt_extra_seconds,
     stream_first_chunk_timeout_seconds,
 )
 from gateway.api.routes._platform import ResolvedAttempt, ResolvedRoute, SettledCost
@@ -249,6 +250,95 @@ def test_first_chunk_timeout_reads_shared_config_keys() -> None:
     )
     assert stream_first_chunk_timeout_seconds(config, tool_mode=False) == 0.5
     assert stream_first_chunk_timeout_seconds(config, tool_mode=True) == 7.0
+
+
+@pytest.mark.parametrize(
+    ("tool_mode", "has_forwarded_tools", "expected_final_timeout"),
+    [
+        pytest.param(False, False, 10.0, id="ordinary-final"),
+        pytest.param(False, True, 30.0, id="forwarded-tools-final"),
+        pytest.param(True, False, 37.0, id="managed-tool-loop-final"),
+        pytest.param(True, True, 37.0, id="managed-loop-with-forwarded-tools-final"),
+    ],
+)
+def test_final_attempt_timeout_relaxes_only_forwarded_tool_requests(
+    tool_mode: bool,
+    has_forwarded_tools: bool,
+    expected_final_timeout: float,
+) -> None:
+    config = GatewayConfig(
+        platform={
+            "streaming_first_chunk_timeout_ms": 3000,
+            "streaming_first_chunk_timeout_ms_tool_loop": 30000,
+            "streaming_final_attempt_extra_first_chunk_timeout_ms": 7000,
+        }
+    )
+
+    base_timeout = stream_first_chunk_timeout_seconds(config, tool_mode=tool_mode)
+    extra_timeout = stream_final_attempt_extra_seconds(
+        config,
+        tool_mode=tool_mode,
+        has_forwarded_tools=has_forwarded_tools,
+    )
+
+    assert base_timeout + extra_timeout == expected_final_timeout
+
+
+@pytest.mark.asyncio
+async def test_streaming_fallback_wires_forwarded_tools_into_final_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = GatewayConfig(
+        platform={
+            "streaming_first_chunk_timeout_ms": 3000,
+            "streaming_first_chunk_timeout_ms_tool_loop": 30000,
+            "streaming_final_attempt_extra_first_chunk_timeout_ms": 7000,
+        }
+    )
+    route = ResolvedRoute(
+        request_id="request-1",
+        fallback_enabled=False,
+        attempts=[
+            ResolvedAttempt(
+                attempt_id="attempt-1",
+                position=1,
+                provider="anthropic",
+                model="claude-test",
+                api_key="test-key",
+                managed=True,
+            )
+        ],
+    )
+    captured: dict[str, Any] = {}
+
+    async def fake_iterate_streaming_attempts(**kwargs: Any) -> tuple[Any, AsyncIterator[Any]]:
+        captured.update(kwargs)
+
+        async def stream() -> AsyncIterator[Any]:
+            yield object()
+
+        return route.attempts[0], stream()
+
+    marker = Response()
+    monkeypatch.setattr(pipeline, "iterate_streaming_attempts", fake_iterate_streaming_attempts)
+    monkeypatch.setattr(pipeline, "build_streaming_response", lambda **_kwargs: marker)
+
+    response = await pipeline.run_streaming_with_fallback(
+        adapter=chat._ADAPTER,
+        route=route,
+        base_request_fields={},
+        config=config,
+        background_tasks=BackgroundTasks(),
+        rate_limit_info=None,
+        tool_ctx=_tool_ctx(
+            config=config,
+            remaining_user_tools=[{"name": "slack_send", "input_schema": {}}],
+        ),
+    )
+
+    assert response is marker
+    assert captured["first_chunk_timeout_seconds"] == 3.0
+    assert captured["final_attempt_extra_seconds"] == 27.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pipeline_settlement.py
+++ b/tests/unit/test_pipeline_settlement.py
@@ -256,7 +256,7 @@ def test_first_chunk_timeout_reads_shared_config_keys() -> None:
     ("tool_mode", "has_forwarded_tools", "expected_final_timeout"),
     [
         pytest.param(False, False, 10.0, id="ordinary-final"),
-        pytest.param(False, True, 30.0, id="forwarded-tools-final"),
+        pytest.param(False, True, 37.0, id="forwarded-tools-final"),
         pytest.param(True, False, 37.0, id="managed-tool-loop-final"),
         pytest.param(True, True, 37.0, id="managed-loop-with-forwarded-tools-final"),
     ],
@@ -338,7 +338,7 @@ async def test_streaming_fallback_wires_forwarded_tools_into_final_timeout(
 
     assert response is marker
     assert captured["first_chunk_timeout_seconds"] == 3.0
-    assert captured["final_attempt_extra_seconds"] == 27.0
+    assert captured["final_attempt_extra_seconds"] == 34.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Final hybrid requests with forwarded provider tools used the plain first-chunk deadline. In the hosted configuration, that can return a 504 after 10 seconds even though tool-heavy requests already have a 30-second criterion.

## What changed

Keep the tight deadline while another fallback remains, but floor a sole or final forwarded-tool request at the existing tool-loop budget. Ordinary final requests and gateway-managed tool-loop deadlines are unchanged.

## Notes

- Targeted timeout tests: 92 passed.
- `make lint` and `make typecheck` passed.
- `make test-unit` reached 2557 passed and 9 skipped, then failed one docs-style check against an ignored local `docs/superpowers/` artifact that is not part of this branch.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #826

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Pi with OpenAI Codex `gpt-5.6-sol`

**Any additional AI details you'd like to share:**

The agent investigated the production symptom, implemented the timeout policy, and ran the checks listed above under human direction.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Updated hybrid streaming timeout handling for final requests that forward provider tools. Final attempts now allow the existing tool-loop timeout, while earlier fallback attempts keep the shorter timeout. Ordinary requests remain unchanged.

Added configuration, documentation, and tests for the new behavior.

## Technical notes

- Added `STREAMING_FALLBACK_FIRST_CHUNK_TIMEOUT_MS_TOOL_LOOP`.
- Updated final-attempt timeout calculation and fallback handling.
- Added unit and configuration coverage.
- Targeted checks, lint, and type checks passed. Unit tests passed with 2,557 tests and 9 skips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->