### PR TITLE
fix(hybrid): forward Anthropic 1h cache-write tokens in usage reports

### DIFF
--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -340,7 +340,9 @@ Content-Type: application/json
     "completion_tokens": 7,
     "total_tokens": 20,
     "cache_read_tokens": 8,            // provider cache-read input tokens
-    "cache_write_tokens": 0           // cache-write (creation) input tokens; Anthropic only
+    "cache_write_tokens": 0,          // cache-write (creation) input tokens; Anthropic only
+    "cache_write_1h_tokens": 0        // subset of cache_write_tokens written with
+                                      // a 1-hour TTL; Anthropic only
   },
   "error_class": "http_401",           // optional on error; omitted when the
                                        // Otari can't classify the failure
@@ -406,6 +408,17 @@ that in mind:
   cache. `cache_read_tokens` and `cache_write_tokens` are reported **separately**
   and are not part of `prompt_tokens`. `cache_write_tokens` is a true cache
   creation charge billed at a premium.
+
+`cache_write_1h_tokens` is an optional **subset** of `cache_write_tokens`: the
+portion created with a one-hour TTL rather than the five-minute default, which
+Anthropic bills at a higher rate. It is never added to `cache_write_tokens`, so
+the five-minute portion is `cache_write_tokens - cache_write_1h_tokens`. A
+receiver that does not price the two TTLs separately can ignore it.
+
+The key is present whenever `cache_write_tokens` is non-zero, and `0` there means
+every write used the five-minute TTL. It is omitted entirely when the report
+carries no cache writes, which is every OpenAI and Gemini report. Absent means
+zero, so a report from an older gateway prices exactly as before.
 
 The platform must accept these additive keys with lenient parsing; a handler that
 rejects unknown fields would 422 the report (a non-retryable status), silently

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -415,7 +415,7 @@ receiver that does not price the two TTLs separately can ignore it.
 
 The key is present whenever `cache_write_tokens` is non-zero, and `0` there means
 every write used the five-minute TTL. It is omitted entirely when the report
-carries no cache writes, which is every OpenAI and Gemini report — hence its
+carries no cache writes, which is every OpenAI and Gemini report; hence its
 absence from the example above. Absent means zero, so a report from an older
 gateway prices exactly as before. A cache-writing report looks like:
 

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -340,9 +340,7 @@ Content-Type: application/json
     "completion_tokens": 7,
     "total_tokens": 20,
     "cache_read_tokens": 8,            // provider cache-read input tokens
-    "cache_write_tokens": 0,          // cache-write (creation) input tokens; Anthropic only
-    "cache_write_1h_tokens": 0        // subset of cache_write_tokens written with
-                                      // a 1-hour TTL; Anthropic only
+    "cache_write_tokens": 0           // cache-write (creation) input tokens; Anthropic only
   },
   "error_class": "http_401",           // optional on error; omitted when the
                                        // Otari can't classify the failure
@@ -417,8 +415,23 @@ receiver that does not price the two TTLs separately can ignore it.
 
 The key is present whenever `cache_write_tokens` is non-zero, and `0` there means
 every write used the five-minute TTL. It is omitted entirely when the report
-carries no cache writes, which is every OpenAI and Gemini report. Absent means
-zero, so a report from an older gateway prices exactly as before.
+carries no cache writes, which is every OpenAI and Gemini report — hence its
+absence from the example above. Absent means zero, so a report from an older
+gateway prices exactly as before. A cache-writing report looks like:
+
+```json
+"usage": {
+  "prompt_tokens": 13,
+  "completion_tokens": 7,
+  "total_tokens": 20,
+  "cache_read_tokens": 8,
+  "cache_write_tokens": 30,
+  "cache_write_1h_tokens": 10
+}
+```
+
+so 10 of those 30 written tokens carry the one-hour TTL and the other 20 the
+five-minute one.
 
 The platform must accept these additive keys with lenient parsing; a handler that
 rejects unknown fields would 422 the report (a non-retryable status), silently

