### PR TITLE
feat(dashboard): publish the deployment's legal page addresses

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -249,9 +249,8 @@ privacy_url: "https://example.com/privacy"
 Each is independent. Unset, the Terms of service row is absent and the Data &
 Privacy row stays disabled. A deployment whose dashboard sits beside a site that
 owns the documents points at that site. `GET /v1/bootstrap` publishes both
-addresses unauthenticated, so do not put a credential in either; unlike
-`data_plane_url`, which refuses one, these are checked only for an absolute
-HTTP or HTTPS scheme.
+addresses unauthenticated, so a credential in either is refused at startup, the
+way `data_plane_url` refuses one. The same check covers `docs_url`.
 
 ## The data-plane address
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -234,6 +234,23 @@ By default the dashboard's Documentation link opens the bundled guide at
 `/#/docs`. Set `docs_url` or `OTARI_DOCS_URL` to point it at an absolute
 HTTP or HTTPS URL. The bundled guide remains available.
 
+## Legal pages
+
+The account menu carries a Terms of service row and a Data & Privacy row for
+whichever of them this deployment has published. Set `terms_url` or
+`OTARI_TERMS_URL`, and `privacy_url` or `OTARI_PRIVACY_URL`, to absolute HTTP or
+HTTPS URLs:
+
+```yaml
+terms_url: "https://example.com/terms"
+privacy_url: "https://example.com/privacy"
+```
+
+Each is independent. Unset, the Terms of service row is absent and the Data &
+Privacy row stays disabled. A deployment whose dashboard sits beside a site that
+owns the documents points at that site; `GET /v1/bootstrap` publishes both
+addresses unauthenticated, so neither may carry a credential.
+
 ## The data-plane address
 
 A hosted control plane does not serve inference. Set `data_plane_url` or

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -248,8 +248,10 @@ privacy_url: "https://example.com/privacy"
 
 Each is independent. Unset, the Terms of service row is absent and the Data &
 Privacy row stays disabled. A deployment whose dashboard sits beside a site that
-owns the documents points at that site; `GET /v1/bootstrap` publishes both
-addresses unauthenticated, so neither may carry a credential.
+owns the documents points at that site. `GET /v1/bootstrap` publishes both
+addresses unauthenticated, so do not put a credential in either; unlike
+`data_plane_url`, which refuses one, these are checked only for an absolute
+HTTP or HTTPS scheme.
 
 ## The data-plane address
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -126,6 +126,12 @@ This guide is bundled into the dashboard at `/#/docs`. Set `docs_url` to make
 the dashboard's Documentation link open a different site. The bundled route
 remains available.
 
+## Legal pages
+
+`terms_url` and `privacy_url` name where this deployment's terms of service and
+privacy notice live. The account menu links each row it has an address for; see
+[Configuration](configuration.md#legal-pages).
+
 ## Development
 
 The dashboard source is under `web/`. The published Docker image includes the

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -3128,7 +3128,7 @@
                 "type": "null"
               }
             ],
-            "description": "Where this deployment's documentation lives, when it is not the operator guide bundled with the gateway. Set, the dashboard's Documentation links open it in a new tab; null, they go to the bundled guide at /#/docs, which stays served either way. A link target an operator configured, validated at startup as an absolute http(s) URL.",
+            "description": "Where this deployment's documentation lives, when it is not the operator guide bundled with the gateway. Set, the dashboard's Documentation links open it in a new tab; null, they go to the bundled guide at /#/docs, which stays served either way. A link target an operator configured, validated at startup as an absolute http(s) URL carrying no credential, since this response is unauthenticated.",
             "title": "Docs Url"
           },
           "mail_ready": {
@@ -3175,7 +3175,7 @@
                 "type": "null"
               }
             ],
-            "description": "Where this deployment's privacy notice lives. Set, the account menu's Data & Privacy row links to it; null, that row stays disabled, which is what a gateway storing its data locally and reporting nothing outward has to say. A link target an operator configured, validated at startup as an absolute http(s) URL.",
+            "description": "Where this deployment's privacy notice lives. Set, the account menu's Data & Privacy row links to it; null, no address is configured and that row stays disabled, carrying the standing note that there is nothing to configure there yet. A link target an operator configured, validated at startup as an absolute http(s) URL carrying no credential, since this response is unauthenticated.",
             "title": "Privacy Url"
           },
           "session_type": {
@@ -3218,7 +3218,7 @@
                 "type": "null"
               }
             ],
-            "description": "Where this deployment's terms of service live. Set, the account menu carries a Terms of service row pointing at them; null, it carries none, because a deployment nobody wrote terms for has none to show. A link target an operator configured, validated at startup as an absolute http(s) URL.",
+            "description": "Where this deployment's terms of service live. Set, the account menu carries a Terms of service row pointing at them; null, no address is configured and the menu carries no such row. A link target an operator configured, validated at startup as an absolute http(s) URL carrying no credential, since this response is unauthenticated.",
             "title": "Terms Url"
           }
         },

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -3166,6 +3166,18 @@
             "title": "Passkeys Ready",
             "type": "boolean"
           },
