### PR TITLE
fix(tenancy): gate the org provider-keys list on organization management

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -18463,7 +18463,7 @@
     },
     "/v1/organizations/me/provider-keys": {
       "get": {
-        "description": "List the caller's organization's provider keys. Any active member may read it.",
+        "description": "List the caller's organization's provider keys. Organization owners and admins only.",
         "operationId": "list_org_provider_keys_v1_organizations_me_provider_keys_get",
         "parameters": [
           {

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -3102,7 +3102,7 @@
         {
           "name": "List Org Provider Keys",
           "request": {
-            "description": "List the caller's organization's provider keys. Any active member may read it.",
+            "description": "List the caller's organization's provider keys. Organization owners and admins only.",
             "header": [],
             "method": "GET",
             "url": {

--- a/src/gateway/api/routes/org_provider_keys.py
+++ b/src/gateway/api/routes/org_provider_keys.py
@@ -69,7 +69,7 @@ async def list_org_provider_keys(
     skip: Annotated[int, Query(ge=0, description="Number of records to skip")] = 0,
     limit: Annotated[int, Query(ge=1, le=1000, description="Maximum number of records to return")] = 100,
 ) -> OrgProviderKeysPublic:
-    """List the caller's organization's provider keys. Any active member may read it."""
+    """List the caller's organization's provider keys. Organization owners and admins only."""
     return await service.list_keys_for_user(
         user=current_identity, include_archived=include_archived, skip=skip, limit=limit
     )

--- a/src/gateway/models/provider_keys.py
+++ b/src/gateway/models/provider_keys.py
@@ -161,19 +161,17 @@ class OrgProviderKey(SQLModel, PrimaryKeyMixin, CreatedAtMixin, UpdatedAtMixin, 
     archived_at: datetime | None = _timestamp_field(default=None, column_kwargs={})
     is_org_default: bool = Field(default=False, nullable=False)
 
-    def to_public(self, *, include_client_args: bool = True) -> OrgProviderKeyPublic:
+    def to_public(self) -> OrgProviderKeyPublic:
         """Serialize for the API. Never includes the key, only ``last4``.
 
         ``client_args`` is arbitrary JSON an admin can set (Bedrock's
         ``region_name``, other client kwargs), and a credential-shaped field
         placed there is never echoed back either: ``redact_secret_like_values``
         masks it the same way ``encrypted_api_key`` itself already stays off
-        the wire (only ``last4`` comes back). That runs regardless of
-        ``include_client_args``, which is a separate, coarser gate: it
-        defaults to included, since every write path (create/update/archive/
-        restore/set-default) is already organization owner/admin-gated, and
-        ``include_client_args=False`` is for the plain-member list read,
-        which is open to every active member, not only admins.
+        the wire (only ``last4`` comes back). No coarser per-audience gate sits
+        over it any more: every path that serializes a key, the list read
+        included, is organization owner/admin-gated (otari-ai#1944), so there is
+        no wider audience to withhold the field from.
         """
         return OrgProviderKeyPublic(
             id=self.id,
@@ -181,7 +179,7 @@ class OrgProviderKey(SQLModel, PrimaryKeyMixin, CreatedAtMixin, UpdatedAtMixin, 
             provider=self.provider,
             name=self.name,
             api_base=self.api_base,
-            client_args=redact_secret_like_values(self.client_args) if include_client_args else None,
+            client_args=redact_secret_like_values(self.client_args),
             last4=self.last4,
             is_org_default=self.is_org_default,
             archived_at=self.archived_at,

--- a/src/gateway/models/provider_keys.py
+++ b/src/gateway/models/provider_keys.py
@@ -168,10 +168,10 @@ class OrgProviderKey(SQLModel, PrimaryKeyMixin, CreatedAtMixin, UpdatedAtMixin, 
         ``region_name``, other client kwargs), and a credential-shaped field
         placed there is never echoed back either: ``redact_secret_like_values``
         masks it the same way ``encrypted_api_key`` itself already stays off
-        the wire (only ``last4`` comes back). No coarser per-audience gate sits
-        over it any more: every path that serializes a key, the list read
-        included, is organization owner/admin-gated (otari-ai#1944), so there is
-        no wider audience to withhold the field from.
+        the wire (only ``last4`` comes back). That masking is the whole
+        protection the field gets, and it is enough because it holds for every
+        reader: this surface has one audience, the organization owners and
+        admins each of its routes is gated on.
         """
         return OrgProviderKeyPublic(
             id=self.id,

--- a/src/gateway/services/tenancy/org_provider_key_service.py
+++ b/src/gateway/services/tenancy/org_provider_key_service.py
@@ -68,7 +68,7 @@ from gateway.models.provider_keys import (
     WorkspaceProviderModelRestrictionsPublic,
 )
 from gateway.models.secret_fields import restore_redacted_values
-from gateway.models.tenancy import MANAGEMENT_ROLES, User, Workspace
+from gateway.models.tenancy import User, Workspace
 from gateway.repositories.tenancy import (
     Candidate,
     OrgProviderKeyRepository,
@@ -375,22 +375,23 @@ class OrgProviderKeyService:
         skip: int = 0,
         limit: int = 100,
     ) -> OrgProviderKeysPublic:
-        """List the caller's organization's keys. Any active member may read it.
+        """List the caller's organization's keys. Organization owners and admins only.
 
-        ``client_args`` is redacted for a plain member: this read is open to
-        every active member, not only owners/admins, and `OrgProviderKey.to_public`
-        explains why that field cannot be assumed safe for that wider audience.
+        Gated like the writes rather than open to every active member: a row
+        names the provider, the endpoint and the credential's last four, and the
+        roles matrix puts the whole provider-key surface out of a member's sight
+        (otari-ai#1944). That is also what retired the per-audience
+        ``client_args`` redaction `OrgProviderKey.to_public` used to carry: with
+        no member reader left, there is no wider audience to withhold it from.
         ``count`` is the total matching rows, not the page size, so a caller
         can page correctly (mirrors ``WorkspaceService.list_workspaces``).
         """
         organization = await self.organizations.get_active_organization_for_user(user)
+        await self.organizations.require_active_organization_management_access(user=user, organization=organization)
         rows, count = await self.keys.list_for_organization(
             organization.id, include_archived=include_archived, skip=skip, limit=limit
         )
-        membership = await self.organizations.members.get_active_by_organization_and_user(organization.id, user.id)
-        is_admin = user.is_superuser or (membership is not None and membership.role in MANAGEMENT_ROLES)
-        data = [row.to_public(include_client_args=is_admin) for row in rows]
-        return OrgProviderKeysPublic(data=data, count=count)
+        return OrgProviderKeysPublic(data=[row.to_public() for row in rows], count=count)
 
     async def create_key_for_user(
         self,

--- a/src/gateway/services/tenancy/org_provider_key_service.py
+++ b/src/gateway/services/tenancy/org_provider_key_service.py
@@ -377,12 +377,11 @@ class OrgProviderKeyService:
     ) -> OrgProviderKeysPublic:
         """List the caller's organization's keys. Organization owners and admins only.
 
-        Gated like the writes rather than open to every active member: a row
-        names the provider, the endpoint and the credential's last four, and the
-        roles matrix puts the whole provider-key surface out of a member's sight
-        (otari-ai#1944). That is also what retired the per-audience
-        ``client_args`` redaction `OrgProviderKey.to_public` used to carry: with
-        no member reader left, there is no wider audience to withhold it from.
+        Gated like every write on this surface, not open to the wider
+        membership: a row names the provider, the endpoint and the credential's
+        last four, which the roles matrix keeps out of a plain member's sight
+        (otari-ai#1944). One audience for the whole surface is also what lets
+        `OrgProviderKey.to_public` serialize ``client_args`` for every caller.
         ``count`` is the total matching rows, not the page size, so a caller
         can page correctly (mirrors ``WorkspaceService.list_workspaces``).
         """

--- a/tests/integration/test_deployment_operator_gate.py
+++ b/tests/integration/test_deployment_operator_gate.py
@@ -98,11 +98,11 @@ _CATALOG_PROBES: list[tuple[str, str]] = [
 # member reaches these by design, so a 403 from any of them means the gate was
 # applied to the wrong family. Only the routes a *member* may reach are listed:
 # several of these routers hold owner/admin routes as well (organization
-# guardrails and pricing are entirely owner/admin), and their own 403 is
-# indistinguishable here from the one this file is about.
+# guardrails and pricing are entirely owner/admin, and the provider-keys list
+# joined them in otari-ai#1944), and their own 403 is indistinguishable here
+# from the one this file is about.
 _TENANT_SCOPED_PROBES: list[tuple[str, str]] = [
     ("GET", "/v1/organizations/me"),
-    ("GET", "/v1/organizations/me/provider-keys"),
     ("GET", "/v1/workspaces"),
     ("GET", "/v1/admin/access"),
 ]

--- a/tests/integration/test_deployment_operator_gate.py
+++ b/tests/integration/test_deployment_operator_gate.py
@@ -221,11 +221,18 @@ def test_an_organization_owner_is_still_not_a_deployment_operator(
         refused = _call(client, "GET", "/v1/keys")
         # ...while the organization they do own answers as before.
         own = _call(client, "GET", "/v1/organizations/me")
+        # Probed at owner rather than member because the provider-keys list is
+        # organization-management-gated (otari-ai#1944), which is what took it
+        # out of `_TENANT_SCOPED_PROBES`. Its own 403 would be
+        # indistinguishable there from this file's; here it says the
+        # deployment-operator gate is still off that router.
+        keys = _call(client, "GET", "/v1/organizations/me/provider-keys")
     finally:
         client.cookies.clear()
 
     assert refused == 403
     assert own == 200
+    assert keys == 200
 
 
 # =============================================================================

--- a/tests/integration/test_org_provider_keys.py
+++ b/tests/integration/test_org_provider_keys.py
@@ -180,10 +180,11 @@ async def test_plain_member_cannot_create_a_key(async_db: AsyncSession) -> None:
         await service.create_key_for_user(user=member, request=_create_request())
 
 
-async def test_plain_member_does_not_see_client_args_but_admin_does(async_db: AsyncSession) -> None:
-    """`client_args` is arbitrary JSON an admin can set, so the list read
-    (open to every active member) redacts it wholesale for a non-admin reader
-    while the admin who set it still sees the non-credential fields back."""
+async def test_plain_member_cannot_list_keys(async_db: AsyncSession) -> None:
+    """The list read is management-gated too (otari-ai#1944): a row names the
+    provider, the endpoint and the credential's last four, and the roles matrix
+    puts that out of a member's sight. The admin who set the key still reads it
+    back, `client_args` included."""
     organization = await _organization(async_db)
     owner = await _member(async_db, organization, role="owner", full_name="Owner")
     member = await _member(async_db, organization, role="member", full_name="Member")
@@ -198,8 +199,24 @@ async def test_plain_member_does_not_see_client_args_but_admin_does(async_db: As
     as_owner = await service.list_keys_for_user(user=owner)
     assert as_owner.data[0].client_args == {"region_name": "us-east-1"}
 
-    as_member = await service.list_keys_for_user(user=member)
-    assert as_member.data[0].client_args is None
+    with pytest.raises(NotAuthorizedError):
+        await service.list_keys_for_user(user=member)
+
+
+async def test_superuser_member_may_still_list_keys(async_db: AsyncSession) -> None:
+    """The gate is `require_active_organization_management_access`, which admits
+    a superuser whatever their role, so the operator identity that reads this
+    surface on a standalone deployment is not locked out by the narrowing above."""
+    organization = await _organization(async_db)
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    operator = await _member(async_db, organization, role="member", full_name="Operator")
+    operator.is_superuser = True
+    async_db.add(operator)
+    await async_db.commit()
+    service = OrgProviderKeyService(async_db)
+    await service.create_key_for_user(user=owner, request=_create_request())
+
+    assert len((await service.list_keys_for_user(user=operator)).data) == 1
 
 
 async def test_credential_shaped_client_args_are_redacted_even_for_the_admin_who_set_them(
@@ -209,9 +226,9 @@ async def test_credential_shaped_client_args_are_redacted_even_for_the_admin_who
     Bedrock support genuinely needs `aws_access_key_id`/`aws_secret_access_key`
     there, so the field cannot simply be rejected outright) never round-trips,
     the same treatment `encrypted_api_key` itself already gets: only `last4`
-    comes back, never the plaintext. This holds even for the admin who set it,
-    not only for a lower-privileged reader -- that is a separate, coarser gate
-    `include_client_args` already covers."""
+    comes back, never the plaintext. The admin who set it is the only reader
+    this surface has left, so the masking has to hold for them: there is no
+    lower-privileged audience a coarser gate could withhold the field from."""
     organization = await _organization(async_db)
     owner = await _member(async_db, organization, role="owner", full_name="Owner")
     service = OrgProviderKeyService(async_db)

--- a/tests/unit/test_org_provider_key_service.py
+++ b/tests/unit/test_org_provider_key_service.py
@@ -203,9 +203,3 @@ def test_to_public_client_args_none_stays_none() -> None:
     key = _key(name="plain")
     assert key.client_args is None
     assert key.to_public().client_args is None
-
-
-def test_to_public_include_client_args_false_still_redacts_nothing_since_it_is_already_none() -> None:
-    key = _key(name="plain")
-    key.client_args = {"aws_secret_access_key": "supersecretvalue"}
-    assert key.to_public(include_client_args=False).client_args is None

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -1950,7 +1950,7 @@ export interface paths {
         };
         /**
          * List Org Provider Keys
-         * @description List the caller's organization's provider keys. Any active member may read it.
+         * @description List the caller's organization's provider keys. Organization owners and admins only.
          */
         get: operations["list_org_provider_keys_v1_organizations_me_provider_keys_get"];
         put?: never;

--- a/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
@@ -222,9 +222,9 @@ describe("OrganizationProviderKeysPage", () => {
     // organization has no keys rather than that they cannot see them.
     const requests = mockApi({
       keys: [orgProviderKey()],
-      // Not an operator either: the fixture's default identity is one, and the
-      // server admits a superuser whatever their organization role, so a plain
-      // member has to say both.
+      // Both flags, not just the role: the fixture's default identity is a
+      // deployment operator, and this page's gate is `canManage` alone, so
+      // saying only the role would leave the case under test ambiguous.
       context: organizationContext({
         role: "member",
         deployment_operator: false,
@@ -250,23 +250,6 @@ describe("OrganizationProviderKeysPage", () => {
         request.url.includes("/v1/organizations/me/provider-keys"),
       ),
     ).toBe(false)
-  })
-
-  it("still lists the keys for a deployment operator whose org role is member", async () => {
-    // The server's gate admits a superuser whatever their organization role, so
-    // the read follows `deployment_operator`, the nearest authority the context
-    // publishes. The write controls keep their own narrower gate.
-    mockApi({
-      keys: [orgProviderKey()],
-      context: organizationContext({
-        role: "member",
-        deployment_operator: true,
-      }),
-    })
-    renderPage(<OrganizationProviderKeysPage />)
-
-    expect(await screen.findByText("Production")).toBeInTheDocument()
-    expect(screen.queryByText(/Only organization owners and admins/)).toBeNull()
   })
 
   it("disables adding a key when the deployment cannot encrypt one", async () => {

--- a/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
@@ -215,21 +215,35 @@ describe("OrganizationProviderKeysPage", () => {
     expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument()
   })
 
-  it("offers no writes to a member who cannot manage the organization", async () => {
-    mockApi({
+  it("withholds the keys and their read from a member who cannot manage the organization", async () => {
+    // The list read is organization owner/admin-gated on the server
+    // (otari-ai#1944), so a member reaching this URL is answered 403. The read
+    // is not made, and the table goes with it: an empty one would say the
+    // organization has no keys rather than that they cannot see them.
+    const requests = mockApi({
       keys: [orgProviderKey()],
       context: organizationContext({ role: "member" }),
     })
     renderPage(<OrganizationProviderKeysPage />)
 
-    await screen.findByText("Production")
+    expect(
+      await screen.findByText(/Only organization owners and admins/),
+    ).toBeInTheDocument()
+    expect(screen.queryByText("Production")).toBeNull()
+    // HeroUI's table is a `grid`, so this is the table itself being absent and
+    // not merely empty of the row above.
+    expect(
+      screen.queryByRole("grid", { name: "Organization provider keys" }),
+    ).toBeNull()
     expect(
       screen.queryByRole("button", { name: "Add provider key" }),
     ).toBeNull()
     expect(screen.queryByRole("button", { name: "Edit" })).toBeNull()
     expect(
-      screen.getByText(/Only organization owners and admins/),
-    ).toBeInTheDocument()
+      requests.some((request) =>
+        request.url.includes("/v1/organizations/me/provider-keys"),
+      ),
+    ).toBe(false)
   })
 
   it("disables adding a key when the deployment cannot encrypt one", async () => {
@@ -284,6 +298,13 @@ describe("OrganizationProviderKeysPage", () => {
     expect(screen.queryByText(/OTARI_SECRET_KEY/)).toBeNull()
     expect(
       screen.queryByRole("button", { name: "Add provider key" }),
+    ).toBeNull()
+    // Nor is the role claimed either way: with the context unread the page
+    // cannot say the caller is a member, so the refusal banner stays off and the
+    // table, whose read is gated on that same role, is not drawn empty.
+    expect(screen.queryByText(/Only organization owners and admins/)).toBeNull()
+    expect(
+      screen.queryByRole("grid", { name: "Organization provider keys" }),
     ).toBeNull()
   })
 

--- a/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
@@ -222,7 +222,13 @@ describe("OrganizationProviderKeysPage", () => {
     // organization has no keys rather than that they cannot see them.
     const requests = mockApi({
       keys: [orgProviderKey()],
-      context: organizationContext({ role: "member" }),
+      // Not an operator either: the fixture's default identity is one, and the
+      // server admits a superuser whatever their organization role, so a plain
+      // member has to say both.
+      context: organizationContext({
+        role: "member",
+        deployment_operator: false,
+      }),
     })
     renderPage(<OrganizationProviderKeysPage />)
 
@@ -244,6 +250,23 @@ describe("OrganizationProviderKeysPage", () => {
         request.url.includes("/v1/organizations/me/provider-keys"),
       ),
     ).toBe(false)
+  })
+
+  it("still lists the keys for a deployment operator whose org role is member", async () => {
+    // The server's gate admits a superuser whatever their organization role, so
+    // the read follows `deployment_operator`, the nearest authority the context
+    // publishes. The write controls keep their own narrower gate.
+    mockApi({
+      keys: [orgProviderKey()],
+      context: organizationContext({
+        role: "member",
+        deployment_operator: true,
+      }),
+    })
+    renderPage(<OrganizationProviderKeysPage />)
+
+    expect(await screen.findByText("Production")).toBeInTheDocument()
+    expect(screen.queryByText(/Only organization owners and admins/)).toBeNull()
   })
 
   it("disables adding a key when the deployment cannot encrypt one", async () => {

--- a/web/src/features/organization/OrganizationProviderKeysPage.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.tsx
@@ -35,7 +35,7 @@ import {
 } from "@/shared/components/ui"
 import { formatRelative } from "@/shared/helpers/format"
 
-import { canManage } from "./roles"
+import { canManage, isDeploymentOperator } from "./roles"
 
 // The organization's own upstream credentials: one BYO key per provider that
 // every workspace under the tenant inherits.
@@ -214,13 +214,22 @@ function KeyForm({
 
 export function OrganizationProviderKeysPage() {
   const context = useOrganizationContext()
-  // One predicate for the whole page now that the list read is
-  // organization-management-gated on the server too (otari-ai#1944): a member
-  // cannot see these rows, not only leave them alone. The read is withheld
-  // rather than fired and refused, the way WorkspacesPage withholds the
-  // operator-only budget reads.
   const canEdit = canManage(context.data)
-  const keys = useOrgProviderKeys(canEdit)
+  // The list read is organization-management-gated on the server too
+  // (otari-ai#1944): a member cannot see these rows, not only leave them alone.
+  // Withheld rather than fired and refused, the way WorkspacesPage withholds
+  // the operator-only budget reads.
+  //
+  // Wider than `canEdit`, and only because the server is: the gate is
+  // `require_active_organization_management_access`, which admits a superuser
+  // whatever their organization role, and `deployment_operator` is the nearest
+  // thing the context publishes to that (`roles.ts` says why `is_superuser`
+  // itself is not on the contract). Withholding the list from an operator who
+  // is a plain member would hide rows the server would hand them. The write
+  // controls keep the narrowing `roles.ts` documents, which is theirs and not
+  // this read's to change.
+  const canRead = canEdit || isDeploymentOperator(context.data)
+  const keys = useOrgProviderKeys(canRead)
   // Same gate the `/providers` page applies, for the same reason: without
   // `OTARI_SECRET_KEY` the gateway cannot encrypt a credential, so the write
   // would fail at submit time.
@@ -397,11 +406,11 @@ export function OrganizationProviderKeysPage() {
         }
       />
 
-      {/* Held back until the context has actually answered: `canEdit` is false
+      {/* Held back until the context has actually answered: `canRead` is false
           while the role is still resolving, and a banner that flashes "you may
           not do this" on every load would be telling most people the opposite
           of the truth. */}
-      {context.data && !canEdit ? (
+      {context.data && !canRead ? (
         <InfoBanner>
           Only organization owners and admins can see this organization's
           provider keys.
@@ -445,7 +454,7 @@ export function OrganizationProviderKeysPage() {
           paint is the table they are about to get rather than an empty state,
           and withheld again if the context read is what failed, since neither
           an empty table nor a spinner is a true answer there. */}
-      {canEdit || context.isPending ? (
+      {canRead || context.isPending ? (
         <DataTable
           ariaLabel="Organization provider keys"
           columns={columns}

--- a/web/src/features/organization/OrganizationProviderKeysPage.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.tsx
@@ -214,7 +214,13 @@ function KeyForm({
 
 export function OrganizationProviderKeysPage() {
   const context = useOrganizationContext()
-  const keys = useOrgProviderKeys()
+  // One predicate for the whole page now that the list read is
+  // organization-management-gated on the server too (otari-ai#1944): a member
+  // cannot see these rows, not only leave them alone. The read is withheld
+  // rather than fired and refused, the way WorkspacesPage withholds the
+  // operator-only budget reads.
+  const canEdit = canManage(context.data)
+  const keys = useOrgProviderKeys(canEdit)
   // Same gate the `/providers` page applies, for the same reason: without
   // `OTARI_SECRET_KEY` the gateway cannot encrypt a credential, so the write
   // would fail at submit time.
@@ -228,7 +234,6 @@ export function OrganizationProviderKeysPage() {
   const [editingId, setEditingId] = useState<string | null>(null)
   const [showArchived, setShowArchived] = useState(false)
 
-  const canEdit = canManage(context.data)
   const editing = keys.data?.find((key) => key.id === editingId) ?? null
   const archivedCount = (keys.data ?? []).filter((key) =>
     Boolean(key.archived_at),
@@ -398,7 +403,8 @@ export function OrganizationProviderKeysPage() {
           of the truth. */}
       {context.data && !canEdit ? (
         <InfoBanner>
-          Only organization owners and admins can add or change provider keys.
+          Only organization owners and admins can see this organization's
+          provider keys.
         </InfoBanner>
       ) : null}
 
@@ -432,14 +438,23 @@ export function OrganizationProviderKeysPage() {
         </Checkbox>
       ) : null}
 
-      <DataTable
-        ariaLabel="Organization provider keys"
-        columns={columns}
-        rows={rows}
-        getRowKey={(row) => row.id}
-        isLoading={keys.isLoading}
-        emptyContent="No provider keys yet. Add one to let every workspace in this organization call that provider."
-      />
+      {/* Withheld from a member along with the read that fills it: the banner
+          above is their whole answer, and an empty table would tell them the
+          organization has no keys rather than that they cannot see them. Drawn
+          as loading while the role is still resolving, so an admin's first
+          paint is the table they are about to get rather than an empty state,
+          and withheld again if the context read is what failed, since neither
+          an empty table nor a spinner is a true answer there. */}
+      {canEdit || context.isPending ? (
+        <DataTable
+          ariaLabel="Organization provider keys"
+          columns={columns}
+          rows={rows}
+          getRowKey={(row) => row.id}
+          isLoading={context.isPending || keys.isLoading}
+          emptyContent="No provider keys yet. Add one to let every workspace in this organization call that provider."
+        />
+      ) : null}
     </div>
   )
 }

--- a/web/src/features/organization/OrganizationProviderKeysPage.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.tsx
@@ -35,7 +35,7 @@ import {
 } from "@/shared/components/ui"
 import { formatRelative } from "@/shared/helpers/format"
 
-import { canManage, isDeploymentOperator } from "./roles"
+import { canManage } from "./roles"
 
 // The organization's own upstream credentials: one BYO key per provider that
 // every workspace under the tenant inherits.
@@ -214,22 +214,21 @@ function KeyForm({
 
 export function OrganizationProviderKeysPage() {
   const context = useOrganizationContext()
-  const canEdit = canManage(context.data)
-  // The list read is organization-management-gated on the server too
-  // (otari-ai#1944): a member cannot see these rows, not only leave them alone.
-  // Withheld rather than fired and refused, the way WorkspacesPage withholds
-  // the operator-only budget reads.
+  // One predicate for the whole page now that the list read is
+  // organization-management-gated on the server too (otari-ai#1944): a member
+  // cannot see these rows, not only leave them alone. Withheld rather than
+  // fired and refused, the way `OrganizationGuardrailsCard` gates its own read
+  // and WorkspacesPage withholds the operator-only budget ones.
   //
-  // Wider than `canEdit`, and only because the server is: the gate is
-  // `require_active_organization_management_access`, which admits a superuser
-  // whatever their organization role, and `deployment_operator` is the nearest
-  // thing the context publishes to that (`roles.ts` says why `is_superuser`
-  // itself is not on the contract). Withholding the list from an operator who
-  // is a plain member would hide rows the server would hand them. The write
-  // controls keep the narrowing `roles.ts` documents, which is theirs and not
-  // this read's to change.
-  const canRead = canEdit || isDeploymentOperator(context.data)
-  const keys = useOrgProviderKeys(canRead)
+  // Deliberately not widened to `isDeploymentOperator`: the server also admits
+  // a superuser whatever their organization role, and `roles.ts` records that
+  // divergence, why it narrows in the safe direction, and that closing it means
+  // growing the membership context a superuser field. `deployment_operator` is
+  // not that field, since it also admits a non-superuser bootstrap identity the
+  // server would refuse, and the rail row is `canManage`-gated too, so no such
+  // caller had a route here to lose.
+  const canEdit = canManage(context.data)
+  const keys = useOrgProviderKeys(canEdit)
   // Same gate the `/providers` page applies, for the same reason: without
   // `OTARI_SECRET_KEY` the gateway cannot encrypt a credential, so the write
   // would fail at submit time.
@@ -406,11 +405,11 @@ export function OrganizationProviderKeysPage() {
         }
       />
 
-      {/* Held back until the context has actually answered: `canRead` is false
+      {/* Held back until the context has actually answered: `canEdit` is false
           while the role is still resolving, and a banner that flashes "you may
           not do this" on every load would be telling most people the opposite
           of the truth. */}
-      {context.data && !canRead ? (
+      {context.data && !canEdit ? (
         <InfoBanner>
           Only organization owners and admins can see this organization's
           provider keys.
@@ -454,7 +453,7 @@ export function OrganizationProviderKeysPage() {
           paint is the table they are about to get rather than an empty state,
           and withheld again if the context read is what failed, since neither
           an empty table nor a spinner is a true answer there. */}
-      {canRead || context.isPending ? (
+      {canEdit || context.isPending ? (
         <DataTable
           ariaLabel="Organization provider keys"
           columns={columns}

--- a/web/src/shared/api/hooks.ts
+++ b/web/src/shared/api/hooks.ts
@@ -2663,6 +2663,10 @@ function invalidateOrgProviderKeys(
 // second query: archiving is reversible, the list is small, and a toggle that
 // refetched would make "show archived" a network round trip for a set the
 // browser already holds.
+//
+// The list itself is organization owner/admin-gated, not member-readable
+// (otari-ai#1944), so a caller reachable by a plain member passes `enabled`
+// false for them rather than rendering the refusal.
 export function useOrgProviderKeys(enabled = true) {
   return useQuery({
     queryKey: [ORGANIZATION_PROVIDER_KEYS],


### PR DESCRIPTION
## Description

`GET /v1/organizations/me/provider-keys` answered any active member with the organization's provider rows (provider, name, `api_base`, `last4`). The 11 Aug roles matrix marks provider keys **Hidden** for members, and every write on the surface was already management-gated, so only the read was out of line.

The list now goes through `require_active_organization_management_access`. That retires `to_public`'s `include_client_args` parameter with it: the coarser gate existed only for the plain-member reader, and with no such reader left, `redact_secret_like_values` is the whole story.

The dashboard page was reachable by URL even though its rail row is admin-gated, so its read is gated on `canManage` rather than fired and refused, and the table is withheld with it (an empty one would say the organization has no keys instead of that the caller cannot see them).

Note for a follow-up in otari-ai, not this PR: `backend/overlay/attached_gateway/service.py` cites `OrgProviderKeyService.list_keys_for_user` as the precedent for its member-readable gateway reads. That precedent is gone, and the second half of the same note ("otari's dashboard drops the session on any 403") no longer holds either. mozilla-ai/otari-ai#1946 already tracks the Gateways row.

## PR Type

- [x] Bug Fix

## Relevant issues

Fixes mozilla-ai/otari-ai#1944

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

`make lint`, `make typecheck`, `make openapi-check`, `make postman-check`, `tests/unit` (2604 passed), the tenancy and gate slice of `tests/integration` (410 passed), `pnpm --dir web run lint`, `typecheck` and `test` (1742 passed) are all green. `ruff format` was deliberately not run: it reflows ~150 unrelated files here.

## AI Usage

- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code

**Any additional AI details you'd like to share:**

Implemented, tested and self-reviewed by the agent; the human author reviews before merge.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Restricted organization provider-key listing to owners and admins.
- Prevented ordinary members from fetching or viewing provider keys.
- Preserved access for authorized superusers and deployment operators.
- Simplified provider-key redaction by removing `include_client_args`.
- Updated dashboard behavior, API documentation, generated schema, Postman documentation, and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->