--- a/src/gateway/api/routes/_platform.py
+++ b/src/gateway/api/routes/_platform.py
@@ -27,7 +27,11 @@ from openai import APITimeoutError as _OpenAIAPITimeoutError
 from pydantic import BaseModel, Field, ValidationError
 
 from gateway.core.config import GatewayConfig
-from gateway.core.usage import cache_read_tokens_of, cache_write_tokens_of
+from gateway.core.usage import (
+    cache_read_tokens_of,
+    cache_write_1h_tokens_of,
+    cache_write_tokens_of,
+)
 from gateway.log_config import logger
 from gateway.metrics import record_abandoned_attempt
 from gateway.models.mcp import McpServerConfig
@@ -945,13 +949,19 @@ async def _report_platform_usage(
         payload["session_label"] = normalized_label
     if outcome == "success":
         if usage is not None:
-            payload["usage"] = {
+            cache_write_tokens = cache_write_tokens_of(usage)
+            usage_payload: dict[str, Any] = {
                 "prompt_tokens": usage.prompt_tokens,
                 "completion_tokens": usage.completion_tokens,
                 "total_tokens": usage.total_tokens,
                 "cache_read_tokens": cache_read_tokens_of(usage),
-                "cache_write_tokens": cache_write_tokens_of(usage),
+                "cache_write_tokens": cache_write_tokens,
             }
+            # Only a cache-writing report can carry a TTL split, so a provider
+            # with no cache-write concept keeps the exact payload it sent before.
+            if cache_write_tokens:
+                usage_payload["cache_write_1h_tokens"] = cache_write_1h_tokens_of(usage)
+            payload["usage"] = usage_payload
     elif error_class is not None:
         payload["error_class"] = error_class
 

--- a/tests/integration/test_hybrid_mode_messages.py
+++ b/tests/integration/test_hybrid_mode_messages.py
@@ -93,6 +93,31 @@ def _message_response(text: str = "hello") -> MessageResponse:
     )
 
 
+def _message_response_with_1h_cache_write() -> MessageResponse:
+    """A response whose cache creation splits across the 5m and 1h TTL buckets."""
+    from anthropic.types.cache_creation import CacheCreation
+
+    return MessageResponse(
+        id="msg_platform",
+        type="message",
+        role="assistant",
+        model="claude-3-5-sonnet-20241022",
+        content=[TextBlock(type="text", text="hello", citations=None)],
+        stop_reason=cast(Any, "end_turn"),
+        stop_sequence=None,
+        usage=MessageUsage(
+            input_tokens=10,
+            output_tokens=7,
+            cache_creation_input_tokens=30,
+            cache_read_input_tokens=3,
+            cache_creation=CacheCreation(ephemeral_5m_input_tokens=20, ephemeral_1h_input_tokens=10),
+            server_tool_use=None,
+            service_tier=None,
+        ),
+        container=None,
+    )
+
+
 def test_hybrid_mode_requires_authorization_header(platform_client: TestClient) -> None:
     response = platform_client.post(
         "/v1/messages",
@@ -159,9 +184,7 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
         if url.endswith("/gateway/provider-keys/resolve"):
             return httpx.Response(
                 200,
-                json=_resolve_payload(
-                    [_attempt(0, attempt_id, "claude-3-5-sonnet-20241022", "sk-platform-key")]
-                ),
+                json=_resolve_payload([_attempt(0, attempt_id, "claude-3-5-sonnet-20241022", "sk-platform-key")]),
             )
         usage_reports.append(body)
         return httpx.Response(
@@ -211,9 +234,56 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
                 "total_tokens": 17,
                 "cache_read_tokens": 3,
                 "cache_write_tokens": 4,
+                "cache_write_1h_tokens": 0,
             },
         }
     ]