+          "privacy_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Where this deployment's privacy notice lives. Set, the account menu's Data & Privacy row links to it; null, that row stays disabled, which is what a gateway storing its data locally and reporting nothing outward has to say. A link target an operator configured, validated at startup as an absolute http(s) URL.",
+            "title": "Privacy Url"
+          },
           "session_type": {
             "description": "The kind of session this deployment issues, not whether the caller holds one. 'local_operator' is the standalone operator sign-in (see sign_in_methods for which credential it currently accepts), 'hosted_user' an otari.ai account, and 'none' a deployment that issues no management session at all.",
             "enum": [
@@ -3196,6 +3208,18 @@
             },
             "title": "Surfaces",
             "type": "array"
+          },
+          "terms_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Where this deployment's terms of service live. Set, the account menu carries a Terms of service row pointing at them; null, it carries none, because a deployment nobody wrote terms for has none to show. A link target an operator configured, validated at startup as an absolute http(s) URL.",
+            "title": "Terms Url"
           }
         },
         "required": [
@@ -3205,6 +3229,8 @@
           "management_url",
           "data_plane_url",
           "docs_url",
+          "terms_url",
+          "privacy_url",
           "sign_in_methods",
           "maintenance_mode",
           "passkeys_ready",

--- a/src/gateway/api/routes/bootstrap.py
+++ b/src/gateway/api/routes/bootstrap.py
@@ -180,23 +180,25 @@ class DeploymentBootstrap(BaseModel):
             "bundled with the gateway. Set, the dashboard's Documentation links open it in a "
             "new tab; null, they go to the bundled guide at /#/docs, which stays served either "
             "way. A link target an operator configured, validated at startup as an absolute "
-            "http(s) URL."
+            "http(s) URL carrying no credential, since this response is unauthenticated."
         )
     )
     terms_url: str | None = Field(
         description=(
             "Where this deployment's terms of service live. Set, the account menu carries a "
-            "Terms of service row pointing at them; null, it carries none, because a "
-            "deployment nobody wrote terms for has none to show. A link target an operator "
-            "configured, validated at startup as an absolute http(s) URL."
+            "Terms of service row pointing at them; null, no address is configured and the "
+            "menu carries no such row. A link target an operator configured, validated at "
+            "startup as an absolute http(s) URL carrying no credential, since this response "
+            "is unauthenticated."
         )
     )
     privacy_url: str | None = Field(
         description=(
             "Where this deployment's privacy notice lives. Set, the account menu's Data & "
-            "Privacy row links to it; null, that row stays disabled, which is what a gateway "
-            "storing its data locally and reporting nothing outward has to say. A link target "
-            "an operator configured, validated at startup as an absolute http(s) URL."
+            "Privacy row links to it; null, no address is configured and that row stays "
+            "disabled, carrying the standing note that there is nothing to configure there "
+            "yet. A link target an operator configured, validated at startup as an absolute "
+            "http(s) URL carrying no credential, since this response is unauthenticated."
         )
     )
     sign_in_methods: list[SignInMethod] = Field(

--- a/src/gateway/api/routes/bootstrap.py
+++ b/src/gateway/api/routes/bootstrap.py
@@ -9,8 +9,8 @@ which mode the gateway is in.
 Registered in both modes, and unauthenticated by necessity: this is what tells a
 browser whether a sign-in screen is even the right thing to show. It therefore
 carries no secret. In particular it never carries the platform token, and
-``management_url``, ``data_plane_url`` and ``docs_url`` are addresses an operator
-configured, not credentials.
+``management_url``, ``data_plane_url``, ``docs_url``, ``terms_url`` and
+``privacy_url`` are addresses an operator configured, not credentials.
 
 The contract is shared with otari.ai, which serves the same shape for its hosted
 deployment (mozilla-ai/otari-ai#1591). ``deployment_type`` and ``session_type``
@@ -183,6 +183,22 @@ class DeploymentBootstrap(BaseModel):
             "http(s) URL."
         )
     )
