### PR TITLE
fix(dashboard): land every signed-in caller on a usage overview

### DIFF
--- a/web/src/features/overview/OverviewPage.test.tsx
+++ b/web/src/features/overview/OverviewPage.test.tsx
@@ -649,3 +649,143 @@ describe("OverviewIndex routing", () => {
     )
   })
 })
+
+// The wire for a caller who does not operate the deployment: `/v1/admin/access`
+// answers an explicit no, the organization context agrees, and the usage hooks
+// therefore read `/v1/organizations/me/usage` (otari#837). Everything else is
+// an endpoint this caller must never be asked to read, so it refuses the way
+// the server would; a leak fails the assertions loudly instead of rendering a
+// plausible tile. Every URL is recorded so the tests can say so.
+function mockScopedApi(b: Bodies): string[] {
+  const requested: string[] = []
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input)
+    requested.push(url)
+    if (url.endsWith("/v1/admin/access")) {
+      return jsonResponse({ granted: false })
+    }
+    if (url.endsWith("/v1/organizations/me")) {
+      return jsonResponse(organizationContext({ deployment_operator: false }))
+    }
+    if (url.includes("/v1/organizations/me/usage/summary")) {
+      if (url.includes("bucket=hour"))
+        return jsonResponse(summary(b.today ?? {}))
+      if (url.includes("end_date=")) return jsonResponse(summary(b.prev ?? {}))
+      return jsonResponse(summary(b.period ?? {}))
+    }
+    if (url.includes("/v1/organizations/me/usage")) {
+      return jsonResponse(b.logs ?? [])
+    }
+    return jsonResponse({ detail: "forbidden" }, 403)
+  })
+  return requested
+}
+
+describe("OverviewIndex for a caller who does not operate the deployment", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("lands on their own usage, not an apology card", async () => {
+    mockScopedApi({
+      today: { cost: 5, request_count: 100, error_count: 1 },
+      period: { cost: 200, request_count: 2000, error_count: 40 },
+      prev: { cost: 100, request_count: 1000, error_count: 5 },
+    })
+    renderPage(<OverviewIndex />)
+
+    // The scoped summaries land as real tiles: today vs 30-day spend, volume,
+    // and the window's error rate, exactly as the operator page renders them.
+    expect(await screen.findByText("$5.00")).toBeInTheDocument()
+    expect(screen.getByText("$200.00")).toBeInTheDocument()
+    expect(screen.getByText("2,000")).toBeInTheDocument()
+    expect(screen.getByText("2.0%")).toBeInTheDocument()
+    // The dead-end card this page replaced (otari-ai#1929) stays gone.
+    expect(
+      screen.queryByText(/This overview is for deployment operators/),
+    ).not.toBeInTheDocument()
+  })
+
+  it("reads only the organization-scoped surface and shows no operator tile", async () => {
+    const requested = mockScopedApi({
+      period: { cost: 200, request_count: 2000 },
+    })
+    renderPage(<OverviewIndex />)
+    await screen.findByText("$200.00")
+
+    // The deployment-wide panels stay on the operator page: no tile here reads
+    // budgets, keys, or the deployment roster.
+    expect(screen.queryByText("Budget health")).not.toBeInTheDocument()
+    expect(screen.queryByText("Active keys")).not.toBeInTheDocument()
+    expect(screen.queryByText("Active members")).not.toBeInTheDocument()
+    // And nothing left the scoped surface: beyond the gate and the context,
+    // every request this page made names /v1/organizations/me/usage. A bare
+    // /v1/usage read here would be a cross-tenant read the server refuses, so
+    // the page must not even attempt it.
+    const scoped = requested.filter(
+      (url) =>
+        !url.endsWith("/v1/admin/access") &&
+        !url.endsWith("/v1/organizations/me"),
+    )
+    expect(scoped.length).toBeGreaterThan(0)
+    for (const url of scoped) {
+      expect(url).toContain("/v1/organizations/me/usage")
+    }
+  })
+
+  it("previews the caller's recent requests with a link to the full log", async () => {
+    mockScopedApi({
+      logs: [
+        {
+          id: "1",
+          user_id: null,
+          api_key_id: null,
+          timestamp: "2026-07-22T00:00:00Z",
+          model: "gpt-5.6",
+          provider: "openai",
+          endpoint: "/v1/chat/completions",
+          prompt_tokens: 10,
+          completion_tokens: 5,
+          total_tokens: 15,
+          cache_read_tokens: 0,
+          cache_write_tokens: 0,
+          cost: 0.5,
+          status: "success",
+          error_message: null,
+          latency_ms: 120,
+        },
+      ],
+    })
+    renderPage(<OverviewIndex />)
+
+    expect(await screen.findByText("gpt-5.6")).toBeInTheDocument()
+    // Activity serves this caller from the same scoped surface, so the preview
+    // may hand them off to it.
+    expect(screen.getByRole("link", { name: /view all/i })).toHaveAttribute(
+      "href",
+      "/activity",
+    )
+  })
+
+  it("reports a failed scoped summary instead of a silent wall of dashes", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.endsWith("/v1/admin/access")) {
+        return jsonResponse({ granted: false })
+      }
+      if (url.endsWith("/v1/organizations/me")) {
+        return jsonResponse(organizationContext({ deployment_operator: false }))
+      }
+      if (url.includes("/v1/organizations/me/usage/summary")) {
+        return jsonResponse({ detail: "usage exploded" }, 500)
+      }
+      if (url.includes("/v1/organizations/me/usage")) {
+        return jsonResponse([])
+      }
+      return jsonResponse({ detail: "forbidden" }, 403)
+    })
+    renderPage(<OverviewIndex />)
+
+    expect(await screen.findByText(/usage exploded/)).toBeInTheDocument()
+  })
+})

