### PR TITLE
feat(growth): resolve GrowthSignalPort at signup and a member's first key

### DIFF
--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -550,7 +550,18 @@ def get_entitlement_port(db: PortSessionDep, container: ContainerDep) -> Entitle
     return container.resolve(EntitlementPort, db)
 
 
-def get_growth_signal_port(db: PortSessionDep, container: ContainerDep) -> GrowthSignalPort:
+# ``get_db`` rather than ``PortSessionDep``, for the reason
+# ``get_telemetry_storage_port`` below gives: both surfaces resolving this port
+# (signup, and a member minting their own key) are standalone-only and already
+# hold a session from ``get_db``, and FastAPI caches a dependency per callable.
+# Naming the same one hands the adapter the caller's session instead of opening
+# a second, independent one against the same database for the same request,
+# which is what an adapter writing an outbox row or a "notified" stamp would
+# need to land its write in a transaction someone commits.
+def get_growth_signal_port(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    container: ContainerDep,
+) -> GrowthSignalPort:
     """Resolve the growth-signal adapter this build bound at startup."""
     return container.resolve(GrowthSignalPort, db)
 

--- a/src/gateway/api/routes/auth_signup.py
+++ b/src/gateway/api/routes/auth_signup.py
@@ -15,11 +15,11 @@ genuinely just claimed.
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, Request
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.api.deps import get_config, get_db
+from gateway.api.deps import GrowthSignalPortDep, get_config, get_db
 from gateway.api.routes._public_auth import mail_unavailable, throttle_public_auth
 from gateway.core.config import GatewayConfig
 from gateway.services.mail import MailNotConfiguredError
@@ -85,8 +85,10 @@ _RESEND_MESSAGE = "If this address is registered and unverified, a verification 
 async def signup(
     body: SignupRequest,
     request: Request,
+    background_tasks: BackgroundTasks,
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
+    growth: GrowthSignalPortDep,
 ) -> SignupResponse:
     """Claim a roster identity, or do nothing: the response never says which.
 
@@ -95,7 +97,7 @@ async def signup(
     """
     throttle_public_auth(request)
     try:
