### PR TITLE
fix(dashboard): open Model pricing to organization admins

### DIFF
--- a/web/src/app/AppShell.test.tsx
+++ b/web/src/app/AppShell.test.tsx
@@ -246,7 +246,7 @@ describe("AppShell responsive layout", () => {
     await renderShell()
 
     const overview = screen.getByRole("link", { name: "Overview" })
-    // Awaited: Providers is one of the eight rows gated `operatorOnly`, so it
+    // Awaited: Providers is one of the four rows gated `operatorOnly`, so it
     // arrives with the membership context rather than with the first paint.
     const providers = await screen.findByRole("link", { name: "Providers" })
     expect(overview).toHaveAttribute("aria-current", "page")
@@ -533,11 +533,11 @@ describe("AppShell surface gating", () => {
     // Same reasoning as above, for the other context: the organization rail is
     // its own registry, and nothing else compares it against a full list.
     await renderShell(bootstrap(), { url: "/organization/members" })
-    // Awaited, not assumed: four of these rows declare `operatorOnly`, so none
+    // Awaited, not assumed: three of these rows declare `operatorOnly`, so none
     // of them exists until `GET /v1/organizations/me` answers. Taking the
     // snapshot without waiting is a race that passes on a fast machine and fails
-    // on CI, which is what it did. One await covers all four, because the caller
-    // axis is one read and they appear in the same paint.
+    // on CI, which is what it did. One await covers all three, because the
+    // caller axis is one read and they appear in the same paint.
     await within(
       screen.getByRole("navigation", { name: "Sidebar" }),
     ).findByRole("link", { name: "Accounts" })

--- a/web/src/app/nav/registry.test.ts
+++ b/web/src/app/nav/registry.test.ts
@@ -96,15 +96,15 @@ describe("nav registry", () => {
     // reason (otari-ai#1941): members create and manage their own keys through
     // `/v1/organizations/me/keys`. Removing a row from here is as
     // much a design decision as adding one.
+    //
+    // Model pricing left it a third way (otari-ai#1943): the page behind it was
+    // never one answer. Its rate overrides are the organization's own and
+    // already management-gated, and its catalog read serves any session, so only
+    // two of its sections were ever the operator's and the page withholds those
+    // rather than the rail withholding the destination.
     expect(
       NAV_ITEMS.filter((item) => item.operatorOnly).map((item) => item.to),
-    ).toEqual([
-      "/providers",
-      "/budgets",
-      "/organization/pricing",
-      "/settings",
-      "/admin/accounts",
-    ])
+    ).toEqual(["/providers", "/budgets", "/settings", "/admin/accounts"])
   })
 
   it("puts each destination on exactly one rail", () => {

--- a/web/src/app/nav/registry.ts
+++ b/web/src/app/nav/registry.ts
@@ -307,18 +307,27 @@ const ORGANIZATION_NAV_SECTIONS = [
       // before (its refresh flow sat in the gateway's runtime Settings next to
       // the master key), so this is where it lives, while one model's rate stays
       // on Models, beside the model it prices.
+      //
+      // No `operatorOnly` any more, because the page behind it is not one
+      // answer: the roles matrix puts Model pricing at Edit for an admin
+      // (otari-ai#1943), and the server already agreed. The organization's own
+      // rate overrides are management-gated, and the catalog read serves any
+      // session; only the refresh flow and the policy read are the operator's,
+      // and the page withholds those from anyone else rather than refusing the
+      // whole destination. Reached from the organization rail, which the shell
+      // already opens only to a caller who manages the organization, so a plain
+      // member is not offered it.
       {
         to: "/organization/pricing",
         label: "Model pricing",
         // `pricing`, not `settings`: the table and the refresh flow are
         // `/v1/pricing`, its own router, and this page reads `/v1/settings` only
-        // for the policy banner. This gateway serves the surfaces as one set, so
-        // the two are the same answer here; the axis exists for the deployment
-        // where they come apart, and there this row would otherwise offer a page
-        // whose data is not served.
+        // for the policy banner an operator sees. This gateway serves the
+        // surfaces as one set, so the two are the same answer here; the axis
+        // exists for the deployment where they come apart, and there this row
+        // would otherwise offer a page whose data is not served.
         surface: "pricing",
         icon: FiTag,
-        operatorOnly: "refused",
       },
     ],
   },

--- a/web/src/features/pricing/ModelPricingPage.test.tsx
+++ b/web/src/features/pricing/ModelPricingPage.test.tsx
@@ -4,8 +4,13 @@ import userEvent from "@testing-library/user-event"
 import type { ReactElement } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import type { GatewaySettings, PricingResponse } from "@/client"
+import type {
+  GatewaySettings,
+  OrganizationContext,
+  PricingResponse,
+} from "@/client"
 import { ModelPricingPage } from "@/features/pricing/ModelPricingPage"
+import { organizationContext } from "@/tests/fixtures"
 import { withRouter } from "@/tests/router"
 
 const SETTINGS: GatewaySettings = {
@@ -55,14 +60,19 @@ function jsonResponse(body: unknown): Response {
   })
 }
 
+// The caller's standing, which decides how much of this page renders. An
+// operator by default, matching the fixture and the deployment most of these
+// tests describe; the admin cases below say otherwise.
 function mockApi(
   options: {
     settings?: Partial<GatewaySettings>
     pricing?: PricingResponse[]
+    context?: OrganizationContext
   } = {},
 ) {
   const settings = { ...SETTINGS, ...options.settings }
   const pricing = options.pricing ?? [price()]
+  const context = options.context ?? organizationContext()
   return vi
     .spyOn(globalThis, "fetch")
     .mockImplementation(async (input, init) => {
@@ -77,8 +87,15 @@ function mockApi(
       if (url.includes("/v1/pricing/refresh") && method === "POST") {
         return jsonResponse(PRICE_REFRESH)
       }
+      // Before the bare `/v1/pricing` arm below and before the context one: the
+      // organization's own overrides are a different surface from the catalog,
+      // and they answer the paged tenancy shape rather than a list.
+      if (url.includes("/v1/organizations/me/pricing")) {
+        return jsonResponse({ data: [], count: 0 })
+      }
       if (url.includes("/v1/settings")) return jsonResponse(settings)
       if (url.includes("/v1/pricing")) return jsonResponse(pricing)
+      if (url.includes("/v1/organizations/me")) return jsonResponse(context)
       return jsonResponse([])
     })
 }
@@ -275,5 +292,68 @@ describe("ModelPricingPage", () => {
           init?.method === "POST",
       ),
     ).toBe(true)
+  })
+
+  it("gives an organization admin the prices and its own overrides, not the catalog", async () => {
+    // The roles matrix puts Model pricing at Edit for an admin (otari-ai#1943),
+    // and the page is two halves: the organization's rate overrides, which the
+    // server already lets an owner or admin write, and the deployment's catalog
+    // controls, which it does not. So an admin gets the first and the price
+    // table, and the second is withheld rather than rendered as a refusal.
+    const fetchMock = mockApi({
+      // An admin, not the owner the fixture defaults to: the matrix row is
+      // about the admin, and `canManage` is what the overrides card asks.
+      context: organizationContext({
+        role: "admin",
+        deployment_operator: false,
+      }),
+    })
+    renderPage(<ModelPricingPage />)
+
+    expect(await screen.findByText("Rate overrides")).toBeInTheDocument()
+    await screen.findByRole("grid", { name: "Model prices" })
+    expect(screen.queryByText("Default pricing catalog")).toBeNull()
+    expect(
+      screen.queryByRole("button", { name: "Check for price updates" }),
+    ).toBeNull()
+    expect(screen.queryByText(/Default pricing is/)).toBeNull()
+
+    // Withheld at the request, not only in the markup. Both reads are
+    // `require_deployment_operator`, so firing them would put a 403 banner on a
+    // page that is the admin's to use (the shape otari#838 removed elsewhere).
+    const asked = fetchMock.mock.calls.map(([url]) => String(url))
+    expect(asked.some((url) => url.includes("/v1/settings"))).toBe(false)
+    expect(asked.some((url) => url.includes("/v1/pricing/refresh"))).toBe(false)
+  })
+
+  it("does not point an admin at an editor they would be refused", async () => {
+    // Since otari#867 a non-operator reads Models with every pricing affordance
+    // gone, and setting a catalog rate is operator-only, so the empty table says
+    // nothing is priced without offering to price one.
+    mockApi({
+      pricing: [],
+      context: organizationContext({ deployment_operator: false }),
+    })
+    renderPage(<ModelPricingPage />)
+
+    expect(
+      await screen.findByText("No model carries a stored price yet."),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/Price one from the Models page/)).toBeNull()
+    expect(screen.queryByText(/A rate is edited beside the model/)).toBeNull()
+  })
+
+  it("keeps the catalog controls for a deployment operator", async () => {
+    // The other side of the split, pinned so a future change cannot quietly take
+    // the catalog away from the caller it belongs to.
+    mockApi()
+    renderPage(<ModelPricingPage />)
+
+    expect(
+      await screen.findByText("Default pricing catalog"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Check for price updates" }),
+    ).toBeInTheDocument()
   })
 })

