### PR TITLE
fix(hybrid): map PLATFORM_HEALTH_PATH and trust only a 2xx from the platform probe

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -268,9 +268,10 @@ this value without authentication.
 ## otari.ai variables
 
 Hybrid mode requires `OTARI_AI_TOKEN`. Optional platform settings control the
-platform API URL, management URL, resolution timeout, usage-report timeout and
-retries, and first-chunk fallback timeout. See [Modes](modes.md) and the
-normative [hybrid-mode protocol](hybrid-mode-protocol.md).
+platform API URL, management URL, health-probe path, resolution timeout,
+usage-report timeout and retries, and first-chunk fallback timeout. See
+[Modes](modes.md) and the normative
+[hybrid-mode protocol](hybrid-mode-protocol.md).
 
 ## Extending Otari with a bootstrap module
 

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -522,7 +522,7 @@ flag.
 | Env var | Default | Notes |
 |---|---|---|
 | `OTARI_AI_TOKEN` | none | Setting this enables hybrid mode. |
-| `PLATFORM_HEALTH_PATH` | `/utils/health-check/` | Path under `base_url` probed to report `platform_reachable` on `GET /health`; `GET /health/readiness` answers `503` when the same probe fails. Point it at a route the peer actually serves: any status below `500`, a `404` included, counts as reachable. |
+| `PLATFORM_HEALTH_PATH` | `/utils/health-check/` | Path under `base_url` probed to report `platform_reachable` on `GET /health`; `GET /health/readiness` answers `503` when the same probe fails. Only a `2xx` counts as reachable, so point it at a route the peer actually serves: a `404`, a `401`, and a redirect to a login page all report unreachable. The default is an otari.ai route. |
 | `PLATFORM_RESOLVE_TIMEOUT_MS` | `5000` | Per-resolve timeout. |
 | `PLATFORM_USAGE_TIMEOUT_MS` | `5000` | Per-usage-report timeout. |
 | `PLATFORM_USAGE_INLINE_TIMEOUT_MS` | `1500` | Budget for the one usage report the response path waits on to attach inline cost. Expiry ships the response without cost; the report itself continues. |

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -522,6 +522,7 @@ flag.
 | Env var | Default | Notes |
 |---|---|---|
 | `OTARI_AI_TOKEN` | none | Setting this enables hybrid mode. |
+| `PLATFORM_HEALTH_PATH` | `/utils/health-check/` | Path under `base_url` that `GET /health` probes to report `platform_reachable`. Point it at a route the peer actually serves: any status below `500`, a `404` included, counts as reachable. |
 | `PLATFORM_RESOLVE_TIMEOUT_MS` | `5000` | Per-resolve timeout. |
 | `PLATFORM_USAGE_TIMEOUT_MS` | `5000` | Per-usage-report timeout. |
 | `PLATFORM_USAGE_INLINE_TIMEOUT_MS` | `1500` | Budget for the one usage report the response path waits on to attach inline cost. Expiry ships the response without cost; the report itself continues. |

--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -522,7 +522,7 @@ flag.
 | Env var | Default | Notes |
 |---|---|---|
 | `OTARI_AI_TOKEN` | none | Setting this enables hybrid mode. |
-| `PLATFORM_HEALTH_PATH` | `/utils/health-check/` | Path under `base_url` that `GET /health` probes to report `platform_reachable`. Point it at a route the peer actually serves: any status below `500`, a `404` included, counts as reachable. |
+| `PLATFORM_HEALTH_PATH` | `/utils/health-check/` | Path under `base_url` probed to report `platform_reachable` on `GET /health`; `GET /health/readiness` answers `503` when the same probe fails. Point it at a route the peer actually serves: any status below `500`, a `404` included, counts as reachable. |
 | `PLATFORM_RESOLVE_TIMEOUT_MS` | `5000` | Per-resolve timeout. |
 | `PLATFORM_USAGE_TIMEOUT_MS` | `5000` | Per-usage-report timeout. |
 | `PLATFORM_USAGE_INLINE_TIMEOUT_MS` | `1500` | Budget for the one usage report the response path waits on to attach inline cost. Expiry ships the response without cost; the report itself continues. |

