### PR TITLE
fix(dashboard): name the person at the foot of the sidebar, not their role

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1574,6 +1574,43 @@
         "title": "BudgetResponse",
         "type": "object"
       },
+      "CallerIdentityPublic": {
+        "description": "Who the caller is, as against what they may do.\n\nThe account control at the foot of the dashboard's sidebar draws a person,\nand no authenticated route reported the caller's own name or address, so it\ndrew a role for everybody who could reach it: \"Operator\", which is not a\nname and on a multi-tenant deployment was not even true\n(mozilla-ai/otari#832).\n\nCarried on the membership context for the reason ``deployment_operator`` is:\nthe shell reads that context before it paints, so an identity taken from it\nneeds no request of its own and cannot arrive a beat after the chrome it\nnames. Publishing it costs nothing either, since it is the caller's own\nidentity and they are holding the credential that resolved to it.\n\nBoth fields are nullable, and for opposite reasons. A local operator\nidentity has no address, because first boot provisions it with a name and\nnothing to sign in with but the master key; a member added to the roster by\naddress has no name until they claim the identity and supply one. So a shell\nhas to be ready to draw either one alone.",
+        "properties": {
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Full Name"
+          },
+          "user_id": {
+            "format": "uuid",
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id"
+        ],
+        "title": "CallerIdentityPublic",
+        "type": "object"
+      },
       "CallerOrganizationMembershipPublic": {
         "description": "One organization the caller belongs to, and their standing in it.\n\nWhat an organization switcher renders. Deliberately not\n``OrganizationMembershipContextPublic``: that one answers \"the organization\nthis request is acting in\" and carries the caller's workspaces in it, which\nfor an organization they are not currently in would be a second read per\nrow.",
         "properties": {
@@ -6242,6 +6279,16 @@
             "default": false,
             "title": "Byo Provider Keys Allowed",
             "type": "boolean"
+          },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CallerIdentityPublic"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "deployment_operator": {
             "default": false,

--- a/src/gateway/models/tenancy.py
+++ b/src/gateway/models/tenancy.py
@@ -481,6 +481,33 @@ class CallerWorkspaceMembershipPublic(SQLModel):
     role: str
 
 
+class CallerIdentityPublic(SQLModel):
+    """Who the caller is, as against what they may do.
+
+    The account control at the foot of the dashboard's sidebar draws a person,
+    and no authenticated route reported the caller's own name or address, so it
+    drew a role for everybody who could reach it: "Operator", which is not a
+    name and on a multi-tenant deployment was not even true
+    (mozilla-ai/otari#832).
+
+    Carried on the membership context for the reason ``deployment_operator`` is:
+    the shell reads that context before it paints, so an identity taken from it
+    needs no request of its own and cannot arrive a beat after the chrome it
+    names. Publishing it costs nothing either, since it is the caller's own
+    identity and they are holding the credential that resolved to it.
+
+    Both fields are nullable, and for opposite reasons. A local operator
+    identity has no address, because first boot provisions it with a name and
+    nothing to sign in with but the master key; a member added to the roster by
+    address has no name until they claim the identity and supply one. So a shell
+    has to be ready to draw either one alone.
+    """
+
+    user_id: uuid.UUID
+    email: str | None = None
+    full_name: str | None = None
+
+
 class OrganizationMembershipContextPublic(SQLModel):
     """An organization plus the caller's standing in it.
 
@@ -493,6 +520,12 @@ class OrganizationMembershipContextPublic(SQLModel):
     status: str
     organization: OrganizationPublic
     workspace_memberships: list[CallerWorkspaceMembershipPublic] = Field(default_factory=list)
+    # Who is signed in, which every other field here describes the authority of
+    # rather than the person holding it. Optional like the fields below it, and
+    # for the same reason: a shell reading a deployment that predates this (or a
+    # platform serving this contract without it) falls back to naming nobody,
+    # rather than failing to parse the context the rest of the chrome needs.
+    caller: CallerIdentityPublic | None = None
     # Whether the dashboard may offer the BYO provider-keys surface. The
     # platform answers "does this org have a self-hosted gateway attached", which
     # in a standalone deployment is always yes: the deployment reading this *is*

--- a/src/gateway/services/tenancy/organization_service.py
+++ b/src/gateway/services/tenancy/organization_service.py
@@ -50,6 +50,7 @@ from gateway.models.tenancy import (
     ActiveOrganizationMemberPublic,
     ActiveOrganizationMembersPublic,
     ActiveOrganizationMemberUpdateRequest,
+    CallerIdentityPublic,
     CallerOrganizationMembershipPublic,
     CallerOrganizationMembershipsPublic,
     CallerWorkspaceMembershipPublic,
@@ -252,6 +253,11 @@ class OrganizationService:
             status=membership.status,
             organization=OrganizationPublic.model_validate(organization),
             workspace_memberships=workspace_memberships,
+            caller=CallerIdentityPublic(
+                user_id=user.id,
+                email=user.email,
+                full_name=user.full_name,
+            ),
             # The platform answers "does this org have a self-hosted gateway
             # attached". A standalone deployment reading this *is* that gateway,
             # so its own provider credentials are always available to it.

--- a/tests/integration/test_organization_usage_scope.py
+++ b/tests/integration/test_organization_usage_scope.py
@@ -545,6 +545,45 @@ def test_every_response_carrying_the_context_carries_the_operator_answer(
         assert renamed.json()["deployment_operator"] is expected, who
 
 
+def test_the_context_names_the_caller_it_describes(client: TestClient, world: _World) -> None:
+    """The identity behind the standing, which is what a shell draws a person from.
+
+    Nothing else on this contract says *who* is signed in, so the dashboard's
+    account control had no name to show and showed a role instead (otari#832).
+    Asserted per identity rather than for shape alone: a field filled from the
+    wrong identity is the failure that matters here, and one filled from a
+    constant would satisfy a shape check.
+    """
+    for who, email in (
+        ("alpha_owner", "owner@alpha.test"),
+        ("alpha_member", "member@alpha.test"),
+        ("superuser", "root@beta.test"),
+    ):
+        code, body = _as(client, world, who, "/v1/organizations/me")
+        assert code == status.HTTP_200_OK, body
+        assert isinstance(body, dict)
+        caller = body["caller"]
+        assert caller["user_id"] == str(world.users[who]), who
+        assert caller["email"] == email, who
+        # What `_identity` gives every one of them: the address's local part.
+        assert caller["full_name"] == email.split("@")[0].title(), who
+
+
+def test_the_context_names_an_identity_that_holds_no_address(
+    client: TestClient, world: _World, master_key_header: dict[str, str]
+) -> None:
+    """The local operator, which is the identity a standalone first boot leaves behind.
+
+    It has a name and no email, so a shell that assumed an address would have
+    nothing to draw for the one caller every standalone deployment has.
+    """
+    response = client.get("/v1/organizations/me", headers=master_key_header)
+    assert response.status_code == status.HTTP_200_OK, response.text
+    caller = response.json()["caller"]
+    assert caller["email"] is None
+    assert caller["full_name"]
+
+
 def test_the_context_reports_whether_provider_keys_can_be_encrypted(client: TestClient, world: _World) -> None:
     """A deployment fact a tenant is allowed to know, because it decides whether their own write works.
 

--- a/web/src/app/AppShell.test.tsx
+++ b/web/src/app/AppShell.test.tsx
@@ -1064,7 +1064,7 @@ describe("AppShell entitlement gating", () => {
 
     // The header carried this until the sidebar grew an account block.
     expect(screen.queryByRole("button", { name: "Log out" })).toBeNull()
-    await user.click(screen.getByRole("button", { name: "Account" }))
+    await user.click(screen.getByRole("button", { name: /^Account:/ }))
     expect(
       await screen.findByRole("button", { name: "Log out" }),
     ).toBeInTheDocument()
@@ -1079,7 +1079,7 @@ describe("AppShell entitlement gating", () => {
     // mobile drawer contains, so without this row the guide has no control
     // pointing at it below the breakpoint. The row carries `md:hidden` for the
     // mirror-image reason: above it, the top bar already answers.
-    await user.click(screen.getByRole("button", { name: "Account" }))
+    await user.click(screen.getByRole("button", { name: /^Account:/ }))
     const guideRow = await screen.findByRole("link", { name: "Documentation" })
     expect(guideRow).toHaveAttribute("href", "/docs")
     expect(guideRow).toHaveClass("md:hidden")

--- a/web/src/app/nav/AccountMenu.test.tsx
+++ b/web/src/app/nav/AccountMenu.test.tsx
@@ -1,28 +1,81 @@
 import { screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { AccountMenu } from "@/app/nav/AccountMenu"
+import type { DeploymentBootstrap, OrganizationContext } from "@/client"
+import { useOrganizationContext } from "@/shared/api/hooks"
 import { DeploymentProvider } from "@/shared/hooks/useDeployment"
-import { bootstrap } from "@/tests/fixtures"
+import {
+  bootstrap,
+  HOSTED_SURFACES,
+  organizationContext,
+} from "@/tests/fixtures"
 import { AppProviders } from "@/tests/providers"
 import { renderWithRouter } from "@/tests/router"
 
+// The trigger names the person, and the person is a field on the membership
+// context, so it is stubbed at fetch like the sidebar's own read of it. Every
+// case installs one, including the ones about the menu's rows: the component
+// makes that request either way, and an unstubbed `fetch` would leave it
+// failing in the background of a test that is not about it.
+function mockCaller(caller: OrganizationContext["caller"]) {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+    Response.json(organizationContext({ caller })),
+  )
+}
+
+// The identity a standalone first boot leaves behind, which the fixture already
+// describes: a name and no address.
+const OPERATOR = organizationContext().caller
+
+// The other thing that read can do. The trigger names nobody rather than
+// guessing, for the same reason it does before the answer lands.
+function mockCallerUnavailable() {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+    Response.json({ detail: "boom" }, { status: 403 }),
+  )
+}
+
+// The trigger reads "Signed in" both before the caller lands and after a read
+// that could not name them, so a case about the second has to observe the
+// settled read rather than the first paint. This probe, mounted beside the menu
+// on the same query, is what those cases wait on.
+function CallerProbe() {
+  const { isSuccess, isError } = useOrganizationContext()
+  return <span>{isSuccess || isError ? "standing settled" : "asking"}</span>
+}
+
 // The menu holds a router Link, so it needs a real router; `renderWithRouter`
 // mounts it at "/" and resolves the first location before the assertions run.
-async function openMenu(overrides: Partial<{ docs_url: string | null }> = {}) {
+async function renderMenu(overrides: Partial<DeploymentBootstrap> = {}) {
   await renderWithRouter(
     <AppProviders>
       <DeploymentProvider value={bootstrap(overrides)}>
         <AccountMenu collapsed={false} />
+        <CallerProbe />
       </DeploymentProvider>
     </AppProviders>,
   )
+}
+
+/** Wait for the caller to have been answered, one way or the other. */
+function settled(): Promise<HTMLElement> {
+  return screen.findByText("standing settled")
+}
+
+async function openMenu(overrides: Partial<DeploymentBootstrap> = {}) {
+  await renderMenu(overrides)
   await userEvent.setup().click(screen.getByRole("button", { name: "Account" }))
 }
 
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
 describe("AccountMenu", () => {
   it("opens the account page, rather than naming a destination it cannot reach", async () => {
+    mockCaller(OPERATOR)
     await openMenu()
 
     const link = await screen.findByRole("link", { name: "Account settings" })
@@ -30,6 +83,7 @@ describe("AccountMenu", () => {
   })
 
   it("keeps the bundled guide reachable on a phone when no docs site is configured", async () => {
+    mockCaller(OPERATOR)
     await openMenu()
 
     const link = await screen.findByRole("link", { name: "Documentation" })
@@ -38,6 +92,7 @@ describe("AccountMenu", () => {
   })
 
   it("retargets the phone's Documentation row at the deployment's own docs site", async () => {
+    mockCaller(OPERATOR)
     await openMenu({ docs_url: "https://docs.otari.ai/en/" })
 
     const link = await screen.findByRole("link", { name: "Documentation" })
@@ -47,5 +102,85 @@ describe("AccountMenu", () => {
     // point: retargeting it must not make it visible where the cluster already
     // draws one.
     expect(link).toHaveClass("md:hidden")
+  })
+
+  // The bug in #832: the trigger named a standing rather than a person, and the
+  // standing it named came from the bootstrap, which says what kind of session
+  // the deployment issues and not who holds this one. So every signed-in member
+  // of a hosted deployment was told they were the operator.
+  it("names the person signed in to a hosted deployment, not a role", async () => {
+    mockCaller({
+      user_id: "44444444-4444-4444-4444-444444444444",
+      email: "ada@example.com",
+      full_name: "Ada Lovelace",
+    })
+    await renderMenu({ deployment_type: "hosted", surfaces: HOSTED_SURFACES })
+
+    expect(await screen.findByText("Ada Lovelace")).toBeInTheDocument()
+    expect(screen.getByText("AL")).toBeInTheDocument()
+    expect(screen.queryByText("Operator")).not.toBeInTheDocument()
+  })
+
+  // Unchanged for the deployment that has one identity, and for a reason worth
+  // pinning: "Operator" is what first boot *names* that identity, so the word
+  // survives as a name where it used to stand in for one.
+  it("still names the operator of a standalone gateway, whose name that is", async () => {
+    mockCaller(OPERATOR)
+    await renderMenu()
+
+    expect(await screen.findByText("Operator")).toBeInTheDocument()
+    expect(screen.getByText("OP")).toBeInTheDocument()
+  })
+
+  // A member added to the roster by address has no name until they claim the
+  // identity, so the address is what identifies them.
+  it("falls back to the address of a member who has not claimed a name", async () => {
+    mockCaller({
+      user_id: "55555555-5555-5555-5555-555555555555",
+      email: "ada.lovelace@example.com",
+      full_name: null,
+    })
+    await renderMenu()
+
+    expect(
+      await screen.findByText("ada.lovelace@example.com"),
+    ).toBeInTheDocument()
+    // Off the local part, and split on its punctuation: the host names the
+    // deployment rather than the person.
+    expect(screen.getByText("AL")).toBeInTheDocument()
+  })
+
+  // Initials are two characters, not two UTF-16 code units: a name outside the
+  // basic plane is two units per character, so indexing one would put half a
+  // surrogate pair in the avatar and draw the replacement mark.
+  it("takes initials by character, so a name outside the basic plane survives", async () => {
+    mockCaller({
+      user_id: "66666666-6666-6666-6666-666666666666",
+      email: null,
+      full_name: "\u{20BB7}\u7530 \u592a\u90ce",
+    })
+    await renderMenu()
+
+    expect(
+      await screen.findByText("\u{20BB7}\u7530 \u592a\u90ce"),
+    ).toBeInTheDocument()
+    expect(screen.getByText("\u{20BB7}\u592a")).toBeInTheDocument()
+  })
+
+  it("names nobody when the caller cannot be read", async () => {
+    mockCallerUnavailable()
+    await renderMenu()
+    await settled()
+
+    expect(screen.getByText("Signed in")).toBeInTheDocument()
+    expect(screen.getByText("··")).toBeInTheDocument()
+  })
+
+  it("names nobody when the deployment reports no identity at all", async () => {
+    mockCaller(undefined)
+    await renderMenu()
+    await settled()
+
+    expect(screen.getByText("Signed in")).toBeInTheDocument()
   })
 })

--- a/web/src/app/nav/AccountMenu.test.tsx
+++ b/web/src/app/nav/AccountMenu.test.tsx
@@ -66,7 +66,11 @@ function settled(): Promise<HTMLElement> {
 
 async function openMenu(overrides: Partial<DeploymentBootstrap> = {}) {
   await renderMenu(overrides)
-  await userEvent.setup().click(screen.getByRole("button", { name: "Account" }))
+  // The trigger's accessible name carries who is signed in, so it is matched on
+  // its prefix rather than in full.
+  await userEvent
+    .setup()
+    .click(screen.getByRole("button", { name: /^Account:/ }))
 }
 
 afterEach(() => {
@@ -148,6 +152,36 @@ describe("AccountMenu", () => {
     // Off the local part, and split on its punctuation: the host names the
     // deployment rather than the person.
     expect(screen.getByText("AL")).toBeInTheDocument()
+  })
+
+  // A name is split on spaces alone. The address path below splits punctuation
+  // too, and one rule for both would initial a hyphenated surname off its
+  // second half.
+  it("initials a hyphenated surname off the name it belongs to", async () => {
+    mockCaller({
+      user_id: "77777777-7777-7777-7777-777777777777",
+      email: null,
+      full_name: "Ada Lovelace-Byron",
+    })
+    await renderMenu()
+
+    expect(await screen.findByText("Ada Lovelace-Byron")).toBeInTheDocument()
+    expect(screen.getByText("AL")).toBeInTheDocument()
+  })
+
+  // The label is the visible half of #832's fix; this is the half a screen
+  // reader gets, and on the collapsed rail it is the only half there is.
+  it("names the person in the trigger's accessible name too", async () => {
+    mockCaller({
+      user_id: "88888888-8888-8888-8888-888888888888",
+      email: "ada@example.com",
+      full_name: "Ada Lovelace",
+    })
+    await renderMenu()
+
+    expect(
+      await screen.findByRole("button", { name: "Account: Ada Lovelace" }),
+    ).toBeInTheDocument()
   })
 
   // Initials are two characters, not two UTF-16 code units: a name outside the

--- a/web/src/app/nav/AccountMenu.tsx
+++ b/web/src/app/nav/AccountMenu.tsx
@@ -83,7 +83,7 @@ const MENU_DIVIDER = "h-px shrink-0 bg-border"
 // name: first boot provisions the identity with it (`OPERATOR_FULL_NAME`), and
 // the roster shows the same word in the same place.
 //
-// Three fallbacks, each for a real identity this deployment can hold. A member
+// Three answers, each for a real identity this deployment can hold. A member
 // added to the roster by address has no name until they claim it, so the
 // address stands in and is a better answer than a role. An identity with
 // neither, and a context that has not landed or could not be read, get
@@ -94,14 +94,23 @@ function sessionIdentity(caller: OrganizationContext["caller"]): {
   initials: string
 } {
   const named = caller?.full_name?.trim()
-  const addressed = caller?.email?.trim()
-  const name = named || addressed
-  if (!name) {
-    return { name: "Signed in", initials: "··" }
+  if (named) {
+    return { name: named, initials: initialsFor(named) }
   }
-  // `||`, not `??`: a name that is only whitespace trims to "" and has already
-  // lost the `name` slot to the address, so it must not keep the initials.
-  return { name, initials: initialsFor(named || localPart(name)) }
+  const addressed = caller?.email?.trim()
+  if (addressed) {
+    // An address has no words to take initials from, so its local part stands
+    // in, and that part is split on its own punctuation as well: an address
+    // spells a name with dots where a name uses spaces, so `ada.lovelace@…`
+    // initials as AL. A name is split on spaces alone, because the same
+    // punctuation means something else in one: `Ada Lovelace-Byron` is two
+    // names, and splitting the hyphen would initial her as AB.
+    return {
+      name: addressed,
+      initials: initialsFor(localPart(addressed), true),
+    }
+  }
+  return { name: "Signed in", initials: "··" }
 }
 
 /** The part of an address that names a person, which is the part before the host. */
@@ -110,16 +119,16 @@ function localPart(email: string): string {
 }
 
 // Two letters, taken the way an avatar takes them: the first letter of the
-// first and last word for a name in parts, and the first two letters of a name
-// that is one word. Addresses are split on their punctuation as well as on
-// spaces, so `ada.lovelace@…` initials as AL rather than AD.
+// first and last word, and the first two letters of a source that is one word.
 //
 // Counted in characters rather than in the code units `[0]` and `slice` count,
 // because a name outside the basic plane (an extension-B CJK character, an
 // emoji) is two units per character: indexing one takes half a surrogate pair
 // and the avatar draws the replacement mark instead of the letter.
-function initialsFor(source: string): string {
-  const words = source.split(/[\s._-]+/).filter(Boolean)
+function initialsFor(source: string, splitPunctuation = false): string {
+  const words = source
+    .split(splitPunctuation ? /[\s._-]+/ : /\s+/)
+    .filter(Boolean)
   if (words.length === 0) {
     return "··"
   }
@@ -289,7 +298,13 @@ export function AccountMenu({ collapsed }: { collapsed: boolean }) {
           otherwise leaves this a pill in the corner. */}
       <Button
         variant="ghost"
-        aria-label="Account"
+        // The identity this control exists to draw, folded into the name: a
+        // static `aria-label` wins over the children, so a screen reader
+        // otherwise hears "Account" and never who is signed in. On the
+        // collapsed rail the name is not rendered at all, so this is the only
+        // place it could reach anybody there. `AppearanceControl` folds its own
+        // visible state in for the same reason.
+        aria-label={`Account: ${identity.name}`}
         className={`${navRowClass({ collapsed })} w-auto! justify-start`}
       >
         <span className="flex h-[1.625rem] w-[1.625rem] shrink-0 items-center justify-center rounded-full border border-border bg-surface-alt text-chrome-initials font-semibold text-muted">

--- a/web/src/app/nav/AccountMenu.tsx
+++ b/web/src/app/nav/AccountMenu.tsx
@@ -12,8 +12,9 @@ import {
   FiShield,
 } from "react-icons/fi"
 
-import type { DeploymentBootstrap } from "@/client"
+import type { OrganizationContext } from "@/client"
 import { useAuth } from "@/features/auth/AuthContext"
+import { useOrganizationContext } from "@/shared/api/hooks"
 import { EntitlementGate } from "@/shared/components/EntitlementGate"
 import { useDeployment } from "@/shared/hooks/useDeployment"
 import {
@@ -69,18 +70,64 @@ const MENU_ROW_DISABLED = "cursor-not-allowed text-muted opacity-60"
 const MENU_ICON_CLASS = `${NAV_ICON_CLASS} text-muted`
 const MENU_DIVIDER = "h-px shrink-0 bg-border"
 
-// Whose session this is, as the trigger at the foot of the rail names it. A
-// standalone gateway issues one, for the operator identity it provisioned
-// itself, and no management route reports the caller's own name or address, so
-// this is the most it can honestly say.
-function sessionIdentity(sessionType: DeploymentBootstrap["session_type"]): {
+// Whose session this is, as the trigger at the foot of the rail names it: the
+// person, not their standing. It used to name a standing, because nothing
+// authenticated reported the caller's own identity and the bootstrap's
+// `session_type` was the only thing to hand; keyed on that, the trigger read
+// "Operator" for every signed-in caller, which is a role rather than a name and
+// on a hosted deployment was not even true of the person reading it (#832).
+// `OrganizationMembershipContextPublic.caller` is the identity itself, on the
+// read `AppShellChrome` already makes, so naming the person costs no request.
+//
+// A standalone operator still reads "Operator", now because that *is* their
+// name: first boot provisions the identity with it (`OPERATOR_FULL_NAME`), and
+// the roster shows the same word in the same place.
+//
+// Three fallbacks, each for a real identity this deployment can hold. A member
+// added to the roster by address has no name until they claim it, so the
+// address stands in and is a better answer than a role. An identity with
+// neither, and a context that has not landed or could not be read, get
+// "Signed in": naming nobody is the honest answer, and it is what the trigger
+// showed before the first paint anyway.
+function sessionIdentity(caller: OrganizationContext["caller"]): {
   name: string
   initials: string
 } {
-  if (sessionType === "local_operator") {
-    return { name: "Operator", initials: "OP" }
+  const named = caller?.full_name?.trim()
+  const addressed = caller?.email?.trim()
+  const name = named || addressed
+  if (!name) {
+    return { name: "Signed in", initials: "··" }
   }
-  return { name: "Signed in", initials: "··" }
+  // `||`, not `??`: a name that is only whitespace trims to "" and has already
+  // lost the `name` slot to the address, so it must not keep the initials.
+  return { name, initials: initialsFor(named || localPart(name)) }
+}
+
+/** The part of an address that names a person, which is the part before the host. */
+function localPart(email: string): string {
+  return email.split("@")[0] ?? email
+}
+
+// Two letters, taken the way an avatar takes them: the first letter of the
+// first and last word for a name in parts, and the first two letters of a name
+// that is one word. Addresses are split on their punctuation as well as on
+// spaces, so `ada.lovelace@…` initials as AL rather than AD.
+//
+// Counted in characters rather than in the code units `[0]` and `slice` count,
+// because a name outside the basic plane (an extension-B CJK character, an
+// emoji) is two units per character: indexing one takes half a surrogate pair
+// and the avatar draws the replacement mark instead of the letter.
+function initialsFor(source: string): string {
+  const words = source.split(/[\s._-]+/).filter(Boolean)
+  if (words.length === 0) {
+    return "··"
+  }
+  const first = Array.from(words[0])
+  const last = Array.from(words[words.length - 1])
+  const letters =
+    words.length > 1 ? `${first[0]}${last[0]}` : first.slice(0, 2).join("")
+  return letters.toUpperCase()
 }
 
 function MenuItem({
@@ -229,9 +276,10 @@ function AppearanceControl() {
 
 export function AccountMenu({ collapsed }: { collapsed: boolean }) {
   const { logout } = useAuth()
-  const { session_type, management_url, docs_url } = useDeployment()
+  const { management_url, docs_url } = useDeployment()
+  const organization = useOrganizationContext()
   const [open, setOpen] = useState(false)
-  const identity = sessionIdentity(session_type)
+  const identity = sessionIdentity(organization.data?.caller)
 
   return (
     <Popover isOpen={open} onOpenChange={setOpen}>

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -4624,6 +4624,39 @@ export interface components {
             user_count: number;
         };
         /**
+         * CallerIdentityPublic
+         * @description Who the caller is, as against what they may do.
+         *
+         *     The account control at the foot of the dashboard's sidebar draws a person,
+         *     and no authenticated route reported the caller's own name or address, so it
+         *     drew a role for everybody who could reach it: "Operator", which is not a
+         *     name and on a multi-tenant deployment was not even true
+         *     (mozilla-ai/otari#832).
+         *
+         *     Carried on the membership context for the reason ``deployment_operator`` is:
+         *     the shell reads that context before it paints, so an identity taken from it
+         *     needs no request of its own and cannot arrive a beat after the chrome it
+         *     names. Publishing it costs nothing either, since it is the caller's own
+         *     identity and they are holding the credential that resolved to it.
+         *
+         *     Both fields are nullable, and for opposite reasons. A local operator
+         *     identity has no address, because first boot provisions it with a name and
+         *     nothing to sign in with but the master key; a member added to the roster by
+         *     address has no name until they claim the identity and supply one. So a shell
+         *     has to be ready to draw either one alone.
+         */
+        CallerIdentityPublic: {
+            /** Email */
+            email?: string | null;
+            /** Full Name */
+            full_name?: string | null;
+            /**
+             * User Id
+             * Format: uuid
+             */
+            user_id: string;
+        };
+        /**
          * CallerOrganizationMembershipPublic
          * @description One organization the caller belongs to, and their standing in it.
          *
@@ -6766,6 +6799,7 @@ export interface components {
              * @default false
              */
             byo_provider_keys_allowed: boolean;
+            caller?: components["schemas"]["CallerIdentityPublic"] | null;
             /**
              * Deployment Operator
              * @default false

--- a/web/src/shared/hooks/useDeployment.tsx
+++ b/web/src/shared/hooks/useDeployment.tsx
@@ -24,11 +24,10 @@
  * password claims the deployment (otari#702), so a member changing theirs on an
  * unclaimed one gets `false` and nothing here moves. Every consumer of that
  * fact has to move together, or the tab that claimed keeps a sign-in screen
- * offering the credential the gateway now refuses, an account menu naming a
- * session kind that ended, and a password page that asks to claim a deployment
- * already claimed. So the claim
- * reports itself through `useRetireMasterKeySignIn` and this provider serves
- * the corrected bootstrap from then on.
+ * offering the credential the gateway now refuses and a password page that asks
+ * to claim a deployment already claimed. So the claim reports itself through
+ * `useRetireMasterKeySignIn` and this provider serves the corrected bootstrap
+ * from then on.
  *
  * Registering the first passkey, or deleting the last one, is the second
  * (otari#652): the gateway publishes `passkey` exactly while some credential

--- a/web/src/tests/fixtures.ts
+++ b/web/src/tests/fixtures.ts
@@ -168,6 +168,14 @@ export function organizationContext(
 ): OrganizationContext {
   return {
     organization_member_id: "22222222-2222-2222-2222-222222222222",
+    // The identity a standalone first boot provisions: a name (OPERATOR_FULL_NAME
+    // in provisioning_service.py) and no address, since the master key is what
+    // signs it in. A test about a rostered member overrides it.
+    caller: {
+      user_id: "33333333-3333-3333-3333-333333333333",
+      email: null,
+      full_name: "Operator",
+    },
     role: "owner",
     status: "active",
     organization: organization(),


### PR DESCRIPTION
## Description

The little account button at the bottom of the sidebar called everybody "Operator". That is a job, not a name, and on a shared deployment it was not even true: the button was reading a value that describes what kind of sign-in the whole deployment uses, which says the same thing for every person, so an ordinary member logging in was told they run the place. The reason it showed a job title at all is that nothing the dashboard could ask told it who was signed in. Now the server includes the signed-in person's own name and address in an answer the dashboard already asks for on every page load, and the button shows the person: their name, or their email address if they have not set a name yet. Someone who signs in to a single-user gateway still sees "Operator", because that is the name the gateway gives that account when it first sets itself up.

`GET /v1/organizations/me` gains `caller` (`user_id`, `email`, `full_name`), beside the standing fields it already publishes. It goes there rather than on a route of its own for the reason `deployment_operator` did in #852: the shell reads that context before it paints, so an identity taken from it costs no request and cannot arrive a beat after the chrome it names. Both name fields are nullable, because a local operator identity has no address and a member added to the roster by address has no name until they claim it, so the trigger falls back address-then-"Signed in".

This closes both halves of #832, not just the first: the issue's suggested one-line fix (key the label on `deployment_type`) would have stopped the false claim while still showing a role, and would still have mislabeled a standalone member who does not operate the deployment.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #832

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Two integration cases pin the new field (per-identity, and the address-less local operator); five component cases pin what the trigger draws. Also smoke-tested in a browser against a real gateway serving the built bundle: the operator's session reads "Operator", and an ordinary rostered member's reads their own address.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via the Claude Code CLI.

**Any additional AI details you'd like to share:**

Implementation, tests and the smoke run were done by the model in back-and-forth with @njbrake, who directed the approach: show the person's name, since "Operator" is a role.

- [x] I am an AI Agent filling out this form (check box if true)
