### PR TITLE
refactor(dashboard): gate the pricing warning on the operator signal

### DIFF
--- a/web/src/features/models/PricingWarning.test.tsx
+++ b/web/src/features/models/PricingWarning.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type { ReactElement } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
-import type { GatewaySettings } from "@/client"
+import type { GatewaySettings, OrganizationContext } from "@/client"
 import { PricingWarning } from "@/features/models/PricingWarning"
 import { organizationContext } from "@/tests/fixtures"
 import { withRouter } from "@/tests/router"
@@ -26,10 +26,13 @@ function jsonResponse(body: unknown, status = 200): Response {
   })
 }
 
+// A context the caller has, or the status the read failed with.
+type ContextResult = OrganizationContext | { failsWith: number }
+
 function mockSettings(
   settings: GatewaySettings,
   rejectedInLastHour = 0,
-  context = organizationContext(),
+  context: ContextResult = organizationContext(),
 ) {
   let current = { ...settings }
   return vi
@@ -41,7 +44,9 @@ function mockSettings(
       // routes or the organization-scoped ones (otari#837). Answered first, and
       // on an exact match, so it cannot shadow /v1/organizations/me/usage.
       if (url.endsWith("/v1/organizations/me")) {
-        return jsonResponse(context)
+        return "failsWith" in context
+          ? jsonResponse({ detail: "Not found" }, context.failsWith)
+          : jsonResponse(context)
       }
       const method = (init?.method ?? "GET").toUpperCase()
       if (url.includes("/v1/settings")) {
@@ -82,7 +87,9 @@ function renderPage(
 // the gate was still undecided.
 async function settleContext(client: QueryClient) {
   await waitFor(() =>
-    expect(client.getQueryData(["organizations", "context"])).toBeDefined(),
+    expect(client.getQueryState(["organizations", "context"])?.status).not.toBe(
+      "pending",
+    ),
   )
 }
 
@@ -273,6 +280,27 @@ describe("PricingWarning", () => {
     expect(
       screen.queryByRole("button", { name: "Enable default pricing" }),
     ).not.toBeInTheDocument()
+  })
+
+  it("still alarms an operator whose organization context fails to load", async () => {
+    // `/v1/settings` refuses with a 403, not a 404, so a failed read of the
+    // signal fails open the way an `operatorOnly: "refused"` rail row does
+    // (`nav/types.ts`). The banner is the only thing reporting that the gateway
+    // is dropping traffic, so withholding it on an unrelated failure strands the
+    // one person who can act.
+    mockSettings(
+      { ...BASE, require_pricing: true, default_pricing: false },
+      12,
+      {
+        failsWith: 404,
+      },
+    )
+    renderPage(<PricingWarning />)
+
+    expect(await screen.findByText(/Requests are rejected/)).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Enable default pricing" }),
+    ).toBeInTheDocument()
   })
 
   it("can be dismissed", async () => {

--- a/web/src/features/models/PricingWarning.test.tsx
+++ b/web/src/features/models/PricingWarning.test.tsx
@@ -26,7 +26,11 @@ function jsonResponse(body: unknown, status = 200): Response {
   })
 }
 
-function mockSettings(settings: GatewaySettings, rejectedInLastHour = 0) {
+function mockSettings(
+  settings: GatewaySettings,
+  rejectedInLastHour = 0,
+  context = organizationContext(),
+) {
   let current = { ...settings }
   return vi
     .spyOn(globalThis, "fetch")
@@ -37,7 +41,7 @@ function mockSettings(settings: GatewaySettings, rejectedInLastHour = 0) {
       // routes or the organization-scoped ones (otari#837). Answered first, and
       // on an exact match, so it cannot shadow /v1/organizations/me/usage.
       if (url.endsWith("/v1/organizations/me")) {
-        return jsonResponse(organizationContext())
+        return jsonResponse(context)
       }
       const method = (init?.method ?? "GET").toUpperCase()
       if (url.includes("/v1/settings")) {
@@ -215,6 +219,30 @@ describe("PricingWarning", () => {
     expect(
       fetchMock.mock.calls.some(([u]) => String(u).includes("/v1/usage/count")),
     ).toBe(false)
+  })
+
+  it("asks nothing of the operator-only settings route for a tenant", async () => {
+    // The alarm and the button that clears it are both deployment-operator-only,
+    // so a caller who does not operate the deployment must not fire the read
+    // that feeds a banner they could never be shown (#834).
+    const fetchMock = mockSettings(
+      { ...BASE, require_pricing: true, default_pricing: false },
+      12,
+      organizationContext({ deployment_operator: false }),
+    )
+    renderPage(<PricingWarning />)
+
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(([u]) =>
+          String(u).endsWith("/v1/organizations/me"),
+        ),
+      ).toBe(true),
+    )
+    expect(
+      fetchMock.mock.calls.some(([u]) => String(u).includes("/v1/settings")),
+    ).toBe(false)
+    expect(screen.queryByText(/Requests are rejected/)).not.toBeInTheDocument()
   })
 
   it("can be dismissed", async () => {

--- a/web/src/features/models/PricingWarning.test.tsx
+++ b/web/src/features/models/PricingWarning.test.tsx
@@ -66,13 +66,23 @@ function countWindows(fetchMock: FetchMock): string[] {
     .map((u) => String(new URLSearchParams(u.split("?")[1]).get("start_date")))
 }
 
-function renderPage(ui: ReactElement) {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+function renderPage(
+  ui: ReactElement,
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+) {
+  render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>, {
+    wrapper: withRouter(),
   })
-  return render(
-    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
-    { wrapper: withRouter() },
+  return client
+}
+
+// Resolves once the organization context has landed in the cache, which is when
+// the operator gate has an answer. `fetch` having been called only says the
+// request started, so an absence asserted on that alone would also hold while
+// the gate was still undecided.
+async function settleContext(client: QueryClient) {
+  await waitFor(() =>
+    expect(client.getQueryData(["organizations", "context"])).toBeDefined(),
   )
 }
 
@@ -230,19 +240,40 @@ describe("PricingWarning", () => {
       12,
       organizationContext({ deployment_operator: false }),
     )
-    renderPage(<PricingWarning />)
+    const client = renderPage(<PricingWarning />)
 
-    await waitFor(() =>
-      expect(
-        fetchMock.mock.calls.some(([u]) =>
-          String(u).endsWith("/v1/organizations/me"),
-        ),
-      ).toBe(true),
-    )
+    await settleContext(client)
     expect(
       fetchMock.mock.calls.some(([u]) => String(u).includes("/v1/settings")),
     ).toBe(false)
     expect(screen.queryByText(/Requests are rejected/)).not.toBeInTheDocument()
+  })
+
+  it("keeps an operator's cached settings out of a tenant's shell", async () => {
+    // A disabled query still serves whatever sits under its key, and the query
+    // client outlives a sign-out, so the session that follows an operator's in
+    // the same tab would otherwise be shown their banner and a button that
+    // would be refused.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    client.setQueryData(["settings"], {
+      ...BASE,
+      require_pricing: true,
+      default_pricing: false,
+    } satisfies GatewaySettings)
+    mockSettings(
+      { ...BASE, require_pricing: true, default_pricing: false },
+      12,
+      organizationContext({ deployment_operator: false }),
+    )
+    renderPage(<PricingWarning />, client)
+
+    await settleContext(client)
+    expect(screen.queryByText(/Requests are rejected/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Enable default pricing" }),
+    ).not.toBeInTheDocument()
   })
 
   it("can be dismissed", async () => {

--- a/web/src/features/models/PricingWarning.test.tsx
+++ b/web/src/features/models/PricingWarning.test.tsx
@@ -249,11 +249,10 @@ describe("PricingWarning", () => {
     expect(screen.queryByText(/Requests are rejected/)).not.toBeInTheDocument()
   })
 
-  it("keeps an operator's cached settings out of a tenant's shell", async () => {
-    // A disabled query still serves whatever sits under its key, and the query
-    // client outlives a sign-out, so the session that follows an operator's in
-    // the same tab would otherwise be shown their banner and a button that
-    // would be refused.
+  it("keeps cached settings out of the banner once the caller is not an operator", async () => {
+    // A disabled query still serves whatever sits under its key, so a caller
+    // demoted mid-session would otherwise keep the banner, and a button that
+    // PATCHes a route now refusing them.
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     })

--- a/web/src/features/models/PricingWarning.tsx
+++ b/web/src/features/models/PricingWarning.tsx
@@ -33,11 +33,17 @@ export function PricingWarning() {
   // `useProviderKeyEncryption` does: a second request to ask the same question
   // is the cost this removes.
   const organization = useOrganizationContext()
-  const settings = useSettings(isDeploymentOperator(organization.data))
+  const isOperator = isDeploymentOperator(organization.data)
+  const settings = useSettings(isOperator)
   const updateSettings = useUpdateSettings()
   const [dismissed, setDismissed] = useState(false)
 
+  // The render is gated on the same answer the request is, because a disabled
+  // query still serves whatever sits under its key and the query client outlives
+  // a sign-out: without this, a session that follows an operator's in the same
+  // tab renders their settings and a button that would be refused.
   const needsPricing =
+    isOperator &&
     settings.data?.require_pricing === true &&
     settings.data.default_pricing === false
   const showing = needsPricing && !dismissed

--- a/web/src/features/models/PricingWarning.tsx
+++ b/web/src/features/models/PricingWarning.tsx
@@ -33,7 +33,14 @@ export function PricingWarning() {
   // `useProviderKeyEncryption` does: a second request to ask the same question
   // is the cost this removes.
   const organization = useOrganizationContext()
-  const isOperator = isDeploymentOperator(organization.data)
+  // Fails open on a failed context read, which is what the rail does with the
+  // same class of gate: `/v1/settings` is `require_deployment_operator`, so it
+  // refuses with a 403 rather than a 404, and `nav/types.ts` settles what that
+  // means with no answer. Here it costs more than a hidden row, because the
+  // banner is the only thing reporting that traffic is being dropped right now.
+  // The ordinary tenant path, a resolved context saying no, still asks nothing.
+  const isOperator =
+    isDeploymentOperator(organization.data) || organization.isError
   const settings = useSettings(isOperator)
   const updateSettings = useUpdateSettings()
   const [dismissed, setDismissed] = useState(false)

--- a/web/src/features/models/PricingWarning.tsx
+++ b/web/src/features/models/PricingWarning.tsx
@@ -2,8 +2,10 @@ import { Button } from "@heroui/react"
 import { Link } from "@tanstack/react-router"
 import { useState } from "react"
 
+import { isDeploymentOperator } from "@/features/organization/roles"
 import {
   useFailureCount,
+  useOrganizationContext,
   useSettings,
   useUpdateSettings,
 } from "@/shared/api/hooks"
@@ -22,7 +24,16 @@ import { HOUR_S } from "@/shared/helpers/timeRange"
 // now) rather than a static config note, and links into the activity log filtered
 // to those failures.
 export function PricingWarning() {
-  const settings = useSettings()
+  // Both the read behind the alarm and the button that clears it are
+  // deployment-operator-only (`require_deployment_operator` on `/v1/settings`),
+  // so the audience is stated here rather than left to be inferred from a
+  // refused query: without it every tenant page load fired a `GET /v1/settings`
+  // that 403s to feed a banner that could never render for them (#834). Off the
+  // organization context, which the shell reads anyway, for the reason
+  // `useProviderKeyEncryption` does: a second request to ask the same question
+  // is the cost this removes.
+  const organization = useOrganizationContext()
+  const settings = useSettings(isDeploymentOperator(organization.data))
   const updateSettings = useUpdateSettings()
   const [dismissed, setDismissed] = useState(false)
 

--- a/web/src/features/models/PricingWarning.tsx
+++ b/web/src/features/models/PricingWarning.tsx
@@ -38,10 +38,9 @@ export function PricingWarning() {
   const updateSettings = useUpdateSettings()
   const [dismissed, setDismissed] = useState(false)
 
-  // The render is gated on the same answer the request is, because a disabled
-  // query still serves whatever sits under its key and the query client outlives
-  // a sign-out: without this, a session that follows an operator's in the same
-  // tab renders their settings and a button that would be refused.
+  // Read through `isOperator` for the reason `ModelsPage` does: a disabled query
+  // still hands back whatever sits under its key, so a caller demoted mid-session
+  // would keep the banner and a button that PATCHes a route now refusing them.
   const needsPricing =
     isOperator &&
     settings.data?.require_pricing === true &&


### PR DESCRIPTION
## Description

The dashboard shows a gateway-wide alarm when the gateway is set to reject requests for models it has no price for. Only the person who runs the deployment can act on it, and only they could ever see it, but nothing in the code said so. What hid it from everyone else was the server refusing the request that feeds it: the banner asked for the deployment's settings on every page load, the server said no to anyone who is not a deployment operator, and with no answer the banner drew nothing. That worked, but it meant every ordinary user's browser fired a request that was always refused, once a minute per page, for a banner they could never be shown. This PR asks the question directly instead: the shell already knows whether the signed-in person operates the deployment, so the banner reads that first and only asks for settings when the answer is yes. Nothing looks different to anyone. There is just one refused request fewer on every page load.

The signal is `deployment_operator` off the organization context, passed as the `enabled` argument to `useSettings()`. Issue #834 names `useDeploymentAdminAccess` / `/v1/admin/access` instead, from before #836 moved the rail's operator answer onto the context; using it here would replace one refused request with one extra request, where the context is a read the shell already makes on every page. `ModelsPage.tsx` and `useProviderKeyEncryption` gate the same operator-only route the same way.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #834

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Dashboard-only, so the checks that apply are `web/AGENTS.md`'s: `pnpm --dir web run lint`, `typecheck`, `test`, and `build`, all clean. No API contract change, so no regenerated spec. The new test asserts a non-operator issues no `GET /v1/settings` and sees no banner; it fails without the change.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via the Claude Code CLI.

**Any additional AI details you'd like to share:**

Implemented and tested by the agent from the issue; @njbrake reviewed before it was opened.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Gated the pricing warning to deployment operators.
- Prevented non-operators from requesting deployment settings or seeing cached pricing warnings.
- Preserved the existing operator warning and pricing update behavior.
- Added tests for non-operators, demoted sessions, and context read failures.

This avoids refused settings requests while keeping user-visible behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->