--- a/src/gateway/api/routes/health.py
+++ b/src/gateway/api/routes/health.py
@@ -6,7 +6,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import get_config, get_db_if_needed
-from gateway.core.config import GatewayConfig
+from gateway.core.config import DEFAULT_PLATFORM_HEALTH_PATH, GatewayConfig
 from gateway.log_config import logger
 from gateway.version import __version__
 
@@ -14,20 +14,33 @@ router = APIRouter(prefix="/health", tags=["health"])
 
 
 async def _check_platform_reachability(config: GatewayConfig) -> bool:
+    """Report whether the platform peer serves its health route.
+
+    Only a 2xx answers that question. A 404 from a peer that does not serve the
+    configured path, a 401 from an authenticated route, and a redirect to a login
+    page all prove something is listening without proving it is the peer this
+    gateway resolves credentials from. Redirects are left unfollowed for the same
+    reason: the 200 at the end of one belongs to whatever it landed on.
+    """
     platform_base_url = config.platform.get("base_url")
     if not platform_base_url:
         return False
 
-    health_path = config.platform.get("health_path", "/utils/health-check/")
+    health_path = config.platform.get("health_path", DEFAULT_PLATFORM_HEALTH_PATH)
     timeout_ms = int(config.platform.get("resolve_timeout_ms", 5000))
     health_url = f"{platform_base_url.rstrip('/')}/{health_path.lstrip('/')}"
 
     try:
-        async with httpx.AsyncClient(timeout=timeout_ms / 1000) as client:
+        async with httpx.AsyncClient(timeout=timeout_ms / 1000, follow_redirects=False) as client:
             response = await client.get(health_url)
-        return response.status_code < 500
-    except (httpx.TimeoutException, httpx.NetworkError):
+    except (httpx.HTTPError, httpx.InvalidURL) as e:
+        logger.debug("Platform health probe to %s failed: %s", health_url, e)
         return False