+    terms_url: str | None = Field(
+        description=(
+            "Where this deployment's terms of service live. Set, the account menu carries a "
+            "Terms of service row pointing at them; null, it carries none, because a "
+            "deployment nobody wrote terms for has none to show. A link target an operator "
+            "configured, validated at startup as an absolute http(s) URL."
+        )
+    )
+    privacy_url: str | None = Field(
+        description=(
+            "Where this deployment's privacy notice lives. Set, the account menu's Data & "
+            "Privacy row links to it; null, that row stays disabled, which is what a gateway "
+            "storing its data locally and reporting nothing outward has to say. A link target "
+            "an operator configured, validated at startup as an absolute http(s) URL."
+        )
+    )
     sign_in_methods: list[SignInMethod] = Field(
         description=(
             "How POST /v1/auth/session may be authenticated right now, sorted. 'master_key' is the "
@@ -266,6 +282,8 @@ async def get_bootstrap(
             # page is the address that reaches the API.
             data_plane_url=None,
             docs_url=config.docs_url,
+            terms_url=config.terms_url,
+            privacy_url=config.privacy_url,
             maintenance_mode=False,
             passkeys_ready=False,
             oauth_providers=[],
@@ -289,6 +307,8 @@ async def get_bootstrap(
         # plane is not, and publishes wherever its operator says the gateway is.
         data_plane_url=config.data_plane_url if hosted else None,
         docs_url=config.docs_url,
+        terms_url=config.terms_url,
+        privacy_url=config.privacy_url,
         maintenance_mode=await _maintenance_mode(db),
         passkeys_ready=config.webauthn_enabled,
         oauth_providers=list(config.oauth_providers),

--- a/src/gateway/api/routes/settings.py
+++ b/src/gateway/api/routes/settings.py
@@ -152,6 +152,8 @@ _CONFIG_VIEW: tuple[tuple[str, tuple[str, ...]], ...] = (
             "enable_metrics",
             "enable_docs",
             "docs_url",
+            "terms_url",
+            "privacy_url",
             "data_plane_url",
             "bootstrap_api_key",
             "log_writer_strategy",

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -14,7 +14,7 @@ import yaml
 from any_llm import AnyLLM, LLMProvider
 from any_llm.exceptions import AnyLLMError
 from dotenv import load_dotenv
-from pydantic import BaseModel, Field, PrivateAttr, field_validator, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from gateway.core.addresses import normalized_address
@@ -452,6 +452,27 @@ class GatewayConfig(BaseSettings):
             "right default for a self-hosted deployment. Set it to retarget those links at "
             "a product documentation site instead; the bundled guide stays reachable at "
             "/#/docs either way."
+        ),
+    )
+    terms_url: str | None = Field(
+        default=None,
+        description=(
+            "Where this deployment's terms of service live, as an absolute http(s) URL "
+            "(e.g. 'https://otari.ai/terms'). Unset, the account menu shows no terms row: a "
+            "deployment nobody wrote terms for has none to point at, which is the ordinary "
+            "case for a self-hosted gateway. Set it and the row appears. A link target an "
+            "operator configured, held to the same bar as docs_url."
+        ),
+    )
+    privacy_url: str | None = Field(
+        default=None,
+        description=(
+            "Where this deployment's privacy notice lives, as an absolute http(s) URL "
+            "(e.g. 'https://otari.ai/privacy'). Unset, the account menu's Data & Privacy row "
+            "stays disabled with the reason it carries today, which is honest for a gateway "
+            "that stores its data locally and reports nothing outward. Set it and the row "
+            "becomes a link to the notice. A link target an operator configured, held to the "
+            "same bar as docs_url."
         ),
     )
     data_plane_url: str | None = Field(
@@ -1741,23 +1762,28 @@ class GatewayConfig(BaseSettings):
             raise ValueError(msg)
         return normalized
 
-    @field_validator("docs_url")
+    @field_validator("docs_url", "terms_url", "privacy_url")
     @classmethod
-    def _validate_docs_url(cls, value: str | None) -> str | None:
-        """Reject a documentation link that is not an absolute http(s) URL.
+    def _validate_link_url(cls, value: str | None, info: ValidationInfo) -> str | None:
+        """Reject a menu link that is not an absolute http(s) URL.
 
-        The deployment bootstrap publishes this to the browser as a link target,
-        so a scheme that is not http(s) would be a script URL an operator put in
-        their own config. Rejected at load rather than dropped per request, for
-        the same reason ``platform.management_url`` is: a typo should be a
+        The deployment bootstrap publishes each of these to the browser as a link
+        target, so a scheme that is not http(s) would be a script URL an operator
+        put in their own config. Rejected at load rather than dropped per request,
+        for the same reason ``platform.management_url`` is: a typo should be a
         startup error, not a Documentation link that silently goes nowhere.
+
+        One validator for the three because they are one kind of value: an
+        address a person follows out of the dashboard, with no downstream
+        consumer that builds a request from it. ``data_plane_url`` is held to a
+        stricter bar for exactly that reason and keeps its own.
         """
         normalized = (value or "").strip()
         if not normalized:
             return None
         parsed = urlsplit(normalized)
         if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-            msg = f"docs_url must be an absolute http(s) URL, got '{value}'"
+            msg = f"{info.field_name} must be an absolute http(s) URL, got '{value}'"
             raise ValueError(msg)
         return normalized
 

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -1777,6 +1777,12 @@ class GatewayConfig(BaseSettings):
         address a person follows out of the dashboard, with no downstream
         consumer that builds a request from it. ``data_plane_url`` is held to a
         stricter bar for exactly that reason and keeps its own.
+
+        Userinfo is the one refusal the three share with ``data_plane_url``, and
+        they share it for its reason rather than theirs: ``GET /v1/bootstrap``
+        is unauthenticated, so a credential written into any of these would
+        reach every browser that asked, which no redaction in the operator-gated
+        config viewer would cover.
         """
         normalized = (value or "").strip()
         if not normalized:
@@ -1784,6 +1790,11 @@ class GatewayConfig(BaseSettings):
         parsed = urlsplit(normalized)
         if parsed.scheme not in {"http", "https"} or not parsed.netloc:
             msg = f"{info.field_name} must be an absolute http(s) URL, got '{value}'"
+            raise ValueError(msg)
+        if parsed.username is not None or parsed.password is not None:
+            # The value is left out of the message, as it is for
+            # ``data_plane_url``: the offending part of it is the credential.
+            msg = f"{info.field_name} must carry no username or password"
             raise ValueError(msg)
         return normalized
 

--- a/tests/unit/test_deployment_bootstrap.py
+++ b/tests/unit/test_deployment_bootstrap.py
@@ -60,20 +60,32 @@ def _standalone(tmp_path: Path, docs_url: str | None = None) -> GatewayConfig:
     )
 
 
-def _hosted(tmp_path: Path, data_plane_url: str | None = None) -> GatewayConfig:
+def _hosted(
+    tmp_path: Path,
+    data_plane_url: str | None = None,
+    *,
+    terms_url: str | None = None,
+    privacy_url: str | None = None,
+) -> GatewayConfig:
     return GatewayConfig(
         mode="hosted",
         database_url=f"sqlite:///{tmp_path / 'bootstrap.db'}",
         master_key=MASTER_KEY,
         data_plane_url=data_plane_url,
+        terms_url=terms_url,
+        privacy_url=privacy_url,
     )
 
 
-def _hybrid(*, docs_url: str | None = None, **platform: str) -> GatewayConfig:
+def _hybrid(
+    *, docs_url: str | None = None, terms_url: str | None = None, privacy_url: str | None = None, **platform: str
+) -> GatewayConfig:
     return GatewayConfig(
         mode="hybrid",
         platform={"base_url": "http://localhost:8100/api/v1", **platform},
         docs_url=docs_url,
+        terms_url=terms_url,
+        privacy_url=privacy_url,
     )
 
 
@@ -92,6 +104,8 @@ def test_standalone_reports_a_local_operator_and_the_full_surface_set(tmp_path: 
         "management_url": None,
         "data_plane_url": None,
         "docs_url": None,
+        "terms_url": None,
+        "privacy_url": None,
         "maintenance_mode": False,
         "passkeys_ready": False,
         "oauth_providers": [],
@@ -316,6 +330,8 @@ def test_hybrid_reports_no_session_no_surfaces_and_the_hosted_url(monkeypatch: p
         "management_url": "https://otari.ai",
         "data_plane_url": None,
         "docs_url": None,
+        "terms_url": None,
+        "privacy_url": None,
         "maintenance_mode": False,
         "passkeys_ready": False,
         "oauth_providers": [],
@@ -435,6 +451,88 @@ def test_a_docs_url_that_is_not_an_http_link_is_refused_at_load(configured: str)
 def test_a_blank_docs_url_is_an_unset_one(configured: str) -> None:
     """A container templating an empty value has not configured a docs site."""
     assert GatewayConfig(docs_url=configured).docs_url is None
+
+
+def test_a_deployment_with_no_legal_urls_leaves_the_account_menu_as_it_was(tmp_path: Path) -> None:
+    """Null both, which is what a self-hosted gateway publishes.
+
+    The dashboard reads that as no Terms of service row and a Data & Privacy row
+    that stays disabled with the reason it has always carried, rather than as a
+    missing field.
+    """
+    app = create_app(_standalone(tmp_path))
+
+    with TestClient(app) as client:
+        body = client.get("/v1/bootstrap").json()
+
+    assert body["terms_url"] is None
+    assert body["privacy_url"] is None
+
+
+
+def test_a_hosted_deployment_publishes_the_legal_pages_on_its_own_site(tmp_path: Path) -> None:
+    """otari-ai#1945: the privacy notice needs a home the composed dashboard can reach.
+
+    A hosted control plane serves its dashboard beside a marketing site that owns
+    the notice and the terms, and it publishes both addresses so the account menu
+    can name them. Nothing else could: ``management_url`` is null here, since
+    this deployment *is* the control plane.
+    """
+    app = create_app(
+        _hosted(
+            tmp_path,
+            terms_url="https://otari.ai/terms",
+            privacy_url="https://otari.ai/privacy",
+        )
+    )
+
+    with TestClient(app) as client:
+        body = client.get("/v1/bootstrap").json()
+
+    assert body["management_url"] is None
+    assert body["terms_url"] == "https://otari.ai/terms"
+    assert body["privacy_url"] == "https://otari.ai/privacy"
+
+
+
+def test_a_hybrid_gateway_carries_its_own_legal_pages_too(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deployment-wide, like ``docs_url``: whoever runs the gateway may have terms of their own."""
+    monkeypatch.setenv("OTARI_AI_TOKEN", PLATFORM_TOKEN)
+    app = create_app(_hybrid(terms_url="https://otari.ai/terms", privacy_url="https://otari.ai/privacy"))
+
+    with TestClient(app) as client:
+        body = client.get("/v1/bootstrap").json()
+
+    assert body["terms_url"] == "https://otari.ai/terms"
+    assert body["privacy_url"] == "https://otari.ai/privacy"
+
+
+
+@pytest.mark.parametrize("field", ["terms_url", "privacy_url"])
+def test_a_legal_url_is_read_from_the_environment(field: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """OTARI_TERMS_URL and OTARI_PRIVACY_URL are the whole configuration surface a container needs."""
+    monkeypatch.setenv(f"OTARI_{field.upper()}", "https://otari.ai/legal")
+
+    config = GatewayConfig(database_url=f"sqlite:///{tmp_path / 'env.db'}")
+
+    assert getattr(config, field) == "https://otari.ai/legal"
+
+
+@pytest.mark.parametrize("field", ["terms_url", "privacy_url"])
+@pytest.mark.parametrize("configured", ["javascript:alert(1)", "otari.ai/terms", "/terms"])
+def test_a_legal_url_that_is_not_an_http_link_is_refused_at_load(field: str, configured: str) -> None:
+    """Held to ``docs_url``'s bar, and by the same validator: the browser turns each into an anchor."""
+    with pytest.raises(ValidationError, match=field):
+        # Built through model_validate so the field name can be a parameter; the
+        # constructor's keywords are typed one field at a time.
+        GatewayConfig.model_validate({field: configured})
+
+
+@pytest.mark.parametrize("field", ["terms_url", "privacy_url"])
+def test_a_blank_legal_url_is_an_unset_one(field: str) -> None:
+    """A container templating an empty value has published no legal page."""
+    assert getattr(GatewayConfig.model_validate({field: "   "}), field) is None
+
 
 
 def test_a_hosted_control_plane_publishes_where_its_data_plane_is(tmp_path: Path) -> None:

--- a/tests/unit/test_deployment_bootstrap.py
+++ b/tests/unit/test_deployment_bootstrap.py
@@ -534,6 +534,45 @@ def test_a_blank_legal_url_is_an_unset_one(field: str) -> None:
     assert getattr(GatewayConfig.model_validate({field: "   "}), field) is None
 
 
+@pytest.mark.parametrize("field", ["docs_url", "terms_url", "privacy_url"])
+@pytest.mark.parametrize(
+    "configured",
+    ["https://token@otari.ai/terms", "https://user:secret@otari.ai/terms"],
+)
+def test_a_link_url_carrying_a_credential_is_refused_at_load(field: str, configured: str) -> None:
+    """The refusal ``data_plane_url`` already made, for the same reason.
+
+    ``GET /v1/bootstrap`` is unauthenticated, so a credential written into any
+    of these link fields would reach every browser that asked for it, which no
+    redaction in the operator-gated config viewer would cover. ``docs_url`` is
+    covered too: it rides the same validator and the same response.
+    """
+    with pytest.raises(ValidationError, match="no username or password"):
+        GatewayConfig.model_validate({field: configured})
+
+
+def test_the_unauthenticated_bootstrap_cannot_publish_a_legal_page_credential(tmp_path: Path) -> None:
+    """The end the refusal above exists to protect, asserted through the route.
+
+    The validator test says the value cannot be built; this says the published
+    payload is what a browser gets, so the two cannot drift apart if somebody
+    later relaxes one of them.
+    """
+    app = create_app(
+        _hosted(
+            tmp_path,
+            terms_url="https://otari.ai/terms",
+            privacy_url="https://otari.ai/privacy",
+        )
+    )
+
+    with TestClient(app) as client:
+        body = client.get("/v1/bootstrap").text
+
+    for field in ('"terms_url"', '"privacy_url"'):
+        assert "@" not in body.split(field)[1].split(",")[0]
+
+
 
 def test_a_hosted_control_plane_publishes_where_its_data_plane_is(tmp_path: Path) -> None:
     """The field otari#823 exists for: the dashboard's snippets are built from it.

--- a/tests/unit/test_settings_endpoint.py
+++ b/tests/unit/test_settings_endpoint.py
@@ -301,6 +301,21 @@ def test_config_view_shows_the_documentation_link_target() -> None:
     assert by_key["docs_url"].settable is False
 
 
+def test_config_view_shows_the_legal_link_targets() -> None:
+    # Same reason as docs_url above: set in YAML or the environment, with no
+    # control for them in the dashboard, so the config viewer is where an
+    # operator confirms the account menu will carry them. Public link targets,
+    # not credentials, so shown verbatim.
+    config = GatewayConfig(terms_url="https://otari.ai/terms", privacy_url="https://otari.ai/privacy")
+    by_key = {field.key: field for field in _config_fields(config)}
+
+    assert by_key["terms_url"].value == "https://otari.ai/terms"
+    assert by_key["privacy_url"].value == "https://otari.ai/privacy"
+    # Read-only: where the legal pages live is a restart-time decision.
+    assert by_key["terms_url"].settable is False
+    assert by_key["privacy_url"].settable is False
+
+
 def test_every_config_field_is_shown_or_deliberately_omitted() -> None:
     """The roster is hand-maintained, so its completeness is checked rather than remembered.
 

--- a/web/e2e/parity.bootstrap.spec.ts
+++ b/web/e2e/parity.bootstrap.spec.ts
@@ -46,6 +46,11 @@ test("the deployment bootstrap is served unauthenticated", async ({
     // links stay on the operator guide bundled with this gateway; see
     // docs/configuration.md#documentation-links.
     docs_url: null,
+    // No terms_url or privacy_url in this e2e environment, so the account menu
+    // carries no Terms of service row and its Data & Privacy row stays
+    // disabled; see docs/configuration.md#legal-pages.
+    terms_url: null,
+    privacy_url: null,
     // Sign-ins are open, which is the resting state: maintenance mode is a
     // stored row an operator sets to freeze them during a redeploy, and
     // nothing in this environment sets it.

--- a/web/e2e/parity.hybrid.spec.ts
+++ b/web/e2e/parity.hybrid.spec.ts
@@ -53,6 +53,10 @@ test.describe("hybrid deployment", () => {
       // gateway may carry a hosted documentation link, and this one configures
       // none, so the bundled guide stays the target.
       docs_url: null,
+      // Deployment-wide for the same reason, and unset here too: a hybrid
+      // gateway may carry legal pages of its own, and this one configures none.
+      terms_url: null,
+      privacy_url: null,
       // Never frozen, because the freeze is on a sign-in this deployment does
       // not serve: a hybrid gateway mints no session for maintenance mode to
       // refuse. Its control plane owns that, as it owns the sign-in itself.

--- a/web/src/app/nav/AccountMenu.test.tsx
+++ b/web/src/app/nav/AccountMenu.test.tsx
@@ -136,6 +136,19 @@ describe("AccountMenu", () => {
     expect(screen.queryByRole("link", { name: "Terms of service" })).toBeNull()
   })
 
+  it("leaves Data & Privacy disabled for a deployment that published terms alone", async () => {
+    await openMenu({ terms_url: "https://otari.ai/terms" })
+
+    expect(
+      await screen.findByRole("link", { name: "Terms of service" }),
+    ).toHaveAttribute("href", "https://otari.ai/terms")
+    // The other direction of the same independence: one address published does
+    // not invent the other, so this row stays the disabled one.
+    expect(
+      screen.getByRole("button", { name: /^Data & Privacy \(/ }),
+    ).toBeDisabled()
+  })
+
   it("retargets the phone's Documentation row at the deployment's own docs site", async () => {
     mockCaller(OPERATOR)
     await openMenu({ docs_url: "https://docs.otari.ai/en/" })

--- a/web/src/app/nav/AccountMenu.test.tsx
+++ b/web/src/app/nav/AccountMenu.test.tsx
@@ -95,6 +95,47 @@ describe("AccountMenu", () => {
     expect(link).not.toHaveAttribute("target")
   })
 
+  it("names no legal page a deployment has not published", async () => {
+    mockCaller(OPERATOR)
+    await openMenu()
+
+    expect(screen.queryByRole("link", { name: "Terms of service" })).toBeNull()
+    // Present but inert, which is the row a gateway with no notice to link
+    // still owes: the surface is coming, and omitting it reads as never.
+    const privacy = await screen.findByRole("button", {
+      name: /^Data & Privacy \(/,
+    })
+    expect(privacy).toBeDisabled()
+  })
+
+  it("links both legal rows at the pages a hosted deployment published", async () => {
+    mockCaller(OPERATOR)
+    await openMenu({
+      terms_url: "https://otari.ai/terms",
+      privacy_url: "https://otari.ai/privacy",
+    })
+
+    const terms = await screen.findByRole("link", { name: "Terms of service" })
+    expect(terms).toHaveAttribute("href", "https://otari.ai/terms")
+    expect(terms).toHaveAttribute("target", "_blank")
+
+    // otari-ai#1945: the notice lives on the marketing site beside the
+    // dashboard, and this row is how a signed-in user reaches it.
+    const privacy = await screen.findByRole("link", { name: "Data & Privacy" })
+    expect(privacy).toHaveAttribute("href", "https://otari.ai/privacy")
+    expect(privacy).toHaveAttribute("target", "_blank")
+  })
+
+  it("keeps the two legal rows independent of each other", async () => {
+    mockCaller(OPERATOR)
+    await openMenu({ privacy_url: "https://otari.ai/privacy" })
+
+    expect(
+      await screen.findByRole("link", { name: "Data & Privacy" }),
+    ).toHaveAttribute("href", "https://otari.ai/privacy")
+    expect(screen.queryByRole("link", { name: "Terms of service" })).toBeNull()
+  })
+
   it("retargets the phone's Documentation row at the deployment's own docs site", async () => {
     mockCaller(OPERATOR)
     await openMenu({ docs_url: "https://docs.otari.ai/en/" })

--- a/web/src/app/nav/AccountMenu.test.tsx
+++ b/web/src/app/nav/AccountMenu.test.tsx
@@ -137,6 +137,7 @@ describe("AccountMenu", () => {
   })
 
   it("leaves Data & Privacy disabled for a deployment that published terms alone", async () => {
+    mockCaller(OPERATOR)
     await openMenu({ terms_url: "https://otari.ai/terms" })
 
     expect(

--- a/web/src/app/nav/AccountMenu.tsx
+++ b/web/src/app/nav/AccountMenu.tsx
@@ -15,7 +15,6 @@ import {
 import type { OrganizationContext } from "@/client"
 import { useAuth } from "@/features/auth/AuthContext"
 import { useOrganizationContext } from "@/shared/api/hooks"
-import { EntitlementGate } from "@/shared/components/EntitlementGate"
 import { useDeployment } from "@/shared/hooks/useDeployment"
 import {
   THEME_PREFERENCES,
@@ -42,10 +41,13 @@ import {
 // the credential it was minted from (otari#653): a session is per-identity
 // since otari#647, and the identity holds a password of its own since otari#649,
 // so the row this menu carried disabled from the start now has a destination.
-// Data & Privacy is still disabled with the reason rather than omitted, because
-// it is coming and a menu that silently lacks it reads as a menu that never
-// will. Terms of service is different again, and gated: it is a hosted
-// document, so it appears only for a deployment that has one to point at.
+// The two legal rows are the deployment's own documents, and each appears only
+// where there is one to point at: `terms_url` and `privacy_url`, the addresses
+// an operator configures and `GET /v1/bootstrap` publishes beside `docs_url`.
+// Terms of service is absent without one, because a gateway nobody wrote terms
+// for has none to show. Data & Privacy falls back to the disabled row instead
+// of vanishing, because the settings surface it will become is coming and a
+// menu that silently lacks it reads as a menu that never will.
 
 const THEME_LABELS: Record<ThemePreference, string> = {
   system: "System",
@@ -285,7 +287,7 @@ function AppearanceControl() {
 
 export function AccountMenu({ collapsed }: { collapsed: boolean }) {
   const { logout } = useAuth()
-  const { management_url, docs_url } = useDeployment()
+  const { docs_url, terms_url, privacy_url } = useDeployment()
   const organization = useOrganizationContext()
   const [open, setOpen] = useState(false)
   const identity = sessionIdentity(organization.data?.caller)
@@ -362,25 +364,34 @@ export function AccountMenu({ collapsed }: { collapsed: boolean }) {
               className="md:hidden"
             />
           )}
-          {/* Hosted-only, and gated twice over: the entitlement says the
-              deployment has terms to show, and `management_url` is where they
-              are. A self-hosted gateway is neither, so the row is absent rather
-              than pointing somewhere invented. */}
-          {management_url ? (
-            <EntitlementGate capability="legal.terms">
-              <MenuExternalLink
-                label="Terms of service"
-                icon={FiFileText}
-                href={`${management_url.replace(/\/$/, "")}/terms`}
-              />
-            </EntitlementGate>
+          {/* Absent rather than pointing somewhere invented. This used to build
+              the address from `management_url` behind a `legal.terms`
+              entitlement, which no deployment could satisfy: that field is set
+              only for a hybrid gateway, which issues no session and so never
+              opens this menu, and nothing granted the capability. So a hosted
+              deployment with terms on its own site had no way to name them
+              (otari-ai#1945). */}
+          {terms_url ? (
+            <MenuExternalLink
+              label="Terms of service"
+              icon={FiFileText}
+              href={terms_url}
+            />
           ) : null}
-          <MenuItem
-            label="Data & Privacy"
-            icon={FiShield}
-            title="The gateway stores its data locally and reports nothing outward, so there is nothing to configure here yet."
-            isDisabled
-          />
+          {privacy_url ? (
+            <MenuExternalLink
+              label="Data & Privacy"
+              icon={FiShield}
+              href={privacy_url}
+            />
+          ) : (
+            <MenuItem
+              label="Data & Privacy"
+              icon={FiShield}
+              title="The gateway stores its data locally and reports nothing outward, so there is nothing to configure here yet."
+              isDisabled
+            />
+          )}
           <div className={MENU_DIVIDER} />
           {/* Neutral, not danger-colored. Ending a session is reversible by
               signing in again, so red here spends the color that marks the

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -5321,6 +5321,11 @@ export interface components {
              */
             passkeys_ready: boolean;
             /**
+             * Privacy Url
+             * @description Where this deployment's privacy notice lives. Set, the account menu's Data & Privacy row links to it; null, that row stays disabled, which is what a gateway storing its data locally and reporting nothing outward has to say. A link target an operator configured, validated at startup as an absolute http(s) URL.
+             */
+            privacy_url: string | null;
+            /**
              * Session Type
              * @description The kind of session this deployment issues, not whether the caller holds one. 'local_operator' is the standalone operator sign-in (see sign_in_methods for which credential it currently accepts), 'hosted_user' an otari.ai account, and 'none' a deployment that issues no management session at all.
              * @enum {string}
@@ -5336,6 +5341,11 @@ export interface components {
              * @description Management API groups this deployment serves, sorted, which is what its dashboard pages gate on. Named surfaces, not capabilities: capability is otari.ai's word for the entitlement (licensing) axis, and this is the deployment (topology) axis. Empty for a hybrid gateway.
              */
             surfaces: string[];
+            /**
+             * Terms Url
+             * @description Where this deployment's terms of service live. Set, the account menu carries a Terms of service row pointing at them; null, it carries none, because a deployment nobody wrote terms for has none to show. A link target an operator configured, validated at startup as an absolute http(s) URL.
+             */
+            terms_url: string | null;
         };
         /**
          * DeploymentUserOrganizationPublic

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -5292,7 +5292,7 @@ export interface components {
             deployment_type: "standalone" | "hosted" | "hybrid";
             /**
              * Docs Url
-             * @description Where this deployment's documentation lives, when it is not the operator guide bundled with the gateway. Set, the dashboard's Documentation links open it in a new tab; null, they go to the bundled guide at /#/docs, which stays served either way. A link target an operator configured, validated at startup as an absolute http(s) URL.
+             * @description Where this deployment's documentation lives, when it is not the operator guide bundled with the gateway. Set, the dashboard's Documentation links open it in a new tab; null, they go to the bundled guide at /#/docs, which stays served either way. A link target an operator configured, validated at startup as an absolute http(s) URL carrying no credential, since this response is unauthenticated.
              */
             docs_url: string | null;
             /**
@@ -5322,7 +5322,7 @@ export interface components {
             passkeys_ready: boolean;
             /**
              * Privacy Url
-             * @description Where this deployment's privacy notice lives. Set, the account menu's Data & Privacy row links to it; null, that row stays disabled, which is what a gateway storing its data locally and reporting nothing outward has to say. A link target an operator configured, validated at startup as an absolute http(s) URL.
+             * @description Where this deployment's privacy notice lives. Set, the account menu's Data & Privacy row links to it; null, no address is configured and that row stays disabled, carrying the standing note that there is nothing to configure there yet. A link target an operator configured, validated at startup as an absolute http(s) URL carrying no credential, since this response is unauthenticated.
              */
             privacy_url: string | null;
             /**
@@ -5343,7 +5343,7 @@ export interface components {
             surfaces: string[];
             /**
              * Terms Url
-             * @description Where this deployment's terms of service live. Set, the account menu carries a Terms of service row pointing at them; null, it carries none, because a deployment nobody wrote terms for has none to show. A link target an operator configured, validated at startup as an absolute http(s) URL.
+             * @description Where this deployment's terms of service live. Set, the account menu carries a Terms of service row pointing at them; null, no address is configured and the menu carries no such row. A link target an operator configured, validated at startup as an absolute http(s) URL carrying no credential, since this response is unauthenticated.
              */
             terms_url: string | null;
         };

--- a/web/src/features/auth/SignupPage.tsx
+++ b/web/src/features/auth/SignupPage.tsx
@@ -40,9 +40,13 @@ import {
  *
  * The platform's Google and GitHub buttons, its newsletter opt-in, and its
  * terms checkbox are all left behind. The first two are #651 and a hosted
- * marketing concern; the third has nothing to link to, since a self-hosted
- * deployment publishes no terms, so the request omits `terms_accepted` rather
- * than asserting an acceptance of a document that does not exist.
+ * marketing concern; the third has nothing to link to on a deployment that
+ * published no terms, so the request omits `terms_accepted` rather than
+ * asserting an acceptance of a document that does not exist. `terms_url` makes
+ * that conditional rather than always true, and the server has carried
+ * `terms_accepted` and its `terms_accepted_at` column throughout, so offering
+ * the checkbox where there is a document to accept is unwired rather than
+ * impossible.
  *
  * `?email=…` prefills the address, which is how the accept-invitation page
  * hands an invitee straight here (otari#835). It arrives read-only, because

--- a/web/src/tests/fixtures.ts
+++ b/web/src/tests/fixtures.ts
@@ -129,6 +129,11 @@ export function bootstrap(
     // Null, because a fixture describes a deployment whose documentation is the
     // bundled guide; the tests about an operator-configured docs site set it.
     docs_url: null,
+    // Null both, because a self-hosted gateway publishes no legal pages of its
+    // own: Terms of service is then absent from the account menu and Data &
+    // Privacy is the disabled row. The account-menu tests set them.
+    terms_url: null,
+    privacy_url: null,
     // Not frozen, because a fixture describes a deployment somebody can sign
     // in to; the maintenance-mode tests override it.
     maintenance_mode: false,


### PR DESCRIPTION
## Description

The account menu has two rows for a deployment's legal documents, Terms of service and Data & Privacy, and neither could ever point anywhere. Terms built its address out of a field only a hybrid gateway sets, and a hybrid gateway shows the landing page instead of this menu; it also sat behind a licence capability nothing grants. Data & Privacy was hardcoded as a greyed-out row. So an operator whose dashboard sits beside a site holding their privacy notice and their terms had no way to link either one, and users of that dashboard had no way in.

This adds two settings, `terms_url` and `privacy_url`, configured the way `docs_url` already is and published by `GET /v1/bootstrap` in every mode. Each row now links to whichever document the deployment has published, independently. Nothing changes for a deployment that sets neither: Terms of service stays absent and Data & Privacy stays disabled with the reason it has always carried, which is honest for a gateway that stores its data locally and reports nothing outward. The three link fields share one validator, so a scheme that is not http(s) is a startup error rather than an anchor that goes nowhere.

## PR Type

- [x] New Feature
- [x] Bug Fix

## Relevant issues

Unblocks mozilla-ai/otari-ai#1945, which closes on the otari-ai side once the pin moves and the hosted deployment sets both values.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

`make lint`, `make typecheck`, `tests/unit` (2614 passed), `pnpm --dir web` lint, typecheck and test (1729 passed), `make openapi-check` and `make postman-check` all pass. The Python integration suite and Playwright were not run locally, no Docker in this environment; two e2e bootstrap payloads are asserted with `toEqual` and were updated, so CI is the confirmation on those.

## AI Usage

- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via the Claude Code CLI.

**Any additional AI details you'd like to share:**

Written by Claude Opus 5 through back-and-forth with @njbrake, who chose the approach: publish both addresses rather than privacy alone, since the terms row was broken for the same reason.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added optional `terms_url` and `privacy_url` settings.
- Published both URLs through `GET /v1/bootstrap` in all deployment modes.
- Updated the account menu to show each legal page independently.
- Kept Terms of Service hidden and Data & Privacy disabled when URLs are not configured.
- Added shared HTTP(S)-only validation for documentation and legal-page URLs.
- Updated signup wording, documentation, API schemas, fixtures, and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->