-        await create_user_for_signup(
+        claimed = await create_user_for_signup(
             db,
             config,
             email=body.email,
@@ -105,6 +107,19 @@ async def signup(
         )
     except MailNotConfiguredError as exc:
         raise mail_unavailable(exc) from None
+    # Only a genuine claim notifies, which is what keeps the seam from undoing
+    # the enumeration-safety above: the response is identical either way, and a
+    # signal an operator's own vendor receives is not something the caller can
+    # observe. ``email`` is set on any claimed identity, which is looked up by
+    # address in the first place.
+    if claimed is not None and claimed.email is not None:
+        await growth.record_signup(
+            background_tasks=background_tasks,
+            user_id=claimed.id,
+            email=claimed.email,
+            full_name=claimed.full_name,
+            created_at=claimed.created_at,
+        )
     return SignupResponse(message=_SIGNUP_MESSAGE)
 
 

--- a/src/gateway/api/routes/organization_keys.py
+++ b/src/gateway/api/routes/organization_keys.py
@@ -36,14 +36,20 @@ import uuid
 from datetime import datetime
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
-from gateway.api.deps import CurrentIdentity, get_config, get_db, verify_master_key
+from gateway.api.deps import (
+    CurrentIdentity,
+    GrowthSignalPortDep,
+    get_config,
+    get_db,
+    verify_master_key,
+)
 from gateway.api.routes.keys import (
     _KEY_EXCEEDS_USER_DETAIL,
     CreateKeyResponse,
@@ -55,6 +61,7 @@ from gateway.core.config import GatewayConfig
 from gateway.models.entities import APIKey, User
 from gateway.models.tenancy import User as TenancyUser
 from gateway.models.tenancy import Workspace
+from gateway.ports.growth_signal_port import GrowthActivationEvent
 from gateway.repositories.users_repository import get_or_create_attribution_user
 from gateway.services.model_access import is_allowlist_subset, validate_allowed_models
 from gateway.services.tenancy import OrganizationService
@@ -148,8 +155,10 @@ async def _caller_context(db: AsyncSession, identity: TenancyUser) -> tuple[uuid
 async def create_own_key(
     request: CreateOwnKeyRequest,
     identity: CurrentIdentity,
+    background_tasks: BackgroundTasks,
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
+    growth: GrowthSignalPortDep,
 ) -> CreateKeyResponse:
     """Create an API key owned by the caller, in a workspace they may see.
 
@@ -229,6 +238,14 @@ async def create_own_key(
     if not is_allowlist_subset(allowed_models, owner.allowed_models):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=_KEY_EXCEEDS_USER_DETAIL)
 
+    # ``record_activation`` puts first-occurrence detection on the caller, and
+    # this schema has nowhere to record "already notified", so the milestone is
+    # derived from the owner's own keys: an index seek on ``api_keys.user_id``,
+    # read before the insert below because afterwards there is always one.
+    first_key = (
+        await db.execute(select(APIKey.id).where(APIKey.user_id == owner.user_id).limit(1))
+    ).scalar_one_or_none() is None
+
     api_key = generate_api_key()
     db_key = APIKey(
         id=str(uuid.uuid4()),
@@ -255,6 +272,18 @@ async def create_own_key(
             detail="Database error",
         ) from None
     await db.refresh(db_key)
+
+    if first_key and identity.email is not None:
+        # Skipped for an identity with no address, which is the bootstrap
+        # operator's normal state (`services/tenancy/provisioning_service`): the
+        # port's ``email`` is what a vendor keys a person on, and there is
+        # nothing to send in its place.
+        await growth.record_activation(
+            background_tasks=background_tasks,
+            event=GrowthActivationEvent.API_KEY_CREATED,
+            user_id=identity.id,
+            email=identity.email,
+        )
 
     key_info = KeyInfo.from_model(db_key)
     return CreateKeyResponse(

--- a/src/gateway/ports/growth_signal_port.py
+++ b/src/gateway/ports/growth_signal_port.py
@@ -84,8 +84,12 @@ class GrowthSignalPort(Protocol):
 
         Only ``API_KEY_CREATED`` is emitted, from
         ``POST /v1/organizations/me/keys``, where first occurrence is the owner
-        holding no key yet. The other three stay uncalled, and an overlay should
-        not expect them:
+        holding no key yet. That derivation is a read of current state, not a
+        once-per-person guarantee: deleting every key re-arms it, and two
+        concurrent creates can both read zero, so an adapter that must fire once
+        per person de-duplicates on its own end rather than relying on this.
+
+        The other three stay uncalled, and an overlay should not expect them:
 
         - ``FIRST_ROUTE_CONFIGURED`` and ``BUDGET_RULE_SET`` would fire from
           ``POST /v1/routing/policies`` and ``POST /v1/budgets``, which are

--- a/src/gateway/ports/growth_signal_port.py
+++ b/src/gateway/ports/growth_signal_port.py
@@ -36,6 +36,14 @@ class GrowthActivationEvent(StrEnum):
     Owned by the port rather than by whichever vendor answers it, so a caller
     never imports a vendor-flavored constant: it names the milestone in domain
     terms and leaves the vendor's own vocabulary to the adapter.
+
+    ``SIGNED_UP`` overlaps :meth:`GrowthSignalPort.record_signup`, and a signup
+    fires that method alone: it carries the address, the name and the creation
+    time a vendor needs to make the record in the first place, where this enum
+    carries only an identity. The value stays because an adapter whose vendor
+    models signup as one more activation event needs something to map onto, but
+    nothing in this tree emits it, so an adapter can treat it as an overlay's
+    own vocabulary rather than a second notification to de-duplicate against.
     """
 
     SIGNED_UP = "signed_up"
@@ -73,6 +81,27 @@ class GrowthSignalPort(Protocol):
         Callers detect first occurrence themselves, as they already must to
         decide whether to call this at all; an adapter may additionally
         de-duplicate on its own end, so a redundant call is safe.
+
+        Only ``API_KEY_CREATED`` is emitted, from
+        ``POST /v1/organizations/me/keys``, where first occurrence is the owner
+        holding no key yet. The other three stay uncalled, and an overlay should
+        not expect them:
+
+        - ``FIRST_ROUTE_CONFIGURED`` and ``BUDGET_RULE_SET`` would fire from
+          ``POST /v1/routing/policies`` and ``POST /v1/budgets``, which are
+          deployment-wide and gated on ``require_deployment_operator``. The
+          milestone would then name whoever holds deployment-wide authority: on
+          a hosted deployment the operator running it rather than any of the
+          tenants whose activation a vendor is watching, and under a header
+          master key nobody at all, since that credential resolves to the
+          bootstrap operator, which deliberately holds no address
+          (``services/tenancy/provisioning_service``). The same reason picks the
+          member key route over the operator's ``POST /v1/keys``.
+        - ``FIRST_REQUEST_ROUTED`` has no moment to fire from.
+          ``services/tenancy/workspace_activation_service`` derives activation
+          from the first successful usage row every time the guide is read,
+          rather than recording it, so there is no instant at which a workspace
+          becomes activated, only a polled read that would notify on every load.
         """
         ...
 
@@ -111,7 +140,15 @@ class GrowthSignalPort(Protocol):
         email: str,
         full_name: str | None,
     ) -> None:
-        """Notify of an edited display name worth reflecting on the vendor's record."""
+        """Notify of an edited display name worth reflecting on the vendor's record.
+
+        Nothing calls this, for the reason ``record_onboarding_completed``
+        gives about its own answers: the surface is not in this tree. An
+        identity's ``full_name`` is written at signup and by OAuth and never
+        edited again, and ``PATCH /v1/users`` edits the ``alias`` on a
+        request-plane attribution row, which is a billing label rather than a
+        person's display name.
+        """
         ...
 
     async def record_account_deleted(
@@ -125,5 +162,12 @@ class GrowthSignalPort(Protocol):
 
         Called with primitives captured before the delete, so an adapter must
         not assume the user row still exists when its background task runs.
+
+        Nothing calls this either: no route here deletes an account.
+        ``DELETE /v1/users`` soft-deletes an attribution row and revokes the
+        keys on it, which ends a spend identity rather than a person, and the
+        one thing that touches an identity itself is
+        ``PATCH /v1/admin/users/{user_id}`` deactivating it, which an operator
+        can undo and which this port has no counterpart for.
         """
         ...

--- a/src/gateway/services/tenancy/user_service.py
+++ b/src/gateway/services/tenancy/user_service.py
@@ -243,7 +243,7 @@ async def create_user_for_signup(
     password: str,
     full_name: str | None = None,
     terms_accepted: bool = False,
-) -> None:
+) -> User | None:
     """Claim an identity ``organization_service`` already put on the roster, or do nothing.
 
     This edition's signup only ever completes an identity an admin already
@@ -267,6 +267,11 @@ async def create_user_for_signup(
     first means a bad password answers the same way whether or not the
     address is real.
 
+    Returns the identity that was claimed, or ``None`` on every enumeration-safe
+    path, so a caller can tell the two apart without the response doing so. That
+    is what lets the route notify ``GrowthSignalPort`` of a genuine signup and
+    stay silent otherwise.
+
     Refuses before writing anything if this deployment cannot mail the
     verification link: a signup that could never be verified would strand the
     caller in the unverified, hard-blocked state #650's sign-in gate enforces.
@@ -289,7 +294,7 @@ async def create_user_for_signup(
         # of the gap the way ``authenticate`` already does for a sign-in on an
         # address with no stored hash.
         await verify_absent_password_async(password)
-        return
+        return None
 
     identity.full_name = identity.full_name or full_name
     identity.hashed_password = await hash_password_async(password)
@@ -310,6 +315,7 @@ async def create_user_for_signup(
             expiry_hours=config.email_verification_expiry_hours,
         ),
     )
+    return identity
 
 
 async def verify_email(db: AsyncSession, *, token: str) -> User:

--- a/tests/integration/test_growth_signal_lifecycle.py
+++ b/tests/integration/test_growth_signal_lifecycle.py
@@ -1,0 +1,279 @@
+"""What actually crosses ``GrowthSignalPort`` on a running app.
+
+The port shipped fully wired and entirely uncalled (otari#796), which is a
+failure nothing reports: the core adapter is a Null Object, so a build that
+binds a real CRM gets a resolved port that is simply never reached and no test,
+log line or type error says so. These tests close that by binding a recording
+adapter through the container, the way an overlay binds its own, and asserting
+on what the seam carried rather than on what the route answered.
+
+The negatives carry as much as the positives. Signup's enumeration-safety is a
+property of the *response*, and a signal fired on an address nobody has touched
+would leak through the seam what the body refuses to say, so the untouched-address
+case asserts silence. The second key asserts silence too: ``record_activation``
+puts first-occurrence detection on the caller, and a milestone that fires on
+every key is not a milestone.
+"""
+
+import uuid
+from collections.abc import Callable, Generator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from sqlmodel import col
+
+from gateway.core.config import GatewayConfig
+from gateway.models.entities import DashboardSession
+from gateway.models.tenancy import Organization, OrganizationMember, User, Workspace, WorkspaceMember
+from gateway.ports.growth_signal_port import GrowthActivationEvent, GrowthSignalPort
+from gateway.services.dashboard_session_service import SESSION_COOKIE_NAME, hash_session_token
+
+PASSWORD = "a-real-password"  # pragma: allowlist secret
+_KEYS = "/v1/organizations/me/keys"
+
+
+class RecordingGrowthAdapter:
+    """A stand-in for an overlay-bound adapter, recording what it was told.
+
+    Records rather than asserts, so a test can name the one call it expects and
+    still fail on an extra one it did not.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def record_signup(
+        self,
+        *,
+        background_tasks: Any,
+        user_id: uuid.UUID,
+        email: str,
+        full_name: str | None,
+        created_at: datetime,
+    ) -> None:
+        self.calls.append(
+            ("signup", {"user_id": user_id, "email": email, "full_name": full_name, "created_at": created_at})
+        )
+
+    async def record_activation(
+        self,
+        *,
+        background_tasks: Any,
+        event: GrowthActivationEvent,
+        user_id: uuid.UUID,
+        email: str,
+    ) -> None:
+        self.calls.append(("activation", {"event": event, "user_id": user_id, "email": email}))
+
+    async def record_onboarding_completed(self, **kwargs: Any) -> None:
+        self.calls.append(("onboarding", kwargs))
+
+    async def record_profile_updated(self, **kwargs: Any) -> None:
+        self.calls.append(("profile_updated", kwargs))
+
+    async def record_account_deleted(self, **kwargs: Any) -> None:
+        self.calls.append(("account_deleted", kwargs))
+
+    def of(self, name: str) -> list[dict[str, Any]]:
+        return [payload for recorded, payload in self.calls if recorded == name]
+
+
+@pytest.fixture
+def growth(client: TestClient) -> RecordingGrowthAdapter:
+    """Rebind the port on the booted app, as ``OTARI_BOOTSTRAP`` would.
+
+    Through the container and not ``dependency_overrides`` so the resolution
+    path under test is the real one: ``get_growth_signal_port`` asking the
+    container for whatever this build bound. The ``client`` fixture boots one
+    app per test, so nothing has to be unbound afterwards.
+    """
+    recorder = RecordingGrowthAdapter()
+    container: Any = client.app.state.container  # type: ignore[attr-defined]
+    container.bind(GrowthSignalPort, lambda session: recorder)
+    return recorder
+
+
+@pytest.fixture
+def mail(test_config: GatewayConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Signup refuses before writing anything unless the link can be mailed."""
+    monkeypatch.setattr(test_config, "mail_transport", "console")
+    monkeypatch.setattr(test_config, "public_base_url", "https://otari.example.com")
+
+
+def _add_member(client: TestClient, master_key_header: dict[str, str], *, email: str) -> None:
+    response = client.post(
+        "/v1/organizations/me/members",
+        json={"email": email, "role": "member"},
+        headers=master_key_header,
+    )
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+
+
+def test_claiming_a_roster_identity_notifies_the_signup(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    growth: RecordingGrowthAdapter,
+    mail: None,
+) -> None:
+    """The whole record a vendor needs to create a contact crosses the seam."""
+    _add_member(client, master_key_header, email="ada@example.com")
+
+    response = client.post(
+        "/v1/auth/signup",
+        json={"email": "ada@example.com", "password": PASSWORD, "full_name": "Ada Lovelace"},
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+
+    signups = growth.of("signup")
+    assert len(signups) == 1, growth.calls
+    assert signups[0]["email"] == "ada@example.com"
+    assert signups[0]["full_name"] == "Ada Lovelace"
+    assert isinstance(signups[0]["user_id"], uuid.UUID)
+    assert isinstance(signups[0]["created_at"], datetime)
+    # ``SIGNED_UP`` overlaps ``record_signup`` and the port settles the overlap
+    # in that method's favor: a signup is one notification, not two.
+    assert growth.of("activation") == []
+
+
+def test_signup_on_an_untouched_address_notifies_nothing(
+    client: TestClient,
+    growth: RecordingGrowthAdapter,
+    mail: None,
+) -> None:
+    """Enumeration-safety has to hold through the seam, not just in the body.
+
+    The response is the same 200 either way (``test_signup_api.py``), so a
+    signal here would tell an operator's vendor precisely what the route
+    declines to tell the caller: that the address was on the roster.
+    """
+    response = client.post(
+        "/v1/auth/signup",
+        json={"email": "nobody@example.com", "password": PASSWORD},
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert growth.calls == []
+
+
+def test_a_second_signup_on_a_claimed_address_notifies_nothing(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    growth: RecordingGrowthAdapter,
+    mail: None,
+) -> None:
+    """A replayed signup is one of the enumeration-safe returns, so it is silent."""
+    _add_member(client, master_key_header, email="grace@example.com")
+    for _ in range(2):
+        response = client.post(
+            "/v1/auth/signup",
+            json={"email": "grace@example.com", "password": PASSWORD},
+        )
+        assert response.status_code == status.HTTP_200_OK, response.text
+
+    assert len(growth.of("signup")) == 1, growth.calls
+
+
+@pytest.fixture
+def member(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    db_session_factory: Callable[[], Session],
+) -> Generator[tuple[uuid.UUID, str]]:
+    """A member of the bootstrapped organization, and their session cookie."""
+    # One master-key call provisions the tenancy root, so the identity below
+    # joins a real organization and workspace rather than inventing them.
+    assert client.get("/v1/organizations/me", headers=master_key_header).status_code == status.HTTP_200_OK
+
+    session = db_session_factory()
+    try:
+        organization = session.execute(select(Organization)).scalars().first()
+        assert organization is not None
+        workspace = (
+            session.execute(select(Workspace).where(col(Workspace.organization_id) == organization.id))
+            .scalars()
+            .first()
+        )
+        assert workspace is not None
+
+        user = User(
+            email="member@example.com",
+            full_name="Member Example",
+            active_organization_id=organization.id,
+        )
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        session.add(
+            OrganizationMember(
+                organization_id=organization.id,
+                user_id=user.id,
+                role="member",
+                status="active",
+            )
+        )
+        session.add(
+            WorkspaceMember(
+                workspace_id=workspace.id,
+                user_id=user.id,
+                role="member",
+                status="active",
+            )
+        )
+        token = "otari-sess-member"
+        session.add(
+            DashboardSession(
+                token_hash=hash_session_token(token),
+                user_id=user.id,
+                created_at=datetime.now(UTC),
+                expires_at=datetime.now(UTC) + timedelta(hours=12),
+            )
+        )
+        session.commit()
+        yield user.id, token
+    finally:
+        session.close()
+
+
+def test_a_members_first_key_notifies_the_activation_and_the_second_does_not(
+    client: TestClient,
+    growth: RecordingGrowthAdapter,
+    member: tuple[uuid.UUID, str],
+) -> None:
+    """The milestone is derived from the owner's own keys, so it fires once."""
+    user_id, cookie = member
+    client.cookies.set(SESSION_COOKIE_NAME, cookie)
+
+    first = client.post(_KEYS, json={"key_name": "first"})
+    assert first.status_code == status.HTTP_200_OK, first.text
+
+    activations = growth.of("activation")
+    assert len(activations) == 1, growth.calls
+    assert activations[0]["event"] is GrowthActivationEvent.API_KEY_CREATED
+    assert activations[0]["user_id"] == user_id
+    assert activations[0]["email"] == "member@example.com"
+
+    second = client.post(_KEYS, json={"key_name": "second"})
+    assert second.status_code == status.HTTP_200_OK, second.text
+    assert len(growth.of("activation")) == 1, growth.calls
+
+
+def test_an_operator_with_no_address_notifies_nothing(
+    client: TestClient,
+    master_key_header: dict[str, str],
+    growth: RecordingGrowthAdapter,
+) -> None:
+    """A header master key names nobody, and the bootstrap operator holds no address.
+
+    ``record_activation`` takes an ``email`` because that is what a vendor keys
+    a person on, and the operator identity deliberately has none
+    (``services/tenancy/provisioning_service``), so this fires nothing rather
+    than inventing a stand-in.
+    """
+    response = client.post(_KEYS, json={"key_name": "operator"}, headers=master_key_header)
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert growth.calls == []


### PR DESCRIPTION
## Description

`POST /v1/auth/signup` calls `record_signup` only on a genuine claim, which `create_user_for_signup` now reports by returning the identity; the response is unchanged either way, so the seam does not undo the route's enumeration-safety. `POST /v1/organizations/me/keys` calls `record_activation(API_KEY_CREATED)`, with first occurrence derived from the owner's own keys before the insert.

The rest of the port stays uncalled, with the reason in each docstring: the two operator-route milestones would name whoever holds deployment-wide authority rather than the person a vendor watches, `FIRST_REQUEST_ROUTED` has no moment because workspace activation is derived on read, and profile edits and account deletion have no surface in this tree. `SIGNED_UP` is settled in `record_signup`'s favor.

Integration tests bind a recording adapter through the container and assert the silences as well as the calls.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Closes #796

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 5 via Claude Code

**Any additional AI details you'd like to share:**

Implemented and self-reviewed by Claude Opus 5 through back-and-forth with @njbrake. The reasoning and decisions are his; the prose and code are Claude's.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added growth notifications for genuine signups.
- Added activation tracking for a user’s first API key.
- Documented supported and intentionally unsupported lifecycle events.
- Shared the request database session with growth adapters.
- Added integration tests for notifications, duplicate actions, and excluded cases.

These changes make growth tracking active, accurate, and transaction-safe while preserving existing API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->