### PR TITLE
feat(dashboard): record existing telemetry in Mixpanel when a key is present

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ OTARI_PORT=8000
 OTARI_AUTO_MIGRATE=true
 OTARI_BOOTSTRAP_API_KEY=true
 
+# Dashboard analytics (optional, build time only). `make dashboard` sources this
+# file, and Vite inlines VITE_* into the bundle. Leave it unset to build a
+# dashboard that loads no Mixpanel SDK and tracks nothing, which is the default.
+# VITE_MIXPANEL_TOKEN=
+
 # Provider credentials used directly by gateway/provider clients
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -10,9 +10,10 @@ OTARI_PORT=8000
 OTARI_AUTO_MIGRATE=true
 OTARI_BOOTSTRAP_API_KEY=true
 
-# Dashboard analytics (optional, build time only). `make dashboard` sources this
-# file, and Vite inlines VITE_* into the bundle. Leave it unset to build a
-# dashboard that loads no Mixpanel SDK and tracks nothing, which is the default.
+# Dashboard analytics (optional, build time only). Vite reads this file
+# (web/vite.config.ts points envDir here) and inlines VITE_* into the bundle.
+# Leave it unset to build a dashboard that loads no Mixpanel SDK and tracks
+# nothing, which is the default and what every release artifact ships.
 # VITE_MIXPANEL_TOKEN=
 
 # Provider credentials used directly by gateway/provider clients

--- a/.github/skills/frontend-standards/SKILL.md
+++ b/.github/skills/frontend-standards/SKILL.md
@@ -7,9 +7,11 @@ description: Guidelines for the otari admin dashboard (`web/`), React 19 + TypeS
 
 `web/` is the dashboard shared by standalone, hosted, and hybrid deployments. It renders the
 management UI or hybrid landing page from `/v1/bootstrap` and uses an HttpOnly session for
-management calls. It is an operator tool, not a marketing surface. The base tracker under
-`src/shared/telemetry/` is a no-op seam an overlay may replace; do not give it an analytics
-implementation in this repository.
+management calls. It is an operator tool, not a marketing surface. Telemetry
+under `src/shared/telemetry/` is gated by `VITE_MIXPANEL_TOKEN`: with no key the Mixpanel SDK
+is never loaded and nothing is tracked, which is the OSS default. Do not invent events beyond
+`TELEMETRY_EVENTS`, do not fire `CHECKOUT_CANCELLED` (no wallet), and do not add a second
+analytics vendor.
 
 Stack: React 19 (with the React Compiler), TypeScript (`strict`), HeroUI v3 (`@heroui/react`),
 Tailwind CSS v4, TanStack Query, TanStack Router (file-based, `web/src/routes/`), Vite,

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,9 @@ COPY web ./
 # it from outside web/. .dockerignore excludes docs/ but re-includes this file.
 COPY docs/dashboard.md /app/docs/dashboard.md
 
-# Optional. Vite inlines VITE_* at build time; an empty value is the OSS
-# default and the dashboard never loads Mixpanel. Pass the project token when
-# building a deployment that should record into Mixpanel.
+# Optional. Vite inlines VITE_* at build time. Unset is the OSS default, and it
+# builds a dashboard that neither bundles nor loads Mixpanel. Pass the project
+# token only when building a deployment that should record into Mixpanel.
 ARG VITE_MIXPANEL_TOKEN
 ENV VITE_MIXPANEL_TOKEN=$VITE_MIXPANEL_TOKEN
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,12 @@ COPY web ./
 # it from outside web/. .dockerignore excludes docs/ but re-includes this file.
 COPY docs/dashboard.md /app/docs/dashboard.md
 
+# Optional. Vite inlines VITE_* at build time; an empty value is the OSS
+# default and the dashboard never loads Mixpanel. Pass the project token when
+# building a deployment that should record into Mixpanel.
+ARG VITE_MIXPANEL_TOKEN
+ENV VITE_MIXPANEL_TOKEN=$VITE_MIXPANEL_TOKEN
+
 # web/vite.config.ts writes to ../src/gateway/static/dashboard, so the bundle
 # lands at /app/src/gateway/static/dashboard for the runtime stage to copy.
 RUN pnpm run build

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ dev:
 # degrades to the tutorial page) and before building a wheel. The Docker image
 # builds it in its own web stage and needs no local Node.
 dashboard: web/node_modules/.install-stamp
+	@set -a; \
+	if [ -f .env ]; then . ./.env; fi; \
+	set +a; \
 	pnpm --dir web run build
 
 # Reinstalling on every rebuild is the wrong price to pay now that the READMEs

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,6 @@ dev:
 # degrades to the tutorial page) and before building a wheel. The Docker image
 # builds it in its own web stage and needs no local Node.
 dashboard: web/node_modules/.install-stamp
-	@set -a; \
-	if [ -f .env ]; then . ./.env; fi; \
-	set +a; \
 	pnpm --dir web run build
 
 # Reinstalling on every rebuild is the wrong price to pay now that the READMEs

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -148,6 +148,22 @@ This guide is bundled into the dashboard at `/#/docs`. Set `docs_url` to make
 the dashboard's Documentation link open a different site. The bundled route
 remains available.
 
+## Analytics
+
+The dashboard sends no analytics unless it was **built** with a Mixpanel project
+token in `VITE_MIXPANEL_TOKEN`. The published Docker image and every release
+artifact are built without one, so a self-hosted gateway loads no analytics SDK,
+opens no connection to Mixpanel, and records nothing. There is no runtime
+setting for this, and no way to turn it on for a build that shipped without a
+token.
+
+A build that does carry one records a fixed list of product events (sign-in,
+sign-up and verification steps, and sidebar navigation), and identifies the
+signed-in member by organization membership id, organization id, organization
+name and role. The token itself is the deployment's opt-in: such a build has no
+consent prompt, so operate one only where telling people about it is your own
+deployment's business to handle.
+
 ## Legal pages
 
 `terms_url` and `privacy_url` name where this deployment's terms of service and

--- a/web/README.md
+++ b/web/README.md
@@ -66,10 +66,12 @@ filesystem events. Fall back to polling:
 VITE_USE_POLLING=1 pnpm run dev
 ```
 
-Dashboard analytics are gated by `VITE_MIXPANEL_TOKEN` (inlined at build time,
-also read from the repo-root `.env` by `make dashboard`). Without a token the
-SDK is never loaded. A local dashboard without a token logs `Mixpanel not
-initialized` once in the browser console.
+Dashboard analytics are gated by `VITE_MIXPANEL_TOKEN`, inlined at build time.
+Vite reads it from the repo-root `.env` (`envDir` in `vite.config.ts`), so
+`pnpm run dev` and `make dashboard` take it from the same file. Without a token
+the SDK is never loaded and nothing is recorded; the dev server logs `Mixpanel
+not initialized` once in the browser console. What a build with a token records
+is documented for operators in [docs/dashboard.md](../docs/dashboard.md).
 
 ## Build
 

--- a/web/README.md
+++ b/web/README.md
@@ -66,6 +66,11 @@ filesystem events. Fall back to polling:
 VITE_USE_POLLING=1 pnpm run dev
 ```
 
