### PR TITLE
fix(api): answer a HEAD probe from the mode stub routers

### DIFF
--- a/src/gateway/api/routes/hosted_mode.py
+++ b/src/gateway/api/routes/hosted_mode.py
@@ -48,7 +48,14 @@ from gateway.core.config import GatewayConfig
 
 _GENERIC_TARGET = "your Otari gateway"
 
-_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+# ``HEAD`` is enumerated rather than inherited. FastAPI derives it from ``GET``
+# only for a route that leaves its methods unspecified, and these give theirs
+# explicitly, so leaving it off answered 405 to the tooling most likely to send
+# it (health probes, link checkers, an SDK's connectivity preflight). 405 is the
+# one status these stubs exist to avoid: it reports that the path is served here
+# and only the verb was wrong, which is the opposite of the fact. The body is
+# empty by definition of the method, so the status carries the whole answer.
+_METHODS = ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
 
 # Every prefix a hosted deployment refuses, with why it is data plane rather
 # than management. Kept as data so a prefix added later cannot pick up a

--- a/src/gateway/api/routes/hybrid_mode.py
+++ b/src/gateway/api/routes/hybrid_mode.py
@@ -2,6 +2,17 @@ from fastapi import APIRouter, HTTPException, status
 
 _DISABLED_DETAIL = "This endpoint is not available in hybrid mode. Manage this resource via the platform UI."
 
+# The method list every stub below shares. ``HEAD`` is enumerated rather than
+# inherited, for the reason ``hosted_mode`` spells out: FastAPI derives it from
+# ``GET`` only for a route that leaves its methods unspecified, so leaving it off
+# answered 405, which says the path is served here and only the verb was wrong.
+# One constant rather than the same literal on twenty-two decorators, so a verb
+# added here reaches every stub in this file instead of the subset somebody
+# remembered. ``hosted_mode`` keeps its own copy: the lists agree today and for
+# the same reason, but a shared one would tie two modules together for a
+# three-word literal.
+_METHODS = ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+
 router = APIRouter(tags=["hybrid-mode"])
 
 
@@ -9,26 +20,26 @@ def _raise_disabled() -> None:
     raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_DISABLED_DETAIL)
 
 
