### PR TITLE
fix(dashboard): serve the Tools pages to non-operators

### DIFF
--- a/web/src/features/tools/ToolsGuardrailsPage.test.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.test.tsx
@@ -5,11 +5,13 @@ import type { ReactElement } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import type {
+  OrganizationContext,
   ToolSettingField,
   ToolSettingsResponse,
   ToolsResponse,
 } from "@/client"
 import { ToolsGuardrailsPage } from "@/features/tools/ToolsGuardrailsPage"
+import { organizationContext } from "@/tests/fixtures"
 import { pickOption } from "@/tests/select"
 
 const FIELDS: ToolSettingField[] = [
@@ -134,6 +136,10 @@ interface MockOpts {
   testBody?: { ok: boolean; reason: string }
   tools?: ToolsResponse
   toolsStatus?: number
+  // The caller's membership context, an operator's by default: the page gates
+  // its deployment-wide reads on `deployment_operator`, so most tests here are
+  // about the forms only an operator sees.
+  context?: OrganizationContext
 }
 
 function mockApi(opts: MockOpts = {}) {
@@ -143,6 +149,9 @@ function mockApi(opts: MockOpts = {}) {
     .mockImplementation(async (input, init) => {
       const url = String(input)
       const method = (init?.method ?? "GET").toUpperCase()
+      if (url.endsWith("/v1/organizations/me")) {
+        return jsonResponse(opts.context ?? organizationContext())
+      }
       if (url.includes("/v1/tools")) {
         if (opts.toolsStatus && opts.toolsStatus >= 400) {
           return jsonResponse({ detail: "nope" }, opts.toolsStatus)
@@ -259,6 +268,9 @@ describe("ToolsGuardrailsPage", () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const url = String(input)
       const method = (init?.method ?? "GET").toUpperCase()
+      if (url.endsWith("/v1/organizations/me")) {
+        return jsonResponse(organizationContext())
+      }
       if (url.includes("/tool-settings/") && url.endsWith("/test")) {
         return jsonResponse({ ok: true, reason: "reachable (HTTP 200)" })
       }
@@ -345,8 +357,10 @@ describe("ToolsGuardrailsPage", () => {
         },
       ],
     }
-    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
-      jsonResponse(withExtra),
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) =>
+      String(input).endsWith("/v1/organizations/me")
+        ? jsonResponse(organizationContext())
+        : jsonResponse(withExtra),
     )
     renderWithClient(<ToolsGuardrailsPage />)
     await screen.findByText("Web search")
@@ -554,5 +568,77 @@ describe("ToolsGuardrailsPage how-to-call card", () => {
     expect(
       screen.queryByRole("heading", { name: "MCP servers" }),
     ).not.toBeInTheDocument()
+  })
+})
+
+// otari-ai#1930: the Tools group is member-visible, but the service settings,
+// the pricing row, and the /v1/search tools are operator-only reads, so for
+// everyone else the page was a 403 banner, and the empty field list also
+// dropped the member-appropriate workspace cards nested under it.
+describe("ToolsGuardrailsPage by caller role", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("shows a non-operator the workspace cards and never fires the operator reads", async () => {
+    const fetchMock = mockApi({
+      context: organizationContext({
+        deployment_operator: false,
+        role: "member",
+      }),
+    })
+    renderWithClient(<ToolsGuardrailsPage />)
+
+    // The two workspace cards, in the state a harness with no selected
+    // workspace lands in; their real forms are covered by their own suites.
+    expect(
+      await screen.findByText(/Per-workspace web search is set on a workspace/),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/Per-workspace code execution is set on a workspace/),
+    ).toBeInTheDocument()
+
+    // No operator form, no deployment search-tools card, and no error banner.
+    expect(screen.queryByLabelText("web_search_url")).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("heading", { name: "Search tools" }),
+    ).not.toBeInTheDocument()
+    const urls = fetchMock.mock.calls.map(([input]) => String(input))
+    expect(urls.some((url) => url.includes("/v1/tool-settings"))).toBe(false)
+    expect(urls.some((url) => url.includes("/v1/search-tools"))).toBe(false)
+  })
+
+  it("keeps a narrowed service page working for a non-operator", async () => {
+    // The sidebar's per-service children render this page with `only`, so the
+    // member-appropriate card has to survive the narrowing too.
+    mockApi({
+      context: organizationContext({
+        deployment_operator: false,
+        role: "member",
+      }),
+    })
+    renderWithClient(<ToolsGuardrailsPage only="sandbox" />)
+
+    expect(
+      await screen.findByText(
+        /Per-workspace code execution is set on a workspace/,
+      ),
+    ).toBeInTheDocument()
+    expect(screen.queryByLabelText("sandbox_url")).not.toBeInTheDocument()
+  })
+
+  it("still renders the operator forms alongside the workspace cards for an operator", async () => {
+    // The operator is a member too: gating the deployment-wide reads must not
+    // have cost them either half of the page.
+    mockApi()
+    renderWithClient(<ToolsGuardrailsPage only="web_search" />)
+
+    expect(await screen.findByLabelText("web_search_url")).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { name: "Search tools" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(/Per-workspace web search is set on a workspace/),
+    ).toBeInTheDocument()
   })
 })