+
+    if not response.is_success:
+        logger.debug("Platform health probe to %s answered %s", health_url, response.status_code)
+        return False
+    return True
 
 
 @router.get("")

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -2289,8 +2289,6 @@ def _apply_platform_env_overrides(config: dict[str, Any]) -> None:
     env_mappings: dict[str, tuple[str, type[Any]]] = {
         "PLATFORM_BASE_URL": ("base_url", str),
         "PLATFORM_MANAGEMENT_URL": ("management_url", str),
-        # The reachability probe's path under base_url. A peer that does not serve
-        # the default answers 404, which the probe still counts as reachable.
         "PLATFORM_HEALTH_PATH": ("health_path", str),
         "PLATFORM_RESOLVE_TIMEOUT_MS": ("resolve_timeout_ms", int),
         "PLATFORM_USAGE_TIMEOUT_MS": ("usage_timeout_ms", int),

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -66,6 +66,10 @@ DEFAULT_PLATFORM_BASE_URL = "https://api.otari.ai/api/v1"
 # link to the dashboard that actually manages this gateway; an operator pointed
 # at a staging platform overrides it with platform.management_url.
 DEFAULT_PLATFORM_MANAGEMENT_URL = "https://otari.ai"
+# The route the reachability probe asks for under DEFAULT_PLATFORM_BASE_URL. It
+# is an otari.ai route, so a deployment resolving against any other peer sets
+# platform.health_path (PLATFORM_HEALTH_PATH) to one that peer serves.
+DEFAULT_PLATFORM_HEALTH_PATH = "/utils/health-check/"
 PLATFORM_TOKEN_ENV_VAR = "OTARI_AI_TOKEN"
 # User-facing config env vars use the OTARI_ prefix (e.g. OTARI_MASTER_KEY,
 # OTARI_PORT), which is also the native pydantic prefix below.

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -2289,6 +2289,9 @@ def _apply_platform_env_overrides(config: dict[str, Any]) -> None:
     env_mappings: dict[str, tuple[str, type[Any]]] = {
         "PLATFORM_BASE_URL": ("base_url", str),
         "PLATFORM_MANAGEMENT_URL": ("management_url", str),
+        # The reachability probe's path under base_url. A peer that does not serve
+        # the default answers 404, which the probe still counts as reachable.
+        "PLATFORM_HEALTH_PATH": ("health_path", str),
         "PLATFORM_RESOLVE_TIMEOUT_MS": ("resolve_timeout_ms", int),
         "PLATFORM_USAGE_TIMEOUT_MS": ("usage_timeout_ms", int),
         # Budget for the one usage report the response path waits on. Expiry

--- a/tests/integration/test_config_env_loading.py
+++ b/tests/integration/test_config_env_loading.py
@@ -396,6 +396,7 @@ def test_load_config_platform_env_overrides(tmp_path: Path, monkeypatch: pytest.
 
     monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
     monkeypatch.setenv("PLATFORM_BASE_URL", "http://localhost:8100/api/v1")
+    monkeypatch.setenv("PLATFORM_HEALTH_PATH", "/healthz")
     monkeypatch.setenv("PLATFORM_RESOLVE_TIMEOUT_MS", "1234")
     monkeypatch.setenv("PLATFORM_USAGE_TIMEOUT_MS", "2345")
     monkeypatch.setenv("PLATFORM_USAGE_INLINE_TIMEOUT_MS", "150")
@@ -405,6 +406,7 @@ def test_load_config_platform_env_overrides(tmp_path: Path, monkeypatch: pytest.
 
     assert config.is_hybrid_mode
     assert config.platform["base_url"] == "http://localhost:8100/api/v1"
+    assert config.platform["health_path"] == "/healthz"
     assert config.platform["resolve_timeout_ms"] == 1234
     assert config.platform["usage_timeout_ms"] == 2345
     assert config.platform["usage_inline_timeout_ms"] == 150

--- a/tests/unit/test_platform_reachability_probe.py
+++ b/tests/unit/test_platform_reachability_probe.py
@@ -1,0 +1,70 @@
+"""The ``platform_reachable`` probe must hit the path the deployment configured.
+
+The default path is a platform route. A peer that does not serve it answers
+404, which the probe counts as reachable, so an unverified peer reports healthy.
+``PLATFORM_HEALTH_PATH`` is what moves the probe off that default in an
+env-only deployment.
+"""
+
+from typing import Any
+
+import httpx
+import pytest
+
+from gateway.api.routes.health import _check_platform_reachability
+from gateway.core.config import load_config
+
+
+class _RecordingTransport(httpx.AsyncBaseTransport):
+    def __init__(self) -> None:
+        self.requested: list[httpx.URL] = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.requested.append(request.url)
+        return httpx.Response(200)
+
+
+@pytest.fixture
+def transport(monkeypatch: pytest.MonkeyPatch) -> _RecordingTransport:
+    recorder = _RecordingTransport()
+    original_init = httpx.AsyncClient.__init__
+
+    def patched_init(self: httpx.AsyncClient, *args: Any, **kwargs: Any) -> None:
+        kwargs["transport"] = recorder
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", patched_init)
+    return recorder
+
+
+@pytest.fixture(autouse=True)
+def _isolated_platform_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ("OTARI_AI_TOKEN", "PLATFORM_BASE_URL", "PLATFORM_HEALTH_PATH", "OTARI_MODE"):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.mark.asyncio
+async def test_health_path_env_var_moves_the_probe(
+    monkeypatch: pytest.MonkeyPatch, transport: _RecordingTransport
+) -> None:
+    monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
+    monkeypatch.setenv("PLATFORM_BASE_URL", "http://platform.test/v1")
+    monkeypatch.setenv("PLATFORM_HEALTH_PATH", "/healthz")
+
+    config = load_config()
+
+    assert await _check_platform_reachability(config) is True
+    assert [str(url) for url in transport.requested] == ["http://platform.test/v1/healthz"]
+
+
+@pytest.mark.asyncio
+async def test_probe_falls_back_to_the_platform_route(
+    monkeypatch: pytest.MonkeyPatch, transport: _RecordingTransport
+) -> None:
+    monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
+    monkeypatch.setenv("PLATFORM_BASE_URL", "http://platform.test/v1")
+
+    config = load_config()
+
+    assert await _check_platform_reachability(config) is True
+    assert [str(url) for url in transport.requested] == ["http://platform.test/v1/utils/health-check/"]

--- a/tests/unit/test_platform_reachability_probe.py
+++ b/tests/unit/test_platform_reachability_probe.py
@@ -6,6 +6,7 @@ The default path is a platform route. A peer that does not serve it answers
 env-only deployment.
 """
 
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -38,9 +39,15 @@ def transport(monkeypatch: pytest.MonkeyPatch) -> _RecordingTransport:
 
 
 @pytest.fixture(autouse=True)
-def _isolated_platform_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def _isolated_platform_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Give each test the env these tests set and nothing else.
+
+    ``load_config`` reads a ``.env`` from the working directory, which would put
+    a contributor's local ``PLATFORM_*`` values back after the deletes below.
+    """
     for name in ("OTARI_AI_TOKEN", "PLATFORM_BASE_URL", "PLATFORM_HEALTH_PATH", "OTARI_MODE"):
         monkeypatch.delenv(name, raising=False)
+    monkeypatch.chdir(tmp_path)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_platform_reachability_probe.py
+++ b/tests/unit/test_platform_reachability_probe.py
@@ -1,9 +1,10 @@
-"""The ``platform_reachable`` probe must hit the path the deployment configured.
+"""The ``platform_reachable`` probe must hit the configured path and believe only a 2xx.
 
-The default path is a platform route. A peer that does not serve it answers
-404, which the probe counts as reachable, so an unverified peer reports healthy.
-``PLATFORM_HEALTH_PATH`` is what moves the probe off that default in an
-env-only deployment.
+Two defects met here. The probe's path could only come from a config file, so an
+env-only deployment was stuck on a route specific to otari.ai; and any status
+below 500 counted as reachable, so the peer that does not serve that route
+answered 404 and still reported healthy. ``PLATFORM_HEALTH_PATH`` fixes the
+first, requiring a 2xx the second.
 """
 
 from pathlib import Path
@@ -13,29 +14,39 @@ import httpx
 import pytest
 
 from gateway.api.routes.health import _check_platform_reachability
-from gateway.core.config import load_config
+from gateway.core.config import DEFAULT_PLATFORM_HEALTH_PATH, load_config
 
 
-class _RecordingTransport(httpx.AsyncBaseTransport):
-    def __init__(self) -> None:
+class _StubTransport(httpx.AsyncBaseTransport):
+    """Answers every probe with one canned response, or raises one canned error."""
+
+    def __init__(self, response: httpx.Response | Exception) -> None:
+        self._response = response
         self.requested: list[httpx.URL] = []
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         self.requested.append(request.url)
-        return httpx.Response(200)
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
 
 
 @pytest.fixture
-def transport(monkeypatch: pytest.MonkeyPatch) -> _RecordingTransport:
-    recorder = _RecordingTransport()
-    original_init = httpx.AsyncClient.__init__
+def probe(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Return a factory installing a stub transport and reporting what was probed."""
 
-    def patched_init(self: httpx.AsyncClient, *args: Any, **kwargs: Any) -> None:
-        kwargs["transport"] = recorder
-        original_init(self, *args, **kwargs)
+    def install(response: httpx.Response | Exception = httpx.Response(200)) -> _StubTransport:
+        stub = _StubTransport(response)
+        original_init = httpx.AsyncClient.__init__
 
-    monkeypatch.setattr(httpx.AsyncClient, "__init__", patched_init)
-    return recorder
+        def patched_init(self: httpx.AsyncClient, *args: Any, **kwargs: Any) -> None:
+            kwargs["transport"] = stub
+            original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(httpx.AsyncClient, "__init__", patched_init)
+        return stub
+
+    return install
 
 
 @pytest.fixture(autouse=True)
@@ -50,28 +61,92 @@ def _isolated_platform_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> N
     monkeypatch.chdir(tmp_path)
 
 
-@pytest.mark.asyncio
-async def test_health_path_env_var_moves_the_probe(
-    monkeypatch: pytest.MonkeyPatch, transport: _RecordingTransport
-) -> None:
+def _hybrid_config(monkeypatch: pytest.MonkeyPatch, health_path: str | None = None) -> Any:
     monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
     monkeypatch.setenv("PLATFORM_BASE_URL", "http://platform.test/v1")
-    monkeypatch.setenv("PLATFORM_HEALTH_PATH", "/healthz")
-
-    config = load_config()
-
-    assert await _check_platform_reachability(config) is True
-    assert [str(url) for url in transport.requested] == ["http://platform.test/v1/healthz"]
+    if health_path is not None:
+        monkeypatch.setenv("PLATFORM_HEALTH_PATH", health_path)
+    return load_config()
 
 
 @pytest.mark.asyncio
-async def test_probe_falls_back_to_the_platform_route(
-    monkeypatch: pytest.MonkeyPatch, transport: _RecordingTransport
-) -> None:
-    monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
-    monkeypatch.setenv("PLATFORM_BASE_URL", "http://platform.test/v1")
-
-    config = load_config()
+async def test_health_path_env_var_moves_the_probe(monkeypatch: pytest.MonkeyPatch, probe: Any) -> None:
+    stub = probe()
+    config = _hybrid_config(monkeypatch, "/healthz")
 
     assert await _check_platform_reachability(config) is True
-    assert [str(url) for url in transport.requested] == ["http://platform.test/v1/utils/health-check/"]
+    assert [str(url) for url in stub.requested] == ["http://platform.test/v1/healthz"]
+
+
+@pytest.mark.asyncio
+async def test_probe_falls_back_to_the_platform_route(monkeypatch: pytest.MonkeyPatch, probe: Any) -> None:
+    stub = probe()
+    config = _hybrid_config(monkeypatch)
+
+    assert await _check_platform_reachability(config) is True
+    assert [str(url) for url in stub.requested] == [
+        f"http://platform.test/v1{DEFAULT_PLATFORM_HEALTH_PATH}"
+    ]
+
+
+@pytest.mark.parametrize("status", [200, 204])
+@pytest.mark.asyncio
+async def test_a_success_reports_reachable(monkeypatch: pytest.MonkeyPatch, probe: Any, status: int) -> None:
+    probe(httpx.Response(status))
+    config = _hybrid_config(monkeypatch)
+
+    assert await _check_platform_reachability(config) is True
+
+
+@pytest.mark.parametrize(
+    ("status", "why"),
+    [
+        (404, "the peer does not serve the configured path"),
+        (401, "the route exists but refused the probe"),
+        (403, "the route exists but refused the probe"),
+        (500, "the peer is serving errors"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_non_success_reports_unreachable(
+    monkeypatch: pytest.MonkeyPatch, probe: Any, status: int, why: str
+) -> None:
+    """A status below 500 used to count as reachable, which is what #877 reports."""
+    probe(httpx.Response(status))
+    config = _hybrid_config(monkeypatch)
+
+    assert await _check_platform_reachability(config) is False, why
+
+
+@pytest.mark.asyncio
+async def test_a_redirect_is_not_followed_and_reports_unreachable(
+    monkeypatch: pytest.MonkeyPatch, probe: Any
+) -> None:
+    """A peer route that bounces to a login page has not answered the probe."""
+    stub = probe(httpx.Response(302, headers={"location": "https://platform.test/login"}))
+    config = _hybrid_config(monkeypatch)
+
+    assert await _check_platform_reachability(config) is False
+    assert [str(url) for url in stub.requested] == [
+        f"http://platform.test/v1{DEFAULT_PLATFORM_HEALTH_PATH}"
+    ]
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        httpx.ConnectTimeout("timed out"),
+        httpx.ConnectError("refused"),
+        httpx.RemoteProtocolError("malformed response"),
+        httpx.ProxyError("bad proxy"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_transport_error_reports_unreachable(
+    monkeypatch: pytest.MonkeyPatch, probe: Any, error: Exception
+) -> None:
+    """Only timeouts and network errors were caught, so the rest reached the client as a 500."""
+    probe(error)
+    config = _hybrid_config(monkeypatch)
+
+    assert await _check_platform_reachability(config) is False

--- a/web/e2e/otari.hybrid.yml
+++ b/web/e2e/otari.hybrid.yml
@@ -11,15 +11,14 @@ host: "127.0.0.1"
 port: 8010
 platform:
   # The standalone gateway this suite already boots, standing in for otari.ai.
-  # Reachability is one HTTP GET that has to answer below 500 (see
+  # Reachability is one HTTP GET that has to answer 2xx (see
   # _check_platform_reachability), so a live gateway is a faithful stand-in and
   # the landing page's connection row is asserted in its "Connected" state
   # rather than only in its failure one.
   base_url: "http://127.0.0.1:8000"
   # Named explicitly rather than left to the default (otari.ai's
-  # /utils/health-check/), which this stand-in does not serve. It would still
-  # report reachable, since a 404 is below 500, so without this the assertion
-  # would pass for the wrong reason.
+  # /utils/health-check/), which this stand-in does not serve and would answer
+  # 404 to, reporting unreachable.
   health_path: "/health"
   # The link the landing page offers, and the value /v1/bootstrap publishes.
   management_url: "https://otari.ai"


### PR DESCRIPTION
When Otari runs in hybrid mode, its health endpoint checks whether the platform it depends on is really up, by asking that platform a question over the network. Two things were wrong with that check. The address it asked could only be half set from environment variables, so anyone running Otari purely from the environment was stuck asking for a page specific to otari.ai. And the check accepted almost any reply as proof of life, including "no such page" and "please log in first". Together those meant Otari could report the platform as healthy when it had never actually reached it.

This fixes both. The address is now fully settable from the environment, and only a genuine success counts as healthy. A deployment pointed at the wrong place now finds out, instead of being told everything is fine.

## Description

`_check_platform_reachability` builds its probe URL from `platform.health_path`, defaulting to `/utils/health-check/`. Two defects, both reported in #877.

**The path could not be set from the environment.** `_apply_platform_env_overrides` mapped `base_url`, `management_url` and the timeouts, but not `health_path`, so only a config file could move it. Adds `PLATFORM_HEALTH_PATH` to `env_mappings`.

**Any status below 500 counted as reachable.** A peer that does not serve the configured path answered 404 and still reported `platform_reachable: "yes"`, with `/health/readiness` returning 200 against a peer nobody had verified. The probe now requires a 2xx: a 404, a 401 from an authenticated route, and a redirect to a login page all report unreachable. Redirects are left unfollowed, so the 200 at the end of one cannot stand in for the peer's own answer.

Two smaller things travel with that. The `except` clause caught only `TimeoutException` and `NetworkError`, leaving `ProtocolError`, `ProxyError`, `UnsupportedProtocol` and `InvalidURL` to surface as a 500 from `/health` rather than a `"no"`; letting an operator aim the probe at an arbitrary route is what makes those reachable in practice. And the default path is hoisted to `DEFAULT_PLATFORM_HEALTH_PATH`, so the route, the docs table and the tests stop keeping separate copies of it.

**Behavior change worth a release note.** A hybrid deployment whose configured health route answers non-2xx, an auth-protected endpoint returning 401 for instance, flips from `platform_reachable: "yes"` to `"no"`, and `/health/readiness` starts returning 503. That is what the issue asks for, but it can pull pods out of rotation on upgrade.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #877

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, tests).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec. No route or docstring changed, so the spec is unaffected; `make openapi-check` and `make postman-check` both report no drift.

Probe tests went from 2 to 13. Six of them fail against the previous implementation (404, 401, 403, the redirect, `RemoteProtocolError`, `ProxyError`), so the new semantics are covered rather than assumed. Local runs: `make lint`, `make typecheck`, full `tests/unit` (2652 passed), `tests/integration` for hybrid surface, health and config env loading (53 passed), and the OSS-edition smoke, all clean against a local PostgreSQL, since this sandbox has no Docker for Testcontainers.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via the Claude Code CLI.

**Any additional AI details you'd like to share:**

Implemented and tested by the agent through back-and-forth with @njbrake; the reasoning and decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)
