### PR TITLE
docs: prune the comments #870 left around the legal URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ The per-request flow (auth → budget → dispatch → reconciliation) spans sev
 
 ## Repository Conventions
 - Prefer minimal, targeted edits over broad refactors, and match the import order and typing style of the file you are in (`TYPE_CHECKING` for type-only imports where it helps, as in `routes/_helpers.py`).
-- Add a comment only where the logic is not obvious; keep docstrings concise and meaningful on public functions and classes.
+- Add a comment only where the logic is not obvious; keep docstrings concise and meaningful on public functions and classes. Do not restate the code, narrate the change, or record what the code used to do: the commit message is where that belongs. Leave the comments around a change shorter than you found them.
 - Preserve security-relevant behavior: header parsing, auth checks, and the error-detail boundary. Do not leak internals in public error responses, and never log secrets, tokens, or raw API keys (the one-time bootstrap key print is the deliberate exception).
 - Keep test additions next to the behavior they cover: unit for pure logic, integration for route or database behavior.
 - CI runs Python 3.14 (`.github/workflows/otari-tests.yml`), matching the Docker image; the package still supports 3.13+ (`requires-python = ">=3.13"`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ The per-request flow (auth → budget → dispatch → reconciliation) spans sev
 
 ## Repository Conventions
 - Prefer minimal, targeted edits over broad refactors, and match the import order and typing style of the file you are in (`TYPE_CHECKING` for type-only imports where it helps, as in `routes/_helpers.py`).
-- Add a comment only where the logic is not obvious; keep docstrings concise and meaningful on public functions and classes. Do not restate the code, narrate the change, or record what the code used to do: the commit message is where that belongs. Leave the comments around a change shorter than you found them.
+- Add a comment only where the logic is not obvious; keep docstrings concise and meaningful on public functions and classes. Do not restate the code, narrate the change, or record what the code used to do: the commit message is where that belongs. Leave the comments around a change shorter than you found them: prune narration, repeated rationale, and implementation history as you touch them.
 - Preserve security-relevant behavior: header parsing, auth checks, and the error-detail boundary. Do not leak internals in public error responses, and never log secrets, tokens, or raw API keys (the one-time bootstrap key print is the deliberate exception).
 - Keep test additions next to the behavior they cover: unit for pure logic, integration for route or database behavior.
 - CI runs Python 3.14 (`.github/workflows/otari-tests.yml`), matching the Docker image; the package still supports 3.13+ (`requires-python = ">=3.13"`).

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -1773,10 +1773,8 @@ class GatewayConfig(BaseSettings):
         for the same reason ``platform.management_url`` is: a typo should be a
         startup error, not a Documentation link that silently goes nowhere.
 
-        One validator for the three because they are one kind of value: an
-        address a person follows out of the dashboard, with no downstream
-        consumer that builds a request from it. ``data_plane_url`` is held to a
-        stricter bar for exactly that reason and keeps its own.
+        ``data_plane_url`` keeps its own, stricter validator: a client builds a
+        request from it rather than following it.
 
         Userinfo is the one refusal the three share with ``data_plane_url``, and
         they share it for its reason rather than theirs: ``GET /v1/bootstrap``

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -1776,7 +1776,7 @@ class GatewayConfig(BaseSettings):
         ``data_plane_url`` keeps its own, stricter validator: a client builds a
         request from it rather than following it.
 
-        Userinfo is the one refusal the three share with ``data_plane_url``, and
+        Userinfo is the one refusal these three fields share with ``data_plane_url``, and
         they share it for its reason rather than theirs: ``GET /v1/bootstrap``
         is unauthenticated, so a credential written into any of these would
         reach every browser that asked, which no redaction in the operator-gated

--- a/web/e2e/parity.bootstrap.spec.ts
+++ b/web/e2e/parity.bootstrap.spec.ts
@@ -46,9 +46,7 @@ test("the deployment bootstrap is served unauthenticated", async ({
     // links stay on the operator guide bundled with this gateway; see
     // docs/configuration.md#documentation-links.
     docs_url: null,
-    // No terms_url or privacy_url in this e2e environment, so the account menu
-    // carries no Terms of service row and its Data & Privacy row stays
-    // disabled; see docs/configuration.md#legal-pages.
+    // No legal pages configured here; see docs/configuration.md#legal-pages.
     terms_url: null,
     privacy_url: null,
     // Sign-ins are open, which is the resting state: maintenance mode is a

--- a/web/e2e/parity.hybrid.spec.ts
+++ b/web/e2e/parity.hybrid.spec.ts
@@ -53,8 +53,7 @@ test.describe("hybrid deployment", () => {
       // gateway may carry a hosted documentation link, and this one configures
       // none, so the bundled guide stays the target.
       docs_url: null,
-      // Deployment-wide for the same reason, and unset here too: a hybrid
-      // gateway may carry legal pages of its own, and this one configures none.
+      // Deployment-wide like docs_url, and unset here too.
       terms_url: null,
       privacy_url: null,
       // Never frozen, because the freeze is on a sign-in this deployment does

--- a/web/src/app/nav/AccountMenu.test.tsx
+++ b/web/src/app/nav/AccountMenu.test.tsx
@@ -100,7 +100,6 @@ describe("AccountMenu", () => {
     await openMenu()
 
     expect(screen.queryByRole("link", { name: "Terms of service" })).toBeNull()
-    // Present but inert rather than absent.
     const privacy = await screen.findByRole("button", {
       name: /^Data & Privacy \(/,
     })

--- a/web/src/app/nav/AccountMenu.test.tsx
+++ b/web/src/app/nav/AccountMenu.test.tsx
@@ -100,8 +100,7 @@ describe("AccountMenu", () => {
     await openMenu()
 
     expect(screen.queryByRole("link", { name: "Terms of service" })).toBeNull()
-    // Present but inert, which is the row a gateway with no notice to link
-    // still owes: the surface is coming, and omitting it reads as never.
+    // Present but inert rather than absent.
     const privacy = await screen.findByRole("button", {
       name: /^Data & Privacy \(/,
     })
@@ -119,8 +118,6 @@ describe("AccountMenu", () => {
     expect(terms).toHaveAttribute("href", "https://otari.ai/terms")
     expect(terms).toHaveAttribute("target", "_blank")
 
-    // otari-ai#1945: the notice lives on the marketing site beside the
-    // dashboard, and this row is how a signed-in user reaches it.
     const privacy = await screen.findByRole("link", { name: "Data & Privacy" })
     expect(privacy).toHaveAttribute("href", "https://otari.ai/privacy")
     expect(privacy).toHaveAttribute("target", "_blank")
@@ -143,8 +140,6 @@ describe("AccountMenu", () => {
     expect(
       await screen.findByRole("link", { name: "Terms of service" }),
     ).toHaveAttribute("href", "https://otari.ai/terms")
-    // The other direction of the same independence: one address published does
-    // not invent the other, so this row stays the disabled one.
     expect(
       screen.getByRole("button", { name: /^Data & Privacy \(/ }),
     ).toBeDisabled()

--- a/web/src/app/nav/AccountMenu.tsx
+++ b/web/src/app/nav/AccountMenu.tsx
@@ -41,13 +41,10 @@ import {
 // the credential it was minted from (otari#653): a session is per-identity
 // since otari#647, and the identity holds a password of its own since otari#649,
 // so the row this menu carried disabled from the start now has a destination.
-// The two legal rows are the deployment's own documents, and each appears only
-// where there is one to point at: `terms_url` and `privacy_url`, the addresses
-// an operator configures and `GET /v1/bootstrap` publishes beside `docs_url`.
-// Terms of service is absent without one, because a gateway nobody wrote terms
-// for has none to show. Data & Privacy falls back to the disabled row instead
-// of vanishing, because the settings surface it will become is coming and a
-// menu that silently lacks it reads as a menu that never will.
+// The legal rows link `terms_url` and `privacy_url` where the deployment set
+// them. Data & Privacy stays a disabled row when unset rather than vanishing:
+// the settings surface it will become is coming, and a menu that silently
+// lacks it reads as a menu that never will.
 
 const THEME_LABELS: Record<ThemePreference, string> = {
   system: "System",
@@ -364,13 +361,6 @@ export function AccountMenu({ collapsed }: { collapsed: boolean }) {
               className="md:hidden"
             />
           )}
-          {/* Absent rather than pointing somewhere invented. This used to build
-              the address from `management_url` behind a `legal.terms`
-              entitlement, which no deployment could satisfy: that field is set
-              only for a hybrid gateway, which issues no session and so never
-              opens this menu, and nothing granted the capability. So a hosted
-              deployment with terms on its own site had no way to name them
-              (otari-ai#1945). */}
           {terms_url ? (
             <MenuExternalLink
               label="Terms of service"

--- a/web/src/app/nav/AccountMenu.tsx
+++ b/web/src/app/nav/AccountMenu.tsx
@@ -41,10 +41,9 @@ import {
 // the credential it was minted from (otari#653): a session is per-identity
 // since otari#647, and the identity holds a password of its own since otari#649,
 // so the row this menu carried disabled from the start now has a destination.
-// The legal rows link `terms_url` and `privacy_url` where the deployment set
-// them. Data & Privacy stays a disabled row when unset rather than vanishing:
-// the settings surface it will become is coming, and a menu that silently
-// lacks it reads as a menu that never will.
+// Data & Privacy stays a disabled row when unset rather than vanishing: the
+// settings surface it will become is coming, and a menu that silently lacks it
+// reads as a menu that never will.
 
 const THEME_LABELS: Record<ThemePreference, string> = {
   system: "System",

--- a/web/src/tests/fixtures.ts
+++ b/web/src/tests/fixtures.ts
@@ -129,9 +129,8 @@ export function bootstrap(
     // Null, because a fixture describes a deployment whose documentation is the
     // bundled guide; the tests about an operator-configured docs site set it.
     docs_url: null,
-    // Null both, because a self-hosted gateway publishes no legal pages of its
-    // own: Terms of service is then absent from the account menu and Data &
-    // Privacy is the disabled row. The account-menu tests set them.
+    // A self-hosted gateway publishes no legal pages. The account-menu tests
+    // set them.
     terms_url: null,
     privacy_url: null,
     // Not frozen, because a fixture describes a deployment somebody can sign

--- a/web/src/tests/fixtures.ts
+++ b/web/src/tests/fixtures.ts
@@ -129,8 +129,8 @@ export function bootstrap(
     // Null, because a fixture describes a deployment whose documentation is the
     // bundled guide; the tests about an operator-configured docs site set it.
     docs_url: null,
-    // A self-hosted gateway publishes no legal pages. The account-menu tests
-    // set them.
+    // Unset, like docs_url: this fixture's deployment publishes none. The
+    // account-menu tests set them.
     terms_url: null,
     privacy_url: null,
     // Not frozen, because a fixture describes a deployment somebody can sign


### PR DESCRIPTION
## Description

Follow-up to #870. That PR added a lot of comment for the amount of code it added, and most of it was not carrying anything the code did not already say. This trims it back and sharpens the rule that was supposed to prevent it.

Deletes the seven-line block above the Terms of service row: it explained the `management_url` and `legal.terms` gating that #870 replaced, which is history about code that no longer exists, already stated in that PR's commit message and body, wrapped around a ternary that reads plainly. Shortens the header note, the bootstrap fixture, both e2e payload comments, three test comments, and one validator docstring paragraph. Kept in every case is the fact the code cannot state: that Data & Privacy stays disabled rather than vanishing, and that `data_plane_url` keeps a stricter validator.

`AGENTS.md` now says no restating the code, no narrating the change, no recording what the code used to do, and leave the comments around a change shorter than you found them. The previous wording, "add a comment only where the logic is not obvious", caught none of it, because narration and history can both claim to be intent.

36 of the 124 dashboard lines #870 added were comment. No behavior changes.

## PR Type

- [x] Refactor
- [x] Documentation

## Relevant issues

Follow-up to #870. No issue.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Comments only, so no test was added or changed and the contract is untouched. Run locally: `pnpm --dir web run lint`, `run typecheck`, `vitest run src/app/nav/AccountMenu.test.tsx` (15 passed), `uv run ruff check src tests scripts`, `pytest tests/unit/test_deployment_bootstrap.py` (71 passed).

## AI Usage

- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via the Claude Code CLI.

**Any additional AI details you'd like to share:**

Written by Claude Opus 5 through back-and-forth with @njbrake, who asked for the trim after reading #870 and pointed at agent-of-empires' `AGENTS.md` as the standard to hold it to. Its two clauses that otari's rule lacked, no preserved implementation history and leave the comments shorter than you found them, are what this adopts.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed redundant comments about legal URL handling across the application, tests, fixtures, and end-to-end tests.
- Kept comments that explain behavior not clear from the code, including the disabled Data & Privacy row and stricter `data_plane_url` validation.
- Tightened `AGENTS.md` guidance to favor concise comments and avoid repeating code or historical context.
- Preserved all application behavior and test logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->