--- a/web/src/features/tools/ToolsGuardrailsPage.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.tsx
@@ -6,12 +6,14 @@ import type {
   ToolSettingField,
   UpdateToolSettingsRequest,
 } from "@/client"
+import { isDeploymentOperator } from "@/features/organization/roles"
 import { OrganizationGuardrailsCard } from "@/features/tools/OrganizationGuardrailsCard"
 import { SearchToolsCard } from "@/features/tools/SearchToolsCard"
 import { WorkspaceCodeExecutionPolicyCard } from "@/features/tools/WorkspaceCodeExecutionPolicyCard"
 import { WorkspaceMcpServersCard } from "@/features/tools/WorkspaceMcpServersCard"
 import { WorkspaceWebSearchCard } from "@/features/tools/WorkspaceWebSearchCard"
 import {
+  useOrganizationContext,
   usePricing,
   useSetPricing,
   useTestService,
@@ -625,9 +627,16 @@ function ServiceRow({
  * still points at.
  */
 export function ToolsGuardrailsPage({ only }: { only?: ToolServiceName } = {}) {
-  const query = useToolSettings()
-  const tools = useTools()
-  const pricing = usePricing()
+  // The Tools group is member-visible for the workspace and organization cards
+  // below, but the service settings, the pricing row, and the /v1/search tools
+  // are deployment-wide, and their reads are operator-only on the server. Gate
+  // them on the same answer the sidebar uses, so a workspace admin gets their
+  // cards rather than a 403 banner over a page of forms they cannot use.
+  const organization = useOrganizationContext()
+  const isOperator = isDeploymentOperator(organization.data)
+  const query = useToolSettings(isOperator)
+  const tools = useTools(isOperator)
+  const pricing = usePricing(isOperator)
   const setPricing = useSetPricing()
   const [pricedTool, setPricedTool] = useState<string | null>(null)
   const [priceErrors, setPriceErrors] = useState<Record<string, string>>({})
@@ -703,7 +712,11 @@ export function ToolsGuardrailsPage({ only }: { only?: ToolServiceName } = {}) {
               "Tools & Guardrails")
             : "Tools & Guardrails"
         }
-        description="Configure the built-in tool and guardrail service endpoints without a restart. Changes apply immediately and persist. URLs are validated for shape (http/https) and can be tested for reachability before saving; the network-safety gates for these services live on the Settings page."
+        description={
+          isOperator
+            ? "Configure the built-in tool and guardrail service endpoints without a restart. Changes apply immediately and persist. URLs are validated for shape (http/https) and can be tested for reachability before saving; the network-safety gates for these services live on the Settings page."
+            : "What your workspace may use of this deployment's built-in tools, and what your organization mandates. The service backends themselves are configured by a deployment operator."
+        }
       />
 
       <ErrorBanner error={query.error} />
@@ -722,7 +735,6 @@ export function ToolsGuardrailsPage({ only }: { only?: ToolServiceName } = {}) {
             (f) => f.service === service.key && !service.order.includes(f.key),
           )
           const fields = [...ordered, ...extra]
-          if (fields.length === 0) return null
           // Absent while /v1/tools is still loading, or if it failed: the card is
           // reference material, so its absence must not hide the editable settings.
           const managed = service.toolId
@@ -732,58 +744,69 @@ export function ToolsGuardrailsPage({ only }: { only?: ToolServiceName } = {}) {
             : undefined
           return (
             <Fragment key={service.key}>
-              <section className="flex flex-col gap-2">
-                {/* Dropped when the page is narrowed to this one service: the
+              {/* The deployment-wide settings card exists only once the
+                  operator-gated read produced this service's fields. The
+                  workspace and organization cards below sit outside this
+                  branch, because their audience is wider than the operator's
+                  and they must not disappear with a read their viewer may not
+                  make. */}
+              {fields.length === 0 ? null : (
+                <section className="flex flex-col gap-2">
+                  {/* Dropped when the page is narrowed to this one service: the
                     page title already says it, and repeating it reads as two
                     headings for the same thing. */}
-                {only ? null : <h2 className="text-title">{service.label}</h2>}
-                <p className="text-sm text-muted">{service.blurb}</p>
-                <Card>
-                  <Card.Content className="flex flex-col divide-y divide-border px-5 py-1">
-                    {service.pricingKey ? (
-                      <ToolPriceRow
-                        pricingKey={service.pricingKey}
-                        configured={
-                          currentRates.get(service.pricingKey) ?? null
-                        }
-                        onSave={(perCall) =>
-                          savePrice(service.pricingKey as string, perCall)
-                        }
-                        saving={pricedTool === service.pricingKey}
-                        saveError={
-                          priceErrors[service.pricingKey] ||
-                          (pricing.error
-                            ? "Could not load the current price. Reload before editing."
-                            : undefined)
-                        }
-                        // Also disabled when the load failed: an errored query leaves
-                        // `configured` null, which renders as "Not priced" and would
-                        // invite an operator to overwrite a rate they cannot see.
-                        disabled={pricing.isLoading || Boolean(pricing.error)}
-                      />
-                    ) : null}
-                    {fields.map((field) => (
-                      <ServiceRow
-                        key={field.key}
-                        field={field}
-                        onSave={(value) => save(field, value)}
-                        saveError={errors[field.key]}
-                        disabled={disabled}
-                      />
-                    ))}
-                    {managed ? <HowToCallCard tool={managed} /> : null}
-                  </Card.Content>
-                </Card>
-              </section>
+                  {only ? null : (
+                    <h2 className="text-title">{service.label}</h2>
+                  )}
+                  <p className="text-sm text-muted">{service.blurb}</p>
+                  <Card>
+                    <Card.Content className="flex flex-col divide-y divide-border px-5 py-1">
+                      {service.pricingKey ? (
+                        <ToolPriceRow
+                          pricingKey={service.pricingKey}
+                          configured={
+                            currentRates.get(service.pricingKey) ?? null
+                          }
+                          onSave={(perCall) =>
+                            savePrice(service.pricingKey as string, perCall)
+                          }
+                          saving={pricedTool === service.pricingKey}
+                          saveError={
+                            priceErrors[service.pricingKey] ||
+                            (pricing.error
+                              ? "Could not load the current price. Reload before editing."
+                              : undefined)
+                          }
+                          // Also disabled when the load failed: an errored query leaves
+                          // `configured` null, which renders as "Not priced" and would
+                          // invite an operator to overwrite a rate they cannot see.
+                          disabled={pricing.isLoading || Boolean(pricing.error)}
+                        />
+                      ) : null}
+                      {fields.map((field) => (
+                        <ServiceRow
+                          key={field.key}
+                          field={field}
+                          onSave={(value) => save(field, value)}
+                          saveError={errors[field.key]}
+                          disabled={disabled}
+                        />
+                      ))}
+                      {managed ? <HowToCallCard tool={managed} /> : null}
+                    </Card.Content>
+                  </Card>
+                </section>
+              )}
               {/* Directly below the in-loop web-search settings, because a searxng
                 search tool that declares no backend URL of its own inherits the
-                one set just above it. */}
+                one set just above it. Operator-only, like the settings above:
+                its rows are the deployment's own /v1/search credentials. */}
               {/* The workspace card goes below both, because it narrows the
                 backend set above it and the /v1/search tools beside it: a
                 workspace switched off may use neither. */}
               {service.key === "web_search" ? (
                 <>
-                  <SearchToolsCard onSaved={showToast} />
+                  {isOperator ? <SearchToolsCard onSaved={showToast} /> : null}
                   <WorkspaceWebSearchCard onSaved={showToast} />
                 </>
               ) : null}

--- a/web/src/shared/api/hooks.ts
+++ b/web/src/shared/api/hooks.ts
@@ -870,21 +870,26 @@ export function useSendTestMail() {
   })
 }
 
-export function useToolSettings() {
+// GET /v1/tool-settings is deployment-operator-only, so the caller passes the
+// client half of that gate (`isDeploymentOperator`) as `enabled` rather than
+// firing a read whose only outcome for anyone else is a 403 banner.
+export function useToolSettings(enabled = true) {
   return useQuery({
     queryKey: [TOOL_SETTINGS],
     queryFn: () => apiFetch<ToolSettingsResponse>("/v1/tool-settings"),
     staleTime: 60_000,
+    enabled,
   })
 }
 
 // The declaration forms this deployment honors. Depends on tool settings
 // (interception, the backend URLs), so a settings save invalidates it.
-export function useTools() {
+export function useTools(enabled = true) {
   return useQuery({
     queryKey: [TOOLS],
     queryFn: () => apiFetch<ToolsResponse>("/v1/tools"),
     staleTime: 60_000,
+    enabled,
   })
 }
 
@@ -1015,10 +1020,11 @@ async function fetchAllPricing(): Promise<PricingResponse[]> {
   return all
 }
 
-export function usePricing() {
+export function usePricing(enabled = true) {
   return useQuery({
     queryKey: [PRICING],
     queryFn: fetchAllPricing,
+    enabled,
   })
 }
 


### PR DESCRIPTION
## Description

The Tools group is member-visible, but `ToolsGuardrailsPage` fired the operator-only `GET /v1/tool-settings` unconditionally, so every non-operator saw a 403 banner, and the `fields.length === 0` short-circuit also dropped the workspace web-search and code-execution cards nested inside it. A workspace admin had no working path to either form.

This gates the deployment-wide reads (`useToolSettings`, `useTools`, `usePricing`, and the search-tools card) on `isDeploymentOperator`, the same answer the sidebar uses, and renders the workspace and organization cards outside the short-circuit. The page header description now speaks to whichever audience is looking at it.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#1930

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Fable 5 (Claude Code)

**Any additional AI details you'd like to share:** Dashboard-only change. Ran `pnpm --dir web run lint`, `typecheck`, and the full vitest suite locally (107 files, 1591 tests), plus `make lint` and `make typecheck`; the Python test suite is untouched by this diff and runs in CI.

- [x] I am an AI Agent filling out this form (check box if true)