### PR TITLE
feat(budgets): give an organization its own budgets and spend ceilings

### DIFF
--- a/alembic/versions/b7e1c4a9d2f5_budgets_belong_to_an_organization.py
+++ b/alembic/versions/b7e1c4a9d2f5_budgets_belong_to_an_organization.py
@@ -44,7 +44,11 @@ is the honest description of a real ceiling whose figure is set elsewhere.
 
 A budget named by a ``users`` row is skipped even on a single-organization
 deployment: that table is the deployment's own, with no tenancy column, so a
-budget handed to a gateway user is not the organization's to redefine.
+budget handed to a gateway user is not the organization's to redefine. A budget
+named by a ``budget_reset_logs`` row is skipped for the same reason one step
+removed: a reset record outlives the assignment that produced it, so such a
+budget *was* handed to a gateway user even where no live ``users`` row still
+points at it, and the reference goes on refusing a delete either way.
 
 ``ondelete="CASCADE"`` matches ``workspace.organization_id``, the neighbouring
 column in the tenancy model. Nothing can reach it yet: this gateway serves no
@@ -102,7 +106,8 @@ def _assign_sole_organization(bind: sa.Connection) -> None:
         sa.text(
             "UPDATE budgets SET organization_id = :organization_id "
             "WHERE organization_id IS NULL "
-            "AND budget_id NOT IN (SELECT budget_id FROM users WHERE budget_id IS NOT NULL)"
+            "AND budget_id NOT IN (SELECT budget_id FROM users WHERE budget_id IS NOT NULL) "
+            "AND budget_id NOT IN (SELECT budget_id FROM budget_reset_logs)"
         ),
         {"organization_id": organizations[0]},
     )

--- a/alembic/versions/b7e1c4a9d2f5_budgets_belong_to_an_organization.py
+++ b/alembic/versions/b7e1c4a9d2f5_budgets_belong_to_an_organization.py
@@ -1,0 +1,115 @@
+"""Give a budget an owning organization, so an admin can define one.
+
+The roles matrix (otari-ai#1943) puts Spend & budgets at Edit for an
+organization admin, and until now a budget was deployment-global with
+``/v1/budgets`` gated on ``require_deployment_operator``: there was no column
+saying whose a budget was, so there was nothing for a tenant-scoped surface to
+scope to. This adds it, and ``/v1/organizations/me/budgets`` writes it.
+
+**Nullable, with no backfill, and that is the contract rather than a shortcut.**
+NULL means the deployment's own budget. Two populations read NULL and both
+should:
+
+- every budget that already exists, which was defined deployment-wide;
+- every budget the otari-ai cutover migration mints. That migration shares one
+  budget per distinct ``(max_budget, budget_duration_sec, reset_alignment)``
+  shape across all the ceilings it writes (see ``docs/budget-migration.md``
+  there), so a shape held by two tenants' ceilings has no single owner and
+  inventing one would hand one tenant's admin control over the other's cap.
+
+Nothing tenant-facing ever lists, offers or repoints a NULL row, so from an
+organization's side a deployment budget does not exist. That is also what keeps
+the cutover migration working untouched: its preflight refuses on a *missing*
+table or column and its inserts name their columns explicitly, so a new nullable
+column is invisible to it and needs no re-transcription and no backfill pass.
+
+**Column, index, then the constraint in a batch**, following
+``7c5ba82a601b``: SQLite has no ALTER TABLE ADD CONSTRAINT, so the foreign key
+goes on inside ``batch_alter_table`` while the plain ADD COLUMN and the index do
+not need it.
+
+**The one backfill, and why it is narrow.** A deployment with exactly one
+organization gets its budgets assigned to it, when nothing outside that
+organization names them. There the operator *is* that organization's owner
+already, so the assignment grants no authority anybody lacked, and without it the
+new Spend page would open read-only on every existing self-hosted deployment.
+
+A deployment with two or more organizations is left entirely alone. Assigning
+there would hand one tenant's admins control over a cap set above them, and for a
+budget shared by two tenants' ceilings there is no single right answer anyway.
+That population is the hosted one, and it is the cutover's to resolve, where the
+planner knows each ceiling's organization; see ``docs/budget-migration.md`` in
+otari-ai. Until then such a ceiling reads back with ``manageable`` false, which
+is the honest description of a real ceiling whose figure is set elsewhere.
+
+A budget named by a ``users`` row is skipped even on a single-organization
+deployment: that table is the deployment's own, with no tenancy column, so a
+budget handed to a gateway user is not the organization's to redefine.
+
+``ondelete="CASCADE"`` matches ``workspace.organization_id``, the neighbouring
+column in the tenancy model. Nothing can reach it yet: this gateway serves no
+organization-delete route. Whoever adds one has to clear the tenant's ceilings
+first, the way ``WorkspaceService._delete_scoped_budgets_for`` already does for a
+workspace, because ``scoped_budgets.budget_id`` is RESTRICT and a cascade
+arriving here would otherwise fail on it rather than on anything that names the
+organization.
+
+Revision ID: b7e1c4a9d2f5
+Revises: a4d7f1c9e2b6
+Create Date: 2026-08-31
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b7e1c4a9d2f5"
+down_revision: str | Sequence[str] | None = "a4d7f1c9e2b6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("budgets", sa.Column("organization_id", sa.Uuid(), nullable=True))
+    op.create_index(op.f("ix_budgets_organization_id"), "budgets", ["organization_id"], unique=False)
+    with op.batch_alter_table("budgets") as batch:
+        batch.create_foreign_key(
+            "fk_budgets_organization_id",
+            "organization",
+            ["organization_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+    _assign_sole_organization(op.get_bind())
+
+
+def _assign_sole_organization(bind: sa.Connection) -> None:
+    """Give every eligible budget to the deployment's organization, if it has just one.
+
+    Reflected tables rather than the ORM models: a migration has to keep working
+    when those models move on, so it names the columns it needs and nothing else.
+    """
+    organizations = list(bind.execute(sa.text("SELECT id FROM organization")).scalars())
+    if len(organizations) != 1:
+        # Two or more tenants, so there is nothing unambiguous to assign. Zero is
+        # the same branch and no chain reaches it (an earlier data migration
+        # seeds "Default organization"), but it is one condition rather than two
+        # so that a database whose tenancy seed was removed does not crash the
+        # upgrade here.
+        return
+    bind.execute(
+        sa.text(
+            "UPDATE budgets SET organization_id = :organization_id "
+            "WHERE organization_id IS NULL "
+            "AND budget_id NOT IN (SELECT budget_id FROM users WHERE budget_id IS NOT NULL)"
+        ),
+        {"organization_id": organizations[0]},
+    )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("budgets") as batch:
+        batch.drop_constraint("fk_budgets_organization_id", type_="foreignkey")
+    op.drop_index(op.f("ix_budgets_organization_id"), table_name="budgets")
+    op.drop_column("budgets", "organization_id")

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -86,6 +86,14 @@ Settings shows the effective non-secret configuration. Some values can be change
 at runtime and others require a restart. The server marks that distinction in the
 settings response.
 
+What a page shows can also depend on who is signed in, not only on the
+deployment. Spend and budgets is the clearest case: an organization owner or
+admin manages their own organization's budgets and the spend ceilings holding
+them, while a deployment operator gets the deployment-wide budgets and the
+gateway users assigned to them. Model pricing splits the same way, with the
+default pricing catalog kept to an operator and the organization's own rate
+overrides open to its admins.
+
 Exact page names and availability can change with deployment mode and installed
 extensions. The running dashboard is the source of truth.
 

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -6205,7 +6205,7 @@
         "type": "object"
       },
       "OrganizationBudgetUpdate": {
-        "description": "Replace a budget's label, figure and period.\n\nA full statement rather than a patch, matching ``PATCH /v1/budgets/{id}``'s\nown fields: every one is optional and an omitted one is left alone, so\nclearing a cap back to uncapped is not expressible here and is a delete. The\nperiod pair is still mutually exclusive, and setting one does not clear the\nother, which is why :func:`_require_single_period_source` re-checks the\n*resulting* pair rather than the submitted one.",
+        "description": "Replace a budget's label, figure and period.\n\nEvery field is optional and keyed on ``model_fields_set``, matching\n``PATCH /v1/budgets/{id}``'s own: an *omitted* field is left alone, and an\nexplicit null clears it, so sending ``max_budget: null`` takes a budget back\nto uncapped, which is what the dashboard's dialog does. The period pair is\nstill mutually exclusive, and setting one does not clear the other, which is\nwhy :func:`_require_single_period_source` re-checks the *resulting* pair\nrather than the submitted one.",
         "properties": {
           "budget_duration_sec": {
             "anyOf": [

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -7096,13 +7096,15 @@
             "anyOf": [
               {
                 "maxLength": 255,
+                "minLength": 1,
+                "pattern": "^\\S+$",
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Narrow the cap to one provider instance; null caps spend across every provider",
+            "description": "Narrow the cap to one provider instance; omit or null to cap spend across every provider. Must name a real instance: a blank value would store a ceiling that never binds",
             "title": "Provider Key Id"
           },
           "scope_id": {

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -6103,6 +6103,11 @@
           "reset_alignment": {
             "anyOf": [
               {
+                "enum": [
+                  "calendar_day",
+                  "calendar_week",
+                  "calendar_month"
+                ],
                 "type": "string"
               },
               {
@@ -6245,6 +6250,11 @@
           "reset_alignment": {
             "anyOf": [
               {
+                "enum": [
+                  "calendar_day",
+                  "calendar_week",
+                  "calendar_month"
+                ],
                 "type": "string"
               },
               {

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -6057,6 +6057,228 @@
         "title": "OrgProviderKeysPublic",
         "type": "object"
       },
+      "OrganizationBudgetCreate": {
+        "description": "Create one budget owned by the caller's organization.",
+        "properties": {
+          "budget_duration_sec": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Seconds between resets, counted from the last one. Mutually exclusive with reset_alignment",
+            "title": "Budget Duration Sec"
+          },
+          "max_budget": {
+            "anyOf": [
+              {
+                "maximum": 999999999999.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Maximum spend in USD over one period; null caps nothing",
+            "title": "Max Budget"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Admin-facing label for the budget",
+            "title": "Name"
+          },
+          "reset_alignment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Reset on a UTC calendar boundary instead of a fixed number of seconds, which is the only way to express a calendar month. Mutually exclusive with budget_duration_sec",
+            "title": "Reset Alignment"
+          }
+        },
+        "title": "OrganizationBudgetCreate",
+        "type": "object"
+      },
+      "OrganizationBudgetPublic": {
+        "description": "One of the organization's budgets, and how much of its own config names it.\n\nCarries no spend rollup. ``BudgetResponse`` on the deployment surface sums\n``users.spend`` over the gateway's ``users`` table, which is deployment-wide\nand has no tenancy column, so the same figure here would be a cross-tenant\nread. What an organization's own spend is, is a question for Usage.\n\n``ceiling_count`` is the organization-relevant fact instead: how many of its\nceilings this budget currently holds, which is what makes a delete refuse.",
+        "properties": {
+          "budget_duration_sec": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Budget Duration Sec"
+          },
+          "budget_id": {
+            "title": "Budget Id",
+            "type": "string"
+          },
+          "ceiling_count": {
+            "title": "Ceiling Count",
+            "type": "integer"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "max_budget": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Budget"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "organization_id": {
+            "format": "uuid",
+            "title": "Organization Id",
+            "type": "string"
+          },
+          "reset_alignment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reset Alignment"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "budget_id",
+          "organization_id",
+          "name",
+          "max_budget",
+          "budget_duration_sec",
+          "reset_alignment",
+          "ceiling_count",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "OrganizationBudgetPublic",
+        "type": "object"
+      },
+      "OrganizationBudgetUpdate": {
+        "description": "Replace a budget's label, figure and period.\n\nA full statement rather than a patch, matching ``PATCH /v1/budgets/{id}``'s\nown fields: every one is optional and an omitted one is left alone, so\nclearing a cap back to uncapped is not expressible here and is a delete. The\nperiod pair is still mutually exclusive, and setting one does not clear the\nother, which is why :func:`_require_single_period_source` re-checks the\n*resulting* pair rather than the submitted one.",
+        "properties": {
+          "budget_duration_sec": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Seconds between resets, counted from the last one. Mutually exclusive with reset_alignment",
+            "title": "Budget Duration Sec"
+          },
+          "max_budget": {
+            "anyOf": [
+              {
+                "maximum": 999999999999.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Maximum spend in USD over one period; null caps nothing",
+            "title": "Max Budget"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Admin-facing label for the budget",
+            "title": "Name"
+          },
+          "reset_alignment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Reset on a UTC calendar boundary instead of a fixed number of seconds, which is the only way to express a calendar month. Mutually exclusive with budget_duration_sec",
+            "title": "Reset Alignment"
+          }
+        },
+        "title": "OrganizationBudgetUpdate",
+        "type": "object"
+      },
+      "OrganizationBudgetsPublic": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/OrganizationBudgetPublic"
+            },
+            "title": "Data",
+            "type": "array"
+          }
+        },
+        "required": [
+          "data",
+          "count"
+        ],
+        "title": "OrganizationBudgetsPublic",
+        "type": "object"
+      },
       "OrganizationCreateRequest": {
         "description": "Create an organization, with the caller as its owner.\n\nName only. The slug is derived server-side and never sent, because it is\nunique where the name is not: two organizations may share a name, and a\nrename deliberately does not move the slug.",
         "properties": {
@@ -6845,6 +7067,261 @@
           "created_at"
         ],
         "title": "OrganizationPublic",
+        "type": "object"
+      },
+      "OrganizationScopedBudgetCreate": {
+        "description": "Attach one of the organization's budgets to a scope inside it.",
+        "properties": {
+          "budget_id": {
+            "description": "The budget this ceiling enforces, which must be one this organization owns",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Budget Id",
+            "type": "string"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Admin-facing label for this ceiling",
+            "title": "Name"
+          },
+          "provider_key_id": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Narrow the cap to one provider instance; null caps spend across every provider",
+            "title": "Provider Key Id"
+          },
+          "scope_id": {
+            "description": "Id of the capped identity: this organization, one of its workspaces, a membership in either, or an API key in one",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Scope Id",
+            "type": "string"
+          },
+          "scope_type": {
+            "description": "Which kind of identity this ceiling caps",
+            "enum": [
+              "organization",
+              "workspace",
+              "workspace_member",
+              "org_member",
+              "api_token"
+            ],
+            "title": "Scope Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "scope_type",
+          "scope_id",
+          "budget_id"
+        ],
+        "title": "OrganizationScopedBudgetCreate",
+        "type": "object"
+      },
+      "OrganizationScopedBudgetPublic": {
+        "description": "One ceiling inside the organization, and the figures it enforces.\n\nThe limit and the period are read through the budget rather than stored here,\nand carried on the wire so a page can render a ceiling without fetching every\nbudget to resolve one id. Same reasoning as ``ScopedBudgetResponse``, whose\nshape this deliberately mirrors.",
+        "properties": {
+          "budget_duration_sec": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Budget Duration Sec"
+          },
+          "budget_id": {
+            "title": "Budget Id",
+            "type": "string"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "current_spend": {
+            "title": "Current Spend",
+            "type": "number"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "manageable": {
+            "title": "Manageable",
+            "type": "boolean"
+          },
+          "max_budget": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Budget"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "period_end": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Period End"
+          },
+          "period_start": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Period Start"
+          },
+          "provider_key_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider Key Id"
+          },
+          "reserved_spend": {
+            "title": "Reserved Spend",
+            "type": "number"
+          },
+          "reset_alignment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reset Alignment"
+          },
+          "scope_id": {
+            "title": "Scope Id",
+            "type": "string"
+          },
+          "scope_type": {
+            "title": "Scope Type",
+            "type": "string"
+          },
+          "updated_at": {
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "scope_type",
+          "scope_id",
+          "provider_key_id",
+          "budget_id",
+          "name",
+          "max_budget",
+          "current_spend",
+          "reserved_spend",
+          "budget_duration_sec",
+          "reset_alignment",
+          "period_start",
+          "period_end",
+          "manageable",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "OrganizationScopedBudgetPublic",
+        "type": "object"
+      },
+      "OrganizationScopedBudgetUpdate": {
+        "description": "Relabel a ceiling, or point it at a different budget of this organization's.\n\nThe scope and the provider narrowing are not editable, for the reason\n``PATCH /v1/scoped-budgets/{id}`` gives: changing either moves the ceiling to\na different identity while carrying its spend, which is a delete and a\ncreate, not an update.",
+        "properties": {
+          "budget_id": {
+            "anyOf": [
+              {
+                "maxLength": 255,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Budget Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "title": "OrganizationScopedBudgetUpdate",
+        "type": "object"
+      },
+      "OrganizationScopedBudgetsPublic": {
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/OrganizationScopedBudgetPublic"
+            },
+            "title": "Data",
+            "type": "array"
+          }
+        },
+        "required": [
+          "data",
+          "count"
+        ],
+        "title": "OrganizationScopedBudgetsPublic",
         "type": "object"
       },
       "PasskeySessionResponse": {
@@ -17320,6 +17797,233 @@
         ]
       }
     },
+    "/v1/organizations/me/budgets": {
+      "get": {
+        "description": "List the budgets this organization has defined. Owners and admins only.",
+        "operationId": "list_organization_budgets_v1_organizations_me_budgets_get",
+        "parameters": [
+          {
+            "description": "Number of records to skip",
+            "in": "query",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of records to skip",
+              "minimum": 0,
+              "title": "Skip",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "description": "Maximum number of records to return",
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationBudgetsPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "List Organization Budgets",
+        "tags": [
+          "organization-budgets"
+        ]
+      },
+      "post": {
+        "description": "Define a budget owned by this organization. Owners and admins only.",
+        "operationId": "create_organization_budget_v1_organizations_me_budgets_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationBudgetCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationBudgetPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Create Organization Budget",
+        "tags": [
+          "organization-budgets"
+        ]
+      }
+    },
+    "/v1/organizations/me/budgets/{budget_id}": {
+      "delete": {
+        "description": "Delete a budget, refused with 409 while a ceiling or workspace default names it.",
+        "operationId": "delete_organization_budget_v1_organizations_me_budgets__budget_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "budget_id",
+            "required": true,
+            "schema": {
+              "title": "Budget Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Delete Organization Budget",
+        "tags": [
+          "organization-budgets"
+        ]
+      },
+      "patch": {
+        "description": "Change a budget's label, figure or period.\n\nEvery ceiling naming it is held to the new figure from here on, which is the\npoint of naming a budget rather than typing an amount per place it applies.",
+        "operationId": "update_organization_budget_v1_organizations_me_budgets__budget_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "budget_id",
+            "required": true,
+            "schema": {
+              "title": "Budget Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationBudgetUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationBudgetPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Update Organization Budget",
+        "tags": [
+          "organization-budgets"
+        ]
+      }
+    },
     "/v1/organizations/me/guardrails": {
       "get": {
         "description": "List the guardrails the caller's organization mandates.\n\nOrganization owners and admins only, unlike the pricing overrides next door\nthat any member may read: these rows name the endpoints this gateway\nconnects to and say which of them carry a credential. A credential is never\nreturned, only whether one is set.",
@@ -18889,6 +19593,233 @@
         "summary": "List Visible Routing Policies",
         "tags": [
           "routing"
+        ]
+      }
+    },
+    "/v1/organizations/me/spend-ceilings": {
+      "get": {
+        "description": "List the ceilings capping identities inside this organization. Owners and admins only.\n\nA ceiling whose budget this organization does not own is listed with\n``manageable`` false rather than omitted: it is enforcing against this\norganization's spend, so leaving it out would let the page read as uncapped.",
+        "operationId": "list_organization_spend_ceilings_v1_organizations_me_spend_ceilings_get",
+        "parameters": [
+          {
+            "description": "Number of records to skip",
+            "in": "query",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of records to skip",
+              "minimum": 0,
+              "title": "Skip",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Maximum number of records to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "description": "Maximum number of records to return",
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationScopedBudgetsPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "List Organization Spend Ceilings",
+        "tags": [
+          "organization-budgets"
+        ]
+      },
+      "post": {
+        "description": "Cap one identity in this organization at one of its budgets.\n\nAnswers 404 when the scope names nothing in this organization, rather than\ncreating a ceiling that can never bind, and 404 when the budget is not this\norganization's.",
+        "operationId": "create_organization_spend_ceiling_v1_organizations_me_spend_ceilings_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationScopedBudgetCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationScopedBudgetPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Create Organization Spend Ceiling",
+        "tags": [
+          "organization-budgets"
+        ]
+      }
+    },
+    "/v1/organizations/me/spend-ceilings/{ceiling_id}": {
+      "delete": {
+        "description": "Remove a ceiling inside this organization.",
+        "operationId": "delete_organization_spend_ceiling_v1_organizations_me_spend_ceilings__ceiling_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ceiling_id",
+            "required": true,
+            "schema": {
+              "title": "Ceiling Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Message"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Delete Organization Spend Ceiling",
+        "tags": [
+          "organization-budgets"
+        ]
+      },
+      "patch": {
+        "description": "Relabel a ceiling, or point it at a different budget of this organization's.\n\nThe scope and the provider narrowing are not editable: changing either would\nmove the ceiling to a different identity while carrying its spend, which is a\ndelete and a create.",
+        "operationId": "update_organization_spend_ceiling_v1_organizations_me_spend_ceilings__ceiling_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ceiling_id",
+            "required": true,
+            "schema": {
+              "title": "Ceiling Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationScopedBudgetUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationScopedBudgetPublic"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Update Organization Spend Ceiling",
+        "tags": [
+          "organization-budgets"
         ]
       }
     },

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -13233,13 +13233,15 @@
             "anyOf": [
               {
                 "maxLength": 255,
+                "minLength": 1,
+                "pattern": "^\\S+$",
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Narrow the default to one provider instance; null applies to every provider",
+            "description": "Narrow the default to one provider instance; omit or null to apply to every provider. Must name a real instance: a blank value would materialize ceilings that never bind",
             "title": "Provider Key Id"
           }
         },

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -2636,6 +2636,287 @@
     {
       "item": [
         {
+          "name": "List Organization Budgets",
+          "request": {
+            "description": "List the budgets this organization has defined. Owners and admins only.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "budgets"
+              ],
+              "query": [
+                {
+                  "description": "Number of records to skip",
+                  "disabled": true,
+                  "key": "skip",
+                  "value": ""
+                },
+                {
+                  "description": "Maximum number of records to return",
+                  "disabled": true,
+                  "key": "limit",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/budgets?skip=&limit="
+            }
+          }
+        },
+        {
+          "name": "Create Organization Budget",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"budget_duration_sec\": 0,\n  \"max_budget\": 0,\n  \"name\": \"string\",\n  \"reset_alignment\": \"string\"\n}"
+            },
+            "description": "Define a budget owned by this organization. Owners and admins only.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "budgets"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/budgets"
+            }
+          }
+        },
+        {
+          "name": "Update Organization Budget",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"budget_duration_sec\": 0,\n  \"max_budget\": 0,\n  \"name\": \"string\",\n  \"reset_alignment\": \"string\"\n}"
+            },
+            "description": "Change a budget's label, figure or period.\n\nEvery ceiling naming it is held to the new figure from here on, which is the\npoint of naming a budget rather than typing an amount per place it applies.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "PATCH",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "budgets",
+                ":budget_id"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/budgets/:budget_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "budget_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Organization Budget",
+          "request": {
+            "description": "Delete a budget, refused with 409 while a ceiling or workspace default names it.",
+            "header": [],
+            "method": "DELETE",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "budgets",
+                ":budget_id"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/budgets/:budget_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "budget_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "List Organization Spend Ceilings",
+          "request": {
+            "description": "List the ceilings capping identities inside this organization. Owners and admins only.\n\nA ceiling whose budget this organization does not own is listed with\n``manageable`` false rather than omitted: it is enforcing against this\norganization's spend, so leaving it out would let the page read as uncapped.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "spend-ceilings"
+              ],
+              "query": [
+                {
+                  "description": "Number of records to skip",
+                  "disabled": true,
+                  "key": "skip",
+                  "value": ""
+                },
+                {
+                  "description": "Maximum number of records to return",
+                  "disabled": true,
+                  "key": "limit",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/spend-ceilings?skip=&limit="
+            }
+          }
+        },
+        {
+          "name": "Create Organization Spend Ceiling",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"scope_type\": \"organization\",\n  \"scope_id\": \"string\",\n  \"budget_id\": \"string\"\n}"
+            },
+            "description": "Cap one identity in this organization at one of its budgets.\n\nAnswers 404 when the scope names nothing in this organization, rather than\ncreating a ceiling that can never bind, and 404 when the budget is not this\norganization's.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "spend-ceilings"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/spend-ceilings"
+            }
+          }
+        },
+        {
+          "name": "Update Organization Spend Ceiling",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"budget_id\": \"string\",\n  \"name\": \"string\"\n}"
+            },
+            "description": "Relabel a ceiling, or point it at a different budget of this organization's.\n\nThe scope and the provider narrowing are not editable: changing either would\nmove the ceiling to a different identity while carrying its spend, which is a\ndelete and a create.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "PATCH",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "spend-ceilings",
+                ":ceiling_id"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/spend-ceilings/:ceiling_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "ceiling_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Delete Organization Spend Ceiling",
+          "request": {
+            "description": "Remove a ceiling inside this organization.",
+            "header": [],
+            "method": "DELETE",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "spend-ceilings",
+                ":ceiling_id"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/spend-ceilings/:ceiling_id",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "ceiling_id",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "name": "organization-budgets"
+    },
+    {
+      "item": [
+        {
           "name": "List Organization Guardrails",
           "request": {
             "description": "List the guardrails the caller's organization mandates.\n\nOrganization owners and admins only, unlike the pricing overrides next door\nthat any member may read: these rows name the endpoints this gateway\nconnects to and say which of them carry a credential. A credential is never\nreturned, only whether one is set.",

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -2679,7 +2679,7 @@
                   "language": "json"
                 }
               },
-              "raw": "{\n  \"budget_duration_sec\": 0,\n  \"max_budget\": 0,\n  \"name\": \"string\",\n  \"reset_alignment\": \"string\"\n}"
+              "raw": "{\n  \"budget_duration_sec\": 0,\n  \"max_budget\": 0,\n  \"name\": \"string\",\n  \"reset_alignment\": \"calendar_day\"\n}"
             },
             "description": "Define a budget owned by this organization. Owners and admins only.",
             "header": [
@@ -2713,7 +2713,7 @@
                   "language": "json"
                 }
               },
-              "raw": "{\n  \"budget_duration_sec\": 0,\n  \"max_budget\": 0,\n  \"name\": \"string\",\n  \"reset_alignment\": \"string\"\n}"
+              "raw": "{\n  \"budget_duration_sec\": 0,\n  \"max_budget\": 0,\n  \"name\": \"string\",\n  \"reset_alignment\": \"calendar_day\"\n}"
             },
             "description": "Change a budget's label, figure or period.\n\nEvery ceiling naming it is held to the new figure from here on, which is the\npoint of naming a budget rather than typing an amount per place it applies.",
             "header": [

--- a/scripts/sdk_codegen/sdk-endpoints.txt
+++ b/scripts/sdk_codegen/sdk-endpoints.txt
@@ -252,6 +252,20 @@ POST /v1/organizations/me/keys                              # dashboard-only
 PATCH /v1/organizations/me/keys/{key_id}                    # dashboard-only
 DELETE /v1/organizations/me/keys/{key_id}                   # dashboard-only
 POST /v1/organizations/me/keys/{key_id}/rotate              # dashboard-only
+# The organization's own budgets and the ceilings enforcing them
+# (otari-ai#1943), excluded for the same reason as the keys above: the
+# organization is resolved from the caller's dashboard session rather than named
+# in the request, so an SDK caller holding a workspace key has no organization
+# for these to act on. The deployment-wide `/v1/budgets` and `/v1/scoped-budgets`
+# families are classified separately above.
+GET /v1/organizations/me/budgets                            # dashboard-only
+POST /v1/organizations/me/budgets                           # dashboard-only
+PATCH /v1/organizations/me/budgets/{budget_id}              # dashboard-only
+DELETE /v1/organizations/me/budgets/{budget_id}             # dashboard-only
+GET /v1/organizations/me/spend-ceilings                     # dashboard-only
+POST /v1/organizations/me/spend-ceilings                    # dashboard-only
+PATCH /v1/organizations/me/spend-ceilings/{ceiling_id}      # dashboard-only
+DELETE /v1/organizations/me/spend-ceilings/{ceiling_id}     # dashboard-only
 GET /v1/organizations/me/guardrails                         # operator surface
 POST /v1/organizations/me/guardrails                        # operator surface
 PATCH /v1/organizations/me/guardrails/{guardrail_id}        # operator surface

--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -30,6 +30,7 @@ from gateway.api.routes import (
     models,
     moderations,
     org_provider_keys,
+    organization_budgets,
     organization_guardrails,
     organization_keys,
     organization_pricing,
@@ -160,6 +161,8 @@ def _register_core_routers(app: FastAPI, config: GatewayConfig) -> None:
     app.include_router(keys.router)
     app.include_router(users.router)
     app.include_router(organizations.router)
+    app.include_router(organization_budgets.budgets_router)
+    app.include_router(organization_budgets.ceilings_router)
     app.include_router(organization_pricing.router)
     app.include_router(organization_guardrails.router)
     # The tenant-scoped read over the same rows ``/v1/usage`` serves to an

--- a/src/gateway/api/routes/budgets.py
+++ b/src/gateway/api/routes/budgets.py
@@ -12,6 +12,7 @@ from gateway.api.deps import get_db, require_deployment_operator
 from gateway.models.entities import Budget, BudgetResetLog, ScopedBudget, User, WorkspaceBudgetDefault
 from gateway.models.money import MAX_USD_LIMIT, as_float, to_usd, to_usd_or_none
 from gateway.models.tenancy import Workspace
+from gateway.services.budget_retiming import cadence_of, retime_ceilings_for_budget
 from gateway.services.scoped_budget_service import ResetAlignment
 
 router = APIRouter(prefix="/v1/budgets", tags=["budgets"])
@@ -254,6 +255,10 @@ async def update_budget(
             detail=f"Budget with id '{budget_id}' not found",
         )
 
+    # Read before the mutation below, because it is what decides whether the
+    # ceilings naming this budget have to be retimed.
+    cadence_before = cadence_of(budget.budget_duration_sec, budget.reset_alignment)
+
     # Name is tri-state: omit leaves it unchanged, while an explicit null clears
     # it back to unnamed (unlike the numeric fields, where null is not meaningful).
     if "name" in request.model_fields_set:
@@ -276,6 +281,24 @@ async def update_budget(
         _require_single_period_source(duration, alignment)
         budget.budget_duration_sec = duration
         budget.reset_alignment = alignment
+
+    # A ceiling holds its own window and reads the cadence through this budget, so
+    # changing the cadence without rewriting the windows leaves the two
+    # disagreeing. In one direction that is an enforcement bug rather than a
+    # cosmetic one: `_roll_expired_periods` only updates a row whose `period_end`
+    # is not null, so a budget moved from "no reset" to a periodic cadence would
+    # leave its ceilings with NULL windows that never roll, accumulating spend
+    # forever. Since `b7e1c4a9d2f5` a budget can also belong to an organization
+    # while this route still sees every one of them, so the ceilings stranded that
+    # way may be a tenant's. Shared with the tenant-scoped surface rather than
+    # written twice.
+    if cadence_of(budget.budget_duration_sec, budget.reset_alignment) != cadence_before:
+        await retime_ceilings_for_budget(
+            db,
+            budget_id=budget.budget_id,
+            duration=budget.budget_duration_sec,
+            alignment=budget.reset_alignment,
+        )
 
     try:
         await db.commit()

--- a/src/gateway/api/routes/organization_budgets.py
+++ b/src/gateway/api/routes/organization_budgets.py
@@ -1,0 +1,174 @@
+"""The caller's organization's spend budgets and ceilings (standalone mode only).
+
+Thin composition over `gateway.services.tenancy.organization_budget_service`:
+resolve the caller's identity, call the service, return its typed result. The
+role gate, the scope resolution and the cross-tenant rules live there, and the
+domain errors it raises carry their own statuses (see
+`gateway.services.tenancy.errors`), so nothing here catches them.
+
+Two routers in one module, as `routes/org_provider_keys.py` does, because they
+are one feature: a budget is the figure and a ceiling is where it applies, and
+splitting them across files would put the two halves of one page in two places.
+
+Scoped to ``/me`` for the same reason `routes/organizations.py` is: a request
+cannot name an organization at all, because the caller's identity already points
+at one, so there is no parameter that could be confused with an authorization
+decision.
+
+These sit *beside* ``/v1/budgets`` and ``/v1/scoped-budgets``, which stay the
+deployment's own surface behind ``require_deployment_operator``. The tables are
+shared; what differs is which rows a caller may reach. A budget with no
+``organization_id`` is the deployment's, and no route here lists, offers or
+repoints one.
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.api.deps import CurrentIdentity, get_db, verify_master_key
+from gateway.api.routes.organizations import Message
+from gateway.services.tenancy.organization_budget_service import (
+    OrganizationBudgetCreate,
+    OrganizationBudgetPublic,
+    OrganizationBudgetService,
+    OrganizationBudgetsPublic,
+    OrganizationBudgetUpdate,
+    OrganizationScopedBudgetCreate,
+    OrganizationScopedBudgetPublic,
+    OrganizationScopedBudgetsPublic,
+    OrganizationScopedBudgetUpdate,
+)
+
+# Master key on the router, as every standalone management router declares it.
+# The role gate is a separate question answered in the service: the credential
+# says a request is authenticated, the membership says whether that identity may
+# set what this organization's members are allowed to spend.
+budgets_router = APIRouter(
+    prefix="/v1/organizations/me/budgets",
+    tags=["organization-budgets"],
+    dependencies=[Depends(verify_master_key)],
+)
+
+ceilings_router = APIRouter(
+    prefix="/v1/organizations/me/spend-ceilings",
+    tags=["organization-budgets"],
+    dependencies=[Depends(verify_master_key)],
+)
+
+
+def get_organization_budget_service(db: Annotated[AsyncSession, Depends(get_db)]) -> OrganizationBudgetService:
+    """Build the service on the request's session."""
+    return OrganizationBudgetService(db)
+
+
+ServiceDep = Annotated[OrganizationBudgetService, Depends(get_organization_budget_service)]
+
+
+@budgets_router.get("")
+async def list_organization_budgets(
+    service: ServiceDep,
+    current_identity: CurrentIdentity,
+    skip: Annotated[int, Query(ge=0, description="Number of records to skip")] = 0,
+    limit: Annotated[int, Query(ge=1, le=1000, description="Maximum number of records to return")] = 100,
+) -> OrganizationBudgetsPublic:
+    """List the budgets this organization has defined. Owners and admins only."""
+    return await service.list_budgets(user=current_identity, skip=skip, limit=limit)
+
+
+@budgets_router.post("", status_code=status.HTTP_201_CREATED)
+async def create_organization_budget(
+    service: ServiceDep,
+    current_identity: CurrentIdentity,
+    body: OrganizationBudgetCreate,
+) -> OrganizationBudgetPublic:
+    """Define a budget owned by this organization. Owners and admins only."""
+    return await service.create_budget(user=current_identity, request=body)
+
+
+@budgets_router.patch("/{budget_id}")
+async def update_organization_budget(
+    service: ServiceDep,
+    current_identity: CurrentIdentity,
+    budget_id: str,
+    body: OrganizationBudgetUpdate,
+) -> OrganizationBudgetPublic:
+    """Change a budget's label, figure or period.
+
+    Every ceiling naming it is held to the new figure from here on, which is the
+    point of naming a budget rather than typing an amount per place it applies.
+    """
+    return await service.update_budget(user=current_identity, budget_id=budget_id, request=body)
+
+
+@budgets_router.delete("/{budget_id}")
+async def delete_organization_budget(
+    service: ServiceDep,
+    current_identity: CurrentIdentity,
+    budget_id: str,
+) -> Message:
+    """Delete a budget, refused with 409 while a ceiling or workspace default names it."""
+    await service.delete_budget(user=current_identity, budget_id=budget_id)
+    return Message(message="Budget deleted")
+
+
+@ceilings_router.get("")
+async def list_organization_spend_ceilings(
+    service: ServiceDep,
+    current_identity: CurrentIdentity,
+    skip: Annotated[int, Query(ge=0, description="Number of records to skip")] = 0,
+    limit: Annotated[int, Query(ge=1, le=1000, description="Maximum number of records to return")] = 100,
+) -> OrganizationScopedBudgetsPublic:
+    """List the ceilings capping identities inside this organization. Owners and admins only.
+
+    A ceiling whose budget this organization does not own is listed with
+    ``manageable`` false rather than omitted: it is enforcing against this
+    organization's spend, so leaving it out would let the page read as uncapped.
+    """
+    return await service.list_ceilings(user=current_identity, skip=skip, limit=limit)
+
+
+@ceilings_router.post("", status_code=status.HTTP_201_CREATED)
+async def create_organization_spend_ceiling(
+    service: ServiceDep,
+    current_identity: CurrentIdentity,
+    body: OrganizationScopedBudgetCreate,
+) -> OrganizationScopedBudgetPublic:
+    """Cap one identity in this organization at one of its budgets.
+
+    Answers 404 when the scope names nothing in this organization, rather than
+    creating a ceiling that can never bind, and 404 when the budget is not this
+    organization's.
+    """
+    return await service.create_ceiling(user=current_identity, request=body)
+
+
+@ceilings_router.patch("/{ceiling_id}")
+async def update_organization_spend_ceiling(
+    service: ServiceDep,
+    current_identity: CurrentIdentity,
+    ceiling_id: str,
+    body: OrganizationScopedBudgetUpdate,
+) -> OrganizationScopedBudgetPublic:
+    """Relabel a ceiling, or point it at a different budget of this organization's.
+
+    The scope and the provider narrowing are not editable: changing either would
+    move the ceiling to a different identity while carrying its spend, which is a
+    delete and a create.
+    """
+    return await service.update_ceiling(user=current_identity, ceiling_id=ceiling_id, request=body)
+
+
+@ceilings_router.delete("/{ceiling_id}")
+async def delete_organization_spend_ceiling(
+    service: ServiceDep,
+    current_identity: CurrentIdentity,
+    ceiling_id: str,
+) -> Message:
+    """Remove a ceiling inside this organization."""
+    await service.delete_ceiling(user=current_identity, ceiling_id=ceiling_id)
+    return Message(message="Spend ceiling deleted")
+
+
+__all__ = ["budgets_router", "ceilings_router"]

