### PR TITLE
feat(dashboard): give members a read-only view of the Build pages

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -89,8 +89,9 @@ curl -X POST http://localhost:8000/v1/workspaces/$WORKSPACE_ID/mcp-servers \
 ```
 
 `GET` lists them, `PATCH /{server_id}` updates one, and `DELETE /{server_id}`
-removes it. Every operation, including the list, needs an organization
-owner/admin or an owner/admin of that workspace.
+removes it. The list is readable by any member who can see the workspace;
+creating, updating, or deleting a server needs an organization owner/admin or
+an owner/admin of that workspace.
 
 - The `authorization_token` is encrypted at rest with `OTARI_SECRET_KEY` and is
   never returned. Responses carry `has_token` instead. On a `PATCH`, omit the

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -18316,6 +18316,40 @@
         ]
       }
     },
+    "/v1/organizations/me/routing-policies": {
+      "get": {
+        "description": "List the routing policies in force in the workspaces this caller may see.\n\nStored policies from the caller's visible workspaces plus the config-file\npolicies, which are deployment-wide and resolve in every workspace. The\nresponse is the shape ``GET /v1/routing/policies`` answers, narrowed to the\ncaller's own organization; only an operator can write any of it.",
+        "operationId": "list_visible_routing_policies_v1_organizations_me_routing_policies_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/PolicyResponse"
+                  },
+                  "title": "Response List Visible Routing Policies V1 Organizations Me Routing Policies Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "List Visible Routing Policies",
+        "tags": [
+          "routing"
+        ]
+      }
+    },
     "/v1/organizations/me/switch": {
       "post": {
         "description": "Point the caller's identity at another organization they belong to.\n\nDistinct from ``PATCH /me``, which renames the organization already active.\nThis changes which organization every later request is scoped to, so\nworkspaces, keys, budgets and usage all follow it. Answers 404 for an\norganization the caller holds no active membership in, whether or not it\nexists.",
@@ -24913,7 +24947,7 @@
     },
     "/v1/workspaces/{workspace_id}/mcp-servers": {
       "get": {
-        "description": "List the MCP servers configured for a workspace.\n\nOrganization owners/admins or this workspace's owners/admins. Reads are\ngated like writes because these rows name the endpoints the gateway\nconnects to on the workspace's behalf. Authorization tokens are never\nincluded; each server reports only whether it has one.",
+        "description": "List the MCP servers configured for a workspace.\n\nReadable by any member who can see the workspace: these servers act on\nevery request a member sends through it, so what they are is a member's\nto view (otari-ai#1942). Changing them stays with organization\nowners/admins or this workspace's owners/admins. Authorization tokens are\nnever included; each server reports only whether it has one.",
         "operationId": "list_workspace_mcp_servers_v1_workspaces__workspace_id__mcp_servers_get",
         "parameters": [
           {

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -3387,6 +3387,233 @@
     {
       "item": [
         {
+          "name": "List Visible Routing Policies",
+          "request": {
+            "description": "List the routing policies in force in the workspaces this caller may see.\n\nStored policies from the caller's visible workspaces plus the config-file\npolicies, which are deployment-wide and resolve in every workspace. The\nresponse is the shape ``GET /v1/routing/policies`` answers, narrowed to the\ncaller's own organization; only an operator can write any of it.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "routing-policies"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/routing-policies"
+            }
+          }
+        },
+        {
+          "name": "List Policies",
+          "request": {
+            "description": "List every routing policy in force, from config.yml and from storage.\n\nEvery scope at once, workspace-wide and user-scoped alike: this is the\nmaster-key management view, not what any one caller resolves.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "routing",
+                "policies"
+              ],
+              "query": [
+                {
+                  "description": "Only stored policies in this workspace. Config-file policies are always included, being deployment-wide. Omit to list the stored policies of every workspace.",
+                  "disabled": true,
+                  "key": "workspace_id",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/routing/policies?workspace_id="
+            }
+          }
+        },
+        {
+          "name": "Set Policy",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"name\": \"string\",\n  \"spec\": {}\n}"
+            },
+            "description": "Create or update a stored policy in one workspace, optionally for one user.\n\nThe spec is validated here and stored as given, so a row can never contain a\nbody this build would refuse at load. The cache is refreshed twice: once before\nvalidating (so the shadowing checks see other writers' policies) and once after\ncommitting (so this worker serves the new policy immediately).\n\n``rename_from`` renames the row instead of keying on ``name``. It is part of\nthis write rather than an endpoint of its own so that an edit which both renames\na policy and re-targets it cannot land half-applied, leaving the old name serving\nthe new spec. The new name is validated exactly as a fresh one is, because a\nrename can walk a policy into every collision a create can. Sending the field\nasserts the named policy is stored, so it never falls back to creating one.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "routing",
+                "policies"
+              ],
+              "raw": "{{baseUrl}}/v1/routing/policies"
+            }
+          }
+        },
+        {
+          "name": "Explain Policy",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"allowed_models\": [\n    \"string\"\n  ],\n  \"budget_remaining_usd\": 0,\n  \"budget_used_pct\": 0,\n  \"key_id\": \"string\",\n  \"name\": \"string\",\n  \"spec\": {},\n  \"user_id\": \"string\",\n  \"workspace_id\": \"00000000-0000-0000-0000-000000000000\"\n}"
+            },
+            "description": "Compile a policy and return the plan, without dispatching anything.\n\nMaster-key gated, and deliberately so: the response enumerates the policy's\ntargets, which is exactly the information a policy exists to keep off the wire.\nIt is a management surface, not a caller-facing one.\n\nAccepts an unsaved ``spec`` as well as a saved ``name``, so a form can validate\nwhat the operator is about to save. The response includes dropped candidates\nwith reasons, which is the part that catches a \"failover\" policy that has\nquietly compiled down to a single attempt.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "routing",
+                "policies",
+                "explain"
+              ],
+              "raw": "{{baseUrl}}/v1/routing/policies/explain"
+            }
+          }
+        },
+        {
+          "name": "Delete Policy",
+          "request": {
+            "description": "Delete a stored policy in one scope.\n\nScoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:\ndeleting one workspace's policy must not touch another's, deleting the\nworkspace-wide policy must not take a user's override with it, and deleting an\noverride must leave the workspace-wide one serving everyone else.",
+            "header": [],
+            "method": "DELETE",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "routing",
+                "policies",
+                ":name"
+              ],
+              "query": [
+                {
+                  "description": "Delete the policy scoped to this user. Omit to delete the workspace-wide one.",
+                  "disabled": true,
+                  "key": "user_id",
+                  "value": ""
+                },
+                {
+                  "description": "Delete the policy in this workspace. Omit for the deployment's default workspace.",
+                  "disabled": true,
+                  "key": "workspace_id",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/routing/policies/:name?user_id=&workspace_id=",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "name",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Rank Candidates",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"user_id\": \"string\",\n  \"examples\": [\n    {\n      \"prompt\": \"string\",\n      \"scores\": {}\n    }\n  ]\n}"
+            },
+            "description": "Record scored examples: one routing-memory record each, plus an audit row.\n\nThe routing-memory record is written before its audit row for each example,\nbecause it is the load-bearing one (the router votes over it) and embedding it\ncan fail; writing the audit row only afterwards means a failed embedding never\nleaves an orphan audit row.\n\nA failed embedding is a 502 that names the model, not a 500. Every example in\nthe batch is embedded, so this is the call an operator makes most often and the\none most likely to meet a misconfigured ``router_embedding_model``.\n\nScore keys are stored canonically as ``instance:model`` (see\n:func:`_validated_scores`), which is the form the router canonicalizes its\ncandidates to, so how a policy spells a candidate cannot decide whether it\nmatches.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "routing",
+                "preferences",
+                "rank"
+              ],
+              "raw": "{{baseUrl}}/v1/routing/preferences/rank"
+            }
+          }
+        },
+        {
+          "name": "Routing Memory Status",
+          "request": {
+            "description": "Report how warm one user's routing memory is in one workspace, per pool.\n\n``user_id`` is required rather than optional because there is no aggregate\nanswer: warmth is per user, and a total across users would describe a pool\nthat no request ever votes over. The same holds across workspaces, which is\nwhy ``workspace_id`` narrows rather than aggregating; it merely defaults\ninstead of being required, because a single-workspace deployment has one\nanswer.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "routing",
+                "status"
+              ],
+              "query": [
+                {
+                  "description": "Whose routing memory to report on.",
+                  "disabled": false,
+                  "key": "user_id",
+                  "value": ""
+                },
+                {
+                  "description": "Which workspace's routing memory to report on. Omit for the default workspace.",
+                  "disabled": true,
+                  "key": "workspace_id",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/routing/status?user_id=&workspace_id="
+            }
+          }
+        }
+      ],
+      "name": "routing"
+    },
+    {
+      "item": [
+        {
           "name": "List Organization Usage",
           "request": {
             "description": "List the caller's organization's usage logs, most recent first.\n\nThe tenant-scoped counterpart of ``GET /v1/usage``: same filters, same bare\nJSON array, same separate ``/count`` for a paginator's total, confined to\nwhat the caller's membership lets them see. Scope is never a parameter here.",
@@ -4475,213 +4702,6 @@
         }
       ],
       "name": "responses"
-    },
-    {
-      "item": [
-        {
-          "name": "List Policies",
-          "request": {
-            "description": "List every routing policy in force, from config.yml and from storage.\n\nEvery scope at once, workspace-wide and user-scoped alike: this is the\nmaster-key management view, not what any one caller resolves.",
-            "header": [],
-            "method": "GET",
-            "url": {
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "v1",
-                "routing",
-                "policies"
-              ],
-              "query": [
-                {
-                  "description": "Only stored policies in this workspace. Config-file policies are always included, being deployment-wide. Omit to list the stored policies of every workspace.",
-                  "disabled": true,
-                  "key": "workspace_id",
-                  "value": ""
-                }
-              ],
-              "raw": "{{baseUrl}}/v1/routing/policies?workspace_id="
-            }
-          }
-        },
-        {
-          "name": "Set Policy",
-          "request": {
-            "body": {
-              "mode": "raw",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              },
-              "raw": "{\n  \"name\": \"string\",\n  \"spec\": {}\n}"
-            },
-            "description": "Create or update a stored policy in one workspace, optionally for one user.\n\nThe spec is validated here and stored as given, so a row can never contain a\nbody this build would refuse at load. The cache is refreshed twice: once before\nvalidating (so the shadowing checks see other writers' policies) and once after\ncommitting (so this worker serves the new policy immediately).\n\n``rename_from`` renames the row instead of keying on ``name``. It is part of\nthis write rather than an endpoint of its own so that an edit which both renames\na policy and re-targets it cannot land half-applied, leaving the old name serving\nthe new spec. The new name is validated exactly as a fresh one is, because a\nrename can walk a policy into every collision a create can. Sending the field\nasserts the named policy is stored, so it never falls back to creating one.",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "method": "POST",
-            "url": {
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "v1",
-                "routing",
-                "policies"
-              ],
-              "raw": "{{baseUrl}}/v1/routing/policies"
-            }
-          }
-        },
-        {
-          "name": "Explain Policy",
-          "request": {
-            "body": {
-              "mode": "raw",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              },
-              "raw": "{\n  \"allowed_models\": [\n    \"string\"\n  ],\n  \"budget_remaining_usd\": 0,\n  \"budget_used_pct\": 0,\n  \"key_id\": \"string\",\n  \"name\": \"string\",\n  \"spec\": {},\n  \"user_id\": \"string\",\n  \"workspace_id\": \"00000000-0000-0000-0000-000000000000\"\n}"
-            },
-            "description": "Compile a policy and return the plan, without dispatching anything.\n\nMaster-key gated, and deliberately so: the response enumerates the policy's\ntargets, which is exactly the information a policy exists to keep off the wire.\nIt is a management surface, not a caller-facing one.\n\nAccepts an unsaved ``spec`` as well as a saved ``name``, so a form can validate\nwhat the operator is about to save. The response includes dropped candidates\nwith reasons, which is the part that catches a \"failover\" policy that has\nquietly compiled down to a single attempt.",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "method": "POST",
-            "url": {
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "v1",
-                "routing",
-                "policies",
-                "explain"
-              ],
-              "raw": "{{baseUrl}}/v1/routing/policies/explain"
-            }
-          }
-        },
-        {
-          "name": "Delete Policy",
-          "request": {
-            "description": "Delete a stored policy in one scope.\n\nScoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:\ndeleting one workspace's policy must not touch another's, deleting the\nworkspace-wide policy must not take a user's override with it, and deleting an\noverride must leave the workspace-wide one serving everyone else.",
-            "header": [],
-            "method": "DELETE",
-            "url": {
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "v1",
-                "routing",
-                "policies",
-                ":name"
-              ],
-              "query": [
-                {
-                  "description": "Delete the policy scoped to this user. Omit to delete the workspace-wide one.",
-                  "disabled": true,
-                  "key": "user_id",
-                  "value": ""
-                },
-                {
-                  "description": "Delete the policy in this workspace. Omit for the deployment's default workspace.",
-                  "disabled": true,
-                  "key": "workspace_id",
-                  "value": ""
-                }
-              ],
-              "raw": "{{baseUrl}}/v1/routing/policies/:name?user_id=&workspace_id=",
-              "variable": [
-                {
-                  "description": "path parameter",
-                  "key": "name",
-                  "value": ""
-                }
-              ]
-            }
-          }
-        },
-        {
-          "name": "Rank Candidates",
-          "request": {
-            "body": {
-              "mode": "raw",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              },
-              "raw": "{\n  \"user_id\": \"string\",\n  \"examples\": [\n    {\n      \"prompt\": \"string\",\n      \"scores\": {}\n    }\n  ]\n}"
-            },
-            "description": "Record scored examples: one routing-memory record each, plus an audit row.\n\nThe routing-memory record is written before its audit row for each example,\nbecause it is the load-bearing one (the router votes over it) and embedding it\ncan fail; writing the audit row only afterwards means a failed embedding never\nleaves an orphan audit row.\n\nA failed embedding is a 502 that names the model, not a 500. Every example in\nthe batch is embedded, so this is the call an operator makes most often and the\none most likely to meet a misconfigured ``router_embedding_model``.\n\nScore keys are stored canonically as ``instance:model`` (see\n:func:`_validated_scores`), which is the form the router canonicalizes its\ncandidates to, so how a policy spells a candidate cannot decide whether it\nmatches.",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/json"
-              }
-            ],
-            "method": "POST",
-            "url": {
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "v1",
-                "routing",
-                "preferences",
-                "rank"
-              ],
-              "raw": "{{baseUrl}}/v1/routing/preferences/rank"
-            }
-          }
-        },
-        {
-          "name": "Routing Memory Status",
-          "request": {
-            "description": "Report how warm one user's routing memory is in one workspace, per pool.\n\n``user_id`` is required rather than optional because there is no aggregate\nanswer: warmth is per user, and a total across users would describe a pool\nthat no request ever votes over. The same holds across workspaces, which is\nwhy ``workspace_id`` narrows rather than aggregating; it merely defaults\ninstead of being required, because a single-workspace deployment has one\nanswer.",
-            "header": [],
-            "method": "GET",
-            "url": {
-              "host": [
-                "{{baseUrl}}"
-              ],
-              "path": [
-                "v1",
-                "routing",
-                "status"
-              ],
-              "query": [
-                {
-                  "description": "Whose routing memory to report on.",
-                  "disabled": false,
-                  "key": "user_id",
-                  "value": ""
-                },
-                {
-                  "description": "Which workspace's routing memory to report on. Omit for the default workspace.",
-                  "disabled": true,
-                  "key": "workspace_id",
-                  "value": ""
-                }
-              ],
-              "raw": "{{baseUrl}}/v1/routing/status?user_id=&workspace_id="
-            }
-          }
-        }
-      ],
-      "name": "routing"
     },
     {
       "item": [
@@ -6702,7 +6722,7 @@
         {
           "name": "List Workspace Mcp Servers",
           "request": {
-            "description": "List the MCP servers configured for a workspace.\n\nOrganization owners/admins or this workspace's owners/admins. Reads are\ngated like writes because these rows name the endpoints the gateway\nconnects to on the workspace's behalf. Authorization tokens are never\nincluded; each server reports only whether it has one.",
+            "description": "List the MCP servers configured for a workspace.\n\nReadable by any member who can see the workspace: these servers act on\nevery request a member sends through it, so what they are is a member's\nto view (otari-ai#1942). Changing them stays with organization\nowners/admins or this workspace's owners/admins. Authorization tokens are\nnever included; each server reports only whether it has one.",
             "header": [],
             "method": "GET",
             "url": {

--- a/scripts/sdk_codegen/sdk-endpoints.txt
+++ b/scripts/sdk_codegen/sdk-endpoints.txt
@@ -243,6 +243,7 @@ GET /v1/organizations/me/usage                              # dashboard-only
 GET /v1/organizations/me/usage/count                        # dashboard-only
 GET /v1/organizations/me/usage/summary                      # dashboard-only
 GET /v1/organizations/me/usage/series                       # dashboard-only
+GET /v1/organizations/me/routing-policies                   # dashboard-only
 GET /v1/organizations/me/guardrails                         # operator surface
 POST /v1/organizations/me/guardrails                        # operator surface
 PATCH /v1/organizations/me/guardrails/{guardrail_id}        # operator surface

--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -32,6 +32,7 @@ from gateway.api.routes import (
     org_provider_keys,
     organization_guardrails,
     organization_pricing,
+    organization_routing,
     organization_usage,
     organizations,
     otlp,
@@ -165,6 +166,9 @@ def _register_core_routers(app: FastAPI, config: GatewayConfig) -> None:
     # rather than beside ``usage.router``, because what it is scoped to is what
     # decides who may call it (otari#837).
     app.include_router(organization_usage.router)
+    # The tenant-scoped read over the same table ``/v1/routing/policies`` serves
+    # to an operator, mounted here for the same reason (otari-ai#1942).
+    app.include_router(organization_routing.router)
     app.include_router(workspaces.router)
     app.include_router(invitations.router)
     app.include_router(workspace_member_budget_policies.router)

--- a/src/gateway/api/routes/organization_routing.py
+++ b/src/gateway/api/routes/organization_routing.py
@@ -1,0 +1,108 @@
+"""The routing policies in force where the caller may see, for a tenant who does not operate the deployment.
+
+``/v1/routing/policies`` is deployment-wide and operator-only, which is right:
+it lists every tenant's stored policies and its ``workspace_id`` parameter is a
+filter the client supplies, so nothing but the operator gate stands between a
+signed-in member and another organization's routing (the escalation
+otari-ai#1880 closed). The roles matrix still wants a member to *view* the
+policies that shape their own requests (otari-ai#1942), so this router is a
+second, narrower reading of the same rows, shaped like ``organization_usage.py``
+(mozilla-ai/otari#837):
+
+* **Scope is derived, never accepted.** It comes from the caller's own
+  ``active_organization_id`` by way of ``resolve_visible_workspace_scope``,
+  which refuses a pointer with no live membership behind it. No request here
+  names an organization or a workspace.
+* **How much of the organization** follows the rule the workspace list already
+  uses: an owner, an admin or a superuser reads every workspace in it, and a
+  member or viewer reads the ones they actively belong to. A member who belongs
+  to no workspace still gets the config-file policies, which are deployment-wide
+  and in force in every workspace they could ever join.
+
+Reads only, one route. Writing a policy stays operator-only on the router above:
+a policy decides which models a name reaches, so a caller who could write one
+could widen their own access.
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from pydantic import ValidationError
+from sqlalchemy import false, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from gateway.api.deps import CurrentIdentity, get_config, get_db, verify_master_key
+from gateway.api.routes.routing import PolicyResponse
+from gateway.core.config import GatewayConfig
+from gateway.log_config import logger
+from gateway.models.entities import RoutingPolicy
+from gateway.models.routing import PolicySpec
+from gateway.models.tenancy import Workspace
+from gateway.services.tenancy import OrganizationService
+from gateway.services.tenancy.authorization import resolve_visible_workspace_scope
+
+router = APIRouter(
+    prefix="/v1/organizations/me/routing-policies",
+    tags=["routing"],
+    # Authentication only, like the rest of the ``/v1/organizations/me`` surface.
+    # What the caller may read is decided per request by the scope below, which
+    # is the pattern the tenant-scoped routers already follow and the reason the
+    # deployment operator gate does not belong here.
+    dependencies=[Depends(verify_master_key)],
+)
+
+
+@router.get("")
+async def list_visible_routing_policies(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    current_identity: CurrentIdentity,
+) -> list[PolicyResponse]:
+    """List the routing policies in force in the workspaces this caller may see.
+
+    Stored policies from the caller's visible workspaces plus the config-file
+    policies, which are deployment-wide and resolve in every workspace. The
+    response is the shape ``GET /v1/routing/policies`` answers, narrowed to the
+    caller's own organization; only an operator can write any of it.
+    """
+    scope = await resolve_visible_workspace_scope(db, user=current_identity, organizations=OrganizationService(db))
+    statement = select(RoutingPolicy)
+    if scope.sees_every_workspace:
+        statement = statement.where(
+            RoutingPolicy.workspace_id.in_(
+                select(col(Workspace.id)).where(col(Workspace.organization_id) == scope.organization.id)
+            )
+        )
+    elif scope.workspace_ids:
+        statement = statement.where(RoutingPolicy.workspace_id.in_(scope.workspace_ids))
+    else:
+        # Belongs to no workspace yet: no stored row is theirs to see, and
+        # deliberately not a 403 (nothing was refused). The config policies
+        # below still apply to every workspace, so they are still listed.
+        statement = statement.where(false())
+    rows = (await db.execute(statement.order_by(RoutingPolicy.name))).scalars().all()
+    policies = []
+    for row in rows:
+        try:
+            parsed = PolicySpec.model_validate(row.spec)
+        except ValidationError:
+            # Listed rather than hidden, matching the operator view: hiding a row
+            # this build cannot parse would make the dashboard disagree with what
+            # actually resolves.
+            logger.warning("Stored routing policy %r does not validate; listing it as-is", row.name)
+            policies.append(PolicyResponse.from_model(row, is_dynamic=False))
+            continue
+        policies.append(PolicyResponse.from_model(row, is_dynamic=parsed.is_dynamic))
+    # Config last, matching the operator list: deployment-wide, in force in every
+    # workspace, listed once and unscoped.
+    for name, spec in config.routing.policies.items():
+        policies.append(
+            PolicyResponse(
+                name=name,
+                spec=spec.model_dump(mode="json", exclude_none=True),
+                source="config",
+                is_dynamic=spec.is_dynamic,
+            )
+        )
+    return sorted(policies, key=lambda policy: (policy.name, str(policy.workspace_id or ""), policy.user_id or ""))

--- a/src/gateway/api/routes/settings.py
+++ b/src/gateway/api/routes/settings.py
@@ -15,7 +15,6 @@ and, where safe, control runtime behavior. Two layers:
 import types
 import typing
 from typing import Annotated, Any, Literal
-from urllib.parse import parse_qsl, quote, urlencode, urlsplit, urlunsplit
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, Field
@@ -47,6 +46,7 @@ from gateway.services.runtime_settings_service import (
     stage_override,
 )
 from gateway.services.secret_box import secret_box_configured
+from gateway.services.url_safety import redact_url_secrets
 from gateway.version import __version__
 
 router = APIRouter(prefix="/v1/settings", tags=["settings"])
@@ -324,46 +324,6 @@ def _scalar_type_name(annotation: Any) -> Literal["bool", "int", "float", "str",
 _REDACTED_URL_FIELDS = frozenset({"database_url", "sandbox_url", "guardrails_url"})
 
 
-def _redact_url_secrets(value: str) -> str:
-    """Mask credentials in a URL while keeping its shape recognizable.
-
-    A ``user:pass@`` password is masked while the username stays visible. A
-    single-component userinfo (``token@host``) is masked whole, since a lone
-    userinfo component is more likely a bearer token than a benign username and
-    the two cannot be told apart. Every query-parameter *value* is masked too
-    (a denylist of "credential-looking" keys cannot be complete, and a config
-    viewer cannot know which value is a secret), while the keys stay visible so
-    the operator can still see what is set. Scheme, host, and path are preserved.
-    """
-    try:
-        parts = urlsplit(value)
-    except ValueError:
-        return value
-
-    netloc = parts.netloc
-    if parts.username is not None or parts.password is not None:
-        host = parts.hostname or ""
-        # An IPv6 literal must keep its brackets or the rebuilt URL is malformed.
-        if ":" in host:
-            host = f"[{host}]"
-        if parts.port is not None:
-            host = f"{host}:{parts.port}"
-        if parts.password is not None:
-            netloc = f"{parts.username or ''}:***@{host}"
-        else:
-            netloc = f"***@{host}"
-
-    query = parts.query
-    if query:
-        pairs = parse_qsl(query, keep_blank_values=True)
-        # quote_via with '*' left safe keeps the mask readable ('***', not '%2A%2A%2A').
-        query = urlencode([(key, "***") for key, _ in pairs], quote_via=quote, safe="*")
-
-    if netloc == parts.netloc and query == parts.query:
-        return value
-    return urlunsplit((parts.scheme, netloc, parts.path, query, parts.fragment))
-
-
 def _field_value(config: GatewayConfig, name: str) -> bool | int | float | str | list[str] | None:
     # ``mode`` is often unset (None) with the real mode derived from the platform
     # token; show the effective mode so the viewer is not misleading.
@@ -371,7 +331,7 @@ def _field_value(config: GatewayConfig, name: str) -> bool | int | float | str |
         return config.effective_mode
     value: bool | int | float | str | list[str] | None = getattr(config, name)
     if name in _REDACTED_URL_FIELDS and isinstance(value, str):
-        return _redact_url_secrets(value)
+        return redact_url_secrets(value)
     return value
 
 

--- a/src/gateway/api/routes/tool_settings.py
+++ b/src/gateway/api/routes/tool_settings.py
@@ -24,7 +24,6 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db, require_deployment_operator
-from gateway.api.routes.settings import _redact_url_secrets
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.services.runtime_settings_service import SettingValue
@@ -38,6 +37,7 @@ from gateway.services.tool_settings_service import (
     stage_override,
     validate_url,
 )
+from gateway.services.url_safety import redact_url_secrets
 
 router = APIRouter(prefix="/v1/tool-settings", tags=["tool-settings"])
 
@@ -102,7 +102,7 @@ class TestServiceResponse(BaseModel):
 def _display_value(config: GatewayConfig, key: str) -> bool | int | str | None:
     value = effective_values(config)[key]
     if key in _URL_FIELDS and isinstance(value, str):
-        return _redact_url_secrets(value)
+        return redact_url_secrets(value)
     # No tool field is float-typed, so the SettingValue here is bool/int/str/None.
     return cast("bool | int | str | None", value)
 

--- a/src/gateway/api/routes/workspace_mcp_servers.py
+++ b/src/gateway/api/routes/workspace_mcp_servers.py
@@ -56,10 +56,11 @@ async def list_workspace_mcp_servers(
 ) -> WorkspaceMcpServersPublic:
     """List the MCP servers configured for a workspace.
 
-    Organization owners/admins or this workspace's owners/admins. Reads are
-    gated like writes because these rows name the endpoints the gateway
-    connects to on the workspace's behalf. Authorization tokens are never
-    included; each server reports only whether it has one.
+    Readable by any member who can see the workspace: these servers act on
+    every request a member sends through it, so what they are is a member's
+    to view (otari-ai#1942). Changing them stays with organization
+    owners/admins or this workspace's owners/admins. Authorization tokens are
+    never included; each server reports only whether it has one.
     """
     return await service.list_servers(user=current_identity, workspace_id=workspace_id, skip=skip, limit=limit)
 

--- a/src/gateway/services/tenancy/workspace_mcp_server_service.py
+++ b/src/gateway/services/tenancy/workspace_mcp_server_service.py
@@ -22,10 +22,12 @@ standalone deployment is not a hosted multi-tenant one:
 
 - Authorization is this repository's own workspace check
   (`services.tenancy.authorization`), so a workspace owner/admin qualifies and
-  not only an organization owner/admin. The platform's stricter *shape* is
-  kept: every operation including the list read is management-gated, because
-  these rows decide which external endpoints the gateway connects to and
-  authenticates against on the workspace's behalf.
+  not only an organization owner/admin. Every *write* is management-gated,
+  because these rows decide which external endpoints the gateway connects to
+  and authenticates against on the workspace's behalf. The list read is not
+  (otari-ai#1942): those endpoints act on every request a member sends through
+  the workspace, so seeing them is a member's to do, and a reader who cannot
+  manage the workspace gets any credential in the URL masked.
 - URL safety is one check in this layer rather than the platform's split
   between a synchronous ingress validator and a service-layer SSRF pass. This
   repository's `validate_mcp_url` is a single async function that already does
@@ -65,7 +67,7 @@ from gateway.services.tenancy.errors import (
     WorkspaceMcpServerUnsafeUrlError,
 )
 from gateway.services.tenancy.organization_service import OrganizationService
-from gateway.services.url_safety import UnsafeURLError, validate_mcp_url
+from gateway.services.url_safety import UnsafeURLError, redact_url_secrets, validate_mcp_url
 
 # What a workspace may configure. A resolved request opens a session to every
 # server it names, so this bounds the fan-out one workspace can ask a gateway
@@ -180,12 +182,22 @@ class WorkspaceMcpServerPublic(BaseModel):
     updated_at: str
 
     @classmethod
-    def from_model(cls, server: WorkspaceMcpServer) -> WorkspaceMcpServerPublic:
+    def from_model(cls, server: WorkspaceMcpServer, *, redact_url: bool = False) -> WorkspaceMcpServerPublic:
+        """Shape one row, optionally masking any credential embedded in its URL.
+
+        ``redact_url`` is what keeps the member read from being a wider
+        disclosure than the management read it was split from: the token column
+        was never returned either way, but nothing rejects a URL that carries a
+        credential in its userinfo (``https://user:secret@host``) or a query
+        parameter, so a caller who may read the row without managing it gets
+        those components masked. A manager sees the URL as stored, because the
+        edit form restates it and would otherwise save the mask back.
+        """
         return cls(
             id=server.id,
             workspace_id=server.workspace_id,
             name=server.name,
-            url=server.url,
+            url=redact_url_secrets(server.url) if redact_url else server.url,
             purpose_hint=server.purpose_hint,
             allowed_tools=server.allowed_tools,
             enabled=server.enabled,
@@ -332,12 +344,17 @@ class WorkspaceMcpServerService:
         Reachable by any member who can see the workspace, like the workspace
         surfaces beside it (`workspace_budget_default_service` is the pattern);
         see `_require_management` for why the gate here is visibility alone.
-        The rows never carry a token either way.
+        The rows never carry a token either way, and a caller who may read the
+        workspace without managing it also gets any credential embedded in the
+        URL itself masked (see `WorkspaceMcpServerPublic.from_model`).
         """
         workspace = await authorization.resolve_visible_workspace(
             self.db, user=user, workspace_id=workspace_id, organizations=self.organizations
         )
         workspace_id = workspace.id
+        manages = await authorization.has_workspace_management_access(
+            self.db, user=user, workspace=workspace, organizations=self.organizations
+        )
         limit = min(limit, _MAX_LIST_LIMIT)
 
         count = (
@@ -361,7 +378,7 @@ class WorkspaceMcpServerService:
             .all()
         )
         return WorkspaceMcpServersPublic(
-            data=[WorkspaceMcpServerPublic.from_model(server) for server in servers],
+            data=[WorkspaceMcpServerPublic.from_model(server, redact_url=not manages) for server in servers],
             count=count,
         )
 

--- a/src/gateway/services/tenancy/workspace_mcp_server_service.py
+++ b/src/gateway/services/tenancy/workspace_mcp_server_service.py
@@ -288,7 +288,7 @@ async def resolve_workspace_mcp_servers(
 
 
 class WorkspaceMcpServerService:
-    """CRUD for a workspace's MCP servers. Every operation is management-gated."""
+    """CRUD for a workspace's MCP servers. Writes are management-gated; the list is not."""
 
     def __init__(self, db: AsyncSession):
         self.db = db
@@ -297,12 +297,13 @@ class WorkspaceMcpServerService:
     async def _require_management(self, user: User, workspace_id: uuid.UUID) -> uuid.UUID:
         """Resolve the workspace and confirm the caller may manage it.
 
-        Reads are gated too, unlike the workspace surfaces beside this one
-        (`workspace_budget_default_service` opens its list to any member).
-        These rows name the external endpoints this gateway will connect to,
-        and which of them carry a credential, which is the platform's own
-        reason for admin-gating its reads; the URL of a workspace's internal
-        tool server is not something every member needs.
+        Writes only. The list used to sit behind this gate too, on the argument
+        that a server's URL is not something every member needs; the roles
+        matrix settled it the other way (otari-ai#1942): a member may *view*
+        what shapes their own requests, and these servers already act on every
+        request the member sends through the workspace. Tokens were never
+        exposed either way (`WorkspaceMcpServerPublic` carries `has_token`
+        alone), so the read gate is member visibility, in `list_servers`.
         """
         workspace = await authorization.resolve_visible_workspace(
             self.db, user=user, workspace_id=workspace_id, organizations=self.organizations
@@ -326,8 +327,17 @@ class WorkspaceMcpServerService:
         skip: int = 0,
         limit: int = 100,
     ) -> WorkspaceMcpServersPublic:
-        """List a page of the workspace's servers, plus the total."""
-        await self._require_management(user, workspace_id)
+        """List a page of the workspace's servers, plus the total.
+
+        Reachable by any member who can see the workspace, like the workspace
+        surfaces beside it (`workspace_budget_default_service` is the pattern);
+        see `_require_management` for why the gate here is visibility alone.
+        The rows never carry a token either way.
+        """
+        workspace = await authorization.resolve_visible_workspace(
+            self.db, user=user, workspace_id=workspace_id, organizations=self.organizations
+        )
+        workspace_id = workspace.id
         limit = min(limit, _MAX_LIST_LIMIT)
 
         count = (

--- a/src/gateway/services/url_safety.py
+++ b/src/gateway/services/url_safety.py
@@ -62,16 +62,18 @@ def redact_url_secrets(value: str) -> str:
 
     netloc = parts.netloc
     if parts.username is not None or parts.password is not None:
-        host = parts.hostname or ""
-        # An IPv6 literal must keep its brackets or the rebuilt URL is malformed.
-        if ":" in host:
-            host = f"[{host}]"
-        if parts.port is not None:
-            host = f"{host}:{parts.port}"
+        # Everything after the last "@" is host[:port], taken as written rather
+        # than rebuilt from `hostname` and `port`. Deliberately not
+        # `SplitResult.port`, which parses lazily and raises ValueError on a
+        # malformed port ("host:bad"): nothing rejects such a URL on the way in
+        # (`validate_mcp_url` reads `hostname` and never the port), so rebuilding
+        # would turn a redaction into a 500 on the read. Taking the text also
+        # keeps an IPv6 literal's brackets without a special case.
+        host_and_port = parts.netloc.rpartition("@")[2]
         if parts.password is not None:
-            netloc = f"{parts.username or ''}:***@{host}"
+            netloc = f"{parts.username or ''}:***@{host_and_port}"
         else:
-            netloc = f"***@{host}"
+            netloc = f"***@{host_and_port}"
 
     query = parts.query
     if query:

--- a/src/gateway/services/url_safety.py
+++ b/src/gateway/services/url_safety.py
@@ -33,10 +33,55 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import socket
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlsplit, urlunsplit
 
 from gateway.core.config import parse_bool_env
 from gateway.core.env import otari_env
+
+
+def redact_url_secrets(value: str) -> str:
+    """Mask credentials in a URL while keeping its shape recognizable.
+
+    A ``user:pass@`` password is masked while the username stays visible. A
+    single-component userinfo (``token@host``) is masked whole, since a lone
+    userinfo component is more likely a bearer token than a benign username and
+    the two cannot be told apart. Every query-parameter *value* is masked too
+    (a denylist of "credential-looking" keys cannot be complete, and a viewer
+    cannot know which value is a secret), while the keys stay visible so the
+    reader can still see what is set. Scheme, host, and path are preserved.
+
+    Lives here rather than beside the settings route that first needed it
+    because the checks in this module are the other half of the same concern,
+    and a service may not import the API layer: the workspace MCP list redacts
+    a stored endpoint for a caller who may read it but not manage it.
+    """
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        return value
+
+    netloc = parts.netloc
+    if parts.username is not None or parts.password is not None:
+        host = parts.hostname or ""
+        # An IPv6 literal must keep its brackets or the rebuilt URL is malformed.
+        if ":" in host:
+            host = f"[{host}]"
+        if parts.port is not None:
+            host = f"{host}:{parts.port}"
+        if parts.password is not None:
+            netloc = f"{parts.username or ''}:***@{host}"
+        else:
+            netloc = f"***@{host}"
+
+    query = parts.query
+    if query:
+        pairs = parse_qsl(query, keep_blank_values=True)
+        # quote_via with '*' left safe keeps the mask readable ('***', not '%2A%2A%2A').
+        query = urlencode([(key, "***") for key, _ in pairs], quote_via=quote, safe="*")
+
+    if netloc == parts.netloc and query == parts.query:
+        return value
+    return urlunsplit((parts.scheme, netloc, parts.path, query, parts.fragment))
 
 
 class UnsafeURLError(ValueError):

--- a/tests/integration/test_organization_routing_policies_scope.py
+++ b/tests/integration/test_organization_routing_policies_scope.py
@@ -1,0 +1,252 @@
+"""The organization-scoped routing-policy read sees the caller's own workspaces and no more.
+
+``/v1/routing/policies`` is deployment-wide and operator-only, and stays that
+way: its ``workspace_id`` parameter is a filter the client supplies, so nothing
+but the operator gate stands between a signed-in member and another
+organization's routing. ``/v1/organizations/me/routing-policies`` is the
+tenant's View half of it (otari-ai#1942), shaped like the usage scope
+(otari#837), and this suite is that file's shape over the ``routing_policies``
+table: two organizations with policies in both, and every assertion names the
+rows that must be absent rather than counting the ones that came back.
+
+The last test is the control: the deployment-wide route must still refuse an
+organization owner. A change that made these pass by loosening that gate would
+have reopened otari-ai#1880.
+"""
+
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from gateway.models.entities import DashboardSession, RoutingPolicy
+from gateway.models.tenancy import Organization, OrganizationMember, User, Workspace, WorkspaceMember
+from gateway.services.dashboard_session_service import SESSION_COOKIE_NAME, hash_session_token
+
+_SCOPED_PATH = "/v1/organizations/me/routing-policies"
+
+
+@dataclass
+class _World:
+    """Two organizations, their workspaces, and one session cookie per identity."""
+
+    alpha: uuid.UUID
+    beta: uuid.UUID
+    workspaces: dict[str, uuid.UUID] = field(default_factory=dict)
+    sessions: dict[str, str] = field(default_factory=dict)
+
+
+# Policy names double as row identity: every assertion below is "these names and
+# no others", which is what makes a leak visible rather than merely miscounted.
+_ALPHA_ONE_POLICIES = ("alpha-one-fast", "alpha-one-cheap")
+_ALPHA_TWO_POLICIES = ("alpha-two-fast",)
+_BETA_POLICIES = ("beta-one-fast",)
+
+
+def _identity(
+    session: Session,
+    *,
+    email: str,
+    organization_id: uuid.UUID,
+    role: str = "member",
+    is_superuser: bool = False,
+    workspace_ids: tuple[uuid.UUID, ...] = (),
+    membership: bool = True,
+) -> str:
+    """Create an identity with a live dashboard session, and return its cookie."""
+    user = User(
+        email=email,
+        full_name=email.split("@")[0].title(),
+        active_organization_id=organization_id,
+        is_superuser=is_superuser,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+
+    if membership:
+        session.add(
+            OrganizationMember(
+                organization_id=organization_id,
+                user_id=user.id,
+                role=role,
+                status="active",
+            )
+        )
+    for workspace_id in workspace_ids:
+        session.add(
+            WorkspaceMember(
+                workspace_id=workspace_id,
+                user_id=user.id,
+                role="member",
+                status="active",
+            )
+        )
+
+    token = f"otari-sess-{email}"
+    session.add(
+        DashboardSession(
+            token_hash=hash_session_token(token),
+            user_id=user.id,
+            created_at=datetime.now(UTC),
+            expires_at=datetime.now(UTC) + timedelta(hours=12),
+        )
+    )
+    session.commit()
+    return token
+
+
+def _policy_rows(session: Session, workspace_id: uuid.UUID, names: tuple[str, ...]) -> None:
+    for name in names:
+        session.add(
+            RoutingPolicy(
+                id=str(uuid.uuid4()),
+                name=name,
+                spec={"select": [{"default": "openai:gpt-4o-mini"}]},
+                workspace_id=workspace_id,
+            )
+        )
+    session.commit()
+
+
+@pytest.fixture
+def world(client: TestClient, master_key_header: dict[str, str], db_session_factory: Callable[[], Session]) -> _World:
+    """Two tenants with stored policies in both, and the identities that read them."""
+    # One master-key call provisions the tenancy root, so the organizations built
+    # below sit beside a real default rather than replacing it.
+    assert client.get("/v1/organizations/me", headers=master_key_header).status_code == status.HTTP_200_OK
+
+    session = db_session_factory()
+    try:
+        alpha = Organization(name="Alpha", slug="alpha")
+        beta = Organization(name="Beta", slug="beta")
+        session.add_all([alpha, beta])
+        session.commit()
+        session.refresh(alpha)
+        session.refresh(beta)
+
+        alpha_one = Workspace(name="Alpha one", organization_id=alpha.id)
+        alpha_two = Workspace(name="Alpha two", organization_id=alpha.id)
+        beta_one = Workspace(name="Beta one", organization_id=beta.id)
+        session.add_all([alpha_one, alpha_two, beta_one])
+        session.commit()
+        for workspace in (alpha_one, alpha_two, beta_one):
+            session.refresh(workspace)
+
+        _policy_rows(session, alpha_one.id, _ALPHA_ONE_POLICIES)
+        _policy_rows(session, alpha_two.id, _ALPHA_TWO_POLICIES)
+        _policy_rows(session, beta_one.id, _BETA_POLICIES)
+
+        built = _World(alpha=alpha.id, beta=beta.id)
+        built.workspaces = {"alpha_one": alpha_one.id, "alpha_two": alpha_two.id, "beta_one": beta_one.id}
+        built.sessions = {
+            "alpha_owner": _identity(session, email="owner@alpha.test", organization_id=alpha.id, role="owner"),
+            "alpha_member": _identity(
+                session,
+                email="member@alpha.test",
+                organization_id=alpha.id,
+                workspace_ids=(alpha_one.id,),
+            ),
+            "alpha_newcomer": _identity(session, email="new@alpha.test", organization_id=alpha.id),
+            "beta_owner": _identity(session, email="owner@beta.test", organization_id=beta.id, role="owner"),
+            "impostor": _identity(
+                session,
+                email="impostor@nowhere.test",
+                organization_id=alpha.id,
+                membership=False,
+            ),
+            "superuser": _identity(
+                session,
+                email="root@beta.test",
+                organization_id=beta.id,
+                role="owner",
+                is_superuser=True,
+            ),
+        }
+        return built
+    finally:
+        session.close()
+
+
+def _as(client: TestClient, world: _World, who: str) -> tuple[int, object]:
+    client.cookies.set(SESSION_COOKIE_NAME, world.sessions[who])
+    try:
+        response = client.get(_SCOPED_PATH)
+        body = response.json() if response.headers.get("content-type", "").startswith("application/json") else None
+        return response.status_code, body
+    finally:
+        client.cookies.clear()
+
+
+def _stored_names(client: TestClient, world: _World, who: str) -> set[str]:
+    """The stored policy names this caller is shown.
+
+    Filtered to ``source == "stored"`` so a config-file policy the test
+    deployment happens to define cannot pad or break an assertion: config
+    policies are deployment-wide by design and outside what this suite pins.
+    """
+    code, body = _as(client, world, who)
+    assert code == status.HTTP_200_OK, body
+    assert isinstance(body, list)
+    return {row["name"] for row in body if row["source"] == "stored"}
+
+
+def test_an_owner_reads_every_workspace_in_their_own_organization(client: TestClient, world: _World) -> None:
+    assert _stored_names(client, world, "alpha_owner") == set(_ALPHA_ONE_POLICIES) | set(_ALPHA_TWO_POLICIES)
+
+
+def test_an_owner_reads_no_other_organizations_rows(client: TestClient, world: _World) -> None:
+    """Stated on its own, because it is the claim the whole route rests on."""
+    assert _stored_names(client, world, "alpha_owner").isdisjoint(_BETA_POLICIES)
+    assert _stored_names(client, world, "beta_owner") == set(_BETA_POLICIES)
+
+
+def test_a_member_reads_only_the_workspaces_they_belong_to(client: TestClient, world: _World) -> None:
+    """``alpha_member`` belongs to Alpha one and not Alpha two.
+
+    Both are their organization's, so an implementation that scoped to the
+    organization alone would pass every other test in this file and fail here.
+    """
+    listed = _stored_names(client, world, "alpha_member")
+    assert listed == set(_ALPHA_ONE_POLICIES)
+    assert listed.isdisjoint(_ALPHA_TWO_POLICIES)
+    assert listed.isdisjoint(_BETA_POLICIES)
+
+
+def test_a_member_of_no_workspace_reads_no_stored_rows_rather_than_a_refusal(
+    client: TestClient, world: _World
+) -> None:
+    """Nothing was refused; no stored policy is theirs to see yet."""
+    code, body = _as(client, world, "alpha_newcomer")
+    assert code == status.HTTP_200_OK, body
+    assert _stored_names(client, world, "alpha_newcomer") == set()
+
+
+def test_a_superuser_reads_their_active_organization_and_not_every_tenant(client: TestClient, world: _World) -> None:
+    """This route is scoped even for an operator; ``/v1/routing/policies`` is where they read across tenants."""
+    listed = _stored_names(client, world, "superuser")
+    assert listed == set(_BETA_POLICIES)
+    assert listed.isdisjoint(_ALPHA_ONE_POLICIES)
+
+
+def test_an_active_organization_pointer_with_no_membership_behind_it_reads_nothing(
+    client: TestClient, world: _World
+) -> None:
+    """The pointer is not the authority; the membership is."""
+    code, body = _as(client, world, "impostor")
+    assert code in {status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND}, body
+
+
+def test_the_deployment_wide_route_still_refuses_a_tenant(client: TestClient, world: _World) -> None:
+    """The control: this route exists so that gate does not have to loosen."""
+    client.cookies.set(SESSION_COOKIE_NAME, world.sessions["alpha_owner"])
+    try:
+        refused = client.get("/v1/routing/policies")
+        assert refused.status_code == status.HTTP_403_FORBIDDEN, refused.text
+    finally:
+        client.cookies.clear()

--- a/tests/integration/test_workspace_mcp_servers.py
+++ b/tests/integration/test_workspace_mcp_servers.py
@@ -425,19 +425,46 @@ async def test_a_metadata_only_update_does_not_revalidate_the_url(async_db: Asyn
 # --------------------------------------------------------------------------- #
 
 
-async def test_a_plain_member_may_neither_read_nor_write(async_db: AsyncSession) -> None:
-    """Reads are gated too: these rows name the endpoints the gateway connects to."""
+async def test_a_plain_member_may_read_but_not_write(async_db: AsyncSession) -> None:
+    """The list is a member's to view (otari-ai#1942); changing a row is not."""
     organization = await _organization(async_db)
     owner = await _member(async_db, organization, role="owner", full_name="Owner")
     workspace = await _workspace(async_db, organization, owner=owner)
     member = await _member(async_db, organization, role="member", full_name="Member")
     await WorkspaceMemberRepository(async_db).create(workspace_id=workspace.id, user_id=member.id, role="member")
     service = WorkspaceMcpServerService(async_db)
+    created = await service.create_server(
+        user=owner, workspace_id=workspace.id, request=_create(authorization_token="secret")
+    )
 
+    listed = await service.list_servers(user=member, workspace_id=workspace.id)
+    assert [server.name for server in listed.data] == ["github"]
+    # Readable does not mean the credential is: the row reports only that one exists.
+    assert listed.data[0].has_token is True
+    assert not hasattr(listed.data[0], "authorization_token")
     with pytest.raises(NotAuthorizedError):
-        await service.list_servers(user=member, workspace_id=workspace.id)
+        await service.create_server(user=member, workspace_id=workspace.id, request=_create(name="other"))
     with pytest.raises(NotAuthorizedError):
-        await service.create_server(user=member, workspace_id=workspace.id, request=_create())
+        await service.update_server(
+            user=member,
+            workspace_id=workspace.id,
+            server_id=created.id,
+            request=WorkspaceMcpServerUpdate(enabled=False),
+        )
+    with pytest.raises(NotAuthorizedError):
+        await service.delete_server(user=member, workspace_id=workspace.id, server_id=created.id)
+
+
+async def test_an_organization_member_outside_the_workspace_cannot_read(async_db: AsyncSession) -> None:
+    """Member visibility is workspace membership, not organization membership."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    outsider = await _member(async_db, organization, role="member", full_name="Outsider")
+    service = WorkspaceMcpServerService(async_db)
+
+    with pytest.raises(WorkspaceNotFoundError):
+        await service.list_servers(user=outsider, workspace_id=workspace.id)
 
 
 async def test_a_workspace_admin_may_manage_without_organization_admin(async_db: AsyncSession) -> None:

--- a/tests/integration/test_workspace_mcp_servers.py
+++ b/tests/integration/test_workspace_mcp_servers.py
@@ -455,6 +455,36 @@ async def test_a_plain_member_may_read_but_not_write(async_db: AsyncSession) -> 
         await service.delete_server(user=member, workspace_id=workspace.id, server_id=created.id)
 
 
+async def test_a_credential_in_the_url_is_masked_for_a_reader_who_cannot_manage(async_db: AsyncSession) -> None:
+    """The member read must not be a wider disclosure than the management one.
+
+    Nothing rejects a URL whose userinfo or query string carries a credential,
+    so opening the list to members would otherwise hand them one. A manager
+    still reads the URL as stored, because the edit form restates it.
+    """
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, owner=owner)
+    member = await _member(async_db, organization, role="member", full_name="Member")
+    await WorkspaceMemberRepository(async_db).create(workspace_id=workspace.id, user_id=member.id, role="member")
+    service = WorkspaceMcpServerService(async_db)
+    await service.create_server(
+        user=owner,
+        workspace_id=workspace.id,
+        request=_create(url="https://svc:hunter2@93.184.216.34/mcp?api_key=secret"),
+    )
+
+    for_member = await service.list_servers(user=member, workspace_id=workspace.id)
+    assert "hunter2" not in for_member.data[0].url
+    assert "secret" not in for_member.data[0].url
+    # Masked, not dropped: the host and path still identify the endpoint.
+    assert "93.184.216.34" in for_member.data[0].url
+    assert "api_key" in for_member.data[0].url
+
+    for_owner = await service.list_servers(user=owner, workspace_id=workspace.id)
+    assert for_owner.data[0].url == "https://svc:hunter2@93.184.216.34/mcp?api_key=secret"
+
+
 async def test_an_organization_member_outside_the_workspace_cannot_read(async_db: AsyncSession) -> None:
     """Member visibility is workspace membership, not organization membership."""
     organization = await _organization(async_db)

--- a/tests/unit/test_url_safety.py
+++ b/tests/unit/test_url_safety.py
@@ -4,6 +4,7 @@ import pytest
 
 from gateway.services.url_safety import (
     UnsafeURLError,
+    redact_url_secrets,
     validate_mcp_url,
     validate_outbound_fetch_url,
     validate_provider_api_base,
@@ -201,3 +202,35 @@ async def test_provider_api_base_off_enables_gate(monkeypatch: pytest.MonkeyPatc
 async def test_provider_api_base_on_keeps_allow_all(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OTARI_PROVIDER_ALLOW_PRIVATE_HOSTS", "on")
     await validate_provider_api_base("https://10.0.0.5/v1")
+
+
+# ---------------------------------------------------------------------------
+# redact_url_secrets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # A password is masked and the username kept, so a reader can still see
+        # which account the endpoint authenticates as.
+        ("https://user:pass@example.com/mcp", "https://user:***@example.com/mcp"),
+        # A lone userinfo component is more likely a bearer token than a name.
+        ("https://token@example.com/mcp", "https://***@example.com/mcp"),
+        # Every query value goes, keys stay: a denylist of credential-looking
+        # keys cannot be complete.
+        ("https://example.com/mcp?api_key=secret", "https://example.com/mcp?api_key=***"),
+        # An IPv6 literal keeps its brackets, or the rebuilt URL is malformed.
+        ("https://user:pass@[::1]:8080/mcp", "https://user:***@[::1]:8080/mcp"),
+        # A port that is not a number reaches this function, because nothing
+        # rejects one on the way in: `validate_mcp_url` reads `hostname` and
+        # never the port. Rebuilding through `SplitResult.port` raised
+        # ValueError here, which turned a member's read of a stored MCP server
+        # into a 500 rather than a masked URL.
+        ("https://svc:token@example.com:bad/mcp", "https://svc:***@example.com:bad/mcp"),
+        # Nothing to mask is returned untouched, not rebuilt.
+        ("https://example.com/mcp", "https://example.com/mcp"),
+    ],
+)
+def test_redact_url_secrets_masks_credentials_without_raising(raw: str, expected: str) -> None:
+    assert redact_url_secrets(raw) == expected

--- a/web/src/app/AppShell.test.tsx
+++ b/web/src/app/AppShell.test.tsx
@@ -494,7 +494,7 @@ describe("AppShell surface gating", () => {
   it("renders every destination the deployment serves", async () => {
     mockMatchMedia(false)
     await renderShell()
-    // Awaited for the reason the organization rail below is: four of these rows
+    // Awaited for the reason the organization rail below is: two of these rows
     // declare `operatorOnly` and arrive with the membership context, so the
     // snapshot is a race without it.
     await within(
@@ -589,14 +589,12 @@ describe("AppShell surface gating", () => {
   it("drops a section header once its whole group is gated away", async () => {
     mockMatchMedia(false)
     await renderShell(bootstrap({ surfaces: ["models"] }))
-    // The one row this deployment keeps is `operatorOnly`, so its heading is
-    // absent with it until the membership context lands.
     await screen.findByRole("link", { name: "Models" })
 
     // "Access" labels keys, providers and the workspace roster; with none of
     // them served, an empty heading over nothing is worse than no heading.
     expect(screen.queryByText("Access")).toBeNull()
-    expect(screen.getByText("Gateway")).toBeInTheDocument()
+    expect(screen.getByText("Build")).toBeInTheDocument()
     // "Observe" goes with them. It labels the request log and the usage
     // rollups, both gated on the usage surface, and the index that used to keep
     // the heading alive now sits in its own group above it. The front page is
@@ -624,14 +622,12 @@ describe("AppShell entitlement gating", () => {
     // would silently drop a page from the sidebar of every gateway.
     await renderShell(bootstrap(), { entitlements: { capabilities: [] } })
 
-    // Routing nests destinations, so it is the group's expander. Awaited
-    // because it declares `operatorOnly` as well, which the row below and the
-    // heading over both do not: the first query here has to be the waiting one.
+    // Routing nests destinations, so it is the group's expander.
     expect(
       await screen.findByRole("button", { name: "Routing" }),
     ).toBeInTheDocument()
     expect(screen.getByRole("link", { name: "Models" })).toBeInTheDocument()
-    expect(screen.getByText("Gateway")).toBeInTheDocument()
+    expect(screen.getByText("Build")).toBeInTheDocument()
   })
 
   it("answers a gated-off destination with a panel, not the page", async () => {

--- a/web/src/app/nav/registry.test.ts
+++ b/web/src/app/nav/registry.test.ts
@@ -89,13 +89,14 @@ describe("nav registry", () => {
     //
     // Activity and Usage left the list in otari#837, which is the other way a
     // row leaves it: not by loosening a gate but by the page behind it gaining a
-    // tenant-scoped read, so there is no longer a caller it refuses. Removing a
-    // row from here is as much a design decision as adding one.
+    // tenant-scoped read, so there is no longer a caller it refuses. Models and
+    // Routing left it the same way (otari-ai#1942): the catalog reads already
+    // served any session, and Routing gained
+    // `/v1/organizations/me/routing-policies`. Removing a row from here is as
+    // much a design decision as adding one.
     expect(
       NAV_ITEMS.filter((item) => item.operatorOnly).map((item) => item.to),
     ).toEqual([
-      "/models",
-      "/routing",
       "/keys",
       "/providers",
       "/budgets",
@@ -311,8 +312,10 @@ describe("nav registry", () => {
     // another repo, so every base heading and disclosure label renders as
     // declared.
     expect(OVERLAY_NAV_LABEL_OVERRIDES).toEqual([])
+    // The label is "Build" (the roles matrix's name for the section,
+    // otari-ai#1942) while the id stays "gateway", the key overlays address.
     const gateway = NAV_SECTIONS.find((section) => section.id === "gateway")
-    expect(gateway?.label).toBe("Gateway")
+    expect(gateway?.label).toBe("Build")
     expect(gateway?.items.map((item) => item.label)).toContain("Routing")
     const general = ORG_NAV_SECTIONS.find(
       (section) => section.id === "org-general",

--- a/web/src/app/nav/registry.ts
+++ b/web/src/app/nav/registry.ts
@@ -39,10 +39,10 @@ import type {
  * it is the rail's destination rather than a member of a category: it is where
  * the sidebar puts you back, not one of the places you go from it. The three
  * below it are the design's: "Observe" is where you look (the request log and
- * the usage rollups over it), "Gateway" is what the gateway serves (models, the
- * policies that route over them, and the tools it can call), and "Access" is who
- * may call it (keys, the upstream credentials those keys spend, and the
- * workspace's roster).
+ * the usage rollups over it), "Build" is what the gateway serves (models, the
+ * policies that route over them, and the tools it can call; the roles matrix's
+ * name for the section, otari-ai#1942), and "Access" is who may call it (keys,
+ * the upstream credentials those keys spend, and the workspace's roster).
  *
  * Each entry declares its own gating, and the two axes are independent:
  * `surface` (does this deployment host it) and `capability` (is it entitled).
@@ -91,15 +91,21 @@ const BASE_NAV_SECTIONS = [
     ],
   },
   {
+    // The id stays "gateway" while the label reads "Build": overlay
+    // contributions and label overrides key on the id, so renaming it would
+    // silently drop whatever a superset build files under this section.
     id: "gateway",
-    label: "Gateway",
+    label: "Build",
     items: [
+      // No `operatorOnly` on Models or Routing any more, per the rule the axis
+      // carries: a row leaves the list by its page ceasing to refuse anyone
+      // (otari-ai#1942). Models reads the catalog any session may read, and
+      // Routing reads the tenant-scoped policy list for a non-operator.
       {
         to: "/models",
         label: "Models",
         surface: "models",
         icon: FiLayers,
-        operatorOnly: "refused",
       },
       // Deliberately not tagged `capability: "routing"`, though otari.ai's
       // registry tags its own Routing item that way. ARCHITECTURE.md's
@@ -114,7 +120,6 @@ const BASE_NAV_SECTIONS = [
         label: "Routing",
         surface: "routing",
         icon: FiRepeat,
-        operatorOnly: "refused",
         // Policies and Guardrails as the navigation prototype groups them. The
         // prototype's third entry, Aliases, is deliberately absent: this
         // dashboard lists an alias as the one-target policy it is, in the same

--- a/web/src/app/nav/types.ts
+++ b/web/src/app/nav/types.ts
@@ -174,7 +174,7 @@ export interface NavItemContribution {
  * with its two fields pointing at this registry's label sites. Both differ in
  * name for the reason the shapes differ: a section's heading is `label` here and
  * `header` there, and nesting is `children` here where there it is a single
- * `NavDisclosure`, so a section here can hold several disclosures (Gateway holds
+ * `NavDisclosure`, so a section here can hold several disclosures (Build holds
  * Routing and Tools) and a rename has to say which.
  */
 export interface NavLabelOverride {

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -1967,6 +1967,31 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/organizations/me/routing-policies": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Visible Routing Policies
+         * @description List the routing policies in force in the workspaces this caller may see.
+         *
+         *     Stored policies from the caller's visible workspaces plus the config-file
+         *     policies, which are deployment-wide and resolve in every workspace. The
+         *     response is the shape ``GET /v1/routing/policies`` answers, narrowed to the
+         *     caller's own organization; only an operator can write any of it.
+         */
+        get: operations["list_visible_routing_policies_v1_organizations_me_routing_policies_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/organizations/me/switch": {
         parameters: {
             query?: never;
@@ -3607,10 +3632,11 @@ export interface paths {
          * List Workspace Mcp Servers
          * @description List the MCP servers configured for a workspace.
          *
-         *     Organization owners/admins or this workspace's owners/admins. Reads are
-         *     gated like writes because these rows name the endpoints the gateway
-         *     connects to on the workspace's behalf. Authorization tokens are never
-         *     included; each server reports only whether it has one.
+         *     Readable by any member who can see the workspace: these servers act on
+         *     every request a member sends through it, so what they are is a member's
+         *     to view (otari-ai#1942). Changing them stays with organization
+         *     owners/admins or this workspace's owners/admins. Authorization tokens are
+         *     never included; each server reports only whether it has one.
          */
         get: operations["list_workspace_mcp_servers_v1_workspaces__workspace_id__mcp_servers_get"];
         put?: never;
@@ -12594,6 +12620,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_visible_routing_policies_v1_organizations_me_routing_policies_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyResponse"][];
                 };
             };
         };

--- a/web/src/features/models/ModelsPage.test.tsx
+++ b/web/src/features/models/ModelsPage.test.tsx
@@ -1302,6 +1302,24 @@ describe("ModelsPage", () => {
       within(aside).queryByRole("button", { name: "Reset" }),
     ).not.toBeInTheDocument()
 
+    // Discovery was never read, so the panel says nothing about it rather than
+    // reporting every model as missing from a list it never fetched.
+    expect(within(aside).queryByText("not discovered")).toBeNull()
+
+    // The three filters that read an operator-only endpoint are absent: with
+    // discovery and metadata withheld, every value but "all" would empty the
+    // table.
+    const filterTrigger = (label: string) =>
+      screen.queryByRole("button", {
+        name: (name) => name === label || name.endsWith(` ${label}`),
+      })
+    expect(filterTrigger("Filter by source")).toBeNull()
+    expect(filterTrigger("Filter by capability")).toBeNull()
+    expect(filterTrigger("Filter by release date")).toBeNull()
+    // The ones that read only the catalog stay.
+    expect(filterTrigger("Filter by provider")).not.toBeNull()
+    expect(filterTrigger("Filter by pricing")).not.toBeNull()
+
     const urls = fetchMock.mock.calls.map(([input]) => String(input))
     expect(urls.some((url) => url.includes("/v1/settings"))).toBe(false)
     expect(urls.some((url) => url.includes("/v1/models/discoverable"))).toBe(

--- a/web/src/features/models/ModelsPage.test.tsx
+++ b/web/src/features/models/ModelsPage.test.tsx
@@ -1270,6 +1270,50 @@ describe("ModelsPage", () => {
     ).toBeInTheDocument()
   })
 
+  it("keeps cached operator data out of a member's page", async () => {
+    // A disabled query still serves whatever sits under its key, so a caller
+    // demoted mid-session would otherwise keep the discovered models and the
+    // metering tooltip they fetched as an operator.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    // A model only discovery knows about, so the assertion is about the
+    // operator-only read rather than about the catalog every session reads.
+    client.setQueryData(["discoverable"], {
+      providers: [
+        {
+          provider: "openai",
+          ok: true,
+          error: null,
+          discovery_unsupported: false,
+          models: [{ id: "gpt-secret", key: "openai:gpt-secret" }],
+        },
+      ],
+    } satisfies DiscoverableModelsResponse)
+    client.setQueryData(["settings"], SETTINGS)
+    mockApi({
+      context: organizationContext({
+        deployment_operator: false,
+        role: "member",
+      }),
+    })
+    render(
+      <QueryClientProvider client={client}>
+        <ModelsPage />
+      </QueryClientProvider>,
+      { wrapper: withRouter({ url: "/" }) },
+    )
+    await screen.findByText("openai:gpt-4o")
+
+    expect(
+      screen.queryByRole("button", {
+        name: /How unpriced models are metered/,
+      }),
+    ).not.toBeInTheDocument()
+    // The discovery-only rows are the operator's read; the catalog stands.
+    expect(screen.queryByText("openai:gpt-secret")).not.toBeInTheDocument()
+  })
+
   it("shows a non-operator the catalog read-only and never fires the operator reads", async () => {
     // The member half of otari-ai#1942: the catalog and the price list serve
     // any session, and everything that writes or is operator-only is absent

--- a/web/src/features/models/ModelsPage.test.tsx
+++ b/web/src/features/models/ModelsPage.test.tsx
@@ -11,11 +11,12 @@ import type {
   ModelMetadata,
   ModelMetadataResponse,
   ModelObject,
+  OrganizationContext,
   PricingResponse,
 } from "@/client"
 import { ModelsPage } from "@/features/models/ModelsPage"
 import * as apiClient from "@/shared/api/client"
-import { pricingResponse } from "@/tests/fixtures"
+import { organizationContext, pricingResponse } from "@/tests/fixtures"
 import { withRouter } from "@/tests/router"
 import { pickOption, selectTrigger } from "@/tests/select"
 
@@ -208,6 +209,10 @@ function mockApi(
     discoverable?: DiscoverableModelsResponse
     metadata?: ModelMetadataResponse
     settings?: GatewaySettings
+    // The caller's membership context, an operator's by default: the page
+    // gates its deployment-wide reads and every write affordance on
+    // `deployment_operator`, so most tests here are about the operator view.
+    context?: OrganizationContext
   } = {},
 ) {
   return vi
@@ -220,6 +225,9 @@ function mockApi(
       }
       if (method === "DELETE") {
         return null as never
+      }
+      if (url.endsWith("/v1/organizations/me")) {
+        return (opts.context ?? organizationContext()) as never
       }
       if (url.includes("/v1/settings")) {
         return (opts.settings ?? SETTINGS) as never
@@ -347,9 +355,11 @@ describe("ModelsPage", () => {
     await screen.findByText("openai:gpt-4o")
 
     // The explanation lives in a tooltip anchored to the pricing header, reached
-    // via a labeled info trigger, rather than a persistent banner.
+    // via a labeled info trigger, rather than a persistent banner. Awaited: the
+    // trigger waits on the settings read, which itself waits on the membership
+    // context that says an operator is asking.
     expect(
-      within(table()).getByRole("button", {
+      await within(table()).findByRole("button", {
         name: /How unpriced models are metered/,
       }),
     ).toBeInTheDocument()
@@ -1258,5 +1268,45 @@ describe("ModelsPage", () => {
         "not priced",
       ),
     ).toBeInTheDocument()
+  })
+
+  it("shows a non-operator the catalog read-only and never fires the operator reads", async () => {
+    // The member half of otari-ai#1942: the catalog and the price list serve
+    // any session, and everything that writes or is operator-only is absent
+    // rather than refused.
+    const fetchMock = mockApi({
+      context: organizationContext({
+        deployment_operator: false,
+        role: "member",
+      }),
+    })
+    const user = userEvent.setup()
+    renderWithClient(<ModelsPage />)
+    await screen.findByText("openai:gpt-4o")
+
+    // The price numbers render as text rather than as edit controls.
+    expect(
+      screen.queryByRole("button", { name: /Edit input price for/ }),
+    ).not.toBeInTheDocument()
+
+    // The detail panel still reports the rates, without the write affordances.
+    await user.click(
+      screen.getByText("openai:gpt-4o").closest("tr") as HTMLElement,
+    )
+    const aside = panel()
+    expect(within(aside).getByText("Input")).toBeInTheDocument()
+    expect(
+      within(aside).queryByRole("button", { name: /Set price|Edit price/ }),
+    ).not.toBeInTheDocument()
+    expect(
+      within(aside).queryByRole("button", { name: "Reset" }),
+    ).not.toBeInTheDocument()
+
+    const urls = fetchMock.mock.calls.map(([input]) => String(input))
+    expect(urls.some((url) => url.includes("/v1/settings"))).toBe(false)
+    expect(urls.some((url) => url.includes("/v1/models/discoverable"))).toBe(
+      false,
+    )
+    expect(urls.some((url) => url.includes("/v1/models/metadata"))).toBe(false)
   })
 })

--- a/web/src/features/models/ModelsPage.tsx
+++ b/web/src/features/models/ModelsPage.tsx
@@ -17,11 +17,13 @@ import {
   type ManualRates,
   SetPriceDialog,
 } from "@/features/models/SetPriceDialog"
+import { isDeploymentOperator } from "@/features/organization/roles"
 import {
   useDeletePricing,
   useDiscoverableModels,
   useModelMetadata,
   useModels,
+  useOrganizationContext,
   usePricing,
   useSetPricing,
   useSettings,
@@ -549,7 +551,11 @@ function InfoTooltip({
 // The default-pricing explanation, surfaced from the pricing column headers
 // instead of a persistent banner. Tone shifts to a warning when metering is off.
 function PricingInfo() {
-  const settings = useSettings()
+  // Self-gated rather than threaded through ModelTable's props: the read is
+  // deployment-operator-only, and the tooltip explains a policy only an
+  // operator can change, so for anyone else the header simply has no note.
+  const organization = useOrganizationContext()
+  const settings = useSettings(isDeploymentOperator(organization.data))
   if (!settings.data) {
     return null
   }
@@ -601,7 +607,15 @@ function PanelSection({
 
 // Price editor inside the detail panel: the selected model's rate, plus
 // set/edit/clear. Reset per model via a `key` on the element that mounts it.
-function PanelPriceEditor({ row }: { row: ModelRow }) {
+// `readOnly` keeps the rates and drops the write affordances, for a caller who
+// may not price anything.
+function PanelPriceEditor({
+  row,
+  readOnly = false,
+}: {
+  row: ModelRow
+  readOnly?: boolean
+}) {
   const setPricing = useSetPricing()
   const deletePricing = useDeletePricing()
   const [editing, setEditing] = useState(false)
@@ -769,32 +783,34 @@ function PanelPriceEditor({ row }: { row: ModelRow }) {
             : "—"
         }
       />
-      <div className="flex items-center gap-2 pt-1">
-        <Button size="sm" variant="outline" onPress={startEdit}>
-          {row.source === "configured" ? "Edit price" : "Set price"}
-        </Button>
-        {row.source === "configured" ? (
-          <>
-            <ConfirmButton
-              confirmLabel="Reset"
-              isPending={deletePricing.isPending}
-              onConfirm={() => deletePricing.mutate(row.key)}
-            >
-              Reset
-            </ConfirmButton>
-            <InfoTooltip label="What reset does">
-              Removes the custom price. The model reverts to the default rate
-              (genai-prices) when default pricing is on, otherwise it is metered
-              at no cost.
-            </InfoTooltip>
-          </>
-        ) : null}
-        {deletePricing.error ? (
-          <span className="text-xs text-danger">
-            {errorMessage(deletePricing.error)}
-          </span>
-        ) : null}
-      </div>
+      {readOnly ? null : (
+        <div className="flex items-center gap-2 pt-1">
+          <Button size="sm" variant="outline" onPress={startEdit}>
+            {row.source === "configured" ? "Edit price" : "Set price"}
+          </Button>
+          {row.source === "configured" ? (
+            <>
+              <ConfirmButton
+                confirmLabel="Reset"
+                isPending={deletePricing.isPending}
+                onConfirm={() => deletePricing.mutate(row.key)}
+              >
+                Reset
+              </ConfirmButton>
+              <InfoTooltip label="What reset does">
+                Removes the custom price. The model reverts to the default rate
+                (genai-prices) when default pricing is on, otherwise it is
+                metered at no cost.
+              </InfoTooltip>
+            </>
+          ) : null}
+          {deletePricing.error ? (
+            <span className="text-xs text-danger">
+              {errorMessage(deletePricing.error)}
+            </span>
+          ) : null}
+        </div>
+      )}
     </div>
   )
 }
@@ -805,11 +821,13 @@ function ModelDetailPanel({
   row,
   metadata,
   metadataAvailable,
+  canEditPricing,
   onClose,
 }: {
   row: ModelRow
   metadata: ModelMetadata | undefined
   metadataAvailable: boolean
+  canEditPricing: boolean
   onClose: () => void
 }) {
   const inputModalities = metadata?.input_modalities ?? []
@@ -862,7 +880,11 @@ function ModelDetailPanel({
               <span className="text-xs text-muted">not discovered</span>
             )}
           </div>
-          <PanelPriceEditor key={row.key} row={row} />
+          <PanelPriceEditor
+            key={row.key}
+            row={row}
+            readOnly={!canEditPricing}
+          />
         </PanelSection>
 
         <PanelSection title="Specs">
@@ -926,7 +948,12 @@ function ModelDetailPanel({
             <span className="text-sm text-muted">
               {metadataAvailable
                 ? "None reported."
-                : "Extended metadata unavailable (models.dev disabled or unreachable)."}
+                : canEditPricing
+                  ? "Extended metadata unavailable (models.dev disabled or unreachable)."
+                  : // The metadata read is operator-only and was never asked, so
+                    // saying models.dev failed would be reporting an outage that
+                    // did not happen.
+                    "Extended metadata is available to deployment operators."}
             </span>
           )}
         </PanelSection>
@@ -1146,21 +1173,28 @@ function PriceCell({
   rowKey: string
   primaryLabel: string
   secondaryLabel: string
-  onEdit: () => void
+  // Absent for a caller who may not write pricing: the number renders as text
+  // rather than as a control that could only earn a 403.
+  onEdit?: () => void
 }) {
-  const number = (value: number | null, label: string) => (
-    <button
-      type="button"
-      aria-label={`Edit ${label} price for ${rowKey}`}
-      className="tabular-nums hover:text-link hover:underline"
-      onClick={(event) => {
-        event.stopPropagation()
-        onEdit()
-      }}
-    >
-      {value == null ? "—" : formatCost(value)}
-    </button>
-  )
+  const number = (value: number | null, label: string) =>
+    onEdit === undefined ? (
+      <span className="tabular-nums">
+        {value == null ? "—" : formatCost(value)}
+      </span>
+    ) : (
+      <button
+        type="button"
+        aria-label={`Edit ${label} price for ${rowKey}`}
+        className="tabular-nums hover:text-link hover:underline"
+        onClick={(event) => {
+          event.stopPropagation()
+          onEdit()
+        }}
+      >
+        {value == null ? "—" : formatCost(value)}
+      </button>
+    )
   return (
     <span className="inline-flex items-center justify-end gap-1">
       {number(primary, primaryLabel)}
@@ -1177,7 +1211,8 @@ function CachingCell({
 }: {
   rates: EffectiveRates
   rowKey: string
-  onEdit: () => void
+  // Absent for a caller who may not write pricing; see PriceCell.
+  onEdit?: () => void
 }) {
   const entries = [
     rates.cacheReadPrice == null
@@ -1190,6 +1225,14 @@ function CachingCell({
       ? null
       : `1h ${formatCost(rates.cacheWrite1hPrice)}`,
   ].filter((entry): entry is string => entry !== null)
+  const label = entries.length > 0 ? entries.join(" · ") : "Input-rate fallback"
+  if (onEdit === undefined) {
+    return (
+      <span className="inline-block max-w-44 text-right text-xs leading-5 text-muted">
+        {label}
+      </span>
+    )
+  }
   return (
     <button
       type="button"
@@ -1200,7 +1243,7 @@ function CachingCell({
         onEdit()
       }}
     >
-      {entries.length > 0 ? entries.join(" · ") : "Input-rate fallback"}
+      {label}
     </button>
   )
 }
@@ -1210,7 +1253,8 @@ function PricingPolicyCell({
   onEdit,
 }: {
   row: ModelRow
-  onEdit: () => void
+  // Absent for a caller who may not write pricing; see PriceCell.
+  onEdit?: () => void
 }) {
   const thresholds = [...row.pricingTiers]
     .sort((a, b) => a.min_input_tokens - b.min_input_tokens)
@@ -1219,6 +1263,13 @@ function PricingPolicyCell({
     thresholds.length === 0
       ? "Base only"
       : `${thresholds.length} tier${thresholds.length === 1 ? "" : "s"} · ≥ ${thresholds.join(", ")}`
+  if (onEdit === undefined) {
+    return (
+      <span className="inline-block max-w-40 text-right text-xs leading-5 text-muted">
+        {label}
+      </span>
+    )
+  }
   return (
     <button
       type="button"
@@ -1254,7 +1305,9 @@ function ModelTable({
   onSortChange: (descriptor: SortDescriptor) => void
   selectedKey: string | null
   onSelect: (key: string) => void
-  onEditPricing: (key: string) => void
+  // Absent for a caller who may not write pricing: the price cells render as
+  // text and row selection (which exists only to feed bulk pricing) is off.
+  onEditPricing?: (key: string) => void
   comparisonContextTokens: number | null
   selectedKeys: Selection
   onSelectionChange: (keys: Selection) => void
@@ -1315,7 +1368,7 @@ function ModelTable({
               rowKey={row.key}
               primaryLabel="input"
               secondaryLabel="output"
-              onEdit={() => onEditPricing(row.key)}
+              onEdit={onEditPricing && (() => onEditPricing(row.key))}
             />
           )
         },
@@ -1331,7 +1384,7 @@ function ModelTable({
           <CachingCell
             rates={effectiveRatesAtContext(row, comparisonContextTokens)}
             rowKey={row.key}
-            onEdit={() => onEditPricing(row.key)}
+            onEdit={onEditPricing && (() => onEditPricing(row.key))}
           />
         ),
       },
@@ -1346,7 +1399,10 @@ function ModelTable({
         header: "Pricing policy",
         align: "end",
         cell: (row) => (
-          <PricingPolicyCell row={row} onEdit={() => onEditPricing(row.key)} />
+          <PricingPolicyCell
+            row={row}
+            onEdit={onEditPricing && (() => onEditPricing(row.key))}
+          />
         ),
       },
     ]
@@ -1366,7 +1422,7 @@ function ModelTable({
       getRowKey={getModelRowKey}
       isLoading={isLoading}
       emptyContent={empty}
-      selectionMode="multiple"
+      selectionMode={onEditPricing ? "multiple" : "none"}
       selectedKeys={selectedKeys}
       onSelectionChange={onSelectionChange}
       sortDescriptor={sortDescriptor}
@@ -1444,11 +1500,17 @@ function DiscoveredErrors({
 }
 
 export function ModelsPage() {
+  // The catalog and the price list serve any signed-in session; discovery,
+  // metadata and settings are deployment-operator-only, so they are withheld
+  // from anyone else rather than fired into a 403 banner (otari-ai#1942). For
+  // a non-operator the page is the read-only catalog view.
+  const organization = useOrganizationContext()
+  const isOperator = isDeploymentOperator(organization.data)
   const models = useModels()
   const pricing = usePricing()
-  const discoverable = useDiscoverableModels()
-  const metadata = useModelMetadata()
-  const settings = useSettings()
+  const discoverable = useDiscoverableModels(isOperator)
+  const metadata = useModelMetadata(isOperator)
+  const settings = useSettings(isOperator)
 
   const setPricing = useSetPricing()
   const [search, setSearch] = useState("")
@@ -1934,21 +1996,25 @@ export function ModelsPage() {
       <span>
         {hasActiveFilters
           ? "No models match your filters."
-          : "No models yet. Add a provider on the Providers page."}
+          : isOperator
+            ? "No models yet. Add a provider on the Providers page."
+            : "No models yet. A deployment operator adds providers."}
       </span>
       <span className="text-xs text-muted">
         A provider that serves no model listing still answers requests, so a
         model you can call may not be listed here.
       </span>
-      <Button
-        size="sm"
-        variant="outline"
-        onPress={() => setCustomPriceKey(searchedSelector ?? "")}
-      >
-        {searchedSelector
-          ? `Price ${searchedSelector}`
-          : "Price a model by hand"}
-      </Button>
+      {isOperator ? (
+        <Button
+          size="sm"
+          variant="outline"
+          onPress={() => setCustomPriceKey(searchedSelector ?? "")}
+        >
+          {searchedSelector
+            ? `Price ${searchedSelector}`
+            : "Price a model by hand"}
+        </Button>
+      ) : null}
     </div>
   )
 
@@ -1963,7 +2029,11 @@ export function ModelsPage() {
     <div className="flex flex-col gap-6">
       <PageHeader
         title="Models"
-        description="Every model your providers can serve. Set a price on any model so budgets and usage tracking work."
+        description={
+          isOperator
+            ? "Every model your providers can serve. Set a price on any model so budgets and usage tracking work."
+            : "Every model this gateway can serve, with the rates your usage is metered at. Providers and pricing are managed by a deployment operator."
+        }
       />
 
       <ErrorBanner
@@ -2082,7 +2152,7 @@ export function ModelsPage() {
             onSortChange={onSortChange}
             selectedKey={selectedKey}
             onSelect={setSelectedKey}
-            onEditPricing={onEditPricing}
+            onEditPricing={isOperator ? onEditPricing : undefined}
             comparisonContextTokens={comparisonContextTokens}
             selectedKeys={selection.selectedKeys}
             onSelectionChange={selection.onSelectionChange}
@@ -2131,6 +2201,7 @@ export function ModelsPage() {
               row={selectedRow}
               metadata={metadataByKey[selectedRow.key]}
               metadataAvailable={metadataAvailable}
+              canEditPricing={isOperator}
               onClose={() => setSelectedKey(null)}
             />
           </aside>

--- a/web/src/features/models/ModelsPage.tsx
+++ b/web/src/features/models/ModelsPage.tsx
@@ -555,11 +555,15 @@ function PricingInfo() {
   // deployment-operator-only, and the tooltip explains a policy only an
   // operator can change, so for anyone else the header simply has no note.
   const organization = useOrganizationContext()
-  const settings = useSettings(isDeploymentOperator(organization.data))
-  if (!settings.data) {
+  const isOperator = isDeploymentOperator(organization.data)
+  const settings = useSettings(isOperator)
+  // Read through `isOperator` for the reason `ModelsPage` does: a disabled
+  // query still serves whatever its key already holds in the cache.
+  const data = isOperator ? settings.data : undefined
+  if (!data) {
     return null
   }
-  if (settings.data.default_pricing) {
+  if (data.default_pricing) {
     return (
       <InfoTooltip label="How unpriced models are metered" tone="info">
         Default pricing is on: models without a configured price are metered
@@ -571,7 +575,7 @@ function PricingInfo() {
   return (
     <InfoTooltip label="How unpriced models are metered" tone="warning">
       Default pricing is off: only models with a configured price are metered.
-      {settings.data.require_pricing
+      {data.require_pricing
         ? " Requests for any other model are rejected (HTTP 402) because require_pricing is on."
         : " Other models are served without cost tracking."}
     </InfoTooltip>
@@ -1516,6 +1520,14 @@ export function ModelsPage() {
   const discoverable = useDiscoverableModels(isOperator)
   const metadata = useModelMetadata(isOperator)
   const settings = useSettings(isOperator)
+  // Read through `isOperator` rather than relied on to be undefined because
+  // the hooks above are disabled: a disabled query still hands back whatever
+  // sits in the cache under its key, so a caller demoted mid-session would
+  // keep seeing what they fetched as an operator. The gate belongs where the
+  // data is rendered, not only where it is fetched.
+  const discoverableData = isOperator ? discoverable.data : undefined
+  const metadataData = isOperator ? metadata.data : undefined
+  const settingsData = isOperator ? settings.data : undefined
 
   const setPricing = useSetPricing()
   const [search, setSearch] = useState("")
@@ -1556,17 +1568,17 @@ export function ModelsPage() {
   const [releaseFilter, setReleaseFilter] = useState("all")
   const [comparisonContext, setComparisonContext] = useState("")
 
-  const metadataByKey = metadata.data?.models ?? {}
-  const metadataAvailable = metadata.data?.available ?? false
+  const metadataByKey = metadataData?.models ?? {}
+  const metadataAvailable = metadataData?.available ?? false
 
   const discoverableKeys = useMemo(
     () =>
       new Set(
-        (discoverable.data?.providers ?? []).flatMap((provider) =>
+        (discoverableData?.providers ?? []).flatMap((provider) =>
           provider.models.map((model) => model.key),
         ),
       ),
-    [discoverable.data],
+    [discoverableData],
   )
 
   const changeSearch = (value: string) => {
@@ -1697,8 +1709,8 @@ export function ModelsPage() {
     // answer: while settings are still loading the flag is undefined, and "not priced"
     // is the one of the two labels that would be asserting something.
     const unpricedSource: PriceSource =
-      settings.data?.default_pricing === false ? "none" : "unknown"
-    for (const provider of discoverable.data?.providers ?? []) {
+      settingsData?.default_pricing === false ? "none" : "unknown"
+    for (const provider of discoverableData?.providers ?? []) {
       for (const model of provider.models) {
         if (seen.has(model.key)) {
           continue
@@ -1722,9 +1734,9 @@ export function ModelsPage() {
       }
     }
     return out
-  }, [rows, discoverable.data, metadataByKey, settings.data?.default_pricing])
+  }, [rows, discoverableData, metadataByKey, settingsData?.default_pricing])
 
-  const discoveredErrors = (discoverable.data?.providers ?? []).filter(
+  const discoveredErrors = (discoverableData?.providers ?? []).filter(
     (provider) => !provider.ok,
   )
 

--- a/web/src/features/models/ModelsPage.tsx
+++ b/web/src/features/models/ModelsPage.tsx
@@ -822,12 +822,17 @@ function ModelDetailPanel({
   metadata,
   metadataAvailable,
   canEditPricing,
+  discoveryKnown,
   onClose,
 }: {
   row: ModelRow
   metadata: ModelMetadata | undefined
   metadataAvailable: boolean
   canEditPricing: boolean
+  // False when `/v1/models/discoverable` was never read, which is the
+  // non-operator case: `isDiscovered` is then absent rather than negative, so
+  // the row says nothing about discovery instead of claiming it failed.
+  discoveryKnown: boolean
   onClose: () => void
 }) {
   const inputModalities = metadata?.input_modalities ?? []
@@ -876,7 +881,7 @@ function ModelDetailPanel({
         <PanelSection title="Pricing">
           <div className="flex items-center gap-2">
             <SourceChip source={row.source} />
-            {row.isDiscovered ? null : (
+            {row.isDiscovered || !discoveryKnown ? null : (
               <span className="text-xs text-muted">not discovered</span>
             )}
           </div>
@@ -2072,28 +2077,38 @@ export function ModelsPage() {
                 { value: "unpriced", label: "Unpriced" },
               ]}
             />
-            <FilterSelect
-              ariaLabel="Filter by source"
-              value={sourceFilter}
-              onChange={changeFilter(setSourceFilter)}
-              options={[
-                { value: "all", label: "Any source" },
-                { value: "discovered", label: "Discovered" },
-                { value: "custom", label: "Custom (not discovered)" },
-              ]}
-            />
-            <FilterSelect
-              ariaLabel="Filter by capability"
-              value={capabilityFilter}
-              onChange={changeFilter(setCapabilityFilter)}
-              options={[
-                { value: "all", label: "Any capability" },
-                ...MODEL_FILTER_CAPABILITIES.map((entry) => ({
-                  value: entry.value,
-                  label: entry.label,
-                })),
-              ]}
-            />
+            {/* Source, capability and release date all read a
+                deployment-operator-only endpoint (`/v1/models/discoverable`
+                for the first, `/v1/models/metadata` for the other two). For a
+                caller those reads were withheld from, every value but "all"
+                would empty the table, so the control is absent rather than
+                offered as one that can only fail. */}
+            {isOperator ? (
+              <FilterSelect
+                ariaLabel="Filter by source"
+                value={sourceFilter}
+                onChange={changeFilter(setSourceFilter)}
+                options={[
+                  { value: "all", label: "Any source" },
+                  { value: "discovered", label: "Discovered" },
+                  { value: "custom", label: "Custom (not discovered)" },
+                ]}
+              />
+            ) : null}
+            {isOperator ? (
+              <FilterSelect
+                ariaLabel="Filter by capability"
+                value={capabilityFilter}
+                onChange={changeFilter(setCapabilityFilter)}
+                options={[
+                  { value: "all", label: "Any capability" },
+                  ...MODEL_FILTER_CAPABILITIES.map((entry) => ({
+                    value: entry.value,
+                    label: entry.label,
+                  })),
+                ]}
+              />
+            ) : null}
             <FilterSelect
               ariaLabel="Minimum context window"
               value={minContext}
@@ -2112,12 +2127,14 @@ export function ModelsPage() {
               onChange={setComparisonContext}
               options={PRICE_COMPARISON_OPTIONS}
             />
-            <FilterSelect
-              ariaLabel="Filter by release date"
-              value={releaseFilter}
-              onChange={changeFilter(setReleaseFilter)}
-              options={RELEASE_OPTIONS}
-            />
+            {isOperator ? (
+              <FilterSelect
+                ariaLabel="Filter by release date"
+                value={releaseFilter}
+                onChange={changeFilter(setReleaseFilter)}
+                options={RELEASE_OPTIONS}
+              />
+            ) : null}
           </div>
 
           <DiscoveredErrors
@@ -2202,6 +2219,7 @@ export function ModelsPage() {
               metadata={metadataByKey[selectedRow.key]}
               metadataAvailable={metadataAvailable}
               canEditPricing={isOperator}
+              discoveryKnown={isOperator}
               onClose={() => setSelectedKey(null)}
             />
           </aside>

--- a/web/src/features/routing/RoutingPage.test.tsx
+++ b/web/src/features/routing/RoutingPage.test.tsx
@@ -223,13 +223,13 @@ function mockApi(
   return { spy, calls }
 }
 
-function renderPage(ui: ReactElement) {
+function renderPage(ui: ReactElement, url = "/") {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   })
   return render(
     <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
-    { wrapper: withRouter() },
+    { wrapper: withRouter({ url }) },
   )
 }
 
@@ -1261,6 +1261,37 @@ describe("RoutingPage", () => {
     expect(urls.some((url) => url.includes("/v1/aliases"))).toBe(false)
     expect(urls.some((url) => url.includes("/v1/tool-settings"))).toBe(false)
     expect(urls.some((url) => url.includes("/v1/users"))).toBe(false)
+  })
+
+  it("withholds the deep-linked add form from a member", async () => {
+    // ?target= seeds `adding` before the membership context settles, so the
+    // role has to be applied at render time. Without that a member on this URL
+    // gets a create form whose only outcome is a refusal, and the read-only
+    // empty state is suppressed behind it.
+    mockApi([], null, [], {
+      context: organizationContext({
+        deployment_operator: false,
+        role: "member",
+      }),
+      memberPolicies: [],
+    })
+    renderPage(<RoutingPage />, "/routing?target=openai:gpt-4o")
+
+    expect(
+      await screen.findByText(/once a deployment operator defines them/),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /Create policy/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("keeps the deep-linked add form for an operator", async () => {
+    mockApi([], null, [], { context: organizationContext() })
+    renderPage(<RoutingPage />, "/routing?target=openai:gpt-4o")
+
+    expect(
+      await screen.findByRole("button", { name: /Create policy/i }),
+    ).toBeInTheDocument()
   })
 
   it("tells a member with no policies who defines them", async () => {

--- a/web/src/features/routing/RoutingPage.test.tsx
+++ b/web/src/features/routing/RoutingPage.test.tsx
@@ -1245,6 +1245,45 @@ describe("RoutingPage", () => {
     ).not.toBeInTheDocument()
   })
 
+  it("keeps cached operator rows out of a member's table", async () => {
+    // A disabled query still serves whatever sits under its key, so a caller
+    // demoted mid-session would otherwise keep seeing the deployment-wide
+    // policies and aliases they fetched as an operator. The pre-seeded client
+    // stands in for that cache.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    client.setQueryData(["routing-policies"], [policy("operator-only", CHAIN)])
+    client.setQueryData(
+      ["aliases"],
+      [
+        {
+          name: "operator-alias",
+          target: "openai:gpt-5",
+          source: "stored",
+          user_id: null,
+        },
+      ],
+    )
+    mockApi([], null, [], {
+      context: organizationContext({
+        deployment_operator: false,
+        role: "member",
+      }),
+      memberPolicies: [policy("mine", CHAIN)],
+    })
+    render(
+      <QueryClientProvider client={client}>
+        <RoutingPage />
+      </QueryClientProvider>,
+      { wrapper: withRouter({ url: "/" }) },
+    )
+
+    expect(await screen.findByText("mine")).toBeInTheDocument()
+    expect(screen.queryByText("operator-only")).not.toBeInTheDocument()
+    expect(screen.queryByText("operator-alias")).not.toBeInTheDocument()
+  })
+
   it("never fires the operator reads for a non-operator", async () => {
     const { calls } = mockApi([], null, [], {
       context: organizationContext({

--- a/web/src/features/routing/RoutingPage.test.tsx
+++ b/web/src/features/routing/RoutingPage.test.tsx
@@ -4,8 +4,13 @@ import userEvent from "@testing-library/user-event"
 import type { ReactElement } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import type { PolicySpec, RoutingPolicyResponse } from "@/client"
+import type {
+  OrganizationContext,
+  PolicySpec,
+  RoutingPolicyResponse,
+} from "@/client"
 import { RoutingPage } from "@/features/routing/RoutingPage"
+import { organizationContext } from "@/tests/fixtures"
 import { withRouter } from "@/tests/router"
 
 const policy = (
@@ -80,6 +85,14 @@ function mockApi(
     source: string
     user_id: string | null
   }[] = [],
+  opts: {
+    // The caller's membership context, an operator's by default: the page picks
+    // its list read off `deployment_operator`, and most tests here are about
+    // the management view.
+    context?: OrganizationContext
+    // What `/v1/organizations/me/routing-policies` answers, for member tests.
+    memberPolicies?: RoutingPolicyResponse[]
+  } = {},
 ) {
   let list = [...policies]
   let aliasList = [...aliases]
@@ -93,6 +106,12 @@ function mockApi(
         init?.body === undefined ? undefined : JSON.parse(String(init.body))
       calls.push({ url, method, body })
 
+      if (url.includes("/v1/organizations/me/routing-policies")) {
+        return jsonResponse(opts.memberPolicies ?? [])
+      }
+      if (url.endsWith("/v1/organizations/me")) {
+        return jsonResponse(opts.context ?? organizationContext())
+      }
       if (url.includes("/v1/routing/policies/explain")) {
         return jsonResponse({
           name: "fast",
@@ -1194,5 +1213,70 @@ describe("RoutingPage", () => {
     expect(
       within(row).getByRole("button", { name: "Examples" }),
     ).toBeInTheDocument()
+  })
+
+  it("lists the tenant-scoped policies read-only for a non-operator", async () => {
+    // The member half of otari-ai#1942: the page reads
+    // /v1/organizations/me/routing-policies and offers nothing that writes.
+    mockApi([], null, [], {
+      context: organizationContext({
+        deployment_operator: false,
+        role: "member",
+      }),
+      memberPolicies: [policy("fast", CHAIN)],
+    })
+    renderPage(<RoutingPage />)
+
+    const row = (await screen.findByText("fast")).closest("tr")!
+    expect(within(row).getByText(/openai:gpt-5-mini/)).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "New policy" }),
+    ).not.toBeInTheDocument()
+    expect(
+      within(row).queryByRole("button", { name: "Edit" }),
+    ).not.toBeInTheDocument()
+    expect(
+      within(row).queryByRole("button", { name: "Delete" }),
+    ).not.toBeInTheDocument()
+    // The Examples panel reads the operator-only /v1/routing/status, so its
+    // opener goes with the rest of the actions column.
+    expect(
+      within(row).queryByRole("button", { name: "Examples" }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("never fires the operator reads for a non-operator", async () => {
+    const { calls } = mockApi([], null, [], {
+      context: organizationContext({
+        deployment_operator: false,
+        role: "member",
+      }),
+      memberPolicies: [policy("fast", CHAIN)],
+    })
+    renderPage(<RoutingPage />)
+    await screen.findByText("fast")
+
+    const urls = calls.map((call) => call.url)
+    expect(urls.some((url) => url.endsWith("/v1/routing/policies"))).toBe(false)
+    expect(urls.some((url) => url.includes("/v1/aliases"))).toBe(false)
+    expect(urls.some((url) => url.includes("/v1/tool-settings"))).toBe(false)
+    expect(urls.some((url) => url.includes("/v1/users"))).toBe(false)
+  })
+
+  it("tells a member with no policies who defines them", async () => {
+    mockApi([], null, [], {
+      context: organizationContext({
+        deployment_operator: false,
+        role: "member",
+      }),
+      memberPolicies: [],
+    })
+    renderPage(<RoutingPage />)
+
+    expect(
+      await screen.findByText(/once a deployment operator defines them/),
+    ).toBeInTheDocument()
+    // The operator's numbered getting-started walkthrough is not for them.
+    expect(screen.queryByText(/Create a policy/)).not.toBeInTheDocument()
   })
 })

--- a/web/src/features/routing/RoutingPage.tsx
+++ b/web/src/features/routing/RoutingPage.tsx
@@ -9,6 +9,7 @@ import type {
   RoutingPolicyResponse,
 } from "@/client"
 import { ModelComboBox } from "@/features/models/ModelComboBox"
+import { isDeploymentOperator } from "@/features/organization/roles"
 import { RouterReadiness } from "@/features/routing/RouterReadiness"
 import { UserComboBox } from "@/features/users/UserComboBox"
 import {
@@ -16,6 +17,8 @@ import {
   useCreateAlias,
   useDeleteAlias,
   useDeleteRoutingPolicy,
+  useOrganizationContext,
+  useOrganizationRoutingPolicies,
   useRoutingPolicies,
   useSetRoutingPolicy,
   useToolSettings,
@@ -1243,8 +1246,23 @@ export function RoutingPage() {
   // selected workspace would therefore show an empty page while those policies
   // were live for that workspace's traffic, and hide a policy the moment it was
   // created. Scope this when resolution is scoped, not before.
-  const policies = useRoutingPolicies()
-  const aliases = useAliases()
+  //
+  // Which list is asked depends on who is signed in (otari-ai#1942): an
+  // operator reads the deployment-wide management view they edit from, and
+  // anyone else reads the tenant-scoped `/v1/organizations/me/routing-policies`
+  // read-only. The member read waits for the context to settle rather than
+  // taking "not yet an operator" as "member", so an operator's page does not
+  // fire a read it is about to drop. Aliases have no tenant-scoped sibling yet,
+  // so a member's table lists policies alone.
+  const organization = useOrganizationContext()
+  const isOperator = isDeploymentOperator(organization.data)
+  const isContextSettled =
+    organization.data !== undefined || organization.isError
+  const policies = useRoutingPolicies(isOperator)
+  const memberPolicies = useOrganizationRoutingPolicies(
+    isContextSettled && !isOperator,
+  )
+  const aliases = useAliases(isOperator)
   const deletePolicy = useDeleteRoutingPolicy()
   const deleteAlias = useDeleteAlias()
   // A deep link may pre-fill the add form with ?target=provider:model.
@@ -1259,16 +1277,25 @@ export function RoutingPage() {
   // Aliases and policies are listed together: an alias is the one-target case,
   // and this page is the only place either is managed.
   const rows: RoutingRow[] = [
-    ...(policies.data ?? []).map((policy) => ({
-      ...policy,
-      kind: "policy" as const,
-    })),
+    ...((isOperator ? policies.data : memberPolicies.data) ?? []).map(
+      (policy) => ({
+        ...policy,
+        kind: "policy" as const,
+      }),
+    ),
     ...(aliases.data ?? []).map(aliasAsRow),
   ].sort(
     (a, b) =>
       a.name.localeCompare(b.name) ||
       (a.user_id ?? "").localeCompare(b.user_id ?? ""),
   )
+  // The context counts as loading too: until it settles, neither list has been
+  // asked, and an empty table would read as "no policies" rather than "not yet".
+  const isListLoading =
+    !isContextSettled ||
+    (isOperator
+      ? policies.isLoading || aliases.isLoading
+      : memberPolicies.isLoading)
 
   // Stable so DataTable's row cache holds; see its docstring.
   const renderDetail = useCallback(
@@ -1285,8 +1312,8 @@ export function RoutingPage() {
     [],
   )
 
-  const columns = useMemo<DataTableColumn<RoutingRow>[]>(
-    () => [
+  const columns = useMemo<DataTableColumn<RoutingRow>[]>(() => {
+    const base: DataTableColumn<RoutingRow>[] = [
       {
         id: "name",
         header: "Policy",
@@ -1360,94 +1387,101 @@ export function RoutingPage() {
           </div>
         ),
       },
-      {
-        id: "actions",
-        header: "",
-        cell: (policy) => {
-          // Teaching is data, not configuration, so it is offered even for a policy
-          // defined in config.yml: an operator can score examples for a policy they
-          // cannot edit here, and without this that policy could never route.
-          // "Examples" rather than "Router": on a Routing page full of routing
-          // policies, "Router" names the thing rather than what opens, and the count
-          // of scored examples is the one number in there that changes. Outlined
-          // rather than ghost so it reads as the row's distinct affordance next to
-          // Edit and Delete.
-          // Only for a backend that learns: a weighted policy has nothing to teach,
-          // so offering Examples on one would promise a screen that cannot help it.
-          const readiness = routerBackendOf(policy.spec) === KNN_BACKEND && (
-            <Button
-              size="sm"
-              variant="outline"
-              onPress={() =>
-                setExpanded((current) =>
-                  current === rowKeyOf(policy) ? null : rowKeyOf(policy),
-                )
+    ]
+    // No actions column for a caller who cannot act: every affordance in it is
+    // either a write or the Examples panel, whose read is operator-only.
+    if (!isOperator) return base
+    base.push({
+      id: "actions",
+      header: "",
+      cell: (policy) => {
+        // Teaching is data, not configuration, so it is offered even for a policy
+        // defined in config.yml: an operator can score examples for a policy they
+        // cannot edit here, and without this that policy could never route.
+        // "Examples" rather than "Router": on a Routing page full of routing
+        // policies, "Router" names the thing rather than what opens, and the count
+        // of scored examples is the one number in there that changes. Outlined
+        // rather than ghost so it reads as the row's distinct affordance next to
+        // Edit and Delete.
+        // Only for a backend that learns: a weighted policy has nothing to teach,
+        // so offering Examples on one would promise a screen that cannot help it.
+        const readiness = routerBackendOf(policy.spec) === KNN_BACKEND && (
+          <Button
+            size="sm"
+            variant="outline"
+            onPress={() =>
+              setExpanded((current) =>
+                current === rowKeyOf(policy) ? null : rowKeyOf(policy),
+              )
+            }
+          >
+            {expanded === rowKeyOf(policy) ? "Hide examples" : "Examples"}
+          </Button>
+        )
+        return policy.source === "config" ? (
+          <div className="flex items-center justify-end gap-2">
+            {readiness}
+            <span className="text-xs text-muted">set in config.yml</span>
+          </div>
+        ) : (
+          <div className="flex items-center justify-end gap-2">
+            {readiness}
+            {isEditableInForm(policy.spec) ? (
+              <Button
+                size="sm"
+                variant="ghost"
+                onPress={() => {
+                  // The table stays mounted while the create form is open, so
+                  // Edit is still reachable from it. Closing the other panels
+                  // keeps this to one form: two stacked forms do not recover on
+                  // their own, since each only closes when cancelled.
+                  setAdding(false)
+                  setEditing(policy)
+                }}
+              >
+                Edit
+              </Button>
+            ) : (
+              <span className="text-xs text-muted">
+                Uses options this form cannot show yet. Edit it through the API
+                so nothing is lost.
+              </span>
+            )}
+            <ConfirmButton
+              confirmLabel="Confirm"
+              isPending={deletePolicy.isPending || deleteAlias.isPending}
+              onConfirm={() =>
+                policy.kind === "alias"
+                  ? deleteAlias.mutate({
+                      name: policy.name,
+                      userId: policy.user_id,
+                    })
+                  : deletePolicy.mutate({
+                      name: policy.name,
+                      userId: policy.user_id,
+                    })
               }
             >
-              {expanded === rowKeyOf(policy) ? "Hide examples" : "Examples"}
-            </Button>
-          )
-          return policy.source === "config" ? (
-            <div className="flex items-center justify-end gap-2">
-              {readiness}
-              <span className="text-xs text-muted">set in config.yml</span>
-            </div>
-          ) : (
-            <div className="flex items-center justify-end gap-2">
-              {readiness}
-              {isEditableInForm(policy.spec) ? (
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onPress={() => {
-                    // The table stays mounted while the create form is open, so
-                    // Edit is still reachable from it. Closing the other panels
-                    // keeps this to one form: two stacked forms do not recover on
-                    // their own, since each only closes when cancelled.
-                    setAdding(false)
-                    setEditing(policy)
-                  }}
-                >
-                  Edit
-                </Button>
-              ) : (
-                <span className="text-xs text-muted">
-                  Uses options this form cannot show yet. Edit it through the
-                  API so nothing is lost.
-                </span>
-              )}
-              <ConfirmButton
-                confirmLabel="Confirm"
-                isPending={deletePolicy.isPending || deleteAlias.isPending}
-                onConfirm={() =>
-                  policy.kind === "alias"
-                    ? deleteAlias.mutate({
-                        name: policy.name,
-                        userId: policy.user_id,
-                      })
-                    : deletePolicy.mutate({
-                        name: policy.name,
-                        userId: policy.user_id,
-                      })
-                }
-              >
-                Delete
-              </ConfirmButton>
-            </div>
-          )
-        },
+              Delete
+            </ConfirmButton>
+          </div>
+        )
       },
-    ],
-    [deletePolicy, deleteAlias, expanded],
-  )
+    })
+    return base
+  }, [deletePolicy, deleteAlias, expanded, isOperator])
 
   return (
     <div className="flex flex-col gap-6">
       <PageHeader
         title="Routing"
-        description="Named models your callers send as `model`. A policy decides which real model serves each request, what is tried if that fails, and which guardrails always run. It can also split traffic across providers by weight, or let a router learn which prompts a cheaper model handles just as well."
+        description={
+          isOperator
+            ? "Named models your callers send as `model`. A policy decides which real model serves each request, what is tried if that fails, and which guardrails always run. It can also split traffic across providers by weight, or let a router learn which prompts a cheaper model handles just as well."
+            : "Named models your callers send as `model`. A policy decides which real model serves each request, what is tried if that fails, and which guardrails always run. These are the policies in force in your workspaces; a deployment operator manages them."
+        }
         action={
-          adding || editing !== null ? undefined : (
+          !isOperator || adding || editing !== null ? undefined : (
             <Button
               variant="primary"
               onPress={() => {
@@ -1464,6 +1498,7 @@ export function RoutingPage() {
       <ErrorBanner
         error={
           policies.error ??
+          memberPolicies.error ??
           aliases.error ??
           deletePolicy.error ??
           deleteAlias.error
@@ -1481,31 +1516,37 @@ export function RoutingPage() {
         <PolicyForm existing={editing} onClose={() => setEditing(null)} />
       ) : null}
 
-      {rows.length === 0 &&
-      !policies.isLoading &&
-      !aliases.isLoading &&
-      !adding ? (
-        <EmptyState title="No routing policies yet">
-          <ol className="flex list-decimal flex-col gap-1 pl-5 text-sm text-muted">
-            <li>
-              Create a policy and point it at the model that should normally
-              serve.
-            </li>
-            <li>
-              Add a fallback chain so a provider outage does not become a failed
-              request.
-            </li>
-            <li>
-              Or split the traffic across two providers by weight, and move the
-              shares as you learn.
-            </li>
-            <li>
-              Or let a router choose per request between a cheap and a strong
-              model, then teach it with a few scored examples.
-            </li>
-            <li>Have your callers send the policy name as their `model`.</li>
-          </ol>
-        </EmptyState>
+      {rows.length === 0 && !isListLoading && !adding ? (
+        isOperator ? (
+          <EmptyState title="No routing policies yet">
+            <ol className="flex list-decimal flex-col gap-1 pl-5 text-sm text-muted">
+              <li>
+                Create a policy and point it at the model that should normally
+                serve.
+              </li>
+              <li>
+                Add a fallback chain so a provider outage does not become a
+                failed request.
+              </li>
+              <li>
+                Or split the traffic across two providers by weight, and move
+                the shares as you learn.
+              </li>
+              <li>
+                Or let a router choose per request between a cheap and a strong
+                model, then teach it with a few scored examples.
+              </li>
+              <li>Have your callers send the policy name as their `model`.</li>
+            </ol>
+          </EmptyState>
+        ) : (
+          <EmptyState title="No routing policies yet">
+            <p className="text-sm text-muted">
+              Policies that apply in your workspaces will be listed here once a
+              deployment operator defines them.
+            </p>
+          </EmptyState>
+        )
       ) : (
         <DataTable
           ariaLabel="Routing policies"
@@ -1514,7 +1555,7 @@ export function RoutingPage() {
           getRowKey={rowKeyOf}
           detailKey={expanded}
           renderDetail={renderDetail}
-          isLoading={policies.isLoading || aliases.isLoading}
+          isLoading={isListLoading}
           emptyContent="No routing policies yet."
         />
       )}

--- a/web/src/features/routing/RoutingPage.tsx
+++ b/web/src/features/routing/RoutingPage.tsx
@@ -1282,6 +1282,12 @@ export function RoutingPage() {
 
   // Aliases and policies are listed together: an alias is the one-target case,
   // and this page is the only place either is managed.
+  //
+  // Both operator lists are read through `isOperator` rather than relied on to
+  // be empty because their hooks are disabled: a disabled query still hands
+  // back whatever sits in the cache under its key, so a caller who was an
+  // operator earlier in the session would keep seeing the deployment-wide rows
+  // after being demoted. The gate belongs where the data is rendered.
   const rows: RoutingRow[] = [
     ...((isOperator ? policies.data : memberPolicies.data) ?? []).map(
       (policy) => ({
@@ -1289,7 +1295,7 @@ export function RoutingPage() {
         kind: "policy" as const,
       }),
     ),
-    ...(aliases.data ?? []).map(aliasAsRow),
+    ...(isOperator ? (aliases.data ?? []) : []).map(aliasAsRow),
   ].sort(
     (a, b) =>
       a.name.localeCompare(b.name) ||
@@ -1487,7 +1493,7 @@ export function RoutingPage() {
             : "Named models your callers send as `model`. A policy decides which real model serves each request, what is tried if that fails, and which guardrails always run. These are the policies in force in your workspaces; a deployment operator manages them."
         }
         action={
-          !isOperator || adding || editing !== null ? undefined : (
+          !isOperator || isAdding || editing !== null ? undefined : (
             <Button
               variant="primary"
               onPress={() => {

--- a/web/src/features/routing/RoutingPage.tsx
+++ b/web/src/features/routing/RoutingPage.tsx
@@ -1273,6 +1273,12 @@ export function RoutingPage() {
   // describes one policy and the operator clicked that policy. A card above the
   // table would put the panel nowhere near the control that opened it.
   const [expanded, setExpanded] = useState<string | null>(null)
+  // `adding` is seeded from ?target= before the membership context settles, so
+  // the role is applied here rather than in the initializer: gating the
+  // initializer would drop an operator's deep link, since `isOperator` is still
+  // false at the moment it runs. A member arriving on that link gets the
+  // read-only empty state instead of a form whose only outcome is a refusal.
+  const isAdding = adding && isOperator
 
   // Aliases and policies are listed together: an alias is the one-target case,
   // and this page is the only place either is managed.
@@ -1505,7 +1511,7 @@ export function RoutingPage() {
         }
       />
 
-      {adding ? (
+      {isAdding ? (
         <PolicyForm
           existing={null}
           initialTarget={initialTarget}
@@ -1516,7 +1522,7 @@ export function RoutingPage() {
         <PolicyForm existing={editing} onClose={() => setEditing(null)} />
       ) : null}
 
-      {rows.length === 0 && !isListLoading && !adding ? (
+      {rows.length === 0 && !isListLoading && !isAdding ? (
         isOperator ? (
           <EmptyState title="No routing policies yet">
             <ol className="flex list-decimal flex-col gap-1 pl-5 text-sm text-muted">

--- a/web/src/features/tools/WorkspaceMcpServersCard.test.tsx
+++ b/web/src/features/tools/WorkspaceMcpServersCard.test.tsx
@@ -343,6 +343,9 @@ describe("WorkspaceMcpServersCard", () => {
     const user = userEvent.setup()
     await renderLoaded(servers)
 
+    // The URL as the server chose to render it for this caller: the service
+    // masks any credential in it for a reader who cannot manage the workspace,
+    // so the card renders what it is given and adds no masking of its own.
     expect(screen.getByText("https://mcp.example.com/github")).toBeVisible()
     // The token stays write-only whoever is reading.
     expect(screen.getByText("Stored")).toBeVisible()

--- a/web/src/features/tools/WorkspaceMcpServersCard.test.tsx
+++ b/web/src/features/tools/WorkspaceMcpServersCard.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import type { WorkspaceMcpServer } from "@/client"
+import type { OrganizationContext, WorkspaceMcpServer } from "@/client"
 import { WorkspaceMcpServersCard } from "@/features/tools/WorkspaceMcpServersCard"
 import { SelectedWorkspaceProvider } from "@/shared/hooks/SelectedWorkspace"
 import { organizationContext, workspaceMcpServer } from "@/tests/fixtures"
@@ -21,11 +21,14 @@ function mockApi({
   servers = [] as WorkspaceMcpServer[],
   writeStatus,
   writeDetail,
+  role = "owner",
 }: {
   memberships?: { workspace_id: string; name: string; role: string }[]
   servers?: WorkspaceMcpServer[]
   writeStatus?: number
   writeDetail?: string
+  // The caller's organization role; a member-view test lowers it.
+  role?: OrganizationContext["role"]
 } = {}): Call[] {
   const calls: Call[] = []
   vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
@@ -52,7 +55,7 @@ function mockApi({
       return Response.json(servers[0] ?? workspaceMcpServer())
     }
     return Response.json(
-      organizationContext({ workspace_memberships: memberships }),
+      organizationContext({ role, workspace_memberships: memberships }),
     )
   })
   return calls
@@ -321,33 +324,42 @@ describe("WorkspaceMcpServersCard", () => {
     )
   })
 
-  it("does not list the servers at all for a member who cannot manage the workspace", async () => {
-    // The read takes the management role server-side, so asking would earn a
-    // 403 over a table that could never fill.
-    const requests: string[] = []
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-      const url = String(input)
-      if (url.includes("/mcp-servers")) {
-        requests.push(url)
-        return new Response("forbidden", { status: 403 })
-      }
-      return Response.json(
-        organizationContext({
-          role: "member",
-          workspace_memberships: [
-            { workspace_id: ALPHA, name: "Alpha", role: "member" },
-          ],
-        }),
-      )
+  it("lists the servers read-only for a member who cannot manage the workspace", async () => {
+    // The list is a member read now (otari-ai#1942): the rows shape every
+    // request the member sends through the workspace. Only the affordances
+    // that change them take the management role.
+    const servers = [
+      workspaceMcpServer({
+        name: "github",
+        url: "https://mcp.example.com/github",
+        has_token: true,
+      }),
+    ]
+    const calls = mockApi({
+      memberships: [{ workspace_id: ALPHA, name: "Alpha", role: "member" }],
+      servers,
+      role: "member",
     })
-    renderCard()
+    const user = userEvent.setup()
+    await renderLoaded(servers)
 
+    expect(screen.getByText("https://mcp.example.com/github")).toBeVisible()
+    // The token stays write-only whoever is reading.
+    expect(screen.getByText("Stored")).toBeVisible()
     expect(
-      await screen.findByText(/managed by an owner or admin/i),
+      screen.getByText(/for an owner or admin of the workspace/),
     ).toBeVisible()
-    expect(requests).toHaveLength(0)
     expect(
-      screen.queryByRole("button", { name: "Add server" }),
+      screen.queryByRole("button", { name: "Add MCP server" }),
     ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Edit" }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Delete" }),
+    ).not.toBeInTheDocument()
+    // Nothing on the page can write, so nothing did.
+    await user.click(screen.getByText("github"))
+    expect(writes(calls)).toHaveLength(0)
   })
 })

--- a/web/src/features/tools/WorkspaceMcpServersCard.tsx
+++ b/web/src/features/tools/WorkspaceMcpServersCard.tsx
@@ -56,13 +56,13 @@ export function WorkspaceMcpServersCard({
 }) {
   const { selected, isLoading: workspaceLoading } = useSelectedWorkspace()
   const context = useOrganizationContext()
-  // The client half of the gate the service enforces, and it gates the *read*
-  // too: these rows name the external endpoints the gateway connects to on the
-  // workspace's behalf, so the service admin-gates listing them as well as
-  // changing them, and asking as a member would earn a 403 banner over a table
-  // that could never fill.
+  // The client half of the *write* gate the service enforces. The list is a
+  // member read now (otari-ai#1942): these servers act on every request the
+  // member sends through the workspace, and the token was never in the rows,
+  // so any member who can see the workspace reads the table and only an owner
+  // or admin gets the affordances that change it.
   const manages = canManageWorkspace(context.data, selected?.role)
-  const workspaceId = selected && manages ? selected.workspace_id : null
+  const workspaceId = selected ? selected.workspace_id : null
   const query = useWorkspaceMcpServers(workspaceId)
   const create = useCreateWorkspaceMcpServer()
   const update = useUpdateWorkspaceMcpServer()
@@ -84,19 +84,6 @@ export function WorkspaceMcpServersCard({
           {workspaceLoading
             ? "Reading the workspaces you belong to."
             : "MCP servers are registered on a workspace you belong to. An owner or admin can add you to one on the Workspaces page."}
-        </InfoBanner>
-      </section>
-    )
-  }
-
-  if (!manages) {
-    return (
-      <section className="flex flex-col gap-2">
-        {heading}
-        <InfoBanner>
-          The MCP servers for {selected.name} are managed by an owner or admin
-          of the workspace, or of the organization. They name endpoints the
-          gateway connects to, so only they can list them.
         </InfoBanner>
       </section>
     )
@@ -186,7 +173,9 @@ export function WorkspaceMcpServersCard({
         </Chip>
       ),
     },
-    {
+  ]
+  if (manages) {
+    columns.push({
       id: "actions",
       header: "",
       cell: (row) => (
@@ -199,16 +188,18 @@ export function WorkspaceMcpServersCard({
           </Button>
         </div>
       ),
-    },
-  ]
+    })
+  }
 
   return (
     <section className="flex flex-col gap-2">
       <div className="flex flex-wrap items-center justify-between gap-2">
         {heading}
-        <Button size="sm" variant="primary" onPress={openAdd}>
-          Add MCP server
-        </Button>
+        {manages ? (
+          <Button size="sm" variant="primary" onPress={openAdd}>
+            Add MCP server
+          </Button>
+        ) : null}
       </div>
 
       <p className="text-sm text-muted">
@@ -217,6 +208,9 @@ export function WorkspaceMcpServersCard({
         request may still pass its own servers inline; these are the ones it
         does not have to carry a URL or a token for. Tokens are stored encrypted
         and are never shown again.
+        {manages
+          ? null
+          : " Registering or changing one is for an owner or admin of the workspace, or of the organization."}
       </p>
 
       <ErrorBanner error={query.error} />
@@ -232,7 +226,11 @@ export function WorkspaceMcpServersCard({
             // Deliberately asserts nothing about the workspace: an empty table
             // is also what a failed request leaves behind, and the banner above
             // is the only thing that knows which of the two happened.
-            emptyContent="No MCP server registered. Add one to let this workspace's requests name it by id."
+            emptyContent={
+              manages
+                ? "No MCP server registered. Add one to let this workspace's requests name it by id."
+                : "No MCP server registered."
+            }
           />
         </Card.Content>
       </Card>

--- a/web/src/shared/api/hooks.ts
+++ b/web/src/shared/api/hooks.ts
@@ -148,6 +148,10 @@ const SEARCH_TOOLS = "search-tools"
 const SEARCH_PROVIDERS = "search-providers"
 const ALIASES = "aliases"
 const ROUTING_POLICIES = "routing-policies"
+// The tenant-scoped sibling of ROUTING_POLICIES. Its own key: the two lists
+// answer different endpoints for different callers, and an operator's policy
+// write invalidates the deployment-wide one it changed.
+const ORGANIZATION_ROUTING_POLICIES = "organization-routing-policies"
 const ROUTER_STATUS = "router-status"
 // Deliberately not nested under MODELS: pricing mutations invalidate that key,
 // and a price change cannot alter which models a provider serves. Sharing the
@@ -271,13 +275,17 @@ export function useGatewayHealth() {
 // Live provider calls, cached gateway-side; kept fresh for the length of a
 // session rather than refetched per open, since the set of models a key can
 // reach does not move minute to minute.
-export function useDiscoverableModels() {
+//
+// `enabled` is the `useToolSettings` composition: the read is
+// deployment-operator-only, so a tenant-facing page declines to ask.
+export function useDiscoverableModels(enabled = true) {
   return useQuery({
     ...NO_RETRY,
     queryKey: [DISCOVERABLE],
     queryFn: () =>
       apiFetch<DiscoverableModelsResponse>("/v1/models/discoverable"),
     staleTime: 5 * 60_000,
+    enabled,
   })
 }
 
@@ -469,12 +477,15 @@ export function useTestProviderCredentials() {
 // Per-model metadata (modalities, capabilities, knowledge cutoff) from the
 // models.dev catalog, keyed by `provider:model`. The gateway fetches and caches
 // it, so this is cheap; kept fresh for a session since the catalog barely moves.
-export function useModelMetadata() {
+// `enabled` is the `useToolSettings` composition: the read is
+// deployment-operator-only, so a tenant-facing page declines to ask.
+export function useModelMetadata(enabled = true) {
   return useQuery({
     ...NO_RETRY,
     queryKey: [METADATA],
     queryFn: () => apiFetch<ModelMetadataResponse>("/v1/models/metadata"),
     staleTime: 10 * 60_000,
+    enabled,
   })
 }
 
@@ -483,20 +494,42 @@ export function useModelMetadata() {
 // resolution reads a process-wide name-keyed cache, so a filtered list would
 // hide live aliases. Leaving the argument here would be a loaded gun beside the
 // comment explaining why it must not be fired.
-export function useAliases() {
+//
+// `enabled` is the `useToolSettings` composition: the read is
+// deployment-operator-only, so a tenant-facing page declines to ask.
+export function useAliases(enabled = true) {
   return useQuery({
     queryKey: [ALIASES],
     queryFn: () => apiFetch<AliasResponse[]>("/v1/aliases"),
     staleTime: 60_000,
+    enabled,
   })
 }
 
-// Unscoped for the same reason as `useAliases` above.
-export function useRoutingPolicies() {
+// Unscoped for the same reason as `useAliases` above, `enabled` too.
+export function useRoutingPolicies(enabled = true) {
   return useQuery({
     queryKey: [ROUTING_POLICIES],
     queryFn: () => apiFetch<RoutingPolicyResponse[]>("/v1/routing/policies"),
     staleTime: 60_000,
+    enabled,
+  })
+}
+
+// The routing policies in force where the caller may see: stored rows from
+// their visible workspaces plus the deployment-wide config ones, the same
+// response shape as `useRoutingPolicies`. This is the read a signed-in member
+// gets (otari-ai#1942); the deployment-wide list above stays operator-only, so
+// the Routing page picks between the two off `isDeploymentOperator`.
+export function useOrganizationRoutingPolicies(enabled = true) {
+  return useQuery({
+    queryKey: [ORGANIZATION_ROUTING_POLICIES],
+    queryFn: () =>
+      apiFetch<RoutingPolicyResponse[]>(
+        "/v1/organizations/me/routing-policies",
+      ),
+    staleTime: 60_000,
+    enabled,
   })
 }
 
@@ -510,6 +543,9 @@ export function useSetRoutingPolicy() {
       }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: [ROUTING_POLICIES] })
+      void queryClient.invalidateQueries({
+        queryKey: [ORGANIZATION_ROUTING_POLICIES],
+      })
       // A policy is listed as a model, so the catalog changes too.
       void queryClient.invalidateQueries({ queryKey: [MODELS] })
     },
@@ -538,6 +574,9 @@ export function useDeleteRoutingPolicy() {
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: [ROUTING_POLICIES] })
+      void queryClient.invalidateQueries({
+        queryKey: [ORGANIZATION_ROUTING_POLICIES],
+      })
       void queryClient.invalidateQueries({ queryKey: [MODELS] })
     },
   })
@@ -638,11 +677,14 @@ export function useDeleteAlias() {
   })
 }
 
-export function useSettings() {
+// `enabled` is the `useToolSettings` composition: the read is
+// deployment-operator-only, so a tenant-facing page declines to ask.
+export function useSettings(enabled = true) {
   return useQuery({
     queryKey: [SETTINGS],
     queryFn: () => apiFetch<GatewaySettings>("/v1/settings"),
     staleTime: 60_000,
+    enabled,
   })
 }
 


### PR DESCRIPTION
## Description

Per the roles matrix behind mozilla-ai/otari-ai#1942, everything under the Build section (Models, Routing, Guardrails, Tools) should be View for members and Edit for operators, and the section itself is named Build. Today Models and Routing are operator-hidden outright, the routing read is operator-only on the server, and the workspace MCP server list refuses members by design.

**Navigation**
- The workspace rail's "Gateway" section is relabeled **Build**; the id stays `gateway`, the key overlay contributions and label overrides address.
- The Models and Routing rows drop `operatorOnly: "refused"`, following the sanctioned exit from that list (a page ceasing to refuse anyone, as Activity and Usage did in #837): `GET /v1/models` and `GET /v1/pricing` already serve any session, and Routing gains a member read below.

**Models (frontend only)**
- The operator-only reads (`/v1/models/discoverable`, `/v1/models/metadata`, `/v1/settings`) take the `enabled` composition #864 established and are withheld from non-operators instead of firing into 403 banners.
- For a member the page is the read-only catalog: price cells render as text, selection and bulk pricing are off, the detail panel keeps the rates and drops set/edit/reset, and the pricing-policy tooltip (which reads `/v1/settings`) self-gates.

**Routing**
- New tenant-scoped read: `GET /v1/organizations/me/routing-policies`, shaped like `organization_usage.py` (#837). The scope is derived from the caller's membership via `resolve_visible_workspace_scope`, never accepted from the request; it returns stored policies from visible workspaces plus the deployment-wide config ones, in the `PolicyResponse` shape. The deployment-wide `GET /v1/routing/policies` stays operator-only, unchanged.
- The Routing page picks its list off `deployment_operator`: operators keep the management view and full CRUD; members get the scoped list read-only, with no actions column (the Examples panel reads the operator-only `/v1/routing/status`) and no alias rows (aliases have no tenant-scoped sibling yet).
- `tests/integration/test_organization_routing_policies_scope.py` covers the scope cross-tenant, modeled on the usage-scope suite, including the control that the deployment-wide route still refuses a tenant.

**MCP servers**
- `WorkspaceMcpServerService.list_servers` now gates on workspace visibility rather than management access; every write keeps `_require_management`. The rows never carried the token (`has_token` only), and these servers already act on every request a member sends through the workspace. The card shows members the table without the add/edit/delete affordances; `docs/mcp.md` and the service docstrings are updated to match the decision the issue records.

**Deliberately out of scope**, per the issue's open questions: filtering a member's model list by provider access (no backend for it yet), a member view of the deployment-global `/v1/tool-settings` (deployment infrastructure config; needs the same tenant-scoping decision the issue flags for hosted mode), and tenant-scoped admin *edit* of models/routing (the issue's explicit open question). #864 already fixed the Tools pages being broken for non-operators (otari-ai#1930).

Also classifies the new endpoint in `scripts/sdk_codegen/sdk-endpoints.txt` (dashboard-only), regenerates the OpenAPI spec, Postman collection, and dashboard client, and updates the stale row counts and gating prose in `web/AGENTS.md`.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Part of mozilla-ai/otari-ai#1942 (member View for the Build pages; the Edit-scope question and the two follow-ups above remain there).

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code (Claude Fable 5)

**Any additional AI details you'd like to share:**

Implemented, tested, and self-reviewed by the agent; scope decisions follow the roles matrix and the repo's #837 precedent for tenant-scoped sibling reads.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Renamed the workspace rail section from “Gateway” to “Build”.
- Added member access to read-only Models and Routing views.
- Added tenant-scoped routing policy reads through `GET /v1/organizations/me/routing-policies`.
- Allowed workspace members to view MCP server lists while keeping changes restricted to administrators.
- Redacted MCP server URL secrets for members.
- Updated navigation, API clients, documentation, Postman collections, and tests.
- Preserved operator-only model management, routing changes, and deployment-wide settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->