--- a/web/src/features/overview/OverviewPage.test.tsx
+++ b/web/src/features/overview/OverviewPage.test.tsx
@@ -767,6 +767,37 @@ describe("OverviewIndex for a caller who does not operate the deployment", () =>
     )
   })
 
+  it("reports a failed previous window instead of silently dropping the trends", async () => {
+    // The previous window's only reader is the trend chips, so its failure has
+    // no tile of its own to show it: without the banner it would just strip
+    // every "vs prev" chip and look like there was nothing to compare.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.endsWith("/v1/admin/access")) {
+        return jsonResponse({ granted: false })
+      }
+      if (url.endsWith("/v1/organizations/me")) {
+        return jsonResponse(organizationContext({ deployment_operator: false }))
+      }
+      if (url.includes("/v1/organizations/me/usage/summary")) {
+        if (url.includes("end_date="))
+          return jsonResponse({ detail: "previous window exploded" }, 500)
+        return jsonResponse(summary({ cost: 200, request_count: 2000 }))
+      }
+      if (url.includes("/v1/organizations/me/usage")) {
+        return jsonResponse([])
+      }
+      return jsonResponse({ detail: "forbidden" }, 403)
+    })
+    renderPage(<OverviewIndex />)
+
+    // Both current windows read the same body here, hence findAllByText.
+    expect((await screen.findAllByText("$200.00")).length).toBeGreaterThan(0)
+    expect(
+      await screen.findByText(/previous window exploded/),
+    ).toBeInTheDocument()
+  })
+
   it("reports a failed scoped summary instead of a silent wall of dashes", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = String(input)

--- a/web/src/features/overview/OverviewPage.tsx
+++ b/web/src/features/overview/OverviewPage.tsx
@@ -297,8 +297,10 @@ function OrganizationOverview() {
   const { today, period, previous, recent } = useUsageOverview()
 
   // Recent activity is excluded for the operator page's reason: it renders its
-  // own inline banner, so including it here would double-report.
-  const loadError = today.error ?? period.error
+  // own inline banner, so including it here would double-report. The previous
+  // window is included: its only reader is the trend chips, so its failure
+  // would otherwise just silently strip them.
+  const loadError = today.error ?? period.error ?? previous.error
 
   const refresh = () => {
     void today.refetch()
@@ -428,6 +430,7 @@ export function OverviewPage({
     setupError ??
     today.error ??
     period.error ??
+    previous.error ??
     health.error ??
     budgets.error ??
     keys.error ??

--- a/web/src/features/overview/OverviewPage.tsx
+++ b/web/src/features/overview/OverviewPage.tsx
@@ -26,7 +26,6 @@ import { Sparkline } from "@/shared/components/charts"
 import { DataTable, type DataTableColumn } from "@/shared/components/DataTable"
 import { TrendChip } from "@/shared/components/TrendChip"
 import {
-  EmptyState,
   ErrorBanner,
   PageHeader,
   PageLoading,
@@ -91,6 +90,48 @@ function useWindows() {
   }, [dayKey])
 }
 
+// The queries every overview variant is built on: the three summary windows
+// behind the usage tiles, and the newest few requests. Every filter carries the
+// shell's selected workspace, so the tiles, the sparklines and the
+// recent-requests strip narrow together with whatever sits beside them. The
+// usage hooks pick the surface for the caller (deployment-wide for an operator,
+// organization-scoped otherwise; see useUsageScope), which is what lets the
+// operator page and the organization page share this derivation.
+function useUsageOverview() {
+  const w = useWindows()
+  const { selected: workspace } = useSelectedWorkspace()
+  const scope = workspace?.workspace_id
+
+  const todayFilters = useMemo(
+    () => ({ workspace_id: scope, start_date: w.today }),
+    [scope, w],
+  )
+  const periodFilters = useMemo(
+    () => ({ workspace_id: scope, start_date: w.periodStart }),
+    [scope, w],
+  )
+  // Bounded previous window ([-60d, -30d)) so it does not overlap the current one.
+  const prevFilters = useMemo(
+    () => ({
+      workspace_id: scope,
+      start_date: w.prevStart,
+      end_date: w.periodStart,
+    }),
+    [scope, w],
+  )
+  const recentFilters = useMemo(() => ({ workspace_id: scope }), [scope])
+
+  // Tiles and the sparkline read only `totals` and `series`, so all three windows
+  // opt out of every breakdown rather than making the server run a GROUP BY per
+  // dimension three times over for numbers this page never shows.
+  const today = useUsageSummary(todayFilters, "hour", NO_BREAKDOWNS)
+  const period = useUsageSummary(periodFilters, "day", NO_BREAKDOWNS)
+  const previous = useUsageSummary(prevFilters, "day", NO_BREAKDOWNS)
+  const recent = useUsageLogs(recentFilters, 0, 5)
+
+  return { scope, today, period, previous, recent }
+}
+
 // A status tile's short word (paired with the color so status never rides on hue
 // alone), keyed off the derived Health.
 const ERROR_WORDS = { ok: "Healthy", warn: "Elevated", alert: "High" } as const
@@ -100,25 +141,138 @@ const BUDGET_WORDS = {
   alert: "Over budget",
 } as const
 
+// The four usage tiles both overviews open with: spend today, spend and request
+// volume over the window, and the window's error rate. A fragment rather than
+// its own grid, so each page seats them beside its own tiles.
+function UsageStatTiles({
+  today,
+  period,
+  previous,
+}: {
+  today: ReturnType<typeof useUsageSummary>
+  period: ReturnType<typeof useUsageSummary>
+  previous: ReturnType<typeof useUsageSummary>
+}) {
+  const todayTotals = today.data?.totals
+  const periodTotals = period.data?.totals
+  const prevTotals = previous.data?.totals
+
+  // The 30-day daily series is already on the wire (used for tile sparklines).
+  // A single point has no trend to draw, so sparklines only appear with 2+ days.
+  const periodSeries = period.data?.series ?? []
+  const hasTrend = periodSeries.length > 1
+
+  const err = errorRateHealth(periodTotals)
+  const errPrev = errorRateHealth(prevTotals)
+  // Each delta is its own const so the tile below can gate its chip on the
+  // fraction rather than on the query: `deltaFraction` also returns null once
+  // the current window has landed but the previous one has not, and when the
+  // previous value is 0. TrendChip renders nothing for a null fraction, but the
+  // *element* is truthy, and StatCard reserves the aside row for whatever it is
+  // handed, so an ungated chip costs a tile 42px of dead space.
+  const costDelta = periodTotals
+    ? deltaFraction(periodTotals.cost, prevTotals?.cost)
+    : null
+  const requestDelta = periodTotals
+    ? deltaFraction(periodTotals.request_count, prevTotals?.request_count)
+    : null
+  const errDelta =
+    err.rate !== null && errPrev.rate !== null
+      ? deltaFraction(err.rate, errPrev.rate)
+      : null
+
+  return (
+    <>
+      <StatCard
+        label="Spend today"
+        value={todayTotals ? formatUsd(todayTotals.cost) : "—"}
+      />
+      <StatCard
+        label="Spend, last 30 days"
+        value={periodTotals ? formatUsd(periodTotals.cost) : "—"}
+        // Spend falling is the improvement, so a rise paints danger while the
+        // arrow keeps telling the truth about which way it went.
+        trend={
+          costDelta !== null ? (
+            <TrendChip
+              fraction={costDelta}
+              polarity="down-is-good"
+              caption="vs prev"
+            />
+          ) : null
+        }
+        chart={
+          hasTrend ? (
+            <Sparkline
+              values={periodSeries.map((p) => p.cost)}
+              ariaLabel="Spend trend over the last 30 days"
+            />
+          ) : undefined
+        }
+      />
+      <StatCard
+        label="Requests, last 30 days"
+        value={periodTotals ? formatNumber(periodTotals.request_count) : "—"}
+        // Volume, so `neutral`: more traffic through the gateway is neither a
+        // win nor a regression on its own, and the error rate tile beside it
+        // is what carries the judgment.
+        trend={
+          requestDelta !== null ? (
+            <TrendChip fraction={requestDelta} caption="vs prev" />
+          ) : null
+        }
+        chart={
+          hasTrend ? (
+            <Sparkline
+              values={periodSeries.map((p) => p.requests)}
+              ariaLabel="Request volume trend over the last 30 days"
+            />
+          ) : undefined
+        }
+      />
+      <StatCard
+        label="Error rate, last 30 days"
+        value={err.rate === null ? "—" : formatPct(err.rate)}
+        status={toStatStatus(err.status)}
+        statusLabel={
+          err.status === "neutral" ? undefined : ERROR_WORDS[err.status]
+        }
+        // Errors falling is the improvement, as with spend.
+        trend={
+          errDelta !== null ? (
+            <TrendChip
+              fraction={errDelta}
+              polarity="down-is-good"
+              caption="vs prev"
+            />
+          ) : null
+        }
+      />
+    </>
+  )
+}
+
 /**
  * The landing route, which is the one page nobody navigates to on purpose.
  *
- * Every panel below it reads a deployment-wide endpoint, and since otari-ai#1880
- * those answer 403 to anyone who is not an operator of the deployment. The gate
- * is here rather than on the queries because the hooks do not all take an
- * `enabled` flag, and a component that is not rendered runs none of them: that
- * is what keeps a member's first page from being nine failed requests.
+ * The operator page's status panels read deployment-wide endpoints (provider
+ * health, budgets, keys, accounts), and since otari-ai#1880 those answer 403
+ * to anyone who is not an operator of the deployment. The gate is here rather
+ * than on the queries because the hooks do not all take an `enabled` flag, and
+ * a component that is not rendered runs none of them: that is what keeps a
+ * tenant's first page from being a row of failed requests.
  *
  * It fails toward the operator view on purpose. Only an explicit `false` shows
- * the member page, so a deployment with no operator surface to ask (hybrid) and
- * a transient failure of the question both land on the panels, which report
- * their own errors, rather than telling a real operator this page is not theirs.
+ * the organization-scoped page, so a deployment with no operator surface to ask
+ * (hybrid) and a transient failure of the question both land on the panels,
+ * which report their own errors, rather than telling a real operator this page
+ * is not theirs.
  */
 export function OverviewIndex() {
   const access = useDeploymentAdminAccess()
 
   if (access.data === false) {
-    return <MemberOverview />
+    return <OrganizationOverview />
   }
   if (access.isLoading) {
     return <PageLoading />
@@ -127,22 +281,63 @@ export function OverviewIndex() {
 }
 
 /**
- * What a signed-in member who does not operate the deployment sees instead.
+ * The landing page for a signed-in caller who does not operate the deployment.
  *
- * Deliberately not `UnavailableHere`: this deployment does serve the page, it is
- * simply not this caller's, and saying the wrong one of those is how a support
- * ticket becomes an outage report. The sidebar still carries the organization
- * destinations they can use, so this points at it rather than repeating it.
+ * The 11 Aug roles matrix has Overview as "my usage" for every role
+ * (otari-ai#1946), so this is a real page rather than a card apologizing for
+ * the operator one (otari-ai#1929): the same usage tiles and recent-request
+ * preview the operator page opens with, served by the scope-aware usage hooks,
+ * which read `/v1/organizations/me/usage` for this caller. The server narrows
+ * those rows to what the caller may read (their organization for an admin, the
+ * workspaces they belong to for a member; otari#837), so nothing here
+ * re-derives roles. The deployment-wide panels (provider health, budgets, keys,
+ * accounts) stay on the operator page, whose endpoints refuse this caller.
  */
-function MemberOverview() {
+function OrganizationOverview() {
+  const { today, period, previous, recent } = useUsageOverview()
+
+  // Recent activity is excluded for the operator page's reason: it renders its
+  // own inline banner, so including it here would double-report.
+  const loadError = today.error ?? period.error
+
+  const refresh = () => {
+    void today.refetch()
+    void period.refetch()
+    void previous.refetch()
+    void recent.refetch()
+  }
+  const isRefreshing =
+    today.isFetching ||
+    period.isFetching ||
+    previous.isFetching ||
+    recent.isFetching
+
   return (
-    <>
-      <PageHeader title="Overview" />
-      <EmptyState
-        title="This overview is for deployment operators"
-        description="It reports on the whole gateway: every key, every workspace's spend, and the provider credentials behind them. Your organization's own pages are in the sidebar."
+    <div className="flex flex-col gap-6">
+      <PageHeader
+        title="Overview"
+        description="At-a-glance spend, traffic, and recent activity in your organization."
+        action={
+          <RefreshButton
+            onRefresh={refresh}
+            isFetching={isRefreshing}
+            updatedAt={period.dataUpdatedAt}
+          />
+        }
       />
-    </>
+
+      <ErrorBanner error={loadError} />
+
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 xl:grid-cols-4">
+        <UsageStatTiles today={today} period={period} previous={previous} />
+      </div>
+
+      <RecentActivity
+        entries={recent.data ?? []}
+        loading={recent.isLoading}
+        error={recent.error}
+      />
+    </div>
   )
 }
 
@@ -192,75 +387,19 @@ export function OverviewPage({
   refreshSetup?: () => void
   setupFetching?: boolean
 }) {
-  const w = useWindows()
-  const { selected: workspace } = useSelectedWorkspace()
-  // Every window carries the selected workspace, so the tiles, the sparkline and
-  // the recent-requests strip narrow with the keys tile beside them. Scoping one
-  // and not the others would put a workspace's key count next to the whole
-  // deployment's spend on the page an operator opens first.
-  const scope = workspace?.workspace_id
-
-  const todayFilters = useMemo(
-    () => ({ workspace_id: scope, start_date: w.today }),
-    [scope, w],
-  )
-  const periodFilters = useMemo(
-    () => ({ workspace_id: scope, start_date: w.periodStart }),
-    [scope, w],
-  )
-  // Bounded previous window ([-60d, -30d)) so it does not overlap the current one.
-  const prevFilters = useMemo(
-    () => ({
-      workspace_id: scope,
-      start_date: w.prevStart,
-      end_date: w.periodStart,
-    }),
-    [scope, w],
-  )
-  const recentFilters = useMemo(() => ({ workspace_id: scope }), [scope])
-
-  // Tiles and the sparkline read only `totals` and `series`, so all three windows
-  // opt out of every breakdown rather than making the server run a GROUP BY per
-  // dimension three times over for numbers this page never shows.
-  const today = useUsageSummary(todayFilters, "hour", NO_BREAKDOWNS)
-  const period = useUsageSummary(periodFilters, "day", NO_BREAKDOWNS)
-  const previous = useUsageSummary(prevFilters, "day", NO_BREAKDOWNS)
+  const usage = useUsageOverview()
+  const { today, period, previous, recent } = usage
   const health = useProviderHealth()
   const budgets = useBudgets()
   // Same scope as the API keys page this tile links to, so the count and the
   // table behind it cannot disagree.
-  const keys = useKeys(scope)
+  const keys = useKeys(usage.scope)
   const users = useUsers()
   const members = useOrganizationMembers()
-  const recent = useUsageLogs(recentFilters, 0, 5)
 
-  const todayTotals = today.data?.totals
-  const periodTotals = period.data?.totals
-  const prevTotals = previous.data?.totals
-
-  // The 30-day daily series is already on the wire (used for tile sparklines).
-  // A single point has no trend to draw, so sparklines only appear with 2+ days.
-  const periodSeries = period.data?.series ?? []
-  const hasTrend = periodSeries.length > 1
-
-  const err = errorRateHealth(periodTotals)
-  const errPrev = errorRateHealth(prevTotals)
-  // Each delta is its own const so the tile below can gate its chip on the
-  // fraction rather than on the query: `deltaFraction` also returns null once
-  // the current window has landed but the previous one has not, and when the
-  // previous value is 0. TrendChip renders nothing for a null fraction, but the
-  // *element* is truthy, and StatCard reserves the aside row for whatever it is
-  // handed, so an ungated chip costs a tile 42px of dead space.
-  const costDelta = periodTotals
-    ? deltaFraction(periodTotals.cost, prevTotals?.cost)
-    : null
-  const requestDelta = periodTotals
-    ? deltaFraction(periodTotals.request_count, prevTotals?.request_count)
-    : null
-  const errDelta =
-    err.rate !== null && errPrev.rate !== null
-      ? deltaFraction(err.rate, errPrev.rate)
-      : null
+  // The status strip reads the window's error rate too; errorRateHealth is
+  // pure, so it is derived here again rather than threaded out of the tiles.
+  const err = errorRateHealth(period.data?.totals)
 
   const budget = budgetHealth(budgets.data ?? [])
   const providerHealth = providerHealthStatus(health.data)
@@ -274,7 +413,7 @@ export function OverviewPage({
   // gateway has no providers AND no recorded usage. Imported OTLP usage lands in
   // the usage tables (with counts_toward_budget=false) through a budget-exempt key
   // and no provider config, so "no providers" alone no longer means "nothing has
-  // happened". `recent` is the unfiltered, all-time log query already loaded below;
+  // happened". `recent` is the all-time log query useUsageOverview already loads;
   // gate on it having resolved so the banner never flashes in then hides.
   const hasAnyUsage = (recent.data?.length ?? 0) > 0
   const showGettingStarted = needsSetup && recent.isSuccess && !hasAnyUsage
@@ -362,71 +501,7 @@ export function OverviewPage({
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 xl:grid-cols-4">
         {/* Tiles gate on data presence, not isLoading, so a failed query reads as
             "—" (unknown) rather than a misleading real zero. */}
-        <StatCard
-          label="Spend today"
-          value={todayTotals ? formatUsd(todayTotals.cost) : "—"}
-        />
-        <StatCard
-          label="Spend, last 30 days"
-          value={periodTotals ? formatUsd(periodTotals.cost) : "—"}
-          // Spend falling is the improvement, so a rise paints danger while the
-          // arrow keeps telling the truth about which way it went.
-          trend={
-            costDelta !== null ? (
-              <TrendChip
-                fraction={costDelta}
-                polarity="down-is-good"
-                caption="vs prev"
-              />
-            ) : null
-          }
-          chart={
-            hasTrend ? (
-              <Sparkline
-                values={periodSeries.map((p) => p.cost)}
-                ariaLabel="Spend trend over the last 30 days"
-              />
-            ) : undefined
-          }
-        />
-        <StatCard
-          label="Requests, last 30 days"
-          value={periodTotals ? formatNumber(periodTotals.request_count) : "—"}
-          // Volume, so `neutral`: more traffic through the gateway is neither a
-          // win nor a regression on its own, and the error rate tile beside it
-          // is what carries the judgment.
-          trend={
-            requestDelta !== null ? (
-              <TrendChip fraction={requestDelta} caption="vs prev" />
-            ) : null
-          }
-          chart={
-            hasTrend ? (
-              <Sparkline
-                values={periodSeries.map((p) => p.requests)}
-                ariaLabel="Request volume trend over the last 30 days"
-              />
-            ) : undefined
-          }
-        />
-        <StatCard
-          label="Error rate, last 30 days"
-          value={err.rate === null ? "—" : formatPct(err.rate)}
-          status={toStatStatus(err.status)}
-          statusLabel={
-            err.status === "neutral" ? undefined : ERROR_WORDS[err.status]
-          }
-          // Errors falling is the improvement, as with spend.
-          trend={
-            errDelta !== null ? (
-              <TrendChip
-                fraction={errDelta}
-                polarity="down-is-good"
-                caption="vs prev"
-              />
-            ) : null
-          }
-        />
+        <UsageStatTiles today={today} period={period} previous={previous} />
         <StatCard
           label="Budget health"
           value={


### PR DESCRIPTION
## Description

A signed-in caller who does not operate the deployment landed on an empty-state card whose copy pointed at organization sidebar pages a plain member does not have. The 11 Aug roles matrix (otari-ai#1946) has Overview as "my usage" for every role, and the usage hooks already serve a non-operator from `/v1/organizations/me/usage` (#837, #842), so the card is replaced with a real landing: the same usage tiles and recent-request preview the operator page opens with, narrowed server-side to what the caller may read.

- The three summary windows, the recent-logs query, and the four usage tiles move out of the operator page into a shared hook (`useUsageOverview`) and fragment (`UsageStatTiles`), so both overviews render the same numbers the same way.
- The deployment-wide panels (provider health, budgets, keys, accounts) stay on the operator page, and the operator's gateway-wide overview is unchanged.
- New tests pin that a non-operator gets real tiles and recent activity, that every request stays on the scoped surface (anything else answers 403 in the mock), and that a failed scoped summary is reported rather than rendered as dashes.

The screenshot matrix logs in as the operator only (no role axis), so the non-operator variant is covered at the Vitest level; a role axis for the screenshot suite would be its own change.

Checks run locally: `pnpm lint`, `pnpm typecheck`, `pnpm exec vitest run` (1592 passed).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#1929

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). No API contract change: the diff is `web/` only.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Fable 5 in Claude Code.

**Any additional AI details you'd like to share:**

Implementation, tests, and the pre-open self-review were done by the agent against the repo's scoped standards (`AGENTS.md`, `web/AGENTS.md`, the frontend-standards skill).

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Show scoped usage data and recent activity to signed-in non-operators.
- Share usage queries and usage tiles between operator and non-operator overview pages.
- Keep deployment-wide health, budget, key, and member panels on the operator page.
- Add tests for scoped data, access enforcement, and failed usage summaries.

This gives each caller a useful landing page while preserving operator-only deployment controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->