--- a/web/src/features/pricing/ModelPricingPage.tsx
+++ b/web/src/features/pricing/ModelPricingPage.tsx
@@ -7,8 +7,10 @@ import { currentPricing } from "@/features/models/pricing"
 // organization's own rates above this catalog, so they belong on this page while
 // the tenancy feature keeps owning them.
 import { RateOverridesCard } from "@/features/organization/RateOverridesCard"
+import { isDeploymentOperator } from "@/features/organization/roles"
 import {
   useConfirmPricingRefresh,
+  useOrganizationContext,
   usePreviewPricingRefresh,
   usePricing,
   useRejectPricingRefresh,
@@ -39,6 +41,22 @@ import { formatCost } from "@/shared/helpers/format"
 // edited next to the model it applies to and reached from three places that all
 // start with a specific model. So the table here links there rather than
 // growing a second copy of that editor.
+//
+// The other split, which is about who is asking (otari-ai#1943): the page holds
+// a deployment-wide half and a tenant-scoped half, and the roles matrix puts it
+// at Edit for an organization admin. So the halves are gated separately rather
+// than the destination being operator-only:
+//
+// - The **catalog policy** and the **refresh flow** are the deployment's. Both
+//   are `require_deployment_operator` server-side (`GET /v1/settings`, and the
+//   three `/v1/pricing/refresh` routes), so they are withheld from anyone else
+//   rather than fired into a 403 banner, the way `ModelsPage` withholds its own
+//   operator-only reads.
+// - The **price table** reads `/v1/pricing`, which `verify_catalog_reader`
+//   already serves to any session.
+// - The **rate overrides** are the organization's own, and
+//   `organization_pricing_service` gates the writes on the same owner-or-admin
+//   role the card already asks about, so it needs nothing here.
 
 function PricingRefreshDialog({
   preview,
@@ -179,6 +197,12 @@ function PricingRefreshSection() {
  * overrides an upstream default. With it off, the table is the whole of what can
  * be billed, and `require_pricing` decides whether anything else is refused
  * outright or served for free.
+ *
+ * Mounted only for a deployment operator, which is why it reads `useSettings()`
+ * with no gate of its own: `GET /v1/settings` is operator-only, so an admin who
+ * saw this banner would be reading a refusal. Unmounted rather than passed a
+ * disabled query, so nothing is left holding a cached answer from a session that
+ * used to be an operator's.
  */
 function CatalogPolicy() {
   const settings = useSettings()
@@ -272,7 +296,18 @@ const COLUMNS: DataTableColumn<PriceRow>[] = [
   },
 ]
 
-function PriceTable() {
+/**
+ * The catalog rows, and where a rate is edited when the caller may edit one.
+ *
+ * `canPrice` is the caller's, not the deployment's: setting a catalog rate is
+ * `POST /v1/pricing`, which is operator-only, and since otari#867 a non-operator
+ * reads Models with every pricing affordance gone. So both sentences that point
+ * at that editor are the operator's, and for anyone else the empty table says
+ * only what is true, that nothing is priced. Passed in rather than resolved here
+ * so the page asks who is calling once and no two sections can answer it
+ * differently.
+ */
+function PriceTable({ canPrice }: { canPrice: boolean }) {
   const pricing = usePricing()
   const rows = pricing.data ? currentRows(pricing.data) : []
 
@@ -289,34 +324,51 @@ function PriceTable() {
             columns={COLUMNS}
             rows={rows}
             getRowKey={(row) => row.modelKey}
-            emptyContent="No model carries a stored price yet. Price one from the Models page."
+            emptyContent={
+              canPrice
+                ? "No model carries a stored price yet. Price one from the Models page."
+                : "No model carries a stored price yet."
+            }
           />
         </Card.Content>
       </Card>
-      <p className="text-sm text-muted">
-        A rate is edited beside the model it applies to, on{" "}
-        <Link
-          to="/models"
-          className="font-medium text-link hover:text-link-hover"
-        >
-          Models
-        </Link>
-        .
-      </p>
+      {canPrice ? (
+        <p className="text-sm text-muted">
+          A rate is edited beside the model it applies to, on{" "}
+          <Link
+            to="/models"
+            className="font-medium text-link hover:text-link-hover"
+          >
+            Models
+          </Link>
+          .
+        </p>
+      ) : null}
     </section>
   )
 }
 
 export function ModelPricingPage() {
+  // The caller axis, read once for the whole page. Withholding the two
+  // deployment-wide sections is not a second opinion about authorization: the
+  // server refuses those reads to a non-operator either way, and this is only
+  // what keeps an admin's own page from being three quarters refusal banner
+  // (the shape otari#838 removed from the members roster).
+  const organization = useOrganizationContext()
+  const isOperator = isDeploymentOperator(organization.data)
   return (
     <div className="flex flex-col gap-6">
       <PageHeader
         title="Model pricing"
         description="What this gateway meters a request at. The catalog applies to every workspace and every key in the organization; a rate override below applies to this organization ahead of it."
       />
-      <CatalogPolicy />
-      <PricingRefreshSection />
-      <PriceTable />
+      {isOperator ? (
+        <>
+          <CatalogPolicy />
+          <PricingRefreshSection />
+        </>
+      ) : null}
+      <PriceTable canPrice={isOperator} />
       <RateOverridesCard />
     </div>
   )


### PR DESCRIPTION
## Description

The [11 Aug roles matrix](https://github.com/mozilla-ai/otari-ai/issues/1946) puts **Model pricing** at Hidden for members and **Edit for admins**. The nav row was `operatorOnly: "refused"`, so a hosted organization's admin could not reach the page that hosts their own rate overrides, even though the server already allowed them to write those overrides.

The page is two halves with two different owners, so the gating splits rather than the destination opening wholesale:

| Section | Server gate | Who sees it now |
| --- | --- | --- |
| Catalog policy banner (`GET /v1/settings`) | `require_deployment_operator` | operator |
| Default pricing catalog / refresh flow (`/v1/pricing/refresh*`) | `require_deployment_operator` | operator |
| Model prices table (`GET /v1/pricing`) | `verify_catalog_reader` (any session) | operator + admin |
| Rate overrides (`/v1/organizations/me/pricing`) | owner-or-admin, in `organization_pricing_service` | operator + admin |

The two operator-only sections are withheld from anyone else rather than fired into a 403 banner, which is how Models has withheld its operator-only reads since #867. The sentences pointing at the per-model editor on Models go with them, since setting a catalog rate is `POST /v1/pricing`.

**No new read is exposed.** Both halves the page keeps were already reachable by URL for any session; this only stops rendering the two that refuse. The row stays out of a member's sidebar because the organization rail opens only to a caller who manages the organization.

Second half of otari-ai#1943, the org-scoped Spend & budgets surface, follows in its own PR.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Refs mozilla-ai/otari-ai#1943, mozilla-ai/otari-ai#1946

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Dashboard-only change, so the suites that matter here are the web ones: `pnpm --dir web run lint`, `pnpm --dir web run typecheck`, and `pnpm --dir web test` (107 files, 1745 tests, all passing). `make lint` was run and is clean. No API contract change, so the OpenAPI spec and the Postman collection are untouched.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

Implemented from the roles-matrix audit in otari-ai#1946. Reviewed by the author before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