-@router.api_route("/v1/users/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
-@router.api_route("/v1/users", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+@router.api_route("/v1/users/{path:path}", methods=_METHODS)
+@router.api_route("/v1/users", methods=_METHODS)
 async def users_disabled() -> None:
     _raise_disabled()
 
 
-@router.api_route("/v1/keys/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
-@router.api_route("/v1/keys", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+@router.api_route("/v1/keys/{path:path}", methods=_METHODS)
+@router.api_route("/v1/keys", methods=_METHODS)
 async def keys_disabled() -> None:
     _raise_disabled()
 
 
-@router.api_route("/v1/budgets/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
-@router.api_route("/v1/budgets", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+@router.api_route("/v1/budgets/{path:path}", methods=_METHODS)
+@router.api_route("/v1/budgets", methods=_METHODS)
 async def budgets_disabled() -> None:
     _raise_disabled()
 
 
-@router.api_route("/v1/usage/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
-@router.api_route("/v1/usage", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+@router.api_route("/v1/usage/{path:path}", methods=_METHODS)
+@router.api_route("/v1/usage", methods=_METHODS)
 async def usage_disabled() -> None:
     _raise_disabled()
 
@@ -37,26 +48,26 @@ async def usage_disabled() -> None:
 # is standalone-only for the same reason as the resources above: in hybrid mode
 # these are owned by the platform. Stubbed so an operator hitting them gets the
 # same "manage via the platform UI" hint instead of a bare 404.
-@router.api_route("/v1/settings/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
-@router.api_route("/v1/settings", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+@router.api_route("/v1/settings/{path:path}", methods=_METHODS)
+@router.api_route("/v1/settings", methods=_METHODS)
 async def settings_disabled() -> None:
     _raise_disabled()
 
 
-@router.api_route("/v1/aliases/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
-@router.api_route("/v1/aliases", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+@router.api_route("/v1/aliases/{path:path}", methods=_METHODS)
+@router.api_route("/v1/aliases", methods=_METHODS)
 async def aliases_disabled() -> None:
     _raise_disabled()
 
 
-@router.api_route("/v1/providers/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
-@router.api_route("/v1/providers", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+@router.api_route("/v1/providers/{path:path}", methods=_METHODS)
+@router.api_route("/v1/providers", methods=_METHODS)
 async def providers_disabled() -> None:
     _raise_disabled()
 
 
-@router.api_route("/v1/pricing/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
-@router.api_route("/v1/pricing", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+@router.api_route("/v1/pricing/{path:path}", methods=_METHODS)
+@router.api_route("/v1/pricing", methods=_METHODS)
 async def pricing_disabled() -> None:
     _raise_disabled()
 
@@ -64,14 +75,14 @@ async def pricing_disabled() -> None:
 # Tenancy is the clearest case of the rule above: a hybrid gateway holds no
 # tenancy state at all, because the platform's control plane is where its
 # organizations and workspaces live.
-@router.api_route("/v1/organizations/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
-@router.api_route("/v1/organizations", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+@router.api_route("/v1/organizations/{path:path}", methods=_METHODS)
+@router.api_route("/v1/organizations", methods=_METHODS)
 async def organizations_disabled() -> None:
     _raise_disabled()
 
 
-@router.api_route("/v1/workspaces/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
-@router.api_route("/v1/workspaces", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+@router.api_route("/v1/workspaces/{path:path}", methods=_METHODS)
+@router.api_route("/v1/workspaces", methods=_METHODS)
 async def workspaces_disabled() -> None:
     _raise_disabled()
 
@@ -79,7 +90,7 @@ async def workspaces_disabled() -> None:
 # Invitations are tenancy, same reasoning as organizations/workspaces above: a
 # hybrid gateway holds no membership state to accept an invitation into, so
 # there is nothing this stub could hand off to even if it tried.
-@router.api_route("/v1/invitations/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
-@router.api_route("/v1/invitations", methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+@router.api_route("/v1/invitations/{path:path}", methods=_METHODS)
+@router.api_route("/v1/invitations", methods=_METHODS)
 async def invitations_disabled() -> None:
     _raise_disabled()

--- a/tests/integration/test_hosted_mode_surface.py
+++ b/tests/integration/test_hosted_mode_surface.py
@@ -101,6 +101,14 @@ def test_hosted_mode_refuses_inference_on_every_verb(hosted_client: TestClient) 
         assert response.status_code == 404, method
         assert response.json() == {"detail": EXPECTED_DETAIL}, method
 
+    # HEAD separately, because it is the one verb with no body to compare and
+    # the one FastAPI would have derived from GET had these stubs left their
+    # methods unspecified. They do not, so it is enumerated, and a regression
+    # that dropped it would answer 405: the path is served here, only the verb
+    # was wrong, which is the opposite of what the stub is for.
+    head = hosted_client.head("/v1/chat/completions")
+    assert head.status_code == 404, "HEAD fell through to a 405"
+
     for method, path in (
         ("get", "/v1/files"),
         ("get", "/v1/files/file-abc"),

--- a/tests/integration/test_hybrid_mode_surface.py
+++ b/tests/integration/test_hybrid_mode_surface.py
@@ -115,8 +115,9 @@ def test_hybrid_mode_disables_dashboard_management_endpoints(monkeypatch: pytest
             assert response.status_code == 404, path
             assert response.json() == expected, path
 
-        # State-changing verbs are stubbed too (api_route covers every method), so
-        # a write cannot slip past the hybrid gate and reach a local handler.
+        # State-changing verbs are stubbed too (every method in the stubs'
+        # shared ``_METHODS``), so a write cannot slip past the hybrid gate and
+        # reach a local handler.
         patch_settings = client.patch("/v1/settings", json={"model_discovery": False})
         assert patch_settings.status_code == 404
         assert patch_settings.json() == expected
@@ -130,6 +131,11 @@ def test_hybrid_mode_disables_dashboard_management_endpoints(monkeypatch: pytest
         assert post_alias.status_code == 404
         assert post_alias.json() == expected
         assert client.delete("/v1/aliases/x").status_code == 404
+        # HEAD is in that list rather than derived from GET, which FastAPI does
+        # only for a route that leaves its methods unspecified. Dropping it
+        # would answer 405, saying the path is served here and only the verb was
+        # wrong. No body to compare on a HEAD, so the status is the assertion.
+        assert client.head("/v1/keys").status_code == 404
 
     reset_config()
     reset_db()


### PR DESCRIPTION
## Description

Both mode stub routers spell their methods out, and FastAPI derives `HEAD` from `GET` only for a route that leaves its methods unspecified, so `HEAD` fell through to a **405**. That is the one status these stubs exist to avoid: 405 reports that the path *is* served on this host and only the verb was wrong, which is the opposite of the fact they are mounted to state.

Verified against a running hosted app before the fix:

```
HEAD  /v1/chat/completions  405
GET   /v1/chat/completions  404  {"detail":"This deployment is a control plane and does not serve inference. ..."}
POST  /v1/chat/completions  404  {"detail":"..."}
```

The verb matters more than its share of traffic suggests: health probes, link checkers and an SDK's connectivity preflight all reach for `HEAD`, so the caller most likely to be diagnosing a wrong host was the one being told the host was right.

**Fixed in `hybrid_mode.py` too**, not only in the `hosted_mode.py` where it was noticed. The sibling had the identical omission for the identical reason, so `HEAD /v1/keys` on a hybrid gateway answered 405 instead of the "manage this via the platform UI" hint. Its method list is now one constant rather than the same literal on twenty-two decorators, which is the same number of changed lines either way and leaves nothing to drift. The two files keep separate copies deliberately: the lists agree today and for the same reason, but sharing one would tie two unrelated stub modules together for a short literal.

A comment beside those decorators claimed `api_route` "covers every method". It covers every method in the list, and that belief is where the bug lived, so it is corrected rather than left to mislead the next reader.

`TRACE` still answers 405 and is left that way: nothing routes it, and no client sends it here.

Found by Copilot's review on #829, which I closed as superseded by #824. This is the one finding from it that #824 does not already carry.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Refs #822

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

`make lint`, `make typecheck`, 2601 unit passed, 1938 integration passed, `make openapi-check` and `make postman-check` both clean (the stubs mount only in their own mode, and the spec is generated in standalone, so it is unchanged).

Tests extend the two existing mode-surface files rather than adding new ones: the `HEAD` assertion goes into `test_hosted_mode_refuses_inference_on_every_verb`, which already walks the other verbs and whose name was not quite true, and into the hybrid file's dashboard-management test beside the write verbs. Both assert status only, since `HEAD` carries no body by definition. Confirmed the assertion bites: reverting `_METHODS` alone fails it with `AssertionError: HEAD fell through to a 405`.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code

**Any additional AI details you'd like to share:**

Originated as a review finding on #829 (from Copilot), verified against a running app, and carried forward on its own once #824 landed the rest.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added explicit `HEAD` support to hosted and hybrid mode stub routes.
- Centralized the hybrid route method list in `_METHODS`.
- Updated surface tests to verify that `HEAD` requests return `404`.
- Kept `TRACE` unsupported, so it continues to return `405`.

These changes ensure probes receive the intended state-refusal response instead of a method error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->