### PR TITLE
ci: announce a new main to the downstream that pins this repo

### DIFF
--- a/.github/workflows/notify-downstream-pin.yml
+++ b/.github/workflows/notify-downstream-pin.yml
@@ -1,0 +1,47 @@
+name: Notify Downstream Pin
+
+# Tell a downstream repository that pins this one as a submodule that main has
+# moved, so its pin can follow within minutes instead of waiting for its own
+# scheduled dependency pass.
+#
+# Outbound only, and deliberately the weakest coupling that does the job: this
+# sends a commit SHA and nothing else, reads nothing back, and knows nothing
+# about what the downstream does with it. Otari does not depend on that
+# repository and this does not make it start.
+#
+# Inert without OTARI_AI_DISPATCH_TOKEN, which is what a fork sees: the job runs
+# and does nothing rather than failing main for a secret it was never going to
+# have. The secret is safe here for the ordinary reason a `push` secret is: a
+# fork cannot raise a push event on this repository, so only a merge to main
+# ever reaches it.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    env:
+      DISPATCH_TOKEN: ${{ secrets.OTARI_AI_DISPATCH_TOKEN }}
+    steps:
+      - name: Announce the new main to mozilla-ai/otari-ai
+        if: env.DISPATCH_TOKEN != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ env.DISPATCH_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'mozilla-ai',
+              repo: 'otari-ai',
+              event_type: 'otari-main-updated',
+              client_payload: { sha: context.sha },
+            })
+            core.info(`Announced ${context.sha}.`)
+
+      - name: Report a missing token without failing the branch
+        if: env.DISPATCH_TOKEN == ''
+        run: echo "::notice::No OTARI_AI_DISPATCH_TOKEN configured; nothing announced."


### PR DESCRIPTION
## Description

The enterprise overlay (`mozilla-ai/otari-ai`) pins this repository as a git submodule, and picks up a merge here only when its own weekly dependency pass runs. That lag is what stranded mozilla-ai/otari-ai#1941: #866 gave members their own API keys, and the overlay's dev deployment kept serving the operator-only behaviour for days afterwards, so a tester there had no way to mint an API key at all.

This adds a `push: [main]` workflow that sends a `repository_dispatch` to that repository with the new commit SHA. The receiving side opens its own pin-bump PR.

Deliberately the weakest coupling that does the job:

- **Outbound only.** A SHA goes out, nothing comes back, and this repository learns nothing about what the downstream does with it. Otari still does not depend on the overlay, and this does not make it start.
- **Inert without the secret**, which is what a fork sees: the job runs and reports a notice rather than failing `main` for a token it was never going to have.
- The secret is safe in a public repo for the ordinary reason a `push` secret is: a fork cannot raise a push event here, so only a merge to `main` ever reaches it.

Needs `OTARI_AI_DISPATCH_TOKEN` configured on this repository before it does anything.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Relevant issues

Unblocks mozilla-ai/otari-ai#1941 from recurring.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). A workflow file has no unit under test; it is exercised by running on `main`.
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). Not run: this touches no Python or TypeScript. The YAML parses.
- [x] Documentation was updated where necessary. None needed.
- [x] If the API contract changed, I regenerated the OpenAPI spec. No API change.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

Written while tracing why a dev tester on the overlay could not generate an API key. The root cause was the stale submodule pin rather than anything in this tree; the corresponding overlay-side changes are mozilla-ai/otari-ai#1964 and #1965.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a workflow that notifies `mozilla-ai/otari-ai` after changes reach `main`.
- The notification includes the new commit SHA.
- The downstream repository can use this notice to update its submodule without waiting for a scheduled check.

## Technical notes

- The workflow also supports manual runs.
- It remains inactive when `OTARI_AI_DISPATCH_TOKEN` is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->