--- a/src/gateway/api/routes/organization_budgets.py
+++ b/src/gateway/api/routes/organization_budgets.py
@@ -1,4 +1,10 @@
-"""The caller's organization's spend budgets and ceilings (standalone mode only).
+"""The caller's organization's spend budgets and ceilings (not hybrid mode).
+
+Mounted by ``_register_core_routers`` for standalone **and hosted** deployments;
+only hybrid mode has no management API. Spelled out rather than the "standalone
+mode only" shorthand the neighbouring ``/v1/organizations/me`` routers use,
+because on this surface the shorthand would name the wrong audience: a hosted
+organization's admin is exactly who otari-ai#1943 added it for.
 
 Thin composition over `gateway.services.tenancy.organization_budget_service`:
 resolve the caller's identity, call the service, return its typed result. The

--- a/src/gateway/models/entities.py
+++ b/src/gateway/models/entities.py
@@ -151,6 +151,26 @@ class Budget(Base):
 
     budget_id: Mapped[str] = mapped_column(primary_key=True, default=lambda: str(uuid.uuid4()))
     name: Mapped[str | None] = mapped_column(default=None)
+    # Which tenant defined this budget, and therefore who may change it.
+    #
+    # NULL means the deployment's own: every budget predating `b7e1c4a9d2f5`
+    # reads NULL, and so does every one the otari-ai cutover migration mints,
+    # because that migration deliberately shares one budget per distinct
+    # (cap, period) shape across the ceilings it writes and a shape shared by two
+    # tenants' ceilings has no single owner. NULL is not "unowned and up for
+    # grabs": the organization-scoped surface never lists, offers or repoints one,
+    # so from a tenant's side it does not exist.
+    #
+    # Nullable and set only on the tenant-scoped create path, which is what keeps
+    # that migration working with no backfill: its preflight refuses on a
+    # *missing* column and its inserts name theirs explicitly, so a new nullable
+    # one is invisible to it.
+    organization_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(),
+        ForeignKey("organization.id", name="fk_budgets_organization_id", ondelete="CASCADE"),
+        default=None,
+        index=True,
+    )
     # Exact, like the counters it is compared against: the gate is
     # ``spend + reserved <= max_budget``, and a cap stored as a binary float
     # would decide a 403 against an amount an operator never typed

--- a/src/gateway/services/budget_retiming.py
+++ b/src/gateway/services/budget_retiming.py
@@ -1,0 +1,84 @@
+"""Move a budget's ceilings onto the cadence it now carries.
+
+A leaf module for the same reason :mod:`gateway.services.budget_periods` is one,
+and it sits directly on top of it. Two surfaces change a budget's period, and
+neither can import the other's module:
+
+- ``api/routes/budgets.py``, the deployment-wide surface.
+- ``services/tenancy/organization_budget_service.py``, the tenant-scoped one,
+  which cannot reach ``scoped_budget_service`` because that module imports
+  ``workspace_scope`` and closes a cycle back through ``tenancy/__init__``.
+
+Without a shared home the retiming would be written twice, and a rule with two
+copies is a rule that will hold on one surface and not the other. This imports
+the entity models and ``budget_periods`` only, so nothing that depends on it
+gains a cycle, and ``tests/unit/test_service_module_imports.py`` pins that.
+
+**Why retiming is necessary at all.** A ceiling holds its own
+``period_start``/``period_end`` and reads the cadence *through* the budget it
+names, so editing the budget's period leaves the two disagreeing. One direction
+is an enforcement bug rather than a cosmetic one:
+``scoped_budget_service._roll_expired_periods`` only ever updates a row whose
+``period_end`` is not null (that guard is what makes the roll a lock-free
+compare-and-swap at the boundary), so a budget moved from "no reset" to a
+periodic cadence leaves its ceilings with NULL windows that never roll at all,
+accumulating spend forever while the API reports the new cadence. The reverse
+leaves a stale boundary that fires exactly once, at an arbitrary moment, zeroing
+counters for no reason anyone can point at.
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.models.entities import ScopedBudget
+from gateway.services.budget_periods import period_window
+
+__all__ = ["cadence_of", "retime_ceilings_for_budget"]
+
+
+def cadence_of(duration: int | None, alignment: str | None) -> tuple[int | None, str | None]:
+    """The pair that decides whether a retiming is needed, as one comparable value.
+
+    Exists so both callers compare the same thing, read before and after the
+    mutation. Keyed on the cadence rather than on "an update happened", because
+    retiming on every write would restart a period for a rename or a limit
+    change, throwing away the part of it a ceiling had already spent.
+    """
+    return (duration, alignment)
+
+
+async def retime_ceilings_for_budget(
+    db: AsyncSession,
+    *,
+    budget_id: str,
+    duration: int | None,
+    alignment: str | None,
+) -> None:
+    """Rewrite the window on every ceiling naming this budget.
+
+    One statement rather than a row per ceiling: the window is derived from the
+    budget and from now, not from anything an individual ceiling holds, so it is
+    the same for all of them.
+
+    Counters are deliberately untouched. Spend already recorded stays, matching
+    what re-pointing a ceiling at a different budget does: the ceiling is the same
+    allowance held to a different figure from here on, not a fresh one.
+    ``reserved_spend`` is left alone too, so a hold taken before the change is
+    still released against the counter it came from.
+
+    Not committed here. The caller owns the transaction, so a write that is
+    refused afterwards takes the retiming back with it.
+
+    A cadence of neither kind clears the window rather than deriving one, which is
+    what "no reset" means and what ``period_window`` returns None for.
+    """
+    window = period_window(datetime.now(UTC), duration=duration, alignment=alignment)
+    period_start, period_end = window if window is not None else (None, None)
+    await db.execute(
+        update(ScopedBudget)
+        .where(ScopedBudget.budget_id == budget_id)
+        .values(period_start=period_start, period_end=period_end)
+        .execution_options(synchronize_session=False)
+    )

--- a/src/gateway/services/tenancy/errors.py
+++ b/src/gateway/services/tenancy/errors.py
@@ -844,6 +844,23 @@ class OrganizationBudgetInUseError(TenancyConflictError):
         )
 
 
+class OrganizationBudgetHeldElsewhereError(TenancyConflictError):
+    """Something outside this organization's own surface still names the budget.
+
+    ``users.budget_id`` and ``budget_reset_logs.budget_id``, neither of which is
+    a tenant's to see: an operator can assign a gateway user to any budget
+    ``GET /v1/budgets`` lists, tenant-owned ones included. Left unchecked the
+    first is nulled out by the ORM and the second fails at the commit, so the
+    refusal says the budget is held without naming the rows holding it.
+    """
+
+    def __init__(self, budget_id: object):
+        super().__init__(
+            f"Budget {budget_id} is still in use outside this organization and cannot be deleted. "
+            "Ask a deployment operator to release it."
+        )
+
+
 class OrganizationScopeNotFoundError(TenancyNotFoundError):
     """The identity a ceiling would cap is not one in the caller's organization.
 
@@ -1090,6 +1107,7 @@ __all__ = [
     "OrgProviderKeyNotFoundError",
     "OrgProviderKeyUnknownProviderError",
     "OrgProviderKeyUnsafeApiBaseError",
+    "OrganizationBudgetHeldElsewhereError",
     "OrganizationBudgetInUseError",
     "OrganizationBudgetNotFoundError",
     "OrganizationGuardrailAlreadyExistsError",

--- a/src/gateway/services/tenancy/errors.py
+++ b/src/gateway/services/tenancy/errors.py
@@ -811,6 +811,72 @@ class WorkspaceBudgetDefaultAlreadyExistsError(TenancyConflictError):
         super().__init__(f"Workspace {workspace_id} already has a budget default for {scope}")
 
 
+class OrganizationBudgetNotFoundError(TenancyNotFoundError):
+    """No budget under this id belongs to the caller's organization.
+
+    One status and one message for three different facts: the id names nothing,
+    it names a deployment budget, or it names another tenant's. Deliberately
+    indistinguishable, for the reason :class:`TenancyNotFoundError` gives; telling
+    them apart would make the response an existence oracle over other tenants'
+    spend configuration.
+    """
+
+    def __init__(self, budget_id: object):
+        super().__init__(f"Budget {budget_id} not found")
+
+
+class OrganizationBudgetInUseError(TenancyConflictError):
+    """The budget still holds ceilings or workspace defaults.
+
+    Both foreign keys are ``RESTRICT``, so the database would refuse the delete
+    anyway, as an ``IntegrityError`` with nothing naming what to go and change.
+    Raised here so the refusal can say which and how many.
+    """
+
+    def __init__(self, budget_id: object, *, ceilings: int, defaults: int):
+        held = []
+        if ceilings:
+            held.append(f"{ceilings} spend {'ceiling' if ceilings == 1 else 'ceilings'}")
+        if defaults:
+            held.append(f"{defaults} workspace member {'default' if defaults == 1 else 'defaults'}")
+        super().__init__(
+            f"Budget {budget_id} is still used by {' and '.join(held)}. Remove or repoint them before deleting it."
+        )
+
+
+class OrganizationScopeNotFoundError(TenancyNotFoundError):
+    """The identity a ceiling would cap is not one in the caller's organization.
+
+    Covers a scope id that names nothing and one that names a row in another
+    organization, as one answer and for the same reason as
+    :class:`OrganizationBudgetNotFoundError`. This is the cross-tenant check on
+    the ceilings surface: a scope id travels as a bare uuid with nothing in it
+    saying whose it is.
+    """
+
+    def __init__(self, scope_type: object, scope_id: object):
+        super().__init__(f"No {scope_type} '{scope_id}' in this organization")
+
+
+class OrganizationScopedBudgetNotFoundError(TenancyNotFoundError):
+    def __init__(self, ceiling_id: object):
+        super().__init__(f"Spend ceiling {ceiling_id} not found")
+
+
+class OrganizationScopedBudgetAlreadyExistsError(TenancyConflictError):
+    """One ceiling per scope, and per scope and provider.
+
+    The two partial unique indexes on ``scoped_budgets`` are the real
+    enforcement; this reports the same rule in words a caller can act on, since
+    neither index name says anything useful to one.
+    """
+
+    def __init__(self, scope_type: object, scope_id: object):
+        super().__init__(
+            f"A spend ceiling already exists for this {scope_type} and provider. Edit that ceiling instead."
+        )
+
+
 class WorkspaceActivationUnavailableError(TenancyConflictError):
     """The first-request setup guide is not on offer for this workspace.
 
@@ -1024,6 +1090,8 @@ __all__ = [
     "OrgProviderKeyNotFoundError",
     "OrgProviderKeyUnknownProviderError",
     "OrgProviderKeyUnsafeApiBaseError",
+    "OrganizationBudgetInUseError",
+    "OrganizationBudgetNotFoundError",
     "OrganizationGuardrailAlreadyExistsError",
     "OrganizationGuardrailCredentialNeedsUrlError",
     "OrganizationGuardrailLimitReachedError",
@@ -1039,6 +1107,9 @@ __all__ = [
     "OAuthNotConfiguredError",
     "OrganizationNotFoundError",
     "OrganizationPricingNotFoundError",
+    "OrganizationScopeNotFoundError",
+    "OrganizationScopedBudgetAlreadyExistsError",
+    "OrganizationScopedBudgetNotFoundError",
     "OrganizationSlugUnavailableError",
     "OrganizationPricingOverlapError",
     "PasskeyAlreadyRegisteredError",

--- a/src/gateway/services/tenancy/organization_budget_service.py
+++ b/src/gateway/services/tenancy/organization_budget_service.py
@@ -58,16 +58,19 @@ from typing import Literal, get_args
 
 from pydantic import BaseModel, Field
 from sqlalchemy import func, or_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 from sqlmodel import col
 
 from gateway.models.entities import APIKey, Budget, ScopedBudget, WorkspaceBudgetDefault
+from gateway.models.entities import User as GatewayUser
 from gateway.models.money import MAX_USD_LIMIT, as_float, to_usd_or_none
 from gateway.models.tenancy import Organization, OrganizationMember, User, Workspace, WorkspaceMember
 from gateway.services.budget_periods import ResetAlignment, period_window
 from gateway.services.budget_retiming import cadence_of, retime_ceilings_for_budget
 from gateway.services.tenancy.errors import (
+    OrganizationBudgetHeldElsewhereError,
     OrganizationBudgetInUseError,
     OrganizationBudgetNotFoundError,
     OrganizationScopedBudgetAlreadyExistsError,
@@ -155,12 +158,13 @@ class OrganizationBudgetCreate(OrganizationBudgetRates):
 class OrganizationBudgetUpdate(OrganizationBudgetRates):
     """Replace a budget's label, figure and period.
 
-    A full statement rather than a patch, matching ``PATCH /v1/budgets/{id}``'s
-    own fields: every one is optional and an omitted one is left alone, so
-    clearing a cap back to uncapped is not expressible here and is a delete. The
-    period pair is still mutually exclusive, and setting one does not clear the
-    other, which is why :func:`_require_single_period_source` re-checks the
-    *resulting* pair rather than the submitted one.
+    Every field is optional and keyed on ``model_fields_set``, matching
+    ``PATCH /v1/budgets/{id}``'s own: an *omitted* field is left alone, and an
+    explicit null clears it, so sending ``max_budget: null`` takes a budget back
+    to uncapped, which is what the dashboard's dialog does. The period pair is
+    still mutually exclusive, and setting one does not clear the other, which is
+    why :func:`_require_single_period_source` re-checks the *resulting* pair
+    rather than the submitted one.
     """
 
 
@@ -589,10 +593,21 @@ class OrganizationBudgetService:
         ``scoped_budgets.budget_id`` and ``workspace_budget_defaults.budget_id``
         are both RESTRICT, so the database would refuse anyway, as an
         ``IntegrityError`` with nothing naming what to go and change. Checked here
-        so the refusal can say which. ``users.budget_id`` is the deployment's own
-        table and cannot name a tenant's budget through any route this service
-        offers, so it is not counted: saying "3 users" to an admin who cannot see
-        the users page would name a thing they cannot act on.
+        so the refusal can say which.
+
+        ``users.budget_id`` is counted but not named. It can hold a tenant's
+        budget, because ``GET /v1/budgets`` is unfiltered and ``POST /v1/users``
+        accepts any id it lists, and ``Budget.users`` is a plain relationship, so
+        deleting the budget would not refuse: the ORM nulls the column out and
+        the assignment an operator made disappears with no refusal to either of
+        them. The count is what stops that, and it says only that the budget is
+        held, because saying "3 users" to an admin who cannot see the users page
+        would name a thing they cannot act on.
+
+        ``budget_reset_logs.budget_id`` is the same shape with a NOT NULL column,
+        so its null-out fails instead, as an ``IntegrityError`` at the commit.
+        Guarded there rather than counted, since a reset log only exists for a
+        budget a user already held.
         """
         organization = await self._managed_organization(user)
         budget = await self._require_own_budget(organization=organization, budget_id=budget_id)
@@ -608,8 +623,20 @@ class OrganizationBudgetService:
         if ceilings or defaults:
             raise OrganizationBudgetInUseError(budget.budget_id, ceilings=ceilings, defaults=defaults)
 
+        assigned = (
+            await self.db.execute(
+                select(func.count()).select_from(GatewayUser).where(GatewayUser.budget_id == budget.budget_id)
+            )
+        ).scalar_one()
+        if assigned:
+            raise OrganizationBudgetHeldElsewhereError(budget.budget_id)
+
         await self.db.delete(budget)
-        await self.db.commit()
+        try:
+            await self.db.commit()
+        except IntegrityError:
+            await self.db.rollback()
+            raise OrganizationBudgetHeldElsewhereError(budget_id) from None
 
     async def _ceiling_count(self, budget_id: str) -> int:
         return (

--- a/src/gateway/services/tenancy/organization_budget_service.py
+++ b/src/gateway/services/tenancy/organization_budget_service.py
@@ -774,10 +774,11 @@ class OrganizationBudgetService:
         )
         period_start, period_end = window if window is not None else (None, None)
 
-        # Checked before the insert rather than caught as an IntegrityError,
-        # because the two partial unique indexes on `scoped_budgets` are what
-        # would refuse it and neither is nameable in a message a human can act on.
-        # The race that leaves is closed by the index itself, which still refuses.
+        # Checked before the insert rather than only caught, because the two
+        # partial unique indexes on `scoped_budgets` are what would refuse it and
+        # neither is nameable in a message a human can act on. The race this
+        # leaves is closed by the index, and translated at the commit below so it
+        # is the same 409 rather than a 500.
         await self._require_no_existing_ceiling(request)
 
         ceiling = ScopedBudget(
@@ -790,7 +791,16 @@ class OrganizationBudgetService:
             period_end=period_end,
         )
         self.db.add(ceiling)
-        await self.db.commit()
+        try:
+            await self.db.commit()
+        except IntegrityError:
+            # The pre-check above is a read, so two concurrent creates can both
+            # pass it and one commit then loses to the partial unique index. The
+            # index is what actually enforces "one ceiling per scope and
+            # provider", and the loser failed for exactly the reason the
+            # pre-check describes, so it gets the same 409 rather than a 500.
+            await self.db.rollback()
+            raise OrganizationScopedBudgetAlreadyExistsError(request.scope_type, request.scope_id) from None
         await self.db.refresh(ceiling)
         return OrganizationScopedBudgetPublic.from_model(ceiling, budget, organization_id=organization.id)
 

--- a/src/gateway/services/tenancy/organization_budget_service.py
+++ b/src/gateway/services/tenancy/organization_budget_service.py
@@ -57,7 +57,7 @@ from datetime import UTC, datetime
 from typing import Literal, get_args
 
 from pydantic import BaseModel, Field
-from sqlalchemy import func, or_, select, update
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 from sqlmodel import col
@@ -66,6 +66,7 @@ from gateway.models.entities import APIKey, Budget, ScopedBudget, WorkspaceBudge
 from gateway.models.money import MAX_USD_LIMIT, as_float, to_usd_or_none
 from gateway.models.tenancy import Organization, OrganizationMember, User, Workspace, WorkspaceMember
 from gateway.services.budget_periods import period_window
+from gateway.services.budget_retiming import cadence_of, retime_ceilings_for_budget
 from gateway.services.tenancy.errors import (
     OrganizationBudgetInUseError,
     OrganizationBudgetNotFoundError,
@@ -213,23 +214,11 @@ class OrganizationScopedBudgetCreate(BaseModel):
             "a membership in either, or an API key in one"
         ),
     )
