### PR TITLE
feat(dashboard): adopt a better palette across both themes

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -13,7 +13,7 @@
     <!-- Browser/OS chrome tint. A meta tag cannot read a custom property, so this
          is a literal copy of --color-primary; the matching `theme_color` in
          /pwa/manifest.webmanifest is the other one. Change all three together. -->
-    <meta name="theme-color" content="#4a7d8f" />
+    <meta name="theme-color" content="#5e6ad2" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-title" content="Otari" />
@@ -62,14 +62,14 @@
         align-items: center;
         justify-content: center;
         min-height: 100vh;
-        background: var(--color-background, #ffffff);
+        background: var(--color-background, #f7f8f8);
       }
       .app-boot-spinner {
         width: 1.75rem;
         height: 1.75rem;
         border-radius: 9999px;
-        border: 2px solid var(--color-border, #d6dce1);
-        border-top-color: var(--color-primary, #4a7d8f);
+        border: 2px solid var(--color-border, rgb(0 0 0 / 0.06));
+        border-top-color: var(--color-primary, #5e6ad2);
         animation: app-boot-spin 0.7s linear infinite;
       }
       @keyframes app-boot-spin {

--- a/web/public/pwa/manifest.webmanifest
+++ b/web/public/pwa/manifest.webmanifest
@@ -7,8 +7,8 @@
   "scope": "/",
   "display": "standalone",
   "orientation": "any",
-  "background_color": "#ffffff",
-  "theme_color": "#4a7d8f",
+  "background_color": "#f7f8f8",
+  "theme_color": "#5e6ad2",
   "icons": [
     {
       "src": "/pwa/icon-192.png",

--- a/web/src/app/AppShell.tsx
+++ b/web/src/app/AppShell.tsx
@@ -652,7 +652,7 @@ function AppShellChrome() {
         type="button"
         inert={backgroundInert}
         onClick={skipToMain}
-        className="sr-only focus:not-sr-only focus:absolute focus:top-3 focus:left-3 focus:z-50 focus:rounded-lg focus:border focus:border-accent focus:bg-surface focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-link focus:shadow-md focus:outline-none"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-3 focus:left-3 focus:z-50 focus:rounded-lg focus:border focus:border-accent focus:bg-surface focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-link focus:shadow-elevation-md focus:outline-none"
       >
         Skip to main content
       </button>

--- a/web/src/app/ConnectionStatus.tsx
+++ b/web/src/app/ConnectionStatus.tsx
@@ -50,7 +50,7 @@ export function ConnectionStatus() {
     <div
       role="alert"
       aria-live="assertive"
-      className="fixed right-4 bottom-4 z-50 flex max-w-sm items-start gap-2.5 rounded-lg border border-danger bg-danger-subtle px-4 py-3 text-sm text-danger shadow-lg"
+      className="fixed right-4 bottom-4 z-50 flex max-w-sm items-start gap-2.5 rounded-lg border border-danger bg-danger-subtle px-4 py-3 text-sm text-danger shadow-elevation-lg"
     >
       <svg
         viewBox="0 0 24 24"

--- a/web/src/app/UpdatePrompt.tsx
+++ b/web/src/app/UpdatePrompt.tsx
@@ -41,7 +41,7 @@ export function UpdatePrompt() {
     <div className="pointer-events-none absolute inset-x-0 top-0 z-50 flex justify-center">
       <div
         role="status"
-        className="pointer-events-auto mt-1.5 flex items-center gap-3 rounded-full border border-accent bg-primary-subtle py-1.5 pr-1.5 pl-4 text-sm text-primary-subtle-foreground shadow-md"
+        className="pointer-events-auto mt-1.5 flex items-center gap-3 rounded-full border border-accent bg-primary-subtle py-1.5 pr-1.5 pl-4 text-sm text-primary-subtle-foreground shadow-elevation-md"
       >
         <span>
           <strong className="font-semibold">An update is available.</strong>{" "}

--- a/web/src/app/nav/AccountMenu.tsx
+++ b/web/src/app/nav/AccountMenu.tsx
@@ -29,8 +29,8 @@ import {
 } from "./rowStyles"
 
 // The control that ends the sidebar, and the menu it opens: account settings,
-// appearance, the legal pages, and the way out. The design's
-// "Menu member · Linear order" artboard is the order and the geometry. Who you
+// appearance, the legal pages, and the way out. The design's account-menu
+// artboard is the order and the geometry. Who you
 // are signed in as is the trigger's own line, not a row inside the menu: the
 // menu repeated it under an avatar the trigger already draws, so that block is
 // gone and /account is where an identity is actually read.

--- a/web/src/app/nav/rowStyles.test.ts
+++ b/web/src/app/nav/rowStyles.test.ts
@@ -26,26 +26,36 @@ describe("navRowClass", () => {
     }
   })
 
-  it("presses a resting row one step further, for either kind of press", () => {
+  it("presses a resting row the other way off the rail", () => {
     // `active` covers the Links and the plain expand buttons; `data-pressed` is
     // what react-aria reports on the rows that are HeroUI Buttons.
+    //
+    // The fill is the page canvas, not a border token used as a fill. Hover
+    // lifts away from the chrome and a press sinks onto the ground behind it,
+    // so the two are told apart by direction rather than by degree.
     for (const variant of ["active", "data-[pressed]"]) {
-      expect(resting).toContain(`${variant}:bg-border`)
+      expect(resting).toContain(`${variant}:bg-background`)
       expect(resting).toContain(`${variant}:text-foreground`)
     }
   })
 
-  it("lifts a selected row off the rail, in both themes", () => {
+  it("lifts a selected row off the rail with one class in both themes", () => {
     expect(selected).toContain("bg-surface-alt")
-    expect(selected).toContain("dark:bg-surface")
     expect(selected).toContain("text-foreground")
+    // No `dark:` override. The surface family sits one rung above the
+    // background family in both themes, so `surface-alt` is a step off the
+    // rail either way. An override here would resolve to the rail's own value
+    // and erase the selection.
+    expect(selected).not.toContain("dark:bg-")
   })
 
-  it("still answers the pointer on a selected row, and only with a hover", () => {
-    expect(selected).toContain("hover:bg-surface")
-    expect(selected).toContain("dark:hover:bg-background")
-    // The current page has nowhere to press to, so the pressed step stops at
-    // the rows that navigate somewhere.
+  it("does not answer the pointer on a selected row at all", () => {
+    // Neither hover nor press. It is the current page, so clicking it is a
+    // no-op and there is nothing for an affordance to promise. A hover fill
+    // here would also collide with a hovered resting row, which already gets
+    // `hover:text-foreground` as well as a fill, and losing "is the row under
+    // my pointer the page I am on" costs more than losing the response.
+    expect(selected).not.toContain("hover:bg-")
     expect(selected).not.toContain("active:")
     expect(selected).not.toContain("data-[pressed]:")
   })

--- a/web/src/app/nav/rowStyles.ts
+++ b/web/src/app/nav/rowStyles.ts
@@ -26,27 +26,37 @@
  * | ---------------- | -------------------- | -------------------- |
  * | resting          | no fill              | no fill              |
  * | hover / focused  | `surface-subtle`     | `surface-subtle`     |
- * | pressed          | `border`             | `border`             |
- * | selected         | `surface-alt`        | `surface`            |
- * | selected + hover | `surface`            | `background`         |
+ * | pressed          | `background`         | `background`         |
+ * | selected         | `surface-alt`        | `surface-alt`        |
+ * | selected + hover | `surface-alt` (none) | `surface-alt` (none) |
  *
- * The first three rows need no `dark:` override because the ramp is a mirror
- * image per theme: `surface-subtle` and then `border` sit one step and then two
- * steps *below* the rail in light, one and two *above* it in dark, and either
- * direction is away from the chrome. Selection is the pair that does need one.
- * `surface-alt` (that is `--color-surface-muted`) is lighter than the rail in
- * light mode, but in dark the two are within a couple of units of lightness, so
- * the chip would be invisible; `dark:bg-surface` is the same lift read the other
- * way, cards sitting below chrome in the dark stack (fields, chrome, cards,
- * body, deepest last). Selected + hover then takes the one further step each
- * theme has left in that direction: pure white in light, the body ground in
- * dark. This is the navigation design's ramp, not an invention, and the selected
- * row is a lifted chip rather than a tinted one, which is why it is no longer
- * `bg-primary-subtle`.
+ * Hover and selection move in opposite directions off the rail, and press moves
+ * in a third. The rail itself is `--color-background-muted`. A hover lifts one
+ * step away from the chrome to `surface-subtle`; a persistent selection lifts a
+ * smaller step to `surface-muted`; a press goes the other way entirely, onto
+ * `--color-background`, the page canvas showing through. Four distinct fills, in
+ * both themes, at matched perceptual steps - no `dark:` override is needed for
+ * any of them, because the surface family is staggered one rung above the
+ * background family in both themes. An earlier ladder put `surface` *below*
+ * chrome in dark and needed `dark:bg-surface` to produce a lift; under the
+ * current mapping that override resolves to the rail's own value and erases the
+ * selection, which is why it is gone.
  *
- * A selected row deliberately has no pressed state. It is the current page, so
- * the press has nowhere to go; it keeps answering the pointer with the hover
- * fill and stops there.
+ * Measured on the running page in dark, as L* from the rail: pressed -2.20,
+ * selected +4.56, hover +7.63. Light mirrors it, and the four fills are
+ * distinct in both themes.
+ *
+ * The selected row is a lifted chip rather than a tinted one, which is why it
+ * is no longer `bg-primary-subtle`.
+ *
+ * A selected row answers the pointer with neither hover nor press. It is the
+ * current page, so clicking it is a no-op and there is nothing for an
+ * affordance to promise. This is a CHANGE from the earlier rule, which kept the
+ * hover fill: `ROW_RESTING` gives a hovered row `hover:text-foreground` as well
+ * as a fill, so a selected row that also took the hover fill became
+ * indistinguishable from a hovered resting one - and losing "is the row under
+ * my pointer the page I am on" costs more than losing a hover response on a row
+ * that does nothing when clicked.
  *
  * **A nested child is indented with padding, not a narrower box.** `3.125rem`
  * clears the parent's icon lane (0.75rem padding + 1rem icon + 0.75rem gap) and
@@ -128,12 +138,11 @@ const ROW_BASE = `flex min-h-11 w-full items-center gap-3 rounded-lg px-3 font-s
  * press can arrive without a hover, from touch or from Space on a focused row.
  */
 const ROW_PRESSED =
-  "active:bg-border active:text-foreground data-[pressed]:bg-border data-[pressed]:text-foreground"
+  "active:bg-background active:text-foreground data-[pressed]:bg-background data-[pressed]:text-foreground"
 
 const ROW_RESTING = `text-muted hover:bg-surface-subtle hover:text-foreground focus-visible:bg-surface-subtle focus-visible:text-foreground ${ROW_PRESSED}`
 
-const ROW_SELECTED =
-  "bg-surface-alt text-foreground hover:bg-surface dark:bg-surface dark:hover:bg-background"
+const ROW_SELECTED = "bg-surface-alt text-foreground"
 
 /** The class list for one sidebar row. */
 export function navRowClass({

--- a/web/src/features/activity/ActivityPage.tsx
+++ b/web/src/features/activity/ActivityPage.tsx
@@ -598,7 +598,7 @@ function TokenBar({ entry }: { entry: UsageEntry }) {
   })
 
   return (
-    <span className="inline-flex flex-col items-end gap-1" title={summary}>
+    <span className="inline-flex flex-col items-end gap-1.5" title={summary}>
       <span className="tabular-nums">{composition.total.toLocaleString()}</span>
       <svg
         viewBox="0 0 100 4"

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -168,7 +168,7 @@ function RevealSecretModal({
         aria-modal="true"
         aria-labelledby="reveal-title"
         onKeyDown={onKeyDown}
-        className="flex max-h-[90vh] w-full max-w-2xl flex-col gap-4 overflow-y-auto rounded-xl bg-surface p-6 shadow-xl"
+        className="flex max-h-[90vh] w-full max-w-2xl flex-col gap-4 overflow-y-auto rounded-xl bg-surface p-6 shadow-modal"
       >
         <h2 id="reveal-title" className="text-lg font-semibold text-foreground">
           {title}
@@ -661,7 +661,7 @@ function AccessChip({ allowed }: { allowed: string[] | null }) {
       ? "text-danger font-medium"
       : tone === "muted"
         ? "text-muted"
-        : "text-accent font-medium"
+        : "text-link font-medium"
   // Surface the exact entries on hover; the count would mislead (a wildcard is many).
   const title = allowed && allowed.length > 0 ? allowed.join(", ") : undefined
   return (

--- a/web/src/features/models/ModelScopeControl.tsx
+++ b/web/src/features/models/ModelScopeControl.tsx
@@ -124,7 +124,7 @@ export function ModelScopeControl({
       onClick={() => chooseMode(value)}
       className={
         mode === value
-          ? "rounded-md bg-surface px-3 py-1.5 text-sm font-medium text-foreground shadow-sm"
+          ? "rounded-md bg-surface px-3 py-1.5 text-sm font-medium text-foreground shadow-elevation-sm"
           : "rounded-md px-3 py-1.5 text-sm text-muted hover:text-foreground"
       }
     >

--- a/web/src/features/models/ModelsPage.tsx
+++ b/web/src/features/models/ModelsPage.tsx
@@ -530,7 +530,7 @@ function InfoTooltip({
         className={`inline-flex h-4 w-4 items-center justify-center rounded-full border text-[10px] leading-none ${
           tone === "warning"
             ? "border-warning text-warning"
-            : "border-border text-muted hover:border-accent hover:text-accent"
+            : "border-border text-muted hover:border-accent hover:text-link"
         }`}
       >
         i
@@ -538,7 +538,7 @@ function InfoTooltip({
       <span
         id={tipId}
         role="tooltip"
-        className="pointer-events-none absolute top-full right-0 z-20 mt-1.5 w-72 rounded-lg border border-border bg-surface px-3 py-2 text-left text-xs font-normal whitespace-normal break-words text-foreground opacity-0 shadow-lg transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+        className="pointer-events-none absolute top-full right-0 z-20 mt-1.5 w-72 rounded-lg border border-border bg-surface px-3 py-2 text-left text-xs font-normal whitespace-normal break-words text-foreground opacity-0 shadow-elevation-lg transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
       >
         {children}
       </span>

--- a/web/src/features/providers/ProvidersPage.tsx
+++ b/web/src/features/providers/ProvidersPage.tsx
@@ -391,7 +391,7 @@ function AddProviderForm({ onClose }: { onClose: () => void }) {
                 onClick={() => setTab(id)}
                 className={
                   tab === id
-                    ? "rounded-md bg-surface px-3 py-1.5 text-sm font-medium text-foreground shadow-sm"
+                    ? "rounded-md bg-surface px-3 py-1.5 text-sm font-medium text-foreground shadow-elevation-sm"
                     : "rounded-md px-3 py-1.5 text-sm text-muted hover:text-foreground"
                 }
               >

--- a/web/src/features/routing/RouterReadiness.tsx
+++ b/web/src/features/routing/RouterReadiness.tsx
@@ -186,7 +186,7 @@ export function RouterReadiness({
             prompts from 0 (bad) to 1 (great) per candidate; two good answers is
             the case that lets the cheaper model win. See{" "}
             <a
-              className="text-accent hover:underline"
+              className="text-link hover:underline"
               href="https://mozilla-ai.github.io/otari/routing/#teach-it"
               target="_blank"
               rel="noreferrer"

--- a/web/src/features/routing/RoutingPage.tsx
+++ b/web/src/features/routing/RoutingPage.tsx
@@ -301,7 +301,7 @@ function ScopePicker({
       onClick={() => onChange(value ? "" : null)}
       className={
         scoped === value
-          ? "rounded-md bg-surface px-3 py-1.5 text-sm font-medium text-foreground shadow-sm"
+          ? "rounded-md bg-surface px-3 py-1.5 text-sm font-medium text-foreground shadow-elevation-sm"
           : "rounded-md px-3 py-1.5 text-sm text-muted hover:text-foreground"
       }
     >
@@ -370,7 +370,7 @@ function ModeToggle({
             onClick={() => onChange(mode)}
             className={
               value === mode
-                ? "rounded-md bg-surface px-3 py-1 text-sm font-medium text-foreground shadow-sm"
+                ? "rounded-md bg-surface px-3 py-1 text-sm font-medium text-foreground shadow-elevation-sm"
                 : "rounded-md px-3 py-1 text-sm text-muted hover:text-foreground"
             }
           >
@@ -918,7 +918,7 @@ function PolicyForm({
                   className={
                     atCandidateCap
                       ? "cursor-not-allowed text-sm text-muted opacity-60"
-                      : "text-sm text-accent hover:underline"
+                      : "text-sm text-link hover:underline"
                   }
                   onClick={() => {
                     setCandidates((prev) => [...prev, ""])
@@ -984,7 +984,7 @@ function PolicyForm({
                   className={
                     atCandidateCap
                       ? "cursor-not-allowed text-sm text-muted opacity-60"
-                      : "text-sm text-accent hover:underline"
+                      : "text-sm text-link hover:underline"
                   }
                   onClick={() => setChain((prev) => [...prev, ""])}
                 >
@@ -1094,7 +1094,7 @@ function PolicyForm({
             {conditions.length === 0 ? (
               <button
                 type="button"
-                className="text-accent hover:underline"
+                className="text-link hover:underline"
                 onClick={() => setConditions([{ threshold: 80, target: "" }])}
               >
                 + Tier down when the budget fills up
@@ -1103,7 +1103,7 @@ function PolicyForm({
             {chain.length === 0 ? (
               <button
                 type="button"
-                className="text-accent hover:underline"
+                className="text-link hover:underline"
                 onClick={() => setChain([""])}
               >
                 + Add a fallback chain
@@ -1112,7 +1112,7 @@ function PolicyForm({
             {candidates.length === 0 ? (
               <button
                 type="button"
-                className="text-accent hover:underline"
+                className="text-link hover:underline"
                 // Seeded with the policy's own target, marked as the safe choice, so
                 // the pool starts from the model this policy already serves and the
                 // operator adds the cheaper one rather than restating everything.
@@ -1129,7 +1129,7 @@ function PolicyForm({
             {candidates.length === 0 ? (
               <button
                 type="button"
-                className="text-accent hover:underline"
+                className="text-link hover:underline"
                 // An even split of the policy's own target with one more provider:
                 // the neutral starting point for load balancing, which the operator
                 // then skews. Seeding 90/10 would be guessing at a canary.
@@ -1160,7 +1160,7 @@ function PolicyForm({
                   }
                   className={
                     guardrails_.configured
-                      ? "text-accent hover:underline"
+                      ? "text-link hover:underline"
                       : "cursor-not-allowed text-muted opacity-60"
                   }
                   onClick={() =>
@@ -1178,7 +1178,7 @@ function PolicyForm({
                   >
                     No guardrails service is configured, so there would be
                     nothing to call.{" "}
-                    <Link to="/tools" className="text-accent hover:underline">
+                    <Link to="/tools" className="text-link hover:underline">
                       Set one up in Tools &amp; Guardrails
                     </Link>
                     .

--- a/web/src/features/settings/Toggle.tsx
+++ b/web/src/features/settings/Toggle.tsx
@@ -36,7 +36,7 @@ export function Toggle({
       }`}
     >
       <span
-        className={`inline-block h-5 w-5 transform rounded-full bg-surface shadow transition-transform ${
+        className={`inline-block h-5 w-5 transform rounded-full bg-surface shadow-elevation-sm transition-transform ${
           checked ? "translate-x-5" : "translate-x-0.5"
         }`}
       />

--- a/web/src/features/tools/ToolsGuardrailsPage.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.tsx
@@ -106,7 +106,7 @@ function SaveToast({ message }: { message: string | null }) {
     <div
       role="status"
       aria-live="polite"
-      className="fixed right-4 bottom-4 z-50 flex items-center gap-2 rounded-lg border border-success bg-success-subtle px-4 py-3 text-sm font-medium text-success shadow-lg"
+      className="fixed right-4 bottom-4 z-50 flex items-center gap-2 rounded-lg border border-success bg-success-subtle px-4 py-3 text-sm font-medium text-success shadow-elevation-lg"
     >
       <svg
         viewBox="0 0 24 24"

--- a/web/src/features/usage/ShareDialog.tsx
+++ b/web/src/features/usage/ShareDialog.tsx
@@ -396,7 +396,7 @@ export function ShareDialog(props: ShareDialogProps) {
             </AlertDialog.Body>
             <AlertDialog.Footer className="flex flex-wrap items-center gap-2">
               {notice !== undefined ? (
-                <span className="mr-auto text-xs text-accent">{notice}</span>
+                <span className="mr-auto text-xs text-link">{notice}</span>
               ) : null}
               <Button variant="ghost" onPress={onClose}>
                 Close

--- a/web/src/shared/components/BulkActionBar.tsx
+++ b/web/src/shared/components/BulkActionBar.tsx
@@ -44,9 +44,9 @@ export function BulkActionBar({
     <div
       role="toolbar"
       aria-label="Bulk actions"
-      className="otari-bulk-bar fixed bottom-4 left-1/2 z-40 flex w-[calc(100%-2rem)] max-w-3xl -translate-x-1/2 flex-wrap items-center gap-3 rounded-xl border border-accent bg-surface px-4 py-2.5 shadow-lg"
+      className="otari-bulk-bar fixed bottom-4 left-1/2 z-40 flex w-[calc(100%-2rem)] max-w-3xl -translate-x-1/2 flex-wrap items-center gap-3 rounded-xl border border-accent bg-surface px-4 py-2.5 shadow-elevation-lg"
     >
-      <span className="text-sm font-medium text-accent">{label}</span>
+      <span className="text-sm font-medium text-link">{label}</span>
       {!allMatching && canSelectAllMatching && matchingTotal != null ? (
         <Button size="sm" variant="ghost" onPress={onSelectAllMatching}>
           Select all {matchingTotal.toLocaleString()} matching this filter

--- a/web/src/shared/components/charts.tsx
+++ b/web/src/shared/components/charts.tsx
@@ -91,7 +91,7 @@ export function ChartTooltip({
     rows.length > 1 ? rows.filter((entry) => (entry.value as number) > 0) : rows
   const total = rows.reduce((sum, entry) => sum + (entry.value as number), 0)
   return (
-    <div className="rounded-md border border-border bg-surface px-2.5 py-1.5 text-xs shadow-sm">
+    <div className="rounded-md border border-border bg-surface px-2.5 py-1.5 text-xs shadow-elevation-sm">
       <div className="text-muted">{heading}</div>
       <div className="mt-0.5 flex flex-col gap-0.5">
         {visible.map((entry, index) => (

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1107,10 +1107,12 @@ body {
 .otari-table .table__row .table__cell {
   border-color: var(--color-border);
 }
-/* HeroUI draws a bottom border on the row as well as on its cells, reading
-   `--separator` directly. The cell rule above covers the cells; without this the
-   row's own border is the one thing in the table that does not follow
-   `--color-border`, which is visible the moment that token carries alpha. */
+/* Aliasing `--separator` is not enough for the row. HeroUI draws a bottom
+   border on the row as well as on its cells, and halves it on the way through:
+   `color-mix(in oklab, var(--separator) 50%, transparent)`. Measured on the
+   built stylesheet, that renders the row edge at alpha 0.029 against the cell's
+   0.06, so the same line is drawn at two strengths. Setting the color here
+   restores one. */
 .otari-table .table__row {
   border-color: var(--color-border);
 }

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -93,84 +93,94 @@
 :root,
 .light,
 [data-theme="light"] {
-  /* ── Surfaces — white cards on a silver-tinted chrome ─────────────────
-     Cool silver neutrals so the teal primary reads cleanly against the
-     chrome (a warm body muddied the teal). Warm tones are reserved for
-     selective attention accents, not the base canvas. Top-down
-     (lightest → darkest):
-       body / fields / cards `#FFFFFF`
-         ↑ contrast step
-       nested cards, hovered rows `#F1F4F6`
-         ↑ small step
-       chrome         `#E8ECEF`   (silver — nav, sidebar, default-bg)
-     Chrome stays a notch deeper than body so HeroUI's default-variant
-     controls (chips, Switch tracks, Checkbox boxes — all bound to
-     `--color-default` → `--color-background-muted`) remain visible
-     against the body / card surfaces rather than vanishing. Saturation
-     kept low so the surfaces recede and the teal primary holds the
-     accent role.                                                      */
-  --color-background: #ffffff; /* page canvas */
-  --color-background-muted: #e8ecef; /* nav/sidebar chrome — light silver */
-  --color-background-subtle: #eef1f4; /* hover/pressed on muted */
-  --color-surface: #ffffff; /* cards, modals — pure white (top layer) */
-  --color-surface-muted: #f1f4f6; /* nested cards, hovered rows */
-  --color-surface-subtle: #e4e9ed; /* dividers, subtle fills */
+  /* ── Surfaces — four levels, two families, staggered ──────────────────
+     Four neutral levels, with the surface family sitting one rung ABOVE
+     the background family rather than sharing rungs with it. Two pairs
+     therefore hold the same value, which is the stagger working and not a
+     duplicate to collapse:
+       #ffffff   background-muted (chrome)  ·  surface        (cards)
+       #f7f8f8   background       (canvas)
+       #f0f1f2   background-subtle          ·  surface-muted
+       #e8e9eb                                 surface-subtle
+     The consequence to expect rather than fix: the nav rail is pure white
+     and the page canvas is DARKER than it. That is the deliberate mirror of
+     dark, where the rail (#0f1011) sits above the canvas (#08090a), and it
+     is what keeps chrome reading distinctly from cards in both themes.
+     HeroUI's default-variant controls (chips, Switch tracks, Checkbox boxes,
+     bound to `--color-default` → `--color-background-muted`) stay visible
+     against the canvas for the same reason.                            */
+  --color-background: #f7f8f8; /* page canvas */
+  --color-background-muted: #ffffff; /* nav/sidebar chrome, one rung above the canvas */
+  --color-background-subtle: #f0f1f2; /* hover/pressed on muted */
+  --color-surface: #ffffff; /* cards, modals (top layer) */
+  --color-surface-muted: #f0f1f2; /* nested cards, hovered rows */
+  --color-surface-subtle: #e8e9eb; /* dividers, subtle fills */
 
-  /* ── Text — brand black + cool neutral muted ─────────────────────────── */
-  --color-text: #1a1a1a; /* primary body and headings (Otari brand black) */
-  --color-text-muted: #545b62; /* secondary text, labels, captions */
-  --color-text-subtle: #62686f; /* tertiary, timestamps, helper text */
+  /* ── Text — three tiers on a neutral ramp ────────────────────────────── */
+  --color-text: #08090a; /* primary body and headings */
+  --color-text-muted: #2c2e33; /* secondary text, labels, captions */
+  --color-text-subtle: #5a5f6b; /* tertiary, timestamps, helper text */
   --color-text-on-primary: #ffffff; /* text on primary-colored bg */
   --color-text-on-inverse: #ffffff; /* text on inverse/dark surface */
 
-  /* ── Borders — light silver to match the chrome ──────────────────────── */
-  --color-border: #d6dce1; /* default 1px dividers, card outlines */
-  --color-border-strong: #aab2b9; /* form-field outlines, prominent borders */
-  --color-border-subtle: #e4e9ed; /* faint internal dividers */
+  /* ── Borders — translucent overlays, three tiers ─────────────────────
+     Alpha rather than opaque hexes, so a border composites correctly on
+     whichever of the four levels it lands on instead of being tuned to one
+     of them. Measured: 0.06 black on white is dL* 2.77.                */
+  --color-border: rgb(0 0 0 / 0.06); /* default 1px dividers, card outlines */
+  --color-border-strong: rgb(
+    0 0 0 / 0.1
+  ); /* form-field outlines, prominent borders */
+  --color-border-subtle: rgb(0 0 0 / 0.03); /* faint internal dividers */
 
-  /* ── Primary (Otari brand teal) ────────────────────────────────────────
-     The brand swatch `#4E8295` lands at only 4.24:1 against white —
-     just under WCAG AA's 4.5:1 for normal text, which leaves button
-     labels under-contrast. Use `#4A7D8F` instead: visually
-     indistinguishable from the brand swatch (<2 ΔE) but lands at
-     4.51:1 against white so white-on-primary button text clears AA.
-     Hover steps toward the Deep Teal, active lands on it.
+  /* ── Primary ───────────────────────────────────────────────────────────
+     `#5e6ad2`. White on it measures 4.70:1, clearing AA for button labels;
+     `#f7f8f8` on it measures 4.417 and does not, which is why
+     `--color-primary-foreground` is pure white in both themes rather than
+     the text token.
 
      Two copies of this value live outside CSS, because neither can read a
      custom property: the `theme-color` meta tag in web/index.html and
      `theme_color` in web/public/pwa/manifest.webmanifest, which tint the
      browser and installed-app chrome. `foundation.test.ts` reads all three
      and fails when they disagree, so change them together.           */
-  --color-primary: #4a7d8f; /* primary CTAs, links, focus rings (brand Teal, AA-tuned) */
-  --color-primary-hover: #3f6d7e;
-  --color-primary-active: #0d475a; /* brand Deep Teal */
-  --color-primary-subtle: #e3edf1; /* selected/soft backgrounds */
+  --color-primary: #5e6ad2; /* primary CTAs, links, focus rings */
+  --color-primary-hover: #4b57c8;
+  --color-primary-active: #4b57c8;
+  --color-primary-subtle: rgb(
+    94 106 210 / 0.12
+  ); /* selected/soft backgrounds */
   --color-primary-foreground: #ffffff; /* text/icons on primary bg */
   /* Text on the subtle fill, which is a different question from text on the
      solid one and does not have the same answer. `--color-primary` itself
-     lands at 3.8:1 on `--color-primary-subtle`, so the obvious reading —
-     "the brand color, on the brand tint" — is under AA for the small text
-     these chips and active nav items are set in. This is the Deep Teal, at
-     8.4:1 on that fill. */
-  --color-primary-subtle-foreground: #0d475a;
+     is under AA on `--color-primary-subtle`, so the obvious reading, "the
+     accent on the accent tint", does not work for the small text these chips
+     and active nav items are set in. This is the darker step instead. */
+  --color-primary-subtle-foreground: #4b57c8;
 
   /* ── Link & focus ───────────────────────────────────────────────────────
-   * Link is a muted teal — clearly distinct from the brand teal accent
+   * Link is the accent's darker step, clearly distinct from the accent itself
    * (reserved for active routes and primary CTAs) but quiet enough that
    * sidebar/footer links don't fight body content for attention. The
    * underline does the heavy lifting; the color is just a nudge. */
-  --color-link: #475866;
-  --color-link-hover: #0d475a;
-  --color-focus: var(--color-primary);
+  --color-link: #4b57c8;
+  --color-link-hover: #5e6ad2;
+  --color-focus: #5e6ad2;
 
   /* ── Status (semantic intent colors) ───────────────────────────────────
-     Success leans teal-green so it harmonizes with the brand primary;
-     the subtle fill consumes the brand "Green" #D2E7D4 directly. The
-     foreground sits at `#1F6648` so text on the subtle fill clears
-     WCAG AA — the lighter `#2E7D5C` on `#D2E7D4` was only 3.8:1, the
-     darker `#1F6648` lands at ~5.2:1. Info shifts to a clearly bluer
-     hue so it stays visually distinct from primary teal in adjacent
-     surfaces (badges, alerts, banners).
+     Five hues, each held at roughly 90% of what sRGB allows at the
+     lightness AA forces on it. Lightness is bounded by AA on
+     `--color-surface-subtle`, the deepest ground any of these words is set
+     on; the worst pairing anywhere in either theme is 4.48:1. Info is a
+     cyan-teal 65 degrees off success and 60 off the accent, so a status
+     badge never reads as a second success or a second accent.
+
+     Light `--color-warning` is a bronze rather than an amber, and that is
+     forced rather than chosen: `text-warning` is real text in 23 places, so
+     it has to clear 4.5:1, and at this hue the sRGB ceiling collapses as
+     lightness rises. A brighter amber is available only as a fill with dark
+     ink on it, which is not how this token is used. If the bronze reads
+     badly the fix is those call sites, not the token.
 
      Warning and danger are one step darker than the swatches they were
      rehomed at, for the reason success is already where it is: a status
@@ -181,17 +191,17 @@
      same hue, and both improve their solid-fill pairing too (white on
      either clears 5.4:1), which is why warning's foreground moves to white
      alongside: near-black on the darker amber would not have.          */
-  --color-success: #1f6648;
-  --color-success-subtle: #d2e7d4;
+  --color-success: #21783d;
+  --color-success-subtle: #e7f7e9;
   --color-success-foreground: #ffffff;
-  --color-warning: #8a6200;
-  --color-warning-subtle: #faf1da;
+  --color-warning: #87631a;
+  --color-warning-subtle: #faf0e0;
   --color-warning-foreground: #ffffff;
-  --color-danger: #c22836; /* clear cherry-red */
-  --color-danger-subtle: #fbe9eb;
+  --color-danger: #cb2526; /* clear cherry-red */
+  --color-danger-subtle: #ffece9;
   --color-danger-foreground: #ffffff;
-  --color-info: #2a6bbe;
-  --color-info-subtle: #e6eef9;
+  --color-info: #267383;
+  --color-info-subtle: #e1f6fc;
   --color-info-foreground: #ffffff;
 
   /* ── Attention (warm accent) — see the @theme block for intent. Warm
@@ -199,25 +209,22 @@
    *    action-required banners + new/unread indicators. ─────────────── */
   /* One step darker than the rehomed swatch, for the same reason as warning
      and danger above: `#C2680F` on `#FBEEDE` was 3.5:1, this is 4.7:1. */
-  --color-attention: #a4560a;
-  --color-attention-subtle: #fbeede;
+  --color-attention: #a5531b;
+  --color-attention-subtle: #ffeee4;
   /* White, for the same reason warning's moved: near-black on the darkened
      attention fill is 3.4:1, white is 5.4:1. */
   --color-attention-foreground: #ffffff;
-  --color-attention-border: #ecc187;
+  --color-attention-border: #d76e26;
 
   /* ── Backdrop — modal/popover dimming. Dark in both themes so a fixed
    *   bg-backdrop/50 darkens the page rather than inverting in dark mode. */
   --color-backdrop: #000000;
 
   /* ── Elevation (light-mode shadow rhythm) ──────────────── */
-  --shadow-sm:
-    0 1px 2px rgba(21, 23, 28, 0.04), 0 1px 3px rgba(21, 23, 28, 0.06);
-  --shadow-md:
-    0 2px 4px rgba(21, 23, 28, 0.06), 0 4px 8px rgba(21, 23, 28, 0.08);
-  --shadow-lg:
-    0 8px 16px rgba(21, 23, 28, 0.08), 0 16px 32px rgba(21, 23, 28, 0.1);
-  --shadow-modal: 0 24px 60px rgba(21, 23, 28, 0.22);
+  --shadow-sm: 0 1px 2px rgb(8 9 10 / 0.04), 0 1px 3px rgb(8 9 10 / 0.06);
+  --shadow-md: 0 2px 4px rgb(8 9 10 / 0.06), 0 4px 8px rgb(8 9 10 / 0.08);
+  --shadow-lg: 0 8px 16px rgb(8 9 10 / 0.08), 0 16px 32px rgb(8 9 10 / 0.1);
+  --shadow-modal: 0 24px 60px rgb(8 9 10 / 0.22);
 
   /* ── Inverse code surface — dark in both themes, because a code block
    *    reads as a terminal rather than as another card. The bundled user
@@ -331,88 +338,100 @@
      in dark because the contrast direction inverts, and keeps the same
      1px border for consistency. */
   --field-background: #ffffff;
-  --field-border: #bcc3c9;
+  --field-border: rgb(0 0 0 / 0.48);
   --field-border-width: 1px;
+  /* Four HeroUI variables the mapping above never claimed. Without them a token
+     change reaches most of the screen but not these: HeroUI's own values are
+     literals, so a Select's value text, a field's shadow and every table and
+     accordion separator keep whatever @heroui/styles ships and stop tracking
+     the palette. Measured before adding them, a full token swap moved 98.2% of
+     the painted properties on eleven routes; these are the rest. */
+  --field-foreground: var(--color-text);
+  --separator: var(--color-border);
+  --separator-secondary: var(--color-border-subtle);
+  --separator-tertiary: var(--color-border-subtle);
 }
 
 .dark,
 [data-theme="dark"] {
-  /* ── Surfaces ───────────────────────────────────────────────────────────
-     Soft gray-teal IDE-style rather than near-black navy. The whole
-     palette has a faint cool/teal undertone so the brand primary doesn't
-     read as alien against the chrome. `--color-background-muted` is
-     intentionally above `--color-surface` so chrome (navbar / sidebar /
-     `--default`-backed controls — Switch track, Checkbox box, default
-     Chip, secondary Button) reads distinctly against the card surface
-     it sits on. Layering top-down: fields `#2D323D` ← chrome `#222731`
-     ← cards `#1B1F27` ← body `#15191F`.                                */
-  --color-background: #15191f;
-  --color-background-muted: #222731;
-  --color-background-subtle: #292e38;
-  --color-surface: #1b1f27;
-  --color-surface-muted: #232831;
-  --color-surface-subtle: #2b313b;
+  /* ── Surfaces — the light block's stagger, mirrored ─────────────────────
+     The same four levels and the same one-rung offset between the two
+     families, read the other way up:
+       #08090a   background       (canvas, the deepest ground)
+       #0f1011   background-muted (chrome)  ·  surface        (cards)
+       #191a1b   background-subtle          ·  surface-muted
+       #1f2023                                 surface-subtle
+     Chrome therefore sits one rung ABOVE the canvas here exactly as it sits
+     one rung above it in light, which is what keeps `--default`-backed
+     controls (Switch track, Checkbox box, default Chip, secondary Button)
+     visible against the cards they sit on.                             */
+  --color-background: #08090a;
+  --color-background-muted: #0f1011;
+  --color-background-subtle: #191a1b;
+  --color-surface: #0f1011;
+  --color-surface-muted: #191a1b;
+  --color-surface-subtle: #1f2023;
 
   /* ── Text ──────────────────────────────────────────────── */
-  --color-text: #f0ede5; /* warm off-white (echoes brand B26 inverted) */
-  --color-text-muted: #9aa4ae;
-  --color-text-subtle: #919ba5;
-  --color-text-on-primary: #0a1419; /* deep teal-black for contrast on light teal */
+  --color-text: #f7f8f8;
+  --color-text-muted: #d0d6e0;
+  --color-text-subtle: #8a8f98;
+  --color-text-on-primary: #0a1419; /* near-black, for ink on a light accent */
   --color-text-on-inverse: #15171c;
 
   /* ── Borders ───────────────────────────────────────────── */
-  --color-border: #343a46;
-  --color-border-strong: #454d5b;
-  --color-border-subtle: #242a35;
+  --color-border: rgb(255 255 255 / 0.08);
+  --color-border-strong: rgb(255 255 255 / 0.14);
+  --color-border-subtle: rgb(255 255 255 / 0.05);
 
-  /* ── Primary (brightened brand teal for dark backgrounds) ───────────────
-     Lifted from #4E8295 to #6fa8bc to clear AA against the dark surfaces
-     (#6fa8bc on #15191f ≈ 7.7:1). Hover is lighter, active drops back to
-     the brand Teal so the chain stays anchored to the Otari palette. */
-  --color-primary: #6fa8bc;
-  --color-primary-hover: #8bbccc;
-  --color-primary-active: #4e8295;
-  --color-primary-subtle: #142b34; /* dark teal selection / soft fill */
-  --color-primary-foreground: #0a1419;
-  /* Same role as the light block's, and the reason it is not simply the
-     brand-on-tint pairing is the same: the contrast direction inverts here,
-     so this is a lifted teal rather than the Deep Teal (8.2:1 on the fill). */
-  --color-primary-subtle-foreground: #9bc9d9;
+  /* ── Primary ───────────────────────────────────────────────────────────
+     The same accent as light, unchanged: it clears AA on these grounds
+     without lifting. Hover brightens, active drops back one step.       */
+  --color-primary: #5e6ad2;
+  --color-primary-hover: #828fff;
+  --color-primary-active: #4b57c8;
+  --color-primary-subtle: rgb(94 106 210 / 0.15); /* selection / soft fill */
+  --color-primary-foreground: #ffffff;
+  /* Same role as the light block's, and not simply the accent-on-tint
+     pairing for the same reason. The contrast direction inverts here, so
+     this is a lifted step rather than a darker one. */
+  --color-primary-subtle-foreground: #a8b1ff;
 
-  /* ── Link & focus — light teal-slate, mirrors the light-mode restraint ──── */
-  --color-link: #9bb3bf;
-  --color-link-hover: #cfdce2;
-  --color-focus: var(--color-primary);
+  /* ── Link & focus — mirrors the light block's restraint ──────────────── */
+  --color-link: #828fff;
+  --color-link-hover: #a8b1ff;
+  --color-focus: #828fff;
 
   /* ── Status ────────────────────────────────────────────── */
-  --color-success: #4fbf95;
-  --color-success-subtle: #13261e;
-  --color-success-foreground: #0a1419;
-  --color-warning: #e5b341;
-  --color-warning-subtle: #2a2113;
-  --color-warning-foreground: #15171c;
-  --color-danger: #f0556a; /* cleaner cherry-red, less orange than a coral */
-  --color-danger-subtle: #2a1418;
-  --color-danger-foreground: #15171c;
-  --color-info: #6aa3e5;
-  --color-info-subtle: #131d2d;
-  --color-info-foreground: #0a1419;
+  --color-success: #2c9a50;
+  --color-success-subtle: #122115;
+  --color-success-foreground: #08090a;
+  --color-warning: #ad7f24;
+  --color-warning-subtle: #241b0c;
+  --color-warning-foreground: #08090a;
+  --color-danger: #f6453f; /* cleaner cherry-red, less orange than a coral */
+  --color-danger-subtle: #2a1715;
+  --color-danger-foreground: #08090a;
+  --color-info: #3393a7;
+  --color-info-subtle: #0a2026;
+  --color-info-foreground: #08090a;
 
   /* ── Attention (warm accent) — brighter honey for dark surfaces.
    *    See the @theme block for what this token is for. ────────────── */
-  --color-attention: #e8a85a;
-  --color-attention-subtle: #2b1e10;
-  --color-attention-foreground: #15171c;
-  --color-attention-border: #62492a;
+  --color-attention: #d16a25;
+  --color-attention-subtle: #281910;
+  --color-attention-foreground: #08090a;
+  --color-attention-border: #a2511a;
 
   /* ── Backdrop — dark in both themes (see light block comment) ────── */
   --color-backdrop: #000000;
 
   /* ── Elevation (deeper shadows on dark) ────────────────── */
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.4);
-  --shadow-md: 0 2px 4px rgba(0, 0, 0, 0.35), 0 4px 8px rgba(0, 0, 0, 0.45);
-  --shadow-lg: 0 8px 16px rgba(0, 0, 0, 0.4), 0 16px 32px rgba(0, 0, 0, 0.55);
-  --shadow-modal: 0 24px 60px rgba(0, 0, 0, 0.55);
+  --shadow-sm: 0 0 0 1px rgb(255 255 255 / 0.05);
+  --shadow-md: 0 0 0 1px rgb(255 255 255 / 0.08);
+  --shadow-lg: 0 0 0 1px rgb(255 255 255 / 0.14);
+  --shadow-modal:
+    0 0 0 1px rgb(255 255 255 / 0.14), 0 24px 60px rgb(0 0 0 / 0.6);
 
   /* Code surface stays inverse on dark too, one step below the card. */
   --color-code-surface: #10161a;
@@ -482,8 +501,8 @@
      body/surface, not from the border weight. A 1px border (matching
      the light block; HeroUI defaults `--field-border-width` to 0)
      firms up the field edge for consistency across themes. */
-  --field-background: #2d323d;
-  --field-border: #404a55;
+  --field-background: rgb(255 255 255 / 0.05);
+  --field-border: rgb(255 255 255 / 0.345);
   --field-border-width: 1px;
 
   /* Mirror of the light block: own the `@theme` alias values directly
@@ -491,6 +510,16 @@
    * block. See the matching comment in the light block above.       */
   --color-background-alt: var(--color-background-muted);
   --color-surface-alt: var(--color-surface-muted);
+  /* Four HeroUI variables the mapping above never claimed. Without them a token
+     change reaches most of the screen but not these: HeroUI's own values are
+     literals, so a Select's value text, a field's shadow and every table and
+     accordion separator keep whatever @heroui/styles ships and stop tracking
+     the palette. Measured before adding them, a full token swap moved 98.2% of
+     the painted properties on eleven routes; these are the rest. */
+  --field-foreground: var(--color-text);
+  --separator: var(--color-border);
+  --separator-secondary: var(--color-border-subtle);
+  --separator-tertiary: var(--color-border-subtle);
 }
 
 /* =============================================================
@@ -854,7 +883,7 @@ body {
  * doubles up with that. But the browser's default `outline: auto` still
  * fires on focusable elements that HeroUI doesn't style (raw anchors,
  * tabindex divs, etc.), producing a system-blue ring that clashes with
- * our brand teal accent. Re-tint only the color of that default outline so
+ * our accent. Re-tint only the color of that default outline so
  * keyboard focus stays consistent across all elements without competing
  * with HeroUI's own indicator. */
 :focus-visible {
@@ -946,6 +975,14 @@ body {
 /* Tooltip content padding: v3's default is cramped at text-xs density.
  * Apply a comfortable padding to every tooltip so individual call sites
  * don't need to override classNames. */
+/* The overlay arrow's outline is `color-mix(in oklab, var(--border) 40%, transparent)`
+   inside @heroui/styles. With a translucent border token that multiplies to
+   near-nothing and the arrow loses its edge, so the tooltip reads the strong
+   tier instead. Scoped to the component, not the theme. */
+.tooltip {
+  --border: var(--color-border-strong);
+}
+
 .tooltip__content {
   padding: 0.5rem 0.75rem;
   font-size: 0.8125rem;
@@ -1070,6 +1107,14 @@ body {
 .otari-table .table__row .table__cell {
   border-color: var(--color-border);
 }
+/* HeroUI draws a bottom border on the row as well as on its cells, reading
+   `--separator` directly. The cell rule above covers the cells; without this the
+   row's own border is the one thing in the table that does not follow
+   `--color-border`, which is visible the moment that token carries alpha. */
+.otari-table .table__row {
+  border-color: var(--color-border);
+}
+
 .otari-table .table__row:hover .table__cell {
   background-color: var(--color-surface-muted);
 }
@@ -1235,8 +1280,8 @@ body {
 .otari-markdown code {
   font-family: var(--font-mono);
   font-size: 0.85em;
-  /* Tinted chip, text ink. Coloring the text with the brand instead would put
-     a mid-tone teal on a pale teal, which clears AA in neither theme. */
+  /* Tinted chip, text ink. Coloring the text with the accent instead would put
+     the accent on its own tint, which clears AA in neither theme. */
   background-color: var(--color-primary-subtle);
   color: var(--color-text);
   padding: 0.1rem 0.35rem;

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -376,8 +376,13 @@
   --color-text: #f7f8f8;
   --color-text-muted: #d0d6e0;
   --color-text-subtle: #8a8f98;
-  --color-text-on-primary: #0a1419; /* near-black, for ink on a light accent */
-  --color-text-on-inverse: #15171c;
+  /* White, not the near-black this held before. That value was correct while
+     the dark accent was a lifted light teal; this palette uses the same
+     `#5e6ad2` in both themes, on which near-black measures 3.96:1 and misses
+     AA. `--color-primary-foreground` beside it answers the same question, so
+     the two agreeing matters more than either value on its own. */
+  --color-text-on-primary: #ffffff;
+  --color-text-on-inverse: #15171c; /* ink on a light surface; 15.85:1 at worst */
 
   /* ── Borders ───────────────────────────────────────────── */
   --color-border: rgb(255 255 255 / 0.08);


### PR DESCRIPTION
## Description

Replaces the dashboard's teal and silver colour foundation with a neutral palette and indigo accent, in both themes.

The palette is four neutral levels mapped onto our six rungs, with the two families **staggered one rung apart** rather than collapsed onto each other. Two token pairs therefore hold the same value in each theme, which is the stagger working rather than a duplicate to tidy away:

```
light   #ffffff  background-muted (chrome) · surface (cards)
        #f7f8f8  background (canvas)
        #f0f1f2  background-subtle · surface-muted
        #e8e9eb  surface-subtle
dark    #08090a  background (canvas)
        #0f1011  background-muted (chrome) · surface (cards)
        #191a1b  background-subtle · surface-muted
        #1f2023  surface-subtle
```

A consequence worth expecting rather than reporting as a bug: **in light, the nav rail is pure white and the page canvas is darker than it.** That is the deliberate mirror of dark, where the rail sits one rung above the canvas, and it is what keeps chrome reading distinctly from cards in both themes.

Everything was measured on the running dashboard rather than in a specimen, across eleven routes in both themes.

### What we changed

- **`--color-primary-foreground` is `#ffffff`, not `#f7f8f8`.** The off-white `#f7f8f8` on the indigo measures 4.417:1 and misses the AA floor by 0.083 on twelve primary buttons. White measures 4.700 and clears it. A correctness repair, marked as a departure in the file.
- **Status, attention and info are ours.** There are no `-subtle` fills for these status colours and no attention or info family at all, so those inks would have landed on our old fills and produced pairings belonging to neither system. Five hues, each held near the sRGB ceiling at the lightness AA forces on it; worst pairing anywhere in either theme is 4.48:1.
- **Field borders are re-derived for WCAG 1.4.11.** The previous input spec measures 1.13:1 against its own fill where 1.4.11 asks 3.0. These clear 3.0 on the fill side and on every rung a field can land on.
- **Dark elevation is a ring, not a shadow stack.** The canvas is L\* 2.43 and the panel 4.63, so a black shadow paints nothing on either. This is an elevation-model change, not a tuning tweak.

### The vendor aliases and the table row border

This is its own item rather than part of the palette, and it is palette-independent.

Four HeroUI variables were never aliased to our tokens: `--field-foreground` and the three `--separator` tiers. HeroUI's values for them are literals, so a Select's value text, a field's shadow, and every table and accordion separator kept whatever `@heroui/styles` ships and stopped tracking the palette. Separately, HeroUI draws a bottom border on a table **row** as well as on its cells, and the existing `.otari-table` patch only covered the cells.

Measured before this change, overriding every `--color-*` token moved **98.2% of the painted properties** on eleven routes in both themes. These five are the remainder. They would be worth doing under any palette; they are noticeable under this one because the border tokens carry alpha.

The tooltip arrow gets a scoped override for the same reason: `@heroui/styles` composites its outline at 40% of `--border`, which a translucent token thins to nearly nothing.

### Nav ramp

Four distinct fills in both themes, from four levels:

| state | token | dark, L\* from rail |
| --- | --- | --- |
| resting | rail (`background-muted`) | 0 |
| pressed | `background` | -2.20 |
| selected | `surface-muted` | +4.56 |
| hover / focus | `surface-subtle` | +7.63 |

Hover lifts away from the chrome and a press sinks onto the canvas behind it, so the two are told apart by direction rather than degree. `--color-background` had never been assigned a nav state; using it is what takes this from three distinct fills to four.

Both `dark:` overrides on the selected row are gone. `dark:bg-surface` now resolves to the rail's own value and erased the selection entirely. The selected row also no longer answers a hover: a hovered resting row already gets `hover:text-foreground` as well as a fill, so a selected row taking the hover fill became indistinguishable from it, and losing "is the row under my pointer the page I am on" costs more than losing a response on a row that does nothing when clicked.

### Shadows

Thirteen sites used bare Tailwind `shadow-*` utilities, which Tailwind inlines with its own values at build time, so they never read our tokens. They now use `shadow-elevation-*`, which do. `KeysPage`'s `shadow-xl` maps to **`shadow-modal`** rather than an invented `xl` step: `shadow-xl` has no token counterpart and the element is a modal.

This matters more than it did: with dark elevation as a ring, a missed site has no elevation at all rather than a slightly wrong one. Verified two ways, because three separate counts of this family disagreed before it was settled. The source now contains no bare shadow utility, and the built stylesheet emits none, which is independent of any regex since Tailwind only generates a utility the source references.

### Accent as text

Thirteen `text-accent` call sites moved to `text-link`. `#5e6ad2` fails AA as text on every surface in both themes (3.47 to 4.70); it is a fill with white on it. Nine of the thirteen were links already wearing the accent. The other four are genuinely accent-coloured text and take `text-link` too, which passes on every surface. Naming them: a notice in `ShareDialog`, a status label in `KeysPage`, a selection count in `BulkActionBar`, and a hover state in `ModelsPage`. A dedicated ink role would be more honest than a link token for those four, and is not in this change.

### One thing worth not deriving yourself

Shipped separates the token figure from its bar on 131.7° of hue at ΔL\* 0.72; 8D separates on ΔL\* 4.45. Lightness separation survives when hue information is removed: in greyscale the shipped pair collapses to 0.72 L\*, effectively merging, while this one holds at 4.45. Under simulated colour-vision deficiency both pairs move by less than 0.4 ΔE, so CVD is not the differentiator; greyscale is.

## Interactive-state coverage

Every token below is declared in **both** theme blocks: nothing exists in one theme and not the other, which is what `foundation.test.ts` enforces and which now holds by construction. The second column is different information: how many rules in the built stylesheet actually read it.

| token | both blocks | `var()` reads in the built CSS |
| --- | --- | --- |
| `--color-primary` | yes | 4 |
| `--color-primary-hover` | yes | **0** |
| `--color-primary-active` | yes | **0** |
| `--color-primary-subtle` | yes | 7 |
| `--color-primary-foreground` | yes | 2 |
| `--color-primary-subtle-foreground` | yes | 2 |
| `--color-link` / `-hover` | yes | 10 / 3 |
| `--color-focus` | yes | 3 |
| status and attention families | yes | 1 to 3 each |
| `--field-foreground` | yes | 51 |
| `--field-border` / `-background` | yes | 26 / 20 |
| `--separator` / `-tertiary` / `-secondary` | yes | 12 / 9 / 1 |

**Declared and reaching the screen are different things, and this table is here to keep them apart.** Two tokens in the whole set are declared, symmetric and read by nothing, and both are on the accent. See the entry below.

`--color-focus` having no hover or active state, and the five status roles having none, are correct rather than gaps: a focus ring is one value by nature and a status colour is not interactive. They were considered.

The four `--field-*` and `--separator` rows are the vendor aliases described above. Their read counts are why the remainder of that 98.2% mattered.

## Known limitations, named

**A button's pressed colour cannot be expressed through the tokens, for three independent reasons, any one sufficient.** `.button:active` and `.button:hover` sit at equal specificity in `@heroui/styles` with hover later in the sheet (offsets 73414 and 73540), so a mouse press, which is always also a hover, always takes the hover background. There is no `--accent-active` variable anywhere in the dist to alias to. And `--color-primary-hover` and `--color-primary-active` are not aliased to HeroUI's accent variables, which is why they read zero above. Every button variant sets `--button-bg-pressed` to its own hover value, so pressed-equals-hover is deliberate upstream rather than an oversight; the press feedback that does exist is `transform: scale(.97)`, in both themes. Measured on a rendered button, not derived.

**Disabled is not expressed at all.** No role declares a disabled colour and `--disabled-opacity` is not aliased, so every disabled state is HeroUI's default opacity over our colours, measuring 2.20:1 in light and 2.54:1 in dark. There is no missed value here; the role was never expressed.

**Field hover and focus are HeroUI's arithmetic over our value.** `--field-border` is ours; `--field-border-hover` and `--field-border-focus` are `color-mix`es HeroUI derives from it. The chain works, measured on a hovered control: alpha 0.48 to 0.521 in light, 0.345 to 0.404 in dark. The point is that the two most-touched states of the most-touched control in the product are values we do not name, and would move silently if those ratios changed.

**Nine call sites opt out of that chain.** `border-field-border`, `border-border` or `focus:border-accent` written into a field's `className` are unlayered app utilities and outrank `@heroui/styles`' layered hover and focus rules, so those controls do not move on hover and take the accent on focus. `app/AppShell.tsx`, `features/models/ModelsPage.tsx`, `features/settings/SettingsPage.tsx`, `shared/components/TablePagination.tsx`, `shared/components/ui.tsx`. Pre-existing, a styling-layer inconsistency rather than a token one, and untouched here.

**Link has no active state, and adding one is not a small change.** The link chain runs in opposite directions per theme: hover recedes in light (6.01 to 4.70 on the card) and advances in dark (6.64 to 9.43). Both clear AA and both give a visible hover, so the inconsistency is in the convention rather than the behaviour. Continuing light's chain fails AA on all four light surfaces (3.05 to 3.71) and reversing it collides with `primary-active`. It would also argue with an existing decision at `globals.css:1263`, where `.otari-markdown a:hover` declines a hover tint on purpose. Out of scope.

**`--color-primary-subtle` has no hover state and that is not a gap:** 18 `bg-` sites and no `hover:bg-primary-subtle` anywhere in `web/src`. Checked and closed.

## What this does not do

- **Radius and disabled opacity still do not follow the tokens.** `--radius` has 183 consumers in the built stylesheet and `--disabled-opacity` 53, and neither is aliased to anything we name. That gap is real, predates this change, and is untouched here.
- **`ShareCard.tsx` will drift.** It renders to a PNG through an `<img>`-rasterized SVG, where `var()` does not resolve, so its fifteen colors are literal by necessity rather than by neglect. They were sampled from the palette this change replaces, so the card will drift from the dashboard it represents. It is left out of scope on purpose: bringing it back into alignment is a second pass with its own constraint, which is that the card is read in someone else's timeline and not on our page.
- **The 4px accent bar for `warning` and `success` reads brown rather than amber.** These tokens are constrained by having to work as text; a non-text step would let the bar read closer to the hue the word implies. A known limitation, not scheduled here.

## Known issues we accepted

- **The warning and attention hierarchy inverts in light.** No single pair of values orders them correctly in both themes. It is a per-theme exception or it is accepted, and we accepted it.
- **The light nav rail is pure white with the canvas darker than the chrome**, as described above. Deliberate, and the mirror of the dark ramp.
- **Light `--color-warning` is a bronze rather than an amber.** Forced rather than chosen: `text-warning` is real text in 23 places so it must clear 4.5:1, and at that hue the sRGB ceiling collapses as lightness rises. It was put on screen and looked at before being accepted. If it reads badly the fix is those 23 call sites, not the token.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

No tracking issue. This change came from direct design direction rather than a reported defect. Several pre-existing contrast defects were found while measuring and are deliberately **not** fixed here; they are not yet filed.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [ ] Documentation was updated where necessary. No documentation describes these values; `.github/skills/frontend-standards/design-tokens.md` describes the token families and their rules, which are unchanged.
- [ ] If the API contract changed, I regenerated the OpenAPI spec. No API contract changed; this is `web/` only.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5, via Claude Code.

**Any additional AI details you'd like to share:**

Values were measured on the running dashboard rather than computed and asserted. Several claims in earlier drafts of this work were withdrawn after measurement contradicted them, including one about colour-vision deficiency that appears corrected in the section above.

- [x] I am an AI Agent filling out this form (check box if true)

