### PR TITLE
fix(dashboard): report provider-key encryption on a tenant-readable contract

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -3974,7 +3974,7 @@
             "type": "boolean"
           },
           "secret_key_configured": {
-            "description": "Whether OTARI_SECRET_KEY is set on the server. Provider credentials are encrypted at rest with it, so the dashboard disables adding stored providers when it is unset.",
+            "description": "Whether OTARI_SECRET_KEY is set on the server. Provider credentials are encrypted at rest with it, so a deployment without it can store none. The dashboard reads the same fact from the membership context's provider_key_encryption_available, because this endpoint is operator-only and the provider-key pages are read by tenants.",
             "title": "Secret Key Configured",
             "type": "boolean"
           },

--- a/src/gateway/api/routes/settings.py
+++ b/src/gateway/api/routes/settings.py
@@ -258,7 +258,9 @@ class GatewaySettings(BaseModel):
     secret_key_configured: bool = Field(
         description=(
             "Whether OTARI_SECRET_KEY is set on the server. Provider credentials are encrypted at rest with it, "
-            "so the dashboard disables adding stored providers when it is unset."
+            "so a deployment without it can store none. The dashboard reads the same fact from the membership "
+            "context's provider_key_encryption_available, because this endpoint is operator-only and the "
+            "provider-key pages are read by tenants."
         )
     )
     config: list[ConfigField]

--- a/tests/integration/test_tenancy_api.py
+++ b/tests/integration/test_tenancy_api.py
@@ -26,6 +26,7 @@ from gateway.models.tenancy import (
     Workspace,
     WorkspaceMember,
 )