+
+
+def test_hybrid_mode_reports_one_hour_cache_write_subset(
+    platform_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 1h cache write is reported as a subset of the cache-write total (#856)."""
+    usage_reports: list[dict[str, Any]] = []
+    attempt_id = "3f1b6a1e-0000-4000-8000-000000000009"
+
+    async def fake_post_platform(
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+        timeout_seconds: float,
+    ) -> httpx.Response:
+        if url.endswith("/gateway/provider-keys/resolve"):
+            return httpx.Response(
+                200,
+                json=_resolve_payload([_attempt(0, attempt_id, "claude-3-5-sonnet-20241022", "sk-platform-key")]),
+            )
+        usage_reports.append(body)
+        return httpx.Response(200, json={"correlation_id": body["correlation_id"], "status": "accepted"})
+
+    async def fake_amessages(**kwargs: Any) -> MessageResponse:
+        return _message_response_with_1h_cache_write()
+
+    monkeypatch.setattr("gateway.api.routes._platform._post_platform", fake_post_platform)
+    monkeypatch.setattr("gateway.api.routes.messages.amessages", fake_amessages)
+
+    response = platform_client.post(
+        "/v1/messages",
+        json={
+            "model": "claude-3-5-sonnet-20241022",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 100,
+        },
+        headers={"Authorization": "Bearer user_test_token"},
+    )
+
+    assert response.status_code == 200, response.text
+    reported = usage_reports[0]["usage"]
+    assert reported["cache_write_tokens"] == 30
+    assert reported["cache_write_1h_tokens"] == 10
+    # The 1h bucket is a subset, never an addition, so the 5m portion is the remainder.
+    assert reported["cache_write_tokens"] - reported["cache_write_1h_tokens"] == 20
 
 
 def test_hybrid_mode_falls_through_on_first_attempt_failure(
@@ -755,9 +825,7 @@ def test_hybrid_mode_tool_loop_streaming_sets_correlation_id_and_reports_usage(
         if url.endswith("/gateway/provider-keys/resolve"):
             return httpx.Response(
                 200,
-                json=_resolve_payload(
-                    [_attempt(0, attempt_id, "claude-3-5-sonnet-20241022", "sk-platform")]
-                ),
+                json=_resolve_payload([_attempt(0, attempt_id, "claude-3-5-sonnet-20241022", "sk-platform")]),
             )
         usage_reports.append(body)
         return httpx.Response(
@@ -1073,6 +1141,7 @@ def test_hybrid_mode_preamble_rejection_uses_anthropic_envelope_and_keeps_retry_
     detail = response.json()["detail"]
     assert detail["type"] == "error"
     assert detail["error"]["type"] == "rate_limit_error"
+
 
 def test_hybrid_mode_tool_loop_streaming_falls_through_pre_lock_in(
     platform_client: TestClient,

--- a/tests/integration/test_hybrid_mode_messages.py
+++ b/tests/integration/test_hybrid_mode_messages.py
@@ -17,6 +17,7 @@ from typing import Any, cast
 
 import httpx
 import pytest
+from anthropic.types import CacheCreation
 from any_llm.types.messages import (
     MessageResponse,
     MessageUsage,
@@ -95,8 +96,6 @@ def _message_response(text: str = "hello") -> MessageResponse:
 
 def _message_response_with_1h_cache_write() -> MessageResponse:
     """A response whose cache creation splits across the 5m and 1h TTL buckets."""
-    from anthropic.types.cache_creation import CacheCreation
-
     return MessageResponse(
         id="msg_platform",
         type="message",
@@ -184,7 +183,9 @@ def test_hybrid_mode_sets_correlation_id_and_reports_usage(
         if url.endswith("/gateway/provider-keys/resolve"):
             return httpx.Response(
                 200,
-                json=_resolve_payload([_attempt(0, attempt_id, "claude-3-5-sonnet-20241022", "sk-platform-key")]),
+                json=_resolve_payload(
+                    [_attempt(0, attempt_id, "claude-3-5-sonnet-20241022", "sk-platform-key")]
+                ),
             )
         usage_reports.append(body)
         return httpx.Response(
@@ -282,8 +283,6 @@ def test_hybrid_mode_reports_one_hour_cache_write_subset(
     reported = usage_reports[0]["usage"]
     assert reported["cache_write_tokens"] == 30
     assert reported["cache_write_1h_tokens"] == 10
-    # The 1h bucket is a subset, never an addition, so the 5m portion is the remainder.
-    assert reported["cache_write_tokens"] - reported["cache_write_1h_tokens"] == 20
 
 
 def test_hybrid_mode_falls_through_on_first_attempt_failure(
@@ -825,7 +824,9 @@ def test_hybrid_mode_tool_loop_streaming_sets_correlation_id_and_reports_usage(
         if url.endswith("/gateway/provider-keys/resolve"):
             return httpx.Response(
                 200,
-                json=_resolve_payload([_attempt(0, attempt_id, "claude-3-5-sonnet-20241022", "sk-platform")]),
+                json=_resolve_payload(
+                    [_attempt(0, attempt_id, "claude-3-5-sonnet-20241022", "sk-platform")]
+                ),
             )
         usage_reports.append(body)
         return httpx.Response(
@@ -1141,7 +1142,6 @@ def test_hybrid_mode_preamble_rejection_uses_anthropic_envelope_and_keeps_retry_
     detail = response.json()["detail"]
     assert detail["type"] == "error"
     assert detail["error"]["type"] == "rate_limit_error"
-
 
 def test_hybrid_mode_tool_loop_streaming_falls_through_pre_lock_in(
     platform_client: TestClient,


### PR DESCRIPTION
## Description

`GatewayUsage` already carries `cache_write_1h_tokens`, but `_report_platform_usage` was forwarding only `cache_read_tokens` and the aggregate `cache_write_tokens`. A settlement authority could see that a cache write happened but not that it used the one-hour TTL, so it couldn't apply the distinct 1h rate that #357 added.

This forwards it with the existing `cache_write_1h_tokens_of` helper and documents it in the protocol.

The one design call worth flagging: the acceptance criteria ask for a zero 1h bucket on five-minute-only writes *and* for Chat, Responses and no-cache reports to stay unchanged. Emitting the key unconditionally satisfies the first and breaks the second — it changed the payload for every OpenAI and Gemini report, and two existing tests failed on exactly that. So the key is emitted only when `cache_write_tokens` is non-zero. An Anthropic report always carries it (`0` meaning every write was 5m), and a provider with no cache-write concept sends the byte-identical payload it sent before. That way I didn't have to edit any existing test to accommodate the change.

Documented as an optional subset, never an addition, so the 5m portion is `cache_write_tokens - cache_write_1h_tokens` and an absent key means zero for older gateways.

## PR Type

- [x] Bug Fix
- [x] Documentation

## Relevant issues

Fixes #856

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec — not applicable here: `POST /gateway/usage` is an outbound call to the platform, so otari's own OpenAPI surface is unchanged.

Test results:

```
make lint       -> architecture ✅, single alembic head, ruff: All checks passed!
make typecheck  -> Success: no issues found in 535 source files
pytest tests/unit tests/integration -> 2664 passed, 9 skipped
```

The new test is `test_hybrid_mode_reports_one_hour_cache_write_subset`, which asserts the 1h bucket is reported as a subset (30 total, 10 at 1h, 20 remaining at 5m). The existing messages test now also pins `cache_write_1h_tokens: 0` for the 5m-only case, and the chat/responses payload assertions are untouched and still pass.

## AI Usage

- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any additional AI details you'd like to share:**

Reproduced the gap by reading `_report_platform_usage` against `messages.py`, then ran the four hybrid suites plus the full unit and integration suites locally under Docker. The conditional-emission decision above came from the two chat/responses failures — worth a look in review, since the alternative reading is to always emit and update those two assertions instead.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added Anthropic one-hour cache-write token reporting.
- Documented the optional field in the hybrid protocol.
- Preserved existing payloads for providers without cache-write data.
- Added coverage for one-hour, five-minute-only, Chat, Responses, and no-cache reports.

## Technical notes

- `cache_write_1h_tokens` is emitted only when cache-write data exists.
- The field is an optional subset of `cache_write_tokens`.
- Five-minute-only writes report zero one-hour tokens.
- Older receivers remain compatible because an omitted field means zero.

## Validation

- Lint, type checking, and unit/integration tests passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->