### PR TITLE
fix(dashboard): gate the workspaces page's operator-only budget reads

### DIFF
--- a/web/src/features/workspaces/WorkspacesPage.test.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.test.tsx
@@ -303,4 +303,90 @@ describe("WorkspacesPage", () => {
     const bravo = (await screen.findByText("Bravo")).closest("tr")!
     expect(within(bravo).getByText("None")).toBeInTheDocument()
   })
+
+  it("withholds the budget column and its reads from a non-operator admin", async () => {
+    // An organization admin who does not operate the deployment may manage
+    // workspaces, but the budgets list answers them 403 (#821). Neither that
+    // read nor the defaults fan-out that only feeds this column is made, and
+    // the column goes with them rather than echoing UUID fragments.
+    const requests = mockApi({
+      context: organizationContext({ deployment_operator: false }),
+      workspaces: [workspace(), workspace({ id: SECOND, name: "Bravo" })],
+      budgetDefaults: {
+        "44444444-4444-4444-4444-444444444444": [
+          workspaceBudgetDefault({ budget_id: "bud-team" }),
+        ],
+      },
+    })
+    renderPage(<WorkspacesPage />)
+
+    await screen.findByText("Bravo")
+    expect(screen.queryByText("Default member budget")).toBeNull()
+    expect(
+      requests.some((request) => request.url.includes("/v1/budgets")),
+    ).toBe(false)
+    expect(
+      requests.some((request) =>
+        request.url.includes("member-budget-policies"),
+      ),
+    ).toBe(false)
+  })
+
+  it("offers a non-operator no default-budget picker on the create form", async () => {
+    const requests = mockApi({
+      context: organizationContext({ deployment_operator: false }),
+    })
+    const user = userEvent.setup()
+    renderPage(<WorkspacesPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Create workspace" }),
+    )
+    await user.type(screen.getByLabelText("Name"), "Research")
+    expect(
+      screen.queryByRole("button", { name: /Default member budget/ }),
+    ).toBeNull()
+    await user.click(screen.getByRole("button", { name: "Create workspace" }))
+
+    // The create itself is theirs to make; only the picker is withheld.
+    const post = requests.find((request) => request.method === "POST")
+    expect(post?.body).toEqual({ name: "Research", description: null })
+    expect(
+      requests.some((request) => request.url.includes("/v1/budgets")),
+    ).toBe(false)
+  })
+
+  it("withholds the default-budget controls from a non-operator's edit form", async () => {
+    const requests = mockApi({
+      context: organizationContext({ deployment_operator: false }),
+    })
+    const user = userEvent.setup()
+    renderPage(<WorkspacesPage />)
+
+    await user.click(await screen.findByRole("button", { name: "Edit" }))
+    const name = await screen.findByLabelText("Name")
+    expect(
+      screen.queryByRole("button", { name: /Default member budget/ }),
+    ).toBeNull()
+    expect(screen.queryByText("Per-provider defaults")).toBeNull()
+
+    // The rename is theirs to make, and saving does not touch the withheld
+    // default: no delete for a "none" the caller never picked.
+    await user.clear(name)
+    await user.type(name, "Renamed")
+    await user.click(screen.getByRole("button", { name: "Save changes" }))
+
+    const patch = requests.find((request) => request.method === "PATCH")
+    expect(patch?.body).toEqual({ name: "Renamed", description: null })
+    const operatorOnly = [
+      "/v1/budgets",
+      "/v1/providers",
+      "member-budget-policies",
+    ]
+    expect(
+      requests.filter((request) =>
+        operatorOnly.some((path) => request.url.includes(path)),
+      ),
+    ).toEqual([])
+  })
 })

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -2,7 +2,7 @@ import { Button, Card, Chip, Spinner } from "@heroui/react"
 import { useEffect, useMemo, useRef, useState } from "react"
 
 import type { Budget, Workspace, WorkspaceBudgetDefault } from "@/client"
