### PR TITLE
feat(dashboard): give organization admins Edit on the Build pages

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -105,6 +105,13 @@ reach, narrowed by any workspace model restriction. A deployment whose providers
 all come from `config.yml` therefore shows every tenant the same catalog it
 always did.
 
+Aliases and stored routing policies are workspace-scoped rows, and the catalog
+reads them for a workspace rather than filtering them by target, so a name alone
+would cross a tenant boundary that the allow-list cannot see. A session is
+therefore shown that layer only where the workspace it comes from is one the
+caller may see, which on a single-tenant deployment is everyone in it. An API key
+is unaffected: it names its own workspace.
+
 ## Capabilities
 
 `model_capabilities` can correct image and PDF support when a compatible

--- a/docs/models.md
+++ b/docs/models.md
@@ -94,6 +94,17 @@ explicitly priced models. For a backend with no listing API, use the instance's
 Hosted mode keeps `GET /v1/models` for control-plane discovery. Hybrid mode
 does not serve the local catalog.
 
+### Who is shown which models
+
+An API key is shown the models its allow-list permits, so the catalog never
+advertises a model that would be refused at inference. A dashboard session is
+answered the same way, from its membership: a caller who operates the deployment
+sees the whole catalog, and anyone else sees every `providers:` instance, which
+is deployment-wide, plus the models their own organization's provider keys
+reach, narrowed by any workspace model restriction. A deployment whose providers
+all come from `config.yml` therefore shows every tenant the same catalog it
+always did.
+
 ## Capabilities
 
 `model_capabilities` can correct image and PDF support when a compatible

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -14869,7 +14869,7 @@
     },
     "/v1/aliases/{name}": {
       "delete": {
-        "description": "Delete a stored alias in one scope.\n\nScoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:\ndeleting one workspace's alias must not touch another's, deleting the\nworkspace-wide alias must not take a user's override with it, and deleting an\noverride must leave the workspace-wide one serving everyone else.",
+        "description": "Delete a stored alias in one scope.",
         "operationId": "delete_alias_v1_aliases__name__delete",
         "parameters": [
           {
@@ -17895,6 +17895,151 @@
         ]
       }
     },
+    "/v1/organizations/me/aliases": {
+      "get": {
+        "description": "List the aliases in force in the workspaces this caller may see.\n\nThe policies list's sibling, over ``model_aliases``, and scoped the same way:\nstored rows from the caller's visible workspaces, plus the config-file\naliases, which are deployment-wide.",
+        "operationId": "list_visible_aliases_v1_organizations_me_aliases_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AliasResponse"
+                  },
+                  "title": "Response List Visible Aliases V1 Organizations Me Aliases Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "List Visible Aliases",
+        "tags": [
+          "aliases"
+        ]
+      },
+      "post": {
+        "description": "Create or update a stored alias in one of the organization's workspaces.\n\nOrganization owners and admins only, with the same two scope rules the policy\nwrite has: ``workspace_id`` is required and resolved inside the caller's\norganization, and ``user_id`` is not accepted.",
+        "operationId": "set_organization_alias_v1_organizations_me_aliases_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AliasRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AliasResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Set Organization Alias",
+        "tags": [
+          "aliases"
+        ]
+      }
+    },
+    "/v1/organizations/me/aliases/{name}": {
+      "delete": {
+        "description": "Delete a stored alias from one of the organization's workspaces. Owners and admins only.",
+        "operationId": "delete_organization_alias_v1_organizations_me_aliases__name__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Delete the alias in this workspace of the caller's organization.",
+            "in": "query",
+            "name": "workspace_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Delete the alias in this workspace of the caller's organization.",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Delete Organization Alias",
+        "tags": [
+          "aliases"
+        ]
+      }
+    },
     "/v1/organizations/me/budgets": {
       "get": {
         "description": "List the budgets this organization has defined. Owners and admins only.",
@@ -19662,7 +19807,7 @@
     },
     "/v1/organizations/me/routing-policies": {
       "get": {
-        "description": "List the routing policies in force in the workspaces this caller may see.\n\nStored policies from the caller's visible workspaces plus the config-file\npolicies, which are deployment-wide and resolve in every workspace. The\nresponse is the shape ``GET /v1/routing/policies`` answers, narrowed to the\ncaller's own organization; only an operator can write any of it.",
+        "description": "List the routing policies in force in the workspaces this caller may see.\n\nStored policies from the caller's visible workspaces plus the config-file\npolicies, which are deployment-wide and resolve in every workspace. The\nresponse is the shape ``GET /v1/routing/policies`` answers, narrowed to the\ncaller's own organization.",
         "operationId": "list_visible_routing_policies_v1_organizations_me_routing_policies_get",
         "responses": {
           "200": {
@@ -19689,6 +19834,117 @@
           }
         ],
         "summary": "List Visible Routing Policies",
+        "tags": [
+          "routing"
+        ]
+      },
+      "post": {
+        "description": "Create or update a stored policy in one of the organization's workspaces.\n\nOrganization owners and admins only. ``workspace_id`` is required and must\nname a workspace of the caller's own organization; ``user_id`` is not\naccepted here.",
+        "operationId": "set_organization_routing_policy_v1_organizations_me_routing_policies_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PolicyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PolicyResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Set Organization Routing Policy",
+        "tags": [
+          "routing"
+        ]
+      }
+    },
+    "/v1/organizations/me/routing-policies/{name}": {
+      "delete": {
+        "description": "Delete a stored policy from one of the organization's workspaces. Owners and admins only.",
+        "operationId": "delete_organization_routing_policy_v1_organizations_me_routing_policies__name__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Delete the policy in this workspace of the caller's organization.",
+            "in": "query",
+            "name": "workspace_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Delete the policy in this workspace of the caller's organization.",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          },
+          {
+            "XApiKeyAuth": []
+          }
+        ],
+        "summary": "Delete Organization Routing Policy",
         "tags": [
           "routing"
         ]
@@ -22482,7 +22738,7 @@
         ]
       },
       "post": {
-        "description": "Create or update a stored policy in one workspace, optionally for one user.\n\nThe spec is validated here and stored as given, so a row can never contain a\nbody this build would refuse at load. The cache is refreshed twice: once before\nvalidating (so the shadowing checks see other writers' policies) and once after\ncommitting (so this worker serves the new policy immediately).\n\n``rename_from`` renames the row instead of keying on ``name``. It is part of\nthis write rather than an endpoint of its own so that an edit which both renames\na policy and re-targets it cannot land half-applied, leaving the old name serving\nthe new spec. The new name is validated exactly as a fresh one is, because a\nrename can walk a policy into every collision a create can. Sending the field\nasserts the named policy is stored, so it never falls back to creating one.",
+        "description": "Create or update a stored policy in one workspace, optionally for one user.\n\nOmitting ``workspace_id`` means the deployment's default workspace, which is\nwhere an operator acting deployment-wide writes.",
         "operationId": "set_policy_v1_routing_policies_post",
         "requestBody": {
           "content": {
@@ -22582,7 +22838,7 @@
     },
     "/v1/routing/policies/{name}": {
       "delete": {
-        "description": "Delete a stored policy in one scope.\n\nScoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:\ndeleting one workspace's policy must not touch another's, deleting the\nworkspace-wide policy must not take a user's override with it, and deleting an\noverride must leave the workspace-wide one serving everyone else.",
+        "description": "Delete a stored policy in one scope.",
         "operationId": "delete_policy_v1_routing_policies__name__delete",
         "parameters": [
           {
@@ -23718,7 +23974,7 @@
     },
     "/v1/tool-settings": {
       "get": {
-        "description": "Return the effective tool/guardrail settings for the dashboard.",
+        "description": "Return the effective tool/guardrail settings for the dashboard.\n\nAuthentication only on the router: the role decides *how much* rather than\nwhether, so this is not the deployment-wide gate ``require_deployment_operator``\nnames. A header master key is the deployment credential and reads everything;\na session reads everything only while it operates the deployment, and\notherwise gets the fields without the service endpoints in them.",
         "operationId": "get_tool_settings_v1_tool_settings_get",
         "responses": {
           "200": {

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -17899,6 +17899,22 @@
       "get": {
         "description": "List the aliases in force in the workspaces this caller may see.\n\nThe policies list's sibling, over ``model_aliases``, and scoped the same way:\nstored rows from the caller's visible workspaces, plus the config-file\naliases, which are deployment-wide.",
         "operationId": "list_visible_aliases_v1_organizations_me_aliases_get",
+        "parameters": [
+          {
+            "description": "Maximum entries to return, stored and config-file together.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 1000,
+              "description": "Maximum entries to return, stored and config-file together.",
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -17913,6 +17929,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "security": [
@@ -19809,6 +19835,22 @@
       "get": {
         "description": "List the routing policies in force in the workspaces this caller may see.\n\nStored policies from the caller's visible workspaces plus the config-file\npolicies, which are deployment-wide and resolve in every workspace. The\nresponse is the shape ``GET /v1/routing/policies`` answers, narrowed to the\ncaller's own organization.",
         "operationId": "list_visible_routing_policies_v1_organizations_me_routing_policies_get",
+        "parameters": [
+          {
+            "description": "Maximum entries to return, stored and config-file together.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 1000,
+              "description": "Maximum entries to return, stored and config-file together.",
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -19823,6 +19865,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "security": [

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -428,7 +428,7 @@
         {
           "name": "Delete Alias",
           "request": {
-            "description": "Delete a stored alias in one scope.\n\nScoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:\ndeleting one workspace's alias must not touch another's, deleting the\nworkspace-wide alias must not take a user's override with it, and deleting an\noverride must leave the workspace-wide one serving everyone else.",
+            "description": "Delete a stored alias in one scope.",
             "header": [],
             "method": "DELETE",
             "url": {
@@ -455,6 +455,96 @@
                 }
               ],
               "raw": "{{baseUrl}}/v1/aliases/:name?user_id=&workspace_id=",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "name",
+                  "value": ""
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "List Visible Aliases",
+          "request": {
+            "description": "List the aliases in force in the workspaces this caller may see.\n\nThe policies list's sibling, over ``model_aliases``, and scoped the same way:\nstored rows from the caller's visible workspaces, plus the config-file\naliases, which are deployment-wide.",
+            "header": [],
+            "method": "GET",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "aliases"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/aliases"
+            }
+          }
+        },
+        {
+          "name": "Set Organization Alias",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"name\": \"string\",\n  \"target\": \"string\"\n}"
+            },
+            "description": "Create or update a stored alias in one of the organization's workspaces.\n\nOrganization owners and admins only, with the same two scope rules the policy\nwrite has: ``workspace_id`` is required and resolved inside the caller's\norganization, and ``user_id`` is not accepted.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "aliases"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/aliases"
+            }
+          }
+        },
+        {
+          "name": "Delete Organization Alias",
+          "request": {
+            "description": "Delete a stored alias from one of the organization's workspaces. Owners and admins only.",
+            "header": [],
+            "method": "DELETE",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "aliases",
+                ":name"
+              ],
+              "query": [
+                {
+                  "description": "Delete the alias in this workspace of the caller's organization.",
+                  "disabled": true,
+                  "key": "workspace_id",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/aliases/:name?workspace_id=",
               "variable": [
                 {
                   "description": "path parameter",
@@ -3848,7 +3938,7 @@
         {
           "name": "List Visible Routing Policies",
           "request": {
-            "description": "List the routing policies in force in the workspaces this caller may see.\n\nStored policies from the caller's visible workspaces plus the config-file\npolicies, which are deployment-wide and resolve in every workspace. The\nresponse is the shape ``GET /v1/routing/policies`` answers, narrowed to the\ncaller's own organization; only an operator can write any of it.",
+            "description": "List the routing policies in force in the workspaces this caller may see.\n\nStored policies from the caller's visible workspaces plus the config-file\npolicies, which are deployment-wide and resolve in every workspace. The\nresponse is the shape ``GET /v1/routing/policies`` answers, narrowed to the\ncaller's own organization.",
             "header": [],
             "method": "GET",
             "url": {
@@ -3862,6 +3952,76 @@
                 "routing-policies"
               ],
               "raw": "{{baseUrl}}/v1/organizations/me/routing-policies"
+            }
+          }
+        },
+        {
+          "name": "Set Organization Routing Policy",
+          "request": {
+            "body": {
+              "mode": "raw",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              },
+              "raw": "{\n  \"name\": \"string\",\n  \"spec\": {}\n}"
+            },
+            "description": "Create or update a stored policy in one of the organization's workspaces.\n\nOrganization owners and admins only. ``workspace_id`` is required and must\nname a workspace of the caller's own organization; ``user_id`` is not\naccepted here.",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "method": "POST",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "routing-policies"
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/routing-policies"
+            }
+          }
+        },
+        {
+          "name": "Delete Organization Routing Policy",
+          "request": {
+            "description": "Delete a stored policy from one of the organization's workspaces. Owners and admins only.",
+            "header": [],
+            "method": "DELETE",
+            "url": {
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "organizations",
+                "me",
+                "routing-policies",
+                ":name"
+              ],
+              "query": [
+                {
+                  "description": "Delete the policy in this workspace of the caller's organization.",
+                  "disabled": true,
+                  "key": "workspace_id",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/routing-policies/:name?workspace_id=",
+              "variable": [
+                {
+                  "description": "path parameter",
+                  "key": "name",
+                  "value": ""
+                }
+              ]
             }
           }
         },
@@ -3904,7 +4064,7 @@
               },
               "raw": "{\n  \"name\": \"string\",\n  \"spec\": {}\n}"
             },
-            "description": "Create or update a stored policy in one workspace, optionally for one user.\n\nThe spec is validated here and stored as given, so a row can never contain a\nbody this build would refuse at load. The cache is refreshed twice: once before\nvalidating (so the shadowing checks see other writers' policies) and once after\ncommitting (so this worker serves the new policy immediately).\n\n``rename_from`` renames the row instead of keying on ``name``. It is part of\nthis write rather than an endpoint of its own so that an edit which both renames\na policy and re-targets it cannot land half-applied, leaving the old name serving\nthe new spec. The new name is validated exactly as a fresh one is, because a\nrename can walk a policy into every collision a create can. Sending the field\nasserts the named policy is stored, so it never falls back to creating one.",
+            "description": "Create or update a stored policy in one workspace, optionally for one user.\n\nOmitting ``workspace_id`` means the deployment's default workspace, which is\nwhere an operator acting deployment-wide writes.",
             "header": [
               {
                 "key": "Content-Type",
@@ -3962,7 +4122,7 @@
         {
           "name": "Delete Policy",
           "request": {
-            "description": "Delete a stored policy in one scope.\n\nScoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:\ndeleting one workspace's policy must not touch another's, deleting the\nworkspace-wide policy must not take a user's override with it, and deleting an\noverride must leave the workspace-wide one serving everyone else.",
+            "description": "Delete a stored policy in one scope.",
             "header": [],
             "method": "DELETE",
             "url": {
@@ -5756,7 +5916,7 @@
         {
           "name": "Get Tool Settings",
           "request": {
-            "description": "Return the effective tool/guardrail settings for the dashboard.",
+            "description": "Return the effective tool/guardrail settings for the dashboard.\n\nAuthentication only on the router: the role decides *how much* rather than\nwhether, so this is not the deployment-wide gate ``require_deployment_operator``\nnames. A header master key is the deployment credential and reads everything;\na session reads everything only while it operates the deployment, and\notherwise gets the fields without the service endpoints in them.",
             "header": [],
             "method": "GET",
             "url": {

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -481,7 +481,15 @@
                 "me",
                 "aliases"
               ],
-              "raw": "{{baseUrl}}/v1/organizations/me/aliases"
+              "query": [
+                {
+                  "description": "Maximum entries to return, stored and config-file together.",
+                  "disabled": true,
+                  "key": "limit",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/aliases?limit="
             }
           }
         },
@@ -3951,7 +3959,15 @@
                 "me",
                 "routing-policies"
               ],
-              "raw": "{{baseUrl}}/v1/organizations/me/routing-policies"
+              "query": [
+                {
+                  "description": "Maximum entries to return, stored and config-file together.",
+                  "disabled": true,
+                  "key": "limit",
+                  "value": ""
+                }
+              ],
+              "raw": "{{baseUrl}}/v1/organizations/me/routing-policies?limit="
             }
           }
         },

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -190,6 +190,12 @@ refuse a target the organization holds no provider access for. Both reads take a
 server-capped `limit`, which bounds the response rather than paginating it. A
 member of the organization reads the same two lists and writes neither.
 
+Those routes are workspace-wide entries only, on the reads as much as the
+writes. A stored policy or alias can also be scoped to one user, and `user_id`
+names an API-key user rather than a dashboard identity, so it is neither a
+tenant's to set nor a tenant's to interpret. Managing a user-scoped entry stays
+on the deployment-wide routes.
+
 The authenticating API key determines which workspace resolves a policy.
 User-scoped entries take precedence over wider entries. A config-file policy
 cannot be changed through the API.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -181,6 +181,14 @@ manage stored policies through the Routing page or `/v1/routing/policies`.
 Stored policies belong to one workspace and can optionally be scoped to one
 user.
 
+An organization's owners and admins manage their own workspaces' policies and
+aliases through `/v1/organizations/me/routing-policies` and
+`/v1/organizations/me/aliases`, which the Routing page uses for a caller who
+does not operate the deployment. Those routes require the workspace named, must
+name a workspace of the caller's own organization, accept no user scope, and
+refuse a target the organization holds no provider access for. A member of the
+organization reads the same two lists and writes neither.
+
 The authenticating API key determines which workspace resolves a policy.
 User-scoped entries take precedence over wider entries. A config-file policy
 cannot be changed through the API.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -186,8 +186,9 @@ aliases through `/v1/organizations/me/routing-policies` and
 `/v1/organizations/me/aliases`, which the Routing page uses for a caller who
 does not operate the deployment. Those routes require the workspace named, must
 name a workspace of the caller's own organization, accept no user scope, and
-refuse a target the organization holds no provider access for. A member of the
-organization reads the same two lists and writes neither.
+refuse a target the organization holds no provider access for. Both reads take a
+server-capped `limit`, which bounds the response rather than paginating it. A
+member of the organization reads the same two lists and writes neither.
 
 The authenticating API key determines which workspace resolves a policy.
 User-scoped entries take precedence over wider entries. A config-file policy

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -35,6 +35,15 @@ Interception is off by default because enabling it changes who performs searches
 for providers that already support a native search tool. It requires
 `web_search_url`.
 
+### Who may read the settings
+
+`GET /v1/tool-settings` answers any signed-in identity, so a member is told how
+the built-in tools behave on their requests. A caller who does not operate the
+deployment is answered without `web_search_url`, `sandbox_url` and
+`guardrails_url`: those name this deployment's own infrastructure, which is what
+the network-safety gates on the Settings page are set against, and no tenant
+acts on them. Changing any setting stays a deployment operator's to do.
+
 ## Pricing a gateway-run tool
 
 In standalone mode, gateway-run tools are priced per successful call:

--- a/scripts/sdk_codegen/sdk-endpoints.txt
+++ b/scripts/sdk_codegen/sdk-endpoints.txt
@@ -244,6 +244,11 @@ GET /v1/organizations/me/usage/count                        # dashboard-only
 GET /v1/organizations/me/usage/summary                      # dashboard-only
 GET /v1/organizations/me/usage/series                       # dashboard-only
 GET /v1/organizations/me/routing-policies                   # dashboard-only
+POST /v1/organizations/me/routing-policies                  # dashboard-only
+DELETE /v1/organizations/me/routing-policies/{name}         # dashboard-only
+GET /v1/organizations/me/aliases                            # dashboard-only
+POST /v1/organizations/me/aliases                           # dashboard-only
+DELETE /v1/organizations/me/aliases/{name}                  # dashboard-only
 # The member's own keys (otari-ai#1941), excluded for the same reason as the
 # usage reads above: scoped by the caller's dashboard session, which an SDK
 # caller does not hold.

--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -182,9 +182,11 @@ def _register_core_routers(app: FastAPI, config: GatewayConfig) -> None:
     # rather than beside the usage routers, because what it is scoped to is what
     # decides who may call it (otari#837).
     app.include_router(organization_usage.router)
-    # The tenant-scoped read over the same table ``/v1/routing/policies`` serves
-    # to an operator, mounted here for the same reason (otari-ai#1942).
-    app.include_router(organization_routing.router)
+    # The tenant-scoped reads and writes over the same tables ``/v1/routing/policies``
+    # and ``/v1/aliases`` serve to an operator, mounted here for the same reason
+    # (otari-ai#1942, otari-ai#1969).
+    app.include_router(organization_routing.policies_router)
+    app.include_router(organization_routing.aliases_router)
     # The member-scoped key surface: the caller's own keys, in workspaces they
     # may see. Mounted here for the reason the usage sibling above is; the
     # deployment-wide ``keys.router`` keeps its operator gate unchanged
@@ -217,6 +219,11 @@ def _register_core_routers(app: FastAPI, config: GatewayConfig) -> None:
     app.include_router(settings.router)
     app.include_router(mail.router)
     app.include_router(maintenance_mode.router)
-    app.include_router(tool_settings.router)
+    # Both prefixed /v1/tool-settings, split by who may call them: the reader is
+    # the one route a tenant may reach, narrowed inside the handler
+    # (otari-ai#1969). Operator first, matching the pair above, though neither
+    # router here ends with a catch-all for the other to sit behind.
+    app.include_router(tool_settings.operator_router)
+    app.include_router(tool_settings.reader_router)
     app.include_router(search_tools.router)
     app.include_router(tools.router)

--- a/src/gateway/api/routes/aliases.py
+++ b/src/gateway/api/routes/aliases.py
@@ -199,16 +199,23 @@ async def list_aliases(
     )
 
 
-@router.post("")
-async def set_alias(
+async def upsert_alias_in_workspace(
     request: AliasRequest,
-    db: Annotated[AsyncSession, Depends(get_db)],
-    config: Annotated[GatewayConfig, Depends(get_config)],
+    db: AsyncSession,
+    config: GatewayConfig,
+    *,
+    workspace_id: uuid.UUID,
 ) -> AliasResponse:
-    """Create or update a stored alias in one workspace, optionally for one user."""
+    """Create or update a stored alias in an already-resolved workspace.
+
+    ``workspace_id`` is a parameter rather than read off ``request`` because the
+    two routers that reach this resolve it differently and must keep doing so:
+    the operator's takes the deployment's default when none is named, while the
+    tenant-scoped one resolves it inside the caller's own organization
+    (``organization_routing``, otari-ai#1969).
+    """
     if request.user_id is not None:
         await _require_user(db, request.user_id)
-    workspace_id = await resolve_managed_workspace_id(db, request.workspace_id)
     await refresh_alias_cache(db)
     _validate(config, request.name, request.target, request.user_id)
 
@@ -254,33 +261,37 @@ async def set_alias(
     return AliasResponse.from_model(alias)
 
 
-@router.delete("/{name:path}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_alias(
-    name: str,
+@router.post("")
+async def set_alias(
+    request: AliasRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
-    user_id: Annotated[
-        str | None,
-        Query(
-            description=(
-                "Delete the alias scoped to this user. Omit to delete the workspace-wide alias "
-                "of that name."
-            )
-        ),
-    ] = None,
-    workspace_id: Annotated[
-        uuid.UUID | None,
-        Query(description="Delete the alias in this workspace. Omit for the deployment's default workspace."),
-    ] = None,
+) -> AliasResponse:
+    """Create or update a stored alias in one workspace, optionally for one user."""
+    return await upsert_alias_in_workspace(
+        request,
+        db,
+        config,
+        workspace_id=await resolve_managed_workspace_id(db, request.workspace_id),
+    )
+
+
+async def delete_alias_in_workspace(
+    name: str,
+    db: AsyncSession,
+    config: GatewayConfig,
+    *,
+    workspace_id: uuid.UUID,
+    user_id: str | None,
 ) -> None:
-    """Delete a stored alias in one scope.
+    """Delete a stored alias in one scope of an already-resolved workspace.
 
     Scoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:
     deleting one workspace's alias must not touch another's, deleting the
     workspace-wide alias must not take a user's override with it, and deleting an
     override must leave the workspace-wide one serving everyone else.
     """
-    target_workspace_id = await resolve_managed_workspace_id(db, workspace_id)
+    target_workspace_id = workspace_id
     alias = (
         await db.execute(
             select(ModelAlias).where(
@@ -311,3 +322,36 @@ async def delete_alias(
         await refresh_alias_cache(db)
     except SQLAlchemyError:
         logger.warning("Alias cache refresh failed after deleting '%s'; converges within TTL", name)
+
+
+@router.delete(
+    "/{name:path}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(require_deployment_operator)],
+)
+async def delete_alias(
+    name: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    user_id: Annotated[
+        str | None,
+        Query(
+            description=(
+                "Delete the alias scoped to this user. Omit to delete the workspace-wide alias "
+                "of that name."
+            )
+        ),
+    ] = None,
+    workspace_id: Annotated[
+        uuid.UUID | None,
+        Query(description="Delete the alias in this workspace. Omit for the deployment's default workspace."),
+    ] = None,
+) -> None:
+    """Delete a stored alias in one scope."""
+    await delete_alias_in_workspace(
+        name,
+        db,
+        config,
+        workspace_id=await resolve_managed_workspace_id(db, workspace_id),
+        user_id=user_id,
+    )

--- a/src/gateway/api/routes/aliases.py
+++ b/src/gateway/api/routes/aliases.py
@@ -324,11 +324,7 @@ async def delete_alias_in_workspace(
         logger.warning("Alias cache refresh failed after deleting '%s'; converges within TTL", name)
 
 
-@router.delete(
-    "/{name:path}",
-    status_code=status.HTTP_204_NO_CONTENT,
-    dependencies=[Depends(require_deployment_operator)],
-)
+@router.delete("/{name:path}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_alias(
     name: str,
     db: Annotated[AsyncSession, Depends(get_db)],

--- a/src/gateway/api/routes/models.py
+++ b/src/gateway/api/routes/models.py
@@ -3,6 +3,7 @@
 import calendar
 import uuid
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -48,7 +49,7 @@ from gateway.services.pricing_service import (
 )
 from gateway.services.provider_kwargs import normalize_pricing_key
 from gateway.services.tenancy.deployment_user_service import DeploymentUserService
-from gateway.services.tenancy.organization_model_access import resolve_session_model_allowlist
+from gateway.services.tenancy.organization_model_access import resolve_session_catalog_scope
 
 if TYPE_CHECKING:
     from any_llm.types.model import Model
@@ -340,15 +341,41 @@ def _dynamic_policy_model(policy_name: str) -> ModelObject:
     )
 
 
+def _catalog_aliases(
+    config: GatewayConfig,
+    *,
+    caller_user_id: str | None,
+    caller_workspace_id: uuid.UUID | None,
+    workspace_layer: bool,
+) -> dict[str, str]:
+    """The aliases to list, with or without the workspace-scoped rows.
+
+    ``workspace_layer`` is false only for a session that may not see the
+    workspace ``effective_aliases`` would read (see
+    ``services/tenancy/organization_model_access``), where the configured aliases
+    are the whole answer: an alias name is not filtered by the model allow-list,
+    because the target it resolves to can be one every tenant may reach.
+    """
+    if not workspace_layer:
+        return dict(config.aliases)
+    return effective_aliases(config, caller_user_id, workspace_id=caller_workspace_id)
+
+
 def _policy_catalog_entries(
-    config: GatewayConfig, caller_user_id: str | None, caller_workspace_id: uuid.UUID | None
+    config: GatewayConfig,
+    caller_user_id: str | None,
+    caller_workspace_id: uuid.UUID | None,
+    *,
+    workspace_layer: bool = True,
 ) -> tuple[dict[str, str], dict[str, PolicySpec]]:
     """Split the policies in force into ``{name: target}`` and dynamic ones.
 
     Reads through :func:`effective_policies`, so stored policies are listed
     alongside the ones from ``config.yml`` and a caller's user-scoped policy wins,
     exactly as it does at request time. Listing only the configured ones would mean
-    a policy created in the dashboard worked but was invisible in the catalog.
+    a policy created in the dashboard worked but was invisible in the catalog. The
+    exception is ``workspace_layer=False``, which is :func:`_catalog_aliases`'s
+    and for the same reason: a stored policy is a workspace's row too.
 
     A static policy is an alias in every way the catalog cares about (one name, one
     target, priced from the target), so it is folded into the alias map and listed
@@ -356,9 +383,13 @@ def _policy_catalog_entries(
     note in :func:`list_models`. A dynamic one is listed separately by
     :func:`_dynamic_policy_model`.
     """
+    if not workspace_layer:
+        policies = dict(config.routing.policies) if config.routing.enabled else {}
+    else:
+        policies = effective_policies(config, caller_user_id, workspace_id=caller_workspace_id)
     static: dict[str, str] = {}
     dynamic: dict[str, PolicySpec] = {}
-    for name, spec in effective_policies(config, caller_user_id, workspace_id=caller_workspace_id).items():
+    for name, spec in policies.items():
         if spec.is_dynamic:
             dynamic[name] = spec
         else:
@@ -442,28 +473,53 @@ async def _get_pricing_map(
     return {p.model_key: p for p in pricings}
 
 
-async def _catalog_allowlist(
+@dataclass(frozen=True)
+class _CatalogScope:
+    """What one caller may be shown of the catalog."""
+
+    allowlist: list[str] | None
+    """``None`` is unrestricted."""
+
+    reads_workspace_layer: bool
+    """Whether the workspace-scoped alias and policy rows may be read at all.
+
+    False only for a dashboard session that may not see the workspace those rows
+    would come from. Every other caller keeps the layer it always read: an API
+    key names its own workspace, and a master key reads the deployment's default,
+    which is where its own writes land.
+    """
+
+
+async def _catalog_scope(
     db: AsyncSession,
     config: GatewayConfig,
     *,
     auth: tuple[APIKey | None, bool],
     session_identity: TenancyUser | None,
-) -> list[str] | None:
-    """The allow-list governing what this caller may be shown. ``None`` is unrestricted.
+) -> _CatalogScope:
+    """What this caller may be shown, by the rule that fits how they authenticated.
 
-    Three callers reach the catalog and each is answered by its own rule. An API
-    key gets its stored allow-list, as it always has. A header master key is the
-    deployment credential itself, so it is unrestricted. A dashboard session is
-    unrestricted only while it operates the deployment; otherwise it is answered
-    by its membership, so a member sees the providers their own organization
-    holds rather than every tenant's (otari-ai#1969).
+    Three callers reach the catalog. An API key gets its stored allow-list, as it
+    has always done. A header master key is the deployment credential itself, so
+    it is unrestricted. A dashboard session is unrestricted only while it
+    operates the deployment; otherwise it is answered by its membership, so a
+    member sees the providers their own organization holds rather than every
+    tenant's, and the workspace-scoped rows only where that workspace is theirs
+    (otari-ai#1969).
     """
     if session_identity is not None:
         if await DeploymentUserService(db).has_administration_access(session_identity):
-            return None
-        return await resolve_session_model_allowlist(db, config, user=session_identity)
+            return _CatalogScope(allowlist=None, reads_workspace_layer=True)
+        scope = await resolve_session_catalog_scope(db, config, user=session_identity)
+        return _CatalogScope(
+            allowlist=scope.allowlist,
+            reads_workspace_layer=scope.reads_default_workspace,
+        )
     api_key, is_master_key = auth
-    return None if is_master_key else await resolve_request_allowlist(db, api_key)
+    return _CatalogScope(
+        allowlist=None if is_master_key else await resolve_request_allowlist(db, api_key),
+        reads_workspace_layer=True,
+    )
 
 
 @catalog_router.get("/models")
@@ -487,6 +543,10 @@ async def list_models(
     # workspace's, which is where its own writes land.
     caller_user_id = auth[0].user_id if auth[0] is not None else None
     caller_workspace_id = auth[0].workspace_id if auth[0] is not None else None
+    # Resolved before the alias and policy layers are read, not only before they
+    # are filtered: it decides whether the workspace-scoped rows may be read at
+    # all, which no filter over targets can decide afterwards.
+    scope = await _catalog_scope(db, config, auth=auth, session_identity=session_identity)
     pricing_map = await _get_pricing_map(db, provider_filter=provider)
     # Snapshot before phase 1 mutates ``pricing_map`` (it pops matched keys), so
     # alias pricing can still be looked up by the target's canonical key. Keys are
@@ -501,8 +561,18 @@ async def list_models(
     # priced from the target), so it joins the alias map and is listed the same
     # way. Startup validation refuses a policy that collides with an alias name,
     # so this merge cannot silently shadow one.
-    configured_aliases = effective_aliases(config, caller_user_id, workspace_id=caller_workspace_id)
-    static_policies, dynamic_policies = _policy_catalog_entries(config, caller_user_id, caller_workspace_id)
+    configured_aliases = _catalog_aliases(
+        config,
+        caller_user_id=caller_user_id,
+        caller_workspace_id=caller_workspace_id,
+        workspace_layer=scope.reads_workspace_layer,
+    )
+    static_policies, dynamic_policies = _policy_catalog_entries(
+        config,
+        caller_user_id,
+        caller_workspace_id,
+        workspace_layer=scope.reads_workspace_layer,
+    )
     aliases = {**configured_aliases, **static_policies}
     # Alias targets are withheld from every phase that could surface the real
     # model, discovery (phase 1) as well as pricing-only (phase 2): publishing the
@@ -604,7 +674,7 @@ async def list_models(
     # catalog never advertises a model that would 403 at inference. Both surfaces
     # feed the SAME matcher the SAME canonical instance:model key; an alias id is a
     # display name, so it is matched on its resolved target. Master key sees all.
-    key_allowlist = await _catalog_allowlist(db, config, auth=auth, session_identity=session_identity)
+    key_allowlist = scope.allowlist
     if key_allowlist is not None:
         # A dynamic policy is listed when the key may use *any* of its candidates,
         # which is what the compiler will do at request time: it drops the ones the
@@ -712,20 +782,22 @@ async def get_model(
 ) -> ModelObject:
     """Get details for a specific model."""
     api_key, _is_master_key = auth
-    # Same scoping as the listing: the caller's own aliases, plus their
-    # workspace's and the configured ones. A master-key caller has neither, so it
-    # reads the configured layer and the default workspace's.
-    aliases = effective_aliases(
+    # Same scoping as the listing, the workspace layer included: the caller's own
+    # aliases, plus their workspace's and the configured ones. A master-key caller
+    # has neither, so it reads the configured layer and the default workspace's.
+    scope = await _catalog_scope(db, config, auth=auth, session_identity=session_identity)
+    aliases = _catalog_aliases(
         config,
-        api_key.user_id if api_key is not None else None,
-        workspace_id=api_key.workspace_id if api_key is not None else None,
+        caller_user_id=api_key.user_id if api_key is not None else None,
+        caller_workspace_id=api_key.workspace_id if api_key is not None else None,
+        workspace_layer=scope.reads_workspace_layer,
     )
 
     # Model access control: a denied model returns 404, indistinguishable from a
     # missing one, so this endpoint cannot be used to probe which models exist
     # behind an allow-list. Uses the same matcher/canonical key as the listing and
     # inference. Master key bypasses.
-    key_allowlist = await _catalog_allowlist(db, config, auth=auth, session_identity=session_identity)
+    key_allowlist = scope.allowlist
     if key_allowlist is not None:
         target = aliases.get(model_id, model_id)
         if not is_model_allowed(key_allowlist, normalize_pricing_key(config, target)):

--- a/src/gateway/api/routes/models.py
+++ b/src/gateway/api/routes/models.py
@@ -10,13 +10,20 @@ from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.api.deps import get_config, get_db, require_deployment_operator, verify_catalog_reader
+from gateway.api.deps import (
+    get_config,
+    get_db,
+    get_session_identity,
+    require_deployment_operator,
+    verify_catalog_reader,
+)
 from gateway.api.routes.pricing import PricingTier
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.models.entities import APIKey, ModelPricing
 from gateway.models.money import as_float
 from gateway.models.routing import PolicySpec
+from gateway.models.tenancy import User as TenancyUser
 from gateway.services.alias_service import effective_aliases
 from gateway.services.model_access import is_model_allowed, resolve_request_allowlist
 from gateway.services.model_catalog_service import (
@@ -40,6 +47,8 @@ from gateway.services.pricing_service import (
     normalize_effective_at,
 )
 from gateway.services.provider_kwargs import normalize_pricing_key
+from gateway.services.tenancy.deployment_user_service import DeploymentUserService
+from gateway.services.tenancy.organization_model_access import resolve_session_model_allowlist
 
 if TYPE_CHECKING:
     from any_llm.types.model import Model
@@ -433,11 +442,36 @@ async def _get_pricing_map(
     return {p.model_key: p for p in pricings}
 
 
+async def _catalog_allowlist(
+    db: AsyncSession,
+    config: GatewayConfig,
+    *,
+    auth: tuple[APIKey | None, bool],
+    session_identity: TenancyUser | None,
+) -> list[str] | None:
+    """The allow-list governing what this caller may be shown. ``None`` is unrestricted.
+
+    Three callers reach the catalog and each is answered by its own rule. An API
+    key gets its stored allow-list, as it always has. A header master key is the
+    deployment credential itself, so it is unrestricted. A dashboard session is
+    unrestricted only while it operates the deployment; otherwise it is answered
+    by its membership, so a member sees the providers their own organization
+    holds rather than every tenant's (otari-ai#1969).
+    """
+    if session_identity is not None:
+        if await DeploymentUserService(db).has_administration_access(session_identity):
+            return None
+        return await resolve_session_model_allowlist(db, config, user=session_identity)
+    api_key, is_master_key = auth
+    return None if is_master_key else await resolve_request_allowlist(db, api_key)
+
+
 @catalog_router.get("/models")
 async def list_models(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
     auth: Annotated[tuple[APIKey | None, bool], Depends(verify_catalog_reader)],
+    session_identity: Annotated[TenancyUser | None, Depends(get_session_identity)],
     provider: Annotated[str | None, Query(description="Filter models by provider name")] = None,
 ) -> ModelListResponse:
     """List all available models.
@@ -570,8 +604,7 @@ async def list_models(
     # catalog never advertises a model that would 403 at inference. Both surfaces
     # feed the SAME matcher the SAME canonical instance:model key; an alias id is a
     # display name, so it is matched on its resolved target. Master key sees all.
-    api_key, is_master_key = auth
-    key_allowlist = None if is_master_key else await resolve_request_allowlist(db, api_key)
+    key_allowlist = await _catalog_allowlist(db, config, auth=auth, session_identity=session_identity)
     if key_allowlist is not None:
         # A dynamic policy is listed when the key may use *any* of its candidates,
         # which is what the compiler will do at request time: it drops the ones the
@@ -675,9 +708,10 @@ async def get_model(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
     auth: Annotated[tuple[APIKey | None, bool], Depends(verify_catalog_reader)],
+    session_identity: Annotated[TenancyUser | None, Depends(get_session_identity)],
 ) -> ModelObject:
     """Get details for a specific model."""
-    api_key, is_master_key = auth
+    api_key, _is_master_key = auth
     # Same scoping as the listing: the caller's own aliases, plus their
     # workspace's and the configured ones. A master-key caller has neither, so it
     # reads the configured layer and the default workspace's.
@@ -691,7 +725,7 @@ async def get_model(
     # missing one, so this endpoint cannot be used to probe which models exist
     # behind an allow-list. Uses the same matcher/canonical key as the listing and
     # inference. Master key bypasses.
-    key_allowlist = None if is_master_key else await resolve_request_allowlist(db, api_key)
+    key_allowlist = await _catalog_allowlist(db, config, auth=auth, session_identity=session_identity)
     if key_allowlist is not None:
         target = aliases.get(model_id, model_id)
         if not is_model_allowed(key_allowlist, normalize_pricing_key(config, target)):

--- a/src/gateway/api/routes/organization_routing.py
+++ b/src/gateway/api/routes/organization_routing.py
@@ -24,6 +24,14 @@ member, Edit for an admin (otari-ai#1942, otari-ai#1969).
   page, because the dashboard renders policies and aliases as one sorted table
   and a page of one beside every row of the other would be incoherent; the bound
   is there for the organization that outgrows the page, not to paginate the page.
+* **Workspace-wide rows only, on the reads as much as the writes.** A stored row
+  may be scoped to one ``users.user_id`` as well as to a workspace, and neither
+  half of this surface handles that scope. The write refuses ``user_id`` because
+  it is a deployment-wide identifier; the read has to agree, or an admin is shown
+  a row they cannot address. While these were listed, Delete on one carried no
+  user scope, so it matched ``user_id IS NULL`` and destroyed the workspace-wide
+  row of that name while answering 204. A tenant cannot interpret the identifier
+  either: it names an API-key user, where a dashboard member is a tenancy UUID.
 * **A write needs a named workspace, resolved inside the organization.** There is
   no default-workspace fallback here, unlike the operator routers: the
   deployment's default workspace is not the tenant's to write into unless it
@@ -73,7 +81,9 @@ from gateway.models.entities import ModelAlias, RoutingPolicy
 from gateway.models.routing import PolicySpec
 from gateway.models.tenancy import User as TenancyUser
 from gateway.models.tenancy import Workspace
+from gateway.services.alias_service import all_alias_names
 from gateway.services.model_access import is_model_allowed
+from gateway.services.policy_store import all_policy_names
 from gateway.services.provider_kwargs import normalize_pricing_key
 from gateway.services.tenancy import OrganizationService
 from gateway.services.tenancy.authorization import (
@@ -154,12 +164,20 @@ async def _require_reachable_targets(
     resolution follows the name. Answered as a 400 naming the target, because it
     is a statement about the body rather than about the caller's role, and the
     catalog the dashboard offers already excludes these.
+
+    A target that names another alias or policy is left alone, because the write
+    helpers refuse chaining a step later and say so precisely. Checking it here
+    first would answer "not available to this organization", which is true of an
+    indirection name and useless for fixing it.
     """
     if not targets:
         return
+    indirections = all_alias_names(config) | all_policy_names(config)
     allowlist = await resolve_session_model_allowlist(db, config, user=user)
     unreachable = [
-        target for target in targets if not is_model_allowed(allowlist, normalize_pricing_key(config, target))
+        target
+        for target in targets
+        if target not in indirections and not is_model_allowed(allowlist, normalize_pricing_key(config, target))
     ]
     if unreachable:
         raise HTTPException(
@@ -224,7 +242,12 @@ async def list_visible_routing_policies(
     caller's own organization.
     """
     scope = await resolve_visible_workspace_scope(db, user=current_identity, organizations=OrganizationService(db))
-    statement = select(RoutingPolicy).where(col(RoutingPolicy.workspace_id).in_(_visible_workspace_ids(scope)))
+    statement = select(RoutingPolicy).where(
+        col(RoutingPolicy.workspace_id).in_(_visible_workspace_ids(scope)),
+        # Workspace-wide only; see the module docstring for why a user-scoped row
+        # is neither this surface's to show nor its to act on.
+        col(RoutingPolicy.user_id).is_(None),
+    )
     rows = (await db.execute(statement.order_by(RoutingPolicy.name).limit(limit))).scalars().all()
     policies = []
     for row in rows:
@@ -314,7 +337,10 @@ async def list_visible_aliases(
     aliases, which are deployment-wide.
     """
     scope = await resolve_visible_workspace_scope(db, user=current_identity, organizations=OrganizationService(db))
-    statement = select(ModelAlias).where(col(ModelAlias.workspace_id).in_(_visible_workspace_ids(scope)))
+    statement = select(ModelAlias).where(
+        col(ModelAlias.workspace_id).in_(_visible_workspace_ids(scope)),
+        col(ModelAlias.user_id).is_(None),
+    )
     rows = (await db.execute(statement.order_by(ModelAlias.name).limit(limit))).scalars().all()
     aliases = [AliasResponse.from_model(row) for row in rows]
     for name, target in config.aliases.items():

--- a/src/gateway/api/routes/organization_routing.py
+++ b/src/gateway/api/routes/organization_routing.py
@@ -1,59 +1,201 @@
-"""The routing policies in force where the caller may see, for a tenant who does not operate the deployment.
+"""The routing configuration of the caller's own organization, for a tenant.
 
-``/v1/routing/policies`` is deployment-wide and operator-only, which is right:
-it lists every tenant's stored policies and its ``workspace_id`` parameter is a
-filter the client supplies, so nothing but the operator gate stands between a
-signed-in member and another organization's routing (the escalation
-otari-ai#1880 closed). The roles matrix still wants a member to *view* the
-policies that shape their own requests (otari-ai#1942), so this router is a
-second, narrower reading of the same rows, shaped like ``organization_usage.py``
-(mozilla-ai/otari#837):
+``/v1/routing/policies`` and ``/v1/aliases`` are deployment-wide and
+operator-only, which is right: they list every tenant's stored rows and take a
+``workspace_id`` the client supplies, so nothing but the operator gate stands
+between a signed-in member and another organization's routing (the escalation
+otari-ai#1880 closed). These routers are a second, narrower reading and writing
+of the same tables, shaped like ``organization_usage.py``
+(mozilla-ai/otari#837), giving the roles matrix what it asks for: View for a
+member, Edit for an admin (otari-ai#1942, otari-ai#1969).
 
-* **Scope is derived, never accepted.** It comes from the caller's own
-  ``active_organization_id`` by way of ``resolve_visible_workspace_scope``,
+* **Scope is derived, never accepted.** The organization comes from the caller's
+  own ``active_organization_id`` by way of ``resolve_visible_workspace_scope``,
   which refuses a pointer with no live membership behind it. No request here
-  names an organization or a workspace.
-* **How much of the organization** follows the rule the workspace list already
-  uses: an owner, an admin or a superuser reads every workspace in it, and a
-  member or viewer reads the ones they actively belong to. A member who belongs
-  to no workspace still gets the config-file policies, which are deployment-wide
-  and in force in every workspace they could ever join.
+  names an organization.
+* **How much of it a read covers** follows the rule the workspace list uses: an
+  owner, an admin or a superuser reads every workspace in the organization, and
+  a member or viewer reads the ones they actively belong to. A member who
+  belongs to no workspace still gets the config-file entries, which are
+  deployment-wide and in force in every workspace they could ever join.
+* **A write needs a named workspace, resolved inside the organization.** There is
+  no default-workspace fallback here, unlike the operator routers: the
+  deployment's default workspace is not the tenant's to write into unless it
+  happens to be one of theirs, and a silent fallback is how it would become one.
 
-Reads only, one route. Writing a policy stays operator-only on the router above:
-a policy decides which models a name reaches, so a caller who could write one
-could widen their own access.
+Aliases and policies did not need an owner column for any of this. Both tables
+already carry a non-nullable ``workspace_id``, and a workspace belongs to exactly
+one organization, so the row's tenant is a join away. That is why this follows
+mozilla-ai/otari#875's shape (a ``/v1/organizations/me/*`` router over the same
+rows) without following its migration.
+
+**What stops a tenant widening their own access.** A policy or an alias decides
+which real model a name reaches, so an unconstrained write is a way to name a
+model the tenant may not call. Every target here is put through the same
+allow-list the catalog is filtered by
+(``services/tenancy/organization_model_access``), so an admin can only point a
+name at something their organization already reaches. That check, not the
+operator gate, is what makes these writes safe to open.
 """
 
+import uuid
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import ValidationError
-from sqlalchemy import false, select
+from sqlalchemy import Select, false, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
 from gateway.api.deps import CurrentIdentity, get_config, get_db, verify_master_key
-from gateway.api.routes.routing import PolicyResponse
+from gateway.api.routes.aliases import (
+    AliasRequest,
+    AliasResponse,
+    delete_alias_in_workspace,
+    upsert_alias_in_workspace,
+)
+from gateway.api.routes.routing import (
+    PolicyRequest,
+    PolicyResponse,
+    delete_policy_in_workspace,
+    upsert_policy_in_workspace,
+    validated_spec,
+)
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
-from gateway.models.entities import RoutingPolicy
+from gateway.models.entities import ModelAlias, RoutingPolicy
 from gateway.models.routing import PolicySpec
+from gateway.models.tenancy import User as TenancyUser
 from gateway.models.tenancy import Workspace
+from gateway.services.model_access import is_model_allowed
+from gateway.services.provider_kwargs import normalize_pricing_key
 from gateway.services.tenancy import OrganizationService
-from gateway.services.tenancy.authorization import resolve_visible_workspace_scope
+from gateway.services.tenancy.authorization import (
+    VisibleWorkspaceScope,
+    resolve_visible_workspace_scope,
+    resolve_workspace_in_organization,
+)
+from gateway.services.tenancy.organization_model_access import resolve_session_model_allowlist
 
-router = APIRouter(
+# Authentication only, like the rest of the ``/v1/organizations/me`` surface.
+# What the caller may read or write is decided per request below, which is the
+# pattern the tenant-scoped routers already follow and the reason the deployment
+# operator gate does not belong here.
+policies_router = APIRouter(
     prefix="/v1/organizations/me/routing-policies",
     tags=["routing"],
-    # Authentication only, like the rest of the ``/v1/organizations/me`` surface.
-    # What the caller may read is decided per request by the scope below, which
-    # is the pattern the tenant-scoped routers already follow and the reason the
-    # deployment operator gate does not belong here.
+    dependencies=[Depends(verify_master_key)],
+)
+
+aliases_router = APIRouter(
+    prefix="/v1/organizations/me/aliases",
+    tags=["aliases"],
     dependencies=[Depends(verify_master_key)],
 )
 
 
-@router.get("")
+async def _writable_workspace_id(
+    db: AsyncSession,
+    config: GatewayConfig,
+    *,
+    user: TenancyUser,
+    workspace_id: uuid.UUID | None,
+    targets: list[str],
+) -> uuid.UUID:
+    """Resolve the workspace a tenant write lands in, refusing what it may not do.
+
+    Three refusals, in the order that keeps each one from leaking what the next
+    would have told the caller. Management access first, so a member learns
+    nothing about which workspaces exist. Then the workspace, resolved inside the
+    caller's own organization, so another tenant's id is a 404 rather than a 403.
+    Then the targets, against the organization's own reach.
+    """
+    organizations = OrganizationService(db)
+    organization = await organizations.get_active_organization_for_user(user)
+    await organizations.require_active_organization_management_access(user=user, organization=organization)
+    if workspace_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="workspace_id is required: an organization's routing entries belong to one of its workspaces.",
+        )
+    workspace = await resolve_workspace_in_organization(
+        db,
+        user=user,
+        workspace_id=workspace_id,
+        organization=organization,
+        organizations=organizations,
+    )
+    await _require_reachable_targets(db, config, user=user, targets=targets)
+    return workspace.id
+
+
+async def _require_reachable_targets(
+    db: AsyncSession,
+    config: GatewayConfig,
+    *,
+    user: TenancyUser,
+    targets: list[str],
+) -> None:
+    """Refuse a target the caller's organization cannot already reach.
+
+    Without this, writing a policy would be a way to reach a provider the
+    organization holds no key for: the name is the tenant's to choose, and
+    resolution follows the name. Answered as a 400 naming the target, because it
+    is a statement about the body rather than about the caller's role, and the
+    catalog the dashboard offers already excludes these.
+    """
+    if not targets:
+        return
+    allowlist = await resolve_session_model_allowlist(db, config, user=user)
+    unreachable = [
+        target for target in targets if not is_model_allowed(allowlist, normalize_pricing_key(config, target))
+    ]
+    if unreachable:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Target(s) {', '.join(sorted(unreachable))} are not available to this organization. "
+                "Add a provider key for them first, or pick a model from the catalog."
+            ),
+        )
+
+
+def _reject_user_scope(user_id: str | None) -> None:
+    """Refuse a user-scoped entry on the tenant surface.
+
+    A user-scoped row names a ``users.user_id``, which is a deployment-wide
+    identifier with nothing in it saying whose it is, so accepting one would make
+    this an existence oracle across tenants. The operator router keeps that scope;
+    an organization admin writes workspace-wide, which is what the roles matrix
+    asks of them.
+    """
+    if user_id is not None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="user_id is not accepted here: an organization's entries are workspace-wide.",
+        )
+
+
+def _visible_workspace_ids(scope: VisibleWorkspaceScope) -> Select[tuple[uuid.UUID]]:
+    """The workspace ids whose stored rows this caller may be shown.
+
+    A subquery rather than a clause over one table, so the policies list and the
+    aliases list express one rule over their two. An owner or admin is a
+    predicate over ``organization_id`` rather than an ``IN`` list, so it does not
+    grow with the tenant.
+    """
+    statement = select(col(Workspace.id))
+    if scope.sees_every_workspace:
+        return statement.where(col(Workspace.organization_id) == scope.organization.id)
+    if scope.workspace_ids:
+        return statement.where(col(Workspace.id).in_(scope.workspace_ids))
+    # Belongs to no workspace yet: no stored row is theirs to see, and
+    # deliberately not a 403 (nothing was refused). The config entries below are
+    # deployment-wide, so they are still listed.
+    return statement.where(false())
+
+
+@policies_router.get("")
 async def list_visible_routing_policies(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
@@ -64,23 +206,10 @@ async def list_visible_routing_policies(
     Stored policies from the caller's visible workspaces plus the config-file
     policies, which are deployment-wide and resolve in every workspace. The
     response is the shape ``GET /v1/routing/policies`` answers, narrowed to the
-    caller's own organization; only an operator can write any of it.
+    caller's own organization.
     """
     scope = await resolve_visible_workspace_scope(db, user=current_identity, organizations=OrganizationService(db))
-    statement = select(RoutingPolicy)
-    if scope.sees_every_workspace:
-        statement = statement.where(
-            RoutingPolicy.workspace_id.in_(
-                select(col(Workspace.id)).where(col(Workspace.organization_id) == scope.organization.id)
-            )
-        )
-    elif scope.workspace_ids:
-        statement = statement.where(RoutingPolicy.workspace_id.in_(scope.workspace_ids))
-    else:
-        # Belongs to no workspace yet: no stored row is theirs to see, and
-        # deliberately not a 403 (nothing was refused). The config policies
-        # below still apply to every workspace, so they are still listed.
-        statement = statement.where(false())
+    statement = select(RoutingPolicy).where(col(RoutingPolicy.workspace_id).in_(_visible_workspace_ids(scope)))
     rows = (await db.execute(statement.order_by(RoutingPolicy.name))).scalars().all()
     policies = []
     for row in rows:
@@ -106,3 +235,117 @@ async def list_visible_routing_policies(
             )
         )
     return sorted(policies, key=lambda policy: (policy.name, str(policy.workspace_id or ""), policy.user_id or ""))
+
+
+@policies_router.post("")
+async def set_organization_routing_policy(
+    request: PolicyRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    current_identity: CurrentIdentity,
+) -> PolicyResponse:
+    """Create or update a stored policy in one of the organization's workspaces.
+
+    Organization owners and admins only. ``workspace_id`` is required and must
+    name a workspace of the caller's own organization; ``user_id`` is not
+    accepted here.
+    """
+    _reject_user_scope(request.user_id)
+    workspace_id = await _writable_workspace_id(
+        db,
+        config,
+        user=current_identity,
+        workspace_id=request.workspace_id,
+        targets=validated_spec(request.name, request.spec).static_selectors(),
+    )
+    return await upsert_policy_in_workspace(request, db, config, workspace_id=workspace_id)
+
+
+@policies_router.delete("/{name:path}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_organization_routing_policy(
+    name: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    current_identity: CurrentIdentity,
+    workspace_id: Annotated[
+        uuid.UUID | None,
+        Query(description="Delete the policy in this workspace of the caller's organization."),
+    ] = None,
+) -> None:
+    """Delete a stored policy from one of the organization's workspaces. Owners and admins only."""
+    resolved = await _writable_workspace_id(
+        db,
+        config,
+        user=current_identity,
+        workspace_id=workspace_id,
+        targets=[],
+    )
+    await delete_policy_in_workspace(name, db, config, workspace_id=resolved, user_id=None)
+
+
+@aliases_router.get("")
+async def list_visible_aliases(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    current_identity: CurrentIdentity,
+) -> list[AliasResponse]:
+    """List the aliases in force in the workspaces this caller may see.
+
+    The policies list's sibling, over ``model_aliases``, and scoped the same way:
+    stored rows from the caller's visible workspaces, plus the config-file
+    aliases, which are deployment-wide.
+    """
+    scope = await resolve_visible_workspace_scope(db, user=current_identity, organizations=OrganizationService(db))
+    statement = select(ModelAlias).where(col(ModelAlias.workspace_id).in_(_visible_workspace_ids(scope)))
+    rows = (await db.execute(statement.order_by(ModelAlias.name))).scalars().all()
+    aliases = [AliasResponse.from_model(row) for row in rows]
+    aliases.extend(
+        AliasResponse(name=name, target=target, source="config") for name, target in config.aliases.items()
+    )
+    return sorted(aliases, key=lambda alias: (alias.name, str(alias.workspace_id or ""), alias.user_id or ""))
+
+
+@aliases_router.post("")
+async def set_organization_alias(
+    request: AliasRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    current_identity: CurrentIdentity,
+) -> AliasResponse:
+    """Create or update a stored alias in one of the organization's workspaces.
+
+    Organization owners and admins only, with the same two scope rules the policy
+    write has: ``workspace_id`` is required and resolved inside the caller's
+    organization, and ``user_id`` is not accepted.
+    """
+    _reject_user_scope(request.user_id)
+    workspace_id = await _writable_workspace_id(
+        db,
+        config,
+        user=current_identity,
+        workspace_id=request.workspace_id,
+        targets=[request.target],
+    )
+    return await upsert_alias_in_workspace(request, db, config, workspace_id=workspace_id)
+
+
+@aliases_router.delete("/{name:path}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_organization_alias(
+    name: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    current_identity: CurrentIdentity,
+    workspace_id: Annotated[
+        uuid.UUID | None,
+        Query(description="Delete the alias in this workspace of the caller's organization."),
+    ] = None,
+) -> None:
+    """Delete a stored alias from one of the organization's workspaces. Owners and admins only."""
+    resolved = await _writable_workspace_id(
+        db,
+        config,
+        user=current_identity,
+        workspace_id=workspace_id,
+        targets=[],
+    )
+    await delete_alias_in_workspace(name, db, config, workspace_id=resolved, user_id=None)

--- a/src/gateway/api/routes/organization_routing.py
+++ b/src/gateway/api/routes/organization_routing.py
@@ -18,6 +18,12 @@ member, Edit for an admin (otari-ai#1942, otari-ai#1969).
   a member or viewer reads the ones they actively belong to. A member who
   belongs to no workspace still gets the config-file entries, which are
   deployment-wide and in force in every workspace they could ever join.
+* **Both reads are bounded.** ``limit`` caps the stored rows a request
+  materializes, and the config-file entries are appended within the same cap, so
+  neither response grows with the tenant. The default is the cap rather than a
+  page, because the dashboard renders policies and aliases as one sorted table
+  and a page of one beside every row of the other would be incoherent; the bound
+  is there for the organization that outgrows the page, not to paginate the page.
 * **A write needs a named workspace, resolved inside the organization.** There is
   no default-workspace fallback here, unlike the operator routers: the
   deployment's default workspace is not the tenant's to write into unless it
@@ -92,6 +98,11 @@ aliases_router = APIRouter(
     tags=["aliases"],
     dependencies=[Depends(verify_master_key)],
 )
+
+# The cap on either list, and its default. High enough that no real organization's
+# routing configuration is truncated by it, low enough that one row per name is
+# never an unbounded read.
+_MAX_ROWS = 1000
 
 
 async def _writable_workspace_id(
@@ -195,11 +206,15 @@ def _visible_workspace_ids(scope: VisibleWorkspaceScope) -> Select[tuple[uuid.UU
     return statement.where(false())
 
 
+_LIMIT = Query(ge=1, le=_MAX_ROWS, description="Maximum entries to return, stored and config-file together.")
+
+
 @policies_router.get("")
 async def list_visible_routing_policies(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
     current_identity: CurrentIdentity,
+    limit: Annotated[int, _LIMIT] = _MAX_ROWS,
 ) -> list[PolicyResponse]:
     """List the routing policies in force in the workspaces this caller may see.
 
@@ -210,7 +225,7 @@ async def list_visible_routing_policies(
     """
     scope = await resolve_visible_workspace_scope(db, user=current_identity, organizations=OrganizationService(db))
     statement = select(RoutingPolicy).where(col(RoutingPolicy.workspace_id).in_(_visible_workspace_ids(scope)))
-    rows = (await db.execute(statement.order_by(RoutingPolicy.name))).scalars().all()
+    rows = (await db.execute(statement.order_by(RoutingPolicy.name).limit(limit))).scalars().all()
     policies = []
     for row in rows:
         try:
@@ -226,6 +241,8 @@ async def list_visible_routing_policies(
     # Config last, matching the operator list: deployment-wide, in force in every
     # workspace, listed once and unscoped.
     for name, spec in config.routing.policies.items():
+        if len(policies) >= limit:
+            break
         policies.append(
             PolicyResponse(
                 name=name,
@@ -288,6 +305,7 @@ async def list_visible_aliases(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
     current_identity: CurrentIdentity,
+    limit: Annotated[int, _LIMIT] = _MAX_ROWS,
 ) -> list[AliasResponse]:
     """List the aliases in force in the workspaces this caller may see.
 
@@ -297,11 +315,12 @@ async def list_visible_aliases(
     """
     scope = await resolve_visible_workspace_scope(db, user=current_identity, organizations=OrganizationService(db))
     statement = select(ModelAlias).where(col(ModelAlias.workspace_id).in_(_visible_workspace_ids(scope)))
-    rows = (await db.execute(statement.order_by(ModelAlias.name))).scalars().all()
+    rows = (await db.execute(statement.order_by(ModelAlias.name).limit(limit))).scalars().all()
     aliases = [AliasResponse.from_model(row) for row in rows]
-    aliases.extend(
-        AliasResponse(name=name, target=target, source="config") for name, target in config.aliases.items()
-    )
+    for name, target in config.aliases.items():
+        if len(aliases) >= limit:
+            break
+        aliases.append(AliasResponse(name=name, target=target, source="config"))
     return sorted(aliases, key=lambda alias: (alias.name, str(alias.workspace_id or ""), alias.user_id or ""))
 
 

--- a/src/gateway/api/routes/routing.py
+++ b/src/gateway/api/routes/routing.py
@@ -205,8 +205,11 @@ class ExplainResponse(BaseModel):
     )
 
 
-def _validated_spec(name: str, spec: dict[str, Any]) -> PolicySpec:
+def validated_spec(name: str, spec: dict[str, Any]) -> PolicySpec:
     """Parse a spec body into a ``PolicySpec``, or raise a 400 naming the field.
+
+    Public because the tenant-scoped router needs the same parse before it can
+    check a policy's targets against what its organization may reach.
 
     The pydantic error is surfaced rather than flattened to a generic message: the
     schema's own messages explain the rules (one `default`, last; no `when` on a
@@ -431,13 +434,20 @@ async def list_policies(
     )
 
 
-@router.post("")
-async def set_policy(
+async def upsert_policy_in_workspace(
     request: PolicyRequest,
-    db: Annotated[AsyncSession, Depends(get_db)],
-    config: Annotated[GatewayConfig, Depends(get_config)],
+    db: AsyncSession,
+    config: GatewayConfig,
+    *,
+    workspace_id: uuid.UUID,
 ) -> PolicyResponse:
-    """Create or update a stored policy in one workspace, optionally for one user.
+    """Create or update a stored policy in an already-resolved workspace.
+
+    ``workspace_id`` is a parameter rather than read off ``request`` because the
+    two routers that reach this resolve it differently and must keep doing so:
+    the operator's takes the deployment's default when none is named, while the
+    tenant-scoped one resolves it inside the caller's own organization
+    (``organization_routing``, otari-ai#1969).
 
     The spec is validated here and stored as given, so a row can never contain a
     body this build would refuse at load. The cache is refreshed twice: once before
@@ -453,8 +463,7 @@ async def set_policy(
     """
     if request.user_id is not None:
         await _require_user(db, request.user_id)
-    workspace_id = await resolve_managed_workspace_id(db, request.workspace_id)
-    spec = _validated_spec(request.name, request.spec)
+    spec = validated_spec(request.name, request.spec)
     await refresh_policy_cache(db)
     _validate_write(config, request.name, spec, request.user_id)
     await _validate_router_pricing(config, db, spec, workspace_id)
@@ -546,28 +555,41 @@ async def set_policy(
     return PolicyResponse.from_model(policy, is_dynamic=spec.is_dynamic)
 
 
-@router.delete("/{name:path}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_policy(
-    name: str,
+@router.post("")
+async def set_policy(
+    request: PolicyRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
-    user_id: Annotated[
-        str | None,
-        Query(description="Delete the policy scoped to this user. Omit to delete the workspace-wide one."),
-    ] = None,
-    workspace_id: Annotated[
-        uuid.UUID | None,
-        Query(description="Delete the policy in this workspace. Omit for the deployment's default workspace."),
-    ] = None,
+) -> PolicyResponse:
+    """Create or update a stored policy in one workspace, optionally for one user.
+
+    Omitting ``workspace_id`` means the deployment's default workspace, which is
+    where an operator acting deployment-wide writes.
+    """
+    return await upsert_policy_in_workspace(
+        request,
+        db,
+        config,
+        workspace_id=await resolve_managed_workspace_id(db, request.workspace_id),
+    )
+
+
+async def delete_policy_in_workspace(
+    name: str,
+    db: AsyncSession,
+    config: GatewayConfig,
+    *,
+    workspace_id: uuid.UUID,
+    user_id: str | None,
 ) -> None:
-    """Delete a stored policy in one scope.
+    """Delete a stored policy in one scope of an already-resolved workspace.
 
     Scoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:
     deleting one workspace's policy must not touch another's, deleting the
     workspace-wide policy must not take a user's override with it, and deleting an
     override must leave the workspace-wide one serving everyone else.
     """
-    target_workspace_id = await resolve_managed_workspace_id(db, workspace_id)
+    target_workspace_id = workspace_id
     policy = (
         await db.execute(
             select(RoutingPolicy).where(
@@ -592,6 +614,30 @@ async def delete_policy(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database error"
         ) from None
     await _refresh_quietly(db, name)
+
+
+@router.delete("/{name:path}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_policy(
+    name: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    config: Annotated[GatewayConfig, Depends(get_config)],
+    user_id: Annotated[
+        str | None,
+        Query(description="Delete the policy scoped to this user. Omit to delete the workspace-wide one."),
+    ] = None,
+    workspace_id: Annotated[
+        uuid.UUID | None,
+        Query(description="Delete the policy in this workspace. Omit for the deployment's default workspace."),
+    ] = None,
+) -> None:
+    """Delete a stored policy in one scope."""
+    await delete_policy_in_workspace(
+        name,
+        db,
+        config,
+        workspace_id=await resolve_managed_workspace_id(db, workspace_id),
+        user_id=user_id,
+    )
 
 
 @router.post("/explain")
@@ -622,7 +668,7 @@ async def explain_policy(
         # normal editing flow: the operator is looking at policy "fast" and wants to
         # know what their unsaved edit would do, with the name kept for the label.
         name = request.name or "(draft)"
-        spec = _validated_spec(name, request.spec)
+        spec = validated_spec(name, request.spec)
     else:
         assert request.name is not None
         name = request.name

--- a/src/gateway/api/routes/tool_settings.py
+++ b/src/gateway/api/routes/tool_settings.py
@@ -63,7 +63,11 @@ reader_router = APIRouter(
     dependencies=[Depends(verify_master_key)],
 )
 
-_URL_FIELDS = frozenset(SERVICE_URL_FIELD.values())
+# Derived from each field's declared type rather than from ``SERVICE_URL_FIELD``,
+# which maps a service to the URL its reachability probe uses. A URL field with
+# no probe endpoint is absent from that map, so deriving the withheld set from it
+# would publish the next such field to a tenant.
+_URL_FIELDS = frozenset(key for key in TOOL_SETTABLE_KEYS if field_type(key) == "url")
 
 # Reachability probe timeout. Short so a mistyped or dead host fails fast in the
 # dashboard rather than hanging the operator's Test click.

--- a/src/gateway/api/routes/tool_settings.py
+++ b/src/gateway/api/routes/tool_settings.py
@@ -7,7 +7,13 @@ validation and per-service reachability tests. Standalone-only and master-key
 gated, mirroring the other management routers.
 
 * ``GET /v1/tool-settings`` returns each field's effective value (the value a
-  request would actually use), grouped by service, with URL passwords masked.
+  request would actually use), grouped by service, with URL passwords masked. It
+  is the one verb here a non-operator may call, because the roles matrix has the
+  Tools pages at View for a member (otari-ai#1969): a member is told what the
+  built-in tools will do to their requests, and the service endpoints are
+  withheld from them entirely rather than masked. Masking a URL still publishes
+  the host, which is internal infrastructure and the input to the SSRF gates on
+  the Settings page.
 * ``PATCH /v1/tool-settings`` persists overrides (an explicit ``null`` clears a
   field back to the configured env/YAML default; an omitted field is unchanged)
   and applies them to the running worker.
@@ -23,10 +29,12 @@ from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from gateway.api.deps import get_config, get_db, require_deployment_operator
+from gateway.api.deps import get_config, get_db, get_session_identity, require_deployment_operator, verify_master_key
 from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
+from gateway.models.tenancy import User as TenancyUser
 from gateway.services.runtime_settings_service import SettingValue
+from gateway.services.tenancy.deployment_user_service import DeploymentUserService
 from gateway.services.tool_settings_service import (
     SERVICE_URL_FIELD,
     TOOL_SETTABLE_KEYS,
@@ -39,10 +47,20 @@ from gateway.services.tool_settings_service import (
 )
 from gateway.services.url_safety import redact_url_secrets
 
-router = APIRouter(
+# Two routers, because one route here must not carry the operator gate, which is
+# the split #895 made for ``models.py``, ``pricing.py`` and ``usage.py``: a
+# router-level dependency always runs, so a route cannot opt out of one in place.
+# The reader declares ``verify_master_key`` and then decides how much to return
+# from the caller's standing, exactly as the tenant-scoped routers do.
+operator_router = APIRouter(
     prefix="/v1/tool-settings",
     tags=["tool-settings"],
     dependencies=[Depends(require_deployment_operator)],
+)
+reader_router = APIRouter(
+    prefix="/v1/tool-settings",
+    tags=["tool-settings"],
+    dependencies=[Depends(verify_master_key)],
 )
 
 _URL_FIELDS = frozenset(SERVICE_URL_FIELD.values())
@@ -111,7 +129,15 @@ def _display_value(config: GatewayConfig, key: str) -> bool | int | str | None:
     return cast("bool | int | str | None", value)
 
 
-def _current_fields(config: GatewayConfig) -> ToolSettingsResponse:
+def _current_fields(config: GatewayConfig, *, include_urls: bool = True) -> ToolSettingsResponse:
+    """The effective value of every editable field, or of the non-URL ones.
+
+    ``include_urls`` is false for a tenant reader. The remaining fields say what
+    a request gets (whether web search is intercepted, how many results, which
+    sandbox image); the URLs say where this deployment's own infrastructure
+    lives, which is nothing a tenant acts on.
+    """
+    keys = TOOL_SETTABLE_KEYS if include_urls else tuple(k for k in TOOL_SETTABLE_KEYS if k not in _URL_FIELDS)
     fields = [
         ToolSettingField(
             key=key,
@@ -120,20 +146,32 @@ def _current_fields(config: GatewayConfig) -> ToolSettingsResponse:
             value=_display_value(config, key),
             description=GatewayConfig.model_fields[key].description,
         )
-        for key in TOOL_SETTABLE_KEYS
+        for key in keys
     ]
     return ToolSettingsResponse(fields=fields)
 
 
-@router.get("")
+@reader_router.get("")
 async def get_tool_settings(
+    db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
+    session_identity: Annotated[TenancyUser | None, Depends(get_session_identity)],
 ) -> ToolSettingsResponse:
-    """Return the effective tool/guardrail settings for the dashboard."""
-    return _current_fields(config)
+    """Return the effective tool/guardrail settings for the dashboard.
+
+    Authentication only on the router: the role decides *how much* rather than
+    whether, so this is not the deployment-wide gate ``require_deployment_operator``
+    names. A header master key is the deployment credential and reads everything;
+    a session reads everything only while it operates the deployment, and
+    otherwise gets the fields without the service endpoints in them.
+    """
+    include_urls = session_identity is None or await DeploymentUserService(db).has_administration_access(
+        session_identity
+    )
+    return _current_fields(config, include_urls=include_urls)
 
 
-@router.patch("")
+@operator_router.patch("")
 async def update_tool_settings(
     request: UpdateToolSettingsRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -173,7 +211,7 @@ async def update_tool_settings(
     return _current_fields(config)
 
 
-@router.post("/{service}/test")
+@operator_router.post("/{service}/test")
 async def test_service(
     service: str,
     request: TestServiceRequest,

--- a/src/gateway/repositories/tenancy/org_provider_key_repository.py
+++ b/src/gateway/repositories/tenancy/org_provider_key_repository.py
@@ -11,7 +11,7 @@ one workspace at a time.
 """
 
 import uuid
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 
 from sqlalchemy import delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -388,6 +388,57 @@ class WorkspaceProviderKeyOverrideRepository:
         )
         return [(key, override) for key, override in result.all()]
 
+    async def candidates_for_workspaces(
+        self,
+        *,
+        organization_id: uuid.UUID,
+        workspace_ids: Collection[uuid.UUID],
+    ) -> dict[uuid.UUID, list[Candidate]]:
+        """:meth:`all_candidates` for several workspaces in one query.
+
+        Keyed by workspace, each list ordered oldest-first as
+        ``resolve_active_key``'s fallback tier requires. A workspace with no
+        override rows still appears, holding the organization's keys with no
+        override beside them, so a caller can read the answer for every id it
+        asked about without a second pass.
+
+        The override join carries ``workspace_id`` into the row rather than
+        filtering on one, which is what lets the query span workspaces: the same
+        key appears once per workspace, with that workspace's override or none.
+        """
+        requested = list(dict.fromkeys(workspace_ids))
+        if not requested:
+            return {}
+        result = await self.db.execute(
+            select(OrgProviderKey, WorkspaceProviderKeyOverride)
+            .outerjoin(
+                WorkspaceProviderKeyOverride,
+                (col(WorkspaceProviderKeyOverride.org_provider_key_id) == col(OrgProviderKey.id))
+                & col(WorkspaceProviderKeyOverride.workspace_id).in_(requested),
+            )
+            .where(
+                col(OrgProviderKey.organization_id) == organization_id,
+                col(OrgProviderKey.archived_at).is_(None),
+            )
+            .order_by(col(OrgProviderKey.provider), col(OrgProviderKey.created_at), col(OrgProviderKey.id))
+        )
+        rows = result.all()
+        # Every requested workspace gets an entry, so an id with no override rows
+        # is answered rather than missing. A key joined to no override belongs to
+        # all of them; one joined to an override belongs to that workspace alone.
+        by_workspace: dict[uuid.UUID, list[Candidate]] = {workspace_id: [] for workspace_id in requested}
+        overridden: dict[tuple[uuid.UUID, uuid.UUID], WorkspaceProviderKeyOverride] = {
+            (override.workspace_id, key.id): override for key, override in rows if override is not None
+        }
+        seen: set[uuid.UUID] = set()
+        for key, _ in rows:
+            if key.id in seen:
+                continue
+            seen.add(key.id)
+            for workspace_id in requested:
+                by_workspace[workspace_id].append((key, overridden.get((workspace_id, key.id))))
+        return by_workspace
+
     async def get_active_key_for_workspace_provider(
         self,
         *,
@@ -419,6 +470,40 @@ class WorkspaceProviderModelRestrictionRepository:
             .order_by(col(WorkspaceProviderModelRestriction.model))
         )
         return list(result.scalars().all())
+
+    async def list_for_workspace_keys(
+        self, pairs: Collection[tuple[uuid.UUID, uuid.UUID]]
+    ) -> dict[tuple[uuid.UUID, uuid.UUID], list[str]]:
+        """:meth:`list_for_workspace_key` for several (workspace, key) pairs at once.
+
+        Only pairs with at least one restriction appear. An absent pair means
+        every model of that key is allowed, which is what an absent row means
+        everywhere else, so a caller must not read a missing key as an empty
+        allow-list.
+        """
+        wanted = set(pairs)
+        if not wanted:
+            return {}
+        result = await self.db.execute(
+            select(
+                col(WorkspaceProviderModelRestriction.workspace_id),
+                col(WorkspaceProviderModelRestriction.org_provider_key_id),
+                col(WorkspaceProviderModelRestriction.model),
+            )
+            .where(
+                col(WorkspaceProviderModelRestriction.workspace_id).in_({workspace for workspace, _ in wanted}),
+                col(WorkspaceProviderModelRestriction.org_provider_key_id).in_({key for _, key in wanted}),
+            )
+            .order_by(col(WorkspaceProviderModelRestriction.model))
+        )
+        # Filtered on the two columns independently, which is one query rather
+        # than one per pair but can also match a pair nobody asked about, so the
+        # combination is checked here.
+        grouped: dict[tuple[uuid.UUID, uuid.UUID], list[str]] = {}
+        for workspace_id, key_id, model in result.all():
+            if (workspace_id, key_id) in wanted:
+                grouped.setdefault((workspace_id, key_id), []).append(model)
+        return grouped
 
     async def get(
         self, *, workspace_id: uuid.UUID, org_provider_key_id: uuid.UUID, model: str

--- a/src/gateway/repositories/tenancy/org_provider_key_repository.py
+++ b/src/gateway/repositories/tenancy/org_provider_key_repository.py
@@ -107,6 +107,25 @@ class OrgProviderKeyRepository(
         )
         return result.scalars().first()
 
+    async def list_provider_names(self, organization_id: uuid.UUID) -> list[str]:
+        """The distinct providers this organization holds a live key for.
+
+        Unpaginated, unlike :meth:`list_for_organization`, because the result is
+        one row per provider rather than per key: the catalog filter needs the
+        whole set to decide what a member may be shown, and a page of it would
+        silently hide providers.
+        """
+        result = await self.db.execute(
+            select(col(OrgProviderKey.provider))
+            .where(
+                col(OrgProviderKey.organization_id) == organization_id,
+                col(OrgProviderKey.archived_at).is_(None),
+            )
+            .distinct()
+            .order_by(col(OrgProviderKey.provider))
+        )
+        return list(result.scalars().all())
+
     async def list_for_organization(
         self,
         organization_id: uuid.UUID,

--- a/src/gateway/repositories/tenancy/org_provider_key_repository.py
+++ b/src/gateway/repositories/tenancy/org_provider_key_repository.py
@@ -107,22 +107,22 @@ class OrgProviderKeyRepository(
         )
         return result.scalars().first()
 
-    async def list_provider_names(self, organization_id: uuid.UUID) -> list[str]:
-        """The distinct providers this organization holds a live key for.
+    async def list_live_keys(self, organization_id: uuid.UUID) -> Sequence[OrgProviderKey]:
+        """Every non-archived key this organization holds, oldest-first per provider.
 
-        Unpaginated, unlike :meth:`list_for_organization`, because the result is
-        one row per provider rather than per key: the catalog filter needs the
-        whole set to decide what a member may be shown, and a page of it would
-        silently hide providers.
+        Unpaginated, unlike :meth:`list_for_organization`, because the caller is
+        deciding what a tenant may reach and a page of it would silently hide
+        providers. Rows rather than distinct provider names, because whether a
+        provider is reachable depends on whether any of its keys can be
+        decrypted, which only the row can answer.
         """
         result = await self.db.execute(
-            select(col(OrgProviderKey.provider))
+            select(OrgProviderKey)
             .where(
                 col(OrgProviderKey.organization_id) == organization_id,
                 col(OrgProviderKey.archived_at).is_(None),
             )
-            .distinct()
-            .order_by(col(OrgProviderKey.provider))
+            .order_by(col(OrgProviderKey.provider), col(OrgProviderKey.created_at), col(OrgProviderKey.id))
         )
         return list(result.scalars().all())
 

--- a/src/gateway/services/tenancy/org_provider_key_service.py
+++ b/src/gateway/services/tenancy/org_provider_key_service.py
@@ -133,6 +133,22 @@ def _row_to_entry(key: OrgProviderKey) -> dict[str, Any]:
     return entry
 
 
+def key_is_usable(key: OrgProviderKey) -> bool:
+    """Whether this key can actually supply a credential on this deployment.
+
+    A row whose secret will not decrypt (no ``OTARI_SECRET_KEY``, or the wrong
+    one) is skipped by the dispatch-path cache below, so anything that reports
+    what a tenant may *reach* has to skip it too, or the catalog advertises
+    models every request through that provider then fails on. Single-sourced
+    here so the two answers cannot drift.
+    """
+    try:
+        _row_to_entry(key)
+    except (SecretBoxUnavailableError, SecretDecryptionError):
+        return False
+    return True
+
+
 def cached_org_provider_kwargs(workspace_id: uuid.UUID, provider: str) -> dict[str, Any] | None:
     """The decrypted overlay entry this worker last loaded for this workspace+provider, if any."""
     entry = _org_cache.get((workspace_id, provider))

--- a/src/gateway/services/tenancy/organization_model_access.py
+++ b/src/gateway/services/tenancy/organization_model_access.py
@@ -1,8 +1,8 @@
-"""Which models a dashboard session may reach, as a ``model_access`` allow-list.
+"""What a dashboard session may be shown of the model catalog.
 
 ``services/model_access`` answers this for an API key, off a stored column. A
-session has no such column: its reach is decided by membership. This module
-produces the answer in that module's own wire shape (canonical ``instance:model``
+session has no such column: its reach is decided by membership. The allow-list
+here is produced in that module's own wire shape (canonical ``instance:model``
 entries plus the ``instance:*`` wildcard) so ``is_model_allowed`` decides both. A
 second matcher would let the catalog and the inference gate disagree about the
 same model.
@@ -22,15 +22,24 @@ An organization holding no BYO key still gets every configured instance, which o
 a standalone deployment is the whole catalog. Opening this filter therefore
 changes nothing for a single-tenant deployment and narrows only where a tenant's
 reach is actually narrower.
+
+The scope also answers one thing the allow-list cannot. Aliases and stored
+policies are workspace-scoped rows, and the catalog reads them for a workspace
+rather than filtering them by target, so a name in a workspace the caller may not
+see would be listed even though every entry it resolves to is permitted. See
+:attr:`SessionCatalogScope.reads_default_workspace`.
 """
 
 import uuid
 from collections import defaultdict
+from dataclasses import dataclass
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
 
 from gateway.core.config import GatewayConfig
-from gateway.models.tenancy import User
+from gateway.models.tenancy import User, Workspace
 from gateway.repositories.tenancy.org_provider_key_repository import (
     Candidate,
     OrgProviderKeyRepository,
@@ -39,9 +48,32 @@ from gateway.repositories.tenancy.org_provider_key_repository import (
     resolve_active_key,
 )
 from gateway.services.provider_kwargs import provider_key
-from gateway.services.tenancy.authorization import resolve_visible_workspace_scope
+from gateway.services.tenancy.authorization import VisibleWorkspaceScope, resolve_visible_workspace_scope
 from gateway.services.tenancy.errors import TenancyForbiddenError, TenancyNotFoundError
 from gateway.services.tenancy.organization_service import OrganizationService
+from gateway.services.workspace_scope import lookup_default_workspace_id
+
+
+@dataclass(frozen=True)
+class SessionCatalogScope:
+    """How much of the catalog one dashboard session may be shown."""
+
+    allowlist: list[str]
+    """``model_access`` entries. Empty means nothing is reachable, which is a real
+    answer: no configured instance and no usable key."""
+
+    reads_default_workspace: bool
+    """Whether the workspace-scoped alias and policy layers may be read.
+
+    ``services/alias_service`` and ``services/policy_store`` read the deployment's
+    default workspace when no workspace is named, which is what a master-key
+    caller wants and what a session used to get. On a multi-tenant deployment that
+    workspace belongs to one organization, so serving its stored aliases to
+    everybody publishes another tenant's names: the allow-list does not catch
+    them, because an alias pointing at a configured instance is a target every
+    tenant may reach. True only when this caller may actually see that workspace,
+    which on a single-tenant deployment is everyone in it.
+    """
 
 
 async def _byo_entries_for_workspaces(
@@ -52,54 +84,72 @@ async def _byo_entries_for_workspaces(
 ) -> set[str]:
     """BYO entries as the caller's own workspaces resolve them.
 
-    One key per (workspace, provider) is what a request would actually use, so
-    ``resolve_active_key`` picks it here too: a provider whose every key this
-    workspace disabled contributes nothing, and a model restriction narrows the
-    wildcard to the models it names. The union across the workspaces, not the
-    intersection: a model one of them can call is a model this caller can call.
+    Two queries whatever the number of workspaces: one for the candidates, one
+    for the restrictions of the keys that survived. One key per (workspace,
+    provider) is what a request would actually use, so ``resolve_active_key``
+    picks it here too: a provider whose every key this workspace disabled
+    contributes nothing, and a model restriction narrows the wildcard to the
+    models it names. The union across the workspaces, not the intersection: a
+    model one of them can call is a model this caller can call.
     """
-    overrides = WorkspaceProviderKeyOverrideRepository(db)
-    restrictions = WorkspaceProviderModelRestrictionRepository(db)
-    entries: set[str] = set()
-    for workspace_id in workspace_ids:
-        candidates = await overrides.all_candidates(organization_id=organization_id, workspace_id=workspace_id)
+    if not workspace_ids:
+        return set()
+    candidates = await WorkspaceProviderKeyOverrideRepository(db).candidates_for_workspaces(
+        organization_id=organization_id, workspace_ids=workspace_ids
+    )
+    active: dict[tuple[uuid.UUID, uuid.UUID], str] = {}
+    for workspace_id, rows in candidates.items():
         by_provider: dict[str, list[Candidate]] = defaultdict(list)
-        for key, override in candidates:
+        for key, override in rows:
             by_provider[key.provider].append((key, override))
         for provider, group in by_provider.items():
-            active = resolve_active_key(group)
-            if active is None:
-                continue
-            allowed = await restrictions.list_for_workspace_key(
-                workspace_id=workspace_id, org_provider_key_id=active.id
-            )
-            prefix = provider_key(provider)
-            # No restriction row means every model of that provider: an absent
-            # narrowing is not an empty allow-list (see
-            # ``WorkspaceProviderModelRestriction``).
-            entries.update({f"{prefix}:{model}" for model in allowed} if allowed else {f"{prefix}:*"})
+            resolved = resolve_active_key(group)
+            if resolved is not None:
+                active[(workspace_id, resolved.id)] = provider
+
+    restrictions = await WorkspaceProviderModelRestrictionRepository(db).list_for_workspace_keys(active)
+    entries: set[str] = set()
+    for (workspace_id, key_id), provider in active.items():
+        prefix = provider_key(provider)
+        allowed = restrictions.get((workspace_id, key_id))
+        # An absent narrowing is not an empty allow-list: no restriction row means
+        # every model of that provider (see ``WorkspaceProviderModelRestriction``).
+        entries.update({f"{prefix}:{model}" for model in allowed} if allowed else {f"{prefix}:*"})
     return entries
 
 
-async def resolve_session_model_allowlist(
+async def _sees_default_workspace(db: AsyncSession, scope: VisibleWorkspaceScope) -> bool:
+    """Whether the deployment's default workspace is one this caller may see.
+
+    Looked up rather than created: ``default_workspace_id`` provisions one when
+    none exists, which a catalog read must not do as a side effect.
+    """
+    default_workspace_id = await lookup_default_workspace_id(db)
+    if default_workspace_id is None:
+        return False
+    if not scope.sees_every_workspace:
+        return default_workspace_id in (scope.workspace_ids or [])
+    owner = (
+        await db.execute(
+            select(col(Workspace.organization_id)).where(col(Workspace.id) == default_workspace_id)
+        )
+    ).scalar_one_or_none()
+    return owner == scope.organization.id
+
+
+async def resolve_session_catalog_scope(
     db: AsyncSession,
     config: GatewayConfig,
     *,
     user: User,
     organizations: OrganizationService | None = None,
-) -> list[str]:
-    """The models this session identity may reach.
-
-    Never ``None``: unrestricted is the deployment operator's answer, and each
-    call site decides that before asking. An empty list is a real answer, and
-    means the deployment configures no provider instance and the caller's
-    organization holds no usable key, which is an empty catalog either way.
+) -> SessionCatalogScope:
+    """What this session identity may be shown. Unrestricted is the caller's own call.
 
     An owner or admin is answered from the organization's providers directly
-    rather than by walking its workspaces. Both are truer to what they may do (a
-    workspace's disable or model restriction is theirs to lift) and bounded: the
-    per-workspace walk below costs a query per workspace, which is fine for the
-    handful a member belongs to and not for a large tenant's whole list.
+    rather than by walking its workspaces. That is both truer to what they may do
+    (a workspace's disable or model restriction is theirs to lift) and cheaper by
+    a query.
 
     A caller with no live organization membership is answered with the configured
     instances rather than refused. That is the same rule applied to an empty
@@ -113,7 +163,8 @@ async def resolve_session_model_allowlist(
     try:
         scope = await resolve_visible_workspace_scope(db, user=user, organizations=services)
     except (TenancyForbiddenError, TenancyNotFoundError):
-        return sorted(entries)
+        return SessionCatalogScope(allowlist=sorted(entries), reads_default_workspace=False)
+
     if scope.sees_every_workspace:
         providers = await OrgProviderKeyRepository(db).list_provider_names(scope.organization.id)
         entries.update(f"{provider_key(provider)}:*" for provider in providers)
@@ -123,7 +174,28 @@ async def resolve_session_model_allowlist(
             organization_id=scope.organization.id,
             workspace_ids=scope.workspace_ids or [],
         )
-    return sorted(entries)
+    return SessionCatalogScope(
+        allowlist=sorted(entries),
+        reads_default_workspace=await _sees_default_workspace(db, scope),
+    )
 
 
-__all__ = ["resolve_session_model_allowlist"]
+async def resolve_session_model_allowlist(
+    db: AsyncSession,
+    config: GatewayConfig,
+    *,
+    user: User,
+    organizations: OrganizationService | None = None,
+) -> list[str]:
+    """The allow-list half of :func:`resolve_session_catalog_scope`.
+
+    For the callers that only decide whether one selector is reachable, which is
+    every write guard: a target does not belong to a workspace until it is
+    stored, so the alias and policy scoping the full result carries says nothing
+    about it.
+    """
+    scope = await resolve_session_catalog_scope(db, config, user=user, organizations=organizations)
+    return scope.allowlist
+
+
+__all__ = ["SessionCatalogScope", "resolve_session_catalog_scope", "resolve_session_model_allowlist"]

--- a/src/gateway/services/tenancy/organization_model_access.py
+++ b/src/gateway/services/tenancy/organization_model_access.py
@@ -50,6 +50,7 @@ from gateway.repositories.tenancy.org_provider_key_repository import (
 from gateway.services.provider_kwargs import provider_key
 from gateway.services.tenancy.authorization import VisibleWorkspaceScope, resolve_visible_workspace_scope
 from gateway.services.tenancy.errors import TenancyForbiddenError, TenancyNotFoundError
+from gateway.services.tenancy.org_provider_key_service import key_is_usable
 from gateway.services.tenancy.organization_service import OrganizationService
 from gateway.services.workspace_scope import lookup_default_workspace_id
 
@@ -104,7 +105,10 @@ async def _byo_entries_for_workspaces(
             by_provider[key.provider].append((key, override))
         for provider, group in by_provider.items():
             resolved = resolve_active_key(group)
-            if resolved is not None:
+            # A key whose secret will not decrypt supplies no credential at
+            # dispatch, so advertising its models would break the rule this
+            # allow-list exists to keep.
+            if resolved is not None and key_is_usable(resolved):
                 active[(workspace_id, resolved.id)] = provider
 
     restrictions = await WorkspaceProviderModelRestrictionRepository(db).list_for_workspace_keys(active)
@@ -166,8 +170,11 @@ async def resolve_session_catalog_scope(
         return SessionCatalogScope(allowlist=sorted(entries), reads_default_workspace=False)
 
     if scope.sees_every_workspace:
-        providers = await OrgProviderKeyRepository(db).list_provider_names(scope.organization.id)
-        entries.update(f"{provider_key(provider)}:*" for provider in providers)
+        entries.update(
+            f"{provider_key(key.provider)}:*"
+            for key in await OrgProviderKeyRepository(db).list_live_keys(scope.organization.id)
+            if key_is_usable(key)
+        )
     else:
         entries |= await _byo_entries_for_workspaces(
             db,

--- a/src/gateway/services/tenancy/organization_model_access.py
+++ b/src/gateway/services/tenancy/organization_model_access.py
@@ -1,0 +1,118 @@
+"""Which models a dashboard session may reach, as a ``model_access`` allow-list.
+
+``services/model_access`` answers this for an API key, off a stored column. A
+session has no such column: its reach is decided by membership. This module
+produces the answer in that module's own wire shape (canonical ``instance:model``
+entries plus the ``instance:*`` wildcard) so ``is_model_allowed`` decides both. A
+second matcher would let the catalog and the inference gate disagree about the
+same model.
+
+Two disjoint addressing schemes decide it, and the split is
+``services/provider_kwargs``'s rather than this module's:
+
+* A selector whose prefix names a ``config.providers`` instance draws its
+  credentials from ``config.yml`` and never touches an organization's keys, so
+  every workspace of every tenant may use it. Each configured instance
+  contributes ``instance:*``.
+* A bare ``provider:model`` selector resolves through the organization's own BYO
+  keys for the request's workspace, so it contributes only where the caller has
+  one.
+
+An organization holding no BYO key still gets every configured instance, which on
+a standalone deployment is the whole catalog. Opening this filter therefore
+changes nothing for a single-tenant deployment and narrows only where a tenant's
+reach is actually narrower.
+"""
+
+import uuid
+from collections import defaultdict
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from gateway.core.config import GatewayConfig
+from gateway.models.tenancy import User
+from gateway.repositories.tenancy.org_provider_key_repository import (
+    Candidate,
+    OrgProviderKeyRepository,
+    WorkspaceProviderKeyOverrideRepository,
+    WorkspaceProviderModelRestrictionRepository,
+    resolve_active_key,
+)
+from gateway.services.provider_kwargs import provider_key
+from gateway.services.tenancy.authorization import resolve_visible_workspace_scope
+from gateway.services.tenancy.organization_service import OrganizationService
+
+
+async def _byo_entries_for_workspaces(
+    db: AsyncSession,
+    *,
+    organization_id: uuid.UUID,
+    workspace_ids: list[uuid.UUID],
+) -> set[str]:
+    """BYO entries as the caller's own workspaces resolve them.
+
+    One key per (workspace, provider) is what a request would actually use, so
+    ``resolve_active_key`` picks it here too: a provider whose every key this
+    workspace disabled contributes nothing, and a model restriction narrows the
+    wildcard to the models it names. The union across the workspaces, not the
+    intersection: a model one of them can call is a model this caller can call.
+    """
+    overrides = WorkspaceProviderKeyOverrideRepository(db)
+    restrictions = WorkspaceProviderModelRestrictionRepository(db)
+    entries: set[str] = set()
+    for workspace_id in workspace_ids:
+        candidates = await overrides.all_candidates(organization_id=organization_id, workspace_id=workspace_id)
+        by_provider: dict[str, list[Candidate]] = defaultdict(list)
+        for key, override in candidates:
+            by_provider[key.provider].append((key, override))
+        for provider, group in by_provider.items():
+            active = resolve_active_key(group)
+            if active is None:
+                continue
+            allowed = await restrictions.list_for_workspace_key(
+                workspace_id=workspace_id, org_provider_key_id=active.id
+            )
+            prefix = provider_key(provider)
+            # No restriction row means every model of that provider: an absent
+            # narrowing is not an empty allow-list (see
+            # ``WorkspaceProviderModelRestriction``).
+            entries.update({f"{prefix}:{model}" for model in allowed} if allowed else {f"{prefix}:*"})
+    return entries
+
+
+async def resolve_session_model_allowlist(
+    db: AsyncSession,
+    config: GatewayConfig,
+    *,
+    user: User,
+    organizations: OrganizationService | None = None,
+) -> list[str]:
+    """The models this session identity may reach.
+
+    Never ``None``: unrestricted is the deployment operator's answer, and each
+    call site decides that before asking. An empty list is a real answer, and
+    means the deployment configures no provider instance and the caller's
+    organization holds no usable key, which is an empty catalog either way.
+
+    An owner or admin is answered from the organization's providers directly
+    rather than by walking its workspaces. Both are truer to what they may do (a
+    workspace's disable or model restriction is theirs to lift) and bounded: the
+    per-workspace walk below costs a query per workspace, which is fine for the
+    handful a member belongs to and not for a large tenant's whole list.
+    """
+    services = organizations if organizations is not None else OrganizationService(db)
+    scope = await resolve_visible_workspace_scope(db, user=user, organizations=services)
+    entries = {f"{instance}:*" for instance in config.providers}
+    if scope.sees_every_workspace:
+        providers = await OrgProviderKeyRepository(db).list_provider_names(scope.organization.id)
+        entries.update(f"{provider_key(provider)}:*" for provider in providers)
+    else:
+        entries |= await _byo_entries_for_workspaces(
+            db,
+            organization_id=scope.organization.id,
+            workspace_ids=scope.workspace_ids or [],
+        )
+    return sorted(entries)
+
+
+__all__ = ["resolve_session_model_allowlist"]

--- a/src/gateway/services/tenancy/organization_model_access.py
+++ b/src/gateway/services/tenancy/organization_model_access.py
@@ -40,6 +40,7 @@ from gateway.repositories.tenancy.org_provider_key_repository import (
 )
 from gateway.services.provider_kwargs import provider_key
 from gateway.services.tenancy.authorization import resolve_visible_workspace_scope
+from gateway.services.tenancy.errors import TenancyForbiddenError, TenancyNotFoundError
 from gateway.services.tenancy.organization_service import OrganizationService
 
 
@@ -99,10 +100,20 @@ async def resolve_session_model_allowlist(
     workspace's disable or model restriction is theirs to lift) and bounded: the
     per-workspace walk below costs a query per workspace, which is fine for the
     handful a member belongs to and not for a large tenant's whole list.
+
+    A caller with no live organization membership is answered with the configured
+    instances rather than refused. That is the same rule applied to an empty
+    tenant, not a fallback around one: they reach no BYO key because there is no
+    organization holding any, and the configured instances are deployment-wide.
+    The routers that exist to answer "which organization" still refuse such a
+    caller; a catalog read is not one of them.
     """
     services = organizations if organizations is not None else OrganizationService(db)
-    scope = await resolve_visible_workspace_scope(db, user=user, organizations=services)
     entries = {f"{instance}:*" for instance in config.providers}
+    try:
+        scope = await resolve_visible_workspace_scope(db, user=user, organizations=services)
+    except (TenancyForbiddenError, TenancyNotFoundError):
+        return sorted(entries)
     if scope.sees_every_workspace:
         providers = await OrgProviderKeyRepository(db).list_provider_names(scope.organization.id)
         entries.update(f"{provider_key(provider)}:*" for provider in providers)

--- a/tests/integration/test_deployment_operator_gate.py
+++ b/tests/integration/test_deployment_operator_gate.py
@@ -105,12 +105,14 @@ _CATALOG_PROBES: list[tuple[str, str]] = [
 # joined them in otari-ai#1944), and their own 403 is indistinguishable here
 # from the one this file is about.
 #
-# ``GET /v1/tool-settings`` is the odd one in this list: its router is
-# deployment-wide and every other verb on it is operator-only. The read resolves
-# the caller itself and *narrows* rather than refuses, withholding the three
-# service-endpoint fields from a non-operator (otari-ai#1969), which is why it
-# belongs here rather than above. What it withholds is pinned in
-# ``test_tool_settings_tenant_read.py``; this file only pins that it answers.
+# ``GET /v1/tool-settings`` sits here because it *narrows* rather than refuses,
+# withholding the three service-endpoint fields from a non-operator
+# (otari-ai#1969). It rides its own ``reader_router`` for that, since a
+# router-level gate always runs and a route cannot opt out of one in place, which
+# is the same split #895 made in ``models.py`` and ``pricing.py``. The write
+# verbs keep the operator router, and their probes are above. What the read
+# withholds is pinned in ``test_tool_settings_tenant_read.py``; this file only
+# pins that it answers.
 _TENANT_SCOPED_PROBES: list[tuple[str, str]] = [
     ("GET", "/v1/organizations/me"),
     ("GET", "/v1/workspaces"),

--- a/tests/integration/test_deployment_operator_gate.py
+++ b/tests/integration/test_deployment_operator_gate.py
@@ -55,7 +55,6 @@ _DEPLOYMENT_WIDE_PROBES: list[tuple[str, str]] = [
     ("GET", "/v1/models/discoverable"),
     ("GET", "/v1/provider-credentials"),
     ("GET", "/v1/search-tools"),
-    ("GET", "/v1/tool-settings"),
     ("GET", "/v1/settings"),
     ("GET", "/v1/settings/mail"),
     ("GET", "/v1/settings/maintenance-mode"),
@@ -105,10 +104,18 @@ _CATALOG_PROBES: list[tuple[str, str]] = [
 # guardrails and pricing are entirely owner/admin, and the provider-keys list
 # joined them in otari-ai#1944), and their own 403 is indistinguishable here
 # from the one this file is about.
+#
+# ``GET /v1/tool-settings`` is the odd one in this list: its router is
+# deployment-wide and every other verb on it is operator-only. The read resolves
+# the caller itself and *narrows* rather than refuses, withholding the three
+# service-endpoint fields from a non-operator (otari-ai#1969), which is why it
+# belongs here rather than above. What it withholds is pinned in
+# ``test_tool_settings_tenant_read.py``; this file only pins that it answers.
 _TENANT_SCOPED_PROBES: list[tuple[str, str]] = [
     ("GET", "/v1/organizations/me"),
     ("GET", "/v1/workspaces"),
     ("GET", "/v1/admin/access"),
+    ("GET", "/v1/tool-settings"),
 ]
 
 

--- a/tests/integration/test_organization_routing_write_scope.py
+++ b/tests/integration/test_organization_routing_write_scope.py
@@ -1,0 +1,275 @@
+"""An organization admin edits their own routing entries, and nobody else's.
+
+The View half of the Build pages landed in mozilla-ai/otari#867; this is the
+Edit half the roles matrix asks for (otari-ai#1969). ``routing_policies`` and
+``model_aliases`` both carry a non-nullable ``workspace_id`` already, so the
+tenant-scoped writers here need no owner column: a workspace belongs to exactly
+one organization, and that is the row's tenant.
+
+Four refusals carry the whole surface, and each has a test that fails on its own
+if the check is dropped: a member may not write at all, another tenant's
+workspace is not found rather than forbidden, a write must name a workspace, and
+a target the organization cannot already reach is refused. The last is the one
+that makes opening these verbs safe: a policy decides which real model a name
+resolves to, so an unconstrained write would be a way to name a model the tenant
+holds no provider key for.
+
+The control at the end is the same as the read suite's: the deployment-wide
+routers must still refuse a tenant, or a change here would have reopened
+otari-ai#1880.
+"""
+
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from gateway.models.entities import DashboardSession
+from gateway.models.provider_keys import OrgProviderKey
+from gateway.models.tenancy import Organization, OrganizationMember, User, Workspace, WorkspaceMember
+from gateway.services.dashboard_session_service import SESSION_COOKIE_NAME, hash_session_token
+
+_POLICIES = "/v1/organizations/me/routing-policies"
+_ALIASES = "/v1/organizations/me/aliases"
+
+# Alpha holds an OpenAI key and Beta an Anthropic one, so each tenant has a
+# target the other cannot reach: that asymmetry is what the target guard is
+# tested against.
+_ALPHA_TARGET = "openai:gpt-4o-mini"
+_BETA_TARGET = "anthropic:claude-3-5-haiku-latest"
+
+
+@dataclass
+class _World:
+    alpha: uuid.UUID
+    beta: uuid.UUID
+    workspaces: dict[str, uuid.UUID] = field(default_factory=dict)
+    sessions: dict[str, str] = field(default_factory=dict)
+
+
+def _identity(
+    session: Session,
+    *,
+    email: str,
+    organization_id: uuid.UUID,
+    role: str = "member",
+    workspace_ids: tuple[uuid.UUID, ...] = (),
+) -> str:
+    user = User(
+        email=email,
+        full_name=email.split("@")[0].title(),
+        active_organization_id=organization_id,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    session.add(OrganizationMember(organization_id=organization_id, user_id=user.id, role=role, status="active"))
+    for workspace_id in workspace_ids:
+        session.add(WorkspaceMember(workspace_id=workspace_id, user_id=user.id, role="member", status="active"))
+    token = f"otari-sess-{email}"
+    session.add(
+        DashboardSession(
+            token_hash=hash_session_token(token),
+            user_id=user.id,
+            created_at=datetime.now(UTC),
+            expires_at=datetime.now(UTC) + timedelta(hours=12),
+        )
+    )
+    session.commit()
+    return token
+
+
+@pytest.fixture
+def world(client: TestClient, master_key_header: dict[str, str], db_session_factory: Callable[[], Session]) -> _World:
+    assert client.get("/v1/organizations/me", headers=master_key_header).status_code == status.HTTP_200_OK
+    session = db_session_factory()
+    try:
+        alpha = Organization(name="Alpha", slug="alpha")
+        beta = Organization(name="Beta", slug="beta")
+        session.add_all([alpha, beta])
+        session.commit()
+        session.refresh(alpha)
+        session.refresh(beta)
+
+        alpha_one = Workspace(name="Alpha one", organization_id=alpha.id)
+        beta_one = Workspace(name="Beta one", organization_id=beta.id)
+        session.add_all([alpha_one, beta_one])
+        session.commit()
+        session.refresh(alpha_one)
+        session.refresh(beta_one)
+
+        for organization_id, provider in ((alpha.id, "openai"), (beta.id, "anthropic")):
+            session.add(
+                OrgProviderKey(
+                    organization_id=organization_id,
+                    provider=provider,
+                    name=f"{provider}-primary",
+                    encrypted_api_key="encrypted",
+                    last4="1234",
+                    is_org_default=True,
+                )
+            )
+        session.commit()
+
+        built = _World(alpha=alpha.id, beta=beta.id)
+        built.workspaces = {"alpha_one": alpha_one.id, "beta_one": beta_one.id}
+        built.sessions = {
+            "alpha_admin": _identity(session, email="admin@alpha.test", organization_id=alpha.id, role="admin"),
+            "alpha_member": _identity(
+                session,
+                email="member@alpha.test",
+                organization_id=alpha.id,
+                workspace_ids=(alpha_one.id,),
+            ),
+            "beta_owner": _identity(session, email="owner@beta.test", organization_id=beta.id, role="owner"),
+        }
+        return built
+    finally:
+        session.close()
+
+
+def _post(client: TestClient, world: _World, who: str, path: str, body: dict[str, Any]) -> Any:
+    client.cookies.set(SESSION_COOKIE_NAME, world.sessions[who])
+    try:
+        return client.post(path, json=body)
+    finally:
+        client.cookies.clear()
+
+
+def _get(client: TestClient, world: _World, who: str, path: str) -> Any:
+    client.cookies.set(SESSION_COOKIE_NAME, world.sessions[who])
+    try:
+        return client.get(path)
+    finally:
+        client.cookies.clear()
+
+
+def _delete(client: TestClient, world: _World, who: str, path: str) -> Any:
+    client.cookies.set(SESSION_COOKIE_NAME, world.sessions[who])
+    try:
+        return client.delete(path)
+    finally:
+        client.cookies.clear()
+
+
+def _policy_body(world: _World, *, name: str, target: str = _ALPHA_TARGET, **extra: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "name": name,
+        "spec": {"select": [{"default": target}]},
+        "workspace_id": str(world.workspaces["alpha_one"]),
+    }
+    body.update(extra)
+    return body
+
+
+def test_an_admin_writes_a_policy_into_their_own_workspace(client: TestClient, world: _World) -> None:
+    created = _post(client, world, "alpha_admin", _POLICIES, _policy_body(world, name="tenant-fast"))
+    assert created.status_code == status.HTTP_200_OK, created.text
+    assert created.json()["workspace_id"] == str(world.workspaces["alpha_one"])
+
+    listed = _get(client, world, "alpha_admin", _POLICIES)
+    assert listed.status_code == status.HTTP_200_OK, listed.text
+    assert "tenant-fast" in {row["name"] for row in listed.json()}
+
+
+def test_a_member_may_read_but_not_write(client: TestClient, world: _World) -> None:
+    """The matrix's whole distinction for these pages, in one test."""
+    assert _get(client, world, "alpha_member", _POLICIES).status_code == status.HTTP_200_OK
+    refused = _post(client, world, "alpha_member", _POLICIES, _policy_body(world, name="member-fast"))
+    assert refused.status_code == status.HTTP_403_FORBIDDEN, refused.text
+
+
+def test_another_tenants_workspace_is_not_found_rather_than_forbidden(client: TestClient, world: _World) -> None:
+    """A bare workspace id says nothing about whose it is, so a 403 would be an oracle."""
+    body = _policy_body(world, name="cross-tenant", target=_BETA_TARGET)
+    body["workspace_id"] = str(world.workspaces["beta_one"])
+    refused = _post(client, world, "alpha_admin", _POLICIES, body)
+    assert refused.status_code == status.HTTP_404_NOT_FOUND, refused.text
+
+
+def test_a_write_must_name_a_workspace(client: TestClient, world: _World) -> None:
+    """No default-workspace fallback here: the deployment's default is not the tenant's."""
+    body = _policy_body(world, name="unscoped")
+    del body["workspace_id"]
+    refused = _post(client, world, "alpha_admin", _POLICIES, body)
+    assert refused.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT, refused.text
+
+
+def test_a_user_scoped_write_is_refused(client: TestClient, world: _World) -> None:
+    """``user_id`` is deployment-wide, so accepting one would make this a cross-tenant oracle."""
+    refused = _post(client, world, "alpha_admin", _POLICIES, _policy_body(world, name="scoped", user_id="someone"))
+    assert refused.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT, refused.text
+
+
+def test_a_target_the_organization_cannot_reach_is_refused(client: TestClient, world: _World) -> None:
+    """The escalation guard: a policy is a name for a model, so writing one must not widen access."""
+    refused = _post(
+        client,
+        world,
+        "alpha_admin",
+        _POLICIES,
+        _policy_body(world, name="borrowed", target=_BETA_TARGET),
+    )
+    assert refused.status_code == status.HTTP_400_BAD_REQUEST, refused.text
+    assert _BETA_TARGET in refused.json()["detail"]
+
+
+def test_every_static_candidate_is_checked_not_only_the_default(client: TestClient, world: _World) -> None:
+    """An on_failure entry dispatches too, so it is as much a target as the default."""
+    body = _policy_body(world, name="fallback-borrowed")
+    body["spec"] = {"select": [{"default": _ALPHA_TARGET}], "on_failure": [_BETA_TARGET]}
+    refused = _post(client, world, "alpha_admin", _POLICIES, body)
+    assert refused.status_code == status.HTTP_400_BAD_REQUEST, refused.text
+
+
+def test_an_admin_deletes_their_own_policy_and_a_member_cannot(client: TestClient, world: _World) -> None:
+    assert _post(client, world, "alpha_admin", _POLICIES, _policy_body(world, name="doomed")).status_code == 200
+    path = f"{_POLICIES}/doomed?workspace_id={world.workspaces['alpha_one']}"
+    assert _delete(client, world, "alpha_member", path).status_code == status.HTTP_403_FORBIDDEN
+    assert _delete(client, world, "alpha_admin", path).status_code == status.HTTP_204_NO_CONTENT
+    assert "doomed" not in {row["name"] for row in _get(client, world, "alpha_admin", _POLICIES).json()}
+
+
+def test_the_alias_sibling_follows_the_same_rules(client: TestClient, world: _World) -> None:
+    """One surface, two tables: whatever the policy writer refuses, the alias writer refuses."""
+    body = {
+        "name": "tenant-alias",
+        "target": _ALPHA_TARGET,
+        "workspace_id": str(world.workspaces["alpha_one"]),
+    }
+    created = _post(client, world, "alpha_admin", _ALIASES, body)
+    assert created.status_code == status.HTTP_200_OK, created.text
+    assert "tenant-alias" in {row["name"] for row in _get(client, world, "alpha_admin", _ALIASES).json()}
+
+    assert _post(client, world, "alpha_member", _ALIASES, body).status_code == status.HTTP_403_FORBIDDEN
+    borrowed = _post(client, world, "alpha_admin", _ALIASES, {**body, "name": "borrowed", "target": _BETA_TARGET})
+    assert borrowed.status_code == status.HTTP_400_BAD_REQUEST, borrowed.text
+
+    path = f"{_ALIASES}/tenant-alias?workspace_id={world.workspaces['alpha_one']}"
+    assert _delete(client, world, "alpha_admin", path).status_code == status.HTTP_204_NO_CONTENT
+
+
+def test_an_alias_list_shows_no_other_tenants_rows(client: TestClient, world: _World) -> None:
+    body = {"name": "beta-alias", "target": _BETA_TARGET, "workspace_id": str(world.workspaces["beta_one"])}
+    assert _post(client, world, "beta_owner", _ALIASES, body).status_code == status.HTTP_200_OK
+    assert "beta-alias" not in {row["name"] for row in _get(client, world, "alpha_admin", _ALIASES).json()}
+
+
+def test_the_deployment_wide_writers_still_refuse_a_tenant(client: TestClient, world: _World) -> None:
+    """The control: these routers exist so those gates do not have to loosen."""
+    assert _post(client, world, "alpha_admin", "/v1/routing/policies", _policy_body(world, name="x")).status_code == (
+        status.HTTP_403_FORBIDDEN
+    )
+    assert _post(
+        client,
+        world,
+        "alpha_admin",
+        "/v1/aliases",
+        {"name": "x", "target": _ALPHA_TARGET},
+    ).status_code == status.HTTP_403_FORBIDDEN

--- a/tests/integration/test_organization_routing_write_scope.py
+++ b/tests/integration/test_organization_routing_write_scope.py
@@ -34,6 +34,7 @@ from gateway.models.entities import DashboardSession
 from gateway.models.provider_keys import OrgProviderKey
 from gateway.models.tenancy import Organization, OrganizationMember, User, Workspace, WorkspaceMember
 from gateway.services.dashboard_session_service import SESSION_COOKIE_NAME, hash_session_token
+from gateway.services.secret_box import encrypt_secret, generate_secret_key
 
 _POLICIES = "/v1/organizations/me/routing-policies"
 _ALIASES = "/v1/organizations/me/aliases"
@@ -43,6 +44,17 @@ _ALIASES = "/v1/organizations/me/aliases"
 # tested against.
 _ALPHA_TARGET = "openai:gpt-4o-mini"
 _BETA_TARGET = "anthropic:claude-3-5-haiku-latest"
+
+
+@pytest.fixture(autouse=True)
+def _secret_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A real key, so the stored credentials below decrypt.
+
+    The target guard asks what the organization can actually reach, and a row
+    whose secret will not decrypt reaches nothing, so without this every write
+    here is refused for the wrong reason.
+    """
+    monkeypatch.setenv("OTARI_SECRET_KEY", generate_secret_key())
 
 
 @dataclass
@@ -110,7 +122,7 @@ def world(client: TestClient, master_key_header: dict[str, str], db_session_fact
                     organization_id=organization_id,
                     provider=provider,
                     name=f"{provider}-primary",
-                    encrypted_api_key="encrypted",
+                    encrypted_api_key=encrypt_secret("sk-test-value"),
                     last4="1234",
                     is_org_default=True,
                 )
@@ -290,3 +302,79 @@ def test_both_lists_are_bounded(client: TestClient, world: _World) -> None:
         assert _get(client, world, "alpha_admin", f"{path}?limit=100000").status_code == (
             status.HTTP_422_UNPROCESSABLE_CONTENT
         )
+
+
+def test_a_user_scoped_row_is_neither_listed_nor_destroyed_by_a_tenant_delete(
+    client: TestClient, master_key_header: dict[str, str], world: _World
+) -> None:
+    """A tenant may not address a user-scoped row, so it may not be shown one either.
+
+    The write refuses ``user_id`` because it is a deployment-wide identifier, and
+    the read has to agree: while these rows were listed, an admin got an Edit and
+    a Delete on one, and the delete carried no user scope, so it matched
+    ``user_id IS NULL`` and destroyed the *workspace-wide* row of that name while
+    answering 204. Both rows sort adjacent under the page's own ordering, so
+    nothing about the result looked wrong.
+    """
+    operator_workspace = str(world.workspaces["alpha_one"])
+    assert (
+        client.post("/v1/users", json={"user_id": "scoped-user"}, headers=master_key_header).status_code == 200
+    )
+    for user_id in (None, "scoped-user"):
+        stored = client.post(
+            "/v1/routing/policies",
+            json={
+                "name": "shared",
+                "spec": {"select": [{"default": _ALPHA_TARGET}]},
+                "workspace_id": operator_workspace,
+                **({"user_id": user_id} if user_id is not None else {}),
+            },
+            headers=master_key_header,
+        )
+        assert stored.status_code == status.HTTP_200_OK, stored.text
+
+    listed = _get(client, world, "alpha_admin", _POLICIES).json()
+    scopes = {(row["name"], row["user_id"]) for row in listed if row["source"] == "stored"}
+    assert ("shared", None) in scopes
+    assert ("shared", "scoped-user") not in scopes, "a user-scoped row is not the tenant's to see"
+
+    deleted = _delete(client, world, "alpha_admin", f"{_POLICIES}/shared?workspace_id={operator_workspace}")
+    assert deleted.status_code == status.HTTP_204_NO_CONTENT, deleted.text
+
+    # The workspace-wide row is the one the tenant addressed and the one that
+    # went; the user-scoped row it never saw is still there.
+    survivors = {
+        (row["name"], row["user_id"])
+        for row in client.get("/v1/routing/policies", headers=master_key_header).json()
+        if row["source"] == "stored"
+    }
+    assert ("shared", "scoped-user") in survivors
+    assert ("shared", None) not in survivors
+
+
+def test_the_alias_list_omits_user_scoped_rows_too(
+    client: TestClient, master_key_header: dict[str, str], world: _World
+) -> None:
+    """The sibling half of the rule above, over ``model_aliases``."""
+    operator_workspace = str(world.workspaces["alpha_one"])
+    assert client.post("/v1/users", json={"user_id": "alias-user"}, headers=master_key_header).status_code == 200
+    for user_id in (None, "alias-user"):
+        stored = client.post(
+            "/v1/aliases",
+            json={
+                "name": "shared-alias",
+                "target": _ALPHA_TARGET,
+                "workspace_id": operator_workspace,
+                **({"user_id": user_id} if user_id is not None else {}),
+            },
+            headers=master_key_header,
+        )
+        assert stored.status_code == status.HTTP_200_OK, stored.text
+
+    scopes = {
+        (row["name"], row["user_id"])
+        for row in _get(client, world, "alpha_admin", _ALIASES).json()
+        if row["source"] == "stored"
+    }
+    assert ("shared-alias", None) in scopes
+    assert ("shared-alias", "alias-user") not in scopes

--- a/tests/integration/test_organization_routing_write_scope.py
+++ b/tests/integration/test_organization_routing_write_scope.py
@@ -273,3 +273,20 @@ def test_the_deployment_wide_writers_still_refuse_a_tenant(client: TestClient, w
         "/v1/aliases",
         {"name": "x", "target": _ALPHA_TARGET},
     ).status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_both_lists_are_bounded(client: TestClient, world: _World) -> None:
+    """A tenant's routing configuration is a read with a server-enforced cap."""
+    for name in ("bound-a", "bound-b", "bound-c"):
+        assert _post(client, world, "alpha_admin", _POLICIES, _policy_body(world, name=name)).status_code == 200
+        alias = {"name": f"{name}-alias", "target": _ALPHA_TARGET, "workspace_id": str(world.workspaces["alpha_one"])}
+        assert _post(client, world, "alpha_admin", _ALIASES, alias).status_code == status.HTTP_200_OK
+
+    for path in (_POLICIES, _ALIASES):
+        bounded = _get(client, world, "alpha_admin", f"{path}?limit=2")
+        assert bounded.status_code == status.HTTP_200_OK, bounded.text
+        assert len(bounded.json()) == 2
+        # The cap is a cap, not a page size the caller can lift.
+        assert _get(client, world, "alpha_admin", f"{path}?limit=100000").status_code == (
+            status.HTTP_422_UNPROCESSABLE_CONTENT
+        )

--- a/tests/integration/test_session_model_catalog_scope.py
+++ b/tests/integration/test_session_model_catalog_scope.py
@@ -293,3 +293,34 @@ def test_an_identity_with_no_live_membership_is_answered_rather_than_refused(
     particular it must not be shown Beta's models just because it points there.
     """
     assert _catalog_as(client, world, "orphan") == set()
+
+
+def test_a_foreign_workspaces_alias_names_are_not_listed(
+    client: TestClient, master_key_header: dict[str, str], world: _World
+) -> None:
+    """An alias name is not filtered by the allow-list, so the layer has to be scoped.
+
+    ``services/alias_service`` reads the deployment's default workspace when no
+    workspace is named, which is what the master-key write below means and what a
+    session used to be answered from. The alias points at a target Alpha *can*
+    reach, so the model allow-list permits it and only the workspace scoping keeps
+    the name out: the case a filter over targets cannot catch (otari-ai#1969).
+    """
+    created = client.post(
+        "/v1/aliases",
+        json={"name": "acme-confidential-summarizer", "target": _OPENAI_MODEL},
+        headers=master_key_header,
+    )
+    assert created.status_code == status.HTTP_200_OK, created.text
+
+    listed = _catalog_as(client, world, "alpha_member")
+    assert "acme-confidential-summarizer" not in listed
+    # The providers themselves are unaffected: this withholds another workspace's
+    # names, not a tenant's models. The target stays listed for the member, and
+    # correctly so: an alias withholds its target to keep the indirection intact,
+    # and there is no indirection here for a caller who is shown no alias.
+    assert listed == {_OPENAI_MODEL, _OPENAI_OTHER}
+
+    # The control: an operator is answered from the workspace the alias lives in,
+    # so the name is still there for the caller it belongs to.
+    assert "acme-confidential-summarizer" in _catalog_as(client, world, "superuser")

--- a/tests/integration/test_session_model_catalog_scope.py
+++ b/tests/integration/test_session_model_catalog_scope.py
@@ -32,6 +32,7 @@ from gateway.models.entities import DashboardSession
 from gateway.models.provider_keys import OrgProviderKey, WorkspaceProviderModelRestriction
 from gateway.models.tenancy import Organization, OrganizationMember, User, Workspace, WorkspaceMember
 from gateway.services.dashboard_session_service import SESSION_COOKIE_NAME, hash_session_token
+from gateway.services.secret_box import encrypt_secret, generate_secret_key
 
 # Priced but undiscovered models: phase 2 of the listing publishes them, so the
 # catalog is deterministic without dialing a provider.
@@ -40,6 +41,17 @@ _OPENAI_OTHER = "openai:gpt-4o"
 _ANTHROPIC_MODEL = "anthropic:claude-3-5-haiku-latest"
 _MISTRAL_MODEL = "mistral:mistral-small-latest"
 _ALL_MODELS = (_OPENAI_MODEL, _OPENAI_OTHER, _ANTHROPIC_MODEL, _MISTRAL_MODEL)
+
+
+@pytest.fixture(autouse=True)
+def _secret_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A real key, so a stored credential decrypts as it would in production.
+
+    Without it every BYO row is unusable and the catalog withholds its provider,
+    which is correct behavior (see the undecryptable-key test below) and would
+    make every other case here vacuous.
+    """
+    monkeypatch.setenv("OTARI_SECRET_KEY", generate_secret_key())
 
 
 @dataclass
@@ -113,12 +125,18 @@ def _unmembered_identity(session: Session, *, email: str, organization_id: uuid.
     return token
 
 
-def _byo_key(session: Session, *, organization_id: uuid.UUID, provider: str) -> uuid.UUID:
+def _byo_key(
+    session: Session,
+    *,
+    organization_id: uuid.UUID,
+    provider: str,
+    encrypted_api_key: str | None = None,
+) -> uuid.UUID:
     key = OrgProviderKey(
         organization_id=organization_id,
         provider=provider,
         name=f"{provider}-primary",
-        encrypted_api_key="encrypted",
+        encrypted_api_key=encrypted_api_key or encrypt_secret("sk-test-value"),
         last4="1234",
         is_org_default=True,
     )
@@ -324,3 +342,29 @@ def test_a_foreign_workspaces_alias_names_are_not_listed(
     # The control: an operator is answered from the workspace the alias lives in,
     # so the name is still there for the caller it belongs to.
     assert "acme-confidential-summarizer" in _catalog_as(client, world, "superuser")
+
+
+def test_a_provider_whose_only_key_will_not_decrypt_is_withheld(
+    client: TestClient, world: _World, db_session_factory: Callable[[], Session]
+) -> None:
+    """The catalog must not advertise what dispatch cannot serve.
+
+    ``refresh_org_provider_cache`` skips a row whose secret will not decrypt, so
+    a request through that provider has no credential. Listing its models would
+    break the rule this filter exists to keep, that the catalog never shows a
+    model the caller cannot actually use.
+    """
+    session = db_session_factory()
+    try:
+        _byo_key(
+            session,
+            organization_id=world.beta,
+            provider="mistral",
+            encrypted_api_key="not-a-fernet-token",
+        )
+    finally:
+        session.close()
+
+    listed = _catalog_as(client, world, "beta_member")
+    assert _ANTHROPIC_MODEL in listed, "beta's decryptable key still counts"
+    assert _MISTRAL_MODEL not in listed, "the undecryptable key's provider is withheld"

--- a/tests/integration/test_session_model_catalog_scope.py
+++ b/tests/integration/test_session_model_catalog_scope.py
@@ -89,6 +89,30 @@ def _identity(
     return token
 
 
+def _unmembered_identity(session: Session, *, email: str, organization_id: uuid.UUID) -> str:
+    """A signed-in identity pointed at a real organization it holds no membership in.
+
+    ``users.active_organization_id`` is a foreign key, so a pointer at nothing is
+    not a state the database can hold; a pointer with no membership behind it is,
+    and it is the one the scope resolver refuses.
+    """
+    user = User(email=email, full_name="Orphan", active_organization_id=organization_id)
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    token = f"otari-sess-{email}"
+    session.add(
+        DashboardSession(
+            token_hash=hash_session_token(token),
+            user_id=user.id,
+            created_at=datetime.now(UTC),
+            expires_at=datetime.now(UTC) + timedelta(hours=12),
+        )
+    )
+    session.commit()
+    return token
+
+
 def _byo_key(session: Session, *, organization_id: uuid.UUID, provider: str) -> uuid.UUID:
     key = OrgProviderKey(
         organization_id=organization_id,
@@ -153,6 +177,9 @@ def world(client: TestClient, master_key_header: dict[str, str], db_session_fact
                 email="member@beta.test",
                 organization_id=beta.id,
                 workspace_ids=(beta_one.id,),
+            ),
+            "orphan": _unmembered_identity(
+                session, email="orphan@nowhere.test", organization_id=beta.id
             ),
             "superuser": _identity(
                 session,
@@ -253,3 +280,16 @@ def test_a_single_model_read_agrees_with_the_listing(client: TestClient, world: 
         assert client.get(f"/v1/models/{_ANTHROPIC_MODEL}").status_code == status.HTTP_404_NOT_FOUND
     finally:
         client.cookies.clear()
+
+
+def test_an_identity_with_no_live_membership_is_answered_rather_than_refused(
+    client: TestClient, world: _World
+) -> None:
+    """A catalog read is not one of the routes whose whole question is "which organization".
+
+    The pointer is not the authority, so this caller reaches no organization's
+    keys, which is an empty list here (the test deployment configures no
+    ``providers:`` block) rather than a 403 over a page that used to render. In
+    particular it must not be shown Beta's models just because it points there.
+    """
+    assert _catalog_as(client, world, "orphan") == set()

--- a/tests/integration/test_session_model_catalog_scope.py
+++ b/tests/integration/test_session_model_catalog_scope.py
@@ -1,0 +1,255 @@
+"""``GET /v1/models`` shows a tenant only the providers their organization reaches.
+
+The roles matrix wants a member's model list narrowed to the providers they have
+access to (otari-ai#1969). The narrowing reuses the allow-list machinery an API
+key already goes through (``services/model_access``), so the assertions here are
+about *which* allow-list a caller is answered by rather than about a second
+matcher:
+
+* a header master key is the deployment credential and is unrestricted;
+* a session that operates the deployment is unrestricted;
+* any other session is answered by its membership, which is every
+  ``config.providers`` instance (deployment-wide, so every tenant reaches them)
+  plus the organization's own BYO providers.
+
+The test deployment configures no ``providers:`` block, so every entry a caller
+is shown here comes from a BYO key. That is the sharp case: a deployment with
+config-file providers gives every tenant those on top, which is why opening this
+filter changes nothing for a single-tenant install.
+"""
+
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from gateway.models.entities import DashboardSession
+from gateway.models.provider_keys import OrgProviderKey, WorkspaceProviderModelRestriction
+from gateway.models.tenancy import Organization, OrganizationMember, User, Workspace, WorkspaceMember
+from gateway.services.dashboard_session_service import SESSION_COOKIE_NAME, hash_session_token
+
+# Priced but undiscovered models: phase 2 of the listing publishes them, so the
+# catalog is deterministic without dialing a provider.
+_OPENAI_MODEL = "openai:gpt-4o-mini"
+_OPENAI_OTHER = "openai:gpt-4o"
+_ANTHROPIC_MODEL = "anthropic:claude-3-5-haiku-latest"
+_MISTRAL_MODEL = "mistral:mistral-small-latest"
+_ALL_MODELS = (_OPENAI_MODEL, _OPENAI_OTHER, _ANTHROPIC_MODEL, _MISTRAL_MODEL)
+
+
+@dataclass
+class _World:
+    alpha: uuid.UUID
+    beta: uuid.UUID
+    workspaces: dict[str, uuid.UUID] = field(default_factory=dict)
+    keys: dict[str, uuid.UUID] = field(default_factory=dict)
+    sessions: dict[str, str] = field(default_factory=dict)
+
+
+def _identity(
+    session: Session,
+    *,
+    email: str,
+    organization_id: uuid.UUID,
+    role: str = "member",
+    is_superuser: bool = False,
+    workspace_ids: tuple[uuid.UUID, ...] = (),
+) -> str:
+    user = User(
+        email=email,
+        full_name=email.split("@")[0].title(),
+        active_organization_id=organization_id,
+        is_superuser=is_superuser,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    session.add(
+        OrganizationMember(organization_id=organization_id, user_id=user.id, role=role, status="active")
+    )
+    for workspace_id in workspace_ids:
+        session.add(
+            WorkspaceMember(workspace_id=workspace_id, user_id=user.id, role="member", status="active")
+        )
+    token = f"otari-sess-{email}"
+    session.add(
+        DashboardSession(
+            token_hash=hash_session_token(token),
+            user_id=user.id,
+            created_at=datetime.now(UTC),
+            expires_at=datetime.now(UTC) + timedelta(hours=12),
+        )
+    )
+    session.commit()
+    return token
+
+
+def _byo_key(session: Session, *, organization_id: uuid.UUID, provider: str) -> uuid.UUID:
+    key = OrgProviderKey(
+        organization_id=organization_id,
+        provider=provider,
+        name=f"{provider}-primary",
+        encrypted_api_key="encrypted",
+        last4="1234",
+        is_org_default=True,
+    )
+    session.add(key)
+    session.commit()
+    session.refresh(key)
+    return key.id
+
+
+@pytest.fixture
+def world(client: TestClient, master_key_header: dict[str, str], db_session_factory: Callable[[], Session]) -> _World:
+    """Two tenants with different BYO providers, and a priced catalog spanning three."""
+    assert client.get("/v1/organizations/me", headers=master_key_header).status_code == status.HTTP_200_OK
+    for model_key in _ALL_MODELS:
+        priced = client.post(
+            "/v1/pricing",
+            json={"model_key": model_key, "input_price_per_million": 1.0, "output_price_per_million": 2.0},
+            headers=master_key_header,
+        )
+        assert priced.status_code == status.HTTP_200_OK, priced.text
+
+    session = db_session_factory()
+    try:
+        alpha = Organization(name="Alpha", slug="alpha")
+        beta = Organization(name="Beta", slug="beta")
+        session.add_all([alpha, beta])
+        session.commit()
+        session.refresh(alpha)
+        session.refresh(beta)
+
+        alpha_one = Workspace(name="Alpha one", organization_id=alpha.id)
+        alpha_two = Workspace(name="Alpha two", organization_id=alpha.id)
+        beta_one = Workspace(name="Beta one", organization_id=beta.id)
+        session.add_all([alpha_one, alpha_two, beta_one])
+        session.commit()
+        for workspace in (alpha_one, alpha_two, beta_one):
+            session.refresh(workspace)
+
+        built = _World(alpha=alpha.id, beta=beta.id)
+        built.workspaces = {"alpha_one": alpha_one.id, "alpha_two": alpha_two.id, "beta_one": beta_one.id}
+        built.keys = {
+            "alpha_openai": _byo_key(session, organization_id=alpha.id, provider="openai"),
+            "beta_anthropic": _byo_key(session, organization_id=beta.id, provider="anthropic"),
+        }
+        built.sessions = {
+            "alpha_owner": _identity(session, email="owner@alpha.test", organization_id=alpha.id, role="owner"),
+            "alpha_member": _identity(
+                session,
+                email="member@alpha.test",
+                organization_id=alpha.id,
+                workspace_ids=(alpha_one.id,),
+            ),
+            "alpha_newcomer": _identity(session, email="new@alpha.test", organization_id=alpha.id),
+            "beta_member": _identity(
+                session,
+                email="member@beta.test",
+                organization_id=beta.id,
+                workspace_ids=(beta_one.id,),
+            ),
+            "superuser": _identity(
+                session,
+                email="root@alpha.test",
+                organization_id=alpha.id,
+                role="owner",
+                is_superuser=True,
+            ),
+        }
+        return built
+    finally:
+        session.close()
+
+
+def _catalog_as(client: TestClient, world: _World, who: str) -> set[str]:
+    client.cookies.set(SESSION_COOKIE_NAME, world.sessions[who])
+    try:
+        response = client.get("/v1/models")
+        assert response.status_code == status.HTTP_200_OK, response.text
+        return {model["id"] for model in response.json()["data"]}
+    finally:
+        client.cookies.clear()
+
+
+def test_the_master_key_still_sees_every_priced_model(
+    client: TestClient, master_key_header: dict[str, str], world: _World
+) -> None:
+    """The control: the deployment credential is not narrowed by anyone's membership."""
+    response = client.get("/v1/models", headers=master_key_header)
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert {model["id"] for model in response.json()["data"]} == set(_ALL_MODELS)
+
+
+def test_a_member_sees_only_their_organizations_providers(client: TestClient, world: _World) -> None:
+    listed = _catalog_as(client, world, "alpha_member")
+    assert listed == {_OPENAI_MODEL, _OPENAI_OTHER}
+    assert _ANTHROPIC_MODEL not in listed
+    assert _MISTRAL_MODEL not in listed
+
+
+def test_two_tenants_are_shown_disjoint_catalogs(client: TestClient, world: _World) -> None:
+    """Stated on its own, because it is the claim the narrowing rests on."""
+    assert _catalog_as(client, world, "alpha_member").isdisjoint(_catalog_as(client, world, "beta_member"))
+
+
+def test_an_admin_is_answered_from_the_organizations_providers_not_one_workspaces(
+    client: TestClient, world: _World
+) -> None:
+    """An owner belongs to no workspace here, and still reads the organization's providers.
+
+    An implementation that walked the caller's workspace memberships would show
+    them nothing, which is the failure this pins.
+    """
+    assert _catalog_as(client, world, "alpha_owner") == {_OPENAI_MODEL, _OPENAI_OTHER}
+
+
+def test_a_member_of_no_workspace_sees_no_byo_models_rather_than_a_refusal(
+    client: TestClient, world: _World
+) -> None:
+    """Nothing was refused; no workspace of theirs holds a key yet."""
+    assert _catalog_as(client, world, "alpha_newcomer") == set()
+
+
+def test_a_deployment_operator_session_is_not_narrowed(client: TestClient, world: _World) -> None:
+    """A superuser operates the deployment, so the catalog is the deployment's."""
+    assert _catalog_as(client, world, "superuser") == set(_ALL_MODELS)
+
+
+def test_a_workspace_model_restriction_narrows_a_members_catalog(
+    client: TestClient, world: _World, db_session_factory: Callable[[], Session]
+) -> None:
+    """The allow-list a workspace already enforces at dispatch decides the listing too."""
+    session = db_session_factory()
+    try:
+        session.add(
+            WorkspaceProviderModelRestriction(
+                workspace_id=world.workspaces["alpha_one"],
+                organization_id=world.alpha,
+                org_provider_key_id=world.keys["alpha_openai"],
+                model="gpt-4o-mini",
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+
+    assert _catalog_as(client, world, "alpha_member") == {_OPENAI_MODEL}
+    # The admin still reads the organization's whole provider, because lifting one
+    # workspace's restriction is theirs to do.
+    assert _catalog_as(client, world, "alpha_owner") == {_OPENAI_MODEL, _OPENAI_OTHER}
+
+
+def test_a_single_model_read_agrees_with_the_listing(client: TestClient, world: _World) -> None:
+    """A model withheld from the listing is 404 by id, never a different answer."""
+    client.cookies.set(SESSION_COOKIE_NAME, world.sessions["alpha_member"])
+    try:
+        assert client.get(f"/v1/models/{_OPENAI_MODEL}").status_code == status.HTTP_200_OK
+        assert client.get(f"/v1/models/{_ANTHROPIC_MODEL}").status_code == status.HTTP_404_NOT_FOUND
+    finally:
+        client.cookies.clear()

--- a/tests/integration/test_tool_settings_tenant_read.py
+++ b/tests/integration/test_tool_settings_tenant_read.py
@@ -1,0 +1,126 @@
+"""``GET /v1/tool-settings`` answers a tenant, without the service endpoints in it.
+
+The roles matrix has the Tools pages at View for a member, and mozilla-ai/otari#867
+deferred this one read because the fields are deployment infrastructure rather
+than anything tenant-scoped (otari-ai#1969). They still are: the decision here is
+that a tenant reads *what the built-in tools do to their requests* and never
+*where those services live*.
+
+So the three URL fields are withheld from a non-operator rather than masked.
+Masking already hides a password, but the host is what the Settings page's
+network-safety gates are set against, and it is not a tenant's to see. The write
+verbs stay operator-only and have their own tests next door in
+``tests/unit/test_tool_settings_endpoint.py``.
+"""
+
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from gateway.models.entities import DashboardSession
+from gateway.models.tenancy import Organization, OrganizationMember, User
+from gateway.services.dashboard_session_service import SESSION_COOKIE_NAME, hash_session_token
+
+_PATH = "/v1/tool-settings"
+_URL_KEYS = {"web_search_url", "sandbox_url", "guardrails_url"}
+
+
+def _identity(session: Session, *, email: str, organization_id: uuid.UUID, is_superuser: bool = False) -> str:
+    user = User(
+        email=email,
+        full_name=email.split("@")[0].title(),
+        active_organization_id=organization_id,
+        is_superuser=is_superuser,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    session.add(OrganizationMember(organization_id=organization_id, user_id=user.id, role="member", status="active"))
+    token = f"otari-sess-{email}"
+    session.add(
+        DashboardSession(
+            token_hash=hash_session_token(token),
+            user_id=user.id,
+            created_at=datetime.now(UTC),
+            expires_at=datetime.now(UTC) + timedelta(hours=12),
+        )
+    )
+    session.commit()
+    return token
+
+
+@pytest.fixture
+def sessions(
+    client: TestClient, master_key_header: dict[str, str], db_session_factory: Callable[[], Session]
+) -> dict[str, str]:
+    assert client.get("/v1/organizations/me", headers=master_key_header).status_code == status.HTTP_200_OK
+    session = db_session_factory()
+    try:
+        organization = Organization(name="Alpha", slug="alpha")
+        session.add(organization)
+        session.commit()
+        session.refresh(organization)
+        return {
+            "member": _identity(session, email="member@alpha.test", organization_id=organization.id),
+            "operator": _identity(
+                session, email="root@alpha.test", organization_id=organization.id, is_superuser=True
+            ),
+        }
+    finally:
+        session.close()
+
+
+def _read_as(client: TestClient, token: str) -> dict[str, Any]:
+    client.cookies.set(SESSION_COOKIE_NAME, token)
+    try:
+        response = client.get(_PATH)
+        assert response.status_code == status.HTTP_200_OK, response.text
+        return {field["key"]: field for field in response.json()["fields"]}
+    finally:
+        client.cookies.clear()
+
+
+def test_a_member_reads_the_settings_without_the_service_endpoints(
+    client: TestClient, sessions: dict[str, str]
+) -> None:
+    fields = _read_as(client, sessions["member"])
+    assert fields, "a member gets the read, not an empty body"
+    assert _URL_KEYS.isdisjoint(fields)
+    # The fields that describe what a request gets are the point of opening it.
+    assert "web_search_max_results" in fields
+    assert "web_search_intercept" in fields
+
+
+def test_an_operator_session_still_reads_the_endpoints(client: TestClient, sessions: dict[str, str]) -> None:
+    assert _URL_KEYS.issubset(_read_as(client, sessions["operator"]))
+
+
+def test_the_master_key_still_reads_everything(
+    client: TestClient, master_key_header: dict[str, str], sessions: dict[str, str]
+) -> None:
+    """The control: the deployment credential is not a tenant and is not narrowed."""
+    response = client.get(_PATH, headers=master_key_header)
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert _URL_KEYS.issubset({field["key"] for field in response.json()["fields"]})
+
+
+def test_the_write_verbs_still_refuse_a_member(client: TestClient, sessions: dict[str, str]) -> None:
+    """Opening the read must not have opened the router."""
+    client.cookies.set(SESSION_COOKIE_NAME, sessions["member"])
+    try:
+        patched = client.patch(_PATH, json={"web_search_max_results": 3})
+        assert patched.status_code == status.HTTP_403_FORBIDDEN, patched.text
+        probed = client.post(f"{_PATH}/web_search/test", json={"url": "http://searxng:8080"})
+        assert probed.status_code == status.HTTP_403_FORBIDDEN, probed.text
+    finally:
+        client.cookies.clear()
+
+
+def test_an_unauthenticated_read_is_still_refused(client: TestClient) -> None:
+    assert client.get(_PATH).status_code == status.HTTP_401_UNAUTHORIZED

--- a/tests/unit/test_operator_gate_declarations.py
+++ b/tests/unit/test_operator_gate_declarations.py
@@ -69,7 +69,7 @@ _DEPLOYMENT_WIDE_ROUTERS: list[tuple[str, APIRouter]] = [
     ("scoped_budgets", scoped_budgets.router),
     ("search_tools", search_tools.router),
     ("settings", settings.router),
-    ("tool_settings", tool_settings.router),
+    ("tool_settings", tool_settings.operator_router),
     ("usage", usage.operator_router),
     ("users", users.router),
 ]
@@ -82,6 +82,7 @@ _DEPLOYMENT_WIDE_ROUTERS: list[tuple[str, APIRouter]] = [
 _NON_OPERATOR_ROUTERS: list[tuple[str, APIRouter, Callable[..., Any]]] = [
     ("models.catalog", models.catalog_router, verify_catalog_reader),
     ("pricing.catalog", pricing.catalog_router, verify_catalog_reader),
+    ("tool_settings.reader", tool_settings.reader_router, verify_master_key),
     ("tools", tools.router, verify_catalog_reader),
     ("usage.ingest", usage.ingest_router, verify_api_key_or_master_key),
 ]

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -12542,7 +12542,10 @@ export interface operations {
     };
     list_visible_aliases_v1_organizations_me_aliases_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Maximum entries to return, stored and config-file together. */
+                limit?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -12556,6 +12559,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AliasResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };
@@ -13645,7 +13657,10 @@ export interface operations {
     };
     list_visible_routing_policies_v1_organizations_me_routing_policies_get: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Maximum entries to return, stored and config-file together. */
+                limit?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -13659,6 +13674,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PolicyResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -324,11 +324,6 @@ export interface paths {
         /**
          * Delete Alias
          * @description Delete a stored alias in one scope.
-         *
-         *     Scoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:
-         *     deleting one workspace's alias must not touch another's, deleting the
-         *     workspace-wide alias must not take a user's override with it, and deleting an
-         *     override must leave the workspace-wide one serving everyone else.
          */
         delete: operations["delete_alias_v1_aliases__name__delete"];
         options?: never;
@@ -1590,6 +1585,58 @@ export interface paths {
         patch: operations["update_active_organization_v1_organizations_me_patch"];
         trace?: never;
     };
+    "/v1/organizations/me/aliases": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Visible Aliases
+         * @description List the aliases in force in the workspaces this caller may see.
+         *
+         *     The policies list's sibling, over ``model_aliases``, and scoped the same way:
+         *     stored rows from the caller's visible workspaces, plus the config-file
+         *     aliases, which are deployment-wide.
+         */
+        get: operations["list_visible_aliases_v1_organizations_me_aliases_get"];
+        put?: never;
+        /**
+         * Set Organization Alias
+         * @description Create or update a stored alias in one of the organization's workspaces.
+         *
+         *     Organization owners and admins only, with the same two scope rules the policy
+         *     write has: ``workspace_id`` is required and resolved inside the caller's
+         *     organization, and ``user_id`` is not accepted.
+         */
+        post: operations["set_organization_alias_v1_organizations_me_aliases_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/organizations/me/aliases/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Organization Alias
+         * @description Delete a stored alias from one of the organization's workspaces. Owners and admins only.
+         */
+        delete: operations["delete_organization_alias_v1_organizations_me_aliases__name__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/organizations/me/budgets": {
         parameters: {
             query?: never;
@@ -2114,12 +2161,40 @@ export interface paths {
          *     Stored policies from the caller's visible workspaces plus the config-file
          *     policies, which are deployment-wide and resolve in every workspace. The
          *     response is the shape ``GET /v1/routing/policies`` answers, narrowed to the
-         *     caller's own organization; only an operator can write any of it.
+         *     caller's own organization.
          */
         get: operations["list_visible_routing_policies_v1_organizations_me_routing_policies_get"];
         put?: never;
-        post?: never;
+        /**
+         * Set Organization Routing Policy
+         * @description Create or update a stored policy in one of the organization's workspaces.
+         *
+         *     Organization owners and admins only. ``workspace_id`` is required and must
+         *     name a workspace of the caller's own organization; ``user_id`` is not
+         *     accepted here.
+         */
+        post: operations["set_organization_routing_policy_v1_organizations_me_routing_policies_post"];
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/organizations/me/routing-policies/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Organization Routing Policy
+         * @description Delete a stored policy from one of the organization's workspaces. Owners and admins only.
+         */
+        delete: operations["delete_organization_routing_policy_v1_organizations_me_routing_policies__name__delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -2743,17 +2818,8 @@ export interface paths {
          * Set Policy
          * @description Create or update a stored policy in one workspace, optionally for one user.
          *
-         *     The spec is validated here and stored as given, so a row can never contain a
-         *     body this build would refuse at load. The cache is refreshed twice: once before
-         *     validating (so the shadowing checks see other writers' policies) and once after
-         *     committing (so this worker serves the new policy immediately).
-         *
-         *     ``rename_from`` renames the row instead of keying on ``name``. It is part of
-         *     this write rather than an endpoint of its own so that an edit which both renames
-         *     a policy and re-targets it cannot land half-applied, leaving the old name serving
-         *     the new spec. The new name is validated exactly as a fresh one is, because a
-         *     rename can walk a policy into every collision a create can. Sending the field
-         *     asserts the named policy is stored, so it never falls back to creating one.
+         *     Omitting ``workspace_id`` means the deployment's default workspace, which is
+         *     where an operator acting deployment-wide writes.
          */
         post: operations["set_policy_v1_routing_policies_post"];
         delete?: never;
@@ -2804,11 +2870,6 @@ export interface paths {
         /**
          * Delete Policy
          * @description Delete a stored policy in one scope.
-         *
-         *     Scoped by ``workspace_id`` and ``user_id`` for the same reason the upsert is:
-         *     deleting one workspace's policy must not touch another's, deleting the
-         *     workspace-wide policy must not take a user's override with it, and deleting an
-         *     override must leave the workspace-wide one serving everyone else.
          */
         delete: operations["delete_policy_v1_routing_policies__name__delete"];
         options?: never;
@@ -3260,6 +3321,12 @@ export interface paths {
         /**
          * Get Tool Settings
          * @description Return the effective tool/guardrail settings for the dashboard.
+         *
+         *     Authentication only on the router: the role decides *how much* rather than
+         *     whether, so this is not the deployment-wide gate ``require_deployment_operator``
+         *     names. A header master key is the deployment credential and reads everything;
+         *     a session reads everything only while it operates the deployment, and
+         *     otherwise gets the fields without the service endpoints in them.
          */
         get: operations["get_tool_settings_v1_tool_settings_get"];
         put?: never;
@@ -12473,6 +12540,91 @@ export interface operations {
             };
         };
     };
+    list_visible_aliases_v1_organizations_me_aliases_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AliasResponse"][];
+                };
+            };
+        };
+    };
+    set_organization_alias_v1_organizations_me_aliases_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AliasRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AliasResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_organization_alias_v1_organizations_me_aliases__name__delete: {
+        parameters: {
+            query?: {
+                /** @description Delete the alias in this workspace of the caller's organization. */
+                workspace_id?: string | null;
+            };
+            header?: never;
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_organization_budgets_v1_organizations_me_budgets_get: {
         parameters: {
             query?: {
@@ -13507,6 +13659,71 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PolicyResponse"][];
+                };
+            };
+        };
+    };
+    set_organization_routing_policy_v1_organizations_me_routing_policies_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PolicyRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PolicyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_organization_routing_policy_v1_organizations_me_routing_policies__name__delete: {
+        parameters: {
+            query?: {
+                /** @description Delete the policy in this workspace of the caller's organization. */
+                workspace_id?: string | null;
+            };
+            header?: never;
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/web/src/features/routing/RoutingPage.test.tsx
+++ b/web/src/features/routing/RoutingPage.test.tsx
@@ -10,6 +10,7 @@ import type {
   RoutingPolicyResponse,
 } from "@/client"
 import { RoutingPage } from "@/features/routing/RoutingPage"
+import { SelectedWorkspaceProvider } from "@/shared/hooks/SelectedWorkspace"
 import { organizationContext } from "@/tests/fixtures"
 import { withRouter } from "@/tests/router"
 
@@ -92,10 +93,19 @@ function mockApi(
     context?: OrganizationContext
     // What `/v1/organizations/me/routing-policies` answers, for member tests.
     memberPolicies?: RoutingPolicyResponse[]
+    // What `/v1/organizations/me/aliases` answers, its sibling.
+    memberAliases?: {
+      name: string
+      target: string
+      source: string
+      user_id: string | null
+    }[]
   } = {},
 ) {
   let list = [...policies]
   let aliasList = [...aliases]
+  let memberList = [...(opts.memberPolicies ?? [])]
+  let memberAliasList = [...(opts.memberAliases ?? [])]
   const calls: { url: string; method: string; body: unknown }[] = []
   const spy = vi
     .spyOn(globalThis, "fetch")
@@ -107,7 +117,45 @@ function mockApi(
       calls.push({ url, method, body })
 
       if (url.includes("/v1/organizations/me/routing-policies")) {
-        return jsonResponse(opts.memberPolicies ?? [])
+        if (method === "POST") {
+          const row = policy(body.name, body.spec)
+          memberList = [
+            ...memberList.filter((item) => item.name !== row.name),
+            row,
+          ]
+          return jsonResponse(row)
+        }
+        if (method === "DELETE") {
+          const name = decodeURIComponent(
+            url.split("?")[0].split("/").pop() ?? "",
+          )
+          memberList = memberList.filter((item) => item.name !== name)
+          return new Response(null, { status: 204 })
+        }
+        return jsonResponse(memberList)
+      }
+      if (url.includes("/v1/organizations/me/aliases")) {
+        if (method === "POST") {
+          const row = {
+            name: body.name as string,
+            target: body.target as string,
+            source: "stored",
+            user_id: null,
+          }
+          memberAliasList = [
+            ...memberAliasList.filter((item) => item.name !== row.name),
+            row,
+          ]
+          return jsonResponse(row)
+        }
+        if (method === "DELETE") {
+          const name = decodeURIComponent(
+            url.split("?")[0].split("/").pop() ?? "",
+          )
+          memberAliasList = memberAliasList.filter((item) => item.name !== name)
+          return new Response(null, { status: 204 })
+        }
+        return jsonResponse(memberAliasList)
       }
       if (url.endsWith("/v1/organizations/me")) {
         return jsonResponse(opts.context ?? organizationContext())
@@ -231,6 +279,34 @@ function renderPage(ui: ReactElement, url = "/") {
     <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
     { wrapper: withRouter({ url }) },
   )
+}
+
+// The workspace a tenant admin's write is scoped to comes from the shell's
+// switcher, so the provider is part of the harness for those tests. Outside it
+// `useSelectedWorkspace` answers "none selected", which is the state that
+// leaves an admin with the read-only page.
+const ADMIN_WORKSPACE = "44444444-4444-4444-4444-444444444444"
+
+function renderInWorkspace(ui: ReactElement, url = "/") {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={client}>
+      <SelectedWorkspaceProvider>{ui}</SelectedWorkspaceProvider>
+    </QueryClientProvider>,
+    { wrapper: withRouter({ url }) },
+  )
+}
+
+function adminContext(): OrganizationContext {
+  return organizationContext({
+    deployment_operator: false,
+    role: "admin",
+    workspace_memberships: [
+      { workspace_id: ADMIN_WORKSPACE, name: "Alpha one", role: "admin" },
+    ],
+  })
 }
 
 afterEach(() => {
@@ -1317,7 +1393,7 @@ describe("RoutingPage", () => {
     renderPage(<RoutingPage />, "/routing?target=openai:gpt-4o")
 
     expect(
-      await screen.findByText(/once a deployment operator defines them/),
+      await screen.findByText(/once your organization's admins define them/),
     ).toBeInTheDocument()
     expect(
       screen.queryByRole("button", { name: /Create policy/i }),
@@ -1344,9 +1420,172 @@ describe("RoutingPage", () => {
     renderPage(<RoutingPage />)
 
     expect(
-      await screen.findByText(/once a deployment operator defines them/),
+      await screen.findByText(/once your organization's admins define them/),
     ).toBeInTheDocument()
     // The operator's numbered getting-started walkthrough is not for them.
     expect(screen.queryByText(/Create a policy/)).not.toBeInTheDocument()
+  })
+})
+
+// otari-ai#1969: the Build pages are Edit for admins. An organization admin
+// writes the tenant-scoped routers, which name the workspace and take no user
+// scope; an operator keeps the deployment-wide ones, unchanged above.
+describe("RoutingPage for an organization admin", () => {
+  it("writes a new policy through the tenant-scoped router", async () => {
+    const { calls } = mockApi([], null, [], {
+      context: adminContext(),
+      memberPolicies: [],
+    })
+    const user = userEvent.setup()
+    renderInWorkspace(<RoutingPage />)
+
+    await user.click(await screen.findByRole("button", { name: "New policy" }))
+    await user.type(
+      screen.getByRole("textbox", { name: /policy name/i }),
+      "tenant-fast",
+    )
+    await user.type(
+      screen.getByRole("combobox", { name: /^serves$/i }),
+      "openai:gpt-5-mini",
+    )
+    // Close the combobox popover, which otherwise aria-hides the submit button.
+    await user.keyboard("{Escape}")
+    await user.click(screen.getByRole("button", { name: "Create policy" }))
+
+    const written = calls.find(
+      (call) =>
+        call.method === "POST" &&
+        call.url.includes("/v1/organizations/me/routing-policies"),
+    )
+    expect(written).toBeDefined()
+    expect(written?.body).toMatchObject({
+      name: "tenant-fast",
+      workspace_id: ADMIN_WORKSPACE,
+    })
+    // The deployment-wide router is never reached, whatever the form did.
+    expect(
+      calls.some(
+        (call) =>
+          call.method === "POST" && call.url.endsWith("/v1/routing/policies"),
+      ),
+    ).toBe(false)
+  })
+
+  it("offers no user scope, which the tenant router refuses", async () => {
+    mockApi([], null, [], { context: adminContext(), memberPolicies: [] })
+    const user = userEvent.setup()
+    renderInWorkspace(<RoutingPage />)
+
+    await user.click(await screen.findByRole("button", { name: "New policy" }))
+    expect(
+      await screen.findByText(/applies to everyone in the selected workspace/i),
+    ).toBeInTheDocument()
+    expect(screen.queryByText("For one user")).not.toBeInTheDocument()
+  })
+
+  it("deletes through the tenant-scoped router, naming the workspace", async () => {
+    const { calls } = mockApi([], null, [], {
+      context: adminContext(),
+      memberPolicies: [policy("doomed", CHAIN)],
+    })
+    const user = userEvent.setup()
+    renderInWorkspace(<RoutingPage />)
+
+    await screen.findByText("doomed")
+    await user.click(screen.getByRole("button", { name: "Delete" }))
+    await user.click(screen.getByRole("button", { name: "Confirm" }))
+
+    const deleted = calls.find((call) => call.method === "DELETE")
+    expect(deleted?.url).toContain("/v1/organizations/me/routing-policies/")
+    expect(deleted?.url).toContain(`workspace_id=${ADMIN_WORKSPACE}`)
+  })
+
+  it("writes an edit back to the row's own workspace, not the selected one", async () => {
+    // An admin's list spans the organization, so the row being edited need not
+    // live in the workspace the switcher points at. Writing to the selection
+    // would create a second policy of that name and leave this one untouched.
+    const OTHER_WORKSPACE = "55555555-5555-5555-5555-555555555555"
+    const { calls } = mockApi([], null, [], {
+      context: adminContext(),
+      memberPolicies: [
+        policy("elsewhere", CHAIN, { workspace_id: OTHER_WORKSPACE }),
+      ],
+    })
+    const user = userEvent.setup()
+    renderInWorkspace(<RoutingPage />)
+
+    await screen.findByText("elsewhere")
+    await user.click(screen.getByRole("button", { name: "Edit" }))
+    await user.click(await screen.findByRole("button", { name: "Save" }))
+
+    const written = calls.find(
+      (call) =>
+        call.method === "POST" &&
+        call.url.includes("/v1/organizations/me/routing-policies"),
+    )
+    expect(written?.body).toMatchObject({ workspace_id: OTHER_WORKSPACE })
+  })
+
+  it("lists the tenant-scoped aliases beside the policies", async () => {
+    mockApi([], null, [], {
+      context: adminContext(),
+      memberPolicies: [policy("mine", CHAIN)],
+      memberAliases: [
+        {
+          name: "tenant-alias",
+          target: "openai:gpt-5",
+          source: "stored",
+          user_id: null,
+        },
+      ],
+    })
+    renderInWorkspace(<RoutingPage />)
+
+    expect(await screen.findByText("mine")).toBeInTheDocument()
+    expect(screen.getByText("tenant-alias")).toBeInTheDocument()
+  })
+
+  it("withholds the write affordances from an admin in no workspace", async () => {
+    // The switcher is seeded from the caller's own memberships, so an admin who
+    // joined none has no workspace to scope a write to and gets the read-only
+    // page rather than a form whose only outcome is a 422.
+    mockApi([], null, [], {
+      context: organizationContext({
+        deployment_operator: false,
+        role: "admin",
+      }),
+      memberPolicies: [policy("mine", CHAIN)],
+    })
+    renderInWorkspace(<RoutingPage />)
+
+    await screen.findByText("mine")
+    expect(
+      screen.queryByRole("button", { name: "New policy" }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Delete" }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("still withholds the write affordances from a member", async () => {
+    mockApi([], null, [], {
+      context: organizationContext({
+        deployment_operator: false,
+        role: "member",
+        workspace_memberships: [
+          { workspace_id: ADMIN_WORKSPACE, name: "Alpha one", role: "member" },
+        ],
+      }),
+      memberPolicies: [policy("mine", CHAIN)],
+    })
+    renderInWorkspace(<RoutingPage />)
+
+    await screen.findByText("mine")
+    expect(
+      screen.queryByRole("button", { name: "New policy" }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Delete" }),
+    ).not.toBeInTheDocument()
   })
 })

--- a/web/src/features/routing/RoutingPage.test.tsx
+++ b/web/src/features/routing/RoutingPage.test.tsx
@@ -99,6 +99,7 @@ function mockApi(
       target: string
       source: string
       user_id: string | null
+      workspace_id?: string
     }[]
   } = {},
 ) {
@@ -141,6 +142,7 @@ function mockApi(
             target: body.target as string,
             source: "stored",
             user_id: null,
+            workspace_id: body.workspace_id as string | undefined,
           }
           memberAliasList = [
             ...memberAliasList.filter((item) => item.name !== row.name),
@@ -1543,6 +1545,66 @@ describe("RoutingPage for an organization admin", () => {
 
     expect(await screen.findByText("mine")).toBeInTheDocument()
     expect(screen.getByText("tenant-alias")).toBeInTheDocument()
+  })
+
+  it("writes an alias edit back to the alias's own workspace", async () => {
+    // The sibling of the policy case above, and it was the one that regressed:
+    // `aliasAsRow` dropped `workspace_id`, so every alias row fell back to the
+    // selected workspace and an edit landed in the wrong one silently.
+    const OTHER_WORKSPACE = "66666666-6666-6666-6666-666666666666"
+    const { calls } = mockApi([], null, [], {
+      context: adminContext(),
+      memberPolicies: [],
+      memberAliases: [
+        {
+          name: "elsewhere-alias",
+          target: "openai:gpt-5",
+          source: "stored",
+          user_id: null,
+          workspace_id: OTHER_WORKSPACE,
+        },
+      ],
+    })
+    const user = userEvent.setup()
+    renderInWorkspace(<RoutingPage />)
+
+    await screen.findByText("elsewhere-alias")
+    await user.click(screen.getByRole("button", { name: "Edit" }))
+    await user.click(await screen.findByRole("button", { name: "Save" }))
+
+    const written = calls.find(
+      (call) =>
+        call.method === "POST" &&
+        call.url.includes("/v1/organizations/me/aliases"),
+    )
+    expect(written?.body).toMatchObject({ workspace_id: OTHER_WORKSPACE })
+  })
+
+  it("deletes an alias from the alias's own workspace", async () => {
+    const OTHER_WORKSPACE = "77777777-7777-7777-7777-777777777777"
+    const { calls } = mockApi([], null, [], {
+      context: adminContext(),
+      memberPolicies: [],
+      memberAliases: [
+        {
+          name: "doomed-alias",
+          target: "openai:gpt-5",
+          source: "stored",
+          user_id: null,
+          workspace_id: OTHER_WORKSPACE,
+        },
+      ],
+    })
+    const user = userEvent.setup()
+    renderInWorkspace(<RoutingPage />)
+
+    await screen.findByText("doomed-alias")
+    await user.click(screen.getByRole("button", { name: "Delete" }))
+    await user.click(screen.getByRole("button", { name: "Confirm" }))
+
+    const deleted = calls.find((call) => call.method === "DELETE")
+    expect(deleted?.url).toContain("/v1/organizations/me/aliases/")
+    expect(deleted?.url).toContain(`workspace_id=${OTHER_WORKSPACE}`)
   })
 
   it("withholds the write affordances from an admin in no workspace", async () => {

--- a/web/src/features/routing/RoutingPage.tsx
+++ b/web/src/features/routing/RoutingPage.tsx
@@ -67,6 +67,10 @@ function aliasAsRow(alias: AliasResponse): RoutingRow {
     spec: { select: [{ default: alias.target }] },
     source: alias.source,
     user_id: alias.user_id,
+    // Carried, not dropped: an edit or a delete goes back to the workspace the
+    // row lives in, and a row without it falls back to the *selected* workspace,
+    // which for an admin whose list spans the organization is a different one.
+    workspace_id: alias.workspace_id,
     is_dynamic: false,
     created_at: alias.created_at,
     updated_at: alias.updated_at,
@@ -613,7 +617,11 @@ function PolicyForm({
       conditions.length > 0 ||
       guardrails.length > 0 ||
       candidates.length > 0)
-  const pending = save.isPending || saveAlias.isPending
+  const pending =
+    save.isPending ||
+    saveAlias.isPending ||
+    saveOrgPolicy.isPending ||
+    saveOrgAlias.isPending
 
   const submit = () => {
     if (!canSubmit || outgrewAlias) return

--- a/web/src/features/routing/RoutingPage.tsx
+++ b/web/src/features/routing/RoutingPage.tsx
@@ -774,7 +774,7 @@ function PolicyForm({
             // Withheld rather than disabled: a user id is a deployment-wide
             // identifier, so the tenant-scoped writer refuses one outright and
             // an organization's entries are workspace-wide.
-            <p className="text-xs text-muted">
+            <p className="text-caption">
               This applies to everyone in the selected workspace.
             </p>
           ) : (

--- a/web/src/features/routing/RoutingPage.tsx
+++ b/web/src/features/routing/RoutingPage.tsx
@@ -9,17 +9,22 @@ import type {
   RoutingPolicyResponse,
 } from "@/client"
 import { ModelComboBox } from "@/features/models/ModelComboBox"
-import { isDeploymentOperator } from "@/features/organization/roles"
+import { canManage, isDeploymentOperator } from "@/features/organization/roles"
 import { RouterReadiness } from "@/features/routing/RouterReadiness"
 import { UserComboBox } from "@/features/users/UserComboBox"
 import {
   useAliases,
   useCreateAlias,
+  useCreateOrganizationAlias,
   useDeleteAlias,
+  useDeleteOrganizationAlias,
+  useDeleteOrganizationRoutingPolicy,
   useDeleteRoutingPolicy,
+  useOrganizationAliases,
   useOrganizationContext,
   useOrganizationRoutingPolicies,
   useRoutingPolicies,
+  useSetOrganizationRoutingPolicy,
   useSetRoutingPolicy,
   useToolSettings,
   useUsers,
@@ -34,6 +39,7 @@ import {
   PageHeader,
 } from "@/shared/components/ui"
 import { useUrlValue } from "@/shared/helpers/urlState"
+import { useSelectedWorkspace } from "@/shared/hooks/SelectedWorkspace"
 
 /** A row on this page: either a routing policy or a stored/config alias.
  *
@@ -397,14 +403,27 @@ function ModeToggle({
 function PolicyForm({
   existing,
   initialTarget = "",
+  workspaceId,
   onClose,
 }: {
   existing: RoutingRow | null
   initialTarget?: string
+  /**
+   * The workspace a tenant admin's write lands in, or null for an operator.
+   *
+   * Null is the deployment-wide surface, which defaults the workspace itself;
+   * a string is the tenant-scoped one, which requires it named and refuses a
+   * user scope. Both mutation pairs are always created, as hooks must be, and
+   * only the pair this says is ever mutated.
+   */
+  workspaceId: string | null
   onClose: () => void
 }) {
   const save = useSetRoutingPolicy()
   const saveAlias = useCreateAlias()
+  const saveOrgPolicy = useSetOrganizationRoutingPolicy()
+  const saveOrgAlias = useCreateOrganizationAlias()
+  const tenantScoped = workspaceId !== null
   const editing = existing !== null
   // Editing an alias writes back through the alias API: it is still a row in
   // model_aliases, and silently rewriting it as a policy would leave the original
@@ -600,8 +619,31 @@ function PolicyForm({
     if (!canSubmit || outgrewAlias) return
     const scope = userId === null ? null : userId.trim()
     if (editingAlias) {
+      if (workspaceId !== null) {
+        saveOrgAlias.mutate(
+          {
+            name: name.trim(),
+            target: effectiveTarget.trim(),
+            workspace_id: workspaceId,
+          },
+          { onSuccess: onClose },
+        )
+        return
+      }
       saveAlias.mutate(
         { name: name.trim(), target: effectiveTarget.trim(), user_id: scope },
+        { onSuccess: onClose },
+      )
+      return
+    }
+    if (workspaceId !== null) {
+      saveOrgPolicy.mutate(
+        {
+          name: name.trim(),
+          spec,
+          workspace_id: workspaceId,
+          ...(renaming ? { rename_from: previousName } : {}),
+        },
         { onSuccess: onClose },
       )
       return
@@ -637,7 +679,14 @@ function PolicyForm({
               "New routing policy"
             )}
           </h2>
-          <ErrorBanner error={save.error ?? saveAlias.error} />
+          <ErrorBanner
+            error={
+              save.error ??
+              saveAlias.error ??
+              saveOrgPolicy.error ??
+              saveOrgAlias.error
+            }
+          />
 
           <div className="grid gap-4 sm:grid-cols-2">
             {editingAlias ? (
@@ -712,6 +761,13 @@ function PolicyForm({
             <p className="text-caption">
               Who this applies to is the other half of the key. It cannot be
               changed here: delete and recreate to move it between scopes.
+            </p>
+          ) : tenantScoped ? (
+            // Withheld rather than disabled: a user id is a deployment-wide
+            // identifier, so the tenant-scoped writer refuses one outright and
+            // an organization's entries are workspace-wide.
+            <p className="text-xs text-muted">
+              This applies to everyone in the selected workspace.
             </p>
           ) : (
             <ScopePicker userId={userId} onChange={setUserId} />
@@ -1235,12 +1291,10 @@ export function RoutingPage() {
   // created. Scope this when resolution is scoped, not before.
   //
   // Which list is asked depends on who is signed in (otari-ai#1942): an
-  // operator reads the deployment-wide management view they edit from, and
-  // anyone else reads the tenant-scoped `/v1/organizations/me/routing-policies`
-  // read-only. The member read waits for the context to settle rather than
-  // taking "not yet an operator" as "member", so an operator's page does not
-  // fire a read it is about to drop. Aliases have no tenant-scoped sibling yet,
-  // so a member's table lists policies alone.
+  // operator reads the deployment-wide management view, and anyone else reads
+  // the tenant-scoped `/v1/organizations/me/*` pair. Both reads wait for the
+  // context to settle rather than taking "not yet an operator" as "member", so
+  // an operator's page does not fire a read it is about to drop.
   const organization = useOrganizationContext()
   const isOperator = isDeploymentOperator(organization.data)
   const isContextSettled =
@@ -1250,8 +1304,29 @@ export function RoutingPage() {
     isContextSettled && !isOperator,
   )
   const aliases = useAliases(isOperator)
+  const memberAliases = useOrganizationAliases(isContextSettled && !isOperator)
   const deletePolicy = useDeleteRoutingPolicy()
   const deleteAlias = useDeleteAlias()
+  const deleteOrgPolicy = useDeleteOrganizationRoutingPolicy()
+  const deleteOrgAlias = useDeleteOrganizationAlias()
+  // Where a tenant admin's write lands, and null for an operator, who writes
+  // deployment-wide. The tenant surface requires the workspace named, so an
+  // admin who belongs to none has nowhere to write and is shown the read-only
+  // page: the switcher is seeded from their own memberships, not the
+  // organization's whole list (otari-ai#1969).
+  const { selected: selectedWorkspace } = useSelectedWorkspace()
+  const writeWorkspaceId = isOperator
+    ? null
+    : (selectedWorkspace?.workspace_id ?? null)
+  const canEdit =
+    isOperator || (canManage(organization.data) && writeWorkspaceId !== null)
+  // An admin's list spans every workspace of the organization, not just the
+  // selected one, so a write to an existing row goes back to the workspace that
+  // row lives in (`rowWorkspace` below, and the Edit form's `workspaceId`).
+  // Using the selection would create a second policy of the same name in the
+  // selected workspace and leave the edited one untouched. Written inline at
+  // both sites rather than as a helper, so the columns memo keeps depending on
+  // two stable values instead of a function rebuilt every render.
   // A deep link may pre-fill the add form with ?target=provider:model.
   const initialTarget = useUrlValue("target")
   const [adding, setAdding] = useState(initialTarget !== "")
@@ -1265,7 +1340,7 @@ export function RoutingPage() {
   // initializer would drop an operator's deep link, since `isOperator` is still
   // false at the moment it runs. A member arriving on that link gets the
   // read-only empty state instead of a form whose only outcome is a refusal.
-  const isAdding = adding && isOperator
+  const isAdding = adding && canEdit
 
   // Aliases and policies are listed together: an alias is the one-target case,
   // and this page is the only place either is managed.
@@ -1282,7 +1357,7 @@ export function RoutingPage() {
         kind: "policy" as const,
       }),
     ),
-    ...(isOperator ? (aliases.data ?? []) : []).map(aliasAsRow),
+    ...((isOperator ? aliases.data : memberAliases.data) ?? []).map(aliasAsRow),
   ].sort(
     (a, b) =>
       a.name.localeCompare(b.name) ||
@@ -1294,7 +1369,7 @@ export function RoutingPage() {
     !isContextSettled ||
     (isOperator
       ? policies.isLoading || aliases.isLoading
-      : memberPolicies.isLoading)
+      : memberPolicies.isLoading || memberAliases.isLoading)
 
   // Stable so DataTable's row cache holds; see its docstring.
   const renderDetail = useCallback(
@@ -1387,7 +1462,7 @@ export function RoutingPage() {
     ]
     // No actions column for a caller who cannot act: every affordance in it is
     // either a write or the Examples panel, whose read is operator-only.
-    if (!isOperator) return base
+    if (!canEdit) return base
     base.push({
       id: "actions",
       header: "",
@@ -1402,19 +1477,22 @@ export function RoutingPage() {
         // Edit and Delete.
         // Only for a backend that learns: a weighted policy has nothing to teach,
         // so offering Examples on one would promise a screen that cannot help it.
-        const readiness = routerBackendOf(policy.spec) === KNN_BACKEND && (
-          <Button
-            size="sm"
-            variant="outline"
-            onPress={() =>
-              setExpanded((current) =>
-                current === rowKeyOf(policy) ? null : rowKeyOf(policy),
-              )
-            }
-          >
-            {expanded === rowKeyOf(policy) ? "Hide examples" : "Examples"}
-          </Button>
-        )
+        // Operator-only within an actions column an admin now also gets: the
+        // panel reads `/v1/routing/status`, which is deployment-wide.
+        const readiness = isOperator &&
+          routerBackendOf(policy.spec) === KNN_BACKEND && (
+            <Button
+              size="sm"
+              variant="outline"
+              onPress={() =>
+                setExpanded((current) =>
+                  current === rowKeyOf(policy) ? null : rowKeyOf(policy),
+                )
+              }
+            >
+              {expanded === rowKeyOf(policy) ? "Hide examples" : "Examples"}
+            </Button>
+          )
         return policy.source === "config" ? (
           <div className="flex items-center justify-end gap-2">
             {readiness}
@@ -1446,18 +1524,34 @@ export function RoutingPage() {
             )}
             <ConfirmButton
               confirmLabel="Confirm"
-              isPending={deletePolicy.isPending || deleteAlias.isPending}
-              onConfirm={() =>
-                policy.kind === "alias"
-                  ? deleteAlias.mutate({
-                      name: policy.name,
-                      userId: policy.user_id,
-                    })
-                  : deletePolicy.mutate({
-                      name: policy.name,
-                      userId: policy.user_id,
-                    })
+              isPending={
+                deletePolicy.isPending ||
+                deleteAlias.isPending ||
+                deleteOrgPolicy.isPending ||
+                deleteOrgAlias.isPending
               }
+              onConfirm={() => {
+                // The tenant surface names the workspace and has no user scope;
+                // the deployment-wide one defaults the workspace and keeps it.
+                const rowWorkspace = isOperator
+                  ? null
+                  : (policy.workspace_id ?? writeWorkspaceId)
+                if (rowWorkspace !== null) {
+                  const scoped = {
+                    name: policy.name,
+                    workspaceId: rowWorkspace,
+                  }
+                  if (policy.kind === "alias") deleteOrgAlias.mutate(scoped)
+                  else deleteOrgPolicy.mutate(scoped)
+                  return
+                }
+                const deployment = {
+                  name: policy.name,
+                  userId: policy.user_id,
+                }
+                if (policy.kind === "alias") deleteAlias.mutate(deployment)
+                else deletePolicy.mutate(deployment)
+              }}
             >
               Delete
             </ConfirmButton>
@@ -1466,7 +1560,16 @@ export function RoutingPage() {
       },
     })
     return base
-  }, [deletePolicy, deleteAlias, expanded, isOperator])
+  }, [
+    canEdit,
+    deleteAlias,
+    deleteOrgAlias,
+    deleteOrgPolicy,
+    deletePolicy,
+    expanded,
+    isOperator,
+    writeWorkspaceId,
+  ])
 
   return (
     <div className="flex flex-col gap-6">
@@ -1475,10 +1578,12 @@ export function RoutingPage() {
         description={
           isOperator
             ? "Named models your callers send as `model`. A policy decides which real model serves each request, what is tried if that fails, and which guardrails always run. It can also split traffic across providers by weight, or let a router learn which prompts a cheaper model handles just as well."
-            : "Named models your callers send as `model`. A policy decides which real model serves each request, what is tried if that fails, and which guardrails always run. These are the policies in force in your workspaces; a deployment operator manages them."
+            : canEdit
+              ? "Named models your callers send as `model`. A policy decides which real model serves each request, what is tried if that fails, and which guardrails always run. What you create here applies in the selected workspace, and can name any model your organization has a provider key for."
+              : "Named models your callers send as `model`. A policy decides which real model serves each request, what is tried if that fails, and which guardrails always run. These are the ones in force in your workspaces; your organization's admins manage them."
         }
         action={
-          !isOperator || isAdding || editing !== null ? undefined : (
+          !canEdit || isAdding || editing !== null ? undefined : (
             <Button
               variant="primary"
               onPress={() => {
@@ -1497,8 +1602,11 @@ export function RoutingPage() {
           policies.error ??
           memberPolicies.error ??
           aliases.error ??
+          memberAliases.error ??
           deletePolicy.error ??
-          deleteAlias.error
+          deleteAlias.error ??
+          deleteOrgPolicy.error ??
+          deleteOrgAlias.error
         }
       />
 
@@ -1506,15 +1614,22 @@ export function RoutingPage() {
         <PolicyForm
           existing={null}
           initialTarget={initialTarget}
+          workspaceId={writeWorkspaceId}
           onClose={() => setAdding(false)}
         />
       ) : null}
       {editing !== null ? (
-        <PolicyForm existing={editing} onClose={() => setEditing(null)} />
+        <PolicyForm
+          existing={editing}
+          workspaceId={
+            isOperator ? null : (editing.workspace_id ?? writeWorkspaceId)
+          }
+          onClose={() => setEditing(null)}
+        />
       ) : null}
 
       {rows.length === 0 && !isListLoading && !isAdding ? (
-        isOperator ? (
+        canEdit ? (
           <EmptyState title="No routing policies yet">
             <ol className="flex list-decimal flex-col gap-1 pl-5 text-sm text-muted">
               <li>
@@ -1539,8 +1654,8 @@ export function RoutingPage() {
         ) : (
           <EmptyState title="No routing policies yet">
             <p className="text-sm text-muted">
-              Policies that apply in your workspaces will be listed here once a
-              deployment operator defines them.
+              Policies that apply in your workspaces will be listed here once
+              your organization's admins define them.
             </p>
           </EmptyState>
         )

--- a/web/src/features/tools/ToolsGuardrailsPage.test.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.test.tsx
@@ -82,6 +82,12 @@ const FIELDS: ToolSettingField[] = [
 
 const RESPONSE: ToolSettingsResponse = { fields: FIELDS }
 
+// What the server hands a non-operator: the same fields with the three
+// service endpoints withheld rather than masked (otari-ai#1969).
+const TENANT_RESPONSE: ToolSettingsResponse = {
+  fields: FIELDS.filter((field) => field.type !== "url"),
+}
+
 // GET /v1/tools drives the "how to call this" card. `accepted_types` is what the
 // deployment currently honors, so it is the interesting axis here.
 const TOOLS: ToolsResponse = {
@@ -131,6 +137,8 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 interface MockOpts {
+  /** The tool-settings body, for the tenant read that comes back without URLs. */
+  settings?: ToolSettingsResponse
   patchStatus?: number
   patchDetail?: string
   testBody?: { ok: boolean; reason: string }
@@ -143,7 +151,7 @@ interface MockOpts {
 }
 
 function mockApi(opts: MockOpts = {}) {
-  let current = RESPONSE
+  let current = opts.settings ?? RESPONSE
   return vi
     .spyOn(globalThis, "fetch")
     .mockImplementation(async (input, init) => {
@@ -580,8 +588,9 @@ describe("ToolsGuardrailsPage by caller role", () => {
     vi.restoreAllMocks()
   })
 
-  it("shows a non-operator the workspace cards and never fires the operator reads", async () => {
+  it("shows a non-operator the workspace cards and the still-operator-only reads are not fired", async () => {
     const fetchMock = mockApi({
+      settings: TENANT_RESPONSE,
       context: organizationContext({
         deployment_operator: false,
         role: "member",
@@ -598,14 +607,40 @@ describe("ToolsGuardrailsPage by caller role", () => {
       screen.getByText(/Per-workspace code execution is set on a workspace/),
     ).toBeInTheDocument()
 
-    // No operator form, no deployment search-tools card, and no error banner.
-    expect(screen.queryByLabelText("web_search_url")).not.toBeInTheDocument()
+    // No deployment search-tools card, whose read is still operator-only.
     expect(
       screen.queryByRole("heading", { name: "Search tools" }),
     ).not.toBeInTheDocument()
     const urls = fetchMock.mock.calls.map(([input]) => String(input))
-    expect(urls.some((url) => url.includes("/v1/tool-settings"))).toBe(false)
     expect(urls.some((url) => url.includes("/v1/search-tools"))).toBe(false)
+  })
+
+  it("renders a non-operator's tool settings as values rather than controls", async () => {
+    mockApi({
+      settings: TENANT_RESPONSE,
+      context: organizationContext({
+        deployment_operator: false,
+        role: "member",
+      }),
+    })
+    renderWithClient(<ToolsGuardrailsPage />)
+
+    // The field is shown, so a member is told what the tools do to their
+    // requests, and it is text: there is no control to press.
+    expect(
+      await screen.findByText("web_search_max_results"),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByLabelText("web_search_max_results"),
+    ).not.toBeInTheDocument()
+    // Deliberately not "no Save button on the page": the workspace cards below
+    // are a member's to edit and have their own.
+    expect(
+      screen.queryByLabelText("web_search_purpose_hint"),
+    ).not.toBeInTheDocument()
+    // The service endpoints never arrive, so nothing renders them either.
+    expect(screen.queryByText("web_search_url")).not.toBeInTheDocument()
+    expect(screen.queryByText("guardrails_url")).not.toBeInTheDocument()
   })
 
   it("keeps a narrowed service page working for a non-operator", async () => {

--- a/web/src/features/tools/ToolsGuardrailsPage.test.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.test.tsx
@@ -641,6 +641,9 @@ describe("ToolsGuardrailsPage by caller role", () => {
     // The service endpoints never arrive, so nothing renders them either.
     expect(screen.queryByText("web_search_url")).not.toBeInTheDocument()
     expect(screen.queryByText("guardrails_url")).not.toBeInTheDocument()
+    // Nor the per-call rate: `/v1/pricing` is still operator-only, so this row
+    // would show a member an editable "Not priced" field that only fails on save.
+    expect(screen.queryByText("Price per call")).not.toBeInTheDocument()
   })
 
   it("keeps a narrowed service page working for a non-operator", async () => {

--- a/web/src/features/tools/ToolsGuardrailsPage.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.tsx
@@ -582,9 +582,7 @@ function ReadOnlyRow({ field }: { field: ToolSettingField }) {
   return (
     <div className={ROW_CLASS}>
       <FieldLabel field={field} />
-      <span className="break-words text-sm text-foreground sm:col-start-2">
-        {shown}
-      </span>
+      <span className="break-words text-body sm:col-start-2">{shown}</span>
     </div>
   )
 }

--- a/web/src/features/tools/ToolsGuardrailsPage.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.tsx
@@ -565,17 +565,46 @@ function HowToCallCard({ tool }: { tool: ManagedTool }) {
   )
 }
 
+// What a member is shown: the same field, as a value rather than as a control.
+// A disabled input would be the cheaper change and the worse one, since it reads
+// as a form that is briefly unavailable rather than as something this caller
+// does not set. The service-endpoint fields never reach here at all: the server
+// withholds them from a non-operator (otari-ai#1969).
+function ReadOnlyRow({ field }: { field: ToolSettingField }) {
+  const shown =
+    field.value === null || field.value === ""
+      ? "Default"
+      : field.value === true
+        ? "On"
+        : field.value === false
+          ? "Off"
+          : String(field.value)
+  return (
+    <div className={ROW_CLASS}>
+      <FieldLabel field={field} />
+      <span className="break-words text-sm text-foreground sm:col-start-2">
+        {shown}
+      </span>
+    </div>
+  )
+}
+
 function ServiceRow({
   field,
   onSave,
   saveError,
   disabled,
+  readOnly,
 }: {
   field: ToolSettingField
   onSave: (value: boolean | number | string | null) => void
   saveError?: string
   disabled: boolean
+  readOnly: boolean
 }) {
+  if (readOnly) {
+    return <ReadOnlyRow field={field} />
+  }
   if (field.type === "url") {
     return (
       <UrlRow
@@ -626,13 +655,14 @@ function ServiceRow({
  */
 export function ToolsGuardrailsPage({ only }: { only?: ToolServiceName } = {}) {
   // The Tools group is member-visible for the workspace and organization cards
-  // below, but the service settings, the pricing row, and the /v1/search tools
-  // are deployment-wide, and their reads are operator-only on the server. Gate
-  // them on the same answer the sidebar uses, so a workspace admin gets their
-  // cards rather than a 403 banner over a page of forms they cannot use.
+  // below. Of the deployment-wide reads above them, only the tool settings now
+  // answer a tenant, without the service endpoints in them (otari-ai#1969), so
+  // that one is asked unconditionally and rendered read-only. The pricing row
+  // and the /v1/search tools stay operator-only on the server, so they are still
+  // gated on the same answer the sidebar uses rather than fired into a 403.
   const organization = useOrganizationContext()
   const isOperator = isDeploymentOperator(organization.data)
-  const query = useToolSettings(isOperator)
+  const query = useToolSettings()
   const tools = useTools(isOperator)
   const pricing = usePricing(isOperator)
   const setPricing = useSetPricing()
@@ -713,7 +743,7 @@ export function ToolsGuardrailsPage({ only }: { only?: ToolServiceName } = {}) {
         description={
           isOperator
             ? "Configure the built-in tool and guardrail service endpoints without a restart. Changes apply immediately and persist. URLs are validated for shape (http/https) and can be tested for reachability before saving; the network-safety gates for these services live on the Settings page."
-            : "What your workspace may use of this deployment's built-in tools, and what your organization mandates. The service backends themselves are configured by a deployment operator."
+            : "How this deployment's built-in tools behave on your requests, what your workspace may use of them, and what your organization mandates. The service backends themselves are a deployment operator's to configure."
         }
       />
 
@@ -788,6 +818,7 @@ export function ToolsGuardrailsPage({ only }: { only?: ToolServiceName } = {}) {
                           onSave={(value) => save(field, value)}
                           saveError={errors[field.key]}
                           disabled={disabled}
+                          readOnly={!isOperator}
                         />
                       ))}
                       {managed ? <HowToCallCard tool={managed} /> : null}

--- a/web/src/features/tools/ToolsGuardrailsPage.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.tsx
@@ -789,7 +789,11 @@ export function ToolsGuardrailsPage({ only }: { only?: ToolServiceName } = {}) {
                   <p className="text-sm text-muted">{service.blurb}</p>
                   <Card>
                     <Card.Content className="flex flex-col divide-y divide-border px-5 py-1">
-                      {service.pricingKey ? (
+                      {/* Operator-only inside a card a member now also sees:
+                          the rate comes from `/v1/pricing`, whose read is still
+                          operator-gated, so a member would get an editable "Not
+                          priced" row that can only fail on save. */}
+                      {isOperator && service.pricingKey ? (
                         <ToolPriceRow
                           pricingKey={service.pricingKey}
                           configured={

--- a/web/src/shared/api/hooks.ts
+++ b/web/src/shared/api/hooks.ts
@@ -160,6 +160,7 @@ const ROUTING_POLICIES = "routing-policies"
 // answer different endpoints for different callers, and an operator's policy
 // write invalidates the deployment-wide one it changed.
 const ORGANIZATION_ROUTING_POLICIES = "organization-routing-policies"
+const ORGANIZATION_ALIASES = "organization-aliases"
 const ROUTER_STATUS = "router-status"
 // Deliberately not nested under MODELS: pricing mutations invalidate that key,
 // and a price change cannot alter which models a provider serves. Sharing the
@@ -547,6 +548,20 @@ export function useOrganizationRoutingPolicies(enabled = true) {
   })
 }
 
+// The aliases in force where the caller may see, the policies list's sibling
+// over `model_aliases` and scoped the same way. This is the read a signed-in
+// member gets (otari-ai#1969); the deployment-wide `useAliases` above stays
+// operator-only, so the Routing page picks between the two off
+// `isDeploymentOperator`.
+export function useOrganizationAliases(enabled = true) {
+  return useQuery({
+    queryKey: [ORGANIZATION_ALIASES],
+    queryFn: () => apiFetch<AliasResponse[]>("/v1/organizations/me/aliases"),
+    staleTime: 60_000,
+    enabled,
+  })
+}
+
 export function useSetRoutingPolicy() {
   const queryClient = useQueryClient()
   return useMutation({
@@ -593,6 +608,91 @@ export function useDeleteRoutingPolicy() {
       })
       void queryClient.invalidateQueries({ queryKey: [MODELS] })
     },
+  })
+}
+
+/**
+ * The four tenant-scoped writers behind the Build pages' Edit for admins.
+ *
+ * Each is its operator sibling above with one difference the server insists on:
+ * the workspace is named rather than defaulted, because the deployment's default
+ * workspace is not the caller's organization's to write into (otari-ai#1969).
+ * `user_id` has no counterpart here at all: an organization's entries are
+ * workspace-wide.
+ *
+ * Both list keys are invalidated by each of them, because which of the two a
+ * page is reading is a function of the caller's role rather than of the write.
+ */
+function invalidateRoutingLists(
+  queryClient: ReturnType<typeof useQueryClient>,
+) {
+  void queryClient.invalidateQueries({ queryKey: [ROUTING_POLICIES] })
+  void queryClient.invalidateQueries({
+    queryKey: [ORGANIZATION_ROUTING_POLICIES],
+  })
+  void queryClient.invalidateQueries({ queryKey: [ALIASES] })
+  void queryClient.invalidateQueries({ queryKey: [ORGANIZATION_ALIASES] })
+  // A policy and an alias are both listed as models, so the catalog changes too.
+  void queryClient.invalidateQueries({ queryKey: [MODELS] })
+}
+
+export function useSetOrganizationRoutingPolicy() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (body: SetRoutingPolicyRequest & { workspace_id: string }) =>
+      apiFetch<RoutingPolicyResponse>("/v1/organizations/me/routing-policies", {
+        method: "POST",
+        body: JSON.stringify(body),
+      }),
+    onSuccess: () => invalidateRoutingLists(queryClient),
+  })
+}
+
+export function useDeleteOrganizationRoutingPolicy() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      name,
+      workspaceId,
+    }: {
+      name: string
+      workspaceId: string
+    }) =>
+      apiFetch<void>(
+        `/v1/organizations/me/routing-policies/${encodeURIComponent(name)}?workspace_id=${encodeURIComponent(workspaceId)}`,
+        { method: "DELETE" },
+      ),
+    onSuccess: () => invalidateRoutingLists(queryClient),
+  })
+}
+
+export function useCreateOrganizationAlias() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (body: CreateAliasRequest & { workspace_id: string }) =>
+      apiFetch<AliasResponse>("/v1/organizations/me/aliases", {
+        method: "POST",
+        body: JSON.stringify(body),
+      }),
+    onSuccess: () => invalidateRoutingLists(queryClient),
+  })
+}
+
+export function useDeleteOrganizationAlias() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({
+      name,
+      workspaceId,
+    }: {
+      name: string
+      workspaceId: string
+    }) =>
+      apiFetch<void>(
+        `/v1/organizations/me/aliases/${encodeURIComponent(name)}?workspace_id=${encodeURIComponent(workspaceId)}`,
+        { method: "DELETE" },
+      ),
+    onSuccess: () => invalidateRoutingLists(queryClient),
   })
 }
 
@@ -932,9 +1032,10 @@ export function useSendTestMail() {
   })
 }
 
-// GET /v1/tool-settings is deployment-operator-only, so the caller passes the
-// client half of that gate (`isDeploymentOperator`) as `enabled` rather than
-// firing a read whose only outcome for anyone else is a 403 banner.
+// Any signed-in caller may read this now (otari-ai#1969); a non-operator is
+// answered without the three service-endpoint fields rather than refused, so a
+// page renders whatever came back instead of gating the read. `enabled` stays
+// for the callers that have a reason not to ask at all.
 export function useToolSettings(enabled = true) {
   return useQuery({
     queryKey: [TOOL_SETTINGS],


### PR DESCRIPTION
## Description

The Edit half of the Build pages, plus the two member-View gaps mozilla-ai/otari#867 left. The issue asked for a scope decision first, taking #875 as the precedent to follow or reject.

**Rejected, because two of its premises are stale.** `routing_policies` and `model_aliases` already carry a non-nullable `workspace_id`, and a workspace belongs to exactly one organization, so those rows have a tenant and need no owner column or migration. Provider access already has a backend too (`org_provider_keys`, plus the workspace overrides and model restrictions). What was missing was the routers over them.

Three surfaces, and the last is what makes the first safe.

**Admin Edit.** `/v1/organizations/me/routing-policies` and `/v1/organizations/me/aliases` gain POST and DELETE beside the existing read, owner-or-admin. A write names its workspace, resolved inside the caller's own organization (a foreign id is 404, never 403), and takes no `user_id`: that is a deployment-wide identifier, so accepting one would make this a cross-tenant existence oracle. The deployment-wide routers keep their operator gate unchanged.

**A member's model list.** `GET /v1/models` answers a dashboard session from its membership rather than treating it as the master key. The answer is a `services/model_access` allow-list, so one matcher decides the catalog and the inference gate: every `config.providers` instance (deployment-wide, so every tenant reaches them) plus the organization's own BYO providers, narrowed by a workspace model restriction. A deployment whose providers all come from `config.yml` is unchanged.

**The escalation guard.** That same allow-list is what a tenant's policy or alias target is checked against. A name is the tenant's to choose and resolution follows the name, so without it an admin write would be a way to reach a provider the organization holds no key for. That check, not the operator gate, is why these verbs can open at all.

**Member tool settings.** `GET /v1/tool-settings` answers any signed-in identity, without `web_search_url`, `sandbox_url` and `guardrails_url` for a non-operator. Withheld rather than masked: masking hides a password and still publishes the host, which is what the Settings page's network-safety gates are set against. Every write verb stays operator-only.

**Dashboard.** Routing gives an admin the same table with its actions, writing through the tenant routers; an edit goes back to the row's own workspace rather than the selected one, since an admin's list spans the organization. Tools renders a non-operator's settings as values rather than as disabled controls. Models needs no change: the narrowing is the server's, and an admin's rate editing is the organization pricing overrides #1943 already opened.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#1969. Completes the Build rows of the roles matrix tracked in mozilla-ai/otari-ai#1942.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Three new integration suites (`test_organization_routing_write_scope.py`, `test_session_model_catalog_scope.py`, `test_tool_settings_tenant_read.py`), plus the dashboard tests. The full unit suite, the whole dashboard suite, `make lint`, mypy, the architecture check and the OSS-edition smoke are green locally. The local Docker daemon died partway through the integration run, so that suite is green for the files this touches and left to CI for the rest.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code (Claude Opus 5, 1M context)

**Any additional AI details you'd like to share:**

Implemented, tested and self-reviewed by the agent. The scope decision above was put to the maintainer before any code was written; the self-review caught the cross-workspace edit bug, which now has a test.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added organization-scoped editing for routing policies and model aliases.
- Limited model visibility to providers available to each organization and workspace.
- Allowed signed-in members to view tool settings without exposing service URLs or pricing controls.
- Updated Build routing and tools pages for organization admins and members.
- Added documentation and tests for tenant boundaries, model access, tool settings, and workspace edits.

## Technical notes

- Added shared model-access and workspace validation logic.
- Reused workspace operations for organization-scoped policy and alias changes.
- Batched provider lookups and capped tenant list results.
- Regenerated the OpenAPI schema and Postman collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->