### PR TITLE
feat(keys): let members create and manage their own API keys

### DIFF
--- a/.github/skills/frontend-standards/naming-conventions.md
+++ b/.github/skills/frontend-standards/naming-conventions.md
@@ -14,8 +14,11 @@ thing is and what it does without opening it.
 ## Variables
 
 Say what the value is, not what type it happens to be. `data`, `info`, `item`, `obj`, and
-`res` describe nothing. Booleans read as a predicate: `isPending`, `hasBudget`,
-`canRevokeKey`, `shouldShowBanner`.
+`res` describe nothing. Booleans read as a predicate, a yes/no question in English:
+`isPending`, `hasBudget`, `canRevokeKey`, `shouldShowBanner`. That covers every boolean a
+reader meets, including props and the boolean fields of a hook's return value
+(`useKeysScope()` answers `isDeploymentWide` and `isReady`, not `deploymentWide` and
+`ready`): a bare noun phrase reads as the thing itself rather than as a question about it.
 
 ```ts
 const isSignedIn = session !== undefined

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -69,6 +69,12 @@ Rotation preserves the key record and invalidates the previous secret.
 A budget-exempt key is also exempt from `require_pricing`. Reserve such keys for
 usage import or other intentional observability-only traffic.
 
+`/v1/keys` manages every key in the caller's organization and requires the
+deployment operator's standing. A signed-in member without it manages their own
+keys at `/v1/organizations/me/keys`, which derives the owner rather than
+accepting one, mints only into a workspace the caller may see, and never issues
+a budget-exempt key.
+
 ## Budgets
 
 Otari enforces budgets before dispatch and reconciles actual cost afterwards.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -23,7 +23,10 @@ x-api-key: <token>
 
 Use API keys for inference. The master key is a deployment-wide administrative
 credential. Dashboard sessions authenticate browser requests, but deployment-wide
-operations also require operator authority.
+operations also require operator authority. Where a tenant needs one of those
+operations, a separately scoped endpoint serves it to the caller's own
+organization: `/v1/organizations/me/usage` for usage, and
+`/v1/organizations/me/keys` for a member's own API keys.
 
 In hybrid mode, the completion APIs accept an otari.ai user token through
 `Authorization: Bearer <token>`. Local API keys and management APIs are not used.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -89,6 +89,11 @@ settings response.
 Exact page names and availability can change with deployment mode and installed
 extensions. The running dashboard is the source of truth.
 
+What a page shows can also depend on who is signed in. On API keys, an operator
+manages every key in the organization and chooses each key's owner, while a
+member sees the same page scoped to their own keys, always billed to themselves
+and never budget-exempt.
+
 ## Observability
 
 Activity is the per-request log. Usage provides aggregates and time series.

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -2760,6 +2760,96 @@
         "title": "CreateKeyResponse",
         "type": "object"
       },
+      "CreateOwnKeyRequest": {
+        "description": "Create-key body for the member surface.\n\nDeliberately not ``CreateKeyRequest``: it carries no ``user_id`` (the owner\nis always the caller) and no ``exclude_from_budget`` (a member must not\nexempt their own spend from enforcement).",
+        "properties": {
+          "allowed_models": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Model allow-list: null = any model your user default allows, [] = deny all, or canonical instance:model entries. A key can only narrow your own model access, never broaden it.",
+            "title": "Allowed Models"
+          },
+          "capture_agent_telemetry": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-key override of the deployment-wide capture_agent_telemetry setting: null (default) inherits it, true always stores this key's coding-agent telemetry, false always discards it.",
+            "title": "Capture Agent Telemetry"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional expiration timestamp",
+            "title": "Expires At"
+          },
+          "key_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional name for the key",
+            "title": "Key Name"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "description": "Optional metadata",
+            "title": "Metadata",
+            "type": "object"
+          },
+          "reject_user_mismatch": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-key override of the deployment-wide reject_user_mismatch setting: null (default) inherits it, true always rejects a request naming a different 'user', false always accepts it. Spend binds to your own user either way.",
+            "title": "Reject User Mismatch"
+          },
+          "workspace_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Workspace this key belongs to, which must be one you may see in your active organization. Omitted means that organization's default workspace, refused when you are not a member of it.",
+            "title": "Workspace Id"
+          }
+        },
+        "title": "CreateOwnKeyRequest",
+        "type": "object"
+      },
       "CreateScopedBudgetRequest": {
         "description": "Request model for creating a scoped budget.",
         "properties": {
@@ -9688,6 +9778,95 @@
           "enabled"
         ],
         "title": "UpdateMaintenanceModeRequest",
+        "type": "object"
+      },
+      "UpdateOwnKeyRequest": {
+        "description": "Update-key body for the member surface.\n\nThe operator's ``UpdateKeyRequest`` minus ``exclude_from_budget``, for the\nreason the create body gives. The tri-state fields follow the same\n``model_fields_set`` idiom: absent = unchanged, null = clear to inherit,\na value = pin it.",
+        "properties": {
+          "allowed_models": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Models"
+          },
+          "capture_agent_telemetry": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Capture Agent Telemetry"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "is_active": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Active"
+          },
+          "key_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key Name"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "reject_user_mismatch": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reject User Mismatch"
+          }
+        },
+        "title": "UpdateOwnKeyRequest",
         "type": "object"
       },
       "UpdateScopedBudgetRequest": {
@@ -17341,6 +17520,296 @@
         "summary": "Update Organization Guardrail",
         "tags": [
           "organization-guardrails"
+        ]
+      }
+    },
+    "/v1/organizations/me/keys": {
+      "get": {
+        "description": "List the caller's own API keys in their active organization, newest first.\n\nOnly keys billed to the caller's own user: an operator-minted key assigned\nto them is theirs to see here, and nobody else's key ever is. Naming a\nworkspace outside their organization lists nothing rather than refusing, so\nthe filter reports no more than the unfiltered read does.",
+        "operationId": "list_own_keys_v1_organizations_me_keys_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Skip",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Only keys in this workspace.",
+            "in": "query",
+            "name": "workspace_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only keys in this workspace.",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/KeyInfo"
+                  },
+                  "title": "Response List Own Keys V1 Organizations Me Keys Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "List Own Keys",
+        "tags": [
+          "organization-keys"
+        ]
+      },
+      "post": {
+        "description": "Create an API key owned by the caller, in a workspace they may see.\n\nThe member-scoped counterpart of ``POST /v1/keys``: the owner is always the\ncaller's own attribution user, the key is always budget-enforced, and the\nworkspace must be visible to the caller (a member of it, or an organization\nowner/admin/superuser, who see every workspace). The secret is returned once.",
+        "operationId": "create_own_key_v1_organizations_me_keys_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOwnKeyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateKeyResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Create Own Key",
+        "tags": [
+          "organization-keys"
+        ]
+      }
+    },
+    "/v1/organizations/me/keys/{key_id}": {
+      "delete": {
+        "description": "Delete (revoke) one of the caller's own API keys.",
+        "operationId": "delete_own_key_v1_organizations_me_keys__key_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "title": "Key Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Delete Own Key",
+        "tags": [
+          "organization-keys"
+        ]
+      },
+      "patch": {
+        "description": "Update one of the caller's own API keys.",
+        "operationId": "update_own_key_v1_organizations_me_keys__key_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "title": "Key Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateOwnKeyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KeyInfo"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Update Own Key",
+        "tags": [
+          "organization-keys"
+        ]
+      }
+    },
+    "/v1/organizations/me/keys/{key_id}/rotate": {
+      "post": {
+        "description": "Rotate the secret of one of the caller's own API keys, in place.\n\nSame contract as the operator's rotate: the row keeps its identity, the new\nraw key is returned once, and the previous secret stops authenticating\nimmediately with no grace window.",
+        "operationId": "rotate_own_key_v1_organizations_me_keys__key_id__rotate_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "title": "Key Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateKeyResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Rotate Own Key",
+        "tags": [
+          "organization-keys"
         ]
       }
     },

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -2779,6 +2779,184 @@
     {
       "item": [
         {
+          "name": "List Own Keys",
+          "request": {
+            "description": "List the caller's own API keys in their active organization, newest first.\n\nOnly keys billed to the caller's own user: an operator-minted key assigned\nto them is theirs to see here, and nobody else's key ever is. Naming a\nworkspace outside their organization lists nothing rather than refusing, so\nthe filter reports no more than the unfiltered read does.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "keys"
+              ],
+              "query": [
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "skip",
+                  "value": ""
+                },
+                {
+                  "description": "",
+                  "disabled": true,
+                  "key": "limit",
+                  "value": ""
+                },
+                {
+                  "description": "Only keys in this workspace.",
+                  "disabled": true,
+                  "key": "workspace_id",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/keys?skip=&limit=&workspace_id="
+            }
+          }
+        },
+        {
+          "name": "Create Own Key",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"allowed_models\": [\n    \"string\"\n  ],\n  \"capture_agent_telemetry\": false,\n  \"expires_at\": \"2024-01-01T00:00:00Z\",\n  \"key_name\": \"string\",\n  \"metadata\": {},\n  \"reject_user_mismatch\": false,\n  \"workspace_id\": \"00000000-0000-0000-0000-000000000000\"\n}"
+            },
+            "description": "Create an API key owned by the caller, in a workspace they may see.\n\nThe member-scoped counterpart of ``POST /v1/keys``: the owner is always the\ncaller's own attribution user, the key is always budget-enforced, and the\nworkspace must be visible to the caller (a member of it, or an organization\nowner/admin/superuser, who see every workspace). The secret is returned once.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "keys"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/keys"
+            }
+          }
+        },
+        {
+          "name": "Update Own Key",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"allowed_models\": [\n    \"string\"\n  ],\n  \"capture_agent_telemetry\": false,\n  \"expires_at\": \"2024-01-01T00:00:00Z\",\n  \"is_active\": false,\n  \"key_name\": \"string\",\n  \"metadata\": {},\n  \"reject_user_mismatch\": false\n}"
+            },
+            "description": "Update one of the caller's own API keys.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "PATCH",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "keys",
+                ":key_id"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/keys/:key_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "key_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Own Key",
+          "request": {
+            "description": "Delete (revoke) one of the caller's own API keys.",
+            "header": [],
+            "method": "DELETE",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "keys",
+                ":key_id"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/keys/:key_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "key_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Rotate Own Key",
+          "request": {
+            "description": "Rotate the secret of one of the caller's own API keys, in place.\n\nSame contract as the operator's rotate: the row keeps its identity, the new\nraw key is returned once, and the previous secret stops authenticating\nimmediately with no grace window.",
+            "header": [],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "keys",
+                ":key_id",
+                "rotate"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/keys/:key_id/rotate",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "key_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "name": "organization-keys"
+    },
+    {
+      "item": [
+        {
           "name": "List Organization Pricing",
           "request": {
             "description": "List the organization's rate overrides.\n\nReadable by any member: these rates decide what the caller's own requests\ncost, so they are not withheld from the people billed at them. Writing needs\nan owner or admin.\n\nPaged on the same bounds the rest of the tenancy surface uses, because the\ntable grows a row per model per period. ``count`` is the total, so a client\nknows whether another page is owed.",

--- a/scripts/sdk_codegen/sdk-endpoints.txt
+++ b/scripts/sdk_codegen/sdk-endpoints.txt
@@ -244,6 +244,14 @@ GET /v1/organizations/me/usage/count                        # dashboard-only
 GET /v1/organizations/me/usage/summary                      # dashboard-only
 GET /v1/organizations/me/usage/series                       # dashboard-only
 GET /v1/organizations/me/routing-policies                   # dashboard-only
+# The member's own keys (otari-ai#1941), excluded for the same reason as the
+# usage reads above: scoped by the caller's dashboard session, which an SDK
+# caller does not hold.
+GET /v1/organizations/me/keys                               # dashboard-only
+POST /v1/organizations/me/keys                              # dashboard-only
+PATCH /v1/organizations/me/keys/{key_id}                    # dashboard-only
+DELETE /v1/organizations/me/keys/{key_id}                   # dashboard-only
+POST /v1/organizations/me/keys/{key_id}/rotate              # dashboard-only
 GET /v1/organizations/me/guardrails                         # operator surface
 POST /v1/organizations/me/guardrails                        # operator surface
 PATCH /v1/organizations/me/guardrails/{guardrail_id}        # operator surface

--- a/src/gateway/AGENTS.md
+++ b/src/gateway/AGENTS.md
@@ -60,8 +60,11 @@ dashboard session. It does not prove that the session may act deployment-wide.
 
 Tenant lookups include the tenant predicate and return 404 for a foreign ID.
 Client filters may narrow the server-derived scope and never widen it. A tenant
-that needs a deployment-wide read gets a separately scoped endpoint, as
-organization usage does; do not loosen the original route.
+that needs a deployment-wide route gets a separately scoped endpoint, as
+organization usage does for reads and `/v1/organizations/me/keys`
+(`organization_keys.py`) does for writes; do not loosen the original route. A
+member's key surface derives its owner as well as its scope, so it takes no
+`user_id` and mints nothing budget-exempt.
 
 The API key determines the billed workspace. Client `user`, workspace, or
 organization fields cannot move billing or credential resolution.

--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -31,6 +31,7 @@ from gateway.api.routes import (
     moderations,
     org_provider_keys,
     organization_guardrails,
+    organization_keys,
     organization_pricing,
     organization_routing,
     organization_usage,
@@ -169,6 +170,11 @@ def _register_core_routers(app: FastAPI, config: GatewayConfig) -> None:
     # The tenant-scoped read over the same table ``/v1/routing/policies`` serves
     # to an operator, mounted here for the same reason (otari-ai#1942).
     app.include_router(organization_routing.router)
+    # The member-scoped key surface: the caller's own keys, in workspaces they
+    # may see. Mounted here for the reason the usage sibling above is; the
+    # deployment-wide ``keys.router`` keeps its operator gate unchanged
+    # (mozilla-ai/otari-ai#1941).
+    app.include_router(organization_keys.router)
     app.include_router(workspaces.router)
     app.include_router(invitations.router)
     app.include_router(workspace_member_budget_policies.router)

--- a/src/gateway/api/routes/keys.py
+++ b/src/gateway/api/routes/keys.py
@@ -51,7 +51,13 @@ async def _caller_organization_id(
 CallerOrganization = Annotated[uuid.UUID, Depends(_caller_organization_id)]
 
 
-async def _load_key_in_organization(db: AsyncSession, key_id: str, organization_id: uuid.UUID) -> APIKey:
+async def _load_key_in_organization(
+    db: AsyncSession,
+    key_id: str,
+    organization_id: uuid.UUID,
+    *,
+    owner_user_id: str | None = None,
+) -> APIKey:
     """Load a key by id within one organization, or raise 404.
 
     Joined to the workspace rather than loaded by id alone: a key belongs to
@@ -61,12 +67,19 @@ async def _load_key_in_organization(db: AsyncSession, key_id: str, organization_
     ``resolve_workspace_in_organization`` rule in
     `services/tenancy/authorization.py`: a 403 would confirm the id names a real
     key somewhere.
+
+    ``owner_user_id`` narrows the load to keys billed to that owner, for the
+    member-scoped routes in ``organization_keys.py``: somebody else's key in the
+    caller's own organization answers the same 404, for the same reason.
     """
-    result = await db.execute(
+    statement = (
         select(APIKey)
         .join(Workspace, col(Workspace.id) == col(APIKey.workspace_id))
         .where(col(APIKey.id) == key_id, col(Workspace.organization_id) == organization_id)
     )
+    if owner_user_id is not None:
+        statement = statement.where(col(APIKey.user_id) == owner_user_id)
+    result = await db.execute(statement)
     key = result.scalar_one_or_none()
 
     if not key:

--- a/src/gateway/api/routes/keys.py
+++ b/src/gateway/api/routes/keys.py
@@ -392,11 +392,16 @@ async def update_key(
     """
     key = await _load_key_in_organization(db, key_id, organization_id)
 
-    if request.key_name is not None:
+    # Tri-state via model_fields_set, like allowed_models below: both columns
+    # are nullable and the dashboard's edit form sends null to clear them
+    # ("Blank clears the expiry"), which an ``is not None`` guard silently
+    # dropped. ``is_active`` and ``exclude_from_budget`` are not nullable, so
+    # ``is not None`` is the whole distinction there.
+    if "key_name" in request.model_fields_set:
         key.key_name = request.key_name
     if request.is_active is not None:
         key.is_active = request.is_active
-    if request.expires_at is not None:
+    if "expires_at" in request.model_fields_set:
         key.expires_at = request.expires_at
     if request.exclude_from_budget is not None:
         key.exclude_from_budget = request.exclude_from_budget

--- a/src/gateway/api/routes/organization_keys.py
+++ b/src/gateway/api/routes/organization_keys.py
@@ -1,0 +1,386 @@
+"""The caller's own API keys, for a tenant who does not operate the deployment.
+
+``/v1/keys`` is deployment-wide and operator-only (otari-ai#1880), which left a
+hosted organization member with no way to mint a key at all: they could not use
+the product without an operator handing them one out of band
+(mozilla-ai/otari-ai#1941). The answer is not a looser gate on that router,
+which scopes to the caller's whole active organization and takes a client-named
+``user_id``; it is the same second-surface shape ``organization_usage.py``
+established for usage reads (otari#837), applied to a write surface:
+
+* **Ownership is derived, never accepted.** A key minted here is billed to the
+  caller's own attribution row (``users.user_id`` = the identity's UUID as a
+  string, the row ``get_or_create_attribution_user`` mints and the activation
+  guide already keys on), and every load below carries that owner predicate.
+  There is no ``user_id`` parameter, so there is nothing for an escalation to
+  travel on, and somebody else's key answers the 404 a nonexistent one does.
+* **The workspace must be one the caller may see.** A named ``workspace_id``
+  goes through ``resolve_workspace_in_organization``, so a workspace in another
+  organization, or one in this organization the caller is not a member of,
+  answers 404 exactly as one that does not exist. Omitting it targets the
+  organization's default workspace, put through the same check.
+* **No budget bypass.** The operator's create takes ``exclude_from_budget``;
+  this one does not, and always mints an enforced key: a member exempting their
+  own key from budget would be minting their own unlimited spend.
+
+The operator's deployment-wide view keeps the gate it has, unchanged. A key
+minted here shows up there like any other row in the organization, and the
+narrow-only ``allowed_models`` rule binds against the caller's own user default
+exactly as it does on the operator surface.
+"""
+
+import uuid
+from datetime import datetime
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from gateway.api.deps import CurrentIdentity, get_config, get_db, verify_master_key
+from gateway.api.routes.keys import (
+    _KEY_EXCEEDS_USER_DETAIL,
+    CreateKeyResponse,
+    KeyInfo,
+    _load_key_in_organization,
+)
+from gateway.auth.models import generate_api_key, hash_key, key_prefix
+from gateway.core.config import GatewayConfig
+from gateway.models.entities import APIKey, User
+from gateway.models.tenancy import User as TenancyUser
+from gateway.models.tenancy import Workspace
+from gateway.repositories.users_repository import get_or_create_attribution_user
+from gateway.services.model_access import is_allowlist_subset, validate_allowed_models
+from gateway.services.tenancy import OrganizationService
+from gateway.services.tenancy.authorization import resolve_workspace_in_organization
+from gateway.services.tenancy.errors import WorkspaceNotFoundError
+from gateway.services.workspace_scope import organization_default_workspace_id
+
+router = APIRouter(
+    prefix="/v1/organizations/me/keys",
+    tags=["organization-keys"],
+    # Authentication only, like the rest of the ``/v1/organizations/me`` surface.
+    # What the caller may touch is decided per request by the owner predicate and
+    # the workspace resolver below, which is why the deployment operator gate
+    # does not belong here.
+    dependencies=[Depends(verify_master_key)],
+)
+
+
+class CreateOwnKeyRequest(BaseModel):
+    """Create-key body for the member surface.
+
+    Deliberately not ``CreateKeyRequest``: it carries no ``user_id`` (the owner
+    is always the caller) and no ``exclude_from_budget`` (a member must not
+    exempt their own spend from enforcement).
+    """
+
+    key_name: str | None = Field(default=None, description="Optional name for the key")
+    expires_at: datetime | None = Field(default=None, description="Optional expiration timestamp")
+    allowed_models: list[str] | None = Field(
+        default=None,
+        description="Model allow-list: null = any model your user default allows, [] = deny all, "
+        "or canonical instance:model entries. A key can only narrow your own model access, "
+        "never broaden it.",
+    )
+    reject_user_mismatch: bool | None = Field(
+        default=None,
+        description="Per-key override of the deployment-wide reject_user_mismatch setting: "
+        "null (default) inherits it, true always rejects a request naming a different 'user', "
+        "false always accepts it. Spend binds to your own user either way.",
+    )
+    capture_agent_telemetry: bool | None = Field(
+        default=None,
+        description="Per-key override of the deployment-wide capture_agent_telemetry setting: "
+        "null (default) inherits it, true always stores this key's coding-agent telemetry, "
+        "false always discards it.",
+    )
+    workspace_id: uuid.UUID | None = Field(
+        default=None,
+        description="Workspace this key belongs to, which must be one you may see in your "
+        "active organization. Omitted means that organization's default workspace, refused "
+        "when you are not a member of it.",
+    )
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Optional metadata")
+
+
+class UpdateOwnKeyRequest(BaseModel):
+    """Update-key body for the member surface.
+
+    The operator's ``UpdateKeyRequest`` minus ``exclude_from_budget``, for the
+    reason the create body gives. The tri-state fields follow the same
+    ``model_fields_set`` idiom: absent = unchanged, null = clear to inherit,
+    a value = pin it.
+    """
+
+    key_name: str | None = None
+    is_active: bool | None = None
+    expires_at: datetime | None = None
+    reject_user_mismatch: bool | None = None
+    capture_agent_telemetry: bool | None = None
+    # Tri-state via model_fields_set: absent = unchanged, null = clear to
+    # unrestricted (within the user default), [] = deny all, list = restrict.
+    allowed_models: list[str] | None = None
+    metadata: dict[str, Any] | None = None
+
+
+async def _caller_context(db: AsyncSession, identity: TenancyUser) -> tuple[uuid.UUID, str]:
+    """The organization this request acts in, and the owner id it acts as.
+
+    The organization is the caller's own ``active_organization_id``, resolved
+    through ``get_active_organization_for_user`` so a pointer with no live
+    membership behind it refuses rather than resolving; moving between
+    organizations is ``POST /v1/organizations/me/switch``. The owner id is the
+    identity's UUID rendered as a string, the attribution convention
+    ``get_or_create_attribution_user`` documents.
+    """
+    organization = await OrganizationService(db).get_active_organization_for_user(identity)
+    return organization.id, str(identity.id)
+
+
+@router.post("")
+async def create_own_key(
+    request: CreateOwnKeyRequest,
+    identity: CurrentIdentity,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+) -> CreateKeyResponse:
+    """Create an API key owned by the caller, in a workspace they may see.
+
+    The member-scoped counterpart of ``POST /v1/keys``: the owner is always the
+    caller's own attribution user, the key is always budget-enforced, and the
+    workspace must be visible to the caller (a member of it, or an organization
+    owner/admin/superuser, who see every workspace). The secret is returned once.
+    """
+    organizations = OrganizationService(db)
+    organization = await organizations.get_active_organization_for_user(identity)
+
+    if request.workspace_id is not None:
+        workspace = await resolve_workspace_in_organization(
+            db,
+            user=identity,
+            workspace_id=request.workspace_id,
+            organization=organization,
+            organizations=organizations,
+        )
+        workspace_id = workspace.id
+    else:
+        resolved = await organization_default_workspace_id(db, organization.id)
+        if resolved is None:
+            # Not reachable through any path that creates an organization here;
+            # refused rather than provisioned, as on the operator surface.
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="This organization has no workspace to hold a key; create one first.",
+            )
+        try:
+            workspace = await resolve_workspace_in_organization(
+                db,
+                user=identity,
+                workspace_id=resolved,
+                organization=organization,
+                organizations=organizations,
+            )
+        except WorkspaceNotFoundError:
+            # The caller named nothing, so "not found" would point them at a
+            # parameter they did not send; say what to do instead.
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="You are not a member of this organization's default workspace; "
+                "pass workspace_id naming a workspace you belong to.",
+            ) from None
+        workspace_id = workspace.id
+
+    try:
+        allowed_models = validate_allowed_models(config, request.allowed_models)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    owner = await get_or_create_attribution_user(
+        db,
+        user_id=str(identity.id),
+        alias=identity.full_name or identity.email,
+    )
+    # A key must not grant more than its user's default, the same narrow-only
+    # rule the operator surface enforces; here the user is always the caller.
+    if not is_allowlist_subset(allowed_models, owner.allowed_models):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=_KEY_EXCEEDS_USER_DETAIL)
+
+    api_key = generate_api_key()
+    db_key = APIKey(
+        id=str(uuid.uuid4()),
+        workspace_id=workspace_id,
+        key_hash=hash_key(api_key),
+        key_prefix=key_prefix(api_key),
+        key_name=request.key_name,
+        user_id=owner.user_id,
+        expires_at=request.expires_at,
+        allowed_models=allowed_models,
+        exclude_from_budget=False,
+        reject_user_mismatch=request.reject_user_mismatch,
+        capture_agent_telemetry=request.capture_agent_telemetry,
+        metadata_=request.metadata,
+    )
+
+    db.add(db_key)
+    try:
+        await db.commit()
+    except SQLAlchemyError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database error",
+        ) from None
+    await db.refresh(db_key)
+
+    key_info = KeyInfo.from_model(db_key)
+    return CreateKeyResponse(
+        **key_info.model_dump(exclude={"last_used_at"}),
+        key=api_key,
+    )
+
+
+@router.get("")
+async def list_own_keys(
+    identity: CurrentIdentity,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=1000)] = 100,
+    workspace_id: Annotated[uuid.UUID | None, Query(description="Only keys in this workspace.")] = None,
+) -> list[KeyInfo]:
+    """List the caller's own API keys in their active organization, newest first.
+
+    Only keys billed to the caller's own user: an operator-minted key assigned
+    to them is theirs to see here, and nobody else's key ever is. Naming a
+    workspace outside their organization lists nothing rather than refusing, so
+    the filter reports no more than the unfiltered read does.
+    """
+    organization_id, owner_user_id = await _caller_context(db, identity)
+    statement = (
+        select(APIKey)
+        .join(Workspace, col(Workspace.id) == col(APIKey.workspace_id))
+        .where(
+            col(Workspace.organization_id) == organization_id,
+            col(APIKey.user_id) == owner_user_id,
+        )
+    )
+    if workspace_id is not None:
+        statement = statement.where(col(APIKey.workspace_id) == workspace_id)
+    # Ordered so paging through more than one page is stable, with the id as a
+    # tiebreak for keys minted in the same instant.
+    statement = statement.order_by(col(APIKey.created_at).desc(), col(APIKey.id))
+    result = await db.execute(statement.offset(skip).limit(limit))
+    keys = result.scalars().all()
+
+    return [KeyInfo.from_model(key) for key in keys]
+
+
+@router.patch("/{key_id}")
+async def update_own_key(
+    key_id: str,
+    request: UpdateOwnKeyRequest,
+    identity: CurrentIdentity,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+) -> KeyInfo:
+    """Update one of the caller's own API keys."""
+    organization_id, owner_user_id = await _caller_context(db, identity)
+    key = await _load_key_in_organization(db, key_id, organization_id, owner_user_id=owner_user_id)
+
+    if request.key_name is not None:
+        key.key_name = request.key_name
+    if request.is_active is not None:
+        key.is_active = request.is_active
+    if request.expires_at is not None:
+        key.expires_at = request.expires_at
+    if "reject_user_mismatch" in request.model_fields_set:
+        key.reject_user_mismatch = request.reject_user_mismatch
+    if "capture_agent_telemetry" in request.model_fields_set:
+        key.capture_agent_telemetry = request.capture_agent_telemetry
+    if "allowed_models" in request.model_fields_set:
+        try:
+            new_allowed = validate_allowed_models(config, request.allowed_models)
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+        # Narrow-only against the caller's own user default (see create_own_key).
+        user_default = (
+            await db.execute(select(User.allowed_models).where(User.user_id == owner_user_id))
+        ).scalar_one_or_none()
+        if not is_allowlist_subset(new_allowed, user_default):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=_KEY_EXCEEDS_USER_DETAIL)
+        key.allowed_models = new_allowed
+    if request.metadata is not None:
+        key.metadata_ = request.metadata
+
+    try:
+        await db.commit()
+    except SQLAlchemyError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database error",
+        ) from None
+    await db.refresh(key)
+
+    return KeyInfo.from_model(key)
+
+
+@router.post("/{key_id}/rotate")
+async def rotate_own_key(
+    key_id: str,
+    identity: CurrentIdentity,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> CreateKeyResponse:
+    """Rotate the secret of one of the caller's own API keys, in place.
+
+    Same contract as the operator's rotate: the row keeps its identity, the new
+    raw key is returned once, and the previous secret stops authenticating
+    immediately with no grace window.
+    """
+    organization_id, owner_user_id = await _caller_context(db, identity)
+    key = await _load_key_in_organization(db, key_id, organization_id, owner_user_id=owner_user_id)
+
+    new_api_key = generate_api_key()
+    key.key_hash = hash_key(new_api_key)
+    key.key_prefix = key_prefix(new_api_key)
+    key.last_used_at = None
+
+    try:
+        await db.commit()
+    except SQLAlchemyError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database error",
+        ) from None
+    await db.refresh(key)
+
+    key_info = KeyInfo.from_model(key)
+    return CreateKeyResponse(
+        **key_info.model_dump(exclude={"last_used_at"}),
+        key=new_api_key,
+    )
+
+
+@router.delete("/{key_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_own_key(
+    key_id: str,
+    identity: CurrentIdentity,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> None:
+    """Delete (revoke) one of the caller's own API keys."""
+    organization_id, owner_user_id = await _caller_context(db, identity)
+    key = await _load_key_in_organization(db, key_id, organization_id, owner_user_id=owner_user_id)
+
+    await db.delete(key)
+    try:
+        await db.commit()
+    except SQLAlchemyError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Database error",
+        ) from None

--- a/src/gateway/api/routes/organization_keys.py
+++ b/src/gateway/api/routes/organization_keys.py
@@ -290,11 +290,15 @@ async def update_own_key(
     organization_id, owner_user_id = await _caller_context(db, identity)
     key = await _load_key_in_organization(db, key_id, organization_id, owner_user_id=owner_user_id)
 
-    if request.key_name is not None:
+    # Tri-state via model_fields_set: both columns are nullable and the
+    # dashboard's edit form sends null to clear them, so "absent" and "null"
+    # have to be told apart. ``is_active`` is not nullable, so ``is not None``
+    # is the whole distinction there.
+    if "key_name" in request.model_fields_set:
         key.key_name = request.key_name
     if request.is_active is not None:
         key.is_active = request.is_active
-    if request.expires_at is not None:
+    if "expires_at" in request.model_fields_set:
         key.expires_at = request.expires_at
     if "reject_user_mismatch" in request.model_fields_set:
         key.reject_user_mismatch = request.reject_user_mismatch

--- a/src/gateway/api/routes/organization_keys.py
+++ b/src/gateway/api/routes/organization_keys.py
@@ -13,7 +13,10 @@ established for usage reads (otari#837), applied to a write surface:
   string, the row ``get_or_create_attribution_user`` mints and the activation
   guide already keys on), and every load below carries that owner predicate.
   There is no ``user_id`` parameter, so there is nothing for an escalation to
-  travel on, and somebody else's key answers the 404 a nonexistent one does.
+  travel on, and somebody else's key answers the 404 a nonexistent one does. An
+  owner an operator has revoked through ``DELETE /v1/users`` stays revoked: this
+  surface refuses rather than reviving the row, which is what would restore the
+  spend that route deactivated.
 * **The workspace must be one the caller may see.** A named ``workspace_id``
   goes through ``resolve_workspace_in_organization``, so a workspace in another
   organization, or one in this organization the caller is not a member of,
@@ -198,6 +201,23 @@ async def create_own_key(
         allowed_models = validate_allowed_models(config, request.allowed_models)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    # ``get_or_create_attribution_user`` revives a soft-deleted row. That is what
+    # the membership paths calling it want (re-adding a member must find their
+    # existing owner, not mint a second one) and the wrong answer here.
+    # ``DELETE /v1/users`` is the operator's revocation of a spend identity: it
+    # soft-deletes the row and deactivates every key it holds, and the data plane
+    # then refuses a request whose owner is deleted. Reviving it is therefore
+    # restoring spend, which is not a member's to do for themselves, so this
+    # refuses where ``POST /v1/keys`` refuses the same owner.
+    revoked = (
+        await db.execute(select(User.deleted_at).where(User.user_id == str(identity.id)))
+    ).scalar_one_or_none()
+    if revoked is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Your spend identity has been deactivated on this deployment; ask an operator to restore it.",
+        )
 
     owner = await get_or_create_attribution_user(
         db,

--- a/tests/integration/test_key_management.py
+++ b/tests/integration/test_key_management.py
@@ -154,6 +154,44 @@ def test_update_api_key(client: TestClient, master_key_header: dict[str, str], a
     assert data["is_active"] is False
 
 
+def test_update_with_null_clears_the_name_and_the_expiry(
+    client: TestClient, master_key_header: dict[str, str], api_key_obj: dict[str, Any]
+) -> None:
+    """Absent means unchanged, null means clear.
+
+    The dashboard's edit form sends null for a blanked name or expiry
+    ("Blank clears the expiry"), which an ``is not None`` guard used to drop
+    silently, so both fields follow the tri-state the allow-list already uses.
+    """
+    expires_at = (datetime.now(UTC) + timedelta(days=30)).isoformat()
+    response = client.patch(
+        f"/v1/keys/{api_key_obj['id']}",
+        json={"key_name": "named", "expires_at": expires_at},
+        headers=master_key_header,
+    )
+    assert response.status_code == 200
+
+    # A body naming neither field changes neither.
+    response = client.patch(
+        f"/v1/keys/{api_key_obj['id']}",
+        json={"is_active": True},
+        headers=master_key_header,
+    )
+    assert response.status_code == 200
+    assert response.json()["key_name"] == "named"
+    assert response.json()["expires_at"] is not None
+
+    response = client.patch(
+        f"/v1/keys/{api_key_obj['id']}",
+        json={"key_name": None, "expires_at": None},
+        headers=master_key_header,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["key_name"] is None
+    assert data["expires_at"] is None
+
+
 def test_update_api_key_metadata(
     client: TestClient, master_key_header: dict[str, str], api_key_obj: dict[str, Any]
 ) -> None:

--- a/tests/integration/test_organization_member_keys.py
+++ b/tests/integration/test_organization_member_keys.py
@@ -1,0 +1,485 @@
+"""The member-scoped key surface touches the caller's own keys and no more.
+
+``/v1/keys`` is deployment-wide and operator-only (otari-ai#1880), which left a
+hosted organization member with no way to mint a key (mozilla-ai/otari-ai#1941).
+``/v1/organizations/me/keys`` is the tenant's half of it, and the whole of its
+correctness is that ownership and workspace scope are decided by the caller's
+identity and memberships rather than by anything the request carries. So the
+suite is written against a world holding two organizations, two members sharing
+a workspace, and keys owned by each, and the assertions name the rows that must
+be absent or refused rather than counting the ones that came back.
+
+The control group at the bottom matters as much as the rest: the deployment-wide
+router must still refuse a plain member, and a member-minted key must never be
+budget-exempt. A change that made the rest pass by loosening either would have
+reopened otari-ai#1880 or opened a budget bypass.
+"""
+
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from gateway.models.entities import DashboardSession
+from gateway.models.entities import User as BillingUser
+from gateway.models.tenancy import Organization, OrganizationMember, User, Workspace, WorkspaceMember
+from gateway.services.dashboard_session_service import SESSION_COOKIE_NAME, hash_session_token
+
+_PREFIX = "/v1/organizations/me/keys"
+
+
+@dataclass
+class _World:
+    """Two organizations, their workspaces, and one session cookie per identity."""
+
+    alpha: uuid.UUID
+    beta: uuid.UUID
+    workspaces: dict[str, uuid.UUID] = field(default_factory=dict)
+    sessions: dict[str, str] = field(default_factory=dict)
+    users: dict[str, uuid.UUID] = field(default_factory=dict)
+
+
+def _identity(
+    session: Session,
+    *,
+    email: str,
+    organization_id: uuid.UUID,
+    role: str = "member",
+    workspace_ids: tuple[uuid.UUID, ...] = (),
+    membership: bool = True,
+) -> tuple[uuid.UUID, str]:
+    """Create an identity with a live dashboard session, and return its cookie."""
+    user = User(
+        email=email,
+        full_name=email.split("@")[0].title(),
+        active_organization_id=organization_id,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+
+    if membership:
+        session.add(
+            OrganizationMember(
+                organization_id=organization_id,
+                user_id=user.id,
+                role=role,
+                status="active",
+            )
+        )
+    for workspace_id in workspace_ids:
+        session.add(
+            WorkspaceMember(
+                workspace_id=workspace_id,
+                user_id=user.id,
+                role="member",
+                status="active",
+            )
+        )
+
+    token = f"otari-sess-{email}"
+    session.add(
+        DashboardSession(
+            token_hash=hash_session_token(token),
+            user_id=user.id,
+            created_at=datetime.now(UTC),
+            expires_at=datetime.now(UTC) + timedelta(hours=12),
+        )
+    )
+    session.commit()
+    return user.id, token
+
+
+@pytest.fixture
+def world(client: TestClient, master_key_header: dict[str, str], db_session_factory: Callable[[], Session]) -> _World:
+    """Two tenants and the identities that act in them."""
+    # One master-key call provisions the tenancy root, so the organizations built
+    # below sit beside a real default rather than replacing it.
+    assert client.get("/v1/organizations/me", headers=master_key_header).status_code == status.HTTP_200_OK
+
+    session = db_session_factory()
+    try:
+        alpha = Organization(name="Alpha", slug="alpha")
+        beta = Organization(name="Beta", slug="beta")
+        session.add_all([alpha, beta])
+        session.commit()
+        session.refresh(alpha)
+        session.refresh(beta)
+
+        # Alpha one is created first, so with no workspace named "Default" it is
+        # what ``organization_default_workspace_id`` resolves, which the
+        # omitted-workspace tests below lean on.
+        alpha_one = Workspace(name="Alpha one", organization_id=alpha.id)
+        session.add(alpha_one)
+        session.commit()
+        alpha_two = Workspace(name="Alpha two", organization_id=alpha.id)
+        beta_one = Workspace(name="Beta one", organization_id=beta.id)
+        session.add_all([alpha_two, beta_one])
+        session.commit()
+        for workspace in (alpha_one, alpha_two, beta_one):
+            session.refresh(workspace)
+
+        built = _World(alpha=alpha.id, beta=beta.id)
+        built.workspaces = {"alpha_one": alpha_one.id, "alpha_two": alpha_two.id, "beta_one": beta_one.id}
+        people = {
+            "alpha_owner": _identity(session, email="owner@alpha.test", organization_id=alpha.id, role="owner"),
+            # Belongs to one of alpha's two workspaces, which is the case the
+            # surface exists for.
+            "alpha_member": _identity(
+                session,
+                email="member@alpha.test",
+                organization_id=alpha.id,
+                workspace_ids=(alpha_one.id,),
+            ),
+            # A second member of the same workspace, so "may see the workspace"
+            # and "owns the key" can be told apart.
+            "alpha_colleague": _identity(
+                session,
+                email="colleague@alpha.test",
+                organization_id=alpha.id,
+                workspace_ids=(alpha_one.id,),
+            ),
+            # In the organization, in none of its workspaces.
+            "alpha_newcomer": _identity(session, email="new@alpha.test", organization_id=alpha.id),
+            "beta_owner": _identity(session, email="owner@beta.test", organization_id=beta.id, role="owner"),
+            # Points at alpha, belongs to nothing: the stale-pointer shape.
+            "impostor": _identity(
+                session,
+                email="impostor@nowhere.test",
+                organization_id=alpha.id,
+                membership=False,
+            ),
+        }
+        built.users = {name: user_id for name, (user_id, _) in people.items()}
+        built.sessions = {name: token for name, (_, token) in people.items()}
+        return built
+    finally:
+        session.close()
+
+
+def _request(
+    client: TestClient,
+    world: _World,
+    who: str,
+    method: str,
+    path: str,
+    json: dict[str, Any] | None = None,
+) -> tuple[int, Any]:
+    client.cookies.set(SESSION_COOKIE_NAME, world.sessions[who])
+    try:
+        response = client.request(method, path, json=json)
+        is_json = response.headers.get("content-type", "").startswith("application/json")
+        body = response.json() if is_json and response.content else None
+        return response.status_code, body
+    finally:
+        client.cookies.clear()
+
+
+def _create(
+    client: TestClient,
+    world: _World,
+    who: str,
+    body: dict[str, Any] | None = None,
+) -> tuple[int, Any]:
+    return _request(client, world, who, "POST", _PREFIX, json=body or {"key_name": f"{who}-key"})
+
+
+# =============================================================================
+# Creating: ownership derived, workspace membership enforced
+# =============================================================================
+
+
+def test_a_member_creates_a_key_in_a_workspace_they_belong_to(client: TestClient, world: _World) -> None:
+    code, body = _create(
+        client,
+        world,
+        "alpha_member",
+        {"key_name": "mine", "workspace_id": str(world.workspaces["alpha_one"])},
+    )
+    assert code == status.HTTP_200_OK, body
+    assert body["key"].strip()
+    # Ownership is derived: the key bills to the caller's own attribution row.
+    assert body["user_id"] == str(world.users["alpha_member"])
+    # And is always budget-enforced; there is no field to say otherwise.
+    assert body["exclude_from_budget"] is False
+
+    # ``CreateKeyResponse`` carries no workspace, so where the key landed is
+    # read back off the list.
+    code, listed = _request(client, world, "alpha_member", "GET", _PREFIX)
+    assert code == status.HTTP_200_OK
+    row = next(row for row in listed if row["id"] == body["id"])
+    assert row["workspace_id"] == str(world.workspaces["alpha_one"])
+
+
+def test_a_member_cannot_mint_into_a_sibling_workspace_they_do_not_belong_to(
+    client: TestClient, world: _World
+) -> None:
+    """Alpha two is their organization's, so scoping to the organization alone would pass everything but this."""
+    code, body = _create(
+        client,
+        world,
+        "alpha_member",
+        {"key_name": "sneaky", "workspace_id": str(world.workspaces["alpha_two"])},
+    )
+    assert code == status.HTTP_404_NOT_FOUND, body
+
+
+def test_a_member_cannot_mint_into_another_organizations_workspace(client: TestClient, world: _World) -> None:
+    code, body = _create(
+        client,
+        world,
+        "alpha_member",
+        {"key_name": "cross-tenant", "workspace_id": str(world.workspaces["beta_one"])},
+    )
+    assert code == status.HTTP_404_NOT_FOUND, body
+
+
+def test_an_owner_may_mint_into_any_workspace_of_their_organization(client: TestClient, world: _World) -> None:
+    """The management arm of the visibility rule, same as every other tenant-scoped surface."""
+    code, body = _create(
+        client,
+        world,
+        "alpha_owner",
+        {"key_name": "owner-key", "workspace_id": str(world.workspaces["alpha_two"])},
+    )
+    assert code == status.HTTP_200_OK, body
+    assert body["user_id"] == str(world.users["alpha_owner"])
+
+
+def test_an_omitted_workspace_means_the_default_one_the_caller_belongs_to(
+    client: TestClient, world: _World
+) -> None:
+    code, body = _create(client, world, "alpha_member", {"key_name": "defaulted"})
+    assert code == status.HTTP_200_OK, body
+
+    code, listed = _request(client, world, "alpha_member", "GET", _PREFIX)
+    assert code == status.HTTP_200_OK
+    row = next(row for row in listed if row["id"] == body["id"])
+    assert row["workspace_id"] == str(world.workspaces["alpha_one"])
+
+
+def test_an_omitted_workspace_refuses_a_caller_outside_the_default_one(client: TestClient, world: _World) -> None:
+    """A member of no workspace gets told what to do, not a 404 about a parameter they did not send."""
+    code, body = _create(client, world, "alpha_newcomer", {"key_name": "nowhere"})
+    assert code == status.HTTP_409_CONFLICT, body
+    assert "workspace" in body["detail"]
+
+
+def test_a_stale_organization_pointer_grants_nothing(client: TestClient, world: _World) -> None:
+    """``active_organization_id`` without a live membership refuses, as everywhere on this surface."""
+    code, body = _create(client, world, "impostor", {"key_name": "stolen"})
+    assert code in {status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND}, body
+
+
+def test_a_member_key_cannot_exceed_their_own_model_default(
+    client: TestClient, world: _World, db_session_factory: Callable[[], Session]
+) -> None:
+    """The narrow-only allowed_models rule binds against the caller's own user row."""
+    session = db_session_factory()
+    try:
+        session.add(BillingUser(user_id=str(world.users["alpha_member"]), allowed_models=["openai:gpt-4o"]))
+        session.commit()
+    finally:
+        session.close()
+
+    code, body = _create(
+        client,
+        world,
+        "alpha_member",
+        {"key_name": "too-wide", "allowed_models": ["openai:*"]},
+    )
+    assert code == status.HTTP_400_BAD_REQUEST, body
+
+    code, body = _create(
+        client,
+        world,
+        "alpha_member",
+        {"key_name": "narrow-enough", "allowed_models": ["openai:gpt-4o"]},
+    )
+    assert code == status.HTTP_200_OK, body
+
+
+# =============================================================================
+# Listing: own keys, and nobody else's
+# =============================================================================
+
+
+def test_a_member_lists_their_own_keys_and_not_a_colleagues(client: TestClient, world: _World) -> None:
+    """Both share Alpha one, so a workspace-scoped list would leak the colleague's key."""
+    code, mine = _create(client, world, "alpha_member", {"key_name": "mine"})
+    assert code == status.HTTP_200_OK
+    code, theirs = _create(client, world, "alpha_colleague", {"key_name": "theirs"})
+    assert code == status.HTTP_200_OK
+
+    code, listed = _request(client, world, "alpha_member", "GET", _PREFIX)
+    assert code == status.HTTP_200_OK, listed
+    ids = {row["id"] for row in listed}
+    assert mine["id"] in ids
+    assert theirs["id"] not in ids
+
+
+def test_an_operator_minted_key_assigned_to_the_member_is_theirs_to_see(
+    client: TestClient, world: _World, master_key_header: dict[str, str]
+) -> None:
+    """Ownership is the billing row, however the key was minted.
+
+    The operator acts in the deployment's default organization, so the key is
+    minted into the member's workspace explicitly; what is being asserted is the
+    owner predicate, not the operator's own scope.
+    """
+    code, listed = _request(client, world, "alpha_member", "GET", _PREFIX)
+    assert code == status.HTTP_200_OK
+    before = {row["id"] for row in listed}
+
+    # The operator's surface takes a client-named owner; naming the member's
+    # attribution id is how a key gets handed to them today.
+    response = client.post(
+        "/v1/keys",
+        headers=master_key_header,
+        json={"key_name": "handed-over", "user_id": str(world.users["alpha_member"])},
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    handed = response.json()
+
+    code, listed = _request(client, world, "alpha_member", "GET", _PREFIX)
+    assert code == status.HTTP_200_OK
+    after = {row["id"] for row in listed}
+    # The operator minted into their own organization's default workspace, which
+    # is outside alpha, so the organization predicate keeps it off this list.
+    assert after == before
+    assert handed["id"] not in after
+
+
+def test_the_workspace_filter_narrows_and_never_widens(client: TestClient, world: _World) -> None:
+    code, created = _create(
+        client,
+        world,
+        "alpha_member",
+        {"key_name": "filtered", "workspace_id": str(world.workspaces["alpha_one"])},
+    )
+    assert code == status.HTTP_200_OK
+
+    code, listed = _request(
+        client, world, "alpha_member", "GET", f"{_PREFIX}?workspace_id={world.workspaces['alpha_one']}"
+    )
+    assert code == status.HTTP_200_OK
+    assert created["id"] in {row["id"] for row in listed}
+
+    # A workspace in another organization lists nothing rather than refusing,
+    # matching the operator surface's filter semantics.
+    code, listed = _request(
+        client, world, "alpha_member", "GET", f"{_PREFIX}?workspace_id={world.workspaces['beta_one']}"
+    )
+    assert code == status.HTTP_200_OK
+    assert listed == []
+
+
+# =============================================================================
+# Acting on a key: the owner predicate on every load
+# =============================================================================
+
+
+def test_a_member_updates_rotates_and_revokes_their_own_key(client: TestClient, world: _World) -> None:
+    code, created = _create(client, world, "alpha_member", {"key_name": "lifecycle"})
+    assert code == status.HTTP_200_OK
+
+    code, updated = _request(
+        client, world, "alpha_member", "PATCH", f"{_PREFIX}/{created['id']}", json={"key_name": "renamed"}
+    )
+    assert code == status.HTTP_200_OK, updated
+    assert updated["key_name"] == "renamed"
+
+    code, rotated = _request(client, world, "alpha_member", "POST", f"{_PREFIX}/{created['id']}/rotate")
+    assert code == status.HTTP_200_OK, rotated
+    assert rotated["id"] == created["id"]
+    assert rotated["key"] != created["key"]
+
+    code, _ = _request(client, world, "alpha_member", "DELETE", f"{_PREFIX}/{created['id']}")
+    assert code == status.HTTP_204_NO_CONTENT
+
+    code, listed = _request(client, world, "alpha_member", "GET", _PREFIX)
+    assert code == status.HTTP_200_OK
+    assert created["id"] not in {row["id"] for row in listed}
+
+
+@pytest.mark.parametrize(
+    ("method", "suffix"),
+    [("PATCH", ""), ("POST", "/rotate"), ("DELETE", "")],
+)
+def test_a_colleagues_key_answers_the_404_a_missing_one_does(
+    client: TestClient, world: _World, method: str, suffix: str
+) -> None:
+    """Same workspace, different owner: the id must be indistinguishable from one that does not exist."""
+    code, theirs = _create(client, world, "alpha_colleague", {"key_name": "not-yours"})
+    assert code == status.HTTP_200_OK
+
+    json = {"key_name": "hijacked"} if method == "PATCH" else None
+    code, body = _request(client, world, "alpha_member", method, f"{_PREFIX}/{theirs['id']}{suffix}", json=json)
+    assert code == status.HTTP_404_NOT_FOUND, body
+
+
+def test_an_update_cannot_exempt_the_key_from_budget(client: TestClient, world: _World) -> None:
+    """The member body has no such field, and sending one anyway changes nothing."""
+    code, created = _create(client, world, "alpha_member", {"key_name": "enforced"})
+    assert code == status.HTTP_200_OK
+    assert created["exclude_from_budget"] is False
+
+    code, updated = _request(
+        client,
+        world,
+        "alpha_member",
+        "PATCH",
+        f"{_PREFIX}/{created['id']}",
+        json={"exclude_from_budget": True},
+    )
+    assert code == status.HTTP_200_OK, updated
+    assert updated["exclude_from_budget"] is False
+
+
+def test_a_create_cannot_name_an_owner_or_exempt_itself(client: TestClient, world: _World) -> None:
+    """The escalation fields of the operator body are inert here, not honored."""
+    code, body = _create(
+        client,
+        world,
+        "alpha_member",
+        {
+            "key_name": "escalation",
+            "user_id": "somebody-else",
+            "exclude_from_budget": True,
+        },
+    )
+    assert code == status.HTTP_200_OK, body
+    assert body["user_id"] == str(world.users["alpha_member"])
+    assert body["exclude_from_budget"] is False
+
+
+# =============================================================================
+# The control group: what must not have moved
+# =============================================================================
+
+
+def test_the_deployment_wide_router_still_refuses_a_member(client: TestClient, world: _World) -> None:
+    """The gate otari-ai#1880 added stays; this surface is a sibling, not a loosening."""
+    code, body = _request(client, world, "alpha_member", "GET", "/v1/keys")
+    assert code == status.HTTP_403_FORBIDDEN, body
+    code, body = _request(client, world, "alpha_member", "POST", "/v1/keys", json={"key_name": "nope"})
+    assert code == status.HTTP_403_FORBIDDEN, body
+
+
+def test_a_member_minted_key_authenticates_on_the_data_plane(client: TestClient, world: _World) -> None:
+    """The key is a real credential, not a dashboard artifact: a bad model on it answers 404, not 401."""
+    code, created = _create(client, world, "alpha_member", {"key_name": "live"})
+    assert code == status.HTTP_200_OK
+
+    response = client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {created['key']}"},
+        json={"model": "does-not-exist:nope", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert response.status_code != status.HTTP_401_UNAUTHORIZED

--- a/tests/integration/test_organization_member_keys.py
+++ b/tests/integration/test_organization_member_keys.py
@@ -26,6 +26,7 @@ from fastapi import status
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from gateway.auth.models import generate_api_key, hash_key, key_prefix
 from gateway.models.entities import APIKey, DashboardSession
 from gateway.models.entities import User as BillingUser
 from gateway.models.tenancy import Organization, OrganizationMember, User, Workspace, WorkspaceMember
@@ -271,6 +272,38 @@ def test_an_omitted_workspace_refuses_a_caller_outside_the_default_one(client: T
     assert "workspace" in body["detail"]
 
 
+def test_a_revoked_spend_identity_cannot_mint_its_way_back(
+    client: TestClient, world: _World, master_key_header: dict[str, str]
+) -> None:
+    """``DELETE /v1/users`` is the operator's revocation, and this surface must not undo it.
+
+    That route soft-deletes the spend identity and deactivates every key it
+    holds, and the data plane refuses a request whose owner is deleted.
+    ``get_or_create_attribution_user`` revives a soft-deleted row, which is what
+    the membership paths want and what a member must not be able to trigger for
+    themselves: the revival makes the identity live again and a fresh key spends.
+    """
+    owner_id = str(world.users["alpha_member"])
+    workspace = str(world.workspaces["alpha_one"])
+    code, first = _create(client, world, "alpha_member", {"key_name": "before", "workspace_id": workspace})
+    assert code == status.HTTP_200_OK, first
+
+    revoke = client.delete(f"/v1/users/{owner_id}", headers=master_key_header)
+    assert revoke.status_code == status.HTTP_204_NO_CONTENT, revoke.text
+
+    code, body = _create(client, world, "alpha_member", {"key_name": "after", "workspace_id": workspace})
+    assert code == status.HTTP_409_CONFLICT, body
+
+    # The revocation still stands afterwards, which is what the operator surface
+    # refusing the same owner reports.
+    response = client.post(
+        "/v1/keys",
+        headers=master_key_header,
+        json={"key_name": "operator", "user_id": owner_id, "workspace_id": workspace},
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
+
+
 def test_a_stale_organization_pointer_grants_nothing(client: TestClient, world: _World) -> None:
     """``active_organization_id`` without a live membership refuses, as everywhere on this surface."""
     code, body = _create(client, world, "impostor", {"key_name": "stolen"})
@@ -324,52 +357,15 @@ def test_a_member_lists_their_own_keys_and_not_a_colleagues(client: TestClient, 
     assert theirs["id"] not in ids
 
 
-def test_a_key_assigned_to_the_member_in_their_organization_is_listed(
-    client: TestClient, world: _World, db_session_factory: Callable[[], Session]
-) -> None:
-    """Ownership is the billing row, however the key was minted.
-
-    Inserted directly rather than over ``POST /v1/keys``, because the operator
-    acts in the deployment's default organization and cannot mint into alpha;
-    what a handed-over key looks like is a row in the member's workspace billed
-    to their attribution user. Dropping the owner predicate from the list query
-    would still pass the colleague test (a different owner), so this is the
-    positive half that pins the predicate itself.
-    """
-    handed_id = str(uuid.uuid4())
-    session = db_session_factory()
-    try:
-        # The attribution row first: api_keys.user_id is a foreign key, and the
-        # member has minted nothing yet in this test's fresh database.
-        session.add(BillingUser(user_id=str(world.users["alpha_member"]), alias="member@alpha.test"))
-        session.commit()
-        session.add(
-            APIKey(
-                id=handed_id,
-                workspace_id=world.workspaces["alpha_one"],
-                key_hash=f"hash-{handed_id}",
-                key_name="handed-over",
-                user_id=str(world.users["alpha_member"]),
-            )
-        )
-        session.commit()
-    finally:
-        session.close()
-
-    code, listed = _request(client, world, "alpha_member", "GET", _PREFIX)
-    assert code == status.HTTP_200_OK
-    assert handed_id in {row["id"] for row in listed}
-
-
-def test_an_operator_minted_key_outside_the_organization_stays_off_the_list(
+def test_an_operator_minted_key_outside_the_organization_stays_invisible(
     client: TestClient, world: _World, master_key_header: dict[str, str]
 ) -> None:
-    """The organization predicate holds even when the owner matches.
+    """A key billed to the member but minted elsewhere is still out of scope.
 
-    The operator acts in the deployment's default organization, so a key they
-    mint with the member's attribution id lands in a workspace outside alpha;
-    the member's list is confined to their active organization and must not
-    show it.
+    The operator acts in the deployment's default organization, so an ownership
+    assignment alone does not reach alpha: the mint lands in that organization's
+    default workspace, and the organization predicate keeps it off this list even
+    though the owner predicate would admit it.
     """
     code, listed = _request(client, world, "alpha_member", "GET", _PREFIX)
     assert code == status.HTTP_200_OK
@@ -388,6 +384,55 @@ def test_an_operator_minted_key_outside_the_organization_stays_off_the_list(
     after = {row["id"] for row in listed}
     assert after == before
     assert handed["id"] not in after
+
+
+def test_a_key_the_member_owns_but_did_not_mint_is_theirs_to_manage(
+    client: TestClient, world: _World, db_session_factory: Callable[[], Session]
+) -> None:
+    """Ownership is the billing row, however the key got there.
+
+    The handed-over case the docstrings promise, which no request can set up:
+    ``POST /v1/keys`` names an owner but mints into the *operator's* organization,
+    so the row is written directly into alpha instead. What is asserted is the
+    owner predicate on its own, and that it carries the whole lifecycle rather
+    than the list alone.
+    """
+    raw = generate_api_key()
+    key_id = str(uuid.uuid4())
+    owner_id = str(world.users["alpha_member"])
+    session = db_session_factory()
+    try:
+        # The attribution row a membership would already have minted; the key's
+        # foreign key needs it before the row it hangs off can exist.
+        session.add(BillingUser(user_id=owner_id, alias="Member"))
+        session.commit()
+        session.add(
+            APIKey(
+                id=key_id,
+                workspace_id=world.workspaces["alpha_one"],
+                key_hash=hash_key(raw),
+                key_prefix=key_prefix(raw),
+                key_name="handed-over",
+                user_id=owner_id,
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+
+    code, listed = _request(client, world, "alpha_member", "GET", _PREFIX)
+    assert code == status.HTTP_200_OK
+    assert key_id in {row["id"] for row in listed}
+
+    # And nobody else's, on the same row: the colleague shares the workspace.
+    code, listed = _request(client, world, "alpha_colleague", "GET", _PREFIX)
+    assert code == status.HTTP_200_OK
+    assert key_id not in {row["id"] for row in listed}
+
+    code, _ = _request(client, world, "alpha_colleague", "DELETE", f"{_PREFIX}/{key_id}")
+    assert code == status.HTTP_404_NOT_FOUND
+    code, _ = _request(client, world, "alpha_member", "DELETE", f"{_PREFIX}/{key_id}")
+    assert code == status.HTTP_204_NO_CONTENT
 
 
 def test_the_workspace_filter_narrows_and_never_widens(client: TestClient, world: _World) -> None:

--- a/tests/integration/test_organization_member_keys.py
+++ b/tests/integration/test_organization_member_keys.py
@@ -26,7 +26,7 @@ from fastapi import status
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from gateway.models.entities import DashboardSession
+from gateway.models.entities import APIKey, DashboardSession
 from gateway.models.entities import User as BillingUser
 from gateway.models.tenancy import Organization, OrganizationMember, User, Workspace, WorkspaceMember
 from gateway.services.dashboard_session_service import SESSION_COOKIE_NAME, hash_session_token
@@ -324,21 +324,57 @@ def test_a_member_lists_their_own_keys_and_not_a_colleagues(client: TestClient, 
     assert theirs["id"] not in ids
 
 
-def test_an_operator_minted_key_assigned_to_the_member_is_theirs_to_see(
-    client: TestClient, world: _World, master_key_header: dict[str, str]
+def test_a_key_assigned_to_the_member_in_their_organization_is_listed(
+    client: TestClient, world: _World, db_session_factory: Callable[[], Session]
 ) -> None:
     """Ownership is the billing row, however the key was minted.
 
-    The operator acts in the deployment's default organization, so the key is
-    minted into the member's workspace explicitly; what is being asserted is the
-    owner predicate, not the operator's own scope.
+    Inserted directly rather than over ``POST /v1/keys``, because the operator
+    acts in the deployment's default organization and cannot mint into alpha;
+    what a handed-over key looks like is a row in the member's workspace billed
+    to their attribution user. Dropping the owner predicate from the list query
+    would still pass the colleague test (a different owner), so this is the
+    positive half that pins the predicate itself.
+    """
+    handed_id = str(uuid.uuid4())
+    session = db_session_factory()
+    try:
+        # The attribution row first: api_keys.user_id is a foreign key, and the
+        # member has minted nothing yet in this test's fresh database.
+        session.add(BillingUser(user_id=str(world.users["alpha_member"]), alias="member@alpha.test"))
+        session.commit()
+        session.add(
+            APIKey(
+                id=handed_id,
+                workspace_id=world.workspaces["alpha_one"],
+                key_hash=f"hash-{handed_id}",
+                key_name="handed-over",
+                user_id=str(world.users["alpha_member"]),
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+
+    code, listed = _request(client, world, "alpha_member", "GET", _PREFIX)
+    assert code == status.HTTP_200_OK
+    assert handed_id in {row["id"] for row in listed}
+
+
+def test_an_operator_minted_key_outside_the_organization_stays_off_the_list(
+    client: TestClient, world: _World, master_key_header: dict[str, str]
+) -> None:
+    """The organization predicate holds even when the owner matches.
+
+    The operator acts in the deployment's default organization, so a key they
+    mint with the member's attribution id lands in a workspace outside alpha;
+    the member's list is confined to their active organization and must not
+    show it.
     """
     code, listed = _request(client, world, "alpha_member", "GET", _PREFIX)
     assert code == status.HTTP_200_OK
     before = {row["id"] for row in listed}
 
-    # The operator's surface takes a client-named owner; naming the member's
-    # attribution id is how a key gets handed to them today.
     response = client.post(
         "/v1/keys",
         headers=master_key_header,
@@ -350,8 +386,6 @@ def test_an_operator_minted_key_assigned_to_the_member_is_theirs_to_see(
     code, listed = _request(client, world, "alpha_member", "GET", _PREFIX)
     assert code == status.HTTP_200_OK
     after = {row["id"] for row in listed}
-    # The operator minted into their own organization's default workspace, which
-    # is outside alpha, so the organization predicate keeps it off this list.
     assert after == before
     assert handed["id"] not in after
 
@@ -406,6 +440,37 @@ def test_a_member_updates_rotates_and_revokes_their_own_key(client: TestClient, 
     code, listed = _request(client, world, "alpha_member", "GET", _PREFIX)
     assert code == status.HTTP_200_OK
     assert created["id"] not in {row["id"] for row in listed}
+
+
+def test_an_update_with_null_clears_the_name_and_the_expiry(client: TestClient, world: _World) -> None:
+    """Absent means unchanged and null means clear, the tri-state the dashboard's edit form sends."""
+    code, created = _create(
+        client,
+        world,
+        "alpha_member",
+        {"key_name": "named", "expires_at": "2030-01-01T00:00:00+00:00"},
+    )
+    assert code == status.HTTP_200_OK
+
+    # A body that names neither field changes neither.
+    code, updated = _request(
+        client, world, "alpha_member", "PATCH", f"{_PREFIX}/{created['id']}", json={"is_active": True}
+    )
+    assert code == status.HTTP_200_OK, updated
+    assert updated["key_name"] == "named"
+    assert updated["expires_at"] is not None
+
+    code, updated = _request(
+        client,
+        world,
+        "alpha_member",
+        "PATCH",
+        f"{_PREFIX}/{created['id']}",
+        json={"key_name": None, "expires_at": None},
+    )
+    assert code == status.HTTP_200_OK, updated
+    assert updated["key_name"] is None
+    assert updated["expires_at"] is None
 
 
 @pytest.mark.parametrize(
@@ -473,7 +538,12 @@ def test_the_deployment_wide_router_still_refuses_a_member(client: TestClient, w
 
 
 def test_a_member_minted_key_authenticates_on_the_data_plane(client: TestClient, world: _World) -> None:
-    """The key is a real credential, not a dashboard artifact: a bad model on it answers 404, not 401."""
+    """The key is a real credential, not a dashboard artifact.
+
+    An unknown model on it earns the model resolver's own 400, which only a
+    request that authenticated can reach; a rejected credential would have
+    stopped at 401.
+    """
     code, created = _create(client, world, "alpha_member", {"key_name": "live"})
     assert code == status.HTTP_200_OK
 
@@ -482,4 +552,5 @@ def test_a_member_minted_key_authenticates_on_the_data_plane(client: TestClient,
         headers={"Authorization": f"Bearer {created['key']}"},
         json={"model": "does-not-exist:nope", "messages": [{"role": "user", "content": "hi"}]},
     )
-    assert response.status_code != status.HTTP_401_UNAUTHORIZED
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.text
+    assert "Unknown or unsupported model" in response.json()["detail"]

--- a/web/src/app/nav/registry.test.ts
+++ b/web/src/app/nav/registry.test.ts
@@ -92,12 +92,13 @@ describe("nav registry", () => {
     // tenant-scoped read, so there is no longer a caller it refuses. Models and
     // Routing left it the same way (otari-ai#1942): the catalog reads already
     // served any session, and Routing gained
-    // `/v1/organizations/me/routing-policies`. Removing a row from here is as
+    // `/v1/organizations/me/routing-policies`. API keys left it for the same
+    // reason (otari-ai#1941): members create and manage their own keys through
+    // `/v1/organizations/me/keys`. Removing a row from here is as
     // much a design decision as adding one.
     expect(
       NAV_ITEMS.filter((item) => item.operatorOnly).map((item) => item.to),
     ).toEqual([
-      "/keys",
       "/providers",
       "/budgets",
       "/organization/pricing",

--- a/web/src/app/nav/registry.ts
+++ b/web/src/app/nav/registry.ts
@@ -174,12 +174,16 @@ const BASE_NAV_SECTIONS = [
     id: "access",
     label: "Access",
     items: [
+      // No `operatorOnly`, for the reason Activity and Usage dropped theirs
+      // (otari-ai#1941 this time): the page reads and mints through
+      // `/v1/organizations/me/keys` for a caller who does not operate the
+      // deployment, so the destination serves every signed-in identity
+      // something true, their own keys.
       {
         to: "/keys",
         label: "API keys",
         surface: "keys",
         icon: FiKey,
-        operatorOnly: "refused",
       },
       // "Providers", not "Provider credentials": the page manages the
       // credential *and* the instance it belongs to, the rail has one line for

--- a/web/src/client/index.ts
+++ b/web/src/client/index.ts
@@ -208,6 +208,10 @@ export type ApiKey = Schemas["KeyInfo"]
 export type CreateKeyRequest = Schemas["CreateKeyRequest"]
 export type CreateKeyResponse = Schemas["CreateKeyResponse"]
 export type UpdateKeyRequest = Schemas["UpdateKeyRequest"]
+// The member surface's bodies (otari-ai#1941): the operator shapes minus the
+// owner and the budget exemption, which that surface derives or refuses.
+export type CreateOwnKeyRequest = Schemas["CreateOwnKeyRequest"]
+export type UpdateOwnKeyRequest = Schemas["UpdateOwnKeyRequest"]
 export type Budget = Schemas["BudgetResponse"]
 export type CreateBudgetRequest = Schemas["CreateBudgetRequest"]
 export type UpdateBudgetRequest = Schemas["UpdateBudgetRequest"]

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -1657,6 +1657,88 @@ export interface paths {
         patch: operations["update_organization_guardrail_v1_organizations_me_guardrails__guardrail_id__patch"];
         trace?: never;
     };
+    "/v1/organizations/me/keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Own Keys
+         * @description List the caller's own API keys in their active organization, newest first.
+         *
+         *     Only keys billed to the caller's own user: an operator-minted key assigned
+         *     to them is theirs to see here, and nobody else's key ever is. Naming a
+         *     workspace outside their organization lists nothing rather than refusing, so
+         *     the filter reports no more than the unfiltered read does.
+         */
+        get: operations["list_own_keys_v1_organizations_me_keys_get"];
+        put?: never;
+        /**
+         * Create Own Key
+         * @description Create an API key owned by the caller, in a workspace they may see.
+         *
+         *     The member-scoped counterpart of ``POST /v1/keys``: the owner is always the
+         *     caller's own attribution user, the key is always budget-enforced, and the
+         *     workspace must be visible to the caller (a member of it, or an organization
+         *     owner/admin/superuser, who see every workspace). The secret is returned once.
+         */
+        post: operations["create_own_key_v1_organizations_me_keys_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/organizations/me/keys/{key_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Own Key
+         * @description Delete (revoke) one of the caller's own API keys.
+         */
+        delete: operations["delete_own_key_v1_organizations_me_keys__key_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Own Key
+         * @description Update one of the caller's own API keys.
+         */
+        patch: operations["update_own_key_v1_organizations_me_keys__key_id__patch"];
+        trace?: never;
+    };
+    "/v1/organizations/me/keys/{key_id}/rotate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Rotate Own Key
+         * @description Rotate the secret of one of the caller's own API keys, in place.
+         *
+         *     Same contract as the operator's rotate: the row keeps its identity, the new
+         *     raw key is returned once, and the previous secret stops authenticating
+         *     immediately with no grace window.
+         */
+        post: operations["rotate_own_key_v1_organizations_me_keys__key_id__rotate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/organizations/me/member-invitations": {
         parameters: {
             query?: never;
@@ -5112,6 +5194,53 @@ export interface components {
             user_id: string | null;
         };
         /**
+         * CreateOwnKeyRequest
+         * @description Create-key body for the member surface.
+         *
+         *     Deliberately not ``CreateKeyRequest``: it carries no ``user_id`` (the owner
+         *     is always the caller) and no ``exclude_from_budget`` (a member must not
+         *     exempt their own spend from enforcement).
+         */
+        CreateOwnKeyRequest: {
+            /**
+             * Allowed Models
+             * @description Model allow-list: null = any model your user default allows, [] = deny all, or canonical instance:model entries. A key can only narrow your own model access, never broaden it.
+             */
+            allowed_models?: string[] | null;
+            /**
+             * Capture Agent Telemetry
+             * @description Per-key override of the deployment-wide capture_agent_telemetry setting: null (default) inherits it, true always stores this key's coding-agent telemetry, false always discards it.
+             */
+            capture_agent_telemetry?: boolean | null;
+            /**
+             * Expires At
+             * @description Optional expiration timestamp
+             */
+            expires_at?: string | null;
+            /**
+             * Key Name
+             * @description Optional name for the key
+             */
+            key_name?: string | null;
+            /**
+             * Metadata
+             * @description Optional metadata
+             */
+            metadata?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Reject User Mismatch
+             * @description Per-key override of the deployment-wide reject_user_mismatch setting: null (default) inherits it, true always rejects a request naming a different 'user', false always accepts it. Spend binds to your own user either way.
+             */
+            reject_user_mismatch?: boolean | null;
+            /**
+             * Workspace Id
+             * @description Workspace this key belongs to, which must be one you may see in your active organization. Omitted means that organization's default workspace, refused when you are not a member of it.
+             */
+            workspace_id?: string | null;
+        };
+        /**
          * CreateScopedBudgetRequest
          * @description Request model for creating a scoped budget.
          */
@@ -8389,6 +8518,33 @@ export interface components {
              * @description True to freeze new dashboard sign-ins, false to allow them again.
              */
             enabled: boolean;
+        };
+        /**
+         * UpdateOwnKeyRequest
+         * @description Update-key body for the member surface.
+         *
+         *     The operator's ``UpdateKeyRequest`` minus ``exclude_from_budget``, for the
+         *     reason the create body gives. The tri-state fields follow the same
+         *     ``model_fields_set`` idiom: absent = unchanged, null = clear to inherit,
+         *     a value = pin it.
+         */
+        UpdateOwnKeyRequest: {
+            /** Allowed Models */
+            allowed_models?: string[] | null;
+            /** Capture Agent Telemetry */
+            capture_agent_telemetry?: boolean | null;
+            /** Expires At */
+            expires_at?: string | null;
+            /** Is Active */
+            is_active?: boolean | null;
+            /** Key Name */
+            key_name?: string | null;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /** Reject User Mismatch */
+            reject_user_mismatch?: boolean | null;
         };
         /**
          * UpdateScopedBudgetRequest
@@ -12055,6 +12211,168 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["OrganizationGuardrailPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_own_keys_v1_organizations_me_keys_get: {
+        parameters: {
+            query?: {
+                skip?: number;
+                limit?: number;
+                /** @description Only keys in this workspace. */
+                workspace_id?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["KeyInfo"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_own_key_v1_organizations_me_keys_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateOwnKeyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateKeyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_own_key_v1_organizations_me_keys__key_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                key_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_own_key_v1_organizations_me_keys__key_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                key_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateOwnKeyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["KeyInfo"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    rotate_own_key_v1_organizations_me_keys__key_id__rotate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                key_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateKeyResponse"];
                 };
             };
             /** @description Validation Error */

--- a/web/src/features/activity/ActivityPage.tsx
+++ b/web/src/features/activity/ActivityPage.tsx
@@ -1270,7 +1270,7 @@ export function ActivityPage() {
   // Deployment-wide and left that way: its registry entries carry no workspace,
   // so there is nothing in them to scope to a tenant yet. A non-operator is not
   // shown a strip reporting somebody else's traffic, and does not ask for one.
-  const inFlight = useInFlightRequests(scope.deploymentWide)
+  const inFlight = useInFlightRequests(scope.isDeploymentWide)
 
   // How far behind the frozen page has fallen. Polled while the count it is
   // compared against is not (see `useUsageCount`), so the difference is "rows that
@@ -1716,7 +1716,8 @@ export function ActivityPage() {
   // who cannot make them is not offered the selection that leads to them: the
   // bulk bar is rendered off `hasSelection`, which this gates.
   const showSelection =
-    scope.deploymentWide && (selectableKeys.length > 0 || selection.allMatching)
+    scope.isDeploymentWide &&
+    (selectableKeys.length > 0 || selection.allMatching)
 
   const deleteUsage = useDeleteUsage()
   const setPrice = useSetUsagePrice()
@@ -1749,11 +1750,11 @@ export function ActivityPage() {
         </div>
         <RequestDetail
           entry={entry}
-          onPriceModel={scope.deploymentWide ? setModelPriceKey : null}
+          onPriceModel={scope.isDeploymentWide ? setModelPriceKey : null}
         />
       </div>
     ),
-    [scope.deploymentWide],
+    [scope.isDeploymentWide],
   )
 
   // A bulk op targets either the current page selection (ids) or, once the operator

--- a/web/src/features/keys/KeysPage.test.tsx
+++ b/web/src/features/keys/KeysPage.test.tsx
@@ -63,11 +63,18 @@ const NEW_SECRET = "gw-NEWSECRET0000000000000000000000000000000000000000000000"
 const REGEN_SECRET =
   "gw-REGEN00000000000000000000000000000000000000000000000000"
 
+// Both key surfaces answer identical shapes, so one handler serves them: the
+// operator's `/v1/keys` and the member's `/v1/organizations/me/keys`
+// (otari-ai#1941). Which one the page asked is what the member-view cases
+// assert, off the spy's recorded URLs.
+const KEYS_URL = /\/v1\/(?:organizations\/me\/)?keys(?:\/|\?|$)/
+
 function mockApi(
   opts: {
     keys?: ApiKey[]
     users?: User[]
     members?: ReturnType<typeof organizationMember>[]
+    deploymentOperator?: boolean
   } = {},
 ) {
   let list = [...(opts.keys ?? [])]
@@ -80,7 +87,7 @@ function mockApi(
       const url = String(input)
       const method = (init?.method ?? "GET").toUpperCase()
 
-      if (url.includes("/v1/keys")) {
+      if (KEYS_URL.test(url)) {
         if (url.endsWith("/rotate") && method === "POST") {
           const id = url.split("/").slice(-2)[0]
           const prefix = REGEN_SECRET.slice(0, 10)
@@ -90,7 +97,7 @@ function mockApi(
           const row = list.find((k) => k.id === id) ?? apiKey({ id })
           return jsonResponse({ ...row, key: REGEN_SECRET, key_prefix: prefix })
         }
-        if (method === "POST" && url.endsWith("/v1/keys")) {
+        if (method === "POST") {
           const body = JSON.parse(String(init?.body)) as {
             key_name?: string | null
             user_id?: string | null
@@ -125,6 +132,28 @@ function mockApi(
       // this, and `fetchAllPaged` reads `data`/`count` rather than a bare list.
       if (url.includes("/v1/organizations/me/members")) {
         return jsonResponse({ data: members, count: members.length })
+      }
+      // Seeds the scope: `deployment_operator` is what routes the page onto the
+      // operator surface or the member one. These suites default to the
+      // operator's view, and the member cases flip it.
+      if (url.endsWith("/v1/organizations/me")) {
+        return jsonResponse({
+          organization_member_id: "om-1",
+          role: "member",
+          status: "active",
+          organization: {
+            id: "org-1",
+            name: "Acme",
+            slug: "acme",
+            created_by_user_id: null,
+            created_at: "2026-01-01T00:00:00+00:00",
+            updated_at: null,
+          },
+          byo_provider_keys_allowed: true,
+          deployment_operator: opts.deploymentOperator ?? true,
+          provider_key_encryption_available: true,
+          workspace_memberships: [],
+        })
       }
       if (url.includes("/v1/users")) {
         return jsonResponse(users)
@@ -894,5 +923,107 @@ describe("KeysPage", () => {
     // readable form, so the column is unchanged from before members existed.
     const row = (await screen.findByText("ci")).closest("tr")!
     expect(within(row).getByText("ci-bot")).toBeInTheDocument()
+  })
+
+  // The member's view of the same page (otari-ai#1941): every hook reads and
+  // writes `/v1/organizations/me/keys`, and the operator-only affordances (the
+  // owner picker, the budget exemption, the Owner column, the links to pages a
+  // member cannot open) are absent rather than present and refused.
+  describe("as a member", () => {
+    it("lists through the member surface, without the Owner column or operator links", async () => {
+      const fetchMock = mockApi({
+        deploymentOperator: false,
+        keys: [apiKey({ id: "key-1", key_name: "mine" })],
+      })
+      renderPage(<KeysPage />)
+
+      const row = (await screen.findByText("mine")).closest("tr")!
+      expect(within(row).getByText("Active")).toBeInTheDocument()
+
+      // The read went to the member surface, and never to the operator one.
+      const listCalls = fetchMock.mock.calls
+        .map(([u]) => String(u))
+        .filter((u) => KEYS_URL.test(u))
+      expect(listCalls.length).toBeGreaterThan(0)
+      for (const u of listCalls) {
+        expect(u).toContain("/v1/organizations/me/keys")
+      }
+
+      // Every key here is the caller's own, so no Owner column; and the pages
+      // the operator paragraph links to would refuse a member.
+      expect(
+        screen.queryByRole("columnheader", { name: "Owner" }),
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole("link", { name: /Spend & budgets/ }),
+      ).not.toBeInTheDocument()
+    })
+
+    it("creates a key with no owner picker and no budget exemption", async () => {
+      const fetchMock = mockApi({ deploymentOperator: false, keys: [] })
+      const usr = userEvent.setup()
+      renderPage(<KeysPage />)
+
+      await screen.findByText("No API keys yet")
+      await usr.click(
+        screen.getByRole("button", { name: "Create your first key" }),
+      )
+
+      // No owner to pick: the key is the caller's own, and Create does not wait
+      // for one.
+      expect(
+        screen.queryByPlaceholderText(/Pick a user/),
+      ).not.toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Create key" })).toBeEnabled()
+
+      await usr.click(screen.getByRole("button", { name: "Advanced" }))
+      expect(
+        screen.queryByLabelText("Exempt this key from budget"),
+      ).not.toBeInTheDocument()
+
+      await usr.type(screen.getByPlaceholderText("ci-bot"), "my-key")
+      await usr.click(screen.getByRole("button", { name: "Create key" }))
+      const dialog = await screen.findByRole("dialog")
+      expect(within(dialog).getByDisplayValue(NEW_SECRET)).toBeInTheDocument()
+
+      const post = fetchMock.mock.calls.find(
+        ([u, init]) =>
+          String(u).endsWith("/v1/organizations/me/keys") &&
+          (init?.method ?? "") === "POST",
+      )
+      expect(post).toBeDefined()
+      const body = JSON.parse(String(post?.[1]?.body))
+      expect(body.key_name).toBe("my-key")
+      // The member body carries neither escalation field.
+      expect(body).not.toHaveProperty("user_id")
+      expect(body).not.toHaveProperty("exclude_from_budget")
+    })
+
+    it("edits through the member surface, with no budget exemption to send", async () => {
+      const fetchMock = mockApi({
+        deploymentOperator: false,
+        keys: [apiKey({ id: "key-1", key_name: "mine" })],
+      })
+      const usr = userEvent.setup()
+      renderPage(<KeysPage />)
+
+      const row = (await screen.findByText("mine")).closest("tr")!
+      await usr.click(within(row).getByRole("button", { name: "Edit" }))
+      expect(
+        screen.queryByLabelText("Exempt this key from budget"),
+      ).not.toBeInTheDocument()
+
+      await usr.click(screen.getByRole("button", { name: "Save changes" }))
+
+      const patch = fetchMock.mock.calls.find(
+        ([u, init]) =>
+          String(u).endsWith("/v1/organizations/me/keys/key-1") &&
+          (init?.method ?? "") === "PATCH",
+      )
+      expect(patch).toBeDefined()
+      expect(JSON.parse(String(patch?.[1]?.body))).not.toHaveProperty(
+        "exclude_from_budget",
+      )
+    })
   })
 })

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -13,6 +13,9 @@ import type {
   ApiKey,
   CreateKeyRequest,
   CreateKeyResponse,
+  CreateOwnKeyRequest,
+  UpdateKeyRequest,
+  UpdateOwnKeyRequest,
   User,
 } from "@/client"
 import {
@@ -25,6 +28,7 @@ import {
   useCreateKey,
   useDeleteKey,
   useKeys,
+  useKeysScope,
   useRotateKey,
   useUpdateKey,
   useUsers,
@@ -380,15 +384,22 @@ function UserMismatchPicker({
   )
 }
 
+// `isDeploymentWide` is which key surface this caller acts on (useKeysScope): an
+// operator names an owner and may exempt the key from budget; a member's key is
+// always their own and always enforced, so neither control is rendered and the
+// body sent is the member surface's narrower shape.
 function CreateKeyForm({
+  isDeploymentWide,
   onClose,
   onCreated,
 }: {
+  isDeploymentWide: boolean
   onClose: () => void
   onCreated: (result: CreateKeyResponse) => void
 }) {
   const create = useCreateKey()
-  const users = useUsers()
+  // `/v1/users` is operator-only; a member's form has no owner picker to feed.
+  const users = useUsers(isDeploymentWide)
   const { selected: workspace, isLoading: workspaceLoading } =
     useSelectedWorkspace()
   const [keyName, setKeyName] = useState("")
@@ -405,10 +416,11 @@ function CreateKeyForm({
 
   const expiresInPast =
     expiresAt !== "" && new Date(expiresAt).getTime() < Date.now()
-  // User-first: a key must name its owner (an existing user or a new id, which the
-  // API creates as a named user). This is what keeps the dashboard from minting the
-  // anonymous virtual users an omitted id would.
-  const ownerMissing = userId.trim() === ""
+  // User-first: an operator's key must name its owner (an existing user or a new
+  // id, which the API creates as a named user). This is what keeps the dashboard
+  // from minting the anonymous virtual users an omitted id would. A member's key
+  // is always their own, so there is nothing to require.
+  const ownerMissing = isDeploymentWide && userId.trim() === ""
   // The workspace comes from the organization context, which resolves after the
   // form paints. Submitting before it does would send no workspace and land the
   // key in the server's default rather than the one the switcher is showing, so
@@ -420,18 +432,25 @@ function CreateKeyForm({
   const submit = () => {
     if (create.isPending || !scopeValid || ownerMissing || workspaceUnresolved)
       return
-    const body: CreateKeyRequest = {
+    const shared = {
       key_name: keyName.trim() || null,
       // The workspace the shell is on. A key belongs to exactly one, and it is
       // what every request on that key is billed to, so it is decided here
       // rather than left to the server's default.
       workspace_id: workspace?.workspace_id,
-      user_id: userId.trim(),
       expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
       allowed_models: allowedModels,
-      exclude_from_budget: excludeFromBudget,
       reject_user_mismatch: rejectUserMismatch,
     }
+    // The member surface derives the owner and refuses a budget exemption, so
+    // its body carries neither field rather than sending values it would ignore.
+    const body: CreateKeyRequest | CreateOwnKeyRequest = isDeploymentWide
+      ? {
+          ...shared,
+          user_id: userId.trim(),
+          exclude_from_budget: excludeFromBudget,
+        }
+      : shared
     create.mutate(body, {
       onSuccess: (result) => {
         // Capture the secret into the reveal BEFORE closing the form, so a render
@@ -473,12 +492,19 @@ function CreateKeyForm({
             }
           />
         </div>
-        <UserComboBox
-          value={userId}
-          onChange={setUserId}
-          users={users.data ?? []}
-          memberLabels={memberLabels}
-        />
+        {isDeploymentWide ? (
+          <UserComboBox
+            value={userId}
+            onChange={setUserId}
+            users={users.data ?? []}
+            memberLabels={memberLabels}
+          />
+        ) : (
+          <p className="text-xs text-muted">
+            This key is yours: requests on it are billed to you and count
+            against your budget.
+          </p>
+        )}
         <button
           type="button"
           className="self-start text-xs font-medium text-link hover:text-link-hover"
@@ -488,21 +514,33 @@ function CreateKeyForm({
         </button>
         {showAdvanced ? (
           <div className="flex flex-col gap-4 rounded-lg border border-border p-4">
-            <OwnerAccessNote userId={userId} users={users.data ?? []} />
+            {isDeploymentWide ? (
+              <OwnerAccessNote userId={userId} users={users.data ?? []} />
+            ) : null}
             <ModelScopeControl
               title="Restrict this key's models"
-              description="By default this key inherits its owner's access. Optionally narrow it to a subset; a key can never exceed its owner's allowed models."
-              anyLabel="Inherit owner access"
+              description={
+                isDeploymentWide
+                  ? "By default this key inherits its owner's access. Optionally narrow it to a subset; a key can never exceed its owner's allowed models."
+                  : "By default this key inherits your model access. Optionally narrow it to a subset; a key can never exceed your allowed models."
+              }
+              anyLabel={
+                isDeploymentWide
+                  ? "Inherit owner access"
+                  : "Inherit your access"
+              }
               initial={null}
               onChange={(value, valid) => {
                 setAllowedModels(value)
                 setScopeValid(valid)
               }}
             />
-            <BudgetExemptToggle
-              checked={excludeFromBudget}
-              onChange={setExcludeFromBudget}
-            />
+            {isDeploymentWide ? (
+              <BudgetExemptToggle
+                checked={excludeFromBudget}
+                onChange={setExcludeFromBudget}
+              />
+            ) : null}
             <UserMismatchPicker
               value={rejectUserMismatch}
               onChange={setRejectUserMismatch}
@@ -532,14 +570,18 @@ function CreateKeyForm({
 }
 
 function EditKeyForm({
+  isDeploymentWide,
   apiKey,
   onClose,
 }: {
+  isDeploymentWide: boolean
   apiKey: ApiKey
   onClose: () => void
 }) {
   const update = useUpdateKey()
-  const users = useUsers()
+  // Operator-only, like the create form's picker; a member edits only their own
+  // key and the note it feeds names other owners.
+  const users = useUsers(isDeploymentWide)
   const [keyName, setKeyName] = useState(apiKey.key_name ?? "")
   const [expiresAt, setExpiresAt] = useState(toDatetimeLocal(apiKey.expires_at))
   const [allowedModels, setAllowedModels] = useState<string[] | null>(
@@ -555,19 +597,17 @@ function EditKeyForm({
 
   const submit = () => {
     if (update.isPending || !scopeValid) return
-    update.mutate(
-      {
-        id: apiKey.id,
-        body: {
-          key_name: keyName.trim() || null,
-          expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
-          allowed_models: allowedModels,
-          exclude_from_budget: excludeFromBudget,
-          reject_user_mismatch: rejectUserMismatch,
-        },
-      },
-      { onSuccess: onClose },
-    )
+    const shared = {
+      key_name: keyName.trim() || null,
+      expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
+      allowed_models: allowedModels,
+      reject_user_mismatch: rejectUserMismatch,
+    }
+    // The member surface has no budget exemption to send (see CreateKeyForm).
+    const body: UpdateKeyRequest | UpdateOwnKeyRequest = isDeploymentWide
+      ? { ...shared, exclude_from_budget: excludeFromBudget }
+      : shared
+    update.mutate({ id: apiKey.id, body }, { onSuccess: onClose })
   }
 
   return (
@@ -592,23 +632,31 @@ function EditKeyForm({
             description="Blank clears the expiry."
           />
         </div>
-        {apiKey.user_id ? (
+        {isDeploymentWide && apiKey.user_id ? (
           <OwnerAccessNote userId={apiKey.user_id} users={users.data ?? []} />
         ) : null}
         <ModelScopeControl
           title="Restrict this key's models"
-          description="This key inherits its owner's access by default. Narrow it to a subset here; it can never exceed the owner's allowed models."
-          anyLabel="Inherit owner access"
+          description={
+            isDeploymentWide
+              ? "This key inherits its owner's access by default. Narrow it to a subset here; it can never exceed the owner's allowed models."
+              : "This key inherits your model access by default. Narrow it to a subset here; it can never exceed your allowed models."
+          }
+          anyLabel={
+            isDeploymentWide ? "Inherit owner access" : "Inherit your access"
+          }
           initial={apiKey.allowed_models}
           onChange={(value, valid) => {
             setAllowedModels(value)
             setScopeValid(valid)
           }}
         />
-        <BudgetExemptToggle
-          checked={excludeFromBudget}
-          onChange={setExcludeFromBudget}
-        />
+        {isDeploymentWide ? (
+          <BudgetExemptToggle
+            checked={excludeFromBudget}
+            onChange={setExcludeFromBudget}
+          />
+        ) : null}
         <UserMismatchPicker
           value={rejectUserMismatch}
           onChange={setRejectUserMismatch}
@@ -675,6 +723,11 @@ export function KeysPage() {
   // Scoped to the workspace the switcher is on: a key belongs to exactly one,
   // and this page is in the workspace context.
   const { selected: workspace } = useSelectedWorkspace()
+  // Which surface the caller acts on decides the page's voice as well as the
+  // endpoints: an operator manages every key in the organization, a member
+  // manages their own (otari-ai#1941).
+  const scope = useKeysScope()
+  const isDeploymentWide = scope.isDeploymentWide
   const keys = useKeys(workspace?.workspace_id)
   const updateKey = useUpdateKey()
   const rotateKey = useRotateKey()
@@ -689,7 +742,10 @@ export function KeysPage() {
   } | null>(null)
 
   const rows = keys.data ?? []
-  const loading = keys.isLoading
+  // An unresolved scope is a loading state: which surface the page reads, and
+  // which affordances it draws, are both undecided until the organization
+  // context answers, and a disabled query reports `isLoading` false.
+  const loading = !scope.isReady || keys.isLoading
   const editingKey = rows.find((k) => k.id === editing) ?? null
   const showOnboarding = !loading && rows.length === 0 && !addOpen
   const selection = useTableSelection()
@@ -783,32 +839,45 @@ export function KeysPage() {
         header: "Status",
         cell: (k) => <StatusChip apiKey={k} />,
       },
-      {
-        id: "owner",
-        header: "Owner",
-        // A member is named; anything else keeps the raw id, which for a
-        // hand-made owner like `ci-bot` is already the readable form. The id
-        // stays in the title so the value actually sent on a request is still
-        // recoverable from this column.
-        cell: (k) => {
-          if (isVirtualUser(k.user_id)) {
-            return (
-              <Chip size="sm" color="default">
-                virtual
-              </Chip>
-            )
-          }
-          const member = k.user_id ? memberLabels.get(k.user_id) : undefined
-          if (member) {
-            return (
-              <span className="text-sm text-foreground" title={k.user_id ?? ""}>
-                {member}
-              </span>
-            )
-          }
-          return <code className="text-xs text-muted">{k.user_id ?? "—"}</code>
-        },
-      },
+      // Every key on a member's page is their own, so an Owner column there
+      // would repeat one name down the table.
+      ...(isDeploymentWide
+        ? [
+            {
+              id: "owner",
+              header: "Owner",
+              // A member is named; anything else keeps the raw id, which for a
+              // hand-made owner like `ci-bot` is already the readable form. The id
+              // stays in the title so the value actually sent on a request is still
+              // recoverable from this column.
+              cell: (k: ApiKey) => {
+                if (isVirtualUser(k.user_id)) {
+                  return (
+                    <Chip size="sm" color="default">
+                      virtual
+                    </Chip>
+                  )
+                }
+                const member = k.user_id
+                  ? memberLabels.get(k.user_id)
+                  : undefined
+                if (member) {
+                  return (
+                    <span
+                      className="text-sm text-foreground"
+                      title={k.user_id ?? ""}
+                    >
+                      {member}
+                    </span>
+                  )
+                }
+                return (
+                  <code className="text-xs text-muted">{k.user_id ?? "—"}</code>
+                )
+              },
+            } satisfies DataTableColumn<ApiKey>,
+          ]
+        : []),
       {
         id: "key",
         header: "Key",
@@ -913,6 +982,7 @@ export function KeysPage() {
       setActive,
       regenerate,
       memberLabels,
+      isDeploymentWide,
     ],
   )
 
@@ -924,7 +994,11 @@ export function KeysPage() {
     <div className="flex flex-col gap-6">
       <PageHeader
         title="API keys"
-        description="Issue and revoke the keys that authenticate callers to this gateway. Secrets are shown once at creation."
+        description={
+          isDeploymentWide
+            ? "Issue and revoke the keys that authenticate callers to this gateway. Secrets are shown once at creation."
+            : "Create and manage your own keys for calling this gateway. Secrets are shown once at creation."
+        }
         action={
           addOpen ? null : (
             <Button
@@ -949,24 +1023,33 @@ export function KeysPage() {
       {/* A key's owner and its spending limit are both set elsewhere now, on the
           organization rail. This page is where an operator arrives looking for
           them, so it says where they went rather than leaving the sidebar to be
-          re-learned. */}
-      <p className="text-sm text-muted">
-        A key spends against its owner's budget. Owners live under{" "}
-        <Link
-          to="/organization/members"
-          className="font-medium text-link hover:text-link-hover"
-        >
-          Organization → Members &amp; roles
-        </Link>
-        , and their limits under{" "}
-        <Link
-          to="/budgets"
-          className="font-medium text-link hover:text-link-hover"
-        >
-          Spend &amp; budgets
-        </Link>
-        .
-      </p>
+          re-learned. A member's keys are their own and both destinations refuse
+          them, so their page states the ownership rule instead of pointing at
+          pages they cannot open. */}
+      {isDeploymentWide ? (
+        <p className="text-sm text-muted">
+          A key spends against its owner's budget. Owners live under{" "}
+          <Link
+            to="/organization/members"
+            className="font-medium text-link hover:text-link-hover"
+          >
+            Organization → Members &amp; roles
+          </Link>
+          , and their limits under{" "}
+          <Link
+            to="/budgets"
+            className="font-medium text-link hover:text-link-hover"
+          >
+            Spend &amp; budgets
+          </Link>
+          .
+        </p>
+      ) : (
+        <p className="text-sm text-muted">
+          These are your keys: requests on them are billed to you and spend
+          against your budget.
+        </p>
+      )}
 
       {showOnboarding ? (
         <EmptyState
@@ -982,6 +1065,7 @@ export function KeysPage() {
 
       {addOpen ? (
         <CreateKeyForm
+          isDeploymentWide={isDeploymentWide}
           onClose={() => setAddOpen(false)}
           onCreated={(result) =>
             setRevealed({ title: "API key created", result })
@@ -994,6 +1078,7 @@ export function KeysPage() {
       {editingKey ? (
         <EditKeyForm
           key={editingKey.id}
+          isDeploymentWide={isDeploymentWide}
           apiKey={editingKey}
           onClose={() => setEditing(null)}
         />
@@ -1020,21 +1105,25 @@ export function KeysPage() {
           >
             Disable
           </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            isDisabled={bulkPending}
-            onPress={() =>
-              void runBulk(selectedKeys, (k) =>
-                updateKey.mutateAsync({
-                  id: k.id,
-                  body: { exclude_from_budget: true },
-                }),
-              )
-            }
-          >
-            Budget-exempt
-          </Button>
+          {/* A member cannot exempt their own spend from enforcement, so the
+              bulk form of the toggle is operator-only like the per-key one. */}
+          {isDeploymentWide ? (
+            <Button
+              size="sm"
+              variant="outline"
+              isDisabled={bulkPending}
+              onPress={() =>
+                void runBulk(selectedKeys, (k) =>
+                  updateKey.mutateAsync({
+                    id: k.id,
+                    body: { exclude_from_budget: true },
+                  }),
+                )
+              }
+            >
+              Budget-exempt
+            </Button>
+          ) : null}
           <Button
             size="sm"
             variant="danger"

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -423,10 +423,13 @@ function CreateKeyForm({
   const ownerMissing = isDeploymentWide && userId.trim() === ""
   // The workspace comes from the organization context, which resolves after the
   // form paints. Submitting before it does would send no workspace and land the
-  // key in the server's default rather than the one the switcher is showing, so
-  // the button waits for that read. It waits for the read, not for a workspace:
-  // a caller who belongs to none resolves to null and must still be able to
-  // create a key, which the server puts in its default.
+  // key somewhere other than the one the switcher is showing, so the button
+  // waits for that read. It waits for the read, not for a workspace: a caller
+  // who belongs to none resolves to null and still submits, and what an omitted
+  // workspace means is then the server's to say. The operator surface mints into
+  // the organization's default; the member surface refuses with a 409 unless the
+  // caller belongs to that default, which is the answer this form surfaces
+  // rather than pre-empting.
   const workspaceUnresolved = workspaceLoading
 
   const submit = () => {

--- a/web/src/shared/api/hooks.ts
+++ b/web/src/shared/api/hooks.ts
@@ -23,6 +23,7 @@ import type {
   CreateOrganizationPricingOverride,
   CreateOrganizationRequest,
   CreateOrgProviderKeyRequest,
+  CreateOwnKeyRequest,
   CreateScopedBudgetRequest,
   CreateSearchToolRequest,
   CreateStoredProviderRequest,
@@ -97,6 +98,7 @@ import type {
   UpdateOrganizationPricingOverride,
   UpdateOrganizationRequest,
   UpdateOrgProviderKeyRequest,
+  UpdateOwnKeyRequest,
   UpdateScopedBudgetRequest,
   UpdateSearchToolRequest,
   UpdateSettingsRequest,
@@ -1143,12 +1145,38 @@ export function useRejectPricingRefresh() {
 const KEYS_PAGE_SIZE = 1000
 const KEYS_MAX_PAGES = 100
 
-async function fetchAllKeys(workspaceId?: string): Promise<ApiKey[]> {
+// Which of the two key surfaces this caller may act on.
+//
+// `/v1/keys` is deployment-wide and refuses anyone who does not operate the
+// deployment; `/v1/organizations/me/keys` serves the caller's own keys, in
+// workspaces they belong to (otari-ai#1941). Both answer identical shapes, so
+// the key hooks below differ only in the prefix they ask. Same construction as
+// `useUsageScope` above, for the same reasons: the organization context is what
+// the shell already reads, an errored context falls through to the narrower
+// surface, and the base is part of every query key it feeds.
+export function useKeysScope(): {
+  base: string
+  isReady: boolean
+  isDeploymentWide: boolean
+} {
+  const context = useOrganizationContext()
+  const isDeploymentWide = context.data?.deployment_operator === true
+  return {
+    base: isDeploymentWide ? "/v1/keys" : "/v1/organizations/me/keys",
+    isReady: context.isSuccess || context.isError,
+    isDeploymentWide,
+  }
+}
+
+async function fetchAllKeys(
+  base: string,
+  workspaceId?: string,
+): Promise<ApiKey[]> {
   const all: ApiKey[] = []
   const scope = workspaceId ? `&workspace_id=${workspaceId}` : ""
   for (let page = 0; page < KEYS_MAX_PAGES; page += 1) {
     const rows = await apiFetch<ApiKey[]>(
-      `/v1/keys?skip=${page * KEYS_PAGE_SIZE}&limit=${KEYS_PAGE_SIZE}${scope}`,
+      `${base}?skip=${page * KEYS_PAGE_SIZE}&limit=${KEYS_PAGE_SIZE}${scope}`,
     )
     all.push(...rows)
     if (rows.length < KEYS_PAGE_SIZE) {
@@ -1160,23 +1188,29 @@ async function fetchAllKeys(workspaceId?: string): Promise<ApiKey[]> {
 
 // The workspace is part of the key, not just the request: switching workspaces
 // has to refetch rather than serve the previous one's keys from cache. Same for
-// the two below. An unset id keeps the deployment-wide view, which is what the
+// the two below. An unset id keeps the whole-scope view, which is what the
 // organization context and a deployment with no workspace selected still want.
 export function useKeys(workspaceId?: string) {
+  const scope = useKeysScope()
   return useQuery({
-    queryKey: [KEYS, workspaceId ?? null],
-    queryFn: () => fetchAllKeys(workspaceId),
+    queryKey: [KEYS, scope.base, workspaceId ?? null],
+    queryFn: () => fetchAllKeys(scope.base, workspaceId),
+    enabled: scope.isReady,
     staleTime: 60_000,
   })
 }
 
 // Create returns the plaintext key exactly once (in `key`); the caller reveals it
-// and must never write the response into the query cache.
+// and must never write the response into the query cache. The member surface's
+// body is a subset of the operator's (no owner, no budget exemption), which is
+// the page's branch to build; the union keeps a member body from being forced
+// to carry fields its endpoint refuses to honor.
 export function useCreateKey() {
   const queryClient = useQueryClient()
+  const scope = useKeysScope()
   return useMutation({
-    mutationFn: (body: CreateKeyRequest) =>
-      apiFetch<CreateKeyResponse>("/v1/keys", {
+    mutationFn: (body: CreateKeyRequest | CreateOwnKeyRequest) =>
+      apiFetch<CreateKeyResponse>(scope.base, {
         method: "POST",
         body: JSON.stringify(body),
       }),
@@ -1186,9 +1220,16 @@ export function useCreateKey() {
 
 export function useUpdateKey() {
   const queryClient = useQueryClient()
+  const scope = useKeysScope()
   return useMutation({
-    mutationFn: ({ id, body }: { id: string; body: UpdateKeyRequest }) =>
-      apiFetch<ApiKey>(`/v1/keys/${encodeURIComponent(id)}`, {
+    mutationFn: ({
+      id,
+      body,
+    }: {
+      id: string
+      body: UpdateKeyRequest | UpdateOwnKeyRequest
+    }) =>
+      apiFetch<ApiKey>(`${scope.base}/${encodeURIComponent(id)}`, {
         method: "PATCH",
         body: JSON.stringify(body),
       }),
@@ -1200,20 +1241,25 @@ export function useUpdateKey() {
 // immediately. Returns the new plaintext once, like create.
 export function useRotateKey() {
   const queryClient = useQueryClient()
+  const scope = useKeysScope()
   return useMutation({
     mutationFn: (id: string) =>
-      apiFetch<CreateKeyResponse>(`/v1/keys/${encodeURIComponent(id)}/rotate`, {
-        method: "POST",
-      }),
+      apiFetch<CreateKeyResponse>(
+        `${scope.base}/${encodeURIComponent(id)}/rotate`,
+        {
+          method: "POST",
+        },
+      ),
     onSuccess: () => void queryClient.invalidateQueries({ queryKey: [KEYS] }),
   })
 }
 
 export function useDeleteKey() {
   const queryClient = useQueryClient()
+  const scope = useKeysScope()
   return useMutation({
     mutationFn: (id: string) =>
-      apiFetch<void>(`/v1/keys/${encodeURIComponent(id)}`, {
+      apiFetch<void>(`${scope.base}/${encodeURIComponent(id)}`, {
         method: "DELETE",
       }),
     onSuccess: () => void queryClient.invalidateQueries({ queryKey: [KEYS] }),
@@ -1531,15 +1577,15 @@ function usageParams(filters: UsageFilters): URLSearchParams {
 // can never read each other's cached rows.
 export function useUsageScope(): {
   base: string
-  ready: boolean
-  deploymentWide: boolean
+  isReady: boolean
+  isDeploymentWide: boolean
 } {
   const context = useOrganizationContext()
-  const deploymentWide = context.data?.deployment_operator === true
+  const isDeploymentWide = context.data?.deployment_operator === true
   return {
-    base: deploymentWide ? "/v1/usage" : "/v1/organizations/me/usage",
-    ready: context.isSuccess || context.isError,
-    deploymentWide,
+    base: isDeploymentWide ? "/v1/usage" : "/v1/organizations/me/usage",
+    isReady: context.isSuccess || context.isError,
+    isDeploymentWide,
   }
 }
 
@@ -1559,7 +1605,7 @@ export function useUsageLogs(
       params.set("limit", String(pageSize))
       return apiFetch<UsageEntry[]>(`${scope.base}?${params.toString()}`)
     },
-    enabled: scope.ready,
+    enabled: scope.isReady,
     placeholderData: keepPreviousData,
     // The log is a snapshot an operator reads, not a feed. On a busy gateway rows
     // arrive faster than anyone can inspect them, so a page that refetched on its
@@ -1586,7 +1632,7 @@ export function useUsageCount(filters: UsageFilters, enabled = true) {
       apiFetch<UsageCount>(
         `${scope.base}/count?${usageParams(filters).toString()}`,
       ),
-    enabled: enabled && scope.ready,
+    enabled: enabled && scope.isReady,
     placeholderData: keepPreviousData,
     staleTime: 10_000,
   })
@@ -1614,7 +1660,7 @@ export function useLiveUsageCount(filters: UsageFilters, enabled = true) {
       apiFetch<UsageCount>(
         `${scope.base}/count?${usageParams(filters).toString()}`,
       ),
-    enabled: enabled && scope.ready,
+    enabled: enabled && scope.isReady,
     refetchInterval: NEW_ROW_POLL_MS,
     staleTime: 0,
     // A failed count is not worth surfacing: it sits beside a refresh button that
@@ -1685,7 +1731,7 @@ export function useFailureCount(windowSeconds: number, enabled = true) {
         `${scope.base}/count?${usageParams(filters).toString()}`,
       )
     },
-    enabled: enabled && scope.ready,
+    enabled: enabled && scope.isReady,
     refetchInterval: FAILURE_COUNT_POLL_MS,
     refetchOnWindowFocus: true,
     staleTime: 0,
@@ -1717,7 +1763,7 @@ export function useRequestGroups(groupIds: readonly string[]) {
       params.set("limit", String(REQUEST_GROUP_PAGE_LIMIT))
       return apiFetch<UsageEntry[]>(`${scope.base}?${params.toString()}`)
     },
-    enabled: ids.length > 0 && scope.ready,
+    enabled: ids.length > 0 && scope.isReady,
     placeholderData: keepPreviousData,
     // A group is immutable once its request finished, so the only reason to
     // refetch is a group that was still in flight when it was first read.
@@ -1812,7 +1858,7 @@ export function useUsageSummary(
         `${scope.base}/summary?${params.toString()}`,
       )
     },
-    enabled: enabled && scope.ready,
+    enabled: enabled && scope.isReady,
     placeholderData: keepPreviousData,
     staleTime: 30_000,
   })
@@ -1838,7 +1884,7 @@ export function useUsageGroupedSeries(
         `${scope.base}/series?${params.toString()}`,
       )
     },
-    enabled: enabled && groupBy !== null && scope.ready,
+    enabled: enabled && groupBy !== null && scope.isReady,
     placeholderData: keepPreviousData,
     staleTime: 30_000,
     // A 404 is version skew (a gateway older than this dashboard, e.g. not yet


### PR DESCRIPTION
## Description

Every `/v1/keys` route is operator-only since otari-ai#1880, and the `/keys` nav row was `operatorOnly: "refused"`, so a hosted organization member had no way to mint or manage an API key at all; an admin had to hand one over out of band. The roles matrix says members create their own keys.

This adds the tenant-scoped sibling surface the usage reads already have (the otari#837 shape), as a write surface, and ungates the Keys page for members against it.

**Backend: `/v1/organizations/me/keys`** (`api/routes/organization_keys.py`), create/list/update/rotate/revoke, authenticated by `verify_master_key` and authorized per request:

- **Ownership is derived, never accepted.** A key minted here bills to the caller's own attribution user (`users.user_id` = the identity's UUID as a string, the row the activation guide already keys on). There is no `user_id` parameter, and every `/{key_id}` load carries the owner predicate as well as the organization one, so a colleague's key in the same workspace answers the 404 a missing key does.
- **The workspace must be one the caller may see.** A named `workspace_id` goes through `resolve_workspace_in_organization` (404 for another organization's workspace and for a sibling workspace the member does not belong to). Omitted, the organization's default workspace is resolved and put through the same check, refused with a 409 naming what to do when the caller is not a member of it.
- **No budget bypass.** The member bodies carry no `exclude_from_budget`; a member-minted key is always enforced, and the narrow-only `allowed_models` rule binds against the caller's own user default exactly as on the operator surface.
- `/v1/keys` keeps `require_deployment_operator` unchanged, asserted in the new suite's control group.

**Dashboard:**

- `useKeysScope()` (the `useUsageScope` construction) routes the five key hooks onto `/v1/keys` for an operator and `/v1/organizations/me/keys` for everyone else, with the base in every query key and an unresolved scope treated as loading.
- The `/keys` nav row drops `operatorOnly`, the same way Activity and Usage left that list in otari#837; `registry.test.ts`'s pinned set moves from eight rows to seven.
- A member's view of the Keys page drops the operator-only affordances rather than offering and refusing them: no owner picker (the key is their own), no budget-exempt toggle or bulk action, no Owner column, and no links to pages that would refuse them.
- The scope hooks' boolean fields are renamed to read as predicates (`isDeploymentWide`, `isReady`), in `useUsageScope` too so the two hooks stay one vocabulary, and the naming-conventions guide now states that booleans read as yes/no questions including props and hook return fields.

**Tests:** `tests/integration/test_organization_member_keys.py` (19 cases: cross-tenant and cross-member 404s, workspace membership on create, escalation fields inert, the operator gate control, and a data-plane authentication check), plus member-view cases in `KeysPage.test.tsx`.

Generated artifacts regenerated and committed: `docs/public/openapi.json`, the Postman collection, `web/src/client/schema.ts`, and the SDK endpoint manifest (`dashboard-only`, like the usage siblings).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#1941

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code (Claude Fable 5)

**Any additional AI details you'd like to share:**

Implemented end to end from the issue by Claude Code; the human in the loop reviewed the direction and the boolean-naming convention.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added member-scoped API key management at `/v1/organizations/me/keys`.
- Members can create, list, update, rotate, and revoke only their own keys.
- Enforced workspace access, ownership isolation, model limits, and budget enforcement.
- Kept operator-only `/v1/keys` behavior unchanged.
- Updated the dashboard so members can manage keys without operator-only controls.
- Renamed scope hook fields to predicate-style names.
- Updated API schemas, documentation, Postman examples, and endpoint coverage data.
- Added integration and dashboard tests for authorization, key lifecycle, budgets, authentication, and member views.

These changes give members safe self-service key management while preserving operator controls and improving clarity across the API and dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->