+Dashboard analytics are gated by `VITE_MIXPANEL_TOKEN` (inlined at build time,
+also read from the repo-root `.env` by `make dashboard`). Without a token the
+SDK is never loaded. A local dashboard without a token logs `Mixpanel not
+initialized` once in the browser console.
+
 ## Build
 
 ```bash

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,7 @@
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-router": "^1.170.31",
     "clsx": "2.1.1",
+    "mixpanel-browser": "^2.82.1",
     "react": "^19.2.8",
     "react-aria-components": "1.20.0",
     "react-dom": "^19.2.8",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
+      mixpanel-browser:
+        specifier: ^2.82.1
+        version: 2.82.1
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -373,6 +376,27 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mixpanel/rrdom@2.0.0-alpha.18.6':
+    resolution: {integrity: sha512-JY1Kr8c5pPmFBdPMLIEm1e0/hw2xvsS515Qqf+5Lpm0AW+2e/ZvA6P6M+z4fXeuachfZZv06UhTvixiUJv355Q==}
+
+  '@mixpanel/rrweb-plugin-console-record@2.0.0-alpha.18.4':
+    resolution: {integrity: sha512-gGxEnNpfWurQht+fpSJbwPV60ug0LAENlk4Ux3XRmYooNJGPBO1TiQHcM7g0yhrKf4tfbTiKKZ4EXzFlOZs/pw==}
+    peerDependencies:
+      '@mixpanel/rrweb': ^2.0.0-alpha.18
+      '@mixpanel/rrweb-utils': ^2.0.0-alpha.18
+
+  '@mixpanel/rrweb-snapshot@2.0.0-alpha.18.6':
+    resolution: {integrity: sha512-8c8TArw8l0mmYPvKc3asq3hIzQ7uVrNVQ4xsVt+ESxHohW8r47ua/YLDpd2jV30FZj4Y3KvGTQl5sXLDI+02Zw==}
+
+  '@mixpanel/rrweb-types@2.0.0-alpha.18.6':
+    resolution: {integrity: sha512-KvaTcbZR4mJ3w1b1fEq4AeSg9rUqvQ1gKko9r56ANUw4fqWam23xoXrLJ8Og+hPYTwIDQ99TkZBVXFTGJqYwpQ==}
+
+  '@mixpanel/rrweb-utils@2.0.0-alpha.18.4':
+    resolution: {integrity: sha512-c3nUbQl19kxHjf8nowFMeXlJw0ZqLesIVBb9t4g1nC4WtaNEPkFotWRdGt5V2cJNQ+aY38/v2uYb8Ren4IcdSQ==}
+
+  '@mixpanel/rrweb@2.0.0-alpha.18.4':
+    resolution: {integrity: sha512-ICpEYDFEEiCoUuQg+de3VvQCsolF4lNHfEM9DBp5Pwuc7EgXqwWV4wUpiRF/NbhoKk+82X1Qe+oqqlKJb/CGFw==}
 
   '@oxc-project/types@0.146.0':
     resolution: {integrity: sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==}
@@ -883,6 +907,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/css-font-loading-module@0.0.7':
+    resolution: {integrity: sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -924,6 +951,9 @@ packages:
 
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
+  '@types/json-logic-js@2.0.5':
+    resolution: {integrity: sha512-hu/FTi0zwCjQEFfbPur275cNoZj6NsuOBhhYNzqoSdfmMhuxFr58OZ957lyIOWc9+kO+2tFlBthRjcxuytD4HA==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -999,6 +1029,9 @@ packages:
   '@vitest/utils@4.1.11':
     resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
+  '@xstate/fsm@1.6.5':
+    resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1048,6 +1081,10 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
 
   baseline-browser-mapping@2.11.15:
     resolution: {integrity: sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA==}
@@ -1379,6 +1416,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-logic-js@2.0.5:
+    resolution: {integrity: sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -1698,6 +1738,12 @@ packages:
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
+
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  mixpanel-browser@2.82.1:
+    resolution: {integrity: sha512-meJv23+7YYUHs08VlIVUC4x9riKnCLy6THQ264idlonBKzOq4LmmubOjOm71nVRm6osqEbXeXH2fwYrNXHRG1g==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2546,6 +2592,34 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mixpanel/rrdom@2.0.0-alpha.18.6':
+    dependencies:
+      '@mixpanel/rrweb-snapshot': 2.0.0-alpha.18.6
+
+  '@mixpanel/rrweb-plugin-console-record@2.0.0-alpha.18.4(@mixpanel/rrweb-utils@2.0.0-alpha.18.4)(@mixpanel/rrweb@2.0.0-alpha.18.4)':
+    dependencies:
+      '@mixpanel/rrweb': 2.0.0-alpha.18.4
+      '@mixpanel/rrweb-utils': 2.0.0-alpha.18.4
+
+  '@mixpanel/rrweb-snapshot@2.0.0-alpha.18.6':
+    dependencies:
+      postcss: 8.5.26
+
+  '@mixpanel/rrweb-types@2.0.0-alpha.18.6': {}
+
+  '@mixpanel/rrweb-utils@2.0.0-alpha.18.4': {}
+
+  '@mixpanel/rrweb@2.0.0-alpha.18.4':
+    dependencies:
+      '@mixpanel/rrdom': 2.0.0-alpha.18.6
+      '@mixpanel/rrweb-snapshot': 2.0.0-alpha.18.6
+      '@mixpanel/rrweb-types': 2.0.0-alpha.18.6
+      '@mixpanel/rrweb-utils': 2.0.0-alpha.18.4
+      '@types/css-font-loading-module': 0.0.7
+      '@xstate/fsm': 1.6.5
+      base64-arraybuffer: 1.0.2
+      mitt: 3.0.1
+
   '@oxc-project/types@0.146.0': {}
 
   '@playwright/test@1.62.1':
@@ -3000,6 +3074,8 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/css-font-loading-module@0.0.7': {}
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-color@3.1.3': {}
@@ -3039,6 +3115,8 @@ snapshots:
   '@types/hast@3.0.5':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/json-logic-js@2.0.5': {}
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -3115,6 +3193,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
+  '@xstate/fsm@1.6.5': {}
+
   agent-base@7.1.4: {}
 
   ansi-colors@4.1.3: {}
@@ -3155,6 +3235,8 @@ snapshots:
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
+
+  base64-arraybuffer@1.0.2: {}
 
   baseline-browser-mapping@2.11.15: {}
 
@@ -3453,6 +3535,8 @@ snapshots:
       - '@noble/hashes'
 
   jsesc@3.1.0: {}
+
+  json-logic-js@2.0.5: {}
 
   json-schema-traverse@1.0.0: {}
 
@@ -3927,6 +4011,16 @@ snapshots:
   minimatch@5.1.9:
     dependencies:
       brace-expansion: 2.1.4
+
+  mitt@3.0.1: {}
+
+  mixpanel-browser@2.82.1:
+    dependencies:
+      '@mixpanel/rrweb': 2.0.0-alpha.18.4
+      '@mixpanel/rrweb-plugin-console-record': 2.0.0-alpha.18.4(@mixpanel/rrweb-utils@2.0.0-alpha.18.4)(@mixpanel/rrweb@2.0.0-alpha.18.4)
+      '@mixpanel/rrweb-utils': 2.0.0-alpha.18.4
+      '@types/json-logic-js': 2.0.5
+      json-logic-js: 2.0.5
 
   ms@2.1.3: {}
 

--- a/web/src/app/TelemetryIdentity.tsx
+++ b/web/src/app/TelemetryIdentity.tsx
@@ -17,13 +17,13 @@ import { useTelemetry } from "@/shared/telemetry/overlayTelemetry"
  * **Withheld until consent is stored.** The identity is the one call that hands
  * a tracker something durable about a person, so this refuses to make it on an
  * undecided browser rather than leaving that decision to whichever module the
- * build resolved the seam to. The base build answers `"unknown"` and always
- * will, so nothing is sent here; a replacement that stores a decision is what
- * turns this on, and flipping that decision re-runs this effect. This is
- * `otari-ai/frontend/src/app/AnalyticsIdentity.tsx`'s gate, kept on the base
- * side of the seam. Withdrawing a decision is the other half of it and forgets
- * an identity already sent, which is the case a gate written only as an early
- * return would miss.
+ * build resolved the seam to. A build with no Mixpanel key answers `"unknown"`,
+ * so nothing is sent there; a key, or a replacement that stores a real
+ * decision, is what turns this on, and flipping that answer re-runs this
+ * effect. This is `otari-ai/frontend/src/app/AnalyticsIdentity.tsx`'s gate,
+ * kept on the base side of the seam. Withdrawing a decision is the other half
+ * of it and forgets an identity already sent, which is the case a gate written
+ * only as an early return would miss.
  *
  * The fields are read out before the effect rather than assembled into an
  * object in the render body, so the effect's dependencies are the values

--- a/web/src/shared/telemetry/mixpanelClient.test.ts
+++ b/web/src/shared/telemetry/mixpanelClient.test.ts
@@ -136,6 +136,27 @@ describe("createMixpanelTelemetry", () => {
     expect(identify).toHaveBeenCalledWith("member-2")
   })
 
+  it("records nothing when consent is not granted", async () => {
+    const { createMixpanelTelemetry } = await import("./mixpanelClient")
+    const telemetry = createMixpanelTelemetry("mp-test-token", "denied")
+
+    telemetry.recordEvent(TELEMETRY_EVENTS.LOGIN_SUCCESS, {
+      authentication_method: "password",
+    })
+
+    expect(telemetry.consent).toBe("denied")
+    expect(track).not.toHaveBeenCalled()
+  })
+
+  it("records nothing while no consent decision is stored", async () => {
+    const { createMixpanelTelemetry } = await import("./mixpanelClient")
+    const telemetry = createMixpanelTelemetry("mp-test-token", "unknown")
+
+    telemetry.recordEvent(TELEMETRY_EVENTS.LOGOUT)
+
+    expect(track).not.toHaveBeenCalled()
+  })
+
   it("resets Mixpanel when identify is handed null", async () => {
     const { createMixpanelTelemetry } = await import("./mixpanelClient")
     const telemetry = createMixpanelTelemetry("mp-test-token")

--- a/web/src/shared/telemetry/mixpanelClient.test.ts
+++ b/web/src/shared/telemetry/mixpanelClient.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { TELEMETRY_EVENTS } from "./events"
+import type { TelemetryIdentity } from "./types"
 
 const init = vi.fn()
 const track = vi.fn()
@@ -17,6 +18,16 @@ vi.mock("mixpanel-browser", () => ({
     people: { set: peopleSet },
   },
 }))
+
+function member(actorId: string): TelemetryIdentity {
+  return {
+    actorId,
+    sessionType: "local_operator",
+    organizationId: "org-1",
+    organizationName: "Default Organization",
+    role: "owner",
+  }
+}
 
 describe("createMixpanelTelemetry", () => {
   beforeEach(() => {
@@ -58,13 +69,7 @@ describe("createMixpanelTelemetry", () => {
     const { createMixpanelTelemetry } = await import("./mixpanelClient")
     const telemetry = createMixpanelTelemetry("mp-test-token")
 
-    telemetry.identify({
-      actorId: "member-1",
-      sessionType: "local_operator",
-      organizationId: "org-1",
-      organizationName: "Default Organization",
-      role: "owner",
-    })
+    telemetry.identify(member("member-1"))
 
     expect(identify).toHaveBeenCalledWith("member-1")
     expect(peopleSet).toHaveBeenCalledWith({
@@ -73,6 +78,62 @@ describe("createMixpanelTelemetry", () => {
       organization_name: "Default Organization",
       role: "owner",
     })
+  })
+
+  it("does not reset before the first identify", async () => {
+    const { createMixpanelTelemetry } = await import("./mixpanelClient")
+    const telemetry = createMixpanelTelemetry("mp-test-token")
+
+    telemetry.identify(member("member-1"))
+
+    expect(reset).not.toHaveBeenCalled()
+    expect(identify).toHaveBeenCalledWith("member-1")
+  })
+
+  it("does not reset when identifying the same actor again", async () => {
+    const { createMixpanelTelemetry } = await import("./mixpanelClient")
+    const telemetry = createMixpanelTelemetry("mp-test-token")
+
+    telemetry.identify(member("member-1"))
+    reset.mockClear()
+    identify.mockClear()
+
+    telemetry.identify(member("member-1"))
+
+    expect(reset).not.toHaveBeenCalled()
+    expect(identify).toHaveBeenCalledWith("member-1")
+  })
+
+  it("resets before identifying a different already-identified actor", async () => {
+    const { createMixpanelTelemetry } = await import("./mixpanelClient")
+    const telemetry = createMixpanelTelemetry("mp-test-token")
+
+    telemetry.identify(member("member-1"))
+    reset.mockClear()
+    identify.mockClear()
+
+    telemetry.identify(member("member-2"))
+
+    expect(reset).toHaveBeenCalledOnce()
+    expect(identify).toHaveBeenCalledWith("member-2")
+    expect(reset.mock.invocationCallOrder[0]).toBeLessThan(
+      identify.mock.invocationCallOrder[0],
+    )
+  })
+
+  it("does not reset on the first identify after a logout reset", async () => {
+    const { createMixpanelTelemetry } = await import("./mixpanelClient")
+    const telemetry = createMixpanelTelemetry("mp-test-token")
+
+    telemetry.identify(member("member-1"))
+    telemetry.identify(null)
+    reset.mockClear()
+    identify.mockClear()
+
+    telemetry.identify(member("member-2"))
+
+    expect(reset).not.toHaveBeenCalled()
+    expect(identify).toHaveBeenCalledWith("member-2")
   })
 
   it("resets Mixpanel when identify is handed null", async () => {

--- a/web/src/shared/telemetry/mixpanelClient.test.ts
+++ b/web/src/shared/telemetry/mixpanelClient.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TELEMETRY_EVENTS } from "./events"
+
+const init = vi.fn()
+const track = vi.fn()
+const identify = vi.fn()
+const reset = vi.fn()
+const peopleSet = vi.fn()
+
+vi.mock("mixpanel-browser", () => ({
+  default: {
+    init,
+    track,
+    identify,
+    reset,
+    people: { set: peopleSet },
+  },
+}))
+
+describe("createMixpanelTelemetry", () => {
+  beforeEach(() => {
+    init.mockClear()
+    track.mockClear()
+    identify.mockClear()
+    reset.mockClear()
+    peopleSet.mockClear()
+  })
+
+  it("inits without autocapture or invented pageviews", async () => {
+    const { createMixpanelTelemetry } = await import("./mixpanelClient")
+    createMixpanelTelemetry("mp-test-token")
+
+    expect(init).toHaveBeenCalledWith(
+      "mp-test-token",
+      expect.objectContaining({
+        autocapture: false,
+        track_pageview: false,
+        record_sessions_percent: 0,
+      }),
+    )
+  })
+
+  it("forwards recordEvent as mixpanel.track", async () => {
+    const { createMixpanelTelemetry } = await import("./mixpanelClient")
+    const telemetry = createMixpanelTelemetry("mp-test-token")
+
+    telemetry.recordEvent(TELEMETRY_EVENTS.LOGIN_SUCCESS, {
+      authentication_method: "password",
+    })
+
+    expect(track).toHaveBeenCalledWith("Login Success", {
+      authentication_method: "password",
+    })
+  })
+
+  it("identifies the actor and sets people properties", async () => {
+    const { createMixpanelTelemetry } = await import("./mixpanelClient")
+    const telemetry = createMixpanelTelemetry("mp-test-token")
+
+    telemetry.identify({
+      actorId: "member-1",
+      sessionType: "local_operator",
+      organizationId: "org-1",
+      organizationName: "Default Organization",
+      role: "owner",
+    })
+
+    expect(identify).toHaveBeenCalledWith("member-1")
+    expect(peopleSet).toHaveBeenCalledWith({
+      session_type: "local_operator",
+      organization_id: "org-1",
+      organization_name: "Default Organization",
+      role: "owner",
+    })
+  })
+
+  it("resets Mixpanel when identify is handed null", async () => {
+    const { createMixpanelTelemetry } = await import("./mixpanelClient")
+    const telemetry = createMixpanelTelemetry("mp-test-token")
+
+    telemetry.identify(null)
+
+    expect(reset).toHaveBeenCalledOnce()
+    expect(identify).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/shared/telemetry/mixpanelClient.test.ts
+++ b/web/src/shared/telemetry/mixpanelClient.test.ts
@@ -9,7 +9,7 @@ const identify = vi.fn()
 const reset = vi.fn()
 const peopleSet = vi.fn()
 
-vi.mock("mixpanel-browser", () => ({
+vi.mock("mixpanel-browser/dist/mixpanel-core.cjs.js", () => ({
   default: {
     init,
     track,
@@ -48,6 +48,9 @@ describe("createMixpanelTelemetry", () => {
         autocapture: false,
         track_pageview: false,
         record_sessions_percent: 0,
+        // The core entry has no recorder bundled, so remote settings must not
+        // be able to ask for one.
+        remote_settings_mode: "disabled",
       }),
     )
   })
@@ -155,6 +158,29 @@ describe("createMixpanelTelemetry", () => {
     telemetry.recordEvent(TELEMETRY_EVENTS.LOGOUT)
 
     expect(track).not.toHaveBeenCalled()
+  })
+
+  it("identifies nobody when consent is not granted", async () => {
+    const { createMixpanelTelemetry } = await import("./mixpanelClient")
+    const telemetry = createMixpanelTelemetry("mp-test-token", "denied")
+
+    telemetry.identify(member("member-1"))
+
+    expect(identify).not.toHaveBeenCalled()
+    expect(peopleSet).not.toHaveBeenCalled()
+    expect(reset).not.toHaveBeenCalled()
+  })
+
+  it("identifies nobody while no consent decision is stored", async () => {
+    const { createMixpanelTelemetry } = await import("./mixpanelClient")
+    const telemetry = createMixpanelTelemetry("mp-test-token", "unknown")
+
+    telemetry.identify(member("member-1"))
+    telemetry.identify(null)
+
+    expect(identify).not.toHaveBeenCalled()
+    expect(peopleSet).not.toHaveBeenCalled()
+    expect(reset).not.toHaveBeenCalled()
   })
 
   it("resets Mixpanel when identify is handed null", async () => {

--- a/web/src/shared/telemetry/mixpanelClient.ts
+++ b/web/src/shared/telemetry/mixpanelClient.ts
@@ -1,0 +1,76 @@
+/**
+ * Mixpanel-backed tracker. Loaded only through a dynamic import, and only
+ * after `readMixpanelToken()` has returned a value, so a build with no key
+ * never fetches this module or `mixpanel-browser`.
+ *
+ * The SDK's ESM build exports only a default (`export { mixpanel as default }`).
+ * Named imports type-check against its `.d.ts` and are `undefined` at runtime.
+ */
+
+import mixpanel from "mixpanel-browser"
+
+import type {
+  Telemetry,
+  TelemetryIdentity,
+  TelemetryProperties,
+} from "@/shared/telemetry/types"
+
+/**
+ * Init options that keep Mixpanel from inventing events of its own.
+ *
+ * Autocapture, pageviews, and session replay would record names that are not
+ * in `TELEMETRY_EVENTS`. The catalog is the whole of what this dashboard
+ * sends, so those features stay off.
+ */
+const MIXPANEL_INIT = {
+  autocapture: false,
+  track_pageview: false,
+  record_sessions_percent: 0,
+  verbose: false,
+  debug: false,
+} as const
+
+function toDict(
+  properties: TelemetryProperties | undefined,
+): Record<string, string | number | boolean | readonly string[]> | undefined {
+  if (properties === undefined) {
+    return undefined
+  }
+  const dict: Record<string, string | number | boolean | readonly string[]> = {}
+  for (const [key, value] of Object.entries(properties)) {
+    if (value !== undefined) {
+      dict[key] = value
+    }
+  }
+  return dict
+}
+
+function peopleProperties(identity: TelemetryIdentity): Record<string, string> {
+  return {
+    session_type: identity.sessionType,
+    organization_id: identity.organizationId,
+    organization_name: identity.organizationName,
+    role: identity.role,
+  }
+}
+
+export function createMixpanelTelemetry(token: string): Telemetry {
+  mixpanel.init(token, MIXPANEL_INIT)
+
+  return {
+    // A Mixpanel key is the deployment opt-in. This build has no consent UI,
+    // so the key is the gate: present means granted, absent never reaches here.
+    consent: "granted",
+    recordEvent: (event, properties) => {
+      mixpanel.track(event, toDict(properties))
+    },
+    identify: (identity) => {
+      if (identity === null) {
+        mixpanel.reset()
+        return
+      }
+      mixpanel.identify(identity.actorId)
+      mixpanel.people.set(peopleProperties(identity))
+    },
+  }
+}

--- a/web/src/shared/telemetry/mixpanelClient.ts
+++ b/web/src/shared/telemetry/mixpanelClient.ts
@@ -11,6 +11,7 @@ import mixpanel from "mixpanel-browser"
 
 import type {
   Telemetry,
+  TelemetryConsent,
   TelemetryIdentity,
   TelemetryProperties,
 } from "@/shared/telemetry/types"
@@ -54,7 +55,20 @@ function peopleProperties(identity: TelemetryIdentity): Record<string, string> {
   }
 }
 
-export function createMixpanelTelemetry(token: string): Telemetry {
+/**
+ * Build the Mixpanel-backed tracker.
+ *
+ * `consent` defaults to `"granted"` because a Mixpanel key is this
+ * deployment's opt-in and there is no consent UI to answer otherwise. It is a
+ * parameter rather than a constant because `types.ts` puts the `recordEvent`
+ * gate on whichever module implements the seam: `TelemetryIdentity` withholds
+ * only the identity, so without the check below a stored refusal would keep
+ * every event firing. A build that grows a real consent source passes it here.
+ */
+export function createMixpanelTelemetry(
+  token: string,
+  consent: TelemetryConsent = "granted",
+): Telemetry {
   mixpanel.init(token, MIXPANEL_INIT)
   // `actorId` is the active organization's membership id, so a switch
   // changes it. mixpanel-browser 2.82.1 `identify` always tracks `$identify`
@@ -67,10 +81,11 @@ export function createMixpanelTelemetry(token: string): Telemetry {
   let identifiedActor: string | undefined
 
   return {
-    // A Mixpanel key is the deployment opt-in. This build has no consent UI,
-    // so the key is the gate: present means granted, absent never reaches here.
-    consent: "granted",
+    consent,
     recordEvent: (event, properties) => {
+      if (consent !== "granted") {
+        return
+      }
       mixpanel.track(event, toDict(properties))
     },
     identify: (identity) => {

--- a/web/src/shared/telemetry/mixpanelClient.ts
+++ b/web/src/shared/telemetry/mixpanelClient.ts
@@ -56,6 +56,15 @@ function peopleProperties(identity: TelemetryIdentity): Record<string, string> {
 
 export function createMixpanelTelemetry(token: string): Telemetry {
   mixpanel.init(token, MIXPANEL_INIT)
+  // `actorId` is the active organization's membership id, so a switch
+  // changes it. mixpanel-browser 2.82.1 `identify` always tracks `$identify`
+  // with `$anon_distinct_id` set to the previous `distinct_id`, and the
+  // server merges those two. That is the anonymous-to-first-user link we
+  // want on the first identify (and after `reset`). It is not what we want
+  // when the previous id is another membership: that would cluster two
+  // actors. Remember the last identified membership and `reset` before a
+  // different one so the previous id is a fresh `$device:` id, not a peer.
+  let identifiedActor: string | undefined
 
   return {
     // A Mixpanel key is the deployment opt-in. This build has no consent UI,
@@ -66,9 +75,17 @@ export function createMixpanelTelemetry(token: string): Telemetry {
     },
     identify: (identity) => {
       if (identity === null) {
+        identifiedActor = undefined
         mixpanel.reset()
         return
       }
+      if (
+        identifiedActor !== undefined &&
+        identifiedActor !== identity.actorId
+      ) {
+        mixpanel.reset()
+      }
+      identifiedActor = identity.actorId
       mixpanel.identify(identity.actorId)
       mixpanel.people.set(peopleProperties(identity))
     },

--- a/web/src/shared/telemetry/mixpanelClient.ts
+++ b/web/src/shared/telemetry/mixpanelClient.ts
@@ -3,11 +3,15 @@
  * after `readMixpanelToken()` has returned a value, so a build with no key
  * never fetches this module or `mixpanel-browser`.
  *
- * The SDK's ESM build exports only a default (`export { mixpanel as default }`).
- * Named imports type-check against its `.d.ts` and are `undefined` at runtime.
+ * Imported by its **core** entry point, not the package root. The root resolves
+ * to `dist/mixpanel.module.js`, which statically bundles the rrweb session
+ * recorder; `dist/mixpanel-core.cjs.js` is the same API with the recorder left
+ * out, and the recorder is code `record_sessions_percent: 0` guarantees never
+ * runs. It exports only a default; named imports type-check against its
+ * `.d.ts` and are `undefined` at runtime.
  */
 
-import mixpanel from "mixpanel-browser"
+import mixpanel from "mixpanel-browser/dist/mixpanel-core.cjs.js"
 
 import type {
   Telemetry,
@@ -21,12 +25,16 @@ import type {
  *
  * Autocapture, pageviews, and session replay would record names that are not
  * in `TELEMETRY_EVENTS`. The catalog is the whole of what this dashboard
- * sends, so those features stay off.
+ * sends, so those features stay off, and remote settings may not turn them
+ * back on.
  */
 const MIXPANEL_INIT = {
   autocapture: false,
   track_pageview: false,
   record_sessions_percent: 0,
+  // The core build has no recorder to load, so remote settings must not be
+  // able to ask for one: it would throw rather than record.
+  remote_settings_mode: "disabled",
   verbose: false,
   debug: false,
 } as const
@@ -60,10 +68,11 @@ function peopleProperties(identity: TelemetryIdentity): Record<string, string> {
  *
  * `consent` defaults to `"granted"` because a Mixpanel key is this
  * deployment's opt-in and there is no consent UI to answer otherwise. It is a
- * parameter rather than a constant because `types.ts` puts the `recordEvent`
- * gate on whichever module implements the seam: `TelemetryIdentity` withholds
- * only the identity, so without the check below a stored refusal would keep
- * every event firing. A build that grows a real consent source passes it here.
+ * parameter rather than a constant because `types.ts` puts the gate on
+ * whichever module implements the seam, and both calls carry it here:
+ * `TelemetryIdentity` withholds only the identity, and it reads `consent` off
+ * the queued wrapper, which cannot know the answer before the chunk resolves.
+ * A build that grows a real consent source passes it here.
  */
 export function createMixpanelTelemetry(
   token: string,
@@ -89,6 +98,9 @@ export function createMixpanelTelemetry(
       mixpanel.track(event, toDict(properties))
     },
     identify: (identity) => {
+      if (consent !== "granted") {
+        return
+      }
       if (identity === null) {
         identifiedActor = undefined
         mixpanel.reset()

--- a/web/src/shared/telemetry/mixpanelToken.test.ts
+++ b/web/src/shared/telemetry/mixpanelToken.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+
+import { isLocalDashboard } from "./mixpanelToken"
+
+describe("isLocalDashboard", () => {
+  it("is true for Vite DEV even on a public hostname", () => {
+    expect(isLocalDashboard("example.com", true)).toBe(true)
+  })
+
+  it("is true for make-dev loopback hosts on a production bundle", () => {
+    expect(isLocalDashboard("localhost", false)).toBe(true)
+    expect(isLocalDashboard("127.0.0.1", false)).toBe(true)
+    expect(isLocalDashboard("[::1]", false)).toBe(true)
+  })
+
+  it("is false for a deployed host on a production bundle", () => {
+    expect(isLocalDashboard("example.com", false)).toBe(false)
+    expect(isLocalDashboard("otari.example", false)).toBe(false)
+  })
+})

--- a/web/src/shared/telemetry/mixpanelToken.test.ts
+++ b/web/src/shared/telemetry/mixpanelToken.test.ts
@@ -1,6 +1,27 @@
 import { describe, expect, it } from "vitest"
 
-import { isLocalDashboard } from "./mixpanelToken"
+import { isLocalDashboard, readMixpanelToken } from "./mixpanelToken"
+
+describe("readMixpanelToken", () => {
+  it("maps a missing or non-string value to undefined", () => {
+    expect(readMixpanelToken(undefined)).toBeUndefined()
+    expect(readMixpanelToken(null)).toBeUndefined()
+    expect(readMixpanelToken(1)).toBeUndefined()
+  })
+
+  it("maps an empty string to undefined", () => {
+    expect(readMixpanelToken("")).toBeUndefined()
+  })
+
+  it("maps whitespace-only to undefined", () => {
+    expect(readMixpanelToken("   ")).toBeUndefined()
+    expect(readMixpanelToken("\n\t")).toBeUndefined()
+  })
+
+  it("trims a valid token", () => {
+    expect(readMixpanelToken("  tok  ")).toBe("tok")
+  })
+})
 
 describe("isLocalDashboard", () => {
   it("is true for Vite DEV even on a public hostname", () => {

--- a/web/src/shared/telemetry/mixpanelToken.test.ts
+++ b/web/src/shared/telemetry/mixpanelToken.test.ts
@@ -4,7 +4,9 @@ import { isLocalDashboard, readMixpanelToken } from "./mixpanelToken"
 
 describe("readMixpanelToken", () => {
   it("maps a missing or non-string value to undefined", () => {
-    expect(readMixpanelToken(undefined)).toBeUndefined()
+    // Do not pass `undefined`: that triggers the default parameter and reads
+    // `import.meta.env.VITE_MIXPANEL_TOKEN`, so a Vitest process with a token
+    // would fail this assertion. `null` and `1` cover the non-string arm.
     expect(readMixpanelToken(null)).toBeUndefined()
     expect(readMixpanelToken(1)).toBeUndefined()
   })

--- a/web/src/shared/telemetry/mixpanelToken.test.ts
+++ b/web/src/shared/telemetry/mixpanelToken.test.ts
@@ -26,18 +26,13 @@ describe("readMixpanelToken", () => {
 })
 
 describe("isLocalDashboard", () => {
-  it("is true for Vite DEV even on a public hostname", () => {
-    expect(isLocalDashboard("example.com", true)).toBe(true)
+  it("is true for Vite DEV", () => {
+    expect(isLocalDashboard(true)).toBe(true)
   })
 
-  it("is true for make-dev loopback hosts on a production bundle", () => {
-    expect(isLocalDashboard("localhost", false)).toBe(true)
-    expect(isLocalDashboard("127.0.0.1", false)).toBe(true)
-    expect(isLocalDashboard("[::1]", false)).toBe(true)
-  })
-
-  it("is false for a deployed host on a production bundle", () => {
-    expect(isLocalDashboard("example.com", false)).toBe(false)
-    expect(isLocalDashboard("otari.example", false)).toBe(false)
+  it("is false for a production bundle, loopback included", () => {
+    // A self-hosted gateway is a production build on localhost:8000, so a
+    // loopback hostname must not earn the "Mixpanel not initialized" line.
+    expect(isLocalDashboard(false)).toBe(false)
   })
 })

--- a/web/src/shared/telemetry/mixpanelToken.ts
+++ b/web/src/shared/telemetry/mixpanelToken.ts
@@ -1,0 +1,35 @@
+/**
+ * The Mixpanel project token the dashboard was built with, if any.
+ *
+ * Vite only exposes `VITE_*` to the client, and it inlines the value at build
+ * time (`make dashboard`, `pnpm run dev`, the Docker web stage). An empty or
+ * whitespace-only value is treated as absent: that is the OSS default, and it
+ * is what keeps the SDK from loading.
+ */
+export function readMixpanelToken(): string | undefined {
+  const raw = import.meta.env.VITE_MIXPANEL_TOKEN
+  if (typeof raw !== "string") {
+    return undefined
+  }
+  const token = raw.trim()
+  return token === "" ? undefined : token
+}
+
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"])
+
+/**
+ * Whether this page is a local dashboard, the case that may announce a missing
+ * Mixpanel key.
+ *
+ * `make dev` serves a production Vite build on localhost, so `import.meta.env.DEV`
+ * is false there and cannot be the only signal. A deployed OSS host is neither
+ * DEV nor a loopback name, and must stay silent.
+ */
+export function isLocalDashboard(
+  hostname: string = typeof window === "undefined"
+    ? ""
+    : window.location.hostname,
+  isDev: boolean = import.meta.env.DEV,
+): boolean {
+  return isDev || LOCAL_HOSTS.has(hostname)
+}

--- a/web/src/shared/telemetry/mixpanelToken.ts
+++ b/web/src/shared/telemetry/mixpanelToken.ts
@@ -6,8 +6,9 @@
  * whitespace-only value is treated as absent: that is the OSS default, and it
  * is what keeps the SDK from loading.
  */
-export function readMixpanelToken(): string | undefined {
-  const raw = import.meta.env.VITE_MIXPANEL_TOKEN
+export function readMixpanelToken(
+  raw: unknown = import.meta.env.VITE_MIXPANEL_TOKEN,
+): string | undefined {
   if (typeof raw !== "string") {
     return undefined
   }

--- a/web/src/shared/telemetry/mixpanelToken.ts
+++ b/web/src/shared/telemetry/mixpanelToken.ts
@@ -16,21 +16,19 @@ export function readMixpanelToken(
   return token === "" ? undefined : token
 }
 
-const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"])
-
 /**
- * Whether this page is a local dashboard, the case that may announce a missing
- * Mixpanel key.
+ * Whether this page is a dev-server dashboard, the one case that may announce a
+ * missing Mixpanel key.
  *
- * `make dev` serves a production Vite build on localhost, so `import.meta.env.DEV`
- * is false there and cannot be the only signal. A deployed OSS host is neither
- * DEV nor a loopback name, and must stay silent.
+ * Deliberately the Vite DEV flag alone, and not a loopback hostname: a
+ * self-hosted gateway is a production build on `http://localhost:8000/` (the
+ * address `README.md` and `docs/dashboard.md` both tell operators to open), so
+ * a hostname test cannot tell an OSS operator from a mozilla.ai developer and
+ * would tell every operator that Mixpanel failed to start. `make dev` serves a
+ * production build and so loses the reminder; `pnpm run dev` still has it.
  */
 export function isLocalDashboard(
-  hostname: string = typeof window === "undefined"
-    ? ""
-    : window.location.hostname,
   isDev: boolean = import.meta.env.DEV,
 ): boolean {
-  return isDev || LOCAL_HOSTS.has(hostname)
+  return isDev
 }