+from gateway.services.secret_box import generate_secret_key
 from gateway.services.tenancy.provisioning_service import (
     BOOTSTRAP_IDENTITY_KEY,
     DEFAULT_ORGANIZATION_NAME,
@@ -112,6 +113,29 @@ def test_first_request_provisions_the_default_organization(
     # A standalone deployment is its own gateway, so its own provider keys are
     # always available to it.
     assert context["byo_provider_keys_allowed"] is True
+
+
+@pytest.mark.parametrize("configured", [True, False])
+def test_context_reports_whether_provider_keys_can_be_encrypted(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+    configured: bool,
+) -> None:
+    """The context carries the fact, so a tenant never has to read /v1/settings for it.
+
+    ``GET /v1/settings`` reports the same thing as ``secret_key_configured`` and
+    is operator-only, so the provider-key pages inferred it from a query that
+    403s for every organization owner (#839).
+    """
+    if configured:
+        monkeypatch.setenv("OTARI_SECRET_KEY", generate_secret_key())
+    else:
+        monkeypatch.delenv("OTARI_SECRET_KEY", raising=False)
+
+    context = _context(client, master_key_header)
+
+    assert context["provider_key_encryption_available"] is configured
 
 
 def test_first_boot_also_provisions_a_default_workspace(

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -5700,7 +5700,7 @@ export interface components {
             require_pricing: boolean;
             /**
              * Secret Key Configured
-             * @description Whether OTARI_SECRET_KEY is set on the server. Provider credentials are encrypted at rest with it, so the dashboard disables adding stored providers when it is unset.
+             * @description Whether OTARI_SECRET_KEY is set on the server. Provider credentials are encrypted at rest with it, so a deployment without it can store none. The dashboard reads the same fact from the membership context's provider_key_encryption_available, because this endpoint is operator-only and the provider-key pages are read by tenants.
              */
             secret_key_configured: boolean;
             /** Version */

--- a/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
@@ -264,6 +264,29 @@ describe("OrganizationProviderKeysPage", () => {
     ).toBe(false)
   })
 
+  it("says nothing about the key when the context read is what failed", async () => {
+    // The shape the original bug had, from the other direction: with no context
+    // the encryption state is unknown, so the page must report the read that
+    // failed rather than claim the key is missing. It behaves correctly today
+    // only because `canManage(undefined)` is false and the banner is gated on
+    // it, which is a role check standing in for an encryption one; this pins the
+    // outcome so a later change to either gate cannot quietly restore the lie.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) =>
+      String(input).includes("/provider-keys")
+        ? jsonResponse({ count: 0, data: [] })
+        : jsonResponse({ detail: "Tenancy is unavailable" }, 500),
+    )
+    renderPage(<OrganizationProviderKeysPage />)
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Tenancy is unavailable",
+    )
+    expect(screen.queryByText(/OTARI_SECRET_KEY/)).toBeNull()
+    expect(
+      screen.queryByRole("button", { name: "Add provider key" }),
+    ).toBeNull()
+  })
+
   it("reports a list that could not be read instead of an empty table", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) =>
       String(input).includes("/provider-keys")

--- a/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
@@ -4,24 +4,9 @@ import userEvent from "@testing-library/user-event"
 import type { ReactElement } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import type {
-  GatewaySettings,
-  OrganizationContext,
-  OrgProviderKey,
-} from "@/client"
+import type { OrganizationContext, OrgProviderKey } from "@/client"
 import { OrganizationProviderKeysPage } from "@/features/organization/OrganizationProviderKeysPage"
 import { organizationContext, orgProviderKey } from "@/tests/fixtures"
-
-const SETTINGS: GatewaySettings = {
-  mode: "hosted",
-  version: "1.0.0",
-  model_discovery: true,
-  default_pricing: true,
-  require_pricing: false,
-  master_key_source: "configured",
-  secret_key_configured: true,
-  config: [],
-}
 
 interface Request {
   url: string
@@ -39,7 +24,6 @@ function jsonResponse(body: unknown, status = 200): Response {
 interface MockOpts {
   keys?: OrgProviderKey[]
   context?: OrganizationContext
-  settings?: GatewaySettings
 }
 
 function mockApi(opts: MockOpts = {}) {
@@ -62,8 +46,12 @@ function mockApi(opts: MockOpts = {}) {
       // through the invalidated list, so one row is enough for all of them.
       return jsonResponse(keys[0] ?? orgProviderKey())
     }
+    // What the deployment actually answers this page's audience: `/v1/settings`
+    // is operator-only and an organization owner is not one. Mocked as the
+    // refusal rather than as a body, so a page that went back to reading it
+    // would fail here rather than pass on a fixture no tenant ever receives.
     if (url.includes("/v1/settings")) {
-      return jsonResponse(opts.settings ?? SETTINGS)
+      return jsonResponse({ detail: "Not authorized" }, 403)
     }
     if (url.includes("/v1/providers/catalog")) {
       return jsonResponse([{ id: "anthropic", name: "Anthropic" }])
@@ -247,13 +235,33 @@ describe("OrganizationProviderKeysPage", () => {
   it("disables adding a key when the deployment cannot encrypt one", async () => {
     // Same gate the deployment-wide providers page applies: without
     // OTARI_SECRET_KEY the write would fail at submit time.
-    mockApi({ settings: { ...SETTINGS, secret_key_configured: false } })
+    mockApi({
+      context: organizationContext({
+        provider_key_encryption_available: false,
+      }),
+    })
     renderPage(<OrganizationProviderKeysPage />)
 
     expect(
       await screen.findByRole("button", { name: "Add provider key" }),
     ).toBeDisabled()
     expect(screen.getByText(/OTARI_SECRET_KEY/)).toBeInTheDocument()
+  })
+
+  it("keeps adding available for an owner the operator-only settings read refuses", async () => {
+    // The bug this page shipped with (#839): the flag was inferred from
+    // `/v1/settings`, which 403s for every organization owner, so the banner
+    // reported a missing key on a deployment where the write path works.
+    const requests = mockApi()
+    renderPage(<OrganizationProviderKeysPage />)
+
+    expect(
+      await screen.findByRole("button", { name: "Add provider key" }),
+    ).toBeEnabled()
+    expect(screen.queryByText(/OTARI_SECRET_KEY/)).toBeNull()
+    expect(
+      requests.some((request) => request.url.includes("/v1/settings")),
+    ).toBe(false)
   })
 
   it("reports a list that could not be read instead of an empty table", async () => {

--- a/web/src/features/organization/OrganizationProviderKeysPage.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.tsx
@@ -20,7 +20,6 @@ import {
   useOrgProviderKeys,
   useRestoreOrgProviderKey,
   useSetOrgProviderKeyDefault,
-  useSettings,
   useUpdateOrgProviderKey,
 } from "@/shared/api/hooks"
 import { DataTable, type DataTableColumn } from "@/shared/components/DataTable"
@@ -215,7 +214,6 @@ function KeyForm({
 export function OrganizationProviderKeysPage() {
   const context = useOrganizationContext()
   const keys = useOrgProviderKeys()
-  const settings = useSettings()
   const archive = useArchiveOrgProviderKey()
   const restore = useRestoreOrgProviderKey()
   const remove = useDeleteOrgProviderKey()
@@ -236,10 +234,15 @@ export function OrganizationProviderKeysPage() {
 
   // Same gate the `/providers` page applies, for the same reason: without
   // `OTARI_SECRET_KEY` the gateway cannot encrypt a credential, so the write
-  // would fail at submit time. Fail closed on an error, open while loading.
-  const secretKeyConfigured = settings.data
-    ? settings.data.secret_key_configured !== false
-    : !settings.isError
+  // would fail at submit time. Read off the membership context rather than
+  // `/v1/settings`, which is operator-only: an organization owner is not one, so
+  // that query 403s for the whole of this page's audience and a refusal used to
+  // read as "the key is missing" (#839). Fail closed on an error, open while
+  // loading; an older gateway omits the field, which reads as configured because
+  // it never gated on it.
+  const secretKeyConfigured = context.data
+    ? context.data.provider_key_encryption_available !== false
+    : !context.isError
 
   const columns: DataTableColumn<OrgProviderKey>[] = [
     {

--- a/web/src/features/organization/OrganizationProviderKeysPage.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.tsx
@@ -18,6 +18,7 @@ import {
   useDeleteOrgProviderKey,
   useOrganizationContext,
   useOrgProviderKeys,
+  useProviderKeyEncryption,
   useRestoreOrgProviderKey,
   useSetOrgProviderKeyDefault,
   useUpdateOrgProviderKey,
@@ -214,6 +215,10 @@ function KeyForm({
 export function OrganizationProviderKeysPage() {
   const context = useOrganizationContext()
   const keys = useOrgProviderKeys()
+  // Same gate the `/providers` page applies, for the same reason: without
+  // `OTARI_SECRET_KEY` the gateway cannot encrypt a credential, so the write
+  // would fail at submit time.
+  const secretKeyConfigured = useProviderKeyEncryption()
   const archive = useArchiveOrgProviderKey()
   const restore = useRestoreOrgProviderKey()
   const remove = useDeleteOrgProviderKey()
@@ -231,18 +236,6 @@ export function OrganizationProviderKeysPage() {
   const rows = (keys.data ?? []).filter(
     (key) => showArchived || !key.archived_at,
   )
-
-  // Same gate the `/providers` page applies, for the same reason: without
-  // `OTARI_SECRET_KEY` the gateway cannot encrypt a credential, so the write
-  // would fail at submit time. Read off the membership context rather than
-  // `/v1/settings`, which is operator-only: an organization owner is not one, so
-  // that query 403s for the whole of this page's audience and a refusal used to
-  // read as "the key is missing" (#839). Fail closed on an error, open while
-  // loading; an older gateway omits the field, which reads as configured because
-  // it never gated on it.
-  const secretKeyConfigured = context.data
-    ? context.data.provider_key_encryption_available !== false
-    : !context.isError
 
   const columns: DataTableColumn<OrgProviderKey>[] = [
     {

--- a/web/src/features/providers/ProvidersPage.test.tsx
+++ b/web/src/features/providers/ProvidersPage.test.tsx
@@ -611,6 +611,9 @@ describe("ProvidersPage", () => {
       ).toBeEnabled(),
     )
     expect(screen.queryByText(/OTARI_SECRET_KEY/)).toBeNull()
+    // The page reads settings only for the pricing hint, so its refusal must not
+    // leave a permanent "Not authorized" alert on a page that otherwise works.
+    expect(screen.queryByRole("alert")).toBeNull()
   })
 
   it("fails closed and disables adding providers when the context can't be loaded", async () => {
@@ -625,6 +628,10 @@ describe("ProvidersPage", () => {
         screen.getByRole("button", { name: "Add provider" }),
       ).toBeDisabled(),
     )
+    // Report the read that actually failed. Claiming the key is unset would be a
+    // guess, and the wrong one whenever the deployment has one.
+    expect(await screen.findByRole("alert")).toHaveTextContent("boom")
+    expect(screen.queryByText(/OTARI_SECRET_KEY/)).toBeNull()
   })
 
   it("retracts an open add form if the context then reports OTARI_SECRET_KEY is unset", async () => {

--- a/web/src/features/providers/ProvidersPage.test.tsx
+++ b/web/src/features/providers/ProvidersPage.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import type {
   GatewaySettings,
   KnownProvider,
+  OrganizationContext,
   ProviderHealth,
   ProviderHealthResponse,
   ProviderInfo,
@@ -14,6 +15,7 @@ import type {
 } from "@/client"
 import { ProvidersPage } from "@/features/providers/ProvidersPage"
 import { PROVIDER_HEALTH_REFRESH_MS } from "@/shared/api/hooks"
+import { organizationContext } from "@/tests/fixtures"
 import { withRouter } from "@/tests/router"
 
 const CAPS = {
@@ -109,12 +111,19 @@ interface MockOpts {
   // is served for the forced-refresh (refresh=true) request, if given.
   health?: ProviderHealth[]
   healthRefresh?: ProviderHealth[]
-  // When set, GET /v1/settings blocks on this promise before responding, so a
-  // test can resolve it to simulate settings landing after the page has already
-  // painted (and the operator has interacted with it).
-  settingsGate?: Promise<unknown>
-  // Force GET /v1/settings to fail, so the fail-closed gate can be exercised.
-  settingsError?: boolean
+  // The caller's membership context, which is where the page reads whether the
+  // deployment can encrypt a provider credential.
+  context?: OrganizationContext
+  // When set, GET /v1/organizations/me blocks on this promise before responding,
+  // so a test can resolve it to simulate the context landing after the page has
+  // already painted (and the operator has interacted with it).
+  contextGate?: Promise<unknown>
+  // Force GET /v1/organizations/me to fail, so the fail-closed gate can be
+  // exercised.
+  contextError?: boolean
+  // Refuse GET /v1/settings the way the operator-only gate does for a caller who
+  // is neither a superuser nor holding the master key.
+  settingsRefused?: boolean
   // When set, POST .../test blocks on this promise, so a test can hold a
   // connection test in flight while the page is used.
   testGate?: Promise<unknown>
@@ -269,14 +278,18 @@ function mockApi(opts: MockOpts = {}) {
         return jsonResponse({ providers: meta })
       }
       if (url.includes("/v1/settings")) {
+        if (opts.settingsRefused) {
+          return jsonResponse({ detail: "Not authorized" }, 403)
+        }
         if (method === "PATCH") {
           settings = { ...settings, ...JSON.parse(String(init?.body)) }
         }
-        if (method === "GET") {
-          if (opts.settingsGate) await opts.settingsGate
-          if (opts.settingsError) return jsonResponse({ detail: "boom" }, 500)
-        }
         return jsonResponse(settings)
+      }
+      if (url.includes("/v1/organizations/me")) {
+        if (opts.contextGate) await opts.contextGate
+        if (opts.contextError) return jsonResponse({ detail: "boom" }, 500)
+        return jsonResponse(opts.context ?? organizationContext())
       }
       return jsonResponse([])
     })
@@ -546,12 +559,14 @@ describe("ProvidersPage", () => {
   it("disables adding providers when OTARI_SECRET_KEY is not set", async () => {
     mockApi({
       stored: [storedProvider("openai", "1234")],
-      settings: { ...SETTINGS, secret_key_configured: false },
+      context: organizationContext({
+        provider_key_encryption_available: false,
+      }),
     })
     renderPage(<ProvidersPage />)
 
     await screen.findByText("••••1234")
-    // The button starts enabled and flips once /v1/settings resolves, so wait
+    // The button starts enabled and flips once the context resolves, so wait
     // for the settled disabled state rather than asserting on first paint.
     expect(await screen.findByText(/OTARI_SECRET_KEY/)).toBeInTheDocument()
     await waitFor(() =>
@@ -565,7 +580,9 @@ describe("ProvidersPage", () => {
     mockApi({
       meta: [],
       stored: [],
-      settings: { ...SETTINGS, secret_key_configured: false },
+      context: organizationContext({
+        provider_key_encryption_available: false,
+      }),
     })
     renderPage(<ProvidersPage />)
 
@@ -577,12 +594,31 @@ describe("ProvidersPage", () => {
     )
   })
 
-  it("fails closed and disables adding providers when settings can't be loaded", async () => {
-    mockApi({ stored: [storedProvider("openai", "1234")], settingsError: true })
+  it("keeps adding providers available when the operator-only settings read is refused", async () => {
+    // #839: the gate used to be inferred from `/v1/settings`, which is
+    // operator-only, so a refusal reported a missing key on a deployment that
+    // has one.
+    mockApi({
+      stored: [storedProvider("openai", "1234")],
+      settingsRefused: true,
+    })
     renderPage(<ProvidersPage />)
 
     await screen.findByText("••••1234")
-    // A settings error leaves the key state unknown; disable rather than let the
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Add provider" }),
+      ).toBeEnabled(),
+    )
+    expect(screen.queryByText(/OTARI_SECRET_KEY/)).toBeNull()
+  })
+
+  it("fails closed and disables adding providers when the context can't be loaded", async () => {
+    mockApi({ stored: [storedProvider("openai", "1234")], contextError: true })
+    renderPage(<ProvidersPage />)
+
+    await screen.findByText("••••1234")
+    // A context error leaves the key state unknown; disable rather than let the
     // operator fill in the form and fail on submit.
     await waitFor(() =>
       expect(
@@ -591,18 +627,20 @@ describe("ProvidersPage", () => {
     )
   })
 
-  it("retracts an open add form if settings then report OTARI_SECRET_KEY is unset", async () => {
-    let releaseSettings = () => {}
-    const settingsGate = new Promise<void>((resolve) => {
-      releaseSettings = resolve
+  it("retracts an open add form if the context then reports OTARI_SECRET_KEY is unset", async () => {
+    let releaseContext = () => {}
+    const contextGate = new Promise<void>((resolve) => {
+      releaseContext = resolve
     })
-    // The onboarding gate ignores settings loading, so the first-run card (and its
-    // enabled add button) is reachable before /v1/settings resolves.
+    // The onboarding gate ignores the context loading, so the first-run card (and
+    // its enabled add button) is reachable before /v1/organizations/me resolves.
     mockApi({
       meta: [],
       stored: [],
-      settings: { ...SETTINGS, secret_key_configured: false },
-      settingsGate,
+      context: organizationContext({
+        provider_key_encryption_available: false,
+      }),
+      contextGate,
     })
     const user = userEvent.setup()
     renderPage(<ProvidersPage />)
@@ -612,9 +650,9 @@ describe("ProvidersPage", () => {
     )
     expect(screen.getByPlaceholderText("Search providers…")).toBeInTheDocument()
 
-    // Settings land late and report the key is unavailable: the form must retract
-    // so its submit can never reach the create mutation.
-    releaseSettings()
+    // The context lands late and reports the key is unavailable: the form must
+    // retract so its submit can never reach the create mutation.
+    releaseContext()
     await waitFor(() =>
       expect(
         screen.queryByPlaceholderText("Search providers…"),

--- a/web/src/features/providers/ProvidersPage.tsx
+++ b/web/src/features/providers/ProvidersPage.tsx
@@ -1056,7 +1056,15 @@ export function ProvidersPage() {
           a permanent "Not authorized" alert for a read nothing here depends on.
           `context.error` takes its place, because the add control now gates on
           the membership context; a write that fails still reports itself
-          through `updateSettings.error`. */}
+          through `updateSettings.error`.
+
+          The cost is that a genuine 500 from that endpoint is silent too, and
+          `needsPricing` then reads false, so the pricing hint disappears with
+          nothing saying why. Taken deliberately: the alternative shows every
+          non-operator a permanent error for a read they were never entitled to
+          make, and the hint is an advisory nudge rather than a control. Telling
+          the two apart needs the page to distinguish a 403 from a 5xx, which is
+          worth doing when the hint earns it. */}
       <ErrorBanner
         error={
           meta.error ??

--- a/web/src/features/providers/ProvidersPage.tsx
+++ b/web/src/features/providers/ProvidersPage.tsx
@@ -15,6 +15,7 @@ import {
   useOrganizationContext,
   useProviderDetail,
   useProviderHealth,
+  useProviderKeyEncryption,
   useProviders,
   useRecheckProviderHealth,
   useSettings,
@@ -837,19 +838,10 @@ export function ProvidersPage() {
   const needsPricing =
     settings.data?.require_pricing === true &&
     settings.data.default_pricing === false
-  // Gate adding providers on the server having OTARI_SECRET_KEY. Read off the
-  // membership context rather than `/v1/settings`: that endpoint is
-  // operator-only, so it 403s for any caller who is not a superuser or holding
-  // the master key, and a refusal used to read as "the key is missing" (#839).
-  // Fail closed: enabled only while the context is still loading (so the button
-  // does not flicker to disabled on first paint) or once a value has actually
-  // loaded that is not `false`. An error leaves us unable to confirm the key, so
-  // we disable rather than let the operator hit a submit-time failure. Older
-  // gateways omit the field; a present-but-missing value reads as configured
-  // (they never gated on it).
-  const secretKeyConfigured = context.data
-    ? context.data.provider_key_encryption_available !== false
-    : !context.isError
+  // Gate adding providers on the server having OTARI_SECRET_KEY, which the
+  // membership context reports and `/v1/settings` no longer answers for every
+  // caller who reaches this page (#839).
+  const secretKeyConfigured = useProviderKeyEncryption()
   const showOnboarding = !loading && rows.length === 0 && !addOpen
 
   // Which test run each row is currently showing. A row's result is only worth
@@ -1058,18 +1050,29 @@ export function ProvidersPage() {
         }
       />
 
+      {/* `settings.error` is deliberately absent. The page reads that endpoint
+          only for the pricing hint below, and it is operator-only, so a caller
+          who may manage providers but is not a deployment operator would carry
+          a permanent "Not authorized" alert for a read nothing here depends on.
+          `context.error` takes its place, because the add control now gates on
+          the membership context; a write that fails still reports itself
+          through `updateSettings.error`. */}
       <ErrorBanner
         error={
           meta.error ??
           stored.error ??
-          settings.error ??
+          context.error ??
           health.error ??
           updateSettings.error ??
           deleteProvider.error
         }
       />
 
-      {!secretKeyConfigured ? (
+      {/* Held back until the context has answered. A context that failed leaves
+          the key state unknown, which disables the control above but is not
+          grounds for telling the operator the key is missing: the banner beside
+          it already names the real error. */}
+      {context.data && !secretKeyConfigured ? (
         <InfoBanner tone="warning">
           <code>OTARI_SECRET_KEY</code> is not set, so provider keys can't be
           encrypted at rest and adding providers from the dashboard is disabled.

--- a/web/src/features/providers/ProvidersPage.tsx
+++ b/web/src/features/providers/ProvidersPage.tsx
@@ -12,6 +12,7 @@ import type {
 import {
   useCreateStoredProvider,
   useDeleteStoredProvider,
+  useOrganizationContext,
   useProviderDetail,
   useProviderHealth,
   useProviders,
@@ -815,6 +816,7 @@ function OnboardingPanel({
 export function ProvidersPage() {
   const meta = useProviders()
   const stored = useStoredProviders()
+  const context = useOrganizationContext()
   const settings = useSettings()
   const health = useProviderHealth()
   const deleteProvider = useDeleteStoredProvider()
@@ -835,16 +837,19 @@ export function ProvidersPage() {
   const needsPricing =
     settings.data?.require_pricing === true &&
     settings.data.default_pricing === false
-  // Gate adding providers on the server having OTARI_SECRET_KEY. Fail closed:
-  // enabled only while settings are still loading (so the button does not
-  // flicker to disabled on first paint) or once a value has actually loaded
-  // that is not `false`. A settings *error* leaves us unable to confirm the
-  // key, so we disable rather than let the operator hit a submit-time failure.
-  // Older gateways omit the field; a present-but-missing value reads as
-  // configured (they never gated on it).
-  const secretKeyConfigured = settings.data
-    ? settings.data.secret_key_configured !== false
-    : !settings.isError
+  // Gate adding providers on the server having OTARI_SECRET_KEY. Read off the
+  // membership context rather than `/v1/settings`: that endpoint is
+  // operator-only, so it 403s for any caller who is not a superuser or holding
+  // the master key, and a refusal used to read as "the key is missing" (#839).
+  // Fail closed: enabled only while the context is still loading (so the button
+  // does not flicker to disabled on first paint) or once a value has actually
+  // loaded that is not `false`. An error leaves us unable to confirm the key, so
+  // we disable rather than let the operator hit a submit-time failure. Older
+  // gateways omit the field; a present-but-missing value reads as configured
+  // (they never gated on it).
+  const secretKeyConfigured = context.data
+    ? context.data.provider_key_encryption_available !== false
+    : !context.isError
   const showOnboarding = !loading && rows.length === 0 && !addOpen
 
   // Which test run each row is currently showing. A row's result is only worth

--- a/web/src/shared/api/hooks.ts
+++ b/web/src/shared/api/hooks.ts
@@ -1839,6 +1839,26 @@ export function useOrganizationContext() {
   })
 }
 
+// Whether the deployment can encrypt a provider credential at rest, i.e. whether
+// OTARI_SECRET_KEY is set on the server. Both provider-key pages gate their add
+// control on it, so the rule lives here rather than twice.
+//
+// Read off the membership context rather than `/v1/settings`, which reports the
+// same fact as `secret_key_configured` but is operator-only: an organization
+// owner is not one, so that query 403s for the whole tenant-facing audience and
+// a refusal used to read as "the key is missing" (#839).
+//
+// Fails closed on an error and open while the context is still loading, so the
+// control does not flicker to disabled on first paint. An older gateway omits
+// the field, and a present-but-missing value reads as configured because those
+// gateways never gated on it.
+export function useProviderKeyEncryption() {
+  const context = useOrganizationContext()
+  return context.data
+    ? context.data.provider_key_encryption_available !== false
+    : !context.isError
+}
+
 // The organizations the caller is an active member of, which is what the
 // organization half of the scope switcher renders. Its own read rather than a
 // field on the context: the context is one organization, and a switcher needs


### PR DESCRIPTION
## Description

An organization owner on a hosted control plane saw a warning banner saying `OTARI_SECRET_KEY` is not set, with "Add provider key" disabled, on a deployment where the key is set and the write path works. The banner was reporting a refused request, not the key.

Both provider-key pages inferred the flag from `GET /v1/settings`, which has been gated on `require_deployment_operator` since #821. That admits a header master key, a superuser, or the bootstrap identity; an organization owner is none of those, so the query 403s for every tenant, and tenants are the organization page's whole audience.

The fix reports the fact on a tenant-readable contract instead of inferring it from an operator-only endpoint:

- `OrganizationMembershipContextPublic` gains `provider_key_encryption_available`, beside `byo_provider_keys_allowed` and for the same reason. `OrganizationService._to_context` fills it from `secret_box_configured()`.
- `OrganizationProviderKeysPage` reads it from the membership context it already loads for `canEdit`, and no longer calls `useSettings` at all.
- `ProvidersPage` moves to the same signal. That page is operator-only in the platform edition but not in standalone, so the same inference was wrong there for any caller who is neither a superuser nor holding the master key.
- `secret_key_configured` stays on the settings payload for the operator surface. Its description no longer claims the dashboard gates on it, since it no longer does.

Nothing changed server-side about authorization: `org_provider_keys` is still tenant-scoped, still keeps `verify_master_key` plus its own role check, and still encrypts normally.

Acceptance from the issue holds: an organization owner on a deployment with the key set sees no banner and an enabled "Add provider key"; with the key genuinely unset, both pages still warn and disable.

### Tests

- `tests/integration/test_tenancy_api.py`: the context reports the flag, parametrized over the key being set and unset.
- `OrganizationProviderKeysPage.test.tsx`: `/v1/settings` is now mocked as the 403 the deployment actually answers this page's audience, so a page that went back to reading it fails here rather than passing on a fixture no tenant receives. One test covers the encryption-unavailable state off the context; one covers the regression directly (owner, refused settings read, add still enabled, no banner, no settings request made).
- `ProvidersPage.test.tsx`: the secret-key gate tests move to the context, `settingsGate`/`settingsError` become `contextGate`/`contextError`, and a new test covers a refused settings read leaving adding enabled.

### Generated artifacts

`docs/public/openapi.json`, the Postman collection, and `web/src/client/schema.ts` are regenerated and committed.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #839

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

Implemented and self-reviewed through the repo's `pr-cycle` skill, against `backend-standards` and `frontend-standards`.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added `provider_key_encryption_available` to the tenant-readable organization context.
- Updated both provider-key pages to use this value instead of the operator-only `/v1/settings` endpoint.
- Preserved correct warnings and disabled controls when encryption is unavailable.
- Added integration and frontend tests for configured, unconfigured, unauthorized, and failed context scenarios.
- Regenerated OpenAPI, Postman, and frontend schema artifacts.

This prevents organization owners from seeing a false `OTARI_SECRET_KEY is not set` warning when `/v1/settings` returns `403`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->