### PR TITLE
fix(dashboard): put the last six bare headings on the type scale

### DIFF
--- a/.github/skills/frontend-standards/design-tokens.md
+++ b/.github/skills/frontend-standards/design-tokens.md
@@ -189,8 +189,12 @@ card title nested two sections deep may be an `<h3>` or an `<h4>` and still wear
 `text-title`. Pick the level that keeps the outline unbroken, then the role that matches the
 meaning.
 
-Headings and the display/heading roles are set in Zilla Slab; body and UI text in Mozilla
-Text; keys, IDs, and code in Fira Code. The faces are self-hosted in `web/public/fonts/` under
+Zilla Slab is spent on `text-display` alone; every other role, `text-heading` included, is set
+in Mozilla Text, because at 18px a slab serif competes with the page title instead of sitting
+under it (otari#807). Keys, IDs, and code are Fira Code. A bare `h1`-`h6` still defaults to the
+display face through the `@layer base` rule in the same file, which is why a heading always
+wears a role: left bare it renders serif, and at any size but the display's that reads as an
+accident. The faces are self-hosted in `web/public/fonts/` under
 SIL OFL 1.1, with each family's license shipped beside it (see the README there), so the
 dashboard's typography needs no third-party request and an air-gapped gateway looks like a
 connected one. Adding a family means adding its license in the same commit;

--- a/.github/skills/frontend-standards/design-tokens.md
+++ b/.github/skills/frontend-standards/design-tokens.md
@@ -191,7 +191,7 @@ meaning.
 
 Zilla Slab is spent on `text-display` alone; every other role, `text-heading` included, is set
 in Mozilla Text, because at 18px a slab serif competes with the page title instead of sitting
-under it (otari#807). Keys, IDs, and code are Fira Code. A bare `h1`-`h6` still defaults to the
+under it (mozilla-ai/otari#807). Keys, IDs, and code are Fira Code. A bare `h1`-`h6` still defaults to the
 display face through the `@layer base` rule in the same file, which is why a heading always
 wears a role: left bare it renders serif, and at any size but the display's that reads as an
 accident. The faces are self-hosted in `web/public/fonts/` under

--- a/web/src/app/HybridLanding.tsx
+++ b/web/src/app/HybridLanding.tsx
@@ -62,9 +62,7 @@ export function HybridLanding() {
             {/* Decorative: the heading beside it already names the product. */}
             <img src="/favicon.svg" alt="" className="h-12 w-12" />
             <div>
-              <h1 className="text-lg font-semibold text-foreground">
-                Otari gateway
-              </h1>
+              <h1 className="text-display">Otari gateway</h1>
               <p className="mt-1 text-sm text-muted">
                 This gateway serves requests. Its providers, routing, budgets
                 and usage are managed on otari.ai.

--- a/web/src/features/auth/PublicAuthLayout.tsx
+++ b/web/src/features/auth/PublicAuthLayout.tsx
@@ -33,7 +33,7 @@ export function PublicAuthLayout({
           <div className="flex flex-col items-center gap-3 text-center">
             <img src="/favicon.svg" alt="Otari" className="h-12 w-12" />
             <div>
-              <h1 className="text-lg font-semibold text-foreground">{title}</h1>
+              <h1 className="text-display">{title}</h1>
               {description ? (
                 <p className="mt-1 text-sm text-muted">{description}</p>
               ) : null}

--- a/web/src/features/invitations/AcceptInvitationPage.tsx
+++ b/web/src/features/invitations/AcceptInvitationPage.tsx
@@ -87,9 +87,7 @@ export function AcceptInvitationPage() {
         <Card.Content className="flex flex-col gap-5 p-7">
           <div className="flex flex-col items-center gap-3 text-center">
             <img src="/favicon.svg" alt="Otari" className="h-12 w-12" />
-            <h1 className="text-lg font-semibold text-foreground">
-              Organization invitation
-            </h1>
+            <h1 className="text-display">Organization invitation</h1>
           </div>
 
           {token === null ? (

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -170,7 +170,7 @@ function RevealSecretModal({
         onKeyDown={onKeyDown}
         className="flex max-h-[90vh] w-full max-w-2xl flex-col gap-4 overflow-y-auto rounded-xl bg-surface p-6 shadow-xl"
       >
-        <h2 id="reveal-title" className="text-lg font-semibold text-foreground">
+        <h2 id="reveal-title" className="text-title">
           {title}
         </h2>
         <InfoBanner tone="warning">

--- a/web/src/features/overview/OverviewPage.tsx
+++ b/web/src/features/overview/OverviewPage.tsx
@@ -574,9 +574,7 @@ function GettingStartedPanel() {
     <Card>
       <Card.Content className="flex flex-col gap-3 p-6">
         <div>
-          <h2 className="text-lg font-semibold text-foreground">
-            Get started with Otari
-          </h2>
+          <h2 className="text-heading">Get started with Otari</h2>
           <p className="mt-1 text-sm text-muted">
             Add a provider to begin serving models. Once it is configured, this
             page will show your gateway&rsquo;s traffic, spend, and health.

--- a/web/src/features/providers/ProvidersPage.tsx
+++ b/web/src/features/providers/ProvidersPage.tsx
@@ -747,9 +747,7 @@ function OnboardingPanel({
     <Card>
       <Card.Content className="flex flex-col gap-4 p-6">
         <div>
-          <h2 className="text-lg font-semibold text-foreground">
-            Welcome to Otari
-          </h2>
+          <h2 className="text-heading">Welcome to Otari</h2>
           <p className="mt-1 text-sm text-muted">
             You are signed in. Add a provider to start serving models: three
             quick steps.

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -480,6 +480,50 @@ describe("semantic tokens only", () => {
   })
 })
 
+// A bare heading is not unstyled: the `@layer base` rule in globals.css hands
+// `h1`-`h6` the display face, so a heading that skips the type scale renders in
+// Zilla Slab at whatever size its hand-rolled classes say. otari#810 migrated
+// 35 sites and still left six behind (otari-ai#1933), which is what a rule
+// without a test does.
+describe("headings wear a type role", () => {
+  const SRC = join(WEB, "src")
+  const sources = readdirSync(SRC, { recursive: true })
+    .map((name) => String(name).replaceAll("\\", "/"))
+    .filter((name) => name.endsWith(".tsx") && !name.endsWith(".test.tsx"))
+
+  it("covers the source tree", () => {
+    // Same guard as the token sweep above: an empty list passes vacuously.
+    expect(sources.length).toBeGreaterThan(30)
+  })
+
+  it.each(sources)("puts every heading in %s on the scale", (name) => {
+    // Block comments go first: Login.tsx narrates its layout in JSX comments
+    // that mention `<h1>` in prose.
+    const source = readFileSync(join(SRC, name), "utf8").replace(
+      /\/\*[\s\S]*?\*\//g,
+      "",
+    )
+    for (const match of source.matchAll(/<h[1-6]\b([^>]*)>/g)) {
+      const attributes = match[1]
+      const literal = attributes.match(/className="([^"]*)"/)
+      if (literal) {
+        expect(
+          literal[1],
+          `${match[0]} in ${name} hand-rolls its type; use text-display, text-heading, or text-title`,
+        ).toMatch(/\btext-(?:display|heading|title)\b/)
+      } else {
+        // No string literal, so the one acceptable shape left is an
+        // expression (Login.tsx's HEADING constant). A heading with no
+        // className at all is the bare case the base layer turns serif.
+        expect(
+          attributes,
+          `${match[0]} in ${name} is a bare heading, which the base layer renders in the display face; give it a type role`,
+        ).toContain("className={")
+      }
+    }
+  })
+})
+
 // The chrome's own type roles, added because the nav files had grown six
 // arbitrary sizes between them (13.5px twice, 13px, 11.5px, 11px, 9px), which is
 // a scale with no single place to read it and nothing to keep it from growing a

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -513,12 +513,32 @@ describe("headings wear a type role", () => {
         ).toMatch(/\btext-(?:display|heading|title)\b/)
       } else {
         // No string literal, so the one acceptable shape left is an
-        // expression (Login.tsx's HEADING constant). A heading with no
-        // className at all is the bare case the base layer turns serif.
+        // expression. A heading with no className at all is the bare case
+        // the base layer turns serif.
+        const expression = attributes.match(/className=\{([^}]*)\}/)
         expect(
-          attributes,
+          expression,
           `${match[0]} in ${name} is a bare heading, which the base layer renders in the display face; give it a type role`,
-        ).toContain("className={")
+        ).not.toBeNull()
+        let value = (expression as RegExpMatchArray)[1].trim()
+        // A lone identifier is read through its declaration in the same
+        // file, which is how Login.tsx spells its HEADING constant. Any
+        // other expression (a ternary, a template) has to name a role in
+        // its own text.
+        if (/^\w+$/.test(value)) {
+          const declaration = source.match(
+            new RegExp(`\\b${value} = "([^"]*)"`),
+          )
+          expect(
+            declaration,
+            `${match[0]} in ${name} reads ${value}, which is not a same-file string constant this test can check; use a literal or a const`,
+          ).not.toBeNull()
+          value = (declaration as RegExpMatchArray)[1]
+        }
+        expect(
+          value,
+          `${match[0]} in ${name} hand-rolls its type; use text-display, text-heading, or text-title`,
+        ).toMatch(/\btext-(?:display|heading|title)\b/)
       }
     }
   })


### PR DESCRIPTION
## Description

`globals.css` hands every bare `h1`-`h6` the display face in `@layer base`, so a heading not on a type role silently renders in Zilla Slab. otari#810 migrated 35 sites but left six, which made the auth-flow titles render 18px serif while Login's sat at the 26px `text-display`.

- The three page-defining `h1`s (`PublicAuthLayout`, `HybridLanding`, `AcceptInvitationPage`) take `text-display`; the two in-page section `h2`s (`ProvidersPage`, `OverviewPage`) take `text-heading`; the `KeysPage` reveal dialog title takes `text-title`, matching the dialogs that already wear it.
- `foundation.test.ts` now sweeps every heading in `src` for a type role, so a seventh straggler fails the suite instead of shipping serif.
- The `design-tokens.md` sentence claiming heading roles are set in Zilla Slab is rewritten: only `text-display` is, post #807.

## PR Type

- [x] Bug Fix
- [x] Documentation

## Relevant issues

Part of mozilla-ai/otari-ai#1933 (the typography.md half lands there).

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Claude Fable 5)

**Any additional AI details you'd like to share:**

Checks run: `pnpm run lint`, `pnpm run typecheck`, `pnpm test` (107 files, 1726 tests, all green). The new heading sweep was verified to fail on a reintroduced offender.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)