-import { canManage } from "@/features/organization/roles"
+import { canManage, isDeploymentOperator } from "@/features/organization/roles"
 import { ApiError } from "@/shared/api/client"
 import {
   useAllWorkspaceBudgetDefaults,
@@ -266,7 +266,16 @@ export function CreateWorkspaceForm({
 }) {
   const create = useCreateWorkspace()
   const createDefault = useCreateWorkspaceBudgetDefault()
-  const budgets = useBudgets()
+  // The budgets list is a deployment-wide read that answers 403 to an
+  // organization admin who does not operate the deployment (#821), so it is not
+  // asked for unless the caller may read it, and the default-budget picker it
+  // feeds is withheld with it (the OrganizationMembersPage pattern, otari#838):
+  // offered anyway, the picker could only say "No default", which misreads as
+  // the deployment having no budgets. Resolved here rather than passed in
+  // because the workspace switcher offers this same form.
+  const context = useOrganizationContext()
+  const operates = isDeploymentOperator(context.data)
+  const budgets = useBudgets(operates)
   const [name, setName] = useState("")
   const [description, setDescription] = useState("")
   const [budgetId, setBudgetId] = useState(NO_DEFAULT)
@@ -357,11 +366,13 @@ export function CreateWorkspaceForm({
           value={description}
           onChange={setDescription}
         />
-        <DefaultBudgetPicker
-          budgets={budgets.data ?? []}
-          value={budgetId}
-          onChange={setBudgetId}
-        />
+        {operates ? (
+          <DefaultBudgetPicker
+            budgets={budgets.data ?? []}
+            value={budgetId}
+            onChange={setBudgetId}
+          />
+        ) : null}
         <div className="flex gap-2">
           <Button
             variant="primary"
@@ -463,8 +474,18 @@ function EditWorkspaceForm({
   onClose: () => void
 }) {
   const update = useUpdateWorkspace()
-  const budgets = useBudgets()
-  const defaults = useWorkspaceBudgetDefaults(workspace.id)
+  // Budgets and providers are deployment-wide reads that answer 403 to an
+  // organization admin who does not operate the deployment (#821), so neither is
+  // asked for unless the caller may read it, and the default-budget controls
+  // they feed are withheld with them (the OrganizationMembersPage pattern,
+  // otari#838): rendered anyway, the picker showed the current default as a raw
+  // UUID and the per-provider section had no provider to offer. The defaults
+  // read itself is workspace-scoped and would answer, but this form only reads
+  // it into those controls, so it is declined together with them.
+  const context = useOrganizationContext()
+  const operates = isDeploymentOperator(context.data)
+  const budgets = useBudgets(operates)
+  const defaults = useWorkspaceBudgetDefaults(operates ? workspace.id : null)
   const createDefault = useCreateWorkspaceBudgetDefault()
   const updateDefault = useUpdateWorkspaceBudgetDefault()
   const deleteDefault = useDeleteWorkspaceBudgetDefault()
@@ -476,7 +497,7 @@ function EditWorkspaceForm({
   const narrowed = (defaults.data ?? []).filter(
     (row) => row.provider_key_id !== null,
   )
-  const providers = useProviders()
+  const providers = useProviders(operates)
   const [name, setName] = useState(workspace.name)
   const [description, setDescription] = useState(workspace.description ?? "")
   const [budgetId, setBudgetId] = useState<string | null>(null)
@@ -491,6 +512,10 @@ function EditWorkspaceForm({
   // Three outcomes rather than one call: the default is its own row, so moving
   // between "none" and a budget is a create or a delete, not a field write.
   const saveDefault = async (): Promise<void> => {
+    // With the picker withheld, an untouched `selectedBudget` over an unfetched
+    // defaults list would read as "none" and delete nothing, but say so rather
+    // than lean on that coincidence.
+    if (!operates) return
     if (selectedBudget === NO_DEFAULT) {
       if (aggregate) {
         await deleteDefault.mutateAsync({
@@ -537,25 +562,29 @@ function EditWorkspaceForm({
           value={description}
           onChange={setDescription}
         />
-        <DefaultBudgetPicker
-          budgets={budgets.data ?? []}
-          value={selectedBudget}
-          onChange={setBudgetId}
-        />
-        <span className="max-w-md text-xs text-muted">
-          Every member of this workspace is held to this budget, each with their
-          own allowance. Changing it applies to members who join afterwards;
-          members already here keep the budget they were given, though editing
-          that budget still moves them.
-        </span>
-        <NarrowedDefaults
-          workspaceId={workspace.id}
-          budgets={budgets.data ?? []}
-          narrowed={narrowed}
-          providers={(providers.data?.providers ?? []).map(
-            (provider) => provider.instance,
-          )}
-        />
+        {operates ? (
+          <>
+            <DefaultBudgetPicker
+              budgets={budgets.data ?? []}
+              value={selectedBudget}
+              onChange={setBudgetId}
+            />
+            <span className="max-w-md text-xs text-muted">
+              Every member of this workspace is held to this budget, each with
+              their own allowance. Changing it applies to members who join
+              afterwards; members already here keep the budget they were given,
+              though editing that budget still moves them.
+            </span>
+            <NarrowedDefaults
+              workspaceId={workspace.id}
+              budgets={budgets.data ?? []}
+              narrowed={narrowed}
+              providers={(providers.data?.providers ?? []).map(
+                (provider) => provider.instance,
+              )}
+            />
+          </>
+        ) : null}
         <div className="flex gap-2">
           <Button
             variant="primary"
@@ -593,7 +622,13 @@ function EditWorkspaceForm({
 export function WorkspacesPage() {
   const context = useOrganizationContext()
   const workspaces = useWorkspaces()
-  const budgets = useBudgets()
+  // The budgets read is deployment-wide and answers 403 to an organization
+  // admin who does not operate the deployment (#821), so it is not asked for
+  // unless the caller may read it, and the column it names is withheld with it
+  // (the OrganizationMembersPage pattern, otari#838): without the names, every
+  // cell could only echo a UUID fragment of the default's id.
+  const operates = isDeploymentOperator(context.data)
+  const budgets = useBudgets(operates)
   const remove = useDeleteWorkspace()
 
   const [creating, setCreating] = useState(false)
@@ -602,7 +637,12 @@ export function WorkspacesPage() {
 
   const rows = workspaces.data ?? []
   const workspaceIds = useMemo(() => rows.map((row) => row.id), [rows])
-  const workspaceDefaults = useAllWorkspaceBudgetDefaults(workspaceIds)
+  // Emptied rather than fetched for a non-operator: the fan-out itself is
+  // workspace-scoped and would answer, but this page only reads it into the
+  // withheld column below.
+  const workspaceDefaults = useAllWorkspaceBudgetDefaults(
+    operates ? workspaceIds : [],
+  )
   // The budget each workspace hands to its members, by workspace. Only the
   // aggregate default (no provider narrowing) is named: that is the one the
   // edit form sets, and a narrowed one is the budget's business, where it shows
@@ -632,8 +672,10 @@ export function WorkspacesPage() {
   const editingWorkspace = rows.find((row) => row.id === editing) ?? null
   const showOnboarding = !workspaces.isLoading && rows.length === 0 && !creating
 
-  const columns = useMemo<DataTableColumn<Workspace>[]>(
-    () => [
+  // The default-budget column is dropped, not emptied, for a caller who cannot
+  // read the budget names it shows; see the note on `operates` above.
+  const columns = useMemo<DataTableColumn<Workspace>[]>(() => {
+    const all: DataTableColumn<Workspace>[] = [
       {
         id: "name",
         header: "Workspace",
@@ -712,9 +754,9 @@ export function WorkspacesPage() {
           </div>
         ),
       },
-    ],
-    [manages, isOnlyWorkspace, defaultBudgetName],
-  )
+    ]
+    return all.filter((column) => operates || column.id !== "default-budget")
+  }, [manages, isOnlyWorkspace, defaultBudgetName, operates])
 
   return (
     <div className="flex flex-col gap-6">

--- a/web/src/shared/api/hooks.ts
+++ b/web/src/shared/api/hooks.ts
@@ -284,11 +284,17 @@ export function useDiscoverableModels() {
 // Static metadata for every configured provider: capabilities, doc and pricing
 // links, display name. Network-free gateway-side (bundled datasets), so it does
 // not move within a session; kept fresh for a few minutes like discovery.
-export function useProviders() {
+//
+// `enabled` is for the same composition `useBudgets` documents: this read is
+// deployment-wide and answers 403 to anyone who does not operate the deployment
+// (#821), so a tenant-facing page declines to ask rather than surfacing the
+// refusal (otari#838).
+export function useProviders(enabled = true) {
   return useQuery({
     queryKey: [PROVIDERS],
     queryFn: () => apiFetch<ProvidersResponse>("/v1/providers"),
     staleTime: 5 * 60_000,
+    enabled,
   })
 }
 


### PR DESCRIPTION
## Description

The workspaces page and both of its forms (the create form is also offered from the workspace switcher) called `useBudgets()` / `useProviders()` ungated. Both endpoints answer 403 to an org owner/admin who does not operate the deployment (#821), so the "Default member budget" column labeled workspaces with UUID fragments, the create form silently offered only "No default", and the edit form showed the current default as a raw UUID over an empty provider list.

This gates both reads on `isDeploymentOperator` (the `OrganizationMembersPage` pattern from otari#838) and withholds what they feed with them: the column, the create form's picker, and the edit form's default-budget controls. `useProviders` gains the same `enabled` parameter `useBudgets` already has.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#1932

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code (Claude Fable 5)

**Any additional AI details you'd like to share:**

Dashboard checks run locally: `pnpm --dir web run lint`, `pnpm --dir web run typecheck`, `pnpm --dir web test` (107 files, 1591 tests). The change is `web/` only, so the backend suite is untouched.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Restricted budget and provider data requests to deployment operators.
- Hid budget-related columns and controls for users without deployment-operator access.
- Updated workspace create and edit flows to save only permitted fields.
- Added tests for non-operator workspace behavior.
- Added an `enabled` option to `useProviders`.
- Lint, typecheck, and tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->