### PR TITLE
feat(dashboard): finish the trend-chip migration on the overview page

### DIFF
--- a/web/src/features/overview/OverviewPage.test.tsx
+++ b/web/src/features/overview/OverviewPage.test.tsx
@@ -155,6 +155,70 @@ describe("OverviewPage", () => {
     expect(screen.getByText("Elevated")).toBeInTheDocument() // error-rate status word (non-hue)
   })
 
+  it("renders period-over-period change as a trend chip, not a glyph", async () => {
+    mockApi({
+      today: { cost: 5, request_count: 100, error_count: 1 },
+      period: { cost: 200, request_count: 2000, error_count: 40 },
+      prev: { cost: 100, request_count: 1600, error_count: 8 },
+    })
+    renderPage(<OverviewPage />)
+    await screen.findByText("$200.00")
+
+    // The chip carries the caption the old plain-text hint carried, so the
+    // comparison still says what it is being compared against. Distinct
+    // percentages per tile, so each assertion is about one chip: spend doubled,
+    // requests rose a quarter, and the error rate went 0.5% -> 2.0%.
+    expect(screen.getByText("+100.0% vs prev")).toBeInTheDocument()
+    expect(screen.getByText("+25.0% vs prev")).toBeInTheDocument()
+    expect(screen.getByText("+300.0% vs prev")).toBeInTheDocument()
+    // And each announces a direction, which the glyph never did: "▲" is
+    // decoration a screen reader skips. TrendChip.test.tsx owns the direction
+    // and polarity mapping; this only asserts the three tiles go through it.
+    // Anchored and counted: unanchored, `up` and `down` also match this page's
+    // own prose, so the assertion would pass with the announcement deleted.
+    expect(
+      screen.getAllByText(/^(no change|up|down)(, (better|worse))?$/),
+    ).toHaveLength(3)
+    // The hand-rolled arrow glyphs are gone from the tiles.
+    expect(screen.queryByText(/[▲▼]/)).not.toBeInTheDocument()
+  })
+
+  it("reads a chip against the metric's own polarity, not the direction alone", async () => {
+    // Spend and the error rate both rose, and both improve by falling, so both
+    // are regressions and say so: direction plus judgment, because polarity puts
+    // good and bad in hue alone. Request volume rose too, but volume carries no
+    // polarity, so it announces the direction and nothing more.
+    mockApi({
+      today: { cost: 5, request_count: 100, error_count: 1 },
+      period: { cost: 200, request_count: 2000, error_count: 40 },
+      prev: { cost: 100, request_count: 1600, error_count: 8 },
+    })
+    renderPage(<OverviewPage />)
+
+    expect(await screen.findByText("$200.00")).toBeInTheDocument()
+    expect(screen.getAllByText("up, worse")).toHaveLength(2)
+    expect(screen.getAllByText("up")).toHaveLength(1)
+  })
+
+  it("reserves no trend row for a tile with no comparable previous window", async () => {
+    // No previous window on the wire leaves every delta null, and TrendChip
+    // renders nothing for a null fraction. The chip has to be gated on the
+    // fraction rather than on the query, or StatCard reserves the aside row for
+    // an element that draws nothing.
+    mockApi({
+      today: { cost: 5 },
+      period: { cost: 200, request_count: 2000, error_count: 40 },
+      prev: { cost: 0, request_count: 0, error_count: 0 },
+    })
+    renderPage(<OverviewPage />)
+    await screen.findByText("$200.00")
+
+    expect(screen.queryByText(/vs prev/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByText(/^(no change|up|down)(, (better|worse))?$/),
+    ).not.toBeInTheDocument()
+  })
+
   it("renders spend and request-volume sparklines from the 30-day series", async () => {
     const series = [
       {

--- a/web/src/features/overview/OverviewPage.test.tsx
+++ b/web/src/features/overview/OverviewPage.test.tsx
@@ -213,10 +213,13 @@ describe("OverviewPage", () => {
     renderPage(<OverviewPage />)
     await screen.findByText("$200.00")
 
-    expect(screen.queryByText(/vs prev/)).not.toBeInTheDocument()
+    // queryAllByText, not queryByText: a regression that renders all three
+    // chips makes queryByText throw on the multiple match rather than fail on
+    // the assertion, which reads as a broken test instead of a broken tile.
+    expect(screen.queryAllByText(/vs prev/)).toHaveLength(0)
     expect(
-      screen.queryByText(/^(no change|up|down)(, (better|worse))?$/),
-    ).not.toBeInTheDocument()
+      screen.queryAllByText(/^(no change|up|down)(, (better|worse))?$/),
+    ).toHaveLength(0)
   })
 
   it("renders spend and request-volume sparklines from the 30-day series", async () => {

--- a/web/src/features/overview/OverviewPage.test.tsx
+++ b/web/src/features/overview/OverviewPage.test.tsx
@@ -162,7 +162,11 @@ describe("OverviewPage", () => {
       prev: { cost: 100, request_count: 1600, error_count: 8 },
     })
     renderPage(<OverviewPage />)
-    await screen.findByText("$200.00")
+    // Await a chip, not "$200.00": every assertion below is about text derived
+    // from the *previous* window, while the value comes from the period query.
+    // Awaiting the value assumes the two land in one commit, so a skew between
+    // the responses would fail the sync assertions that follow.
+    await screen.findByText("+100.0% vs prev")
 
     // The chip carries the caption the old plain-text hint carried, so the
     // comparison still says what it is being compared against. Distinct
@@ -179,8 +183,11 @@ describe("OverviewPage", () => {
     expect(
       screen.getAllByText(/^(no change|up|down)(, (better|worse))?$/),
     ).toHaveLength(3)
-    // The hand-rolled arrow glyphs are gone from the tiles.
-    expect(screen.queryByText(/[▲▼]/)).not.toBeInTheDocument()
+    // The hand-rolled arrow glyphs are gone from the tiles. queryAllByText for
+    // the same reason as below: queryByText throws on a multiple match, so a
+    // regression restoring the glyph on all three tiles would report a broken
+    // test rather than a broken tile.
+    expect(screen.queryAllByText(/[▲▼]/)).toHaveLength(0)
   })
 
   it("reads a chip against the metric's own polarity, not the direction alone", async () => {
@@ -195,7 +202,8 @@ describe("OverviewPage", () => {
     })
     renderPage(<OverviewPage />)
 
-    expect(await screen.findByText("$200.00")).toBeInTheDocument()
+    // The chip again, not the value: same previous-window dependency as above.
+    expect(await screen.findByText("+100.0% vs prev")).toBeInTheDocument()
     expect(screen.getAllByText("up, worse")).toHaveLength(2)
     expect(screen.getAllByText("up")).toHaveLength(1)
   })
@@ -220,6 +228,15 @@ describe("OverviewPage", () => {
     expect(
       screen.queryAllByText(/^(no change|up|down)(, (better|worse))?$/),
     ).toHaveLength(0)
+    // And the row itself is not reserved, which is the half the assertions
+    // above cannot see: TrendChip renders no text for a null fraction either
+    // way, so gating the chip on `periodTotals` instead of on the fraction
+    // leaves them green while the tile keeps 42px of dead space. Asserted on
+    // the utility for the reason ui.test.tsx does it: jsdom performs no layout,
+    // so the reservation is observable only as the class. Scoped to this tile,
+    // since Budget health reserves the row off its own hint.
+    const tile = screen.getByText("Spend, last 30 days").parentElement!
+    expect(tile.querySelector(".min-h-10\\.5")).toBeNull()
   })
 
   it("renders spend and request-volume sparklines from the 30-day series", async () => {

--- a/web/src/features/overview/OverviewPage.tsx
+++ b/web/src/features/overview/OverviewPage.tsx
@@ -24,8 +24,8 @@ import {
 } from "@/shared/api/hooks"
 import { Sparkline } from "@/shared/components/charts"
 import { DataTable, type DataTableColumn } from "@/shared/components/DataTable"
+import { TrendChip } from "@/shared/components/TrendChip"
 import {
-  DeltaHint,
   EmptyState,
   ErrorBanner,
   PageHeader,
@@ -245,6 +245,18 @@ export function OverviewPage({
 
   const err = errorRateHealth(periodTotals)
   const errPrev = errorRateHealth(prevTotals)
+  // Each delta is its own const so the tile below can gate its chip on the
+  // fraction rather than on the query: `deltaFraction` also returns null once
+  // the current window has landed but the previous one has not, and when the
+  // previous value is 0. TrendChip renders nothing for a null fraction, but the
+  // *element* is truthy, and StatCard reserves the aside row for whatever it is
+  // handed, so an ungated chip costs a tile 42px of dead space.
+  const costDelta = periodTotals
+    ? deltaFraction(periodTotals.cost, prevTotals?.cost)
+    : null
+  const requestDelta = periodTotals
+    ? deltaFraction(periodTotals.request_count, prevTotals?.request_count)
+    : null
   const errDelta =
     err.rate !== null && errPrev.rate !== null
       ? deltaFraction(err.rate, errPrev.rate)
@@ -357,10 +369,14 @@ export function OverviewPage({
         <StatCard
           label="Spend, last 30 days"
           value={periodTotals ? formatUsd(periodTotals.cost) : "—"}
-          hint={
-            periodTotals ? (
-              <DeltaHint
-                fraction={deltaFraction(periodTotals.cost, prevTotals?.cost)}
+          // Spend falling is the improvement, so a rise paints danger while the
+          // arrow keeps telling the truth about which way it went.
+          trend={
+            costDelta !== null ? (
+              <TrendChip
+                fraction={costDelta}
+                polarity="down-is-good"
+                caption="vs prev"
               />
             ) : null
           }
@@ -376,14 +392,12 @@ export function OverviewPage({
         <StatCard
           label="Requests, last 30 days"
           value={periodTotals ? formatNumber(periodTotals.request_count) : "—"}
-          hint={
-            periodTotals ? (
-              <DeltaHint
-                fraction={deltaFraction(
-                  periodTotals.request_count,
-                  prevTotals?.request_count,
-                )}
-              />
+          // Volume, so `neutral`: more traffic through the gateway is neither a
+          // win nor a regression on its own, and the error rate tile beside it
+          // is what carries the judgment.
+          trend={
+            requestDelta !== null ? (
+              <TrendChip fraction={requestDelta} caption="vs prev" />
             ) : null
           }
           chart={
@@ -402,7 +416,16 @@ export function OverviewPage({
           statusLabel={
             err.status === "neutral" ? undefined : ERROR_WORDS[err.status]
           }
-          hint={err.rate !== null ? <DeltaHint fraction={errDelta} /> : null}
+          // Errors falling is the improvement, as with spend.
+          trend={
+            errDelta !== null ? (
+              <TrendChip
+                fraction={errDelta}
+                polarity="down-is-good"
+                caption="vs prev"
+              />
+            ) : null
+          }
         />
         <StatCard
           label="Budget health"

--- a/web/src/shared/components/ui.tsx
+++ b/web/src/shared/components/ui.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   Card,
+  Chip,
   ComboBox,
   Input,
   Label,
@@ -18,7 +19,7 @@ import { Checkbox as AriaCheckbox } from "react-aria-components"
 
 import { ApiError } from "@/shared/api/client"
 import { copyToClipboard } from "@/shared/helpers/clipboard"
-import { formatPct, formatRelative } from "@/shared/helpers/format"
+import { formatRelative } from "@/shared/helpers/format"
 
 // The box visual, split out so it can hold optimistic state: react-aria only
 // reports the new `isSelected` after the whole collection re-renders (O(rows)
@@ -138,19 +139,21 @@ export type StatStatus = "ok" | "warn" | "alert"
 // and that rule is unlayered while a Tailwind utility sits in @layer utilities;
 // unlayered always wins, whatever the specificity. Without the bang the
 // shorthand `border:` resets this tile's left edge back to a hairline.
-const STAT_STATUS: Record<StatStatus, { accent: string; pill: string }> = {
-  ok: {
-    accent: "border-l-success!",
-    pill: "border-success bg-success-subtle text-success",
-  },
-  warn: {
-    accent: "border-l-warning!",
-    pill: "border-warning bg-warning-subtle text-warning",
-  },
-  alert: {
-    accent: "border-l-danger!",
-    pill: "border-danger bg-danger-subtle text-danger",
-  },
+//
+// The pill beside the value is HeroUI's own Chip, for the reason TrendChip is:
+// `globals.css` aliases the status bases the chip's CSS reads (`--success`,
+// `--warning`, `--danger`) onto our tokens, so naming a status here is all it
+// takes for both themes to follow the foundation. This used to be a hand-rolled
+// <span> carrying its own border/bg/text triple per status, which restated in
+// three class strings what the library already derives, and left the status pill
+// and the trend chip on the same tile as two different shapes.
+const STAT_STATUS: Record<
+  StatStatus,
+  { accent: string; chip: "success" | "warning" | "danger" }
+> = {
+  ok: { accent: "border-l-success!", chip: "success" },
+  warn: { accent: "border-l-warning!", chip: "warning" },
+  alert: { accent: "border-l-danger!", chip: "danger" },
 }
 
 export function StatCard({
@@ -203,11 +206,12 @@ export function StatCard({
           {value}
         </span>
         {status && statusLabel ? (
-          <span
-            className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${STAT_STATUS[status].pill}`}
-          >
-            {statusLabel}
-          </span>
+          // `soft` and `sm` are TrendChip's defaults too, so a tile carrying
+          // both (the error-rate tile carries a status word and a delta) draws
+          // one shape at one weight rather than two.
+          <Chip variant="soft" color={STAT_STATUS[status].chip} size="sm">
+            <Chip.Label>{statusLabel}</Chip.Label>
+          </Chip>
         ) : null}
       </span>
       {/* One row under the value carrying both the movement (the chip) and the
@@ -271,18 +275,6 @@ export function StatCard({
     )
   }
   return <Card className={cardClass}>{body}</Card>
-}
-
-// Period-over-period change hint. Pairs an arrow glyph with the number (never hue
-// alone) so direction reads without color. null hides it (no comparable previous).
-export function DeltaHint({ fraction }: { fraction: number | null }) {
-  if (fraction === null) return null
-  const arrow = fraction > 0 ? "▲" : fraction < 0 ? "▼" : "•"
-  return (
-    <span className="text-muted">
-      {arrow} {formatPct(Math.abs(fraction))} vs prev
-    </span>
-  )
 }
 
 export function errorMessage(error: unknown): string {


### PR DESCRIPTION
## Description

`TrendChip` landed in #801 with no call sites, and #815 moved the Usage page onto it. Both left
the Overview page behind: its three tiles with a period-over-period change still printed
`▲ 225.5% vs prev` through `DeltaHint`, where the arrow is decoration a screen reader skips and
the text reads identically whichever way the number went. #815's own "Not in scope" section named
this as the rest of the migration, and said `DeltaHint` could retire in it.

This is that follow-up, and it is the last of the three.

### The chips

| Tile | Polarity | Why |
| --- | --- | --- |
| Spend, last 30 days | `down-is-good` | Spend falling is the improvement |
| Requests, last 30 days | `neutral` | Volume. More traffic is neither a win nor a regression on its own, and the error-rate tile beside it carries the judgment |
| Error rate, last 30 days | `down-is-good` | Errors falling is the improvement |
| Spend today, Budget health, Active keys, Active members | n/a | No delta on the wire, untouched |

Same polarity reasoning as #815, so the two pages agree on what a rising number means: `neutral`
on volume is a deliberate choice rather than an omission, since painting rising traffic green
would assert something the gateway does not know.

Each delta is a named const (`costDelta`, `requestDelta`, beside the `errDelta` that already
existed) and each chip is gated on it being non-null. That is the shape the review on #815
arrived at, for a reason worth restating: `TrendChip` renders nothing for a null fraction, but the
*element* is truthy, and `StatCard` tests `trend || hint || chart` to decide whether to reserve
the aside row, so an ungated chip costs a tile 42px of dead space while the previous window is in
flight. Gating on the fraction rather than on the query also covers the two cases a `periodTotals ?`
guard would miss: the current window landed and the previous has not, and a previous value of 0.

The deltas move from `hint` into the `trend` slot #815 added, so the chip leads the aside row and
`DeltaHint` retires with its last caller.

### The status pill

`StatCard`'s status word ("On track", "Elevated") moves onto HeroUI's `Chip` in the same pass.
It was a hand-rolled `<span>` carrying a `border`/`bg`/`text` class triple per status, restating
in three class strings what the library already derives from an aliased token, and it left the
status word and the trend chip on one tile drawing two different shapes at two different weights.
`globals.css` already aliases `--success`, `--warning` and `--danger` onto our tokens, so all
three statuses follow the foundation in both themes with nothing named locally, which is the same
argument #801 made for building `TrendChip` on `Chip` rather than on a `<span>`. Both are now
`soft`/`sm`, and `STAT_STATUS` carries a color name instead of a class triple. The tile's left
accent bar is untouched: that is the card, not the chip.

Not folded in: `Badge` (`ui.tsx`) is a third hand-rolled pill, with a `muted` tone that has no
status color and call sites across the Tools cards and several tables. Moving it is its own
change.

### Tests

Three new tests on `OverviewPage`, written against the findings the review on #815 raised rather
than repeating the mistakes:

- The fixture gives each tile a **distinct** delta (spend +100%, requests +25%, error rate +300%),
  so no assertion can be satisfied by a sibling tile's chip.
- The announcement matcher is **anchored and counted**
  (`/^(no change|up|down)(, (better|worse))?$/` at length 3). Unanchored, `up` and `down` also
  match this page's own prose, and the assertion would pass with the announcement deleted, which
  is exactly how it passed on #815 before review caught it.
- One test pins polarity (`up, worse` twice, a bare `up` once), so a chip that lost its judgment
  fails. `TrendChip.test.tsx` already owns the fraction-to-direction mapping, so these do not
  re-cover it.
- One test pins that a previous window of zeroes reserves no row, which is the gating above.

No test was added for the status pill. The visible behavior is the same word in the same place,
and the only assertion that could tell the two implementations apart is a class selector, which
the review on #801 rejected outright ("a test that breaks on a restyle teaches everyone to stop
trusting the suite"). The existing `"Elevated"` and `"On track"` assertions still cover that the
word renders, in both the unit suite and `parity.overview.spec.ts`.

### Verification

`pnpm --dir web run lint`, `pnpm --dir web run typecheck` and `pnpm --dir web test` all pass:
106 files, 1560 tests. `make lint` passes too, though no Python changed, so it has nothing to say
about this diff.

Worth repeating from #815, because it cost time again: the dashboard suite fails wholesale on
Node 26 and passes on Node 22, which is what `otari-dashboard.yml` and the Docker web stage use.
Run it on 22.

Read against a local gateway on this branch rather than from the fixtures alone. No API contract
changed, so the OpenAPI spec and the Postman collection are untouched. No page was added, so no
screenshot entry is owed. The bundle is not committed.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None open. #814 scoped its follow-up to the Usage page and was closed by #815; the Overview
remainder was named in #815's description rather than filed as an issue of its own.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Dashboard-only change, so the checks that apply are the dashboard's, listed under Verification
above.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

The agent was pointed at #801 and #815, including their inline review threads, and asked to carry
the approach and the findings forward rather than re-derive them. The anchored-and-counted
matcher, the gate-on-the-fraction shape, and the refusal to assert on a class name all come from
those reviews.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added gated trend chips to the Spend, Requests, and Error Rate tiles.
- Applied metric-specific trend meaning.
- Replaced custom status pills with shared `Chip` components.
- Removed the unused `DeltaHint` component.
- Added tests for trend values, direction announcements, polarity, and zero-valued previous periods.

These changes improve consistency, accessibility, and clarity on the Overview page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->