-    # Absent means every provider. A *present* value has to be a real instance
-    # name, so it is constrained rather than only length-checked: resolution
-    # matches `provider_key_id == provider_instance OR IS NULL`
-    # (`applicable_budgets`), and an empty or whitespace-only string is neither.
-    # It would store as a narrowed row under `uq_scoped_budgets_scope_with_key`,
-    # list like any other ceiling, and never bind, which is the same
-    # created-listed-and-silently-unenforced failure `_require_scope_exists`
-    # refuses a bad scope for, and it fails in the permissive direction.
-    #
-    # Blank is refused rather than folded into null: null is a *wider* cap, so
-    # accepting "" as "every provider" would silently cap more than the caller
-    # asked for. A pattern rather than a check in the dashboard, so the rule holds
-    # for every client and is published in the schema, as
-    # `organization_pricing`'s model-key pattern is. Whitespace is excluded
-    # outright because an instance name cannot contain any: the model-key pattern
-    # already forbids it in the provider half, since the allow-list is keyed on
-    # `"{instance}:{model}"`.
+    # Absent means every provider; a present value must name a real instance.
+    # Resolution matches `provider_key_id == provider_instance OR IS NULL`, and a
+    # blank string is neither, so it would store, list, and never bind. Refused
+    # rather than folded into null, because null is the *wider* cap and coercing
+    # would silently cap more than the caller asked for.
     provider_key_id: str | None = Field(
         default=None,
         min_length=1,
@@ -550,7 +539,7 @@ class OrganizationBudgetService:
         # moved at all: retiming a ceiling whose cadence did not change would
         # restart its window for a rename or a figure change, throwing away the
         # part of the period it had already spent.
-        cadence_before = (budget.budget_duration_sec, budget.reset_alignment)
+        cadence_before = cadence_of(budget.budget_duration_sec, budget.reset_alignment)
 
         fields = request.model_fields_set
         if "name" in fields:
@@ -566,41 +555,21 @@ class OrganizationBudgetService:
         # refuses, and neither field alone looks wrong.
         _require_single_period_source(budget.budget_duration_sec, budget.reset_alignment)
 
-        if (budget.budget_duration_sec, budget.reset_alignment) != cadence_before:
-            await self._retime_ceilings(budget)
+        if cadence_of(budget.budget_duration_sec, budget.reset_alignment) != cadence_before:
+            # Shared with the deployment-wide surface rather than written twice,
+            # so a rule this important cannot hold on one and not the other.
+            await retime_ceilings_for_budget(
+                self.db,
+                budget_id=budget.budget_id,
+                duration=budget.budget_duration_sec,
+                alignment=budget.reset_alignment,
+            )
 
         await self.db.commit()
         await self.db.refresh(budget)
         return OrganizationBudgetPublic.from_model(
             budget,
             ceiling_count=await self._ceiling_count(budget.budget_id),
-        )
-
-    async def _retime_ceilings(self, budget: Budget) -> None:
-        """Move every ceiling naming this budget onto the cadence it now carries.
-
-        One statement rather than a row per ceiling: the window is the same for
-        all of them, since it is derived from the budget and from now, not from
-        anything the ceiling holds. Not committed here; the caller owns the
-        transaction, so a refused update takes the retiming back with it.
-
-        A cadence of neither kind clears the window rather than computing one,
-        which is what "no reset" means and what ``period_window`` returns None
-        for. That is the direction that has to clear rather than be left stale: a
-        row keeping an old ``period_end`` under no cadence would roll once, at the
-        moment that stale boundary passed, and zero its spend for no reason.
-        """
-        window = period_window(
-            datetime.now(UTC),
-            duration=budget.budget_duration_sec,
-            alignment=budget.reset_alignment,
-        )
-        period_start, period_end = window if window is not None else (None, None)
-        await self.db.execute(
-            update(ScopedBudget)
-            .where(ScopedBudget.budget_id == budget.budget_id)
-            .values(period_start=period_start, period_end=period_end)
-            .execution_options(synchronize_session=False)
         )
 
     async def delete_budget(self, *, user: User, budget_id: str) -> None:

--- a/src/gateway/services/tenancy/organization_budget_service.py
+++ b/src/gateway/services/tenancy/organization_budget_service.py
@@ -57,7 +57,7 @@ from datetime import UTC, datetime
 from typing import Literal, get_args
 
 from pydantic import BaseModel, Field
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 from sqlmodel import col
@@ -528,9 +528,29 @@ class OrganizationBudgetService:
 
         Every ceiling naming it moves with it, which is the point of naming one:
         a budget is the figure, and the ceilings are where it applies.
+
+        **Changing the cadence retimes every ceiling naming this budget**, in this
+        transaction. A ceiling holds its own window and reads the cadence through
+        the budget, so leaving the windows alone would leave the two disagreeing,
+        and in one direction that is an enforcement bug rather than a cosmetic
+        one: ``_roll_expired_periods`` is guarded on ``period_end IS NOT NULL``,
+        so a budget moved from "no reset" to a periodic cadence would leave its
+        ceilings with NULL windows that never roll, accumulating spend forever
+        while this API reported the new cadence.
+
+        The counters are deliberately **not** zeroed, matching what repointing a
+        ceiling at a different budget already does: spend already recorded stays,
+        and the ceiling is the same allowance held to a different figure from here
+        on. ``reserved_spend`` is untouched so a hold taken before the change is
+        still released against the right counter.
         """
         organization = await self._managed_organization(user)
         budget = await self._require_own_budget(organization=organization, budget_id=budget_id)
+        # Read before the mutation, because that is what says whether the cadence
+        # moved at all: retiming a ceiling whose cadence did not change would
+        # restart its window for a rename or a figure change, throwing away the
+        # part of the period it had already spent.
+        cadence_before = (budget.budget_duration_sec, budget.reset_alignment)
 
         fields = request.model_fields_set
         if "name" in fields:
@@ -546,11 +566,41 @@ class OrganizationBudgetService:
         # refuses, and neither field alone looks wrong.
         _require_single_period_source(budget.budget_duration_sec, budget.reset_alignment)
 
+        if (budget.budget_duration_sec, budget.reset_alignment) != cadence_before:
+            await self._retime_ceilings(budget)
+
         await self.db.commit()
         await self.db.refresh(budget)
         return OrganizationBudgetPublic.from_model(
             budget,
             ceiling_count=await self._ceiling_count(budget.budget_id),
+        )
+
+    async def _retime_ceilings(self, budget: Budget) -> None:
+        """Move every ceiling naming this budget onto the cadence it now carries.
+
+        One statement rather than a row per ceiling: the window is the same for
+        all of them, since it is derived from the budget and from now, not from
+        anything the ceiling holds. Not committed here; the caller owns the
+        transaction, so a refused update takes the retiming back with it.
+
+        A cadence of neither kind clears the window rather than computing one,
+        which is what "no reset" means and what ``period_window`` returns None
+        for. That is the direction that has to clear rather than be left stale: a
+        row keeping an old ``period_end`` under no cadence would roll once, at the
+        moment that stale boundary passed, and zero its spend for no reason.
+        """
+        window = period_window(
+            datetime.now(UTC),
+            duration=budget.budget_duration_sec,
+            alignment=budget.reset_alignment,
+        )
+        period_start, period_end = window if window is not None else (None, None)
+        await self.db.execute(
+            update(ScopedBudget)
+            .where(ScopedBudget.budget_id == budget.budget_id)
+            .values(period_start=period_start, period_end=period_end)
+            .execution_options(synchronize_session=False)
         )
 
     async def delete_budget(self, *, user: User, budget_id: str) -> None:

--- a/src/gateway/services/tenancy/organization_budget_service.py
+++ b/src/gateway/services/tenancy/organization_budget_service.py
@@ -1,0 +1,814 @@
+"""An organization's own spend budgets and the ceilings that enforce them.
+
+The tenant-scoped half of budgets. ``/v1/budgets`` and ``/v1/scoped-budgets``
+stay what they are, the deployment's own surface behind
+``require_deployment_operator``; this is what an organization admin gets
+instead, and the roles matrix (otari-ai#1943) is what says they should have one:
+Spend & budgets is Hidden for a member and Edit for an admin, and before this
+both routers refused a tenant outright, so a hosted organization could manage
+neither its own caps nor the ceilings holding them.
+
+Two objects, because the schema has two and they answer different questions:
+
+- A :class:`Budget` is *what a cap is*: a USD figure and the period it is spent
+  over. ``budgets.organization_id`` says whose it is, and this service only ever
+  reads or writes rows carrying the caller's own.
+- A :class:`ScopedBudget` is *who is capped*: an organization, a workspace, a
+  membership in either, or a single API key, optionally narrowed to one provider
+  instance. It names a budget and holds its own counters, so the limit is read
+  through the budget and never copied.
+
+Three rules live here rather than in the route.
+
+**The caller's organization is resolved from their identity, never from the
+request.** Scoped to ``/me`` for the reason ``routes/organizations.py`` is:
+a request cannot name an organization at all, so there is no parameter to
+confuse with an authorization decision.
+
+**Only a management role may read or write.** Unlike the pricing overrides,
+where a member may see what their own requests are priced at, this is
+Hidden for a member in the matrix: a cap is a statement about what colleagues
+may spend, and the roster it implies is not a member's to read. So both halves
+take ``require_active_organization_management_access``.
+
+**Every scope must resolve into the caller's own organization, and every budget
+must be owned by it.** A scope id is a bare uuid on the wire with nothing in it
+saying which tenant it belongs to, so an unresolved one is the whole of the
+cross-tenant risk on this surface: without the check, an admin could cap another
+organization's workspace, or point their own ceiling at another organization's
+budget and then edit that budget's figure. Both answer 404 rather than 403, for
+the reason :class:`TenancyNotFoundError` gives: another tenant's row must not be
+distinguishable from one that was never created.
+
+A **NULL** ``organization_id`` is the deployment's own budget: the rows that
+predate ``b7e1c4a9d2f5`` and the ones the otari-ai cutover mints, which are
+shared across tenants by shape and so have no single owner. Nothing here lists,
+offers or repoints one. An organization's *existing* ceilings may still name one,
+because the cutover wrote them that way, so a ceiling reads back with the real
+figures it enforces (they are carried on the ceiling, read through the budget)
+and ``manageable`` false, rather than being hidden and leaving the page claiming
+the organization is uncapped.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Literal, get_args
+
+from pydantic import BaseModel, Field
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
+from sqlmodel import col
+
+from gateway.models.entities import APIKey, Budget, ScopedBudget, WorkspaceBudgetDefault
+from gateway.models.money import MAX_USD_LIMIT, as_float, to_usd_or_none
+from gateway.models.tenancy import Organization, OrganizationMember, User, Workspace, WorkspaceMember
+from gateway.services.budget_periods import period_window
+from gateway.services.tenancy.errors import (
+    OrganizationBudgetInUseError,
+    OrganizationBudgetNotFoundError,
+    OrganizationScopedBudgetAlreadyExistsError,
+    OrganizationScopedBudgetNotFoundError,
+    OrganizationScopeNotFoundError,
+    TenancyValidationError,
+)
+from gateway.services.tenancy.organization_service import OrganizationService
+
+# The scopes this surface understands, spelled out rather than imported from
+# `scoped_budget_service`: that module reaches `workspace_scope`, which reaches
+# `tenancy.provisioning_service`, which runs `tenancy/__init__`, which imports
+# this package. `WorkspaceService._delete_scoped_budgets_for` avoids the same
+# cycle the same way, and `tests/unit/test_service_module_imports.py` pins it.
+# The values are identical to `ScopeType`, and
+# `tests/unit/test_organization_budget_scopes.py` asserts that rather than
+# trusting it.
+SCOPE_ORGANIZATION = "organization"
+SCOPE_WORKSPACE = "workspace"
+SCOPE_WORKSPACE_MEMBER = "workspace_member"
+SCOPE_ORG_MEMBER = "org_member"
+SCOPE_API_TOKEN = "api_token"
+
+# Spelled as a `Literal` and not just as the constants above, because the
+# `Literal` is what puts the allowed values in the OpenAPI schema and refuses an
+# unknown one at the boundary, exactly as `ScopeType` does for the deployment
+# router. The constants stay for the resolution code, where a bare string
+# comparison reads worse than a name.
+OrganizationScopeType = Literal["organization", "workspace", "workspace_member", "org_member", "api_token"]
+ORGANIZATION_SCOPE_TYPES: tuple[str, ...] = get_args(OrganizationScopeType)
+
+_MAX_LIST_LIMIT = 1000
+
+_PERIOD_DESCRIPTION = (
+    "Seconds between resets, counted from the last one. Mutually exclusive with reset_alignment"
+)
+_ALIGNMENT_DESCRIPTION = (
+    "Reset on a UTC calendar boundary instead of a fixed number of seconds, which is the only way "
+    "to express a calendar month. Mutually exclusive with budget_duration_sec"
+)
+
+
+def _require_single_period_source(duration: int | None, alignment: str | None) -> None:
+    """Refuse the state ``ck_budgets_single_period_source`` refuses, with a message.
+
+    The same rule ``routes/budgets.py`` states for the deployment surface, and it
+    has to be stated on this one too: a period comes from a duration or from a
+    calendar boundary, and both set is one concept encoded twice, storable only
+    with an "ignored when" rule to give it a meaning. Checked here so the refusal
+    is a 400 naming the pair rather than the CHECK surfacing as a 500.
+    """
+    if duration is not None and alignment is not None:
+        raise TenancyValidationError("A budget resets on budget_duration_sec or on reset_alignment, not both")
+
+
+class OrganizationBudgetRates(BaseModel):
+    """The figure and the period a budget holds, shared by the create and update bodies."""
+
+    name: str | None = Field(default=None, max_length=200, description="Admin-facing label for the budget")
+    max_budget: float | None = Field(
+        default=None,
+        ge=0,
+        le=MAX_USD_LIMIT,
+        description="Maximum spend in USD over one period; null caps nothing",
+    )
+    budget_duration_sec: int | None = Field(default=None, gt=0, description=_PERIOD_DESCRIPTION)
+    reset_alignment: str | None = Field(default=None, description=_ALIGNMENT_DESCRIPTION)
+
+
+class OrganizationBudgetCreate(OrganizationBudgetRates):
+    """Create one budget owned by the caller's organization."""
+
+
+class OrganizationBudgetUpdate(OrganizationBudgetRates):
+    """Replace a budget's label, figure and period.
+
+    A full statement rather than a patch, matching ``PATCH /v1/budgets/{id}``'s
+    own fields: every one is optional and an omitted one is left alone, so
+    clearing a cap back to uncapped is not expressible here and is a delete. The
+    period pair is still mutually exclusive, and setting one does not clear the
+    other, which is why :func:`_require_single_period_source` re-checks the
+    *resulting* pair rather than the submitted one.
+    """
+
+
+class OrganizationBudgetPublic(BaseModel):
+    """One of the organization's budgets, and how much of its own config names it.
+
+    Carries no spend rollup. ``BudgetResponse`` on the deployment surface sums
+    ``users.spend`` over the gateway's ``users`` table, which is deployment-wide
+    and has no tenancy column, so the same figure here would be a cross-tenant
+    read. What an organization's own spend is, is a question for Usage.
+
+    ``ceiling_count`` is the organization-relevant fact instead: how many of its
+    ceilings this budget currently holds, which is what makes a delete refuse.
+    """
+
+    budget_id: str
+    organization_id: uuid.UUID
+    name: str | None
+    max_budget: float | None
+    budget_duration_sec: int | None
+    reset_alignment: str | None
+    ceiling_count: int
+    created_at: str
+    updated_at: str
+
+    @classmethod
+    def from_model(cls, budget: Budget, *, ceiling_count: int) -> OrganizationBudgetPublic:
+        # `organization_id` is narrowed rather than declared optional: every row
+        # this service returns was filtered on the caller's own, so a null here
+        # would be a bug in the query and not a state the wire should describe.
+        if budget.organization_id is None:  # pragma: no cover - the queries filter it
+            raise OrganizationBudgetNotFoundError(budget.budget_id)
+        return cls(
+            budget_id=budget.budget_id,
+            organization_id=budget.organization_id,
+            name=budget.name,
+            # Narrowed on the way out: the cap is exact in the database, while
+            # the wire contract and the dashboard client stay float.
+            max_budget=as_float(budget.max_budget),
+            budget_duration_sec=budget.budget_duration_sec,
+            reset_alignment=budget.reset_alignment,
+            ceiling_count=ceiling_count,
+            created_at=budget.created_at.isoformat(),
+            updated_at=budget.updated_at.isoformat(),
+        )
+
+
+class OrganizationBudgetsPublic(BaseModel):
+    data: list[OrganizationBudgetPublic]
+    count: int
+
+
+class OrganizationScopedBudgetCreate(BaseModel):
+    """Attach one of the organization's budgets to a scope inside it."""
+
+    scope_type: OrganizationScopeType = Field(description="Which kind of identity this ceiling caps")
+    scope_id: str = Field(
+        min_length=1,
+        max_length=255,
+        description=(
+            "Id of the capped identity: this organization, one of its workspaces, "
+            "a membership in either, or an API key in one"
+        ),
+    )
+    provider_key_id: str | None = Field(
+        default=None,
+        max_length=255,
+        description="Narrow the cap to one provider instance; null caps spend across every provider",
+    )
+    budget_id: str = Field(
+        min_length=1,
+        max_length=255,
+        description="The budget this ceiling enforces, which must be one this organization owns",
+    )
+    name: str | None = Field(default=None, max_length=200, description="Admin-facing label for this ceiling")
+
+
+class OrganizationScopedBudgetUpdate(BaseModel):
+    """Relabel a ceiling, or point it at a different budget of this organization's.
+
+    The scope and the provider narrowing are not editable, for the reason
+    ``PATCH /v1/scoped-budgets/{id}`` gives: changing either moves the ceiling to
+    a different identity while carrying its spend, which is a delete and a
+    create, not an update.
+    """
+
+    budget_id: str | None = Field(default=None, min_length=1, max_length=255)
+    name: str | None = Field(default=None, max_length=200)
+
+
+class OrganizationScopedBudgetPublic(BaseModel):
+    """One ceiling inside the organization, and the figures it enforces.
+
+    The limit and the period are read through the budget rather than stored here,
+    and carried on the wire so a page can render a ceiling without fetching every
+    budget to resolve one id. Same reasoning as ``ScopedBudgetResponse``, whose
+    shape this deliberately mirrors.
+    """
+
+    id: str
+    scope_type: str
+    scope_id: str
+    provider_key_id: str | None
+    budget_id: str
+    name: str | None
+    max_budget: float | None
+    current_spend: float
+    reserved_spend: float
+    budget_duration_sec: int | None
+    reset_alignment: str | None
+    period_start: str | None
+    period_end: str | None
+    # Whether the budget behind this ceiling is one this organization owns, and
+    # so whether its figure can be changed here at all. False for a ceiling the
+    # otari-ai cutover pointed at a deployment budget: the ceiling is real and
+    # enforcing, and the amount it holds is set outside this organization.
+    manageable: bool
+    created_at: str
+    updated_at: str
+
+    @classmethod
+    def from_model(
+        cls,
+        ceiling: ScopedBudget,
+        budget: Budget,
+        *,
+        organization_id: uuid.UUID,
+    ) -> OrganizationScopedBudgetPublic:
+        return cls(
+            id=ceiling.id,
+            scope_type=ceiling.scope_type,
+            scope_id=ceiling.scope_id,
+            provider_key_id=ceiling.provider_key_id,
+            budget_id=ceiling.budget_id,
+            name=ceiling.name,
+            max_budget=as_float(budget.max_budget),
+            current_spend=float(ceiling.current_spend),
+            reserved_spend=float(ceiling.reserved_spend),
+            budget_duration_sec=budget.budget_duration_sec,
+            reset_alignment=budget.reset_alignment,
+            period_start=ceiling.period_start.isoformat() if ceiling.period_start else None,
+            period_end=ceiling.period_end.isoformat() if ceiling.period_end else None,
+            manageable=budget.organization_id == organization_id,
+            created_at=ceiling.created_at.isoformat(),
+            updated_at=ceiling.updated_at.isoformat(),
+        )
+
+
+class OrganizationScopedBudgetsPublic(BaseModel):
+    data: list[OrganizationScopedBudgetPublic]
+    count: int
+
+
+class OrganizationBudgetService:
+    """Read and write the caller's organization's budgets and spend ceilings."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.organizations = OrganizationService(db)
+
+    # ------------------------------------------------------------------
+    # Identity and scope resolution
+    # ------------------------------------------------------------------
+
+    async def _managed_organization(self, user: User) -> Organization:
+        """The caller's organization, having checked they may manage its spend.
+
+        One gate for reads and writes alike. See the module docstring: the matrix
+        puts this surface at Hidden for a member, which is a stronger line than
+        the pricing overrides take, and a cap names colleagues.
+        """
+        organization = await self.organizations.get_active_organization_for_user(user)
+        await self.organizations.require_active_organization_management_access(
+            user=user,
+            organization=organization,
+        )
+        return organization
+
+    async def _scope_organization_id(self, *, scope_type: str, scope_id: str) -> uuid.UUID | None:
+        """Which organization a scope belongs to, or None when it resolves to nothing.
+
+        The whole cross-tenant check on this surface, so it resolves every scope
+        rather than trusting any of them. ``api_token`` keys on a string id and
+        the rest on UUIDs, matching ``_SCOPE_SUBJECTS`` on the deployment router;
+        a scope id that is not a UUID where one is required resolves to nothing
+        rather than raising, because a typo and another tenant's row have to be
+        the same answer.
+        """
+        if scope_type == SCOPE_API_TOKEN:
+            key = (
+                await self.db.execute(select(APIKey.workspace_id).where(APIKey.id == scope_id))
+            ).scalar_one_or_none()
+            if key is None:
+                return None
+            return await self._workspace_organization_id(key)
+
+        try:
+            identifier = uuid.UUID(scope_id)
+        except ValueError:
+            return None
+
+        if scope_type == SCOPE_ORGANIZATION:
+            found = (
+                await self.db.execute(select(col(Organization.id)).where(col(Organization.id) == identifier))
+            ).scalar_one_or_none()
+            return found
+        if scope_type == SCOPE_WORKSPACE:
+            return await self._workspace_organization_id(identifier)
+        if scope_type == SCOPE_ORG_MEMBER:
+            return (
+                await self.db.execute(
+                    select(col(OrganizationMember.organization_id)).where(col(OrganizationMember.id) == identifier)
+                )
+            ).scalar_one_or_none()
+        if scope_type == SCOPE_WORKSPACE_MEMBER:
+            workspace_id = (
+                await self.db.execute(
+                    select(col(WorkspaceMember.workspace_id)).where(col(WorkspaceMember.id) == identifier)
+                )
+            ).scalar_one_or_none()
+            if workspace_id is None:
+                return None
+            return await self._workspace_organization_id(workspace_id)
+        # Not reachable through the routes, which validate `scope_type` against
+        # `ORGANIZATION_SCOPE_TYPES` in the schema, so an unknown one here is a
+        # caller inside this process and resolving to nothing is the safe answer.
+        return None
+
+    async def _workspace_organization_id(self, workspace_id: uuid.UUID) -> uuid.UUID | None:
+        return (
+            await self.db.execute(
+                select(col(Workspace.organization_id)).where(col(Workspace.id) == workspace_id)
+            )
+        ).scalar_one_or_none()
+
+    async def _require_scope_in_organization(
+        self,
+        *,
+        organization: Organization,
+        scope_type: str,
+        scope_id: str,
+    ) -> None:
+        """Refuse a scope that resolves to nothing, or into another organization.
+
+        Both as 404 and with one message, so the response cannot be read as an
+        oracle for whether another tenant holds that id.
+        """
+        if scope_type not in ORGANIZATION_SCOPE_TYPES:
+            raise TenancyValidationError(f"Unknown scope type: {scope_type}")
+        owner = await self._scope_organization_id(scope_type=scope_type, scope_id=scope_id)
+        if owner is None or owner != organization.id:
+            raise OrganizationScopeNotFoundError(scope_type, scope_id)
+
+    async def _require_own_budget(self, *, organization: Organization, budget_id: str) -> Budget:
+        """A budget this organization owns, or 404.
+
+        Filtered on ``organization_id`` in the query rather than fetched and
+        checked, so a deployment budget and another tenant's are one answer and
+        neither can be told from a budget that does not exist.
+        """
+        budget = (
+            await self.db.execute(
+                select(Budget).where(
+                    Budget.budget_id == budget_id,
+                    Budget.organization_id == organization.id,
+                )
+            )
+        ).scalar_one_or_none()
+        if budget is None:
+            raise OrganizationBudgetNotFoundError(budget_id)
+        return budget
+
+    # ------------------------------------------------------------------
+    # Budgets
+    # ------------------------------------------------------------------
+
+    async def list_budgets(
+        self,
+        *,
+        user: User,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> OrganizationBudgetsPublic:
+        """A page of the organization's own budgets, with how many ceilings hold each."""
+        organization = await self._managed_organization(user)
+        limit = min(limit, _MAX_LIST_LIMIT)
+
+        count = (
+            await self.db.execute(
+                select(func.count()).select_from(Budget).where(Budget.organization_id == organization.id)
+            )
+        ).scalar_one()
+
+        budgets = (
+            (
+                await self.db.execute(
+                    select(Budget)
+                    .where(Budget.organization_id == organization.id)
+                    .order_by(Budget.created_at, Budget.budget_id)
+                    .offset(skip)
+                    .limit(limit)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        # One grouped count for the page rather than one query per row: a long
+        # lived organization has many budgets and this is the read its Spend page
+        # makes first.
+        held: dict[str, int] = {
+            budget_id: count
+            for budget_id, count in (
+                await self.db.execute(
+                    select(ScopedBudget.budget_id, func.count())
+                    .where(ScopedBudget.budget_id.in_([budget.budget_id for budget in budgets]))
+                    .group_by(ScopedBudget.budget_id)
+                )
+            ).all()
+        }
+        return OrganizationBudgetsPublic(
+            data=[
+                OrganizationBudgetPublic.from_model(budget, ceiling_count=held.get(budget.budget_id, 0))
+                for budget in budgets
+            ],
+            count=count,
+        )
+
+    async def create_budget(self, *, user: User, request: OrganizationBudgetCreate) -> OrganizationBudgetPublic:
+        """Create a budget owned by the caller's organization."""
+        organization = await self._managed_organization(user)
+        _require_single_period_source(request.budget_duration_sec, request.reset_alignment)
+
+        budget = Budget(
+            organization_id=organization.id,
+            name=request.name,
+            max_budget=to_usd_or_none(request.max_budget),
+            budget_duration_sec=request.budget_duration_sec,
+            reset_alignment=request.reset_alignment,
+        )
+        self.db.add(budget)
+        await self.db.commit()
+        await self.db.refresh(budget)
+        # Freshly created, so nothing can name it yet.
+        return OrganizationBudgetPublic.from_model(budget, ceiling_count=0)
+
+    async def update_budget(
+        self,
+        *,
+        user: User,
+        budget_id: str,
+        request: OrganizationBudgetUpdate,
+    ) -> OrganizationBudgetPublic:
+        """Change one of the organization's budgets.
+
+        Every ceiling naming it moves with it, which is the point of naming one:
+        a budget is the figure, and the ceilings are where it applies.
+        """
+        organization = await self._managed_organization(user)
+        budget = await self._require_own_budget(organization=organization, budget_id=budget_id)
+
+        fields = request.model_fields_set
+        if "name" in fields:
+            budget.name = request.name
+        if "max_budget" in fields:
+            budget.max_budget = to_usd_or_none(request.max_budget)
+        if "budget_duration_sec" in fields:
+            budget.budget_duration_sec = request.budget_duration_sec
+        if "reset_alignment" in fields:
+            budget.reset_alignment = request.reset_alignment
+        # The *resulting* pair, not the submitted one: setting a duration on a
+        # budget that already resets on a calendar boundary is what the CHECK
+        # refuses, and neither field alone looks wrong.
+        _require_single_period_source(budget.budget_duration_sec, budget.reset_alignment)
+
+        await self.db.commit()
+        await self.db.refresh(budget)
+        return OrganizationBudgetPublic.from_model(
+            budget,
+            ceiling_count=await self._ceiling_count(budget.budget_id),
+        )
+
+    async def delete_budget(self, *, user: User, budget_id: str) -> None:
+        """Delete one of the organization's budgets, refusing while anything names it.
+
+        ``scoped_budgets.budget_id`` and ``workspace_budget_defaults.budget_id``
+        are both RESTRICT, so the database would refuse anyway, as an
+        ``IntegrityError`` with nothing naming what to go and change. Checked here
+        so the refusal can say which. ``users.budget_id`` is the deployment's own
+        table and cannot name a tenant's budget through any route this service
+        offers, so it is not counted: saying "3 users" to an admin who cannot see
+        the users page would name a thing they cannot act on.
+        """
+        organization = await self._managed_organization(user)
+        budget = await self._require_own_budget(organization=organization, budget_id=budget_id)
+
+        ceilings = await self._ceiling_count(budget.budget_id)
+        defaults = (
+            await self.db.execute(
+                select(func.count())
+                .select_from(WorkspaceBudgetDefault)
+                .where(WorkspaceBudgetDefault.budget_id == budget.budget_id)
+            )
+        ).scalar_one()
+        if ceilings or defaults:
+            raise OrganizationBudgetInUseError(budget.budget_id, ceilings=ceilings, defaults=defaults)
+
+        await self.db.delete(budget)
+        await self.db.commit()
+
+    async def _ceiling_count(self, budget_id: str) -> int:
+        return (
+            await self.db.execute(
+                select(func.count()).select_from(ScopedBudget).where(ScopedBudget.budget_id == budget_id)
+            )
+        ).scalar_one()
+
+    # ------------------------------------------------------------------
+    # Ceilings
+    # ------------------------------------------------------------------
+
+    async def _organization_scope_filter(self, organization: Organization) -> ColumnElement[bool]:
+        """The predicate matching every ceiling whose scope sits in this organization.
+
+        Built from the organization's own ids rather than by resolving each row,
+        because ``scoped_budgets`` holds no tenancy column and no foreign key: the
+        table is keyed on ``(scope_type, scope_id)`` strings by design, so the
+        only way to ask "which of these are mine" is to name the ids that are.
+        Four id sets, one query each, which is bounded by the size of the
+        organization rather than by the number of ceilings.
+        """
+        workspace_ids = (
+            (
+                await self.db.execute(
+                    select(col(Workspace.id)).where(col(Workspace.organization_id) == organization.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        org_member_ids = (
+            (
+                await self.db.execute(
+                    select(col(OrganizationMember.id)).where(
+                        col(OrganizationMember.organization_id) == organization.id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        workspace_member_ids = (
+            (
+                await self.db.execute(
+                    select(col(WorkspaceMember.id)).where(col(WorkspaceMember.workspace_id).in_(workspace_ids))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        key_ids = (
+            (await self.db.execute(select(APIKey.id).where(APIKey.workspace_id.in_(workspace_ids)))).scalars().all()
+        )
+
+        workspace_strings = [str(value) for value in workspace_ids]
+        return or_(
+            (ScopedBudget.scope_type == SCOPE_ORGANIZATION) & (ScopedBudget.scope_id == str(organization.id)),
+            (ScopedBudget.scope_type == SCOPE_WORKSPACE) & ScopedBudget.scope_id.in_(workspace_strings),
+            (ScopedBudget.scope_type == SCOPE_ORG_MEMBER)
+            & ScopedBudget.scope_id.in_([str(value) for value in org_member_ids]),
+            (ScopedBudget.scope_type == SCOPE_WORKSPACE_MEMBER)
+            & ScopedBudget.scope_id.in_([str(value) for value in workspace_member_ids]),
+            (ScopedBudget.scope_type == SCOPE_API_TOKEN) & ScopedBudget.scope_id.in_(list(key_ids)),
+        )
+
+    async def list_ceilings(
+        self,
+        *,
+        user: User,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> OrganizationScopedBudgetsPublic:
+        """A page of the ceilings that cap identities inside this organization.
+
+        Includes the ones naming a deployment budget, reported with ``manageable``
+        false: they are enforcing against this organization's spend today (the
+        otari-ai cutover wrote them), so leaving them out would let the page read
+        as uncapped.
+        """
+        organization = await self._managed_organization(user)
+        limit = min(limit, _MAX_LIST_LIMIT)
+        scope_filter = await self._organization_scope_filter(organization)
+
+        count = (
+            await self.db.execute(select(func.count()).select_from(ScopedBudget).where(scope_filter))
+        ).scalar_one()
+
+        # Joined rather than a lookup per row: the limit and the period live on
+        # the budget, so a page of ceilings would otherwise be a page of round
+        # trips. The join is inner, which is safe because `budget_id` is NOT NULL
+        # with a RESTRICT foreign key, so a ceiling always has its budget.
+        rows = (
+            await self.db.execute(
+                select(ScopedBudget, Budget)
+                .join(Budget, Budget.budget_id == ScopedBudget.budget_id)
+                .where(scope_filter)
+                .order_by(ScopedBudget.created_at, ScopedBudget.id)
+                .offset(skip)
+                .limit(limit)
+            )
+        ).all()
+        return OrganizationScopedBudgetsPublic(
+            data=[
+                OrganizationScopedBudgetPublic.from_model(ceiling, budget, organization_id=organization.id)
+                for ceiling, budget in rows
+            ],
+            count=count,
+        )
+
+    async def create_ceiling(
+        self,
+        *,
+        user: User,
+        request: OrganizationScopedBudgetCreate,
+    ) -> OrganizationScopedBudgetPublic:
+        """Cap one identity inside the organization at one of its budgets."""
+        organization = await self._managed_organization(user)
+        await self._require_scope_in_organization(
+            organization=organization,
+            scope_type=request.scope_type,
+            scope_id=request.scope_id,
+        )
+        budget = await self._require_own_budget(organization=organization, budget_id=request.budget_id)
+
+        # The window opens now rather than on first spend, so a period-limited
+        # ceiling has a defined end before any request has arrived. An aligned one
+        # opens on the boundary it is already past, so its first period is the
+        # remainder of the calendar period it was created in. Same derivation as
+        # `POST /v1/scoped-budgets`, through the leaf module both import.
+        window = period_window(
+            datetime.now(UTC),
+            duration=budget.budget_duration_sec,
+            alignment=budget.reset_alignment,
+        )
+        period_start, period_end = window if window is not None else (None, None)
+
+        # Checked before the insert rather than caught as an IntegrityError,
+        # because the two partial unique indexes on `scoped_budgets` are what
+        # would refuse it and neither is nameable in a message a human can act on.
+        # The race that leaves is closed by the index itself, which still refuses.
+        await self._require_no_existing_ceiling(request)
+
+        ceiling = ScopedBudget(
+            scope_type=request.scope_type,
+            scope_id=request.scope_id,
+            provider_key_id=request.provider_key_id,
+            budget_id=budget.budget_id,
+            name=request.name,
+            period_start=period_start,
+            period_end=period_end,
+        )
+        self.db.add(ceiling)
+        await self.db.commit()
+        await self.db.refresh(ceiling)
+        return OrganizationScopedBudgetPublic.from_model(ceiling, budget, organization_id=organization.id)
+
+    async def _require_no_existing_ceiling(self, request: OrganizationScopedBudgetCreate) -> None:
+        stmt = select(func.count()).select_from(ScopedBudget).where(
+            ScopedBudget.scope_type == request.scope_type,
+            ScopedBudget.scope_id == request.scope_id,
+        )
+        if request.provider_key_id is None:
+            stmt = stmt.where(ScopedBudget.provider_key_id.is_(None))
+        else:
+            stmt = stmt.where(ScopedBudget.provider_key_id == request.provider_key_id)
+        if (await self.db.execute(stmt)).scalar_one():
+            raise OrganizationScopedBudgetAlreadyExistsError(request.scope_type, request.scope_id)
+
+    async def update_ceiling(
+        self,
+        *,
+        user: User,
+        ceiling_id: str,
+        request: OrganizationScopedBudgetUpdate,
+    ) -> OrganizationScopedBudgetPublic:
+        """Relabel a ceiling, or point it at a different budget of this organization's.
+
+        Repointing takes a budget the organization owns, which is what stops an
+        admin attaching their ceiling to a deployment budget or another tenant's
+        and then editing that budget's figure. A ceiling that currently names a
+        deployment budget can therefore be moved onto one of the organization's
+        own, which is how a cutover-migrated ceiling becomes manageable.
+        """
+        organization = await self._managed_organization(user)
+        ceiling = await self._require_own_ceiling(organization=organization, ceiling_id=ceiling_id)
+        budget = (await self.db.execute(select(Budget).where(Budget.budget_id == ceiling.budget_id))).scalar_one()
+
+        # Tri-state on `name`, keyed on `model_fields_set` rather than on the
+        # value: omitting it leaves it alone, and an explicit null clears it back
+        # to unnamed, which is a state a create can produce.
+        if "name" in request.model_fields_set:
+            ceiling.name = request.name
+        if request.budget_id is not None and request.budget_id != ceiling.budget_id:
+            budget = await self._require_own_budget(organization=organization, budget_id=request.budget_id)
+            ceiling.budget_id = budget.budget_id
+            # Retiming restarts the window from now rather than re-deriving an
+            # end from a `period_start` belonging to the old budget's cadence.
+            # Spend already recorded stays: the ceiling is the same allowance,
+            # held to a different figure from here on.
+            window = period_window(
+                datetime.now(UTC),
+                duration=budget.budget_duration_sec,
+                alignment=budget.reset_alignment,
+            )
+            ceiling.period_start, ceiling.period_end = window if window is not None else (None, None)
+
+        await self.db.commit()
+        await self.db.refresh(ceiling)
+        return OrganizationScopedBudgetPublic.from_model(ceiling, budget, organization_id=organization.id)
+
+    async def delete_ceiling(self, *, user: User, ceiling_id: str) -> None:
+        """Remove a ceiling inside the organization.
+
+        A request holding a reservation against it settles into nothing
+        afterwards, which is the right outcome: the ceiling no longer exists to be
+        credited. Same note as ``DELETE /v1/scoped-budgets/{id}``.
+        """
+        organization = await self._managed_organization(user)
+        ceiling = await self._require_own_ceiling(organization=organization, ceiling_id=ceiling_id)
+        await self.db.delete(ceiling)
+        await self.db.commit()
+
+    async def _require_own_ceiling(self, *, organization: Organization, ceiling_id: str) -> ScopedBudget:
+        """A ceiling whose scope sits in this organization, or 404.
+
+        Resolved through the scope rather than through the budget it names: a
+        cutover-migrated ceiling caps this organization while naming a deployment
+        budget, and it is still this organization's ceiling to remove.
+        """
+        ceiling = (
+            await self.db.execute(select(ScopedBudget).where(ScopedBudget.id == ceiling_id))
+        ).scalar_one_or_none()
+        if ceiling is None:
+            raise OrganizationScopedBudgetNotFoundError(ceiling_id)
+        owner = await self._scope_organization_id(scope_type=ceiling.scope_type, scope_id=ceiling.scope_id)
+        if owner is None or owner != organization.id:
+            raise OrganizationScopedBudgetNotFoundError(ceiling_id)
+        return ceiling
+
+
+__all__ = [
+    "ORGANIZATION_SCOPE_TYPES",
+    "OrganizationScopeType",
+    "OrganizationBudgetCreate",
+    "OrganizationBudgetPublic",
+    "OrganizationBudgetService",
+    "OrganizationBudgetUpdate",
+    "OrganizationBudgetsPublic",
+    "OrganizationScopedBudgetCreate",
+    "OrganizationScopedBudgetPublic",
+    "OrganizationScopedBudgetUpdate",
+    "OrganizationScopedBudgetsPublic",
+]

--- a/src/gateway/services/tenancy/organization_budget_service.py
+++ b/src/gateway/services/tenancy/organization_budget_service.py
@@ -213,10 +213,32 @@ class OrganizationScopedBudgetCreate(BaseModel):
             "a membership in either, or an API key in one"
         ),
     )
+    # Absent means every provider. A *present* value has to be a real instance
+    # name, so it is constrained rather than only length-checked: resolution
+    # matches `provider_key_id == provider_instance OR IS NULL`
+    # (`applicable_budgets`), and an empty or whitespace-only string is neither.
+    # It would store as a narrowed row under `uq_scoped_budgets_scope_with_key`,
+    # list like any other ceiling, and never bind, which is the same
+    # created-listed-and-silently-unenforced failure `_require_scope_exists`
+    # refuses a bad scope for, and it fails in the permissive direction.
+    #
+    # Blank is refused rather than folded into null: null is a *wider* cap, so
+    # accepting "" as "every provider" would silently cap more than the caller
+    # asked for. A pattern rather than a check in the dashboard, so the rule holds
+    # for every client and is published in the schema, as
+    # `organization_pricing`'s model-key pattern is. Whitespace is excluded
+    # outright because an instance name cannot contain any: the model-key pattern
+    # already forbids it in the provider half, since the allow-list is keyed on
+    # `"{instance}:{model}"`.
     provider_key_id: str | None = Field(
         default=None,
+        min_length=1,
         max_length=255,
-        description="Narrow the cap to one provider instance; null caps spend across every provider",
+        pattern=r"^\S+$",
+        description=(
+            "Narrow the cap to one provider instance; omit or null to cap spend across every provider. "
+            "Must name a real instance: a blank value would store a ceiling that never binds"
+        ),
     )
     budget_id: str = Field(
         min_length=1,

--- a/src/gateway/services/tenancy/organization_budget_service.py
+++ b/src/gateway/services/tenancy/organization_budget_service.py
@@ -65,7 +65,7 @@ from sqlmodel import col
 from gateway.models.entities import APIKey, Budget, ScopedBudget, WorkspaceBudgetDefault
 from gateway.models.money import MAX_USD_LIMIT, as_float, to_usd_or_none
 from gateway.models.tenancy import Organization, OrganizationMember, User, Workspace, WorkspaceMember
-from gateway.services.budget_periods import period_window
+from gateway.services.budget_periods import ResetAlignment, period_window
 from gateway.services.budget_retiming import cadence_of, retime_ceilings_for_budget
 from gateway.services.tenancy.errors import (
     OrganizationBudgetInUseError,
@@ -134,7 +134,18 @@ class OrganizationBudgetRates(BaseModel):
         description="Maximum spend in USD over one period; null caps nothing",
     )
     budget_duration_sec: int | None = Field(default=None, gt=0, description=_PERIOD_DESCRIPTION)
-    reset_alignment: str | None = Field(default=None, description=_ALIGNMENT_DESCRIPTION)
+    # The `Literal`, not a bare `str`: an unrecognized alignment is stored happily
+    # and then raises out of `period_window` the first time a window is derived
+    # from it, which is a 500 on creating a ceiling or on retiming one rather than
+    # a 422 on the request that introduced it. `_roll_expired_periods` degrades
+    # safely (it logs and leaves the exhausted window in place) but the API paths
+    # do not, so the value is refused at the boundary and published in the schema,
+    # matching what `CreateBudgetRequest` on the deployment route already does.
+    #
+    # The response models keep `str | None` on purpose: they echo whatever is
+    # stored, and narrowing them would turn a row holding an unexpected value into
+    # a failed read rather than a readable row someone can go and fix.
+    reset_alignment: ResetAlignment | None = Field(default=None, description=_ALIGNMENT_DESCRIPTION)
 
 
 class OrganizationBudgetCreate(OrganizationBudgetRates):

--- a/src/gateway/services/tenancy/workspace_budget_default_service.py
+++ b/src/gateway/services/tenancy/workspace_budget_default_service.py
@@ -74,10 +74,23 @@ class WorkspaceMemberBudgetPolicyCreate(BaseModel):
         max_length=255,
         description="The budget this workspace hands to every member",
     )
+    # Absent means every provider; a present value must name a real instance.
+    # Constrained rather than only length-checked because this template is
+    # materialized verbatim into a ceiling per member, and a ceiling whose
+    # `provider_key_id` is a blank string binds to nothing: resolution matches
+    # `provider_key_id == provider_instance OR IS NULL` and blank is neither, so
+    # every member would get a cap that is stored, listed, and never enforced.
+    # Reachable by an organization or workspace owner/admin, not only an operator,
+    # which is why it is refused here rather than left to the dashboard.
     provider_key_id: str | None = Field(
         default=None,
+        min_length=1,
         max_length=255,
-        description="Narrow the default to one provider instance; null applies to every provider",
+        pattern=r"^\S+$",
+        description=(
+            "Narrow the default to one provider instance; omit or null to apply to every provider. "
+            "Must name a real instance: a blank value would materialize ceilings that never bind"
+        ),
     )
 
 

--- a/src/gateway/services/tenancy/workspace_budget_default_service.py
+++ b/src/gateway/services/tenancy/workspace_budget_default_service.py
@@ -337,10 +337,25 @@ class WorkspaceBudgetDefaultService:
             raise WorkspaceBudgetDefaultBudgetNotFoundError(default.budget_id)
         return budget
 
-    async def _require_budget(self, budget_id: str) -> Budget:
-        """The budget a caller named, refused as 404 when it does not exist."""
+    async def _require_budget(self, budget_id: str, *, organization_id: uuid.UUID) -> Budget:
+        """The budget a caller named, refused as 404 when it is not theirs to name.
+
+        ``organization_id`` is the workspace's, and a budget carrying a different
+        one is refused as though it did not exist. Before ``b7e1c4a9d2f5`` there
+        was nothing to check: every budget was the deployment's, defined by an
+        operator, and any of them was as valid a template as any other. Now that
+        an admin can define one (otari-ai#1943), an unchecked id here would let
+        one organization's admin hand their workspace another organization's
+        budget, and then move what that other tenant is capped at by editing it.
+
+        A budget with **no** organization stays nameable: those are the
+        deployment's own, including the ones an operator defined and the ones the
+        otari-ai cutover minted, and a workspace default has always been able to
+        name one. Narrowing that too would break every existing default on
+        upgrade.
+        """
         budget = await self.db.get(Budget, budget_id)
-        if budget is None:
+        if budget is None or (budget.organization_id is not None and budget.organization_id != organization_id):
             raise WorkspaceBudgetDefaultBudgetNotFoundError(budget_id)
         return budget
 
@@ -456,7 +471,7 @@ class WorkspaceBudgetDefaultService:
 
         # Before the lock's write, so an unknown budget is a 404 rather than a
         # foreign-key violation reported as "this default already exists".
-        budget = await self._require_budget(request.budget_id)
+        budget = await self._require_budget(request.budget_id, organization_id=workspace.organization_id)
         default = WorkspaceBudgetDefault(
             workspace_id=workspace.id,
             budget_id=budget.budget_id,
@@ -506,7 +521,7 @@ class WorkspaceBudgetDefaultService:
         )
         default = await self._get_or_404(workspace, default_id)
 
-        budget = await self._require_budget(request.budget_id)
+        budget = await self._require_budget(request.budget_id, organization_id=workspace.organization_id)
         default.budget_id = budget.budget_id
 
         await self.db.commit()

--- a/tests/integration/test_budget_dashboard.py
+++ b/tests/integration/test_budget_dashboard.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime
 from decimal import Decimal
+from uuid import uuid4
 
 from fastapi.testclient import TestClient
 from sqlalchemy import delete, select
@@ -274,3 +275,110 @@ def test_deleting_a_budget_a_ceiling_enforces_is_refused(
     db_session.execute(delete(ScopedBudget).where(ScopedBudget.budget_id == budget_id))
     db_session.commit()
     assert client.delete(f"/v1/budgets/{budget_id}", headers=master_key_header).status_code == 204
+
+
+def test_a_cadence_change_retimes_the_ceilings_naming_the_budget(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    db_session: Session,
+) -> None:
+    """The direction that is an enforcement bug, not a cosmetic one.
+
+    `_roll_expired_periods` only updates a row whose `period_end` is not null, so
+    a ceiling left with a NULL window under a periodic budget never rolls at all:
+    it accumulates spend forever while the API reports the new cadence. Since
+    `b7e1c4a9d2f5` a budget can also belong to an organization while this route
+    still sees every one, so the ceilings stranded this way may be a tenant's.
+    """
+    budget_id = _make_budget(client, master_key_header)
+    # A budget with no cadence materializes a ceiling with no window.
+    ceiling = ScopedBudget(scope_type="workspace", scope_id=str(uuid4()), budget_id=budget_id)
+    db_session.add(ceiling)
+    db_session.commit()
+    assert ceiling.period_end is None
+
+    patched = client.patch(
+        f"/v1/budgets/{budget_id}",
+        json={"reset_alignment": "calendar_month"},
+        headers=master_key_header,
+    )
+    assert patched.status_code == 200, patched.json()
+
+    db_session.expire_all()
+    retimed = db_session.get(ScopedBudget, ceiling.id)
+    assert retimed is not None
+    assert retimed.period_start is not None
+    assert retimed.period_end is not None
+
+
+def test_dropping_a_cadence_clears_the_ceiling_window(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    db_session: Session,
+) -> None:
+    """The reverse, which would otherwise roll once at a boundary that no longer means anything."""
+    created = client.post(
+        "/v1/budgets", json={"max_budget": 100.0, "reset_alignment": "calendar_day"}, headers=master_key_header
+    ).json()
+    budget_id = created["budget_id"]
+    ceiling = ScopedBudget(
+        scope_type="workspace",
+        scope_id=str(uuid4()),
+        budget_id=budget_id,
+        period_start=datetime(2026, 8, 1, tzinfo=UTC),
+        period_end=datetime(2026, 8, 2, tzinfo=UTC),
+    )
+    db_session.add(ceiling)
+    db_session.commit()
+
+    patched = client.patch(
+        f"/v1/budgets/{budget_id}",
+        json={"reset_alignment": None},
+        headers=master_key_header,
+    )
+    assert patched.status_code == 200, patched.json()
+
+    db_session.expire_all()
+    cleared = db_session.get(ScopedBudget, ceiling.id)
+    assert cleared is not None
+    assert cleared.period_start is None
+    assert cleared.period_end is None
+
+
+def test_a_rename_does_not_restart_a_ceiling_period(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    db_session: Session,
+) -> None:
+    """Retiming is keyed on the cadence, so unrelated edits leave the window alone.
+
+    Otherwise every typo fix in a budget's name would throw away the part of the
+    period its ceilings had already spent.
+    """
+    created = client.post(
+        "/v1/budgets", json={"max_budget": 100.0, "reset_alignment": "calendar_day"}, headers=master_key_header
+    ).json()
+    budget_id = created["budget_id"]
+    start, end = datetime(2026, 8, 1, tzinfo=UTC), datetime(2026, 8, 2, tzinfo=UTC)
+    ceiling = ScopedBudget(
+        scope_type="workspace",
+        scope_id=str(uuid4()),
+        budget_id=budget_id,
+        period_start=start,
+        period_end=end,
+    )
+    db_session.add(ceiling)
+    db_session.commit()
+
+    patched = client.patch(
+        f"/v1/budgets/{budget_id}",
+        json={"name": "renamed", "max_budget": 500.0},
+        headers=master_key_header,
+    )
+    assert patched.status_code == 200, patched.json()
+
+    db_session.expire_all()
+    untouched = db_session.get(ScopedBudget, ceiling.id)
+    assert untouched is not None
+    assert untouched.period_start == start
+    assert untouched.period_end == end

--- a/tests/integration/test_organization_budgets.py
+++ b/tests/integration/test_organization_budgets.py
@@ -194,6 +194,37 @@ def test_every_recognized_alignment_is_accepted(
         assert created.json()["reset_alignment"] == alignment
 
 
+def test_a_budget_a_gateway_user_holds_is_refused_rather_than_unassigned(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """The delete refuses instead of silently clearing ``users.budget_id``.
+
+    An operator can assign a gateway user to any budget ``GET /v1/budgets``
+    lists, tenant-owned ones included. ``Budget.users`` is a plain relationship,
+    so an unchecked delete does not fail: the ORM nulls the column out, and an
+    admin who cannot see that table removes the operator's assignment with it.
+    """
+    budget = client.post(_BUDGETS, json=_budget_body(), headers=master_key_header).json()
+    user_id = f"holder-{uuid.uuid4().hex[:8]}"
+    created = client.post(
+        "/v1/users",
+        json={"user_id": user_id, "budget_id": budget["budget_id"]},
+        headers=master_key_header,
+    )
+    assert created.status_code in {status.HTTP_200_OK, status.HTTP_201_CREATED}, created.text
+
+    refused = client.delete(f"{_BUDGETS}/{budget['budget_id']}", headers=master_key_header)
+    assert refused.status_code == status.HTTP_409_CONFLICT, refused.text
+    assert "still in use" in refused.json()["detail"]
+
+    # The assignment is still the operator's, and the budget is still there.
+    still_assigned = client.get(f"/v1/users/{user_id}", headers=master_key_header)
+    assert still_assigned.status_code == status.HTTP_200_OK, still_assigned.text
+    assert still_assigned.json()["budget_id"] == budget["budget_id"]
+    assert client.get(_BUDGETS, headers=master_key_header).json()["count"] == 1
+
+
 def test_an_unknown_budget_is_not_found(client: TestClient, master_key_header: dict[str, str]) -> None:
     missing = client.patch(f"{_BUDGETS}/nope", json={"name": "x"}, headers=master_key_header)
     assert missing.status_code == status.HTTP_404_NOT_FOUND, missing.text

--- a/tests/integration/test_organization_budgets.py
+++ b/tests/integration/test_organization_budgets.py
@@ -17,6 +17,7 @@ tenant's.
 """
 
 import uuid
+from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 
@@ -27,7 +28,16 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
-from gateway.models.entities import APIKey, Budget, ScopedBudget, WorkspaceBudgetDefault
+from gateway.models.entities import (
+    APIKey,
+    Budget,
+    BudgetResetLog,
+    ScopedBudget,
+    WorkspaceBudgetDefault,
+)
+from gateway.models.entities import (
+    User as ApiUser,
+)
 from gateway.models.tenancy import Organization, OrganizationMember, User, Workspace, WorkspaceMember
 from gateway.repositories.tenancy import (
     OrganizationMemberRepository,
@@ -38,6 +48,7 @@ from gateway.repositories.tenancy import (
 )
 from gateway.services.tenancy.errors import (
     NotAuthorizedError,
+    OrganizationBudgetHeldElsewhereError,
     OrganizationBudgetInUseError,
     OrganizationBudgetNotFoundError,
     OrganizationScopedBudgetAlreadyExistsError,
@@ -935,6 +946,111 @@ async def test_a_delete_is_refused_while_a_workspace_default_names_the_budget(as
     await async_db.flush()
 
     with pytest.raises(OrganizationBudgetInUseError, match="workspace member default"):
+        await service.delete_budget(user=owner, budget_id=budget.budget_id)
+
+
+@pytest.mark.asyncio
+async def test_a_concurrent_duplicate_ceiling_is_a_conflict_not_a_crash(
+    async_db: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The race the pre-check cannot close, translated rather than escaping as a 500.
+
+    The pre-check is a read, so two creates can both pass it and one commit then
+    loses to the partial unique index. Simulated deterministically by inserting
+    the colliding row after the pre-check would have run and before the commit,
+    which is the same ordering a concurrent writer produces.
+    """
+    organization = await _organization(async_db, slug="acme-race")
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationBudgetService(async_db)
+    budget = await service.create_budget(user=owner, request=_create())
+    request = OrganizationScopedBudgetCreate(
+        scope_type="organization",
+        scope_id=str(organization.id),
+        budget_id=budget.budget_id,
+    )
+
+    original = service._require_no_existing_ceiling
+
+    async def insert_the_winner(candidate: OrganizationScopedBudgetCreate) -> None:
+        await original(candidate)
+        # The competing writer, landing between the check and this call's commit.
+        async_db.add(
+            ScopedBudget(
+                scope_type=candidate.scope_type,
+                scope_id=candidate.scope_id,
+                budget_id=candidate.budget_id,
+            )
+        )
+        await async_db.flush()
+
+    # Through `monkeypatch` rather than a bare assignment, which mypy refuses on
+    # a bound method and which would leave the patch in place if the assertion
+    # below raised.
+    monkeypatch.setattr(service, "_require_no_existing_ceiling", insert_the_winner)
+
+    with pytest.raises(OrganizationScopedBudgetAlreadyExistsError):
+        await service.create_ceiling(user=owner, request=request)
+
+@pytest.mark.asyncio
+async def test_an_explicit_null_clears_the_cap_as_the_schema_says(async_db: AsyncSession) -> None:
+    """The behavior the update model's description used to deny.
+
+    Each field is tri-state on `model_fields_set`, so an explicit null is a value:
+    it clears the cap back to uncapped rather than being ignored. The description
+    said clearing was a delete, which is published in the OpenAPI schema and would
+    have sent a client to the wrong endpoint.
+    """
+    organization = await _organization(async_db, slug="acme-clear-cap")
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationBudgetService(async_db)
+    budget = await service.create_budget(user=owner, request=_create(max_budget=100.0))
+    assert budget.max_budget == 100.0
+
+    cleared = await service.update_budget(
+        user=owner,
+        budget_id=budget.budget_id,
+        request=OrganizationBudgetUpdate(max_budget=None),
+    )
+
+    assert cleared.max_budget is None
+    # And an omitted field is still left alone, which is what makes it a patch.
+    renamed = await service.update_budget(
+        user=owner,
+        budget_id=budget.budget_id,
+        request=OrganizationBudgetUpdate(name="Uncapped"),
+    )
+    assert renamed.max_budget is None
+    assert renamed.name == "Uncapped"
+
+@pytest.mark.asyncio
+async def test_a_delete_is_refused_while_a_reset_record_names_the_budget(async_db: AsyncSession) -> None:
+    """The reference that outlives the assignment which produced it.
+
+    A user can detach after a reset, leaving no live `users.budget_id` while the
+    `budget_reset_logs` row remains and goes on refusing the delete.
+    """
+    organization = await _organization(async_db, slug="acme-reset-hold")
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationBudgetService(async_db)
+    budget = await service.create_budget(user=owner, request=_create())
+    async_db.add(ApiUser(user_id="detached-user", budget_id=None))
+    await async_db.flush()
+    async_db.add(
+        BudgetResetLog(
+            user_id="detached-user",
+            budget_id=budget.budget_id,
+            previous_spend=Decimal("1.5"),
+            reset_at=datetime.now(UTC),
+        )
+    )
+    await async_db.flush()
+
+    # `OrganizationBudgetHeldElsewhereError`, not the in-use error: a reset log is
+    # not a tenant's row to be told about, and its NOT NULL column makes the
+    # ORM's null-out fail at the commit rather than being caught by a count.
+    with pytest.raises(OrganizationBudgetHeldElsewhereError):
         await service.delete_budget(user=owner, budget_id=budget.budget_id)
 
 

--- a/tests/integration/test_organization_budgets.py
+++ b/tests/integration/test_organization_budgets.py
@@ -136,6 +136,58 @@ def test_a_patch_that_would_state_both_periods_is_refused(
     assert refused.status_code == status.HTTP_400_BAD_REQUEST, refused.text
 
 
+@pytest.mark.parametrize("alignment", ["weekly", "calendar_fortnight", "CALENDAR_DAY", ""])
+def test_an_unrecognized_reset_alignment_is_refused_on_the_request(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    alignment: str,
+) -> None:
+    """422 on the request that introduces it, not 500 on the next window derivation.
+
+    An unrecognized alignment stores happily and then raises out of
+    ``period_window`` the first time a window is derived from it, which is
+    creating a ceiling or retiming one after a cadence change. "weekly" is the
+    plausible mistake: it is a period name a caller would reasonably try, and it
+    is not one of the three calendar boundaries.
+    """
+    refused = client.post(
+        _BUDGETS,
+        json={"name": "Monthly", "max_budget": 100.0, "reset_alignment": alignment},
+        headers=master_key_header,
+    )
+    assert refused.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT, refused.text
+
+
+def test_an_unrecognized_reset_alignment_is_refused_on_an_update(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """The update path too, which is the one that reaches the retiming."""
+    budget = client.post(_BUDGETS, json=_budget_body(), headers=master_key_header).json()
+
+    refused = client.patch(
+        f"{_BUDGETS}/{budget['budget_id']}",
+        json={"reset_alignment": "weekly"},
+        headers=master_key_header,
+    )
+    assert refused.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT, refused.text
+
+
+def test_every_recognized_alignment_is_accepted(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """The other half, so the constraint cannot creep into refusing a valid boundary."""
+    for alignment in ("calendar_day", "calendar_week", "calendar_month"):
+        created = client.post(
+            _BUDGETS,
+            json={"name": alignment, "max_budget": 10.0, "reset_alignment": alignment},
+            headers=master_key_header,
+        )
+        assert created.status_code == status.HTTP_201_CREATED, created.text
+        assert created.json()["reset_alignment"] == alignment
+
+
 def test_an_unknown_budget_is_not_found(client: TestClient, master_key_header: dict[str, str]) -> None:
     missing = client.patch(f"{_BUDGETS}/nope", json={"name": "x"}, headers=master_key_header)
     assert missing.status_code == status.HTTP_404_NOT_FOUND, missing.text

--- a/tests/integration/test_organization_budgets.py
+++ b/tests/integration/test_organization_budgets.py
@@ -243,6 +243,56 @@ def test_an_unknown_scope_type_is_refused_by_the_schema(
     assert refused.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT, refused.text
 
 
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_a_blank_provider_narrowing_is_refused(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    blank: str,
+) -> None:
+    """A ceiling narrowed to nothing would be created, listed, and never enforced.
+
+    ``applicable_budgets`` matches ``provider_key_id == provider_instance OR IS
+    NULL``, and a blank string is neither: it stores as a narrowed row under
+    ``uq_scoped_budgets_scope_with_key`` and binds to no request ever. That is the
+    same permissive-direction failure a scope naming nothing has, so it is refused
+    at the schema rather than normalized, since folding it into null would quietly
+    cap *more* than the caller asked for.
+    """
+    budget = client.post(_BUDGETS, json=_budget_body(), headers=master_key_header).json()
+
+    refused = client.post(
+        _CEILINGS,
+        json={
+            "scope_type": "organization",
+            "scope_id": budget["organization_id"],
+            "provider_key_id": blank,
+            "budget_id": budget["budget_id"],
+        },
+        headers=master_key_header,
+    )
+    assert refused.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT, refused.text
+
+
+def test_an_omitted_provider_narrowing_still_caps_every_provider(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """The other half of the rule above: absent is the aggregate cap, and stays so."""
+    budget = client.post(_BUDGETS, json=_budget_body(), headers=master_key_header).json()
+
+    created = client.post(
+        _CEILINGS,
+        json={
+            "scope_type": "organization",
+            "scope_id": budget["organization_id"],
+            "budget_id": budget["budget_id"],
+        },
+        headers=master_key_header,
+    )
+    assert created.status_code == status.HTTP_201_CREATED, created.text
+    assert created.json()["provider_key_id"] is None
+
+
 def test_deleting_a_budget_a_ceiling_names_is_refused(
     client: TestClient,
     master_key_header: dict[str, str],

--- a/tests/integration/test_organization_budgets.py
+++ b/tests/integration/test_organization_budgets.py
@@ -17,6 +17,7 @@ tenant's.
 """
 
 import uuid
+from decimal import Decimal
 from typing import Any
 
 import pytest
@@ -558,6 +559,148 @@ async def test_every_scope_kind_resolves_to_its_organization(async_db: AsyncSess
         assert created.manageable is True
 
     assert (await service.list_ceilings(user=owner)).count == len(scopes)
+
+
+@pytest.mark.asyncio
+async def test_giving_a_cadence_to_a_budget_that_had_none_retimes_its_ceilings(async_db: AsyncSession) -> None:
+    """The case that is an enforcement bug rather than a cosmetic one.
+
+    ``_roll_expired_periods`` only ever updates a row whose ``period_end`` is not
+    null, so a ceiling left with a NULL window under a periodic budget never rolls
+    at all: it accumulates spend forever while this API reports the new cadence.
+    """
+    organization = await _organization(async_db, slug="acme-cadence-none")
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationBudgetService(async_db)
+    budget = await service.create_budget(
+        user=owner,
+        request=_create(name="No reset", reset_alignment=None, max_budget=50.0),
+    )
+    ceiling = await service.create_ceiling(
+        user=owner,
+        request=OrganizationScopedBudgetCreate(
+            scope_type="organization",
+            scope_id=str(organization.id),
+            budget_id=budget.budget_id,
+        ),
+    )
+    assert ceiling.period_start is None
+    assert ceiling.period_end is None
+
+    await service.update_budget(
+        user=owner,
+        budget_id=budget.budget_id,
+        request=OrganizationBudgetUpdate(reset_alignment="calendar_month"),
+    )
+
+    retimed = (await service.list_ceilings(user=owner)).data[0]
+    assert retimed.period_start is not None
+    assert retimed.period_end is not None
+    assert retimed.reset_alignment == "calendar_month"
+
+
+@pytest.mark.asyncio
+async def test_taking_a_cadence_away_clears_the_window(async_db: AsyncSession) -> None:
+    """The other direction, which would otherwise roll once at a stale boundary.
+
+    A ceiling keeping an old ``period_end`` under a budget that no longer resets
+    would zero its spend the moment that boundary passed, for no reason anyone
+    could point at.
+    """
+    organization = await _organization(async_db, slug="acme-cadence-drop")
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationBudgetService(async_db)
+    budget = await service.create_budget(user=owner, request=_create())
+    await service.create_ceiling(
+        user=owner,
+        request=OrganizationScopedBudgetCreate(
+            scope_type="organization",
+            scope_id=str(organization.id),
+            budget_id=budget.budget_id,
+        ),
+    )
+
+    await service.update_budget(
+        user=owner,
+        budget_id=budget.budget_id,
+        request=OrganizationBudgetUpdate(reset_alignment=None),
+    )
+
+    cleared = (await service.list_ceilings(user=owner)).data[0]
+    assert cleared.period_start is None
+    assert cleared.period_end is None
+
+
+@pytest.mark.asyncio
+async def test_retiming_keeps_the_spend_already_recorded(async_db: AsyncSession) -> None:
+    """A cadence change is not a reset.
+
+    Same rule repointing a ceiling at a different budget already follows: the
+    window moves, the counters do not, so the allowance is held to a different
+    figure from here on rather than handed back.
+    """
+    organization = await _organization(async_db, slug="acme-cadence-spend")
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationBudgetService(async_db)
+    budget = await service.create_budget(user=owner, request=_create())
+    created = await service.create_ceiling(
+        user=owner,
+        request=OrganizationScopedBudgetCreate(
+            scope_type="organization",
+            scope_id=str(organization.id),
+            budget_id=budget.budget_id,
+        ),
+    )
+    stored = await async_db.get(ScopedBudget, created.id)
+    assert stored is not None
+    stored.current_spend = Decimal("7.5")
+    stored.reserved_spend = Decimal("1.25")
+    await async_db.flush()
+
+    await service.update_budget(
+        user=owner,
+        budget_id=budget.budget_id,
+        request=OrganizationBudgetUpdate(reset_alignment="calendar_day"),
+    )
+
+    kept = (await service.list_ceilings(user=owner)).data[0]
+    assert kept.current_spend == 7.5
+    # Untouched, so a hold taken before the change still releases against the
+    # counter it was taken from.
+    assert kept.reserved_spend == 1.25
+
+
+@pytest.mark.asyncio
+async def test_a_change_that_is_not_the_cadence_leaves_the_window_alone(async_db: AsyncSession) -> None:
+    """Renaming or repricing must not restart a period.
+
+    Retiming on every update would throw away the part of the period a ceiling
+    had already spent, every time somebody fixed a typo in a budget's name.
+    """
+    organization = await _organization(async_db, slug="acme-cadence-stable")
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationBudgetService(async_db)
+    budget = await service.create_budget(user=owner, request=_create())
+    created = await service.create_ceiling(
+        user=owner,
+        request=OrganizationScopedBudgetCreate(
+            scope_type="organization",
+            scope_id=str(organization.id),
+            budget_id=budget.budget_id,
+        ),
+    )
+
+    await service.update_budget(
+        user=owner,
+        budget_id=budget.budget_id,
+        request=OrganizationBudgetUpdate(name="Renamed", max_budget=999.0),
+    )
+
+    unchanged = (await service.list_ceilings(user=owner)).data[0]
+    assert unchanged.period_start == created.period_start
+    assert unchanged.period_end == created.period_end
+    # The figure did move, which is the whole point of naming a budget.
+    assert unchanged.max_budget == 999.0
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_organization_budgets.py
+++ b/tests/integration/test_organization_budgets.py
@@ -56,6 +56,12 @@ from gateway.services.tenancy.organization_budget_service import (
 _BUDGETS = "/v1/organizations/me/budgets"
 _CEILINGS = "/v1/organizations/me/spend-ceilings"
 
+# `HTTP_422_UNPROCESSABLE_CONTENT`, not `..._ENTITY`, in the schema-refusal
+# assertions below. The two are both 422; `_ENTITY` is the deprecated alias and
+# reading it emits a `StarletteDeprecationWarning` (verified against Starlette
+# 1.3.1). Noted here because the swap has been suggested twice in review, in the
+# wrong direction each time.
+
 
 # =============================================================================
 # The HTTP surface

--- a/tests/integration/test_organization_budgets.py
+++ b/tests/integration/test_organization_budgets.py
@@ -1,0 +1,738 @@
+"""The tenant-scoped budget and spend-ceiling endpoints, and their tenant boundary.
+
+Two halves, for the reason `test_organization_pricing_routes.py` gives.
+
+The **HTTP surface** is exercised through the client, which can only ever act as
+the one superuser operator identity a standalone deployment provisions. That is
+enough for the statuses, the shapes, and the rules that do not depend on who is
+asking (a period stated twice, a duplicate ceiling, a delete refused while
+something names the budget).
+
+The **rules that decide who may reach what** are exercised at the service layer,
+with identities built at whatever role and in whatever organization a case needs.
+That is where the interesting failures live, and they are the point of this
+surface existing: before otari-ai#1943 a tenant could reach neither budgets nor
+ceilings, and the risk in opening them is that an admin reaches *another*
+tenant's.
+"""
+
+import uuid
+from typing import Any
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from gateway.models.entities import APIKey, Budget, ScopedBudget, WorkspaceBudgetDefault
+from gateway.models.tenancy import Organization, OrganizationMember, User, Workspace, WorkspaceMember
+from gateway.repositories.tenancy import (
+    OrganizationMemberRepository,
+    OrganizationRepository,
+    UserRepository,
+    WorkspaceMemberRepository,
+    WorkspaceRepository,
+)
+from gateway.services.tenancy.errors import (
+    NotAuthorizedError,
+    OrganizationBudgetInUseError,
+    OrganizationBudgetNotFoundError,
+    OrganizationScopedBudgetAlreadyExistsError,
+    OrganizationScopedBudgetNotFoundError,
+    OrganizationScopeNotFoundError,
+    TenancyValidationError,
+)
+from gateway.services.tenancy.organization_budget_service import (
+    OrganizationBudgetCreate,
+    OrganizationBudgetService,
+    OrganizationBudgetUpdate,
+    OrganizationScopedBudgetCreate,
+    OrganizationScopedBudgetUpdate,
+)
+
+_BUDGETS = "/v1/organizations/me/budgets"
+_CEILINGS = "/v1/organizations/me/spend-ceilings"
+
+
+# =============================================================================
+# The HTTP surface
+# =============================================================================
+
+
+def _budget_body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {"name": "Engineering monthly", "max_budget": 250.0, "reset_alignment": "calendar_month"}
+    body.update(overrides)
+    return body
+
+
+def test_a_budget_is_created_listed_changed_and_deleted(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    created = client.post(_BUDGETS, json=_budget_body(), headers=master_key_header)
+    assert created.status_code == status.HTTP_201_CREATED, created.text
+    budget = created.json()
+    assert budget["max_budget"] == 250.0
+    assert budget["reset_alignment"] == "calendar_month"
+    # Nothing names it yet, which is what makes it deletable below.
+    assert budget["ceiling_count"] == 0
+    # Stamped with the caller's organization rather than left for the client to
+    # claim: the request cannot name one at all.
+    assert budget["organization_id"]
+
+    listed = client.get(_BUDGETS, headers=master_key_header)
+    assert listed.status_code == status.HTTP_200_OK, listed.text
+    assert listed.json()["count"] == 1
+    assert listed.json()["data"][0]["budget_id"] == budget["budget_id"]
+
+    changed = client.patch(
+        f"{_BUDGETS}/{budget['budget_id']}",
+        json={"max_budget": 500.0, "name": "Engineering monthly (raised)"},
+        headers=master_key_header,
+    )
+    assert changed.status_code == status.HTTP_200_OK, changed.text
+    assert changed.json()["max_budget"] == 500.0
+    # Untouched by a patch that did not mention it.
+    assert changed.json()["reset_alignment"] == "calendar_month"
+
+    deleted = client.delete(f"{_BUDGETS}/{budget['budget_id']}", headers=master_key_header)
+    assert deleted.status_code == status.HTTP_200_OK, deleted.text
+    assert client.get(_BUDGETS, headers=master_key_header).json()["count"] == 0
+
+
+def test_a_budget_refuses_two_period_sources(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """``ck_budgets_single_period_source`` as a 400 naming the pair, not a 500."""
+    refused = client.post(
+        _BUDGETS,
+        json=_budget_body(budget_duration_sec=86_400, reset_alignment="calendar_month"),
+        headers=master_key_header,
+    )
+    assert refused.status_code == status.HTTP_400_BAD_REQUEST, refused.text
+    assert "not both" in refused.json()["detail"]
+
+
+def test_a_patch_that_would_state_both_periods_is_refused(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """The *resulting* pair is what the CHECK refuses, and neither field alone looks wrong.
+
+    A budget already resetting on a calendar boundary, sent a duration and
+    nothing else, is the case a check on the submitted body would miss.
+    """
+    budget = client.post(_BUDGETS, json=_budget_body(), headers=master_key_header).json()
+
+    refused = client.patch(
+        f"{_BUDGETS}/{budget['budget_id']}",
+        json={"budget_duration_sec": 86_400},
+        headers=master_key_header,
+    )
+    assert refused.status_code == status.HTTP_400_BAD_REQUEST, refused.text
+
+
+def test_an_unknown_budget_is_not_found(client: TestClient, master_key_header: dict[str, str]) -> None:
+    missing = client.patch(f"{_BUDGETS}/nope", json={"name": "x"}, headers=master_key_header)
+    assert missing.status_code == status.HTTP_404_NOT_FOUND, missing.text
+
+
+def test_a_ceiling_is_created_listed_relabeled_and_deleted(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    budget = client.post(_BUDGETS, json=_budget_body(), headers=master_key_header).json()
+    organization_id = budget["organization_id"]
+
+    created = client.post(
+        _CEILINGS,
+        json={
+            "scope_type": "organization",
+            "scope_id": organization_id,
+            "budget_id": budget["budget_id"],
+            "name": "Whole org",
+        },
+        headers=master_key_header,
+    )
+    assert created.status_code == status.HTTP_201_CREATED, created.text
+    ceiling = created.json()
+    # The figure and the period are read through the budget and carried here, so
+    # a page can render a ceiling without fetching every budget to resolve one id.
+    assert ceiling["max_budget"] == 250.0
+    assert ceiling["reset_alignment"] == "calendar_month"
+    # A calendar-aligned budget opens a window immediately, rather than on first
+    # spend, so a periodic cap has a defined end before any request arrives.
+    assert ceiling["period_start"] is not None
+    assert ceiling["period_end"] is not None
+    # This organization's own budget, so its figure is changeable here.
+    assert ceiling["manageable"] is True
+
+    listed = client.get(_CEILINGS, headers=master_key_header)
+    assert listed.status_code == status.HTTP_200_OK, listed.text
+    assert [row["id"] for row in listed.json()["data"]] == [ceiling["id"]]
+
+    relabeled = client.patch(
+        f"{_CEILINGS}/{ceiling['id']}",
+        json={"name": None},
+        headers=master_key_header,
+    )
+    assert relabeled.status_code == status.HTTP_200_OK, relabeled.text
+    # An explicit null clears the label back to unnamed, which a create can produce.
+    assert relabeled.json()["name"] is None
+
+    deleted = client.delete(f"{_CEILINGS}/{ceiling['id']}", headers=master_key_header)
+    assert deleted.status_code == status.HTTP_200_OK, deleted.text
+    assert client.get(_CEILINGS, headers=master_key_header).json()["count"] == 0
+
+
+def test_a_second_ceiling_on_one_scope_is_refused(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """The partial unique index, reported as words a caller can act on."""
+    budget = client.post(_BUDGETS, json=_budget_body(), headers=master_key_header).json()
+    body = {
+        "scope_type": "organization",
+        "scope_id": budget["organization_id"],
+        "budget_id": budget["budget_id"],
+    }
+    assert client.post(_CEILINGS, json=body, headers=master_key_header).status_code == status.HTTP_201_CREATED
+
+    refused = client.post(_CEILINGS, json=body, headers=master_key_header)
+    assert refused.status_code == status.HTTP_409_CONFLICT, refused.text
+
+
+def test_a_ceiling_on_an_unknown_scope_is_refused(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """Refused rather than created, because a scope naming nothing never binds.
+
+    A ceiling on a typo is created, listed, and silently unenforced, with nothing
+    anywhere to surface it. Same rule ``POST /v1/scoped-budgets`` states.
+    """
+    budget = client.post(_BUDGETS, json=_budget_body(), headers=master_key_header).json()
+
+    refused = client.post(
+        _CEILINGS,
+        json={
+            "scope_type": "workspace",
+            "scope_id": str(uuid.uuid4()),
+            "budget_id": budget["budget_id"],
+        },
+        headers=master_key_header,
+    )
+    assert refused.status_code == status.HTTP_404_NOT_FOUND, refused.text
+
+
+def test_an_unknown_scope_type_is_refused_by_the_schema(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """The ``Literal`` is what publishes the values and refuses the rest."""
+    budget = client.post(_BUDGETS, json=_budget_body(), headers=master_key_header).json()
+
+    refused = client.post(
+        _CEILINGS,
+        json={"scope_type": "galaxy", "scope_id": "x", "budget_id": budget["budget_id"]},
+        headers=master_key_header,
+    )
+    assert refused.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT, refused.text
+
+
+def test_deleting_a_budget_a_ceiling_names_is_refused(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """RESTRICT, reported as a 409 saying what to go and change."""
+    budget = client.post(_BUDGETS, json=_budget_body(), headers=master_key_header).json()
+    client.post(
+        _CEILINGS,
+        json={
+            "scope_type": "organization",
+            "scope_id": budget["organization_id"],
+            "budget_id": budget["budget_id"],
+        },
+        headers=master_key_header,
+    )
+
+    refused = client.delete(f"{_BUDGETS}/{budget['budget_id']}", headers=master_key_header)
+    assert refused.status_code == status.HTTP_409_CONFLICT, refused.text
+    assert "1 spend ceiling" in refused.json()["detail"]
+
+    # And the list reports the hold, so the page can say so before trying.
+    listed = client.get(_BUDGETS, headers=master_key_header).json()
+    assert listed["data"][0]["ceiling_count"] == 1
+
+
+def test_the_deployment_budget_list_is_not_this_one(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """A budget defined here is the organization's, and one defined there is not.
+
+    The two surfaces share the table, so this pins the filter rather than
+    assuming it: ``/v1/budgets`` sees everything, and this list sees only rows
+    carrying the caller's organization.
+    """
+    deployment = client.post("/v1/budgets", json={"name": "Deployment wide"}, headers=master_key_header)
+    assert deployment.status_code == status.HTTP_200_OK, deployment.text
+    tenant = client.post(_BUDGETS, json=_budget_body(), headers=master_key_header).json()
+
+    scoped = client.get(_BUDGETS, headers=master_key_header).json()
+    assert [row["budget_id"] for row in scoped["data"]] == [tenant["budget_id"]]
+
+    everything = client.get("/v1/budgets", headers=master_key_header).json()
+    assert {row["budget_id"] for row in everything} == {
+        deployment.json()["budget_id"],
+        tenant["budget_id"],
+    }
+
+
+def test_a_ceiling_may_not_name_a_deployment_budget(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """404, and the same 404 an id naming nothing gets.
+
+    This is the rule that keeps the surface honest: a deployment budget is not
+    the organization's to enforce with, because editing its figure afterwards
+    would move a cap the deployment set.
+    """
+    deployment = client.post("/v1/budgets", json={"name": "Deployment wide"}, headers=master_key_header).json()
+    tenant = client.post(_BUDGETS, json=_budget_body(), headers=master_key_header).json()
+
+    refused = client.post(
+        _CEILINGS,
+        json={
+            "scope_type": "organization",
+            "scope_id": tenant["organization_id"],
+            "budget_id": deployment["budget_id"],
+        },
+        headers=master_key_header,
+    )
+    assert refused.status_code == status.HTTP_404_NOT_FOUND, refused.text
+
+
+# =============================================================================
+# Who may reach what
+#
+# At the service layer, because the API can only act as the deployment's one
+# operator identity, which is a superuser and an owner everywhere.
+# =============================================================================
+
+async def _organization(db: AsyncSession, *, slug: str) -> Organization:
+    return await OrganizationRepository(db).create_organization(
+        name=slug.title(), slug=slug, created_by_user_id=None
+    )
+
+
+async def _member(db: AsyncSession, organization: Organization, *, role: str, full_name: str) -> User:
+    user = await UserRepository(db).create_local_identity(
+        full_name=full_name,
+        active_organization_id=organization.id,
+        is_superuser=False,
+    )
+    await OrganizationMemberRepository(db).create_membership(
+        organization_id=organization.id,
+        user_id=user.id,
+        role=role,
+    )
+    return user
+
+
+async def _workspace(db: AsyncSession, organization: Organization, *, name: str, owner: User) -> Workspace:
+    workspace = await WorkspaceRepository(db).create_workspace(
+        name=name,
+        organization_id=organization.id,
+        created_by_user_id=owner.id,
+    )
+    await WorkspaceMemberRepository(db).create(workspace_id=workspace.id, user_id=owner.id, role="owner")
+    return workspace
+
+
+def _create(**overrides: Any) -> OrganizationBudgetCreate:
+    fields: dict[str, Any] = {"name": "Monthly", "max_budget": 100.0, "reset_alignment": "calendar_month"}
+    fields.update(overrides)
+    return OrganizationBudgetCreate(**fields)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", ["owner", "admin"])
+async def test_a_management_role_may_define_a_budget(async_db: AsyncSession, role: str) -> None:
+    organization = await _organization(async_db, slug=f"acme-write-{role}")
+    identity = await _member(async_db, organization, role=role, full_name=f"{role} person")
+
+    created = await OrganizationBudgetService(async_db).create_budget(user=identity, request=_create())
+
+    assert created.organization_id == organization.id
+    assert created.max_budget == 100.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", ["member", "viewer"])
+async def test_a_non_management_role_may_not_define_a_budget(async_db: AsyncSession, role: str) -> None:
+    organization = await _organization(async_db, slug=f"acme-refuse-{role}")
+    identity = await _member(async_db, organization, role=role, full_name=f"{role} person")
+
+    with pytest.raises(NotAuthorizedError):
+        await OrganizationBudgetService(async_db).create_budget(user=identity, request=_create())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", ["member", "viewer"])
+async def test_a_non_management_role_may_not_even_read_them(async_db: AsyncSession, role: str) -> None:
+    """Stricter than the pricing overrides, and deliberately.
+
+    The roles matrix puts Spend & budgets at Hidden for a member, where Model
+    pricing is a read they get: a rate is what *you* are billed at, and a cap is
+    a statement about what colleagues may spend.
+    """
+    organization = await _organization(async_db, slug=f"acme-read-{role}")
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    reader = await _member(async_db, organization, role=role, full_name=f"{role} reader")
+    service = OrganizationBudgetService(async_db)
+    await service.create_budget(user=owner, request=_create())
+
+    with pytest.raises(NotAuthorizedError):
+        await service.list_budgets(user=reader)
+
+    with pytest.raises(NotAuthorizedError):
+        await service.list_ceilings(user=reader)
+
+
+@pytest.mark.asyncio
+async def test_an_admin_may_not_reach_another_organizations_budget(async_db: AsyncSession) -> None:
+    """The core cross-tenant rule on the budget half.
+
+    Not found rather than forbidden: another tenant's row must be
+    indistinguishable from one that was never created, or the response is an
+    existence oracle over their spend configuration.
+    """
+    theirs = await _organization(async_db, slug="globex-budget")
+    their_owner = await _member(async_db, theirs, role="owner", full_name="Their owner")
+    mine = await _organization(async_db, slug="acme-budget")
+    my_admin = await _member(async_db, mine, role="admin", full_name="My admin")
+    service = OrganizationBudgetService(async_db)
+    their_budget = await service.create_budget(user=their_owner, request=_create())
+
+    with pytest.raises(OrganizationBudgetNotFoundError):
+        await service.update_budget(
+            user=my_admin,
+            budget_id=their_budget.budget_id,
+            request=OrganizationBudgetUpdate(max_budget=1.0),
+        )
+
+    with pytest.raises(OrganizationBudgetNotFoundError):
+        await service.delete_budget(user=my_admin, budget_id=their_budget.budget_id)
+
+    # And it is not in their list either, which is the read half of the same rule.
+    assert (await service.list_budgets(user=my_admin)).count == 0
+
+
+@pytest.mark.asyncio
+async def test_an_admin_may_not_cap_another_organizations_workspace(async_db: AsyncSession) -> None:
+    """The core cross-tenant rule on the ceilings half.
+
+    A scope id travels as a bare uuid with nothing in it saying whose it is, so
+    an unresolved one is the whole of the risk here.
+    """
+    theirs = await _organization(async_db, slug="globex-scope")
+    their_owner = await _member(async_db, theirs, role="owner", full_name="Their owner")
+    their_workspace = await _workspace(async_db, theirs, name="Theirs", owner=their_owner)
+    mine = await _organization(async_db, slug="acme-scope")
+    my_admin = await _member(async_db, mine, role="admin", full_name="My admin")
+    service = OrganizationBudgetService(async_db)
+    my_budget = await service.create_budget(user=my_admin, request=_create())
+
+    with pytest.raises(OrganizationScopeNotFoundError):
+        await service.create_ceiling(
+            user=my_admin,
+            request=OrganizationScopedBudgetCreate(
+                scope_type="workspace",
+                scope_id=str(their_workspace.id),
+                budget_id=my_budget.budget_id,
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_every_scope_kind_resolves_to_its_organization(async_db: AsyncSession) -> None:
+    """All five, because each resolves through a different table.
+
+    A scope kind whose resolution is wrong in the permissive direction is a
+    cross-tenant hole, and one wrong in the strict direction is a cap an admin
+    cannot set. Both are worth one assertion each.
+    """
+    organization = await _organization(async_db, slug="acme-scopes")
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, name="Engineering", owner=owner)
+    membership = (
+        (await async_db.execute(select(OrganizationMember).where(col(OrganizationMember.user_id) == owner.id)))
+        .scalars()
+        .first()
+    )
+    assert membership is not None
+    workspace_member = (
+        (await async_db.execute(select(WorkspaceMember).where(col(WorkspaceMember.workspace_id) == workspace.id)))
+        .scalars()
+        .first()
+    )
+    assert workspace_member is not None
+    key = APIKey(id="sk-scope-test", key_hash="hash-scope-test", workspace_id=workspace.id)
+    async_db.add(key)
+    await async_db.flush()
+
+    service = OrganizationBudgetService(async_db)
+    scopes = {
+        "organization": str(organization.id),
+        "workspace": str(workspace.id),
+        "org_member": str(membership.id),
+        "workspace_member": str(workspace_member.id),
+        "api_token": key.id,
+    }
+    for scope_type, scope_id in scopes.items():
+        budget = await service.create_budget(user=owner, request=_create(name=f"For {scope_type}"))
+        created = await service.create_ceiling(
+            user=owner,
+            request=OrganizationScopedBudgetCreate(
+                scope_type=scope_type,  # type: ignore[arg-type]
+                scope_id=scope_id,
+                budget_id=budget.budget_id,
+            ),
+        )
+        assert created.scope_type == scope_type
+        assert created.manageable is True
+
+    assert (await service.list_ceilings(user=owner)).count == len(scopes)
+
+
+@pytest.mark.asyncio
+async def test_a_ceiling_on_a_deployment_budget_is_listed_but_not_manageable(async_db: AsyncSession) -> None:
+    """The state the otari-ai cutover leaves behind, described honestly.
+
+    It writes ceilings naming budgets it shares across tenants by shape, so they
+    carry no owner. Omitting them would let the page read as uncapped while the
+    organization was in fact capped; reporting them as manageable would offer an
+    edit the surface refuses.
+    """
+    organization = await _organization(async_db, slug="acme-migrated")
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    deployment_budget = Budget(name="Shaped by the cutover", max_budget=None, budget_duration_sec=86_400)
+    async_db.add(deployment_budget)
+    await async_db.flush()
+    async_db.add(
+        ScopedBudget(
+            scope_type="organization",
+            scope_id=str(organization.id),
+            budget_id=deployment_budget.budget_id,
+        )
+    )
+    await async_db.flush()
+    service = OrganizationBudgetService(async_db)
+
+    listed = await service.list_ceilings(user=owner)
+
+    assert listed.count == 1
+    assert listed.data[0].manageable is False
+    # Its real figures, so the page is not lying about what binds.
+    assert listed.data[0].budget_duration_sec == 86_400
+
+
+@pytest.mark.asyncio
+async def test_such_a_ceiling_can_be_moved_onto_the_organizations_own_budget(async_db: AsyncSession) -> None:
+    """The way out of that state, per ceiling, without touching the shared budget.
+
+    Repointing never edits the budget the ceiling used to name: enforcement reads
+    through a budget, so editing one would silently re-cap every other ceiling
+    naming it, possibly in another tenant.
+    """
+    organization = await _organization(async_db, slug="acme-repoint")
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    deployment_budget = Budget(name="Shared", max_budget=None, budget_duration_sec=86_400)
+    async_db.add(deployment_budget)
+    await async_db.flush()
+    ceiling = ScopedBudget(
+        scope_type="organization",
+        scope_id=str(organization.id),
+        budget_id=deployment_budget.budget_id,
+    )
+    async_db.add(ceiling)
+    await async_db.flush()
+    service = OrganizationBudgetService(async_db)
+    mine = await service.create_budget(user=owner, request=_create())
+
+    moved = await service.update_ceiling(
+        user=owner,
+        ceiling_id=ceiling.id,
+        request=OrganizationScopedBudgetUpdate(budget_id=mine.budget_id),
+    )
+
+    assert moved.manageable is True
+    assert moved.max_budget == 100.0
+    # The budget it stopped naming is untouched, still holding what it held.
+    still_there = await async_db.get(Budget, deployment_budget.budget_id)
+    assert still_there is not None
+    assert still_there.budget_duration_sec == 86_400
+
+
+@pytest.mark.asyncio
+async def test_an_admin_may_not_repoint_a_ceiling_at_a_foreign_budget(async_db: AsyncSession) -> None:
+    """The same rule on the update path, which is the one an attacker would try.
+
+    Creating a ceiling checks the budget; so must repointing one, or the check is
+    a formality that one extra request walks around.
+    """
+    theirs = await _organization(async_db, slug="globex-repoint")
+    their_owner = await _member(async_db, theirs, role="owner", full_name="Their owner")
+    mine = await _organization(async_db, slug="acme-repoint-refuse")
+    my_owner = await _member(async_db, mine, role="owner", full_name="My owner")
+    service = OrganizationBudgetService(async_db)
+    their_budget = await service.create_budget(user=their_owner, request=_create())
+    my_budget = await service.create_budget(user=my_owner, request=_create())
+    ceiling = await service.create_ceiling(
+        user=my_owner,
+        request=OrganizationScopedBudgetCreate(
+            scope_type="organization",
+            scope_id=str(mine.id),
+            budget_id=my_budget.budget_id,
+        ),
+    )
+
+    with pytest.raises(OrganizationBudgetNotFoundError):
+        await service.update_ceiling(
+            user=my_owner,
+            ceiling_id=ceiling.id,
+            request=OrganizationScopedBudgetUpdate(budget_id=their_budget.budget_id),
+        )
+
+
+@pytest.mark.asyncio
+async def test_an_admin_may_not_delete_another_organizations_ceiling(async_db: AsyncSession) -> None:
+    theirs = await _organization(async_db, slug="globex-ceiling")
+    their_owner = await _member(async_db, theirs, role="owner", full_name="Their owner")
+    mine = await _organization(async_db, slug="acme-ceiling")
+    my_admin = await _member(async_db, mine, role="admin", full_name="My admin")
+    service = OrganizationBudgetService(async_db)
+    their_budget = await service.create_budget(user=their_owner, request=_create())
+    theirs_ceiling = await service.create_ceiling(
+        user=their_owner,
+        request=OrganizationScopedBudgetCreate(
+            scope_type="organization",
+            scope_id=str(theirs.id),
+            budget_id=their_budget.budget_id,
+        ),
+    )
+
+    with pytest.raises(OrganizationScopedBudgetNotFoundError):
+        await service.delete_ceiling(user=my_admin, ceiling_id=theirs_ceiling.id)
+
+    with pytest.raises(OrganizationScopedBudgetNotFoundError):
+        await service.update_ceiling(
+            user=my_admin,
+            ceiling_id=theirs_ceiling.id,
+            request=OrganizationScopedBudgetUpdate(name="mine now"),
+        )
+
+    # And it is not in their list, which is what the page would show.
+    assert (await service.list_ceilings(user=my_admin)).count == 0
+
+
+@pytest.mark.asyncio
+async def test_a_delete_is_refused_while_a_workspace_default_names_the_budget(async_db: AsyncSession) -> None:
+    """The other RESTRICT holder, counted separately so the message can say which."""
+    organization = await _organization(async_db, slug="acme-default-hold")
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, name="Engineering", owner=owner)
+    service = OrganizationBudgetService(async_db)
+    budget = await service.create_budget(user=owner, request=_create())
+    async_db.add(WorkspaceBudgetDefault(workspace_id=workspace.id, budget_id=budget.budget_id))
+    await async_db.flush()
+
+    with pytest.raises(OrganizationBudgetInUseError, match="workspace member default"):
+        await service.delete_budget(user=owner, budget_id=budget.budget_id)
+
+
+@pytest.mark.asyncio
+async def test_a_scope_id_that_is_not_a_uuid_is_not_found_rather_than_a_crash(async_db: AsyncSession) -> None:
+    """A typo and another tenant's row have to be the same answer, including a malformed id."""
+    organization = await _organization(async_db, slug="acme-malformed")
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationBudgetService(async_db)
+    budget = await service.create_budget(user=owner, request=_create())
+
+    with pytest.raises(OrganizationScopeNotFoundError):
+        await service.create_ceiling(
+            user=owner,
+            request=OrganizationScopedBudgetCreate(
+                scope_type="workspace",
+                scope_id="not-a-uuid",
+                budget_id=budget.budget_id,
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_second_ceiling_narrowed_to_a_provider_is_allowed(async_db: AsyncSession) -> None:
+    """Two axes, so one scope may hold an aggregate cap and a per-provider one.
+
+    A request must pass every row that applies to it, which is why the aggregate
+    and the narrowed row are separate ceilings rather than a conflict.
+    """
+    organization = await _organization(async_db, slug="acme-two-axes")
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationBudgetService(async_db)
+    budget = await service.create_budget(user=owner, request=_create())
+    await service.create_ceiling(
+        user=owner,
+        request=OrganizationScopedBudgetCreate(
+            scope_type="organization",
+            scope_id=str(organization.id),
+            budget_id=budget.budget_id,
+        ),
+    )
+
+    narrowed = await service.create_ceiling(
+        user=owner,
+        request=OrganizationScopedBudgetCreate(
+            scope_type="organization",
+            scope_id=str(organization.id),
+            provider_key_id="openai-eu",
+            budget_id=budget.budget_id,
+        ),
+    )
+
+    assert narrowed.provider_key_id == "openai-eu"
+    assert (await service.list_ceilings(user=owner)).count == 2
+
+    with pytest.raises(OrganizationScopedBudgetAlreadyExistsError):
+        await service.create_ceiling(
+            user=owner,
+            request=OrganizationScopedBudgetCreate(
+                scope_type="organization",
+                scope_id=str(organization.id),
+                provider_key_id="openai-eu",
+                budget_id=budget.budget_id,
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_scope_type_reaching_the_service_is_a_validation_error(async_db: AsyncSession) -> None:
+    """Unreachable through the routes, where the ``Literal`` refuses it first.
+
+    Asserted because the service is importable on its own and a caller inside
+    this process is not held to the request schema.
+    """
+    organization = await _organization(async_db, slug="acme-bad-scope")
+    service = OrganizationBudgetService(async_db)
+
+    with pytest.raises(TenancyValidationError):
+        await service._require_scope_in_organization(
+            organization=organization,
+            scope_type="galaxy",
+            scope_id=str(organization.id),
+        )

--- a/tests/integration/test_workspace_member_budget_policies.py
+++ b/tests/integration/test_workspace_member_budget_policies.py
@@ -838,3 +838,69 @@ async def test_bootstrap_survives_a_default_naming_a_budget_that_is_gone(
     # The marker landed, so the deployment is still bootstrappable rather than
     # re-provisioning (and re-failing) on every later request.
     assert (await ensure_bootstrap_identity(async_db)).id == operator.id
+
+
+async def test_a_default_may_not_name_another_organizations_budget(async_db: AsyncSession) -> None:
+    """The hole otari-ai#1943 would have opened, closed with the column it added.
+
+    Before ``b7e1c4a9d2f5`` every budget was the deployment's, defined by an
+    operator, so any of them was as valid a template as any other and there was
+    nothing to check. Now that an admin can define one, an unchecked ``budget_id``
+    here would let one organization's admin hand their own workspace another
+    organization's budget, and then move what that tenant is capped at by editing
+    it: the ceilings materialized from the default read the figure *through* the
+    budget.
+
+    404, not 403, for the reason every other foreign-row refusal here is.
+    """
+    theirs = await _organization(async_db, slug="globex-default")
+    their_owner = await _member(async_db, theirs, role="owner", full_name="Their owner")
+    their_budget_id = await _budget(async_db, max_budget=10.0)
+    their_budget = await async_db.get(Budget, their_budget_id)
+    assert their_budget is not None
+    their_budget.organization_id = theirs.id
+
+    mine = await _organization(async_db, slug="acme-default")
+    my_owner = await _member(async_db, mine, role="owner", full_name="My owner")
+    my_workspace = await _workspace(async_db, mine, name="Engineering", owner=my_owner)
+    await async_db.flush()
+    service = WorkspaceBudgetDefaultService(async_db)
+
+    with pytest.raises(WorkspaceBudgetDefaultBudgetNotFoundError):
+        await service.create_default(
+            user=my_owner,
+            workspace_id=my_workspace.id,
+            request=WorkspaceMemberBudgetPolicyCreate(budget_id=their_budget_id),
+        )
+
+    # Their own workspace may still name it, which is what makes the check about
+    # the tenant boundary rather than about the column being set at all.
+    their_workspace = await _workspace(async_db, theirs, name="Theirs", owner=their_owner)
+    created = await service.create_default(
+        user=their_owner,
+        workspace_id=their_workspace.id,
+        request=WorkspaceMemberBudgetPolicyCreate(budget_id=their_budget_id),
+    )
+    assert created.budget_id == their_budget_id
+
+
+async def test_a_default_may_still_name_a_deployment_budget(async_db: AsyncSession) -> None:
+    """A budget with no organization stays nameable, or upgrade breaks every default.
+
+    Those are the deployment's own: the ones an operator defined and the ones the
+    otari-ai cutover minted, all of which read NULL. Narrowing them out here would
+    refuse the very defaults that already exist.
+    """
+    organization = await _organization(async_db, slug="acme-deployment-budget")
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    workspace = await _workspace(async_db, organization, name="Engineering", owner=owner)
+    deployment_budget_id = await _budget(async_db, max_budget=10.0)
+    await async_db.flush()
+
+    created = await WorkspaceBudgetDefaultService(async_db).create_default(
+        user=owner,
+        workspace_id=workspace.id,
+        request=WorkspaceMemberBudgetPolicyCreate(budget_id=deployment_budget_id),
+    )
+
+    assert created.budget_id == deployment_budget_id

--- a/tests/integration/test_workspace_member_budget_policies.py
+++ b/tests/integration/test_workspace_member_budget_policies.py
@@ -14,6 +14,7 @@ from decimal import Decimal
 
 import pytest
 import pytest_asyncio
+from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
@@ -904,3 +905,28 @@ async def test_a_default_may_still_name_a_deployment_budget(async_db: AsyncSessi
     )
 
     assert created.budget_id == deployment_budget_id
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+async def test_a_default_refuses_a_blank_provider_narrowing(async_db: AsyncSession, blank: str) -> None:
+    """A blank narrowing would materialize a never-binding ceiling per member.
+
+    Worse here than on a single ceiling: `create_default` fans the template out
+    across every active member, so one bad request leaves a whole workspace with
+    caps that are stored, listed, and enforced against nothing. Refused at the
+    schema rather than normalized, because null is the wider rule and coercing
+    would silently apply the cap to every provider instead of one.
+
+    Validated at the request model, since this surface is reachable by an
+    organization or workspace owner/admin rather than only by an operator.
+    """
+    with pytest.raises(ValidationError):
+        WorkspaceMemberBudgetPolicyCreate(budget_id="b1", provider_key_id=blank)
+
+
+async def test_a_default_still_accepts_a_real_provider_instance(async_db: AsyncSession) -> None:
+    """The other half of the rule, so the pattern cannot creep into refusing valid names."""
+    request = WorkspaceMemberBudgetPolicyCreate(budget_id="b1", provider_key_id="openai-eu")
+    assert request.provider_key_id == "openai-eu"
+    # Omitted stays the aggregate default.
+    assert WorkspaceMemberBudgetPolicyCreate(budget_id="b1").provider_key_id is None

--- a/tests/unit/test_budget_organization_backfill_chain.py
+++ b/tests/unit/test_budget_organization_backfill_chain.py
@@ -90,7 +90,7 @@ def _add_budget(engine: Engine, budget_id: str) -> None:
         )
 
 
-def _add_gateway_user(engine: Engine, *, user_id: str, budget_id: str) -> None:
+def _add_gateway_user(engine: Engine, *, user_id: str, budget_id: str | None) -> None:
     with engine.begin() as connection:
         connection.execute(
             text(
@@ -203,6 +203,37 @@ def test_a_budget_handed_to_a_gateway_user_is_skipped(sqlite_before: tuple[Confi
     command.upgrade(config, _REVISION)
 
     assert _owners(engine) == {"shared": None, "tenant-only": organization_id}
+
+
+def test_a_budget_with_a_reset_record_is_skipped(sqlite_before: tuple[Config, Engine]) -> None:
+    """A reset record outlives the assignment that produced it.
+
+    So a budget carrying one was handed to a gateway user even where no live
+    ``users`` row still points at it, and the reference goes on refusing a delete
+    either way. Skipped for the same reason the live assignment is.
+    """
+    config, engine = sqlite_before
+    organization_id = _sole_organization(engine)
+    _add_budget(engine, "had-a-user")
+    _add_budget(engine, "never-had-one")
+    # The exact shape that makes this distinct from the live-assignment case: the
+    # user has since detached, so `users.budget_id` is null and the `users` clause
+    # does not exclude the budget, while the reset record still names it.
+    # `budget_reset_logs.user_id` is NOT NULL at this revision, so the row needs a
+    # user to hang off.
+    _add_gateway_user(engine, user_id="detached", budget_id=None)
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO budget_reset_logs (user_id, budget_id, previous_spend, reset_at) "
+                "VALUES ('detached', 'had-a-user', 1.0, :n)"
+            ),
+            {"n": _NOW},
+        )
+
+    command.upgrade(config, _REVISION)
+
+    assert _owners(engine) == {"had-a-user": None, "never-had-one": organization_id}
 
 
 def test_the_downgrade_removes_the_column(sqlite_before: tuple[Config, Engine]) -> None:

--- a/tests/unit/test_budget_organization_backfill_chain.py
+++ b/tests/unit/test_budget_organization_backfill_chain.py
@@ -57,7 +57,11 @@ def _sole_organization(engine: Engine) -> str:
     backfill fires on an ordinary upgrade instead of being dead code.
     """
     with engine.begin() as connection:
-        return list(connection.execute(text("SELECT id FROM organization")).scalars())[0]
+        # `str(...)` rather than indexing straight into the result: a raw textual
+        # query is untyped, so mypy sees `Any` and `--disallow-any-return` refuses
+        # it. On SQLite the column is CHAR(32), so this is a narrowing, not a
+        # conversion.
+        return str(list(connection.execute(text("SELECT id FROM organization")).scalars())[0])
 
 
 def _add_organization(engine: Engine, *, name: str, slug: str) -> str:

--- a/tests/unit/test_budget_organization_backfill_chain.py
+++ b/tests/unit/test_budget_organization_backfill_chain.py
@@ -1,0 +1,211 @@
+"""``b7e1c4a9d2f5``'s ownership backfill, on SQLite, over the three populations.
+
+The revision adds ``budgets.organization_id`` and then assigns it, but only in
+the one case where assigning grants nobody anything they did not already hold: a
+deployment with exactly one organization, whose operator is that organization's
+owner. Getting the guard wrong in the permissive direction would hand one
+tenant's admins authority over a cap set above them, so the guard is what is
+under test here rather than the ADD COLUMN.
+
+SQLite because the OSS base ships it by default and because the revision goes
+through ``batch_alter_table`` to add its foreign key, which is the SQLite-only
+path and the one where a table rebuild can drop a constraint.
+"""
+
+from collections.abc import Iterator
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import Engine, create_engine, inspect, text
+
+import gateway.models  # noqa: F401  (registers every table on the shared metadata)
+
+_ALEMBIC_DIR = Path(__file__).resolve().parents[2] / "alembic"
+_REVISION = "b7e1c4a9d2f5"
+_BEFORE = "a4d7f1c9e2b6"
+_NOW = "2026-08-31 00:00:00"
+
+
+def _alembic_config(database_url: str) -> Config:
+    config = Config()
+    config.set_main_option("script_location", str(_ALEMBIC_DIR))
+    config.set_main_option("sqlalchemy.url", database_url)
+    config.attributes["configure_logger"] = False
+    return config
+
+
+@pytest.fixture
+def sqlite_before(tmp_path: Path) -> Iterator[tuple[Config, Engine]]:
+    database_url = f"sqlite:///{tmp_path / 'budget-owner.db'}"
+    config = _alembic_config(database_url)
+    command.upgrade(config, _BEFORE)
+    engine = create_engine(database_url)
+    try:
+        yield config, engine
+    finally:
+        engine.dispose()
+
+
+def _sole_organization(engine: Engine) -> str:
+    """The organization the migration chain itself seeds.
+
+    A real deployment is never at this revision without one: an earlier data
+    migration provisions "Default organization", which is exactly why the
+    backfill fires on an ordinary upgrade instead of being dead code.
+    """
+    with engine.begin() as connection:
+        return list(connection.execute(text("SELECT id FROM organization")).scalars())[0]
+
+
+def _add_organization(engine: Engine, *, name: str, slug: str) -> str:
+    # `uuid4().hex`, not `str(uuid4())`: SQLAlchemy's `Uuid` stores as CHAR(32)
+    # on SQLite, so a dashed string would not compare equal to the seeded row's.
+    organization_id = uuid4().hex
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO organization (id, name, slug, created_at, updated_at) "
+                "VALUES (:id, :name, :slug, :n, :n)"
+            ),
+            {"id": organization_id, "name": name, "slug": slug, "n": _NOW},
+        )
+    return organization_id
+
+
+def _add_budget(engine: Engine, budget_id: str) -> None:
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO budgets (budget_id, name, max_budget, budget_duration_sec, created_at, updated_at) "
+                "VALUES (:id, :id, 25.0, 86400, :n, :n)"
+            ),
+            {"id": budget_id, "n": _NOW},
+        )
+
+
+def _add_gateway_user(engine: Engine, *, user_id: str, budget_id: str) -> None:
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "INSERT INTO users (user_id, spend, reserved, budget_id, blocked, created_at, updated_at, metadata) "
+                "VALUES (:user_id, 0, 0, :budget_id, 0, :n, :n, '{}')"
+            ),
+            {"user_id": user_id, "budget_id": budget_id, "n": _NOW},
+        )
+
+
+def _owners(engine: Engine) -> dict[str, str | None]:
+    with engine.begin() as connection:
+        return {
+            row[0]: row[1] for row in connection.execute(text("SELECT budget_id, organization_id FROM budgets"))
+        }
+
+
+def test_the_column_and_its_index_arrive(sqlite_before: tuple[Config, Engine]) -> None:
+    config, engine = sqlite_before
+    assert "organization_id" not in {column["name"] for column in inspect(engine).get_columns("budgets")}
+
+    command.upgrade(config, _REVISION)
+
+    assert "organization_id" in {column["name"] for column in inspect(engine).get_columns("budgets")}
+    assert "ix_budgets_organization_id" in {index["name"] for index in inspect(engine).get_indexes("budgets")}
+
+
+def test_the_period_check_survives_the_batch_rebuild(sqlite_before: tuple[Config, Engine]) -> None:
+    """The rule worth losing sleep over, for the reason ``test_exact_budget_schema_chain`` gives.
+
+    ``batch_alter_table`` recreates the table on SQLite, and a CHECK is the kind
+    of thing a rebuild silently drops. A budget resetting on both a duration and
+    a calendar boundary would then be storable and meaningless.
+    """
+    config, engine = sqlite_before
+    command.upgrade(config, _REVISION)
+
+    with pytest.raises(Exception, match="ck_budgets_single_period_source|CHECK constraint"):
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    "INSERT INTO budgets (budget_id, budget_duration_sec, reset_alignment, created_at, updated_at) "
+                    "VALUES ('both', 86400, 'calendar_month', :n, :n)"
+                ),
+                {"n": _NOW},
+            )
+
+
+def test_a_single_organization_deployment_gets_its_budgets(sqlite_before: tuple[Config, Engine]) -> None:
+    """The ordinary upgrade, and the one where the operator is already that org's owner."""
+    config, engine = sqlite_before
+    organization_id = _sole_organization(engine)
+    _add_budget(engine, "b1")
+    _add_budget(engine, "b2")
+
+    command.upgrade(config, _REVISION)
+
+    assert _owners(engine) == {"b1": organization_id, "b2": organization_id}
+
+
+def test_a_multi_organization_deployment_is_left_alone(sqlite_before: tuple[Config, Engine]) -> None:
+    """The case the guard exists for.
+
+    Assigning here would hand one tenant's admins a cap set above them, and for a
+    budget the otari-ai cutover shared across two tenants' ceilings there is no
+    single right answer at all. Left NULL, which reads as the deployment's own and
+    is invisible to every tenant.
+    """
+    config, engine = sqlite_before
+    # Beside the one the chain seeds, which makes two.
+    _add_organization(engine, name="Globex", slug="globex")
+    _add_budget(engine, "b1")
+
+    command.upgrade(config, _REVISION)
+
+    assert _owners(engine) == {"b1": None}
+
+
+def test_a_deployment_with_no_organization_is_left_alone(sqlite_before: tuple[Config, Engine]) -> None:
+    """The defensive arm of the same guard, which no chain reaches on its own.
+
+    Asserted anyway because ``len(organizations) != 1`` is one branch covering
+    both "too many" and "none", and a version of it that indexed first would
+    crash the upgrade on a database whose tenancy seed had been removed.
+    """
+    config, engine = sqlite_before
+    with engine.begin() as connection:
+        connection.execute(text("DELETE FROM organization"))
+    _add_budget(engine, "b1")
+
+    command.upgrade(config, _REVISION)
+
+    assert _owners(engine) == {"b1": None}
+
+
+def test_a_budget_handed_to_a_gateway_user_is_skipped(sqlite_before: tuple[Config, Engine]) -> None:
+    """``users`` is the deployment's own table, with no tenancy column at all.
+
+    A budget an operator handed to a gateway user is not the organization's to
+    redefine, even on a single-organization deployment: moving its figure would
+    move what that user may spend, and the page that assigns it is one an admin
+    cannot see.
+    """
+    config, engine = sqlite_before
+    organization_id = _sole_organization(engine)
+    _add_budget(engine, "shared")
+    _add_budget(engine, "tenant-only")
+    _add_gateway_user(engine, user_id="u1", budget_id="shared")
+
+    command.upgrade(config, _REVISION)
+
+    assert _owners(engine) == {"shared": None, "tenant-only": organization_id}
+
+
+def test_the_downgrade_removes_the_column(sqlite_before: tuple[Config, Engine]) -> None:
+    config, engine = sqlite_before
+    _add_budget(engine, "b1")
+    command.upgrade(config, _REVISION)
+
+    command.downgrade(config, _BEFORE)
+
+    assert "organization_id" not in {column["name"] for column in inspect(engine).get_columns("budgets")}

--- a/tests/unit/test_organization_budget_scopes.py
+++ b/tests/unit/test_organization_budget_scopes.py
@@ -1,0 +1,45 @@
+"""The tenant-scoped budget surface understands exactly the scopes enforcement does.
+
+``organization_budget_service`` spells the five scope names out rather than
+importing ``ScopeType`` from ``scoped_budget_service``, because that module
+reaches ``workspace_scope`` and closes an import cycle back through
+``tenancy/__init__`` (its own docstring, and
+``test_service_module_imports.py``, carry the detail). A second roster is a
+second thing to keep in step, and the failure it would cause is quiet: a scope
+this surface accepts but resolution does not know is a ceiling that is created,
+listed, and never enforced, which fails in the permissive direction.
+
+So the copy is asserted rather than trusted. Importing both modules here is
+fine: a test is not part of the graph the cycle runs through.
+"""
+
+from typing import get_args
+
+from gateway.services.scoped_budget_service import SCOPE_TYPES, ScopeType
+from gateway.services.tenancy.organization_budget_service import (
+    ORGANIZATION_SCOPE_TYPES,
+    OrganizationScopeType,
+)
+
+
+def test_the_two_scope_rosters_are_the_same_set() -> None:
+    assert set(ORGANIZATION_SCOPE_TYPES) == set(SCOPE_TYPES)
+
+
+def test_the_literals_agree_so_the_schema_publishes_the_same_values() -> None:
+    """Set equality is not enough: the ``Literal`` is what the OpenAPI schema carries.
+
+    A value present in one ``Literal`` and not the other would be refused at one
+    boundary and accepted at the other, whatever the tuples say.
+    """
+    assert set(get_args(OrganizationScopeType)) == set(get_args(ScopeType))
+
+
+def test_every_scope_name_is_spelled_the_same_on_the_wire() -> None:
+    """No renaming between the two surfaces.
+
+    ``scope_type`` is a stored string, so a ceiling written by one surface is read
+    by the other and by ``applicable_budgets``. A tidier spelling here would
+    orphan every row the deployment surface wrote.
+    """
+    assert sorted(ORGANIZATION_SCOPE_TYPES) == sorted(SCOPE_TYPES)

--- a/tests/unit/test_service_module_imports.py
+++ b/tests/unit/test_service_module_imports.py
@@ -45,6 +45,11 @@ _MODULES = [
     # It spells the five scope names out instead, and
     # `test_organization_budget_scopes.py` pins those against `ScopeType`.
     "gateway.services.tenancy.organization_budget_service",
+    # budget_retiming is the leaf both budget surfaces share. It must stay
+    # importable on its own: the tenant-scoped service cannot reach
+    # `scoped_budget_service`, so if this module ever grew an import back into
+    # the tenancy package the shared rule would have to be duplicated again.
+    "gateway.services.budget_retiming",
     # workspace_mcp_server_service reaches authorization and organization_service
     # the same way, and is additionally imported from the request pipeline, which
     # is a second entry point into the graph.

--- a/tests/unit/test_service_module_imports.py
+++ b/tests/unit/test_service_module_imports.py
@@ -38,6 +38,13 @@ _MODULES = [
     # here for the same reason as the two above them.
     "gateway.services.tenancy.workspace_budget_default_service",
     "gateway.services.tenancy.authorization",
+    # organization_budget_service reaches organization_service and the entity
+    # models but deliberately not `scoped_budget_service`, which would close the
+    # cycle described in its own module docstring: that module reaches
+    # `workspace_scope` -> `tenancy.provisioning_service` -> `tenancy/__init__`.
+    # It spells the five scope names out instead, and
+    # `test_organization_budget_scopes.py` pins those against `ScopeType`.
+    "gateway.services.tenancy.organization_budget_service",
     # workspace_mcp_server_service reaches authorization and organization_service
     # the same way, and is additionally imported from the request pipeline, which
     # is a second entry point into the graph.

--- a/web/e2e/screenshots/authenticated.spec.ts
+++ b/web/e2e/screenshots/authenticated.spec.ts
@@ -120,3 +120,128 @@ test.describe("organization rail", () => {
     await captureScreenshot(page, "organization-model-pricing")
   })
 })
+
+/**
+ * The organization-admin view of Spend & budgets.
+ *
+ * `/budgets` above captures the deployment-operator page, because `login`
+ * exchanges the master key and that session is the bootstrap operator, so
+ * `deployment_operator` is true and the route resolves to the other page every
+ * time. Nothing else in this suite renders the admin page, which the frontend
+ * standards owe a screenshot for.
+ *
+ * A seeded admin identity with a password would be the faithful way in, and this
+ * harness has no password login: `login` is the only auth path and it is
+ * master-key only. So the caller's own context read is stubbed instead, which is
+ * the technique `public.spec.ts` already uses for the invitation pages. The two
+ * organization-scoped reads are stubbed with it, because a master-key session is
+ * still what the gateway sees and it would answer them for the operator's
+ * organization rather than the shape this page is being captured for.
+ *
+ * What this does and does not cover: the layout, both themes and all three
+ * viewports, which is what the matrix is for. It is not a claim that the role
+ * gate works, which the vitest suite and the route tests own.
+ */
+async function stubAdminSpendView(page: Page): Promise<void> {
+  await page.route("**/v1/organizations/me", async (route) => {
+    const response = await route.fetch()
+    const context = await response.json()
+    await route.fulfill({
+      json: { ...context, role: "admin", deployment_operator: false },
+    })
+  })
+  await page.route("**/v1/organizations/me/budgets*", async (route) => {
+    await route.fulfill({
+      json: {
+        data: [
+          {
+            budget_id: "11111111-1111-1111-1111-111111111111",
+            organization_id: "22222222-2222-2222-2222-222222222222",
+            name: "Engineering monthly",
+            max_budget: 2500,
+            budget_duration_sec: null,
+            reset_alignment: "calendar_month",
+            ceiling_count: 2,
+            created_at: "2026-08-01T00:00:00+00:00",
+            updated_at: "2026-08-01T00:00:00+00:00",
+          },
+          {
+            budget_id: "33333333-3333-3333-3333-333333333333",
+            organization_id: "22222222-2222-2222-2222-222222222222",
+            name: "Trials, daily",
+            max_budget: 25,
+            budget_duration_sec: null,
+            reset_alignment: "calendar_day",
+            ceiling_count: 0,
+            created_at: "2026-08-02T00:00:00+00:00",
+            updated_at: "2026-08-02T00:00:00+00:00",
+          },
+        ],
+        count: 2,
+      },
+    })
+  })
+  await page.route("**/v1/organizations/me/spend-ceilings*", async (route) => {
+    await route.fulfill({
+      json: {
+        data: [
+          {
+            id: "44444444-4444-4444-4444-444444444444",
+            scope_type: "organization",
+            scope_id: "22222222-2222-2222-2222-222222222222",
+            provider_key_id: null,
+            budget_id: "11111111-1111-1111-1111-111111111111",
+            name: "Whole organization",
+            max_budget: 2500,
+            current_spend: 412.5,
+            reserved_spend: 3.25,
+            budget_duration_sec: null,
+            reset_alignment: "calendar_month",
+            period_start: "2026-08-01T00:00:00+00:00",
+            period_end: "2026-09-01T00:00:00+00:00",
+            manageable: true,
+            created_at: "2026-08-01T00:00:00+00:00",
+            updated_at: "2026-08-01T00:00:00+00:00",
+          },
+          {
+            // The row the otari-ai cutover writes: enforcing, and its figure set
+            // outside this organization. Included so the marker is captured.
+            id: "55555555-5555-5555-5555-555555555555",
+            scope_type: "workspace",
+            scope_id: "66666666-6666-6666-6666-666666666666",
+            provider_key_id: "openai-eu",
+            budget_id: "77777777-7777-7777-7777-777777777777",
+            name: null,
+            max_budget: 100,
+            current_spend: 12,
+            reserved_spend: 0,
+            budget_duration_sec: 86400,
+            reset_alignment: null,
+            period_start: "2026-08-30T00:00:00+00:00",
+            period_end: "2026-08-31T00:00:00+00:00",
+            manageable: false,
+            created_at: "2026-08-01T00:00:00+00:00",
+            updated_at: "2026-08-01T00:00:00+00:00",
+          },
+        ],
+        count: 2,
+      },
+    })
+  })
+}
+
+test.describe("organization admin", () => {
+  test("organization spend and budgets", async ({ page }) => {
+    await login(page)
+    await stubAdminSpendView(page)
+    await gotoRoute(page, "/budgets")
+    await expect(
+      page.getByRole("heading", { name: /spend & budgets/i }).first(),
+    ).toBeVisible()
+    // Awaited past the loading rows, so the capture is the populated tables
+    // rather than two spinners.
+    await expect(page.getByText("Engineering monthly")).toBeVisible()
+    await expect(page.getByText("Set at the deployment level")).toBeVisible()
+    await captureScreenshot(page, "organization-spend-budgets")
+  })
+})

--- a/web/src/app/AppShell.test.tsx
+++ b/web/src/app/AppShell.test.tsx
@@ -246,7 +246,7 @@ describe("AppShell responsive layout", () => {
     await renderShell()
 
     const overview = screen.getByRole("link", { name: "Overview" })
-    // Awaited: Providers is one of the four rows gated `operatorOnly`, so it
+    // Awaited: Providers is one of the three rows gated `operatorOnly`, so it
     // arrives with the membership context rather than with the first paint.
     const providers = await screen.findByRole("link", { name: "Providers" })
     expect(overview).toHaveAttribute("aria-current", "page")
@@ -533,11 +533,11 @@ describe("AppShell surface gating", () => {
     // Same reasoning as above, for the other context: the organization rail is
     // its own registry, and nothing else compares it against a full list.
     await renderShell(bootstrap(), { url: "/organization/members" })
-    // Awaited, not assumed: three of these rows declare `operatorOnly`, so none
-    // of them exists until `GET /v1/organizations/me` answers. Taking the
-    // snapshot without waiting is a race that passes on a fast machine and fails
-    // on CI, which is what it did. One await covers all three, because the
-    // caller axis is one read and they appear in the same paint.
+    // Awaited, not assumed: two of these rows declare `operatorOnly`, so neither
+    // exists until `GET /v1/organizations/me` answers. Taking the snapshot
+    // without waiting is a race that passes on a fast machine and fails on CI,
+    // which is what it did. One await covers both, because the caller axis is
+    // one read and they appear in the same paint.
     await within(
       screen.getByRole("navigation", { name: "Sidebar" }),
     ).findByRole("link", { name: "Accounts" })

--- a/web/src/app/nav/registry.test.ts
+++ b/web/src/app/nav/registry.test.ts
@@ -102,9 +102,15 @@ describe("nav registry", () => {
     // already management-gated, and its catalog read serves any session, so only
     // two of its sections were ever the operator's and the page withholds those
     // rather than the rail withholding the destination.
+    //
+    // Spend & budgets left it a fourth way, in the same issue: the route now
+    // resolves to *two* pages, the deployment's for an operator and the
+    // organization's own for an owner or admin, so there is no caller the
+    // destination refuses. That is the shape to copy for the rows still on this
+    // list, not a loosened gate.
     expect(
       NAV_ITEMS.filter((item) => item.operatorOnly).map((item) => item.to),
-    ).toEqual(["/providers", "/budgets", "/settings", "/admin/accounts"])
+    ).toEqual(["/providers", "/settings", "/admin/accounts"])
   })
 
   it("puts each destination on exactly one rail", () => {

--- a/web/src/app/nav/registry.ts
+++ b/web/src/app/nav/registry.ts
@@ -295,12 +295,18 @@ const ORGANIZATION_NAV_SECTIONS = [
     id: "org-money",
     label: "Cost & billing",
     items: [
+      // No `operatorOnly`, because the destination is two pages now: an
+      // operator gets the deployment's budgets and an organization owner or
+      // admin gets their own organization's (otari-ai#1943). The roles matrix
+      // has this row at Edit for an admin, and `/v1/organizations/me/budgets`
+      // plus `/v1/organizations/me/spend-ceilings` are what it edits. A plain
+      // member is not offered it, because the organization rail opens only to a
+      // caller who manages the organization.
       {
         to: "/budgets",
         label: "Spend & budgets",
         surface: "budgets",
         icon: FiDollarSign,
-        operatorOnly: "refused",
       },
       // Tenant-scoped in fact as well as in the design: a rate applies to every
       // workspace and every key in the deployment. The catalog had no home

--- a/web/src/client/index.ts
+++ b/web/src/client/index.ts
@@ -279,6 +279,18 @@ export type CreateOrganizationPricingOverride =
   Schemas["OrganizationModelPricingCreate"]
 export type UpdateOrganizationPricingOverride =
   Schemas["OrganizationModelPricingUpdate"]
+// The organization's own budgets and the ceilings enforcing them, which are the
+// tenant-scoped counterparts to `Budget` and `ScopedBudget` above. Separate
+// types rather than the same ones: these carry an owner and, on a ceiling,
+// whether its figure is this organization's to change.
+export type OrganizationBudget = Schemas["OrganizationBudgetPublic"]
+export type CreateOrganizationBudget = Schemas["OrganizationBudgetCreate"]
+export type UpdateOrganizationBudget = Schemas["OrganizationBudgetUpdate"]
+export type OrganizationSpendCeiling = Schemas["OrganizationScopedBudgetPublic"]
+export type CreateOrganizationSpendCeiling =
+  Schemas["OrganizationScopedBudgetCreate"]
+export type UpdateOrganizationSpendCeiling =
+  Schemas["OrganizationScopedBudgetUpdate"]
 export type PricingRefreshChange = Schemas["PricingRefreshChangeResponse"]
 export type PricingRefreshPreview = Schemas["PricingRefreshPreviewResponse"]
 export type ProviderInfo = Schemas["ProviderInfoSchema"]

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -6936,12 +6936,13 @@ export interface components {
          * OrganizationBudgetUpdate
          * @description Replace a budget's label, figure and period.
          *
-         *     A full statement rather than a patch, matching ``PATCH /v1/budgets/{id}``'s
-         *     own fields: every one is optional and an omitted one is left alone, so
-         *     clearing a cap back to uncapped is not expressible here and is a delete. The
-         *     period pair is still mutually exclusive, and setting one does not clear the
-         *     other, which is why :func:`_require_single_period_source` re-checks the
-         *     *resulting* pair rather than the submitted one.
+         *     Every field is optional and keyed on ``model_fields_set``, matching
+         *     ``PATCH /v1/budgets/{id}``'s own: an *omitted* field is left alone, and an
+         *     explicit null clears it, so sending ``max_budget: null`` takes a budget back
+         *     to uncapped, which is what the dashboard's dialog does. The period pair is
+         *     still mutually exclusive, and setting one does not clear the other, which is
+         *     why :func:`_require_single_period_source` re-checks the *resulting* pair
+         *     rather than the submitted one.
          */
         OrganizationBudgetUpdate: {
             /**

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -1590,6 +1590,57 @@ export interface paths {
         patch: operations["update_active_organization_v1_organizations_me_patch"];
         trace?: never;
     };
+    "/v1/organizations/me/budgets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Organization Budgets
+         * @description List the budgets this organization has defined. Owners and admins only.
+         */
+        get: operations["list_organization_budgets_v1_organizations_me_budgets_get"];
+        put?: never;
+        /**
+         * Create Organization Budget
+         * @description Define a budget owned by this organization. Owners and admins only.
+         */
+        post: operations["create_organization_budget_v1_organizations_me_budgets_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/organizations/me/budgets/{budget_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Organization Budget
+         * @description Delete a budget, refused with 409 while a ceiling or workspace default names it.
+         */
+        delete: operations["delete_organization_budget_v1_organizations_me_budgets__budget_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Organization Budget
+         * @description Change a budget's label, figure or period.
+         *
+         *     Every ceiling naming it is held to the new figure from here on, which is the
+         *     point of naming a budget rather than typing an amount per place it applies.
+         */
+        patch: operations["update_organization_budget_v1_organizations_me_budgets__budget_id__patch"];
+        trace?: never;
+    };
     "/v1/organizations/me/guardrails": {
         parameters: {
             query?: never;
@@ -2072,6 +2123,66 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/v1/organizations/me/spend-ceilings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Organization Spend Ceilings
+         * @description List the ceilings capping identities inside this organization. Owners and admins only.
+         *
+         *     A ceiling whose budget this organization does not own is listed with
+         *     ``manageable`` false rather than omitted: it is enforcing against this
+         *     organization's spend, so leaving it out would let the page read as uncapped.
+         */
+        get: operations["list_organization_spend_ceilings_v1_organizations_me_spend_ceilings_get"];
+        put?: never;
+        /**
+         * Create Organization Spend Ceiling
+         * @description Cap one identity in this organization at one of its budgets.
+         *
+         *     Answers 404 when the scope names nothing in this organization, rather than
+         *     creating a ceiling that can never bind, and 404 when the budget is not this
+         *     organization's.
+         */
+        post: operations["create_organization_spend_ceiling_v1_organizations_me_spend_ceilings_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/organizations/me/spend-ceilings/{ceiling_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Organization Spend Ceiling
+         * @description Remove a ceiling inside this organization.
+         */
+        delete: operations["delete_organization_spend_ceiling_v1_organizations_me_spend_ceilings__ceiling_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Organization Spend Ceiling
+         * @description Relabel a ceiling, or point it at a different budget of this organization's.
+         *
+         *     The scope and the provider narrowing are not editable: changing either would
+         *     move the ceiling to a different identity while carrying its spend, which is a
+         *     delete and a create.
+         */
+        patch: operations["update_organization_spend_ceiling_v1_organizations_me_spend_ceilings__ceiling_id__patch"];
         trace?: never;
     };
     "/v1/organizations/me/switch": {
@@ -6761,6 +6872,107 @@ export interface components {
             data: components["schemas"]["OrgProviderKeyPublic"][];
         };
         /**
+         * OrganizationBudgetCreate
+         * @description Create one budget owned by the caller's organization.
+         */
+        OrganizationBudgetCreate: {
+            /**
+             * Budget Duration Sec
+             * @description Seconds between resets, counted from the last one. Mutually exclusive with reset_alignment
+             */
+            budget_duration_sec?: number | null;
+            /**
+             * Max Budget
+             * @description Maximum spend in USD over one period; null caps nothing
+             */
+            max_budget?: number | null;
+            /**
+             * Name
+             * @description Admin-facing label for the budget
+             */
+            name?: string | null;
+            /**
+             * Reset Alignment
+             * @description Reset on a UTC calendar boundary instead of a fixed number of seconds, which is the only way to express a calendar month. Mutually exclusive with budget_duration_sec
+             */
+            reset_alignment?: string | null;
+        };
+        /**
+         * OrganizationBudgetPublic
+         * @description One of the organization's budgets, and how much of its own config names it.
+         *
+         *     Carries no spend rollup. ``BudgetResponse`` on the deployment surface sums
+         *     ``users.spend`` over the gateway's ``users`` table, which is deployment-wide
+         *     and has no tenancy column, so the same figure here would be a cross-tenant
+         *     read. What an organization's own spend is, is a question for Usage.
+         *
+         *     ``ceiling_count`` is the organization-relevant fact instead: how many of its
+         *     ceilings this budget currently holds, which is what makes a delete refuse.
+         */
+        OrganizationBudgetPublic: {
+            /** Budget Duration Sec */
+            budget_duration_sec: number | null;
+            /** Budget Id */
+            budget_id: string;
+            /** Ceiling Count */
+            ceiling_count: number;
+            /** Created At */
+            created_at: string;
+            /** Max Budget */
+            max_budget: number | null;
+            /** Name */
+            name: string | null;
+            /**
+             * Organization Id
+             * Format: uuid
+             */
+            organization_id: string;
+            /** Reset Alignment */
+            reset_alignment: string | null;
+            /** Updated At */
+            updated_at: string;
+        };
+        /**
+         * OrganizationBudgetUpdate
+         * @description Replace a budget's label, figure and period.
+         *
+         *     A full statement rather than a patch, matching ``PATCH /v1/budgets/{id}``'s
+         *     own fields: every one is optional and an omitted one is left alone, so
+         *     clearing a cap back to uncapped is not expressible here and is a delete. The
+         *     period pair is still mutually exclusive, and setting one does not clear the
+         *     other, which is why :func:`_require_single_period_source` re-checks the
+         *     *resulting* pair rather than the submitted one.
+         */
+        OrganizationBudgetUpdate: {
+            /**
+             * Budget Duration Sec
+             * @description Seconds between resets, counted from the last one. Mutually exclusive with reset_alignment
+             */
+            budget_duration_sec?: number | null;
+            /**
+             * Max Budget
+             * @description Maximum spend in USD over one period; null caps nothing
+             */
+            max_budget?: number | null;
+            /**
+             * Name
+             * @description Admin-facing label for the budget
+             */
+            name?: string | null;
+            /**
+             * Reset Alignment
+             * @description Reset on a UTC calendar boundary instead of a fixed number of seconds, which is the only way to express a calendar month. Mutually exclusive with budget_duration_sec
+             */
+            reset_alignment?: string | null;
+        };
+        /** OrganizationBudgetsPublic */
+        OrganizationBudgetsPublic: {
+            /** Count */
+            count: number;
+            /** Data */
+            data: components["schemas"]["OrganizationBudgetPublic"][];
+        };
+        /**
          * OrganizationCreateRequest
          * @description Create an organization, with the caller as its owner.
          *
@@ -7186,6 +7398,103 @@ export interface components {
             slug: string;
             /** Updated At */
             updated_at?: string | null;
+        };
+        /**
+         * OrganizationScopedBudgetCreate
+         * @description Attach one of the organization's budgets to a scope inside it.
+         */
+        OrganizationScopedBudgetCreate: {
+            /**
+             * Budget Id
+             * @description The budget this ceiling enforces, which must be one this organization owns
+             */
+            budget_id: string;
+            /**
+             * Name
+             * @description Admin-facing label for this ceiling
+             */
+            name?: string | null;
+            /**
+             * Provider Key Id
+             * @description Narrow the cap to one provider instance; null caps spend across every provider
+             */
+            provider_key_id?: string | null;
+            /**
+             * Scope Id
+             * @description Id of the capped identity: this organization, one of its workspaces, a membership in either, or an API key in one
+             */
+            scope_id: string;
+            /**
+             * Scope Type
+             * @description Which kind of identity this ceiling caps
+             * @enum {string}
+             */
+            scope_type: "organization" | "workspace" | "workspace_member" | "org_member" | "api_token";
+        };
+        /**
+         * OrganizationScopedBudgetPublic
+         * @description One ceiling inside the organization, and the figures it enforces.
+         *
+         *     The limit and the period are read through the budget rather than stored here,
+         *     and carried on the wire so a page can render a ceiling without fetching every
+         *     budget to resolve one id. Same reasoning as ``ScopedBudgetResponse``, whose
+         *     shape this deliberately mirrors.
+         */
+        OrganizationScopedBudgetPublic: {
+            /** Budget Duration Sec */
+            budget_duration_sec: number | null;
+            /** Budget Id */
+            budget_id: string;
+            /** Created At */
+            created_at: string;
+            /** Current Spend */
+            current_spend: number;
+            /** Id */
+            id: string;
+            /** Manageable */
+            manageable: boolean;
+            /** Max Budget */
+            max_budget: number | null;
+            /** Name */
+            name: string | null;
+            /** Period End */
+            period_end: string | null;
+            /** Period Start */
+            period_start: string | null;
+            /** Provider Key Id */
+            provider_key_id: string | null;
+            /** Reserved Spend */
+            reserved_spend: number;
+            /** Reset Alignment */
+            reset_alignment: string | null;
+            /** Scope Id */
+            scope_id: string;
+            /** Scope Type */
+            scope_type: string;
+            /** Updated At */
+            updated_at: string;
+        };
+        /**
+         * OrganizationScopedBudgetUpdate
+         * @description Relabel a ceiling, or point it at a different budget of this organization's.
+         *
+         *     The scope and the provider narrowing are not editable, for the reason
+         *     ``PATCH /v1/scoped-budgets/{id}`` gives: changing either moves the ceiling to
+         *     a different identity while carrying its spend, which is a delete and a
+         *     create, not an update.
+         */
+        OrganizationScopedBudgetUpdate: {
+            /** Budget Id */
+            budget_id?: string | null;
+            /** Name */
+            name?: string | null;
+        };
+        /** OrganizationScopedBudgetsPublic */
+        OrganizationScopedBudgetsPublic: {
+            /** Count */
+            count: number;
+            /** Data */
+            data: components["schemas"]["OrganizationScopedBudgetPublic"][];
         };
         /**
          * PasskeySessionResponse
@@ -12101,6 +12410,139 @@ export interface operations {
             };
         };
     };
+    list_organization_budgets_v1_organizations_me_budgets_get: {
+        parameters: {
+            query?: {
+                /** @description Number of records to skip */
+                skip?: number;
+                /** @description Maximum number of records to return */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationBudgetsPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_organization_budget_v1_organizations_me_budgets_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OrganizationBudgetCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationBudgetPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_organization_budget_v1_organizations_me_budgets__budget_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                budget_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Message"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_organization_budget_v1_organizations_me_budgets__budget_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                budget_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OrganizationBudgetUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationBudgetPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_organization_guardrails_v1_organizations_me_guardrails_get: {
         parameters: {
             query?: {
@@ -13002,6 +13444,139 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PolicyResponse"][];
+                };
+            };
+        };
+    };
+    list_organization_spend_ceilings_v1_organizations_me_spend_ceilings_get: {
+        parameters: {
+            query?: {
+                /** @description Number of records to skip */
+                skip?: number;
+                /** @description Maximum number of records to return */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationScopedBudgetsPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_organization_spend_ceiling_v1_organizations_me_spend_ceilings_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OrganizationScopedBudgetCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationScopedBudgetPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_organization_spend_ceiling_v1_organizations_me_spend_ceilings__ceiling_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                ceiling_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Message"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_organization_spend_ceiling_v1_organizations_me_spend_ceilings__ceiling_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                ceiling_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OrganizationScopedBudgetUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrganizationScopedBudgetPublic"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -9888,7 +9888,7 @@ export interface components {
             budget_id: string;
             /**
              * Provider Key Id
-             * @description Narrow the default to one provider instance; null applies to every provider
+             * @description Narrow the default to one provider instance; omit or null to apply to every provider. Must name a real instance: a blank value would materialize ceilings that never bind
              */
             provider_key_id?: string | null;
         };

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -7416,7 +7416,7 @@ export interface components {
             name?: string | null;
             /**
              * Provider Key Id
-             * @description Narrow the cap to one provider instance; null caps spend across every provider
+             * @description Narrow the cap to one provider instance; omit or null to cap spend across every provider. Must name a real instance: a blank value would store a ceiling that never binds
              */
             provider_key_id?: string | null;
             /**

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -6895,7 +6895,7 @@ export interface components {
              * Reset Alignment
              * @description Reset on a UTC calendar boundary instead of a fixed number of seconds, which is the only way to express a calendar month. Mutually exclusive with budget_duration_sec
              */
-            reset_alignment?: string | null;
+            reset_alignment?: ("calendar_day" | "calendar_week" | "calendar_month") | null;
         };
         /**
          * OrganizationBudgetPublic
@@ -6963,7 +6963,7 @@ export interface components {
              * Reset Alignment
              * @description Reset on a UTC calendar boundary instead of a fixed number of seconds, which is the only way to express a calendar month. Mutually exclusive with budget_duration_sec
              */
-            reset_alignment?: string | null;
+            reset_alignment?: ("calendar_day" | "calendar_week" | "calendar_month") | null;
         };
         /** OrganizationBudgetsPublic */
         OrganizationBudgetsPublic: {

--- a/web/src/features/budgets/BudgetsPage.test.tsx
+++ b/web/src/features/budgets/BudgetsPage.test.tsx
@@ -4,10 +4,15 @@ import userEvent from "@testing-library/user-event"
 import type { ReactElement } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import type { Budget, BudgetResetLog, User } from "@/client"
+import type {
+  Budget,
+  BudgetResetLog,
+  OrganizationContext,
+  User,
+} from "@/client"
 import { BudgetsPage } from "@/features/budgets/BudgetsPage"
 import { DeploymentProvider } from "@/shared/hooks/useDeployment"
-import { bootstrap } from "@/tests/fixtures"
+import { bootstrap, organizationContext } from "@/tests/fixtures"
 
 function testUser(user_id: string): User {
   return {
@@ -56,11 +61,16 @@ function mockApi(
     users?: User[]
     failedUserUpdates?: string[]
     updateUser?: (userId: string) => Response | Promise<Response>
+    // Who is asking, which is what decides which of the two pages this route
+    // renders. An operator by default, so every case below describes the
+    // deployment-wide page it always described.
+    context?: OrganizationContext
   } = {},
 ) {
   let list = [...(opts.budgets ?? [])]
   const resetLogs = opts.resetLogs ?? []
   const users = opts.users ?? []
+  const context = opts.context ?? organizationContext()
 
   return vi
     .spyOn(globalThis, "fetch")
@@ -110,6 +120,13 @@ function mockApi(
         }
         return jsonResponse(list)
       }
+      if (url.includes("/v1/organizations/me/budgets")) {
+        return jsonResponse({ data: [], count: 0 })
+      }
+      if (url.includes("/v1/organizations/me/spend-ceilings")) {
+        return jsonResponse({ data: [], count: 0 })
+      }
+      if (url.includes("/v1/organizations/me")) return jsonResponse(context)
       return jsonResponse([])
     })
 }
@@ -546,5 +563,46 @@ describe("BudgetsPage", () => {
       )
       expect(del).toBeTruthy()
     })
+  })
+
+  it("gives an organization admin their own budgets, not the deployment's", async () => {
+    // One route, two pages (otari-ai#1943). Every deployment-wide read this
+    // file's other cases make answers 403 to a tenant, so an admin gets the
+    // organization-scoped page instead of a screen of refusals.
+    const requests = mockApi({
+      budgets: [budget()],
+      // An admin, not the owner the fixture defaults to: the matrix row is
+      // about the admin, and it is the weaker of the two management roles.
+      context: organizationContext({
+        role: "admin",
+        deployment_operator: false,
+      }),
+    })
+    renderPage(<BudgetsPage />)
+
+    expect(
+      await screen.findByRole("grid", { name: "Organization budgets" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("grid", { name: "Organization spend ceilings" }),
+    ).toBeInTheDocument()
+
+    // Withheld at the request, not only in the markup.
+    const read = requests.mock.calls.map(([url]) => String(url))
+    expect(read.some((url) => /\/v1\/budgets/.test(url))).toBe(false)
+    expect(read.some((url) => /\/v1\/scoped-budgets/.test(url))).toBe(false)
+    expect(read.some((url) => /\/v1\/users/.test(url))).toBe(false)
+  })
+
+  it("keeps the deployment page for an operator", async () => {
+    // The other side of the split, pinned so a future change cannot quietly
+    // take the deployment's budgets away from the caller who owns them.
+    mockApi({ budgets: [budget({ name: "Deployment wide" })] })
+    renderPage(<BudgetsPage />)
+
+    expect(await screen.findByText("Deployment wide")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("grid", { name: "Organization budgets" }),
+    ).toBeNull()
   })
 })

--- a/web/src/features/budgets/BudgetsPage.tsx
+++ b/web/src/features/budgets/BudgetsPage.tsx
@@ -6,6 +6,7 @@ import type {
   CreateBudgetRequest,
   User,
 } from "@/client"
+import { isDeploymentOperator } from "@/features/organization/roles"
 import { UserMultiSelect } from "@/features/users/UserMultiSelect"
 import {
   useAllWorkspaceBudgetDefaults,
@@ -13,6 +14,7 @@ import {
   useBudgets,
   useCreateBudget,
   useDeleteBudget,
+  useOrganizationContext,
   useUpdateBudget,
   useUpdateUser,
   useUsers,
@@ -28,11 +30,14 @@ import {
   ErrorBanner,
   InfoBanner,
   PageHeader,
+  PageLoading,
 } from "@/shared/components/ui"
 import {
   resolveSelectedIds,
   useTableSelection,
 } from "@/shared/helpers/tableSelection"
+
+import { OrganizationBudgetsPage } from "./OrganizationBudgetsPage"
 
 // ---------- formatting ----------
 
@@ -479,7 +484,16 @@ function budgetLabel(budget: Budget): string {
   return budget.name ?? shortId(budget.budget_id)
 }
 
-export function BudgetsPage() {
+/**
+ * The deployment's own budgets page, which is what an operator sees.
+ *
+ * Deployment-wide end to end: `/v1/budgets`, the gateway's `users` table, and
+ * every workspace's member default, all behind `require_deployment_operator`.
+ * Unchanged by otari-ai#1943, which added the tenant-scoped page beside it
+ * rather than reshaping this one, because the two surfaces answer to different
+ * callers and read different rows.
+ */
+function DeploymentBudgetsPage() {
   const budgets = useBudgets()
   const users = useUsers()
   const workspaces = useWorkspaces()
@@ -935,4 +949,36 @@ export function BudgetsPage() {
       />
     </div>
   )
+}
+
+/**
+ * Spend & budgets, picking the page for whoever is asking.
+ *
+ * One route with two pages behind it, the way Routing does since otari#867: an
+ * operator gets the deployment's budgets, and an organization owner or admin
+ * gets their own organization's, which is the surface otari-ai#1943 added. Not
+ * two rail rows, because it is one destination in the design and one row in the
+ * roles matrix; and not one merged page, because the two read different tables
+ * and every deployment-wide read here answers 403 to a tenant.
+ *
+ * Held until the context lands rather than defaulting to one of them. Guessing
+ * would either flash the operator page at an admin and swap it, or fire the
+ * deployment-wide reads as an admin and paint their refusals; the shell already
+ * waits on this query, so the cost is a spinner that is usually already over.
+ */
+export function BudgetsPage() {
+  const organization = useOrganizationContext()
+
+  if (organization.isPending && !organization.data) {
+    return <PageLoading label="Loading spend and budgets…" />
+  }
+  // Fails towards the operator page on an errored context, matching what the
+  // rail does with this row: it is the page that was here before, its reads say
+  // in their own words when they are refused, and an admin seeing that is a
+  // worse-looking version of a page they can still reach, where the reverse
+  // would hide the deployment's budgets from the one caller who owns them.
+  if (organization.data && !isDeploymentOperator(organization.data)) {
+    return <OrganizationBudgetsPage organization={organization.data} />
+  }
+  return <DeploymentBudgetsPage />
 }

--- a/web/src/features/budgets/OrganizationBudgetDialog.tsx
+++ b/web/src/features/budgets/OrganizationBudgetDialog.tsx
@@ -1,0 +1,181 @@
+import { AlertDialog, Button } from "@heroui/react"
+import { useEffect, useState } from "react"
+
+import type { OrganizationBudget } from "@/client"
+import { Field } from "@/shared/components/Field"
+import { ErrorBanner, FilterSelect } from "@/shared/components/ui"
+
+import { PERIOD_OPTIONS, periodValue } from "./organizationBudget"
+
+// The form behind both Add and Edit for one of the organization's budgets. One
+// component rather than two: the fields are identical, and the endpoint is a
+// PATCH that leaves an omitted field alone, so an edit sends the same shape an
+// add does.
+
+export interface OrganizationBudgetDraft {
+  name: string | null
+  max_budget: number | null
+  budget_duration_sec: number | null
+  reset_alignment: string | null
+}
+
+/** A typed amount, or undefined when it is not a number this can send. */
+function parseLimit(raw: string): number | undefined {
+  const trimmed = raw.trim()
+  // Blank is a deliberate value here, not a missing one: it means no limit.
+  if (trimmed === "") return undefined
+  const parsed = Number(trimmed)
+  if (!Number.isFinite(parsed) || parsed < 0) return undefined
+  return parsed
+}
+
+function limitToInput(value: number | null | undefined): string {
+  return value === null || value === undefined ? "" : String(value)
+}
+
+export interface OrganizationBudgetDialogProps {
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+  /** The budget being edited; absent means this is an add. */
+  editing?: OrganizationBudget
+  isPending: boolean
+  error: unknown
+  onSubmit: (draft: OrganizationBudgetDraft) => void
+}
+
+export function OrganizationBudgetDialog({
+  isOpen,
+  onOpenChange,
+  editing,
+  isPending,
+  error,
+  onSubmit,
+}: OrganizationBudgetDialogProps) {
+  const [name, setName] = useState("")
+  const [limit, setLimit] = useState("")
+  const [period, setPeriod] = useState("calendar_month")
+
+  // Reseeded every time it opens, for the reason `PricingOverrideDialog` gives:
+  // the dialog stays mounted across close and reopen, and these values decide
+  // what colleagues may spend, so inheriting the last budget's figure into a
+  // different one is the expensive kind of mistake.
+  useEffect(() => {
+    if (!isOpen) return
+    setName(editing?.name ?? "")
+    setLimit(limitToInput(editing?.max_budget))
+    setPeriod(periodValue(editing))
+  }, [isOpen, editing])
+
+  const amount = parseLimit(limit)
+  const limitInvalid = limit.trim() !== "" && amount === undefined
+
+  // A duration-carrying budget (one the deployment surface created) opens on
+  // "No reset", and saving would clear the duration rather than keep it. Said
+  // out loud, because the form cannot show a period it does not offer.
+  const clearsDuration =
+    editing !== undefined &&
+    !editing.reset_alignment &&
+    editing.budget_duration_sec !== null &&
+    editing.budget_duration_sec !== undefined &&
+    period === "none"
+
+  const submit = () => {
+    if (limitInvalid) return
+    const option = PERIOD_OPTIONS.find(
+      (candidate) => candidate.value === period,
+    )
+    onSubmit({
+      name: name.trim() === "" ? null : name.trim(),
+      max_budget: amount ?? null,
+      // Only ever one of the two is sent with a value, because a budget resets
+      // on a duration or on a boundary and the database refuses both.
+      budget_duration_sec: null,
+      reset_alignment: option?.alignment ?? null,
+    })
+  }
+
+  return (
+    <AlertDialog isOpen={isOpen} onOpenChange={onOpenChange}>
+      {isOpen ? (
+        <AlertDialog.Backdrop>
+          <AlertDialog.Container placement="center" size="md">
+            <AlertDialog.Dialog>
+              <AlertDialog.Header>
+                <AlertDialog.Heading>
+                  {editing ? "Edit budget" : "Add budget"}
+                </AlertDialog.Heading>
+              </AlertDialog.Header>
+              <AlertDialog.Body className="flex flex-col gap-4">
+                <p className="text-sm text-muted">
+                  A budget is an amount and the period it is spent over. It caps
+                  nothing on its own: a spend ceiling below is what points it at
+                  an organization, a workspace, or a key.
+                </p>
+                <ErrorBanner error={error} />
+                <Field
+                  label="Name"
+                  value={name}
+                  onChange={setName}
+                  placeholder="Engineering monthly"
+                  autoFocus
+                  description="Optional. What this budget is called wherever it is handed out."
+                />
+                <Field
+                  label="Limit (USD)"
+                  value={limit}
+                  onChange={setLimit}
+                  placeholder="250"
+                  isInvalid={limitInvalid}
+                  errorMessage="Enter an amount of zero or more, or leave it blank for no limit."
+                  description="Leave blank for no limit, which admits every request."
+                />
+                <FilterSelect
+                  label="Resets"
+                  value={period}
+                  onChange={setPeriod}
+                  options={PERIOD_OPTIONS.map((option) => ({
+                    value: option.value,
+                    label: option.label,
+                  }))}
+                />
+                {editing && editing.ceiling_count > 0 ? (
+                  <p className="text-sm text-muted">
+                    {editing.ceiling_count === 1
+                      ? "1 spend ceiling is held to this budget and moves with it."
+                      : `${editing.ceiling_count} spend ceilings are held to this budget and move with it.`}{" "}
+                    Spend already recorded stays; the new figure applies from
+                    here on.
+                  </p>
+                ) : null}
+                {clearsDuration ? (
+                  <p className="text-sm text-warning">
+                    This budget currently resets on a rolling interval, which
+                    this form does not offer. Saving replaces it with the period
+                    chosen above.
+                  </p>
+                ) : null}
+              </AlertDialog.Body>
+              <AlertDialog.Footer>
+                <Button
+                  variant="ghost"
+                  isDisabled={isPending}
+                  onPress={() => onOpenChange(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  isDisabled={limitInvalid}
+                  isPending={isPending}
+                  onPress={submit}
+                >
+                  {editing ? "Save budget" : "Add budget"}
+                </Button>
+              </AlertDialog.Footer>
+            </AlertDialog.Dialog>
+          </AlertDialog.Container>
+        </AlertDialog.Backdrop>
+      ) : null}
+    </AlertDialog>
+  )
+}

--- a/web/src/features/budgets/OrganizationBudgetDialog.tsx
+++ b/web/src/features/budgets/OrganizationBudgetDialog.tsx
@@ -5,7 +5,11 @@ import type { OrganizationBudget } from "@/client"
 import { Field } from "@/shared/components/Field"
 import { ErrorBanner, FilterSelect } from "@/shared/components/ui"
 
-import { PERIOD_OPTIONS, periodValue } from "./organizationBudget"
+import {
+  PERIOD_OPTIONS,
+  periodValue,
+  type ResetAlignment,
+} from "./organizationBudget"
 
 // The form behind both Add and Edit for one of the organization's budgets. One
 // component rather than two: the fields are identical, and the endpoint is a
@@ -16,7 +20,9 @@ export interface OrganizationBudgetDraft {
   name: string | null
   max_budget: number | null
   budget_duration_sec: number | null
-  reset_alignment: string | null
+  // The generated union, not `string`: see `ResetAlignment` for why restating it
+  // as a string broke the build when the endpoint narrowed the field.
+  reset_alignment: ResetAlignment | null
 }
 
 /** A typed amount, or undefined when it is not a number this can send. */

--- a/web/src/features/budgets/OrganizationBudgetsCard.tsx
+++ b/web/src/features/budgets/OrganizationBudgetsCard.tsx
@@ -1,0 +1,178 @@
+import { Button, Card } from "@heroui/react"
+import { useState } from "react"
+
+import type { OrganizationBudget } from "@/client"
+import {
+  useCreateOrganizationBudget,
+  useDeleteOrganizationBudget,
+  useOrganizationBudgets,
+  useUpdateOrganizationBudget,
+} from "@/shared/api/hooks"
+import { ConfirmDialog } from "@/shared/components/ConfirmDialog"
+import { DataTable, type DataTableColumn } from "@/shared/components/DataTable"
+import { ErrorBanner } from "@/shared/components/ui"
+import {
+  OrganizationBudgetDialog,
+  type OrganizationBudgetDraft,
+} from "./OrganizationBudgetDialog"
+import { budgetLabel, limitLabel, periodLabel } from "./organizationBudget"
+
+// The organization's own budgets: the figures, without yet saying where they
+// apply. The ceilings card below is what applies them.
+//
+// Deliberately no spend column. The deployment's budgets page shows one, summed
+// over the gateway's `users` table, which is deployment-wide and carries no
+// tenancy: the same figure here would be a cross-tenant read. What an
+// organization has spent is Usage's question; what a *ceiling* has spent against
+// its own counters is on the ceilings table, where it belongs.
+
+export function OrganizationBudgetsCard() {
+  const budgets = useOrganizationBudgets()
+  const create = useCreateOrganizationBudget()
+  const update = useUpdateOrganizationBudget()
+  const remove = useDeleteOrganizationBudget()
+
+  const [isDialogOpen, setDialogOpen] = useState(false)
+  const [editing, setEditing] = useState<OrganizationBudget>()
+  const [pendingDelete, setPendingDelete] = useState<OrganizationBudget>()
+
+  const rows = budgets.data ?? []
+
+  const openAdd = () => {
+    setEditing(undefined)
+    setDialogOpen(true)
+  }
+
+  const openEdit = (budget: OrganizationBudget) => {
+    setEditing(budget)
+    setDialogOpen(true)
+  }
+
+  const submit = (draft: OrganizationBudgetDraft) => {
+    const onDone = { onSuccess: () => setDialogOpen(false) }
+    if (editing) {
+      update.mutate({ id: editing.budget_id, body: draft }, onDone)
+      return
+    }
+    create.mutate(draft, onDone)
+  }
+
+  const columns: DataTableColumn<OrganizationBudget>[] = [
+    {
+      id: "name",
+      header: "Budget",
+      isRowHeader: true,
+      cell: (row) => (
+        <span className="text-sm text-foreground">{budgetLabel(row)}</span>
+      ),
+    },
+    {
+      id: "limit",
+      header: "Limit",
+      align: "end",
+      cell: (row) => limitLabel(row.max_budget),
+    },
+    {
+      id: "resets",
+      header: "Resets",
+      cell: (row) => periodLabel(row),
+    },
+    {
+      id: "ceilings",
+      header: "Held by",
+      align: "end",
+      // The organization-relevant fact, and the one that makes a delete refuse:
+      // a budget nothing names is deletable, and one that is named is not.
+      cell: (row) =>
+        row.ceiling_count === 0
+          ? "Nothing yet"
+          : `${row.ceiling_count} ${row.ceiling_count === 1 ? "ceiling" : "ceilings"}`,
+    },
+    {
+      id: "actions",
+      header: "",
+      cell: (row) => (
+        <div className="flex justify-end gap-1">
+          <Button size="sm" variant="ghost" onPress={() => openEdit(row)}>
+            Edit
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onPress={() => setPendingDelete(row)}
+          >
+            Delete
+          </Button>
+        </div>
+      ),
+    },
+  ]
+
+  return (
+    <section className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-title">Budgets</h2>
+        <Button size="sm" variant="primary" onPress={openAdd}>
+          Add budget
+        </Button>
+      </div>
+
+      <p className="text-sm text-muted">
+        An amount and the period it is spent over. A budget caps nothing until a
+        spend ceiling below points it at something, and editing one moves every
+        ceiling that holds it.
+      </p>
+
+      <ErrorBanner error={budgets.error} />
+
+      <Card>
+        <Card.Content className="p-0">
+          <DataTable
+            ariaLabel="Organization budgets"
+            columns={columns}
+            rows={rows}
+            getRowKey={(row) => row.budget_id}
+            isLoading={budgets.isPending && !budgets.data}
+            // Says nothing about the organization: an empty table is also what a
+            // failed read leaves behind, and the banner above is the only thing
+            // that knows which happened.
+            emptyContent="No budget yet. Add one, then point a spend ceiling at it."
+          />
+        </Card.Content>
+      </Card>
+
+      <OrganizationBudgetDialog
+        isOpen={isDialogOpen}
+        onOpenChange={setDialogOpen}
+        editing={editing}
+        isPending={create.isPending || update.isPending}
+        error={editing ? update.error : create.error}
+        onSubmit={submit}
+      />
+
+      <ConfirmDialog
+        isOpen={pendingDelete !== undefined}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(undefined)
+        }}
+        heading="Delete budget"
+        body={
+          pendingDelete
+            ? pendingDelete.ceiling_count > 0
+              ? `${budgetLabel(pendingDelete)} is held by ${pendingDelete.ceiling_count} spend ${pendingDelete.ceiling_count === 1 ? "ceiling" : "ceilings"}, so this will be refused. Remove or repoint them first.`
+              : `${budgetLabel(pendingDelete)} stops existing. Nothing holds it, so no cap changes.`
+            : null
+        }
+        confirmLabel="Delete budget"
+        isPending={remove.isPending}
+        error={remove.error}
+        onConfirm={() => {
+          if (!pendingDelete) return
+          remove.mutate(pendingDelete.budget_id, {
+            onSuccess: () => setPendingDelete(undefined),
+          })
+        }}
+      />
+    </section>
+  )
+}

--- a/web/src/features/budgets/OrganizationBudgetsPage.test.tsx
+++ b/web/src/features/budgets/OrganizationBudgetsPage.test.tsx
@@ -358,6 +358,34 @@ describe("OrganizationBudgetsPage", () => {
     expect(await screen.findByText(/Add a budget first/)).toBeInTheDocument()
   })
 
+  it("will not save a ceiling still holding a budget the organization does not own", async () => {
+    // `FilterSelect` carries an unmatched value as its own option rather than
+    // dropping it, so the deployment budget stays selected and Save looked
+    // enabled while submitting an id the endpoint answers 404 for.
+    mockApi({
+      ceilings: [
+        spendCeiling({
+          manageable: false,
+          // A budget id that is not among the organization's own, which is what
+          // `manageable: false` means on the wire.
+          budget_id: "dddddddd-9999-9999-9999-999999999999",
+        }),
+      ],
+    })
+    const user = userEvent.setup()
+    renderPage()
+    const table = await screen.findByRole("grid", {
+      name: "Organization spend ceilings",
+    })
+
+    await user.click(await within(table).findByRole("button", { name: "Edit" }))
+
+    expect(
+      await screen.findByText(/Choose one of your own to take it over/),
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Save ceiling" })).toBeDisabled()
+  })
+
   it("sends only the label and the budget when editing a ceiling", async () => {
     // The endpoint ignores the scope on a PATCH, because changing it would move
     // the ceiling to another identity while carrying its spend.

--- a/web/src/features/budgets/OrganizationBudgetsPage.test.tsx
+++ b/web/src/features/budgets/OrganizationBudgetsPage.test.tsx
@@ -1,0 +1,395 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import type { OrganizationBudget, OrganizationSpendCeiling } from "@/client"
+import { OrganizationBudgetsPage } from "@/features/budgets/OrganizationBudgetsPage"
+import { DeploymentProvider } from "@/shared/hooks/useDeployment"
+import { bootstrap, organizationContext, workspace } from "@/tests/fixtures"
+
+interface RecordedRequest {
+  url: string
+  method: string
+  body: unknown
+}
+
+function organizationBudget(
+  overrides: Partial<OrganizationBudget> = {},
+): OrganizationBudget {
+  return {
+    budget_id: "bbbbbbbb-1111-2222-3333-444444444444",
+    organization_id: "11111111-1111-1111-1111-111111111111",
+    name: "Engineering monthly",
+    max_budget: 250,
+    budget_duration_sec: null,
+    reset_alignment: "calendar_month",
+    ceiling_count: 0,
+    created_at: "2026-01-01T00:00:00+00:00",
+    updated_at: "2026-01-01T00:00:00+00:00",
+    ...overrides,
+  }
+}
+
+function spendCeiling(
+  overrides: Partial<OrganizationSpendCeiling> = {},
+): OrganizationSpendCeiling {
+  return {
+    id: "cccccccc-1111-2222-3333-444444444444",
+    scope_type: "organization",
+    scope_id: "11111111-1111-1111-1111-111111111111",
+    provider_key_id: null,
+    budget_id: "bbbbbbbb-1111-2222-3333-444444444444",
+    name: null,
+    max_budget: 250,
+    current_spend: 12.5,
+    reserved_spend: 0,
+    budget_duration_sec: null,
+    reset_alignment: "calendar_month",
+    period_start: "2026-08-01T00:00:00+00:00",
+    period_end: "2026-09-01T00:00:00+00:00",
+    manageable: true,
+    created_at: "2026-01-01T00:00:00+00:00",
+    updated_at: "2026-01-01T00:00:00+00:00",
+    ...overrides,
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+// Mocked at the `@/client` boundary (a real `fetch`), per the standards: the
+// hooks and their invalidation are part of what is under test.
+function mockApi({
+  budgets = [organizationBudget()],
+  ceilings = [] as OrganizationSpendCeiling[],
+  writeStatus = 201,
+}: {
+  budgets?: OrganizationBudget[]
+  ceilings?: OrganizationSpendCeiling[]
+  writeStatus?: number
+} = {}) {
+  const requests: RecordedRequest[] = []
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const url = String(input)
+    const method = (init?.method ?? "GET").toUpperCase()
+    requests.push({
+      url,
+      method,
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    })
+    if (url.includes("/v1/organizations/me/spend-ceilings")) {
+      if (method === "GET") {
+        return jsonResponse({ data: ceilings, count: ceilings.length })
+      }
+      if (method === "DELETE") return jsonResponse({ message: "deleted" })
+      return jsonResponse(spendCeiling(), writeStatus)
+    }
+    if (url.includes("/v1/organizations/me/budgets")) {
+      if (method === "GET") {
+        return jsonResponse({ data: budgets, count: budgets.length })
+      }
+      if (method === "DELETE") return jsonResponse({ message: "deleted" })
+      return jsonResponse(organizationBudget(), writeStatus)
+    }
+    if (url.includes("/v1/workspaces")) {
+      return jsonResponse({
+        data: [workspace({ name: "Engineering" })],
+        count: 1,
+      })
+    }
+    return jsonResponse([])
+  })
+  return requests
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <DeploymentProvider value={bootstrap()}>
+      <QueryClientProvider client={client}>
+        <OrganizationBudgetsPage
+          // The caller this page exists for: an admin who does not operate the
+          // deployment. The fixture defaults to an owner who does, which is the
+          // one caller that would reach the other page instead.
+          organization={organizationContext({
+            role: "admin",
+            deployment_operator: false,
+          })}
+        />
+      </QueryClientProvider>
+    </DeploymentProvider>,
+  )
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("OrganizationBudgetsPage", () => {
+  it("reads only the organization's own surfaces, never the deployment's", async () => {
+    // The point of the page. `/v1/budgets` and `/v1/scoped-budgets` answer 403
+    // to a tenant, so touching either would paint a refusal on a page that is
+    // the admin's to use.
+    const requests = mockApi()
+    renderPage()
+    await screen.findByRole("grid", { name: "Organization budgets" })
+
+    const read = requests.map((request) => request.url)
+    expect(
+      read.some((url) => url.includes("/v1/organizations/me/budgets")),
+    ).toBe(true)
+    expect(
+      read.some((url) => url.includes("/v1/organizations/me/spend-ceilings")),
+    ).toBe(true)
+    for (const url of read) {
+      expect(url).not.toMatch(/\/v1\/budgets/)
+      expect(url).not.toMatch(/\/v1\/scoped-budgets/)
+    }
+  })
+
+  it("lists a budget with its limit, period and how many ceilings hold it", async () => {
+    mockApi({ budgets: [organizationBudget({ ceiling_count: 2 })] })
+    renderPage()
+
+    const table = await screen.findByRole("grid", {
+      name: "Organization budgets",
+    })
+    // Awaited: `DataTable` renders the grid with a loading row, so the grid
+    // exists a beat before its rows do.
+    expect(
+      await within(table).findByText("Engineering monthly"),
+    ).toBeInTheDocument()
+    expect(within(table).getByText(/250/)).toBeInTheDocument()
+    expect(within(table).getByText(/1st at 00:00 UTC/)).toBeInTheDocument()
+    expect(within(table).getByText("2 ceilings")).toBeInTheDocument()
+  })
+
+  it("shows no spend column on a budget, because that figure is not the tenant's", async () => {
+    // The deployment page sums `users.spend`, which is deployment-wide and has
+    // no tenancy column, so the same column here would be a cross-tenant read.
+    mockApi()
+    renderPage()
+
+    const table = await screen.findByRole("grid", {
+      name: "Organization budgets",
+    })
+    expect(
+      within(table).queryByRole("columnheader", { name: /spent/i }),
+    ).toBeNull()
+  })
+
+  it("creates a budget as a calendar period rather than a duration", async () => {
+    // A duration is measured from the last reset, so "Monthly" as 30 days is a
+    // 1.5 percent more generous product than the calendar month an admin means.
+    const requests = mockApi({ budgets: [] })
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByRole("grid", { name: "Organization budgets" })
+
+    await user.click(screen.getByRole("button", { name: "Add budget" }))
+    await user.type(screen.getByLabelText("Name"), "Design")
+    await user.type(screen.getByLabelText("Limit (USD)"), "75")
+    const submit = screen.getAllByRole("button", { name: "Add budget" }).at(-1)
+    await user.click(submit as HTMLElement)
+
+    await waitFor(() =>
+      expect(
+        requests.some(
+          (request) =>
+            request.method === "POST" &&
+            request.url.includes("/v1/organizations/me/budgets"),
+        ),
+      ).toBe(true),
+    )
+    const posted = requests.find(
+      (request) =>
+        request.method === "POST" &&
+        request.url.includes("/v1/organizations/me/budgets"),
+    )
+    expect(posted?.body).toMatchObject({
+      name: "Design",
+      max_budget: 75,
+      reset_alignment: "calendar_month",
+      budget_duration_sec: null,
+    })
+  })
+
+  it("refuses a limit that is not an amount rather than sending it", async () => {
+    mockApi({ budgets: [] })
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByRole("grid", { name: "Organization budgets" })
+
+    await user.click(screen.getByRole("button", { name: "Add budget" }))
+    await user.type(screen.getByLabelText("Limit (USD)"), "-5")
+
+    const submit = screen.getAllByRole("button", { name: "Add budget" }).at(-1)
+    expect(submit).toBeDisabled()
+  })
+
+  it("says a blank limit means no limit rather than zero", async () => {
+    mockApi({ budgets: [organizationBudget({ max_budget: null })] })
+    renderPage()
+
+    const table = await screen.findByRole("grid", {
+      name: "Organization budgets",
+    })
+    expect(await within(table).findByText("No limit")).toBeInTheDocument()
+  })
+
+  it("warns that deleting a held budget will be refused, before trying", async () => {
+    mockApi({ budgets: [organizationBudget({ ceiling_count: 3 })] })
+    const user = userEvent.setup()
+    renderPage()
+    const table = await screen.findByRole("grid", {
+      name: "Organization budgets",
+    })
+
+    await user.click(
+      await within(table).findByRole("button", { name: "Delete" }),
+    )
+
+    expect(
+      await screen.findByText(
+        /held by 3 spend ceilings, so this will be refused/,
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it("lists a ceiling with what it caps and what it has spent", async () => {
+    mockApi({
+      ceilings: [
+        spendCeiling({
+          scope_type: "workspace",
+          scope_id: workspace().id,
+          current_spend: 12.5,
+          reserved_spend: 2,
+        }),
+      ],
+    })
+    renderPage()
+
+    const table = await screen.findByRole("grid", {
+      name: "Organization spend ceilings",
+    })
+    expect(
+      await within(table).findByText("Engineering (workspace)"),
+    ).toBeInTheDocument()
+    expect(within(table).getByText("Every provider")).toBeInTheDocument()
+    // Reserved counts towards the cap and is not spend yet, so both are shown:
+    // the ceiling refuses on their sum.
+    expect(within(table).getByText(/held/)).toBeInTheDocument()
+  })
+
+  it("marks a ceiling whose budget is set outside the organization", async () => {
+    // What the otari-ai cutover writes. Listed rather than hidden, because it is
+    // enforcing today and omitting it would let the page read as uncapped.
+    mockApi({ ceilings: [spendCeiling({ manageable: false })] })
+    renderPage()
+
+    const table = await screen.findByRole("grid", {
+      name: "Organization spend ceilings",
+    })
+    expect(
+      await within(table).findByText("Set at the deployment level"),
+    ).toBeInTheDocument()
+  })
+
+  it("never names the deployment operator to a tenant", async () => {
+    // An operator is an internal role a tenant can neither see nor change, so
+    // no copy on this page may explain a limit by naming one.
+    mockApi({ ceilings: [spendCeiling({ manageable: false })] })
+    const { container } = renderPage()
+    // Awaited past the loading rows, so the assertion reads the real copy rather
+    // than a table that has not rendered its marker yet.
+    await screen.findByText("Set at the deployment level")
+
+    expect(container.textContent).not.toMatch(/operator/i)
+    expect(container.textContent).not.toMatch(/superuser/i)
+  })
+
+  it("creates a ceiling against the whole organization by default", async () => {
+    const requests = mockApi()
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByRole("grid", { name: "Organization spend ceilings" })
+
+    await user.click(screen.getByRole("button", { name: "Add ceiling" }))
+    const submit = screen.getAllByRole("button", { name: "Add ceiling" }).at(-1)
+    await user.click(submit as HTMLElement)
+
+    await waitFor(() =>
+      expect(
+        requests.some(
+          (request) =>
+            request.method === "POST" &&
+            request.url.includes("/v1/organizations/me/spend-ceilings"),
+        ),
+      ).toBe(true),
+    )
+    const posted = requests.find(
+      (request) =>
+        request.method === "POST" &&
+        request.url.includes("/v1/organizations/me/spend-ceilings"),
+    )
+    // The scope an admin reaches this page to set, held to the organization's
+    // own first budget.
+    expect(posted?.body).toMatchObject({
+      scope_type: "organization",
+      budget_id: organizationBudget().budget_id,
+    })
+  })
+
+  it("will not offer a ceiling with no budget to hold", async () => {
+    mockApi({ budgets: [] })
+    const user = userEvent.setup()
+    renderPage()
+    await screen.findByRole("grid", { name: "Organization spend ceilings" })
+
+    await user.click(screen.getByRole("button", { name: "Add ceiling" }))
+
+    expect(await screen.findByText(/Add a budget first/)).toBeInTheDocument()
+  })
+
+  it("sends only the label and the budget when editing a ceiling", async () => {
+    // The endpoint ignores the scope on a PATCH, because changing it would move
+    // the ceiling to another identity while carrying its spend.
+    const requests = mockApi({ ceilings: [spendCeiling()] })
+    const user = userEvent.setup()
+    renderPage()
+    const table = await screen.findByRole("grid", {
+      name: "Organization spend ceilings",
+    })
+
+    await user.click(await within(table).findByRole("button", { name: "Edit" }))
+    await user.type(screen.getByLabelText("Name"), "Whole org")
+    await user.click(screen.getByRole("button", { name: "Save ceiling" }))
+
+    await waitFor(() =>
+      expect(requests.some((request) => request.method === "PATCH")).toBe(true),
+    )
+    const patched = requests.find((request) => request.method === "PATCH")
+    expect(Object.keys(patched?.body as object).sort()).toEqual([
+      "budget_id",
+      "name",
+    ])
+  })
+
+  it("reports a failed read rather than an empty organization", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      jsonResponse({ detail: "nope" }, 500),
+    )
+    renderPage()
+
+    // An empty table after a failed read says "nothing is capped", which is the
+    // opposite of what a 500 means.
+    expect((await screen.findAllByRole("alert")).length).toBeGreaterThan(0)
+  })
+})

--- a/web/src/features/budgets/OrganizationBudgetsPage.test.tsx
+++ b/web/src/features/budgets/OrganizationBudgetsPage.test.tsx
@@ -382,6 +382,27 @@ describe("OrganizationBudgetsPage", () => {
     ])
   })
 
+  it("names a failed workspace roster instead of just offering no workspaces", async () => {
+    // Without this the owner sees the consequence (no workspace to pick, rows
+    // reading "A workspace") and never the cause.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.includes("/v1/workspaces")) {
+        return jsonResponse({ detail: "workspaces unavailable" }, 500)
+      }
+      if (url.includes("/v1/organizations/me/spend-ceilings")) {
+        return jsonResponse({ data: [], count: 0 })
+      }
+      if (url.includes("/v1/organizations/me/budgets")) {
+        return jsonResponse({ data: [organizationBudget()], count: 1 })
+      }
+      return jsonResponse([])
+    })
+    renderPage()
+
+    expect((await screen.findAllByRole("alert")).length).toBeGreaterThan(0)
+  })
+
   it("reports a failed read rather than an empty organization", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       jsonResponse({ detail: "nope" }, 500),

--- a/web/src/features/budgets/OrganizationBudgetsPage.tsx
+++ b/web/src/features/budgets/OrganizationBudgetsPage.tsx
@@ -1,0 +1,38 @@
+import type { OrganizationContext } from "@/client"
+import { PageHeader } from "@/shared/components/ui"
+
+import { OrganizationBudgetsCard } from "./OrganizationBudgetsCard"
+import { SpendCeilingsCard } from "./SpendCeilingsCard"
+
+// Spend & budgets, for an organization owner or admin.
+//
+// The tenant-scoped half of `BudgetsPage`, which keeps the deployment-wide page
+// an operator sees. The roles matrix (otari-ai#1943) puts this row at Edit for an
+// admin and Hidden for a member, and before this it was operator-only end to
+// end: `/v1/budgets` gates every handler on `require_deployment_operator` and
+// `/v1/scoped-budgets` gates its whole router, so a hosted organization could
+// manage neither its own caps nor where they applied.
+//
+// Two sections, because the schema has two objects and they answer different
+// questions: a budget is *what a cap is*, and a ceiling is *who is capped*. They
+// stay separate rather than merging into one table of "caps", because one budget
+// is deliberately shared by several ceilings, and a merged row would have to
+// either duplicate the figure or hide the sharing. The second is what makes
+// raising a limit one edit rather than one per place it applies.
+
+export function OrganizationBudgetsPage({
+  organization,
+}: {
+  organization: OrganizationContext
+}) {
+  return (
+    <div className="flex flex-col gap-6">
+      <PageHeader
+        title="Spend & budgets"
+        description="What this organization may spend, and where each limit applies. A request is refused when any ceiling covering it is out of headroom."
+      />
+      <OrganizationBudgetsCard />
+      <SpendCeilingsCard organizationName={organization.organization.name} />
+    </div>
+  )
+}

--- a/web/src/features/budgets/SpendCeilingDialog.tsx
+++ b/web/src/features/budgets/SpendCeilingDialog.tsx
@@ -70,10 +70,28 @@ export function SpendCeilingDialog({
     setName(editing?.name ?? "")
   }, [isOpen, editing, budgets])
 
-  const budgetOptions = budgets.map((budget) => ({
+  const ownOptions = budgets.map((budget) => ({
     value: budget.budget_id,
     label: `${budgetLabel(budget)} — ${limitLabel(budget.max_budget)}`,
   }))
+  // A ceiling holding a budget set at the deployment level opens on an id no
+  // option carries, and `FilterSelect` renders such a value as itself: a raw
+  // uuid where the budget's name belongs. Carried as its own labelled option
+  // instead, so the current selection reads as what it is and choosing one of
+  // the organization's own is still the way out.
+  const editingIsForeign =
+    editing !== undefined &&
+    !editing.manageable &&
+    !budgets.some((budget) => budget.budget_id === editing.budget_id)
+  const budgetOptions = editingIsForeign
+    ? [
+        {
+          value: editing.budget_id,
+          label: `Set at the deployment level — ${limitLabel(editing.max_budget)}`,
+        },
+        ...ownOptions,
+      ]
+    : ownOptions
 
   const targetOptions = [
     {
@@ -86,7 +104,7 @@ export function SpendCeilingDialog({
     })),
   ]
 
-  const noBudgets = budgets.length === 0
+  const noBudgets = budgetOptions.length === 0
   const blockedReason = noBudgets
     ? "Add a budget first. A ceiling enforces a budget, so there is nothing for this one to hold."
     : budgetId === ""

--- a/web/src/features/budgets/SpendCeilingDialog.tsx
+++ b/web/src/features/budgets/SpendCeilingDialog.tsx
@@ -105,11 +105,19 @@ export function SpendCeilingDialog({
   ]
 
   const noBudgets = budgetOptions.length === 0
+  // Labelling the deployment-level option is what makes the current selection
+  // readable; this is what stops it being *saved* unchanged. The endpoint
+  // resolves a ceiling's budget against the organization's own, so submitting
+  // that id is a guaranteed 404, and an enabled Save that always fails is worse
+  // than one that says what it needs.
+  const budgetIsOwned = budgets.some((budget) => budget.budget_id === budgetId)
   const blockedReason = noBudgets
     ? "Add a budget first. A ceiling enforces a budget, so there is nothing for this one to hold."
     : budgetId === ""
       ? "Choose the budget this ceiling enforces."
-      : undefined
+      : budgetIsOwned
+        ? undefined
+        : "This ceiling holds a budget set at the deployment level. Choose one of your own to take it over."
 
   const submit = () => {
     if (blockedReason !== undefined) return

--- a/web/src/features/budgets/SpendCeilingDialog.tsx
+++ b/web/src/features/budgets/SpendCeilingDialog.tsx
@@ -1,0 +1,208 @@
+import { AlertDialog, Button } from "@heroui/react"
+import { useEffect, useState } from "react"
+
+import type {
+  OrganizationBudget,
+  OrganizationSpendCeiling,
+  Workspace,
+} from "@/client"
+import { Field } from "@/shared/components/Field"
+import { ErrorBanner, FilterSelect } from "@/shared/components/ui"
+
+import { budgetLabel, limitLabel, scopeLabel } from "./organizationBudget"
+
+// The form behind both Add and Edit for a spend ceiling.
+//
+// Add and Edit differ here in a way the budget dialog's do not, and the
+// difference is the endpoint's: the scope and the provider narrowing are not
+// editable, because changing either would move the ceiling to a different
+// identity while carrying its spend, which is a delete and a create. So an edit
+// shows them as read-only facts and offers only the label and the budget.
+
+export interface SpendCeilingDraft {
+  scope_type: "organization" | "workspace"
+  scope_id: string
+  provider_key_id: string | null
+  budget_id: string
+  name: string | null
+}
+
+const ORGANIZATION_SCOPE = "organization"
+
+export interface SpendCeilingDialogProps {
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+  /** The ceiling being edited; absent means this is an add. */
+  editing?: OrganizationSpendCeiling
+  /** The organization's own budgets, which are the only ones a ceiling may name. */
+  budgets: readonly OrganizationBudget[]
+  workspaces: readonly Workspace[]
+  organizationName: string
+  isPending: boolean
+  error: unknown
+  onSubmit: (draft: SpendCeilingDraft) => void
+}
+
+export function SpendCeilingDialog({
+  isOpen,
+  onOpenChange,
+  editing,
+  budgets,
+  workspaces,
+  organizationName,
+  isPending,
+  error,
+  onSubmit,
+}: SpendCeilingDialogProps) {
+  // "organization", or a workspace id. One control rather than a kind and an id,
+  // because the two scopes this page creates are a closed list and asking for a
+  // kind first would be a step with one real choice in it.
+  const [target, setTarget] = useState(ORGANIZATION_SCOPE)
+  const [budgetId, setBudgetId] = useState("")
+  const [provider, setProvider] = useState("")
+  const [name, setName] = useState("")
+
+  useEffect(() => {
+    if (!isOpen) return
+    setTarget(ORGANIZATION_SCOPE)
+    setBudgetId(editing?.budget_id ?? budgets[0]?.budget_id ?? "")
+    setProvider(editing?.provider_key_id ?? "")
+    setName(editing?.name ?? "")
+  }, [isOpen, editing, budgets])
+
+  const budgetOptions = budgets.map((budget) => ({
+    value: budget.budget_id,
+    label: `${budgetLabel(budget)} — ${limitLabel(budget.max_budget)}`,
+  }))
+
+  const targetOptions = [
+    {
+      value: ORGANIZATION_SCOPE,
+      label: `${organizationName} (whole organization)`,
+    },
+    ...workspaces.map((workspace) => ({
+      value: workspace.id,
+      label: `${workspace.name} (workspace)`,
+    })),
+  ]
+
+  const noBudgets = budgets.length === 0
+  const blockedReason = noBudgets
+    ? "Add a budget first. A ceiling enforces a budget, so there is nothing for this one to hold."
+    : budgetId === ""
+      ? "Choose the budget this ceiling enforces."
+      : undefined
+
+  const submit = () => {
+    if (blockedReason !== undefined) return
+    onSubmit({
+      scope_type: target === ORGANIZATION_SCOPE ? "organization" : "workspace",
+      // The editing path never reaches here with a changed scope: the endpoint
+      // ignores both fields on a PATCH and the controls are not rendered.
+      scope_id: editing?.scope_id ?? target,
+      provider_key_id: provider.trim() === "" ? null : provider.trim(),
+      budget_id: budgetId,
+      name: name.trim() === "" ? null : name.trim(),
+    })
+  }
+
+  return (
+    <AlertDialog isOpen={isOpen} onOpenChange={onOpenChange}>
+      {isOpen ? (
+        <AlertDialog.Backdrop>
+          <AlertDialog.Container placement="center" size="md">
+            <AlertDialog.Dialog>
+              <AlertDialog.Header>
+                <AlertDialog.Heading>
+                  {editing ? "Edit spend ceiling" : "Add spend ceiling"}
+                </AlertDialog.Heading>
+              </AlertDialog.Header>
+              <AlertDialog.Body className="flex flex-col gap-4">
+                <p className="text-sm text-muted">
+                  A ceiling holds one identity to one budget. Every ceiling that
+                  applies to a request has to pass, so an organization-wide cap
+                  and a workspace cap both bind.
+                </p>
+                <ErrorBanner error={error} />
+                {editing ? (
+                  <div className="flex flex-col gap-1">
+                    <span className="text-sm font-medium text-foreground">
+                      Capping
+                    </span>
+                    <span className="text-sm text-muted">
+                      {scopeLabel(editing, { organizationName, workspaces })}
+                      {editing.provider_key_id
+                        ? `, on ${editing.provider_key_id}`
+                        : ", on every provider"}
+                    </span>
+                    <span className="text-xs text-muted">
+                      What a ceiling caps cannot be changed. Delete it and add
+                      one for the other identity.
+                    </span>
+                  </div>
+                ) : (
+                  <>
+                    <FilterSelect
+                      label="Capping"
+                      value={target}
+                      onChange={setTarget}
+                      options={targetOptions}
+                    />
+                    <Field
+                      label="Provider instance"
+                      value={provider}
+                      onChange={setProvider}
+                      placeholder="openai-eu"
+                      description="Optional. Narrows the cap to one provider; leave blank to cap spend across every provider."
+                    />
+                  </>
+                )}
+                <FilterSelect
+                  label="Budget"
+                  value={budgetId}
+                  onChange={setBudgetId}
+                  options={budgetOptions}
+                  disabled={noBudgets}
+                />
+                <Field
+                  label="Name"
+                  value={name}
+                  onChange={setName}
+                  placeholder="Whole organization"
+                  description="Optional. A label for this ceiling, separate from the budget's own name."
+                />
+                {editing && !editing.manageable ? (
+                  <p className="text-sm text-muted">
+                    This ceiling currently holds a budget set at the deployment
+                    level. Choosing one of your own moves it, and leaves that
+                    budget as it is.
+                  </p>
+                ) : null}
+                {blockedReason ? (
+                  <p className="text-sm text-warning">{blockedReason}</p>
+                ) : null}
+              </AlertDialog.Body>
+              <AlertDialog.Footer>
+                <Button
+                  variant="ghost"
+                  isDisabled={isPending}
+                  onPress={() => onOpenChange(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  isDisabled={blockedReason !== undefined}
+                  isPending={isPending}
+                  onPress={submit}
+                >
+                  {editing ? "Save ceiling" : "Add ceiling"}
+                </Button>
+              </AlertDialog.Footer>
+            </AlertDialog.Dialog>
+          </AlertDialog.Container>
+        </AlertDialog.Backdrop>
+      ) : null}
+    </AlertDialog>
+  )
+}

--- a/web/src/features/budgets/SpendCeilingsCard.tsx
+++ b/web/src/features/budgets/SpendCeilingsCard.tsx
@@ -1,0 +1,234 @@
+import { Button, Card, Chip } from "@heroui/react"
+import { useState } from "react"
+
+import type { OrganizationSpendCeiling } from "@/client"
+import {
+  useCreateOrganizationSpendCeiling,
+  useDeleteOrganizationSpendCeiling,
+  useOrganizationBudgets,
+  useOrganizationSpendCeilings,
+  useUpdateOrganizationSpendCeiling,
+  useWorkspaces,
+} from "@/shared/api/hooks"
+import { ConfirmDialog } from "@/shared/components/ConfirmDialog"
+import { DataTable, type DataTableColumn } from "@/shared/components/DataTable"
+import { ErrorBanner } from "@/shared/components/ui"
+import { formatDate, formatUsd } from "@/shared/helpers/format"
+
+import { limitLabel, periodLabel, scopeLabel } from "./organizationBudget"
+import {
+  SpendCeilingDialog,
+  type SpendCeilingDraft,
+} from "./SpendCeilingDialog"
+
+// Where the organization's budgets actually apply, and what has been spent
+// against each.
+//
+// Two kinds of row can appear that this card does not create. A member's ceiling
+// is set on Members & roles, beside the person it caps; and a ceiling naming a
+// budget set at the deployment level is what the otari-ai cutover writes. Both
+// are listed, because both are enforcing against this organization today and
+// leaving them out would let the page read as uncapped. The second is marked, so
+// a figure nobody here can change does not look editable.
+
+function spentLabel(ceiling: OrganizationSpendCeiling): string {
+  const spent = formatUsd(ceiling.current_spend)
+  if (ceiling.reserved_spend === 0) return spent
+  // Reserved is held against in-flight requests and settles into spend or is
+  // released, so it counts towards the cap and is not spend yet. Both shown,
+  // because a ceiling refuses on their sum.
+  return `${spent} (+${formatUsd(ceiling.reserved_spend)} held)`
+}
+
+export function SpendCeilingsCard({
+  organizationName,
+}: {
+  organizationName: string
+}) {
+  const ceilings = useOrganizationSpendCeilings()
+  const budgets = useOrganizationBudgets()
+  const workspaces = useWorkspaces()
+  const create = useCreateOrganizationSpendCeiling()
+  const update = useUpdateOrganizationSpendCeiling()
+  const remove = useDeleteOrganizationSpendCeiling()
+
+  const [isDialogOpen, setDialogOpen] = useState(false)
+  const [editing, setEditing] = useState<OrganizationSpendCeiling>()
+  const [pendingDelete, setPendingDelete] = useState<OrganizationSpendCeiling>()
+
+  const rows = ceilings.data ?? []
+  const workspaceRows = workspaces.data ?? []
+
+  const openAdd = () => {
+    setEditing(undefined)
+    setDialogOpen(true)
+  }
+
+  const openEdit = (ceiling: OrganizationSpendCeiling) => {
+    setEditing(ceiling)
+    setDialogOpen(true)
+  }
+
+  const submit = (draft: SpendCeilingDraft) => {
+    const onDone = { onSuccess: () => setDialogOpen(false) }
+    if (editing) {
+      // Only the two fields the endpoint accepts on a PATCH. Sending the scope
+      // would be ignored, and sending it anyway would suggest it could change.
+      update.mutate(
+        {
+          id: editing.id,
+          body: { budget_id: draft.budget_id, name: draft.name },
+        },
+        onDone,
+      )
+      return
+    }
+    create.mutate(draft, onDone)
+  }
+
+  const columns: DataTableColumn<OrganizationSpendCeiling>[] = [
+    {
+      id: "scope",
+      header: "Capping",
+      isRowHeader: true,
+      cell: (row) => (
+        <div className="flex flex-col gap-0.5">
+          <span className="text-sm text-foreground">
+            {scopeLabel(row, { organizationName, workspaces: workspaceRows })}
+          </span>
+          {row.name ? (
+            <span className="text-xs text-muted">{row.name}</span>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      id: "provider",
+      header: "Provider",
+      cell: (row) => row.provider_key_id ?? "Every provider",
+    },
+    {
+      id: "limit",
+      header: "Limit",
+      align: "end",
+      cell: (row) => (
+        <div className="flex flex-col items-end gap-0.5">
+          <span>{limitLabel(row.max_budget)}</span>
+          {row.manageable ? null : (
+            // Not a warning: the ceiling is correct and enforcing, it simply is
+            // not this organization's figure to change. The word "deployment"
+            // rather than any role, which is not a tenant's to see.
+            <Chip size="sm" variant="secondary">
+              Set at the deployment level
+            </Chip>
+          )}
+        </div>
+      ),
+    },
+    {
+      id: "spent",
+      header: "Spent this period",
+      align: "end",
+      cell: (row) => spentLabel(row),
+    },
+    {
+      id: "resets",
+      header: "Resets",
+      cell: (row) => (
+        <div className="flex flex-col gap-0.5">
+          <span>{periodLabel(row)}</span>
+          {row.period_end ? (
+            <span className="text-xs text-muted">
+              Next on {formatDate(row.period_end)}
+            </span>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      id: "actions",
+      header: "",
+      cell: (row) => (
+        <div className="flex justify-end gap-1">
+          <Button size="sm" variant="ghost" onPress={() => openEdit(row)}>
+            Edit
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onPress={() => setPendingDelete(row)}
+          >
+            Delete
+          </Button>
+        </div>
+      ),
+    },
+  ]
+
+  return (
+    <section className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-title">Spend ceilings</h2>
+        <Button size="sm" variant="primary" onPress={openAdd}>
+          Add ceiling
+        </Button>
+      </div>
+
+      <p className="text-sm text-muted">
+        What each budget actually caps. A request has to pass every ceiling that
+        applies to it, so an organization-wide cap and a workspace cap both
+        bind. A member&rsquo;s own ceiling is set on Members &amp; roles, beside
+        the person it caps.
+      </p>
+
+      <ErrorBanner error={ceilings.error} />
+
+      <Card>
+        <Card.Content className="p-0">
+          <DataTable
+            ariaLabel="Organization spend ceilings"
+            columns={columns}
+            rows={rows}
+            getRowKey={(row) => row.id}
+            isLoading={ceilings.isPending && !ceilings.data}
+            emptyContent="Nothing is capped yet. Add a ceiling to hold an organization or a workspace to a budget."
+          />
+        </Card.Content>
+      </Card>
+
+      <SpendCeilingDialog
+        isOpen={isDialogOpen}
+        onOpenChange={setDialogOpen}
+        editing={editing}
+        budgets={budgets.data ?? []}
+        workspaces={workspaceRows}
+        organizationName={organizationName}
+        isPending={create.isPending || update.isPending}
+        error={editing ? update.error : create.error}
+        onSubmit={submit}
+      />
+
+      <ConfirmDialog
+        isOpen={pendingDelete !== undefined}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(undefined)
+        }}
+        heading="Delete spend ceiling"
+        body={
+          pendingDelete
+            ? `${scopeLabel(pendingDelete, { organizationName, workspaces: workspaceRows })} stops being capped by this budget from the next request. The budget itself is left alone, and so is every other ceiling holding it.`
+            : null
+        }
+        confirmLabel="Delete ceiling"
+        isPending={remove.isPending}
+        error={remove.error}
+        onConfirm={() => {
+          if (!pendingDelete) return
+          remove.mutate(pendingDelete.id, {
+            onSuccess: () => setPendingDelete(undefined),
+          })
+        }}
+      />
+    </section>
+  )
+}

--- a/web/src/features/budgets/SpendCeilingsCard.tsx
+++ b/web/src/features/budgets/SpendCeilingsCard.tsx
@@ -181,7 +181,15 @@ export function SpendCeilingsCard({
         the person it caps.
       </p>
 
-      <ErrorBanner error={ceilings.error} />
+      {/* All three reads, not just the ceilings. A failed workspace roster
+          leaves the dialog with no workspace to offer and the table naming
+          "A workspace" for rows it cannot resolve, and a failed budget list
+          leaves it with nothing to hold a ceiling to; without this the owner
+          sees the consequence and never the cause. First error wins, because
+          one banner saying something true beats three stacked. */}
+      <ErrorBanner
+        error={ceilings.error ?? workspaces.error ?? budgets.error}
+      />
 
       <Card>
         <Card.Content className="p-0">

--- a/web/src/features/budgets/organizationBudget.test.ts
+++ b/web/src/features/budgets/organizationBudget.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest"
+
+import type { OrganizationBudget } from "@/client"
+import {
+  budgetLabel,
+  limitLabel,
+  PERIOD_OPTIONS,
+  periodLabel,
+  periodValue,
+  scopeLabel,
+} from "@/features/budgets/organizationBudget"
+import { workspace } from "@/tests/fixtures"
+
+function budget(
+  overrides: Partial<OrganizationBudget> = {},
+): OrganizationBudget {
+  return {
+    budget_id: "abcd1234-2222-3333-4444-555555555555",
+    organization_id: "11111111-1111-1111-1111-111111111111",
+    name: null,
+    max_budget: 250,
+    budget_duration_sec: null,
+    reset_alignment: "calendar_month",
+    ceiling_count: 0,
+    created_at: "2026-01-01T00:00:00+00:00",
+    updated_at: "2026-01-01T00:00:00+00:00",
+    ...overrides,
+  }
+}
+
+describe("limitLabel", () => {
+  it("says an absent limit is no limit, not zero", () => {
+    // A budget with no `max_budget` admits every request, which is the opposite
+    // of what "$0.00" reads as.
+    expect(limitLabel(null)).toBe("No limit")
+    expect(limitLabel(undefined)).toBe("No limit")
+  })
+
+  it("formats a real limit as money", () => {
+    expect(limitLabel(250)).toContain("250")
+  })
+
+  it("keeps a zero limit distinct from an absent one", () => {
+    // Zero is a real cap that refuses everything, and an operator can set it.
+    expect(limitLabel(0)).not.toBe("No limit")
+  })
+})
+
+describe("periodLabel", () => {
+  it("names each calendar boundary with the instant it resets on", () => {
+    expect(
+      periodLabel({
+        reset_alignment: "calendar_day",
+        budget_duration_sec: null,
+      }),
+    ).toContain("UTC midnight")
+    expect(
+      periodLabel({
+        reset_alignment: "calendar_week",
+        budget_duration_sec: null,
+      }),
+    ).toContain("Monday")
+    expect(
+      periodLabel({
+        reset_alignment: "calendar_month",
+        budget_duration_sec: null,
+      }),
+    ).toContain("1st")
+  })
+
+  it("says a duration is measured from the last reset, not from a clock time", () => {
+    // The distinction the page exists to keep honest: 86400 does not mean
+    // "resets at midnight", it means "at least 24 hours, restarted on next use".
+    const label = periodLabel({
+      reset_alignment: null,
+      budget_duration_sec: 86_400,
+    })
+    expect(label).toContain("1 day")
+    expect(label).toContain("from the last reset")
+  })
+
+  it("falls back to seconds for a duration that is not whole hours", () => {
+    expect(
+      periodLabel({ reset_alignment: null, budget_duration_sec: 90 }),
+    ).toBe("Every 90s, from the last reset")
+  })
+
+  it("says never when a budget carries no period at all", () => {
+    expect(
+      periodLabel({ reset_alignment: null, budget_duration_sec: null }),
+    ).toBe("Never")
+  })
+
+  it("prefers the alignment when a row somehow carries both", () => {
+    // The database refuses the pair, so this is unreachable through either
+    // surface; asserted because the alignment is the one that actually governs
+    // the reset in `_aligned_window`, so a row read from a hand-edited database
+    // should not be described by the field that is ignored.
+    expect(
+      periodLabel({
+        reset_alignment: "calendar_month",
+        budget_duration_sec: 86_400,
+      }),
+    ).toContain("1st")
+  })
+})
+
+describe("periodValue", () => {
+  it("opens the form on the budget's own boundary", () => {
+    expect(periodValue(budget({ reset_alignment: "calendar_day" }))).toBe(
+      "calendar_day",
+    )
+  })
+
+  it("defaults a new budget to monthly", () => {
+    expect(periodValue(undefined)).toBe("calendar_month")
+  })
+
+  it("opens on no reset for a duration the form cannot express", () => {
+    // Rather than proposing a boundary the budget never had. The dialog warns
+    // that saving replaces the duration, which is the honest version of this.
+    expect(
+      periodValue(
+        budget({ reset_alignment: null, budget_duration_sec: 86_400 }),
+      ),
+    ).toBe("none")
+  })
+
+  it("only ever returns a value the picker offers", () => {
+    const offered = PERIOD_OPTIONS.map((option) => option.value)
+    for (const alignment of [
+      "calendar_day",
+      "calendar_week",
+      "calendar_month",
+    ]) {
+      expect(offered).toContain(
+        periodValue(budget({ reset_alignment: alignment })),
+      )
+    }
+    expect(offered).toContain(periodValue(undefined))
+  })
+})
+
+describe("budgetLabel", () => {
+  it("uses the name when there is one", () => {
+    expect(budgetLabel(budget({ name: "Engineering monthly" }))).toBe(
+      "Engineering monthly",
+    )
+  })
+
+  it("falls back to the head of the id, which is what an operator can match on", () => {
+    expect(budgetLabel(budget({ name: null }))).toBe("abcd1234")
+  })
+})
+
+describe("scopeLabel", () => {
+  const context = {
+    organizationName: "Acme",
+    workspaces: [workspace({ name: "Engineering" })],
+  }
+
+  it("names the organization and says it is the whole of it", () => {
+    expect(
+      scopeLabel(
+        { scope_type: "organization", scope_id: "irrelevant" },
+        context,
+      ),
+    ).toBe("Acme (whole organization)")
+  })
+
+  it("resolves a workspace id to its name", () => {
+    expect(
+      scopeLabel(
+        { scope_type: "workspace", scope_id: workspace().id },
+        context,
+      ),
+    ).toBe("Engineering (workspace)")
+  })
+
+  it("does not invent a name for a workspace it has not loaded", () => {
+    // The roster read can fail or still be in flight, and a ceiling is real
+    // either way. "A workspace" is less than the truth and none of it is wrong.
+    expect(
+      scopeLabel(
+        {
+          scope_type: "workspace",
+          scope_id: "77777777-7777-7777-7777-777777777777",
+        },
+        context,
+      ),
+    ).toBe("A workspace")
+  })
+
+  it("names a membership or a key by kind and a short id", () => {
+    // Neither has a name this page has read, and a membership id is not a
+    // person's name. The kind plus enough id to match on is what it can say.
+    expect(
+      scopeLabel(
+        {
+          scope_type: "workspace_member",
+          scope_id: "12345678-9999-9999-9999-999999999999",
+        },
+        context,
+      ),
+    ).toBe("A workspace member (12345678…)")
+    expect(
+      scopeLabel({ scope_type: "api_token", scope_id: "sk-abc" }, context),
+    ).toBe("An API key (sk-abc)")
+  })
+
+  it("falls back to the raw kind for a scope a newer gateway added", () => {
+    expect(
+      scopeLabel({ scope_type: "something_new", scope_id: "x" }, context),
+    ).toBe("something_new")
+  })
+})

--- a/web/src/features/budgets/organizationBudget.ts
+++ b/web/src/features/budgets/organizationBudget.ts
@@ -7,11 +7,26 @@
  */
 
 import type {
+  CreateOrganizationBudget,
   OrganizationBudget,
   OrganizationSpendCeiling,
   Workspace,
 } from "@/client"
 import { formatUsd } from "@/shared/helpers/format"
+
+/**
+ * The calendar boundaries the API accepts, derived from the generated client
+ * rather than restated here.
+ *
+ * Restating them as `string` is what broke the build once: the endpoint narrowed
+ * `reset_alignment` to a three-value enum and every local `string` stopped
+ * assigning to it. Deriving the type means the next change to that enum is a
+ * type error at the two places that construct one, not a widening that compiles
+ * and sends a value the server refuses.
+ */
+export type ResetAlignment = NonNullable<
+  CreateOrganizationBudget["reset_alignment"]
+>
 
 /**
  * The periods this page offers, as calendar boundaries rather than seconds.
@@ -31,7 +46,7 @@ import { formatUsd } from "@/shared/helpers/format"
 export const PERIOD_OPTIONS: readonly {
   value: string
   label: string
-  alignment: string | undefined
+  alignment: ResetAlignment | undefined
 }[] = [
   { value: "none", label: "No reset", alignment: undefined },
   { value: "calendar_day", label: "Daily", alignment: "calendar_day" },

--- a/web/src/features/budgets/organizationBudget.ts
+++ b/web/src/features/budgets/organizationBudget.ts
@@ -1,0 +1,132 @@
+/**
+ * The vocabulary the organization's Spend page is written in.
+ *
+ * Pure derivations, in their own module so the two cards and their dialogs share
+ * one answer rather than three: what a period is called, what a budget's figure
+ * reads as, and how a ceiling's scope is named on screen.
+ */
+
+import type {
+  OrganizationBudget,
+  OrganizationSpendCeiling,
+  Workspace,
+} from "@/client"
+import { formatUsd } from "@/shared/helpers/format"
+
+/**
+ * The periods this page offers, as calendar boundaries rather than seconds.
+ *
+ * The API accepts either (`reset_alignment` or `budget_duration_sec`, never
+ * both), and this surface deliberately only writes the first. A duration is a
+ * rolling integer measured from the last reset, so "86400" does not mean "resets
+ * at midnight", it means "at least 24 hours, restarted on the next request":
+ * on a quiet workspace the reset walks through the morning and stays there. And
+ * a month has no duration at all, since 30 days is a 1.5 percent more generous
+ * product than a calendar month. An admin picking "Monthly" means the calendar,
+ * so that is what is stored.
+ *
+ * A ceiling created by the deployment surface may still carry a duration, which
+ * is why `periodLabel` reads both.
+ */
+export const PERIOD_OPTIONS: readonly {
+  value: string
+  label: string
+  alignment: string | undefined
+}[] = [
+  { value: "none", label: "No reset", alignment: undefined },
+  { value: "calendar_day", label: "Daily", alignment: "calendar_day" },
+  { value: "calendar_week", label: "Weekly", alignment: "calendar_week" },
+  { value: "calendar_month", label: "Monthly", alignment: "calendar_month" },
+]
+
+const ALIGNMENT_LABELS: Record<string, string> = {
+  calendar_day: "Daily, at UTC midnight",
+  calendar_week: "Weekly, Monday 00:00 UTC",
+  calendar_month: "Monthly, the 1st at 00:00 UTC",
+}
+
+const HOUR = 3_600
+const DAY = 86_400
+
+/** Which `PERIOD_OPTIONS` value a stored budget corresponds to, for the form. */
+export function periodValue(budget: OrganizationBudget | undefined): string {
+  if (!budget) return "calendar_month"
+  if (budget.reset_alignment) return budget.reset_alignment
+  // A duration-based budget has no option of its own here, so the form opens on
+  // "No reset" rather than silently proposing to convert it. Saving would then
+  // clear the duration, which the field description says.
+  return "none"
+}
+
+/** How a period reads in a table cell, for either way a budget can carry one. */
+export function periodLabel(
+  budget: Pick<OrganizationBudget, "reset_alignment" | "budget_duration_sec">,
+): string {
+  if (budget.reset_alignment) {
+    return ALIGNMENT_LABELS[budget.reset_alignment] ?? budget.reset_alignment
+  }
+  const seconds = budget.budget_duration_sec
+  if (seconds === null || seconds === undefined) return "Never"
+  if (seconds % DAY === 0) {
+    const days = seconds / DAY
+    return `Every ${days} ${days === 1 ? "day" : "days"}, from the last reset`
+  }
+  if (seconds % HOUR === 0) {
+    const hours = seconds / HOUR
+    return `Every ${hours} ${hours === 1 ? "hour" : "hours"}, from the last reset`
+  }
+  return `Every ${seconds}s, from the last reset`
+}
+
+/** A budget's cap, where an absent one is uncapped rather than zero. */
+export function limitLabel(value: number | null | undefined): string {
+  // Not `formatUsd(0)`: a budget with no `max_budget` admits every request,
+  // which is the opposite of what "$0.00" reads as.
+  if (value === null || value === undefined) return "No limit"
+  return formatUsd(value)
+}
+
+/** How a budget is named on screen: its label, else the head of its id. */
+export function budgetLabel(
+  budget: Pick<OrganizationBudget, "name" | "budget_id">,
+): string {
+  return budget.name ?? budget.budget_id.split("-")[0]
+}
+
+/**
+ * What a ceiling caps, in words.
+ *
+ * `scope_id` is a bare id on the wire, so a name has to be resolved from
+ * something the page already read. Workspaces and the organization itself have
+ * one; a membership or an API key does not, and its kind plus the head of its id
+ * is more honest than a name invented here. Those two kinds are not creatable on
+ * this page (a member's ceiling is set on Members & roles), so what this renders
+ * is either a row created here or one the otari-ai cutover wrote.
+ */
+export function scopeLabel(
+  ceiling: Pick<OrganizationSpendCeiling, "scope_type" | "scope_id">,
+  context: { organizationName: string; workspaces: readonly Workspace[] },
+): string {
+  switch (ceiling.scope_type) {
+    case "organization":
+      return `${context.organizationName} (whole organization)`
+    case "workspace": {
+      const workspace = context.workspaces.find(
+        (candidate) => candidate.id === ceiling.scope_id,
+      )
+      return workspace ? `${workspace.name} (workspace)` : "A workspace"
+    }
+    case "workspace_member":
+      return `A workspace member (${shortId(ceiling.scope_id)})`
+    case "org_member":
+      return `An organization member (${shortId(ceiling.scope_id)})`
+    case "api_token":
+      return `An API key (${shortId(ceiling.scope_id)})`
+    default:
+      return ceiling.scope_type
+  }
+}
+
+function shortId(value: string): string {
+  return value.length > 8 ? `${value.slice(0, 8)}…` : value
+}

--- a/web/src/shared/api/hooks.ts
+++ b/web/src/shared/api/hooks.ts
@@ -3153,8 +3153,9 @@ export function useCreateOrganizationBudget() {
   })
 }
 
-// PATCH, not PUT: an omitted field is left alone, so the form sends only what it
-// changed and clearing a cap back to uncapped is a delete rather than a null.
+// PATCH, not PUT: an omitted field is left alone and an explicit null clears it,
+// which is what lets the dialog send `max_budget: null` to take a budget back to
+// uncapped without deleting it.
 export function useUpdateOrganizationBudget() {
   const queryClient = useQueryClient()
   return useMutation({

--- a/web/src/shared/api/hooks.ts
+++ b/web/src/shared/api/hooks.ts
@@ -17,11 +17,13 @@ import type {
   CreateBudgetRequest,
   CreateKeyRequest,
   CreateKeyResponse,
+  CreateOrganizationBudget,
   CreateOrganizationGuardrailRequest,
   CreateOrganizationMemberRequest,
   CreateOrganizationMemberResult,
   CreateOrganizationPricingOverride,
   CreateOrganizationRequest,
+  CreateOrganizationSpendCeiling,
   CreateOrgProviderKeyRequest,
   CreateOwnKeyRequest,
   CreateScopedBudgetRequest,
@@ -50,10 +52,12 @@ import type {
   ModelListResponse,
   ModelMetadataResponse,
   Organization,
+  OrganizationBudget,
   OrganizationContext,
   OrganizationGuardrail,
   OrganizationMember,
   OrganizationPricingOverride,
+  OrganizationSpendCeiling,
   OrgProviderKey,
   Passkey,
   PasskeysResponse,
@@ -93,10 +97,12 @@ import type {
   UpdateBudgetRequest,
   UpdateDeploymentUserRequest,
   UpdateKeyRequest,
+  UpdateOrganizationBudget,
   UpdateOrganizationGuardrailRequest,
   UpdateOrganizationMemberRequest,
   UpdateOrganizationPricingOverride,
   UpdateOrganizationRequest,
+  UpdateOrganizationSpendCeiling,
   UpdateOrgProviderKeyRequest,
   UpdateOwnKeyRequest,
   UpdateScopedBudgetRequest,
@@ -180,6 +186,12 @@ const DEPLOYMENT_ADMIN = "deployment-admin"
 // key is: the organization context is read on nearly every page, and a rate
 // edit should not make all of them refetch.
 const ORGANIZATION_PRICING = "organization-pricing"
+// The organization's own budgets and ceilings, keyed apart from BUDGETS and
+// SCOPED_BUDGETS above: those are the deployment-wide reads, which answer 403
+// to a tenant, so one key for both would serve a cached operator answer to an
+// admin and invalidate reads neither caller can make.
+const ORGANIZATION_BUDGETS = "organization-budgets"
+const ORGANIZATION_SPEND_CEILINGS = "organization-spend-ceilings"
 const ORGANIZATION_GUARDRAILS = "organization-guardrails"
 // The organization's own upstream provider credentials. Its own key for the
 // reason the two above have one: this is read by one page, and a credential
@@ -3070,6 +3082,148 @@ export function useDeleteOrganizationPricing() {
         method: "DELETE",
       }),
     onSuccess: () => invalidateOrganizationPricing(queryClient),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// The organization's own budgets and spend ceilings
+//
+// The tenant-scoped counterpart to `useBudgets` / `useScopedBudgets` above,
+// which read `/v1/budgets` and `/v1/scoped-budgets` and have answered 403 to
+// anyone who does not operate the deployment since #821. These read the
+// caller's own organization instead, and are owner-or-admin on both halves:
+// unlike the rate overrides, a cap is a statement about what colleagues may
+// spend, so the roles matrix has it Hidden for a member (otari-ai#1943).
+//
+// A ceiling naming a budget the organization does not own reports `manageable`
+// false. Those are what the otari-ai cutover writes, and they are listed rather
+// than hidden because they are enforcing today; the page offers to move one onto
+// one of the organization's own budgets instead of pretending it can edit the
+// figure.
+// ---------------------------------------------------------------------------
+
+export function useOrganizationBudgets(enabled = true) {
+  return useQuery({
+    queryKey: [ORGANIZATION_BUDGETS],
+    // Paged through with the tenancy walker rather than read in one shot, for
+    // the reason `useOrganizationPricing` gives: the endpoint caps `limit`
+    // server-side, and the cap is what would silently truncate a long-lived
+    // organization's list.
+    queryFn: () =>
+      fetchAllPaged<OrganizationBudget>("/v1/organizations/me/budgets"),
+    staleTime: 60_000,
+    enabled,
+  })
+}
+
+export function useOrganizationSpendCeilings(enabled = true) {
+  return useQuery({
+    queryKey: [ORGANIZATION_SPEND_CEILINGS],
+    queryFn: () =>
+      fetchAllPaged<OrganizationSpendCeiling>(
+        "/v1/organizations/me/spend-ceilings",
+      ),
+    staleTime: 60_000,
+    enabled,
+  })
+}
+
+// Both keys move together on every write. A budget's figure is read *through*
+// the budget by every ceiling naming it, so changing one changes what those
+// ceilings report; and creating a ceiling changes a budget's `ceiling_count`,
+// which is what makes its delete refuse.
+function invalidateOrganizationSpend(
+  queryClient: ReturnType<typeof useQueryClient>,
+) {
+  void queryClient.invalidateQueries({ queryKey: [ORGANIZATION_BUDGETS] })
+  void queryClient.invalidateQueries({
+    queryKey: [ORGANIZATION_SPEND_CEILINGS],
+  })
+}
+
+export function useCreateOrganizationBudget() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (body: CreateOrganizationBudget) =>
+      apiFetch<OrganizationBudget>("/v1/organizations/me/budgets", {
+        method: "POST",
+        body: JSON.stringify(body),
+      }),
+    onSuccess: () => invalidateOrganizationSpend(queryClient),
+  })
+}
+
+// PATCH, not PUT: an omitted field is left alone, so the form sends only what it
+// changed and clearing a cap back to uncapped is a delete rather than a null.
+export function useUpdateOrganizationBudget() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      id,
+      body,
+    }: {
+      id: string
+      body: UpdateOrganizationBudget
+    }) =>
+      apiFetch<OrganizationBudget>(
+        `/v1/organizations/me/budgets/${encodeURIComponent(id)}`,
+        { method: "PATCH", body: JSON.stringify(body) },
+      ),
+    onSuccess: () => invalidateOrganizationSpend(queryClient),
+  })
+}
+
+export function useDeleteOrganizationBudget() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiFetch<{ message: string }>(
+        `/v1/organizations/me/budgets/${encodeURIComponent(id)}`,
+        { method: "DELETE" },
+      ),
+    onSuccess: () => invalidateOrganizationSpend(queryClient),
+  })
+}
+
+export function useCreateOrganizationSpendCeiling() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (body: CreateOrganizationSpendCeiling) =>
+      apiFetch<OrganizationSpendCeiling>(
+        "/v1/organizations/me/spend-ceilings",
+        { method: "POST", body: JSON.stringify(body) },
+      ),
+    onSuccess: () => invalidateOrganizationSpend(queryClient),
+  })
+}
+
+export function useUpdateOrganizationSpendCeiling() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      id,
+      body,
+    }: {
+      id: string
+      body: UpdateOrganizationSpendCeiling
+    }) =>
+      apiFetch<OrganizationSpendCeiling>(
+        `/v1/organizations/me/spend-ceilings/${encodeURIComponent(id)}`,
+        { method: "PATCH", body: JSON.stringify(body) },
+      ),
+    onSuccess: () => invalidateOrganizationSpend(queryClient),
+  })
+}
+
+export function useDeleteOrganizationSpendCeiling() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiFetch<{ message: string }>(
+        `/v1/organizations/me/spend-ceilings/${encodeURIComponent(id)}`,
+        { method: "DELETE" },
+      ),
+    onSuccess: () => invalidateOrganizationSpend(queryClient),
   })
 }
 


### PR DESCRIPTION
## Description

Second half of otari-ai#1943. The [11 Aug roles matrix](https://github.com/mozilla-ai/otari-ai/issues/1946) puts **Spend & budgets** at Hidden for members and **Edit for admins**, and both routers refused a tenant outright: `/v1/budgets` gates every handler on `require_deployment_operator`, `/v1/scoped-budgets` gates its whole router. There was also nothing for a tenant-scoped surface to scope *to*, because a budget had no owner.

> #872 has merged; this is retargeted to `main` and rebased, so it is its own commits.
>
> **On the diff size:** of ~6,000 added lines, 1,838 are the three regenerated artifacts (`openapi.json`, the Postman collection, `web/src/client/schema.ts`), 1,751 are tests across 10 files, and 2,430 are source and docs across 19.

### Backend

`budgets.organization_id` (revision `b7e1c4a9d2f5`) is the owner, and two routers write it:

| Endpoint | Answers |
| --- | --- |
| `/v1/organizations/me/budgets` | **what a cap is**: a USD figure and the period it is spent over |
| `/v1/organizations/me/spend-ceilings` | **who is capped**: the org, a workspace, a membership in either, or a key |

Both are owner-or-admin for **reads as well as writes**, which is stricter than the rate overrides on purpose: the matrix has this Hidden for a member, where a rate is a read they get. A rate is what you are billed at; a cap is a statement about what colleagues may spend.

Every scope is resolved to its organization before use, and every budget is filtered on `organization_id` in the query. A scope id travels as a bare UUID with nothing in it saying whose it is, so an unresolved one is the whole of the cross-tenant risk here. Both refuse with 404, never 403, so another tenant's row is indistinguishable from one that never existed.

### `organization_id IS NULL` means the deployment's own

No route here lists, offers or repoints one, so from a tenant's side a deployment budget does not exist. That is deliberate rather than incidental: the otari-ai cutover mints **one budget per distinct `(cap, period)` shape**, shared across the ceilings it writes, so a shape held by two tenants has no single owner.

Such a ceiling is still **listed**, with its real figures and `manageable: false`, because it is enforcing against the organization today and hiding it would let the page read as uncapped. Repointing it at one of the organization's own budgets is the way out, per ceiling, and never edits the shared row.

### Migration

Nullable, and the backfill assigns ownership **only** on a deployment with exactly one organization, where the operator is already that organization's owner, so it grants nobody anything they did not hold. A multi-organization deployment is left completely alone: assigning there would hand one tenant's admins a cap set above them. That population is the hosted one and is the cutover's to resolve.

The cutover script needs no change to keep working (its preflight refuses on a *missing* column and its inserts name theirs explicitly), but the **data** consequence is real: migrated budgets land unowned, so hosted admins get a read-only page until the planner keys minted budgets on `(shape, organization)` and stamps the owner. That is a follow-up in `otari-ai` on `otari_v1`, not a dependency: this degrades gracefully without it.

### Also closed here

`workspace_budget_default_service` validated that a `budget_id` existed but not whose it was. Harmless while every budget was the deployment's; with an owner column, an unchecked id would let one organization's admin hand their workspace another organization's budget and then move that tenant's cap by editing it. A budget with **no** organization stays nameable, or upgrade would refuse every default that already exists.

### Frontend

`/budgets` resolves to two pages, the way Routing picks between its two reads since #867: an operator keeps the deployment's budgets, and an owner or admin gets their own organization's. The nav row drops `operatorOnly` rather than loosening it, because there is no longer a caller the destination refuses.

Three things the page says carefully: no spend column on a budget (the deployment page sums `users.spend`, which has no tenancy column, so the same figure would be a cross-tenant read); a ceiling the organization does not own is marked "Set at the deployment level", naming **no role**, since an operator is internal and not a tenant's to see, which a test pins; and periods are written as calendar boundaries, never durations, because 30 days is a 1.5 percent more generous product than the calendar month an admin means by "Monthly".

### Review findings

Copilot raised one, CodeRabbit four, all five addressed and resolved on their threads: a blank `provider_key_id` storing a ceiling that binds to nothing; a budget cadence change leaving linked ceiling windows stale (the serious one, see below); a `standalone mode only` docstring that is wrong for hosted; the ceilings card showing only one of its three reads' errors; and a `no-any-return` that failed CI's typecheck.

The cadence one deserves calling out because it was worse than the report: `_roll_expired_periods` only updates a row whose `period_end` is not null, so a budget moved from "no reset" to a periodic cadence left its ceilings with **NULL windows that never roll**, accumulating spend forever while the API reported the new cadence.

One finding skipped, with a reason: CodeRabbit asked for the scope-membership filter to move from Python into SQL. It cannot portably. `scoped_budgets.scope_id` is a string written as `str(uuid)`, while SQLAlchemy's `Uuid` stores as CHAR(32) on SQLite, so an SQL-side comparison would match dashed against undashed there and silently return no ceilings at all. `WorkspaceService._delete_scoped_budgets_for` resolves the same ids the same way for the same reason.

### Deliberately out of scope

Per-member spend ceilings stay on Members & roles and stay operator-gated. That is a different row in the matrix and is tracked separately in otari-ai#1946.

**Correction to an earlier version of this section**, which said the two `provider_key_id` siblings were both "operator-facing contracts this PR does not own". That was wrong about one of them, and it understated it:

- `WorkspaceMemberBudgetPolicyCreate` is **tenant-reachable**, not operator-facing: it is gated on `require_workspace_management_access`, which grants an organization or workspace owner/admin, and `materialize_for_default` copies the field verbatim into a ceiling per member. A tenant admin sending `""` therefore fanned out a never-binding ceiling across a whole workspace. **Fixed here.**
- `PATCH /v1/budgets/{id}` had the same un-retimed cadence bug. It is operator-only, but this PR is what put tenant data in its reach: budgets now carry `organization_id` while `/v1/budgets` still sees all of them, so an operator editing a cadence there could leave a *tenant's* ceilings with NULL windows that never roll. **Fixed here**, with the retiming logic moved to a leaf module both surfaces share rather than duplicated.
- `CreateScopedBudgetRequest` on `/v1/scoped-budgets` is genuinely operator-only and keeps the unconstrained field. Left as a follow-up, because narrowing it turns a previously accepted input into a 422 on a published operator API.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Refs mozilla-ai/otari-ai#1943, mozilla-ai/otari-ai#1946

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

`make lint`, `make typecheck` (544 files), `make openapi-check` and `make postman-check` all clean. Backend: the full integration and unit suites pass, including 36 route and tenant-boundary tests, 7 migration-chain tests over all three deployment populations, and 3 pinning the scope roster against `ScopeType`. Frontend: `pnpm --dir web run lint`, `typecheck`, and 1806 tests passing, 34 of them new. `/budgets` already has a screenshot entry and the route is unchanged.

**Correction to an earlier version of this checklist:** it claimed the Definition of Done checks had been run locally, but types were checked with `mypy src/gateway` rather than `make typecheck`, which is bare `uv run mypy` and covers the tests as well. That is how a `no-any-return` in one of this branch's own test helpers reached CI. `make typecheck` is now run and clean.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

Implemented from the roles-matrix audit in otari-ai#1946, against the cutover contract in that repo's `docs/budget-migration.md`. Reviewed by the author before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added organization-owned budgets and spend ceilings.
- Limited organization budget management to owners and admins.
- Added organization budget API routes, frontend pages, forms, and data hooks.
- Preserved deployment-wide budgets and marked their ceilings as non-manageable in organization views.
- Enforced organization boundaries for budgets, workspaces, and scopes.
- Retimed spend-ceiling periods when budget cadence changes.
- Rejected blank provider identifiers and invalid reset alignments.
- Added safe migration backfill rules and tests for routes, boundaries, migrations, cadence changes, and frontend behavior.

## Technical notes

- Prevented deletion of budgets assigned to gateway users.
- Added deployment and organization access handling to the budgets page.
- Regenerated API artifacts and updated dashboard documentation and Postman examples.
- Per-member spend ceilings remain out of scope.
- Operator-only scoped-budget provider validation remains tracked separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->