--- a/web/src/shared/telemetry/overlayTelemetry.test.ts
+++ b/web/src/shared/telemetry/overlayTelemetry.test.ts
@@ -148,6 +148,37 @@ describe("createTelemetry with a key", () => {
     createTelemetry(undefined, { isLocal: false, loadClient, log: vi.fn() })
     expect(loadClient).not.toHaveBeenCalled()
   })
+
+  it("discards the in-flight queue and later calls after load failure", async () => {
+    let rejectLoad!: (reason: unknown) => void
+    const loadClient = vi.fn(
+      () =>
+        new Promise<Telemetry>((_, reject) => {
+          rejectLoad = reject
+        }),
+    )
+
+    const telemetry = createTelemetry("mp-test-token", {
+      isLocal: false,
+      loadClient,
+      log: vi.fn(),
+    })
+
+    telemetry.recordEvent(TELEMETRY_EVENTS.LOGIN_SUCCESS, {
+      authentication_method: "password",
+    })
+    telemetry.identify(identity())
+
+    const load = loadClient.mock.results[0]?.value as Promise<Telemetry>
+    rejectLoad(new Error("chunk failed"))
+    await expect(load).rejects.toThrow("chunk failed")
+
+    expect(() => {
+      telemetry.recordEvent(TELEMETRY_EVENTS.LOGOUT)
+      telemetry.identify(null)
+    }).not.toThrow()
+    expect(loadClient).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe("the base telemetry seam", () => {

--- a/web/src/shared/telemetry/overlayTelemetry.test.ts
+++ b/web/src/shared/telemetry/overlayTelemetry.test.ts
@@ -1,23 +1,32 @@
 import { readdirSync, readFileSync } from "node:fs"
 import { join } from "node:path"
 
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { TELEMETRY_EVENTS } from "./events"
-import { useTelemetry } from "./overlayTelemetry"
+import {
+  createTelemetry,
+  loadMixpanelClient,
+  useTelemetry,
+} from "./overlayTelemetry"
+import type { Telemetry } from "./types"
 
 // Resolved from the Vitest root (web/) rather than from import.meta.url, which
 // the jsdom environment reports as an http URL. Same reason as
 // `src/architecture.test.ts`.
 const WEB = process.cwd()
 
+const TELEMETRY_DIR = join(WEB, "src", "shared", "telemetry")
+
 /**
  * Names an analytics, error-reporting or support vendor whose SDK would put
  * telemetry in the bundle. Substrings, because a package can arrive scoped
  * (`@sentry/react`) or suffixed (`mixpanel-browser`).
+ *
+ * `mixpanel-browser` is the one allowed vendor: it may be declared, and it
+ * may only load when a Mixpanel key is present.
  */
-const VENDORS = [
-  "mixpanel",
+const OTHER_VENDORS = [
   "matomo",
   "piwik",
   "intercom",
@@ -35,60 +44,155 @@ const VENDORS = [
   "google-analytics",
 ]
 
-describe("the base telemetry seam", () => {
-  it("records nothing", () => {
-    const telemetry = useTelemetry()
+const ALLOWED_MIXPANEL = "mixpanel-browser"
 
-    // A no-op has no observable effect to assert, so what is asserted is that
-    // calling it neither throws nor answers with anything: an implementation
-    // that started returning a queue, a client, or a promise would be doing
-    // something, and this build is meant to do nothing.
+function identity() {
+  return {
+    actorId: "member-1",
+    sessionType: "local_operator" as const,
+    organizationId: "org-1",
+    organizationName: "Default Organization",
+    role: "owner",
+  }
+}
+
+describe("createTelemetry without a key", () => {
+  it("records nothing and does not load the SDK", () => {
+    const loadClient = vi.fn<(token: string) => Promise<Telemetry>>()
+    const log = vi.fn()
+    const telemetry = createTelemetry(undefined, {
+      isLocal: false,
+      loadClient,
+      log,
+    })
+
     expect(
       telemetry.recordEvent(TELEMETRY_EVENTS.LOGIN_SUCCESS, {
         authentication_method: "password",
       }),
     ).toBeUndefined()
-    expect(
-      telemetry.identify({
-        actorId: "member-1",
-        sessionType: "local_operator",
-        organizationId: "org-1",
-        organizationName: "Default Organization",
-        role: "owner",
-      }),
-    ).toBeUndefined()
+    expect(telemetry.identify(identity())).toBeUndefined()
     expect(telemetry.identify(null)).toBeUndefined()
+    expect(loadClient).not.toHaveBeenCalled()
+    expect(log).not.toHaveBeenCalled()
   })
 
   it("reports no stored consent decision, which is not consent", () => {
-    // "unknown" rather than "granted": a build with no consent UI has asked
-    // nobody. `TelemetryIdentity` is what turns that into a withheld identity.
+    expect(
+      createTelemetry(undefined, { isLocal: false, log: vi.fn() }).consent,
+    ).toBe("unknown")
+  })
+
+  it("logs Mixpanel not initialized once on a local dashboard, then stops", () => {
+    const loadClient = vi.fn<(token: string) => Promise<Telemetry>>()
+    const log = vi.fn()
+    const telemetry = createTelemetry(undefined, {
+      isLocal: true,
+      loadClient,
+      log,
+    })
+
+    telemetry.recordEvent(TELEMETRY_EVENTS.LOGOUT)
+    telemetry.recordEvent(TELEMETRY_EVENTS.LOGIN_FAILED)
+    telemetry.identify(null)
+
+    expect(log).toHaveBeenCalledTimes(1)
+    expect(log).toHaveBeenCalledWith("Mixpanel not initialized")
+    expect(loadClient).not.toHaveBeenCalled()
+  })
+
+  it("stays silent on a deployed host without a key", () => {
+    const log = vi.fn()
+    createTelemetry(undefined, { isLocal: false, log, loadClient: vi.fn() })
+    expect(log).not.toHaveBeenCalled()
+  })
+})
+
+describe("createTelemetry with a key", () => {
+  it("loads the Mixpanel client and forwards events", async () => {
+    const recordEvent = vi.fn<(event: string, properties?: object) => void>()
+    const identify = vi.fn()
+    const loaded: Telemetry = {
+      consent: "granted",
+      recordEvent,
+      identify,
+    }
+    const loadClient = vi.fn(async () => loaded)
+    const log = vi.fn()
+
+    const telemetry = createTelemetry("mp-test-token", {
+      isLocal: true,
+      loadClient,
+      log,
+    })
+
+    expect(telemetry.consent).toBe("granted")
+    expect(loadClient).toHaveBeenCalledWith("mp-test-token")
+    expect(log).not.toHaveBeenCalled()
+
+    telemetry.recordEvent(TELEMETRY_EVENTS.LOGIN_SUCCESS, {
+      authentication_method: "password",
+    })
+    telemetry.identify(identity())
+
+    await vi.waitFor(() => {
+      expect(recordEvent).toHaveBeenCalledWith("Login Success", {
+        authentication_method: "password",
+      })
+      expect(identify).toHaveBeenCalledWith(identity())
+    })
+  })
+
+  it("does not load Mixpanel when the key is absent even if loadClient is supplied", () => {
+    const loadClient = vi.fn<(token: string) => Promise<Telemetry>>()
+    createTelemetry(undefined, { isLocal: false, loadClient, log: vi.fn() })
+    expect(loadClient).not.toHaveBeenCalled()
+  })
+})
+
+describe("the base telemetry seam", () => {
+  it("records nothing when this process has no Mixpanel key", () => {
+    const telemetry = useTelemetry()
+
+    expect(
+      telemetry.recordEvent(TELEMETRY_EVENTS.LOGIN_SUCCESS, {
+        authentication_method: "password",
+      }),
+    ).toBeUndefined()
+    expect(telemetry.identify(identity())).toBeUndefined()
+    expect(telemetry.identify(null)).toBeUndefined()
+  })
+
+  it("reports no stored consent decision without a key", () => {
     expect(useTelemetry().consent).toBe("unknown")
   })
 
   it("answers with one stable object, as a replacement must", () => {
-    // `TelemetryIdentity` holds `identify` and `consent` in an effect's
-    // dependencies, so a tracker handing out a fresh object each call would
-    // re-identify forever. The base default is the reference for that contract.
     expect(useTelemetry()).toBe(useTelemetry())
   })
 
-  it("imports nothing but its own contract", () => {
+  it("does not statically import mixpanel-browser", () => {
     const source = readFileSync(
-      join(WEB, "src", "shared", "telemetry", "overlayTelemetry.ts"),
+      join(TELEMETRY_DIR, "overlayTelemetry.ts"),
       "utf8",
     )
-    const imports = [...source.matchAll(/from\s+"([^"]+)"/g)].map(
-      (match) => match[1],
+
+    expect(source).not.toMatch(/from\s+["']mixpanel-browser["']/)
+    expect(source).not.toMatch(/import\s+["']mixpanel-browser["']/)
+  })
+
+  it("loads the Mixpanel client only through a dynamic import", () => {
+    const source = readFileSync(
+      join(TELEMETRY_DIR, "overlayTelemetry.ts"),
+      "utf8",
     )
 
-    // The seam is what an OSS build ships, so it may not reach a vendor SDK
-    // even lazily. The contract is the whole of it; `events.ts` is not needed
-    // here because this module names no event. Asserted in its `@/…` form
-    // rather than as `./types`, which is the point of the note on that import:
-    // a replacement lives in the overlay's tree, where a relative sibling path
-    // would resolve somewhere else entirely.
-    expect(imports).toEqual(["@/shared/telemetry/types"])
+    expect(source).toMatch(
+      /import\(\s*["']@\/shared\/telemetry\/mixpanelClient["']\s*\)/,
+    )
+    expect(source).not.toMatch(
+      /from\s+["']@\/shared\/telemetry\/mixpanelClient["']/,
+    )
   })
 })
 
@@ -100,20 +204,18 @@ describe("the base build's dependencies", () => {
     devDependencies?: Record<string, string>
   }
 
-  it("declare no telemetry vendor", () => {
-    // The other half of "the base emits nothing": a dashboard that shipped an
-    // analytics SDK and merely declined to call it would still hand every
-    // operator's browser a script from a third party. devDependencies are
-    // checked too, because Vite bundles from the import graph and not from
-    // which section of the manifest a package was declared in.
+  it("may declare mixpanel-browser and no other telemetry vendor", () => {
     const declared = [
       ...Object.keys(manifest.dependencies ?? {}),
       ...Object.keys(manifest.devDependencies ?? {}),
     ]
 
+    expect(declared).toContain(ALLOWED_MIXPANEL)
     expect(
-      declared.filter((name) =>
-        VENDORS.some((vendor) => name.toLowerCase().includes(vendor)),
+      declared.filter(
+        (name) =>
+          name !== ALLOWED_MIXPANEL &&
+          OTHER_VENDORS.some((vendor) => name.toLowerCase().includes(vendor)),
       ),
     ).toEqual([])
   })
@@ -193,9 +295,6 @@ describe("the wiring behind the catalog", () => {
       (name) => !NOT_FIRED_HERE.includes(name),
     ),
   )("records %s from a base source file", (name) => {
-    // A name nothing fires is a step of the funnel a superset build would
-    // silently lose: the base default records nothing either way, so no test
-    // that mocks the seam fails when a call site quietly goes away.
     expect(
       sources.some(({ source }) => source.includes(`TELEMETRY_EVENTS.${name}`)),
     ).toBe(true)
@@ -207,5 +306,31 @@ describe("the wiring behind the catalog", () => {
         source.includes(`TELEMETRY_EVENTS.${name}`),
       ),
     ).toEqual([])
+  })
+})
+
+describe("always-loaded telemetry modules", () => {
+  it("never statically import mixpanel-browser", () => {
+    const alwaysLoaded = [
+      "overlayTelemetry.ts",
+      "mixpanelToken.ts",
+      "events.ts",
+      "types.ts",
+      "errorCode.ts",
+    ]
+    for (const name of alwaysLoaded) {
+      const source = readFileSync(join(TELEMETRY_DIR, name), "utf8")
+      expect(source, name).not.toMatch(/from\s+["']mixpanel-browser["']/)
+      expect(source, name).not.toMatch(/import\s+["']mixpanel-browser["']/)
+    }
+  })
+})
+
+describe("loadMixpanelClient", () => {
+  it("is the dynamic import used only after a key is present", () => {
+    // The function exists so Vite puts mixpanel-browser in an async chunk.
+    // Calling it without a key is what the gate above forbids; this only
+    // asserts the export stays a function the queued tracker can call.
+    expect(typeof loadMixpanelClient).toBe("function")
   })
 })

--- a/web/src/shared/telemetry/overlayTelemetry.test.ts
+++ b/web/src/shared/telemetry/overlayTelemetry.test.ts
@@ -46,6 +46,11 @@ const OTHER_VENDORS = [
 
 const ALLOWED_MIXPANEL = "mixpanel-browser"
 
+// Any static import of the vendor, under any of its entry points.
+// mixpanelClient.ts imports it as "mixpanel-browser/dist/mixpanel-core.cjs.js",
+// so a pattern anchored on the bare specifier would let a deep one through.
+const VENDOR_IMPORT = /(?:from|import)\s+["']mixpanel-browser(?:\/[^"']*)?["']/
+
 function identity() {
   return {
     actorId: "member-1",
@@ -208,8 +213,7 @@ describe("the base telemetry seam", () => {
       "utf8",
     )
 
-    expect(source).not.toMatch(/from\s+["']mixpanel-browser["']/)
-    expect(source).not.toMatch(/import\s+["']mixpanel-browser["']/)
+    expect(source).not.toMatch(VENDOR_IMPORT)
   })
 
   it("loads the Mixpanel client only through a dynamic import", () => {
@@ -351,9 +355,40 @@ describe("always-loaded telemetry modules", () => {
     ]
     for (const name of alwaysLoaded) {
       const source = readFileSync(join(TELEMETRY_DIR, name), "utf8")
-      expect(source, name).not.toMatch(/from\s+["']mixpanel-browser["']/)
-      expect(source, name).not.toMatch(/import\s+["']mixpanel-browser["']/)
+      expect(source, name).not.toMatch(VENDOR_IMPORT)
     }
+  })
+})
+
+describe("keyless build", () => {
+  // The runtime gate stops the SDK being fetched; it cannot stop Rolldown
+  // writing it to disk, because the dynamic import earns its own chunk from the
+  // module graph before dead code is eliminated. `excludeMixpanelWithoutKey` in
+  // vite.config.ts replaces the client module with an inert stub when no key is
+  // configured, which is what keeps mixpanel-browser out of an OSS artifact.
+  // These pin the two halves that have to agree: which module id the plugin
+  // matches, and that the stub satisfies the seam's contract.
+  const config = readFileSync(join(WEB, "vite.config.ts"), "utf8")
+
+  it("replaces the module the client actually lives in", () => {
+    const match = config.match(/const MIXPANEL_CLIENT = "([^"]+)"/)
+    expect(match?.[1]).toBe("src/shared/telemetry/mixpanelClient.ts")
+    expect(
+      readdirSync(TELEMETRY_DIR).includes("mixpanelClient.ts"),
+      "the path MIXPANEL_CLIENT names must exist",
+    ).toBe(true)
+  })
+
+  it("stubs the export loadMixpanelClient calls, answering no consent", () => {
+    const stub = config.slice(config.indexOf("const MIXPANEL_STUB"))
+    expect(stub).toMatch(/createMixpanelTelemetry/)
+    expect(stub).toMatch(/consent: \\?"unknown\\?"/)
+    expect(stub).toMatch(/recordEvent/)
+    expect(stub).toMatch(/identify/)
+  })
+
+  it("only stubs a build, so the dev server keeps the real client", () => {
+    expect(config).toMatch(/apply: "build"/)
   })
 })
 

--- a/web/src/shared/telemetry/overlayTelemetry.ts
+++ b/web/src/shared/telemetry/overlayTelemetry.ts
@@ -1,52 +1,110 @@
+import {
+  isLocalDashboard,
+  readMixpanelToken,
+} from "@/shared/telemetry/mixpanelToken"
 import type { Telemetry } from "@/shared/telemetry/types"
 
 /**
- * The tracker the base build ships, and it records nothing.
+ * The tracker the dashboard ships.
  *
- * This dashboard carries no telemetry, and that is the correct state rather
- * than an omission: `web/package.json` declares no analytics vendor, and an OSS
- * gateway that reported to one by default would be a defect. What this module
- * adds is a **seam**, not telemetry. The base default stays a genuine no-op and
- * pulls in no dependency, so an OSS build is free of telemetry code as well as
- * of telemetry traffic.
+ * Gated by key presence, not by edition. `VITE_MIXPANEL_TOKEN` is inlined at
+ * build time. Without a token this module records nothing, loads no SDK, and
+ * (on a local dashboard only) logs `Mixpanel not initialized` once. With a
+ * token it dynamically imports `mixpanelClient`, which is the only module
+ * that may touch `mixpanel-browser`.
  *
- * An overlay replaces this module at build time to record the events its own
- * deployment has consent for. The events worth recording are fired from the
- * sign-in screen, the signup and verification pages, and the sidebar, all of
- * which are Otari's files; without this seam an overlay would have to edit them,
- * which ARCHITECTURE.md's "cardinal rules for contributors" rule 6 forbids, or
- * re-implement those pages, which is the duplicate shell this track exists to
- * retire.
+ * **Reach it by its `@/…` specifier.** An overlay may still replace this file
+ * at build time. A relative import of the seam would miss that alias. Same
+ * pattern as `src/app/nav/overlaySections.ts`.
  *
- * **Reach it by its `@/…` specifier.** The override is an exact-match alias on
- * `@/shared/telemetry/overlayTelemetry` in the superset build's Vite config
- * (the `ee_else_ce` mechanism; `otari-ai/frontend/vite.config.ts` is the working
- * one). A relative import resolves to a file path that alias never sees, so it
- * would quietly keep this no-op in every edition and the events would go
- * missing with no error anywhere. Same seam pattern as
- * `src/app/nav/overlaySections.ts`, one grain wider: a cross-cutting module
- * rather than a nav contribution.
- *
- * The shape a replacement implements is `types.ts` beside this file, and the
- * names it receives are `events.ts`. Neither is swapped: both sides of the
- * override read one declaration of each, so a replacement cannot drift from the
- * vocabulary its call sites use.
- *
- * Which is why the import below is `@/shared/telemetry/types` and not the
- * `./types` a same-directory sibling would ordinarily be written as. A
- * replacement is a file in the overlay's own tree, not in this directory, so a
- * relative sibling path is the one thing in this module that cannot survive
- * being copied: over there it would resolve against the overlay directory and
- * either fail to resolve or, worse, find something else. Written this way, the
- * file is copyable verbatim.
+ * The contract lives in `types.ts` and the names in `events.ts`. Neither is
+ * swapped. This file imports the contract as `@/shared/telemetry/types` so a
+ * replacement copied into an overlay tree still resolves it.
  */
+
+const UNINITIALIZED_MESSAGE = "Mixpanel not initialized"
+
 const NO_TELEMETRY: Telemetry = {
-  // Not "denied": nothing has been asked and nothing decided. A build that adds
-  // a consent UI is what turns this into an answer.
+  // Not "denied": nothing has been asked and nothing decided. A missing key
+  // is not a stored refusal; it is the absence of a tracker.
   consent: "unknown",
   recordEvent: () => undefined,
   identify: () => undefined,
 }
+
+export async function loadMixpanelClient(token: string): Promise<Telemetry> {
+  const { createMixpanelTelemetry } = await import(
+    "@/shared/telemetry/mixpanelClient"
+  )
+  return createMixpanelTelemetry(token)
+}
+
+function createQueuedTelemetry(
+  token: string,
+  loadClient: (token: string) => Promise<Telemetry>,
+): Telemetry {
+  let client: Telemetry | undefined
+  const pending: Array<(loaded: Telemetry) => void> = []
+
+  void loadClient(token)
+    .then((loaded) => {
+      client = loaded
+      for (const apply of pending) {
+        apply(loaded)
+      }
+      pending.length = 0
+    })
+    .catch(() => {
+      pending.length = 0
+    })
+
+  const enqueue = (apply: (loaded: Telemetry) => void): void => {
+    if (client) {
+      apply(client)
+      return
+    }
+    pending.push(apply)
+  }
+
+  return {
+    consent: "granted",
+    recordEvent: (event, properties) => {
+      enqueue((loaded) => {
+        loaded.recordEvent(event, properties)
+      })
+    },
+    identify: (identity) => {
+      enqueue((loaded) => {
+        loaded.identify(identity)
+      })
+    },
+  }
+}
+
+export function createTelemetry(
+  token: string | undefined = readMixpanelToken(),
+  {
+    isLocal = isLocalDashboard(),
+    loadClient = loadMixpanelClient,
+    log = (message: string): void => {
+      console.info(message)
+    },
+  }: {
+    isLocal?: boolean
+    loadClient?: (token: string) => Promise<Telemetry>
+    log?: (message: string) => void
+  } = {},
+): Telemetry {
+  if (token === undefined) {
+    if (isLocal) {
+      log(UNINITIALIZED_MESSAGE)
+    }
+    return NO_TELEMETRY
+  }
+  return createQueuedTelemetry(token, loadClient)
+}
+
+let cached: Telemetry | undefined
 
 /**
  * A hook rather than bare functions, for the two reasons the platform's
@@ -57,5 +115,6 @@ const NO_TELEMETRY: Telemetry = {
  * dependencies, and a fresh object each render would re-identify forever.
  */
 export function useTelemetry(): Telemetry {
-  return NO_TELEMETRY
+  cached ??= createTelemetry()
+  return cached
 }

--- a/web/src/shared/telemetry/overlayTelemetry.ts
+++ b/web/src/shared/telemetry/overlayTelemetry.ts
@@ -44,10 +44,14 @@ function createQueuedTelemetry(
   loadClient: (token: string) => Promise<Telemetry>,
 ): Telemetry {
   let client: Telemetry | undefined
+  let failed = false
   const pending: Array<(loaded: Telemetry) => void> = []
 
   void loadClient(token)
     .then((loaded) => {
+      if (failed) {
+        return
+      }
       client = loaded
       for (const apply of pending) {
         apply(loaded)
@@ -55,10 +59,15 @@ function createQueuedTelemetry(
       pending.length = 0
     })
     .catch(() => {
+      failed = true
       pending.length = 0
+      client = NO_TELEMETRY
     })
 
   const enqueue = (apply: (loaded: Telemetry) => void): void => {
+    if (failed) {
+      return
+    }
     if (client) {
       apply(client)
       return

--- a/web/src/shared/telemetry/overlayTelemetry.ts
+++ b/web/src/shared/telemetry/overlayTelemetry.ts
@@ -49,9 +49,6 @@ function createQueuedTelemetry(
 
   void loadClient(token)
     .then((loaded) => {
-      if (failed) {
-        return
-      }
       client = loaded
       for (const apply of pending) {
         apply(loaded)
@@ -59,9 +56,11 @@ function createQueuedTelemetry(
       pending.length = 0
     })
     .catch(() => {
+      // A failed chunk is never retried, so drop the queue and stop taking
+      // new work: otherwise every later call retains a closure for the
+      // lifetime of the page.
       failed = true
       pending.length = 0
-      client = NO_TELEMETRY
     })
 
   const enqueue = (apply: (loaded: Telemetry) => void): void => {

--- a/web/src/shared/telemetry/types.ts
+++ b/web/src/shared/telemetry/types.ts
@@ -33,8 +33,10 @@ export type TelemetryProperties = Readonly<
  * Part of the seam rather than an assumption inside it. Consent is what gates
  * every call in the platform's working implementation, and a seam that did not
  * carry it would leave the base able to hand an identity to a tracker that had
- * no permission to hold one. `"unknown"` is "nothing decided", which is what a
- * build with no consent UI answers and is not a synonym for `"granted"`.
+ * no permission to hold one. `"unknown"` is "nothing decided", and it is what a
+ * build with no Mixpanel key answers: absence of a tracker, not a refusal.
+ * A build with a key answers `"granted"`, because this dashboard has no consent
+ * UI and `VITE_MIXPANEL_TOKEN` is the deployment's opt-in standing in for one.
  */
 export type TelemetryConsent = "granted" | "denied" | "unknown"
 
@@ -70,10 +72,11 @@ export interface TelemetryIdentity {
  * `identify` and not for `recordEvent`, and the split is deliberate rather than
  * an oversight: an identity is the one call that hands a tracker something
  * durable about a person, so `TelemetryIdentity` withholds it here, while every
- * `recordEvent` call site fires unconditionally and a replacement owns that
- * gate. That is where the platform's own gate lives (`trackEvent` in
- * `otari-ai/frontend/src/shared/helpers/mixpanel.ts` checks `hasConsent`
- * itself), and it is why `consent` is on this interface at all: an
+ * `recordEvent` call site fires unconditionally and whichever module implements
+ * this interface owns that gate. `createMixpanelTelemetry` is that module in
+ * this build and makes the check itself, which is where the platform's own gate
+ * lives too (`trackEvent` in `otari-ai/frontend/src/shared/helpers/mixpanel.ts`
+ * checks `hasConsent`). It is why `consent` is on this interface at all: an
  * implementation cannot gate what it is never told.
  */
 export interface Telemetry {

--- a/web/src/tests/telemetry.ts
+++ b/web/src/tests/telemetry.ts
@@ -14,8 +14,9 @@ import type {
  * The base module is a no-op unless `VITE_MIXPANEL_TOKEN` is set, so a test
  * asserting that an event fires has nothing to observe unless it replaces the
  * module the way a superset build does. That replacement is what this is: one
- * shared spy, so the six consumers that record something do not each invent
- * their own shape for the tracker and then agree with themselves about it.
+ * shared spy, so AppShell, TelemetryIdentity, and the six auth modules do
+ * not each invent their own shape for the tracker and then agree with
+ * themselves about it.
  *
  * A test reaches it through the async factory form, because `vi.mock` is hoisted
  * above the imports and a factory referencing one directly would run before it

--- a/web/src/tests/telemetry.ts
+++ b/web/src/tests/telemetry.ts
@@ -11,11 +11,11 @@ import type {
 /**
  * A recording stand-in for the telemetry seam.
  *
- * The base module is a genuine no-op, so a test asserting that an event fires
- * has nothing to observe unless it replaces the module the way a superset build
- * does. That replacement is what this is: one shared spy, so the six consumers
- * that record something do not each invent their own shape for the tracker and
- * then agree with themselves about it.
+ * The base module is a no-op unless `VITE_MIXPANEL_TOKEN` is set, so a test
+ * asserting that an event fires has nothing to observe unless it replaces the
+ * module the way a superset build does. That replacement is what this is: one
+ * shared spy, so the six consumers that record something do not each invent
+ * their own shape for the tracker and then agree with themselves about it.
  *
  * A test reaches it through the async factory form, because `vi.mock` is hoisted
  * above the imports and a factory referencing one directly would run before it

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** Mixpanel project token. Empty or unset means the SDK is never loaded. */
+  readonly VITE_MIXPANEL_TOKEN?: string
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,6 +3,7 @@ import babel from "@rolldown/plugin-babel"
 import tailwindcss from "@tailwindcss/vite"
 import { tanstackRouter } from "@tanstack/router-plugin/vite"
 import react, { reactCompilerPreset } from "@vitejs/plugin-react"
+import { loadEnv } from "vite"
 import { defineConfig } from "vitest/config"
 import { pwaManifest } from "./pwaManifest.ts"
 
@@ -26,6 +27,13 @@ const outDir = fileURLToPath(
 const webRoot = fileURLToPath(new URL("./", import.meta.url))
 const docsDir = fileURLToPath(new URL("../docs", import.meta.url))
 
+// Vite reads .env from envDir, which defaults to this directory. Point it at the
+// repo root so one .env serves the gateway and the dashboard, and so `pnpm run
+// dev` and `make dashboard` read the same file rather than needing the token in
+// two places. Only VITE_* is exposed to the client, so the provider keys beside
+// it in that file are never inlined.
+const repoRoot = fileURLToPath(new URL("../", import.meta.url))
+
 // The gateway serves the dashboard and the API from one origin, so the app
 // fetches "/v1/..." and "/health" as same-origin paths. `pnpm run dev` serves
 // only the SPA, so proxy those to a running gateway. Override the target to
@@ -33,6 +41,45 @@ const docsDir = fileURLToPath(new URL("../docs", import.meta.url))
 //   OTARI_DEV_API=https://your-app.up.railway.app pnpm run dev
 const apiTarget = process.env.OTARI_DEV_API ?? "http://localhost:8000"
 const apiProxy = { target: apiTarget, changeOrigin: true }
+
+// Mixpanel is gated at runtime by VITE_MIXPANEL_TOKEN, but that gate cannot keep
+// the SDK out of the artifact: Rolldown gives the dynamic import in
+// shared/telemetry/overlayTelemetry.ts its own chunk from the module graph,
+// before any dead code is eliminated, so a build with no key still writes ~128 kB
+// of mixpanel-browser to disk. It is never fetched, and shipping it in an OSS
+// release anyway is the part worth avoiding. So a keyless build resolves the
+// client module to an inert stub: the chunk still exists, the vendor is not in
+// it. Replacing the module rather than aliasing the specifier keeps this out of
+// resolve.alias, where "@/shared/telemetry/mixpanelClient" would have to be
+// matched ahead of "@".
+const MIXPANEL_CLIENT = "src/shared/telemetry/mixpanelClient.ts"
+const MIXPANEL_STUB =
+  "export function createMixpanelTelemetry() {\n" +
+  "  return {\n" +
+  '    consent: "unknown",\n' +
+  "    recordEvent: () => undefined,\n" +
+  "    identify: () => undefined,\n" +
+  "  }\n" +
+  "}\n"
+
+const excludeMixpanelWithoutKey = {
+  name: "exclude-mixpanel-without-key",
+  apply: "build",
+  enforce: "pre" as const,
+  hasKey: false,
+  config(_: unknown, { mode }: { mode: string }) {
+    const { VITE_MIXPANEL_TOKEN } = loadEnv(mode, repoRoot, "VITE_")
+    excludeMixpanelWithoutKey.hasKey = (VITE_MIXPANEL_TOKEN ?? "").trim() !== ""
+  },
+  load(id: string) {
+    if (excludeMixpanelWithoutKey.hasKey) {
+      return null
+    }
+    return id.replace(/\\/g, "/").endsWith(MIXPANEL_CLIENT)
+      ? MIXPANEL_STUB
+      : null
+  },
+}
 
 // Which gateway the dev server talks to decides which master key signs you in,
 // and the app reports an unreachable or unauthorized gateway as an invalid key.
@@ -60,11 +107,13 @@ const webStorageOptOut =
 
 export default defineConfig({
   base: "/",
+  envDir: repoRoot,
   plugins: [
     // Generates src/routeTree.gen.ts from src/routes/, and splits each route's
     // component into its own chunk (autoCodeSplitting), which is why a route
     // file may export nothing but `Route`. Must precede the React plugin: it
     // rewrites the route modules that plugin then compiles.
+    excludeMixpanelWithoutKey,
     tanstackRouter({ target: "react", autoCodeSplitting: true }),
     react(),
     // The React Compiler memoizes components and derived values at build time,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Record the existing dashboard telemetry catalog in Mixpanel when a project token is present. One codebase, gated by key presence: OSS users have no Mixpanel key, so this must do nothing.

- **No key:** load nothing and track nothing. No SDK fetch, no network, no console noise on a deployed host.
- **`make dev` without a key:** the browser logs exactly `Mixpanel not initialized` once (localhost or Vite DEV), then stops. It does not init.
- **With `VITE_MIXPANEL_TOKEN`:** dynamically import `mixpanel-browser` and forward the existing `useTelemetry` calls. Call sites are unchanged.
- Event names are unchanged from `TELEMETRY_EVENTS`. `CHECKOUT_CANCELLED` stays named and unfired (no wallet).
- This is not the HubSpot overlay-only pattern. Nathan floated "impl in otari-ai, interface in OSS" then said he might have been thinking of HubSpot (otari-ai#1749, which 404s). Toto's simpler path wins: events live in this dashboard; a missing key is a no-op.

The token is a Vite build-time env var (`VITE_MIXPANEL_TOKEN`). `make dashboard` sources the repo-root `.env` so the same file `make dev` uses can supply it. The Docker web stage accepts an optional `VITE_MIXPANEL_TOKEN` build ARG.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Hygiene/telemetry follow-up from Toto in #otari-oss-refactor and Fede's Aug 21 notes. No issue number. Started without Fede's supervision; not requesting reviewers.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (dashboard Vitest: no-key load/track gate, local `Mixpanel not initialized` log, catalog pin, `CHECKOUT_CANCELLED` unfired).
- [x] I ran the Definition of Done checks locally (`pnpm --dir web run lint`, `pnpm --dir web run typecheck`, `pnpm --dir web test`: 1606 passed). Backend `make lint` / `make typecheck` / `make test` were not required (no `src/gateway/` Python change).
- [x] Documentation was updated where necessary (`web/AGENTS.md`, frontend-standards skill, `web/README.md`).
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). (N/A: no API change.)

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Cursor Grok 4.6 (cloud agent)

**Any additional AI details you'd like to share:** Product decisions were locked from Slack (#otari-oss-refactor) and Granola (Aug 21 Mixpanel notes). Draft only; do not request reviewers (especially not jigjigjig / Fede).

- [x] I am an AI Agent filling out this form (check box if true)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc0a8c4a-3a34-4a7e-981d-a002e18efedc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc0a8c4a-3a34-4a7e-981d-a002e18efedc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds optional Mixpanel analytics to the dashboard.

- Records existing telemetry events only when `VITE_MIXPANEL_TOKEN` is configured.
- Keeps keyless builds free of Mixpanel loading, tracking, and production console output.
- Documents event coverage, configuration, and deployment behavior.
- Adds Docker and Vite configuration for build-time token handling.
- Adds comprehensive tests for tracking, identity, consent, loading, and failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->