### PR TITLE
fix(dashboard): clear the accessibility debt in the key reveal, confirms, type scale and touch targets

### DIFF
--- a/web/src/features/activity/ActivityPage.tsx
+++ b/web/src/features/activity/ActivityPage.tsx
@@ -857,13 +857,17 @@ function RoutingPlan({ entry }: { entry: UsageEntry }) {
                 <td className="px-3 py-2 tabular-nums">
                   {attempt.attempt_position ?? "?"}
                 </td>
-                <td className="px-3 py-2 break-all text-foreground">
-                  {pricingSelectorOf(attempt)}
-                  {attempt.id === entry.id ? (
-                    <span className="ml-2 rounded-full border border-border px-1.5 py-0.5 text-[10px] text-muted">
-                      this row
+                <td className="px-3 py-2 text-foreground">
+                  <span className="flex flex-wrap items-center gap-2">
+                    <span className="break-all">
+                      {pricingSelectorOf(attempt)}
                     </span>
-                  ) : null}
+                    {attempt.id === entry.id ? (
+                      <span className="rounded-full border border-border px-1.5 py-0.5 text-overline">
+                        this row
+                      </span>
+                    ) : null}
+                  </span>
                 </td>
                 <td className="px-3 py-2">
                   {selectionReasonLabel(attempt.selection_reason) ?? "—"}
@@ -1923,7 +1927,7 @@ export function ActivityPage() {
                   the count inside is a summary of it. */}
               <span
                 role="img"
-                className="inline-flex items-center rounded-full border border-border bg-primary-subtle px-1.5 py-0.5 text-[11px] font-medium text-primary-subtle-foreground"
+                className="inline-flex items-center rounded-full border border-border bg-primary-subtle px-1.5 py-0.5 text-xs font-medium text-primary-subtle-foreground"
                 title={detail}
                 aria-label={`Gateway tools: ${detail}`}
               >

--- a/web/src/features/activity/ActivityTimeline.test.tsx
+++ b/web/src/features/activity/ActivityTimeline.test.tsx
@@ -225,6 +225,20 @@ describe("ActivityTimeline", () => {
     expect(pan).toHaveAttribute("aria-valuenow", "1")
   })
 
+  it("gives the pan handle a 44px grab area, not the stripe's 10px", () => {
+    // The handle is what a finger has to land on, and the stripe it draws is a
+    // 10px child of it. jsdom does not lay out, so the assertion is on the
+    // classes that decide the box: a 44px row (`h-11`, the HIG floor) with the
+    // handle spanning it top to bottom.
+    renderTimeline({
+      windowStart: "2026-07-11T00:00:00.000Z",
+      windowEnd: "2026-07-12T00:00:00.000Z",
+    })
+    const pan = screen.getByRole("slider", { name: "Pan the selected window" })
+    expect(pan.className).toContain("inset-y-0")
+    expect(pan.parentElement?.className).toContain("h-11")
+  })
+
   it("renders no pan rail at the full extent (nothing to pan)", () => {
     renderTimeline()
     expect(

--- a/web/src/features/activity/ActivityTimeline.tsx
+++ b/web/src/features/activity/ActivityTimeline.tsx
@@ -358,10 +358,19 @@ export function ActivityTimeline({
                 rendered while zoomed (at the full extent there is nothing to
                 pan), so it never takes space or a tab stop otherwise. */}
             {zoomed || panSel ? (
+              // The row is 44px so the handle inside it is a real touch target;
+              // the track and the handle keep the 10px they read best at, drawn
+              // as children so the grab area is the whole height rather than
+              // the stripe. A thumb the size of the stripe is unpannable on a
+              // phone, which is the only place the zoom is hard to redo.
               <div
                 ref={railRef}
-                className="relative h-2.5 w-full rounded-full bg-surface-alt"
+                className="relative flex h-11 w-full items-center"
               >
+                <div
+                  aria-hidden="true"
+                  className="absolute inset-x-0 h-2.5 rounded-full bg-surface-alt"
+                />
                 <div
                   role="slider"
                   aria-label="Pan the selected window"
@@ -370,7 +379,7 @@ export function ActivityTimeline({
                   aria-valuenow={Math.min(sel.startIndex, panMax)}
                   aria-valuetext={`Window starting at ${formatTick(starts[sel.startIndex] ?? starts[0], bucket)}`}
                   tabIndex={0}
-                  className="absolute inset-y-0 cursor-grab touch-none rounded-full bg-accent/40 outline-none hover:bg-accent/60 focus-visible:ring-2 focus-visible:ring-accent active:cursor-grabbing"
+                  className="group absolute inset-y-0 flex cursor-grab touch-none items-center outline-none active:cursor-grabbing"
                   style={{
                     left: `${loPct}%`,
                     width: `${Math.max(2, hiPct - loPct)}%`,
@@ -388,7 +397,9 @@ export function ActivityTimeline({
                   onPointerMove={onPanMove}
                   onPointerUp={endPan}
                   onPointerCancel={endPan}
-                />
+                >
+                  <div className="h-2.5 w-full rounded-full bg-accent/40 group-hover:bg-accent/60 group-focus-visible:ring-2 group-focus-visible:ring-accent" />
+                </div>
               </div>
             ) : null}
           </div>

--- a/web/src/features/budgets/BudgetsPage.tsx
+++ b/web/src/features/budgets/BudgetsPage.tsx
@@ -261,7 +261,7 @@ function BudgetForm({
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-title">{title}</div>
+        <h2 className="text-title">{title}</h2>
         <ErrorBanner error={error} />
         <Field
           label="Name (optional)"
@@ -390,10 +390,18 @@ function ResetHistory({ budgetId }: { budgetId: string }) {
       <table className="w-full border-collapse text-xs">
         <thead className="text-left text-muted">
           <tr>
-            <th className="py-1.5 pr-4 font-medium">User</th>
-            <th className="py-1.5 pr-4 font-medium">Spend cleared</th>
-            <th className="py-1.5 pr-4 font-medium">Reset at</th>
-            <th className="py-1.5 font-medium">Next reset</th>
+            <th scope="col" className="py-1.5 pr-4 font-medium">
+              User
+            </th>
+            <th scope="col" className="py-1.5 pr-4 font-medium">
+              Spend cleared
+            </th>
+            <th scope="col" className="py-1.5 pr-4 font-medium">
+              Reset at
+            </th>
+            <th scope="col" className="py-1.5 font-medium">
+              Next reset
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -598,7 +606,7 @@ function DeploymentBudgetsPage() {
             {/* Only a prefix is rendered, so the id an API call needs is not on the
               page in full; the copy hands over the whole thing. */}
             <CopyableValue value={b.budget_id} label="budget id">
-              <code className="text-[11px] text-muted" title={b.budget_id}>
+              <code className="text-caption" title={b.budget_id}>
                 {shortId(b.budget_id)}
               </code>
             </CopyableValue>

--- a/web/src/features/keys/KeysPage.test.tsx
+++ b/web/src/features/keys/KeysPage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { screen, within } from "@testing-library/react"
+import { screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type { ReactElement } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
@@ -364,6 +364,87 @@ describe("KeysPage", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
   })
 
+  it("refuses a backdrop press and inerts the page behind the reveal", async () => {
+    mockApi({ keys: [] })
+    const user = userEvent.setup()
+    renderPage(<KeysPage />)
+
+    await screen.findByText("No API keys yet")
+    await user.click(
+      screen.getByRole("button", { name: "Create your first key" }),
+    )
+    await user.type(screen.getByPlaceholderText(/Pick a user/), "alice")
+    await user.keyboard("{Escape}")
+    await user.click(screen.getByRole("button", { name: "Create key" }))
+
+    const dialog = await screen.findByRole("dialog")
+    // The page behind is out of the accessibility tree, so the create action
+    // the reveal came from is not reachable while the secret is on screen.
+    expect(screen.queryByRole("button", { name: "Create key" })).toBeNull()
+
+    await user.click(
+      document.querySelector('[data-slot="modal-backdrop"]') as HTMLElement,
+    )
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+
+    await user.click(
+      within(dialog).getByRole("button", { name: /I.?ve saved this key/ }),
+    )
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("returns focus to the page's create action when the reveal closes", async () => {
+    mockApi({ keys: [] })
+    const user = userEvent.setup()
+    renderPage(<KeysPage />)
+
+    await screen.findByText("No API keys yet")
+    await user.click(
+      screen.getByRole("button", { name: "Create your first key" }),
+    )
+    await user.type(screen.getByPlaceholderText(/Pick a user/), "alice")
+    await user.keyboard("{Escape}")
+    await user.click(screen.getByRole("button", { name: "Create key" }))
+
+    const dialog = await screen.findByRole("dialog")
+    await user.click(
+      within(dialog).getByRole("button", { name: /I.?ve saved this key/ }),
+    )
+
+    // The form that opened the reveal is gone by now, so the dialog's own
+    // restore has nowhere to land and focus would otherwise be on <body>.
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        screen.getByRole("button", { name: "Create key" }),
+      ),
+    )
+  })
+
+  it("moves focus onto the confirm and back on cancel, so a regenerate never drops it", async () => {
+    mockApi({ keys: [apiKey()] })
+    const user = userEvent.setup()
+    renderPage(<KeysPage />)
+
+    const row = (await screen.findByText("ci-bot")).closest("tr")!
+    await user.click(within(row).getByRole("button", { name: "Regenerate" }))
+
+    // Arming unmounts the button that was pressed, so focus has to follow the
+    // swap rather than falling back to <body>.
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        within(row).getByRole("button", { name: "Regenerate" }),
+      ),
+    )
+    expect(document.activeElement).not.toBe(document.body)
+
+    await user.click(within(row).getByRole("button", { name: "Cancel" }))
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        within(row).getByRole("button", { name: "Regenerate" }),
+      ),
+    )
+  })
+
   it("confirms Copied when the clipboard API is available", async () => {
     mockApi({ keys: [] })
     const user = userEvent.setup()
@@ -514,7 +595,7 @@ describe("KeysPage", () => {
     await user.keyboard("{Escape}")
     // The exempt toggle lives under the Advanced disclosure.
     await user.click(screen.getByRole("button", { name: "Advanced" }))
-    await user.click(screen.getByLabelText("Exempt this key from budget"))
+    await user.click(screen.getByLabelText("Exempt from budget"))
     await user.click(screen.getByRole("button", { name: "Create key" }))
 
     const post = fetchMock.mock.calls.find(
@@ -740,9 +821,7 @@ describe("KeysPage", () => {
 
     const row = (await screen.findByText("ci-bot")).closest("tr")!
     await user.click(within(row).getByRole("button", { name: "Edit" }))
-    await user.click(
-      await screen.findByLabelText("Exempt this key from budget"),
-    )
+    await user.click(await screen.findByLabelText("Exempt from budget"))
     await user.click(screen.getByRole("button", { name: "Save changes" }))
 
     const patch = fetchMock.mock.calls.find(
@@ -978,7 +1057,7 @@ describe("KeysPage", () => {
 
       await usr.click(screen.getByRole("button", { name: "Advanced" }))
       expect(
-        screen.queryByLabelText("Exempt this key from budget"),
+        screen.queryByLabelText("Exempt from budget"),
       ).not.toBeInTheDocument()
 
       await usr.type(screen.getByPlaceholderText("ci-bot"), "my-key")
@@ -1010,7 +1089,7 @@ describe("KeysPage", () => {
       const row = (await screen.findByText("mine")).closest("tr")!
       await usr.click(within(row).getByRole("button", { name: "Edit" }))
       expect(
-        screen.queryByLabelText("Exempt this key from budget"),
+        screen.queryByLabelText("Exempt from budget"),
       ).not.toBeInTheDocument()
 
       await usr.click(screen.getByRole("button", { name: "Save changes" }))

--- a/web/src/features/keys/KeysPage.test.tsx
+++ b/web/src/features/keys/KeysPage.test.tsx
@@ -267,7 +267,10 @@ describe("KeysPage", () => {
     await user.click(screen.getByRole("button", { name: "Create key" }))
 
     // The reveal shows the secret and a runnable curl snippet with the key injected.
-    const dialog = await screen.findByRole("dialog")
+    // Named by its own heading, which is what the parity spec locates it by.
+    const dialog = await screen.findByRole("dialog", {
+      name: "API key created",
+    })
     expect(within(dialog).getByDisplayValue(NEW_SECRET)).toBeInTheDocument()
     const curl = within(dialog).getByDisplayValue(
       new RegExp(`Otari-Key: ${NEW_SECRET}`),

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -1,8 +1,8 @@
-import { Button, Card, Chip } from "@heroui/react"
+import { Button, Card, Chip, Modal } from "@heroui/react"
 import { Link } from "@tanstack/react-router"
 import {
-  type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
+  type RefObject,
   useCallback,
   useEffect,
   useMemo,
@@ -39,6 +39,7 @@ import { DataTable, type DataTableColumn } from "@/shared/components/DataTable"
 import { Field } from "@/shared/components/Field"
 import { MissingGatewayAddressNotice } from "@/shared/components/MissingGatewayAddressNotice"
 import {
+  Checkbox,
   CopyField,
   EmptyState,
   ErrorBanner,
@@ -58,6 +59,7 @@ import {
   useTableSelection,
 } from "@/shared/helpers/tableSelection"
 import { useSelectedWorkspace } from "@/shared/hooks/SelectedWorkspace"
+import { useConfirmationFocus } from "@/shared/hooks/useConfirmationFocus"
 import { useDeployment } from "@/shared/hooks/useDeployment"
 
 // ---------- helpers ----------
@@ -105,19 +107,22 @@ const getKeyRowKey = (k: ApiKey): string => k.id
 
 // ---------- one-time reveal ----------
 
-// The highest-stakes moment: the plaintext key is shown once. A focus-trapped
-// dialog that cannot be dismissed by backdrop or Esc, only by an explicit "I've
-// saved this key". Doubles as an activation moment: a copy-paste first call.
+// The highest-stakes moment: the plaintext key is shown once, so the dialog
+// refuses a backdrop press and Esc and closes only on an explicit "I've saved
+// this key". `ConfirmDialog` passes the same two props the other way round,
+// because dismissing a confirm costs nothing and dismissing this loses the key.
+// Doubles as an activation moment: a copy-paste first call.
 function RevealSecretModal({
   title,
   result,
+  returnFocusRef,
   onClose,
 }: {
   title: string
   result: CreateKeyResponse
+  returnFocusRef: RefObject<HTMLButtonElement | null>
   onClose: () => void
 }) {
-  const dialogRef = useRef<HTMLDivElement>(null)
   const secretRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null)
   // Where a request from this deployment belongs, which is not always the address
   // that served this page: a hosted control plane serves the dashboard and not
@@ -132,23 +137,20 @@ function RevealSecretModal({
     secretRef.current?.select()
   }, [])
 
-  const onKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-    // Esc is intentionally ignored; closing is an explicit acknowledgement.
-    if (event.key !== "Tab") return
-    const focusables = dialogRef.current?.querySelectorAll<HTMLElement>(
-      'button, input, textarea, a[href], [tabindex]:not([tabindex="-1"])',
-    )
-    if (!focusables || focusables.length === 0) return
-    const first = focusables[0]
-    const last = focusables[focusables.length - 1]
-    if (event.shiftKey && document.activeElement === first) {
-      event.preventDefault()
-      last.focus()
-    } else if (!event.shiftKey && document.activeElement === last) {
-      event.preventDefault()
-      first.focus()
-    }
-  }
+  useEffect(
+    () => () => {
+      // The dialog restores focus to its own trigger, which is hidden here
+      // because the reveal opens from a mutation result, so the restore has
+      // nowhere to land. A frame later it has had its turn: an empty
+      // document.body then means nothing caught the focus.
+      requestAnimationFrame(() => {
+        if (document.activeElement === document.body) {
+          returnFocusRef.current?.focus()
+        }
+      })
+    },
+    [returnFocusRef],
+  )
 
   // The same two calls the setup guide hands out with its own key; the builders
   // are shared so an operator cannot be shown two dialects of one request.
@@ -162,61 +164,67 @@ function RevealSecretModal({
     : undefined
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-backdrop/40 p-4"
-      role="presentation"
-    >
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="reveal-title"
-        onKeyDown={onKeyDown}
-        className="flex max-h-[90vh] w-full max-w-2xl flex-col gap-4 overflow-y-auto rounded-xl bg-surface p-6 shadow-xl"
-      >
-        <h2 id="reveal-title" className="text-title">
-          {title}
-        </h2>
-        <InfoBanner tone="warning">
-          Copy this key now. For security it is shown only once and cannot be
-          retrieved later. If you lose it, use Regenerate to issue a new secret.
-        </InfoBanner>
-        <p className="text-xs text-muted">
-          Model access: {accessLabel(result.allowed_models).text}.
-        </p>
-        <CopyField label="Secret key" value={secret} fieldRef={secretRef} />
-        <div className="flex flex-col gap-2">
-          <div>
-            <div className="text-sm font-medium text-foreground">
-              Make your first call
-            </div>
-            {snippets === undefined ? (
-              <MissingGatewayAddressNotice />
-            ) : (
+    <Modal isOpen>
+      {/* The reveal opens from a mutation result rather than a press, and HeroUI
+          warns when the trigger slot is empty; `WorkspaceSwitcher` fills it the
+          same way. */}
+      <Modal.Trigger className="hidden">Show the new key</Modal.Trigger>
+      <Modal.Backdrop isDismissable={false} isKeyboardDismissDisabled>
+        {/* `scroll="outside"` because globals.css pins `.modal__body` to
+            `overflow: visible`: with the default the two snippets past the fold
+            would be clipped by the dialog with nothing able to scroll them. */}
+        <Modal.Container placement="center" scroll="outside">
+          <Modal.Dialog>
+            <Modal.Header>
+              <Modal.Heading className="text-title">{title}</Modal.Heading>
+            </Modal.Header>
+            <Modal.Body className="flex flex-col gap-4">
+              <InfoBanner tone="warning">
+                Copy this key now. For security it is shown only once and cannot
+                be retrieved later. If you lose it, use Regenerate to issue a
+                new secret.
+              </InfoBanner>
               <p className="text-xs text-muted">
-                Replace <code>{SNIPPET_MODEL_PLACEHOLDER}</code> with a model
-                from the Models page.
+                Model access: {accessLabel(result.allowed_models).text}.
               </p>
-            )}
-          </div>
-          {snippets !== undefined ? (
-            <>
-              <CopyField label="curl" value={snippets.curl} multiline />
               <CopyField
-                label="Python (OpenAI SDK)"
-                value={snippets.python}
-                multiline
+                label="Secret key"
+                value={secret}
+                fieldRef={secretRef}
               />
-            </>
-          ) : null}
-        </div>
-        <div className="flex justify-end">
-          <Button variant="primary" onPress={onClose}>
-            I&rsquo;ve saved this key
-          </Button>
-        </div>
-      </div>
-    </div>
+              <div className="flex flex-col gap-2">
+                <div>
+                  <h3 className="text-title">Make your first call</h3>
+                  {snippets === undefined ? (
+                    <MissingGatewayAddressNotice />
+                  ) : (
+                    <p className="text-xs text-muted">
+                      Replace <code>{SNIPPET_MODEL_PLACEHOLDER}</code> with a
+                      model from the Models page.
+                    </p>
+                  )}
+                </div>
+                {snippets !== undefined ? (
+                  <>
+                    <CopyField label="curl" value={snippets.curl} multiline />
+                    <CopyField
+                      label="Python (OpenAI SDK)"
+                      value={snippets.python}
+                      multiline
+                    />
+                  </>
+                ) : null}
+              </div>
+            </Modal.Body>
+            <Modal.Footer>
+              <Button variant="primary" onPress={onClose}>
+                I&rsquo;ve saved this key
+              </Button>
+            </Modal.Footer>
+          </Modal.Dialog>
+        </Modal.Container>
+      </Modal.Backdrop>
+    </Modal>
   )
 }
 
@@ -236,10 +244,16 @@ function InlineConfirm({
   onConfirm: () => void
 }) {
   const [armed, setArmed] = useState(false)
+  const { triggerRef, confirmRef } = useConfirmationFocus(armed)
 
   if (!armed) {
     return (
-      <Button size="sm" variant="danger-soft" onPress={() => setArmed(true)}>
+      <Button
+        ref={triggerRef}
+        size="sm"
+        variant="danger-soft"
+        onPress={() => setArmed(true)}
+      >
         {trigger}
       </Button>
     )
@@ -250,6 +264,7 @@ function InlineConfirm({
       <span className="max-w-xs text-xs text-warning">{message}</span>
       <span className="inline-flex gap-1">
         <Button
+          ref={confirmRef}
           size="sm"
           variant="danger"
           isDisabled={isPending}
@@ -323,22 +338,18 @@ function BudgetExemptToggle({
   onChange: (value: boolean) => void
 }) {
   return (
-    <label className="flex items-start gap-2 rounded-lg border border-border p-3 text-sm">
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
-        className="mt-0.5 h-4 w-4 accent-accent"
-        aria-label="Exempt this key from budget"
-      />
-      <span className="flex flex-col gap-0.5">
+    <div className="flex flex-col gap-0.5 rounded-lg border border-border p-3">
+      {/* The consequence sits beside the control rather than inside its label:
+          a checkbox whose accessible name is a whole paragraph is read out in
+          full on every focus. */}
+      <Checkbox isSelected={checked} onChange={onChange}>
         <span className="font-medium text-foreground">Exempt from budget</span>
-        <span className="text-xs text-muted">
-          Requests on this key are logged with their cost but never counted
-          toward the owner&apos;s budget or spend, and never blocked by it.
-        </span>
-      </span>
-    </label>
+      </Checkbox>
+      <p className="text-xs text-muted">
+        Requests on this key are logged with their cost but never counted toward
+        the owner&apos;s budget or spend, and never blocked by it.
+      </p>
+    </div>
   )
 }
 
@@ -467,7 +478,7 @@ function CreateKeyForm({
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-title">Create API key</div>
+        <h2 className="text-title">Create API key</h2>
         <ErrorBanner error={create.error} />
         <div className="grid gap-4 sm:grid-cols-2">
           <Field
@@ -616,9 +627,9 @@ function EditKeyForm({
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-title">
+        <h2 className="text-title">
           Edit <code>{apiKey.key_name ?? apiKey.id}</code>
-        </div>
+        </h2>
         <ErrorBanner error={update.error} />
         <div className="grid gap-4 sm:grid-cols-2">
           <Field
@@ -743,6 +754,11 @@ export function KeysPage() {
     title: string
     result: CreateKeyResponse
   } | null>(null)
+  // Where focus lands when the reveal closes. The control that opened it is
+  // either gone (the create form) or behind a confirm that has been consumed
+  // (a regenerate), so the page's own primary action is the stable landing
+  // spot nearest to where the operator was.
+  const createButtonRef = useRef<HTMLButtonElement>(null)
 
   const rows = keys.data ?? []
   // An unresolved scope is a loading state: which surface the page reads, and
@@ -1005,6 +1021,7 @@ export function KeysPage() {
         action={
           addOpen ? null : (
             <Button
+              ref={createButtonRef}
               variant="primary"
               onPress={() => {
                 setEditing(null)
@@ -1178,6 +1195,7 @@ export function KeysPage() {
         <RevealSecretModal
           title={revealed.title}
           result={revealed.result}
+          returnFocusRef={createButtonRef}
           onClose={() => {
             setRevealed(null)
             // Drop the one-time secret from mutation state so reopening Create/Regenerate

--- a/web/src/features/models/ModelsPage.tsx
+++ b/web/src/features/models/ModelsPage.tsx
@@ -529,7 +529,7 @@ function InfoTooltip({
         type="button"
         aria-label={label}
         aria-describedby={tipId}
-        className={`inline-flex h-4 w-4 items-center justify-center rounded-full border text-[10px] leading-none ${
+        className={`inline-flex h-4 w-4 items-center justify-center rounded-full border text-xs leading-none ${
           tone === "warning"
             ? "border-warning text-warning"
             : "border-border text-muted hover:border-accent hover:text-accent"

--- a/web/src/features/organization/CreateOrganizationForm.tsx
+++ b/web/src/features/organization/CreateOrganizationForm.tsx
@@ -22,7 +22,7 @@ export function CreateOrganizationForm({ onClose }: { onClose: () => void }) {
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-title">Create organization</div>
+        <h2 className="text-title">Create organization</h2>
         <ErrorBanner error={create.error ?? switchTo.error} />
         <Field
           label="Name"

--- a/web/src/features/organization/OrganizationGeneralPage.tsx
+++ b/web/src/features/organization/OrganizationGeneralPage.tsx
@@ -42,7 +42,7 @@ function OrganizationDetails({
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-title">Details</div>
+        <h2 className="text-title">Details</h2>
         <ErrorBanner error={update.error} />
         <Field
           label="Organization name"

--- a/web/src/features/organization/OrganizationMembersPage.tsx
+++ b/web/src/features/organization/OrganizationMembersPage.tsx
@@ -210,7 +210,7 @@ function AddMemberForm({ onClose }: { onClose: () => void }) {
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-title">Add member</div>
+        <h2 className="text-title">Add member</h2>
         <ErrorBanner error={add.error} />
         <div className="grid gap-4 sm:grid-cols-2">
           <Field
@@ -332,7 +332,7 @@ function InviteMemberForm({ onClose }: { onClose: () => void }) {
     return (
       <Card>
         <Card.Content className="flex flex-col gap-4 p-5">
-          <div className="text-title">Invitation sent</div>
+          <h2 className="text-title">Invitation sent</h2>
           {result.mail_sent ? (
             <InfoBanner>
               An email with an accept link was sent to{" "}
@@ -368,7 +368,7 @@ function InviteMemberForm({ onClose }: { onClose: () => void }) {
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-title">Invite member</div>
+        <h2 className="text-title">Invite member</h2>
         <ErrorBanner error={invite.error} />
         <div className="grid gap-4 sm:grid-cols-2">
           <Field
@@ -637,7 +637,7 @@ function MemberEditor({
   return (
     <Card>
       <Card.Content className="flex flex-col gap-5 p-5">
-        <div className="text-title">Edit {memberLabel(member)}</div>
+        <h2 className="text-title">Edit {memberLabel(member)}</h2>
         <ErrorBanner error={error} />
 
         {!operates ? null : spendRow ? (
@@ -665,10 +665,16 @@ function MemberEditor({
             <table className="w-full min-w-lg text-sm">
               <thead>
                 <tr className="text-left text-xs text-muted">
-                  <th className="py-1 font-medium">Workspace</th>
-                  <th className="py-1 font-medium">Role</th>
+                  <th scope="col" className="py-1 font-medium">
+                    Workspace
+                  </th>
+                  <th scope="col" className="py-1 font-medium">
+                    Role
+                  </th>
                   {operates ? (
-                    <th className="py-1 font-medium">Budget</th>
+                    <th scope="col" className="py-1 font-medium">
+                      Budget
+                    </th>
                   ) : null}
                 </tr>
               </thead>
@@ -679,18 +685,14 @@ function MemberEditor({
                   return (
                     <tr key={workspace.id} className="border-t border-border">
                       <td className="py-1.5">
-                        <label className="flex items-center gap-2 text-foreground">
-                          <input
-                            type="checkbox"
-                            checked={row.member}
-                            onChange={(event) =>
-                              setRow(workspace.id, {
-                                member: event.target.checked,
-                              })
-                            }
-                          />
+                        <Checkbox
+                          isSelected={row.member}
+                          onChange={(isSelected) =>
+                            setRow(workspace.id, { member: isSelected })
+                          }
+                        >
                           {workspace.name}
-                        </label>
+                        </Checkbox>
                       </td>
                       <td className="py-1.5">
                         <FilterSelect

--- a/web/src/features/organization/OrganizationProviderKeysPage.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.tsx
@@ -134,9 +134,9 @@ function KeyForm({
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-title">
+        <h2 className="text-title">
           {editing ? `Edit ${editing.name}` : "Add provider key"}
-        </div>
+        </h2>
         <ErrorBanner error={create.error ?? update.error} />
 
         {editing ? (

--- a/web/src/features/providers/ProvidersPage.tsx
+++ b/web/src/features/providers/ProvidersPage.tsx
@@ -462,9 +462,9 @@ function EditProviderForm({
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-title">
+        <h2 className="text-title">
           Edit <code>{provider.instance}</code>
-        </div>
+        </h2>
         <ErrorBanner error={update.error} />
         <div className="grid gap-4 sm:grid-cols-2">
           <Field

--- a/web/src/features/routing/RoutingPage.tsx
+++ b/web/src/features/routing/RoutingPage.tsx
@@ -623,7 +623,7 @@ function PolicyForm({
     <div className="flex flex-col gap-4">
       <Card>
         <Card.Content className="flex flex-col gap-5 p-5">
-          <div className="text-title">
+          <h2 className="text-title">
             {editing ? (
               <>
                 Edit {existing.kind === "alias" ? "alias" : "policy"}{" "}
@@ -638,7 +638,7 @@ function PolicyForm({
             ) : (
               "New routing policy"
             )}
-          </div>
+          </h2>
           <ErrorBanner error={save.error ?? saveAlias.error} />
 
           <div className="grid gap-4 sm:grid-cols-2">

--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -12,6 +12,7 @@ import {
   useUpdateSettings,
 } from "@/shared/api/hooks"
 import {
+  Checkbox,
   ErrorBanner,
   FilterSelect,
   InfoBanner,
@@ -658,15 +659,9 @@ export function SettingsPage() {
           }}
           className="min-w-0 flex-1 rounded-lg border border-border bg-surface-alt px-3 py-2 text-sm text-foreground focus:border-accent focus:outline-none"
         />
-        <label className="flex items-center gap-2 text-sm text-muted">
-          <input
-            type="checkbox"
-            checked={settableOnly}
-            onChange={(event) => setSettableOnly(event.target.checked)}
-            className="h-4 w-4 accent-accent"
-          />
+        <Checkbox isSelected={settableOnly} onChange={setSettableOnly}>
           Settable only
-        </label>
+        </Checkbox>
       </div>
 
       {data ? (

--- a/web/src/features/tools/OrganizationGuardrailsCard.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/shared/api/hooks"
 import {
   Badge,
+  Checkbox,
   ConfirmButton,
   ErrorBanner,
   errorMessage,
@@ -96,19 +97,15 @@ function WorkspaceScope({
       {everywhere ? null : (
         <div className="flex flex-wrap gap-3">
           {workspaces.map((workspace) => (
-            <label
+            <Checkbox
               key={workspace.id}
-              className="flex items-center gap-1 text-sm text-muted"
+              ariaLabel={`${scopeName}: ${workspace.name}`}
+              isSelected={selected.includes(workspace.id)}
+              isDisabled={disabled}
+              onChange={() => onToggle(workspace.id)}
             >
-              <input
-                type="checkbox"
-                aria-label={`${scopeName}: ${workspace.name}`}
-                checked={selected.includes(workspace.id)}
-                disabled={disabled}
-                onChange={() => onToggle(workspace.id)}
-              />
               {workspace.name}
-            </label>
+            </Checkbox>
           ))}
           {workspaces.length === 0 ? (
             <span className="text-xs text-muted">

--- a/web/src/features/workspaces/WorkspaceMembersPanel.tsx
+++ b/web/src/features/workspaces/WorkspaceMembersPanel.tsx
@@ -146,7 +146,7 @@ export function WorkspaceMembersPanel({
 
   return (
     <div className="flex flex-col gap-4 p-4">
-      <div className="text-title">Members of {workspaceName}</div>
+      <h2 className="text-title">Members of {workspaceName}</h2>
       <ErrorBanner
         error={members.error ?? updateRole.error ?? removeMember.error}
       />

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -325,7 +325,7 @@ export function CreateWorkspaceForm({
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-title">Create workspace</div>
+        <h2 className="text-title">Create workspace</h2>
         {/* A refusal about the name is carried by the name, not by a block above
             the form that resizes whatever frames it. What is left here is what
             no field state can honestly say: a failure the operator cannot
@@ -545,9 +545,9 @@ function EditWorkspaceForm({
   return (
     <Card>
       <Card.Content className="flex flex-col gap-4 p-5">
-        <div className="text-title">
+        <h2 className="text-title">
           Edit <code>{workspace.name}</code>
-        </div>
+        </h2>
         <ErrorBanner
           error={
             update.error ??

--- a/web/src/shared/components/BulkActionBar.test.tsx
+++ b/web/src/shared/components/BulkActionBar.test.tsx
@@ -44,6 +44,22 @@ describe("BulkActionBar", () => {
     expect(onSelectAllMatching).toHaveBeenCalled()
   })
 
+  it("announces the count, which changes as rows are ticked", () => {
+    render(
+      <BulkActionBar
+        selectedCount={3}
+        allMatching={false}
+        matchingTotal={4231}
+        canSelectAllMatching={false}
+        onSelectAllMatching={vi.fn()}
+        onClear={vi.fn()}
+      >
+        <Button size="sm">Delete</Button>
+      </BulkActionBar>,
+    )
+    expect(screen.getByRole("status")).toHaveTextContent("3 selected")
+  })
+
   it("reads the whole-filter selection when all matching", () => {
     render(
       <BulkActionBar

--- a/web/src/shared/components/BulkActionBar.tsx
+++ b/web/src/shared/components/BulkActionBar.tsx
@@ -46,7 +46,14 @@ export function BulkActionBar({
       aria-label="Bulk actions"
       className="otari-bulk-bar fixed bottom-4 left-1/2 z-40 flex w-[calc(100%-2rem)] max-w-3xl -translate-x-1/2 flex-wrap items-center gap-3 rounded-xl border border-accent bg-surface px-4 py-2.5 shadow-lg"
     >
-      <span className="text-sm font-medium text-accent">{label}</span>
+      {/* The count changes as rows are ticked, with no focus move to carry it. */}
+      <span
+        role="status"
+        aria-live="polite"
+        className="text-sm font-medium text-accent"
+      >
+        {label}
+      </span>
       {!allMatching && canSelectAllMatching && matchingTotal != null ? (
         <Button size="sm" variant="ghost" onPress={onSelectAllMatching}>
           Select all {matchingTotal.toLocaleString()} matching this filter

--- a/web/src/shared/components/TablePagination.test.tsx
+++ b/web/src/shared/components/TablePagination.test.tsx
@@ -72,6 +72,13 @@ describe("TablePagination", () => {
     expect(screen.getByRole("button", { name: "Next page" })).toBeEnabled()
   })
 
+  it("announces the range, which changes with no focus move to carry it", () => {
+    setup()
+    // `role="status"` rather than a plain span: paging, resizing and filtering
+    // all rewrite this text in place, and the controls that did it keep focus.
+    expect(screen.getByRole("status")).toHaveTextContent("1–100 of 4,231")
+  })
+
   it("with an unknown total and a short page, disables next", () => {
     setup({ total: null, hasNextFallback: false, rowsOnPage: 40, page: 2 })
     expect(screen.getByRole("button", { name: "Next page" })).toBeDisabled()

--- a/web/src/shared/components/TablePagination.tsx
+++ b/web/src/shared/components/TablePagination.tsx
@@ -108,7 +108,16 @@ export function TablePagination({
       </div>
 
       <div className="flex items-center gap-3">
-        <span className="text-sm text-muted tabular-nums">{summary}</span>
+        {/* The live text the spinner above defers to: the range changes in
+            place on every page, page-size and filter change, and a screen
+            reader has nothing else to learn the new one from. */}
+        <span
+          role="status"
+          aria-live="polite"
+          className="text-sm text-muted tabular-nums"
+        >
+          {summary}
+        </span>
         <div className="flex items-center gap-1">
           <Button
             size="sm"

--- a/web/src/shared/components/charts.test.tsx
+++ b/web/src/shared/components/charts.test.tsx
@@ -18,6 +18,32 @@ const STACK_SERIES: SeriesDef[] = [
 ]
 
 describe("TrendChart", () => {
+  it("sets axis ticks from the type scale rather than a raw px size", () => {
+    const { container } = render(
+      <TrendChart
+        data={[
+          { x: "2025-07-19T00:00:00Z", cost: 400 },
+          { x: "2025-07-20T00:00:00Z", cost: 840.5 },
+        ]}
+        series={COST_SERIES}
+        formatValue={(v: number) => `$${v}`}
+        ariaLabel="cost per day"
+        showYAxis
+      />,
+    )
+
+    const ticks = container.querySelectorAll(
+      "text.recharts-cartesian-axis-tick-value",
+    )
+    expect(ticks.length).toBeGreaterThan(0)
+    for (const tick of ticks) {
+      // `text-xs` is the scale's 12px floor; a `font-size` attribute here is
+      // the raw value the class replaced.
+      expect(tick.classList.contains("text-xs")).toBe(true)
+      expect(tick.getAttribute("font-size")).toBeNull()
+    }
+  })
+
   it("renders a single-series recharts bar chart with one bar per point", () => {
     const { container } = render(
       <TrendChart

--- a/web/src/shared/components/charts.tsx
+++ b/web/src/shared/components/charts.tsx
@@ -20,6 +20,15 @@ import {
 
 const BRAND = "var(--color-primary)"
 
+// Axis ticks are SVG `<text>`, so their size comes from a class rather than a
+// `fontSize` number: `text-xs` is the type scale's 12px floor and nothing below
+// it is legible. The fill stays a prop, which recharts writes as a presentation
+// attribute.
+const AXIS_TICK = {
+  className: "text-xs",
+  fill: "var(--color-text-muted)",
+} as const
+
 // One series of a (possibly stacked) trend chart. `color` is a CSS color,
 // normally one of the fixed `--color-chart-cat-*` slots or a step of
 // `--color-chart-ramp-*` (both validated per theme in globals.css), or a
@@ -275,7 +284,7 @@ export function TrendChart({
             interval="preserveStartEnd"
             minTickGap={40}
             tickFormatter={formatXTick}
-            tick={{ fontSize: 10, fill: "var(--color-text-muted)" }}
+            tick={AXIS_TICK}
           />
           {showYAxis ? (
             <YAxis
@@ -283,7 +292,7 @@ export function TrendChart({
               tickLine={false}
               axisLine={false}
               tickFormatter={(value: number) => formatValue(value)}
-              tick={{ fontSize: 10, fill: "var(--color-text-muted)" }}
+              tick={AXIS_TICK}
             />
           ) : null}
           <Tooltip

--- a/web/src/shared/components/ui.test.tsx
+++ b/web/src/shared/components/ui.test.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
+  ConfirmButton,
   CopyableValue,
   CopyButton,
   EmptyState,
@@ -139,13 +140,54 @@ describe("CopyButton", () => {
     const { container } = render(
       <CopyButton value="openai:gpt-4o" label="model id" />,
     )
-    expect(container.textContent).toBe("")
+    // `sr-only` is clipped and taken out of flow, so the announcement below is
+    // not part of what the cell lays out; everything else here would be.
+    const laidOut = () => {
+      const clone = container.cloneNode(true) as HTMLElement
+      for (const node of clone.querySelectorAll(".sr-only")) node.remove()
+      return clone.textContent
+    }
+    expect(laidOut()).toBe("")
 
     await user.click(screen.getByRole("button", { name: "Copy model id" }))
     await screen.findByText("Copied!")
 
     // The confirmation is an overlay, not a sibling of the id it copied.
-    expect(container.textContent).toBe("")
+    expect(laidOut()).toBe("")
+  })
+
+  it("announces the outcome, which a press-opened tooltip does not", async () => {
+    const user = userEvent.setup()
+    const { container } = render(
+      <CopyButton value="openai:gpt-4o" label="model id" />,
+    )
+    const live = container.querySelector("[aria-live]") as HTMLElement
+    expect(live.textContent).toBe("")
+
+    await user.click(screen.getByRole("button", { name: "Copy model id" }))
+
+    await waitFor(() =>
+      expect(live.textContent).toBe("Copied model id to clipboard."),
+    )
+  })
+
+  it("announces a blocked copy rather than staying silent", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockRejectedValue(
+      new Error("not a secure context"),
+    )
+    const { container } = render(
+      <CopyButton value="openai:gpt-4o" label="model id" />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "Copy model id" }))
+
+    const live = container.querySelector("[aria-live]") as HTMLElement
+    await waitFor(() =>
+      expect(live.textContent).toBe(
+        "Could not copy model id. Select the value and press Ctrl/Cmd-C.",
+      ),
+    )
   })
 
   it("clears the confirmation on its own", async () => {
@@ -416,5 +458,66 @@ describe("FilterMultiComboBox", () => {
     expect(remaining).toHaveAttribute("aria-disabled", "true")
     await user.click(remaining)
     expect(onChange).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("ConfirmButton", () => {
+  it("hands focus to the confirm and back on cancel", async () => {
+    const user = userEvent.setup()
+    render(
+      <ConfirmButton confirmLabel="Delete permanently" onConfirm={() => {}}>
+        Delete
+      </ConfirmButton>,
+    )
+
+    const trigger = screen.getByRole("button", { name: "Delete" })
+    await user.click(trigger)
+
+    // Arming unmounts the trigger, which drops focus to <body> unless the pair
+    // that replaces it takes it: this is the delete button of a table row.
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        screen.getByRole("button", { name: "Delete permanently" }),
+      ),
+    )
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        screen.getByRole("button", { name: "Delete" }),
+      ),
+    )
+  })
+
+  it("leaves focus alone until it is armed", () => {
+    render(
+      <>
+        <button type="button">elsewhere</button>
+        <ConfirmButton confirmLabel="Delete permanently" onConfirm={() => {}}>
+          Delete
+        </ConfirmButton>
+      </>,
+    )
+    const elsewhere = screen.getByRole("button", { name: "elsewhere" })
+    elsewhere.focus()
+
+    // Mounting a row of these must not pull focus out of whatever the operator
+    // was doing.
+    expect(document.activeElement).toBe(elsewhere)
+  })
+
+  it("confirms through the second press", async () => {
+    const onConfirm = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <ConfirmButton confirmLabel="Delete permanently" onConfirm={onConfirm}>
+        Delete
+      </ConfirmButton>,
+    )
+
+    await user.click(screen.getByRole("button", { name: "Delete" }))
+    expect(onConfirm).not.toHaveBeenCalled()
+    await user.click(screen.getByRole("button", { name: "Delete permanently" }))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
   })
 })

--- a/web/src/shared/components/ui.tsx
+++ b/web/src/shared/components/ui.tsx
@@ -20,6 +20,7 @@ import { Checkbox as AriaCheckbox } from "react-aria-components"
 import { ApiError } from "@/shared/api/client"
 import { copyToClipboard } from "@/shared/helpers/clipboard"
 import { formatRelative } from "@/shared/helpers/format"
+import { useConfirmationFocus } from "@/shared/hooks/useConfirmationFocus"
 
 // The box visual, split out so it can hold optimistic state: react-aria only
 // reports the new `isSelected` after the whole collection re-renders (O(rows)
@@ -102,15 +103,23 @@ export function Checkbox({
   isSelected,
   onChange,
   isDisabled = false,
+  ariaLabel,
   children,
 }: {
   isSelected: boolean
   onChange: (isSelected: boolean) => void
   isDisabled?: boolean
+  /**
+   * An accessible name that says more than the visible label does, for a group
+   * whose labels repeat across the page (one workspace list per guardrail, say).
+   * Keep the visible text inside it, so speech input still reaches the control.
+   */
+  ariaLabel?: string
   children: ReactNode
 }) {
   return (
     <AriaCheckbox
+      aria-label={ariaLabel}
       isSelected={isSelected}
       onChange={onChange}
       isDisabled={isDisabled}
@@ -655,6 +664,16 @@ export function CopyButton({ value, label }: { value: string; label: string }) {
           ? "Copy blocked, select the value and press Ctrl/Cmd-C"
           : "Copied!"}
       </Tooltip.Content>
+      {/* A tooltip opened by a press rather than by focus is not announced, and
+          the outcome is the whole point of the press. `CopyField` says its own
+          the same way. */}
+      <span aria-live="polite" className="sr-only">
+        {state === "copied"
+          ? `Copied ${label} to clipboard.`
+          : state === "failed"
+            ? `Could not copy ${label}. Select the value and press Ctrl/Cmd-C.`
+            : ""}
+      </span>
     </Tooltip.Root>
   )
 }
@@ -762,11 +781,13 @@ export function ConfirmButton({
   isPending?: boolean
 }) {
   const [armed, setArmed] = useState(false)
+  const { triggerRef, confirmRef } = useConfirmationFocus(armed)
 
   if (armed) {
     return (
       <span className="inline-flex items-center gap-1">
         <Button
+          ref={confirmRef}
           size="sm"
           variant="danger"
           isDisabled={isPending}
@@ -787,7 +808,12 @@ export function ConfirmButton({
   }
 
   return (
-    <Button size="sm" variant="danger-soft" onPress={() => setArmed(true)}>
+    <Button
+      ref={triggerRef}
+      size="sm"
+      variant="danger-soft"
+      onPress={() => setArmed(true)}
+    >
       {children}
     </Button>
   )

--- a/web/src/shared/hooks/useConfirmationFocus.ts
+++ b/web/src/shared/hooks/useConfirmationFocus.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from "react"
+
+/**
+ * Keeps focus on the two-step confirm pattern (a trigger that swaps itself for
+ * a Confirm/Cancel pair, and back).
+ *
+ * The swap unmounts the element that has focus, and the browser answers that by
+ * moving focus to `<body>`: a keyboard user pressing Delete loses their place,
+ * and a screen reader announces nothing at all. These are the most destructive
+ * controls on the page, so the arm step has to hand focus to Confirm and the
+ * cancel step has to hand it back.
+ */
+export function useConfirmationFocus(armed: boolean): {
+  triggerRef: React.RefObject<HTMLButtonElement | null>
+  confirmRef: React.RefObject<HTMLButtonElement | null>
+} {
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const confirmRef = useRef<HTMLButtonElement>(null)
+  // Nothing has been unmounted before the first arm, so the mount render must
+  // not pull focus away from wherever the page put it.
+  const wasArmed = useRef(false)
+
+  useEffect(() => {
+    if (armed) {
+      wasArmed.current = true
+      confirmRef.current?.focus()
+    } else if (wasArmed.current) {
+      triggerRef.current?.focus()
+    }
+  }, [armed])
+
+  return { triggerRef, confirmRef }
+}

--- a/web/src/shared/hooks/useConfirmationFocus.ts
+++ b/web/src/shared/hooks/useConfirmationFocus.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react"
+import { type RefObject, useEffect, useRef } from "react"
 
 /**
  * Keeps focus on the two-step confirm pattern (a trigger that swaps itself for
@@ -11,8 +11,8 @@ import { useEffect, useRef } from "react"
  * cancel step has to hand it back.
  */
 export function useConfirmationFocus(armed: boolean): {
-  triggerRef: React.RefObject<HTMLButtonElement | null>
-  confirmRef: React.RefObject<HTMLButtonElement | null>
+  triggerRef: RefObject<HTMLButtonElement | null>
+  confirmRef: RefObject<HTMLButtonElement | null>
 } {
   const triggerRef = useRef<HTMLButtonElement>(null)
   const confirmRef = useRef<HTMLButtonElement>(null)

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -560,12 +560,13 @@ describe("the shell chrome's type roles", () => {
     // produces no CSS, on text that looks merely unstyled rather than broken.
     expect(CSS).toContain(`@utility ${role} {`)
   })
+})
 
+// The scale's smallest step is 12px (`--text-xs`), so a size written at a call
+// site is either a duplicate of a step or under the floor. This was scoped to
+// `src/app/nav` while the chrome roles were the only ones being enforced.
+describe("no font size is written at a call site", () => {
   it("leaves no arbitrary font size anywhere in the tree", () => {
-    // Scoped to `src/app/nav` when the chrome roles landed, and tree-wide now
-    // that the rest of the pages are on the scale too. The floor the scale
-    // offers is 12px (`--text-xs`), and every spelling under it was an
-    // arbitrary value at a call site: 10px axis ticks, 10px and 11px badges.
     const SRC = join(WEB, "src")
     const offenders = readdirSync(SRC, { recursive: true })
       .map((name) => String(name).replaceAll("\\", "/"))
@@ -607,6 +608,10 @@ describe("checkboxes come from the design foundation", () => {
   const sources = readdirSync(SRC, { recursive: true })
     .map((name) => String(name).replaceAll("\\", "/"))
     .filter((name) => name.endsWith(".tsx") && !name.endsWith(".test.tsx"))
+
+  it("covers the source tree", () => {
+    expect(sources.length).toBeGreaterThan(30)
+  })
 
   it.each(sources)("uses no raw checkbox in %s", (name) => {
     expect(

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -561,16 +561,87 @@ describe("the shell chrome's type roles", () => {
     expect(CSS).toContain(`@utility ${role} {`)
   })
 
-  it("leaves no arbitrary font size in the nav chrome", () => {
-    const NAV = join(WEB, "src", "app", "nav")
-    const offenders = readdirSync(NAV)
+  it("leaves no arbitrary font size anywhere in the tree", () => {
+    // Scoped to `src/app/nav` when the chrome roles landed, and tree-wide now
+    // that the rest of the pages are on the scale too. The floor the scale
+    // offers is 12px (`--text-xs`), and every spelling under it was an
+    // arbitrary value at a call site: 10px axis ticks, 10px and 11px badges.
+    const SRC = join(WEB, "src")
+    const offenders = readdirSync(SRC, { recursive: true })
+      .map((name) => String(name).replaceAll("\\", "/"))
       .filter((name) => /\.tsx?$/.test(name) && !/\.test\.tsx?$/.test(name))
       .filter((name) =>
         // `text-[` followed by a digit: an arbitrary size, as opposed to an
         // arbitrary color, which the token rules above already cover.
-        /text-\[\d/.test(readFileSync(join(NAV, name), "utf8")),
+        /text-\[\d/.test(readFileSync(join(SRC, name), "utf8")),
       )
 
-    expect(offenders, "use a text-chrome-* role, or add one").toEqual([])
+    expect(
+      offenders,
+      "use a type role (text-caption, text-overline, …) or a text-chrome-* one, or add one",
+    ).toEqual([])
+  })
+})
+
+// Touch targets. The rule ("at least 44px on the phone viewport") is in the
+// frontend-standards responsiveness guide and was written at ~180 `size="sm"`
+// call sites that do not meet it, so it is enforced as one floor in the
+// stylesheet rather than as a className each of them has to remember.
+describe("the phone viewport's touch-target floor", () => {
+  it("raises every HeroUI button to 44px below the shell's mobile boundary", () => {
+    // `[data-slot="button"]` is HeroUI's Button and nothing else, and 767px is
+    // AppShell's own MOBILE_QUERY, so the rule turns on exactly where the
+    // sidebar becomes a drawer.
+    expect(CSS).toMatch(
+      /@media \(max-width: 767px\) \{\s*\[data-slot="button"\] \{\s*min-height: 2\.75rem;\s*min-width: 2\.75rem;/,
+    )
+  })
+})
+
+// Form controls. The shared `Checkbox` (`shared/components/ui.tsx`) is the one
+// on the tokens, and a bare `<input type="checkbox">` is the browser's own:
+// system blue in both themes, and a 13px box on a page whose smallest touch
+// target is meant to be 44.
+describe("checkboxes come from the design foundation", () => {
+  const SRC = join(WEB, "src")
+  const sources = readdirSync(SRC, { recursive: true })
+    .map((name) => String(name).replaceAll("\\", "/"))
+    .filter((name) => name.endsWith(".tsx") && !name.endsWith(".test.tsx"))
+
+  it.each(sources)("uses no raw checkbox in %s", (name) => {
+    expect(
+      readFileSync(join(SRC, name), "utf8"),
+      `${name} hand-rolls a checkbox; use Checkbox from shared/components/ui`,
+    ).not.toContain('type="checkbox"')
+  })
+})
+
+// Column headers. A `<th>` with no `scope` leaves a screen reader guessing
+// which cells it heads, and the dashboard's hand-rolled tables (the ones that
+// are not `DataTable`, which gets this from react-aria) are where they live.
+describe("every column header says what it heads", () => {
+  const SRC = join(WEB, "src")
+  const sources = readdirSync(SRC, { recursive: true })
+    .map((name) => String(name).replaceAll("\\", "/"))
+    .filter((name) => name.endsWith(".tsx") && !name.endsWith(".test.tsx"))
+
+  it("covers the source tree", () => {
+    expect(sources.length).toBeGreaterThan(30)
+  })
+
+  it.each(sources)("gives every <th> in %s a scope", (name) => {
+    // Block comments first, for the same reason the heading sweep above drops
+    // them: `ActivityPage` explains its header row in a JSX comment that spells
+    // `<th>` in prose.
+    const source = readFileSync(join(SRC, name), "utf8").replace(
+      /\/\*[\s\S]*?\*\//g,
+      "",
+    )
+    for (const match of source.matchAll(/<th\b([^>]*)>/g)) {
+      expect(
+        match[1],
+        `${match[0]} in ${name} has no scope; a column header is scope="col" and a row header scope="row"`,
+      ).toMatch(/\bscope=/)
+    }
   })
 })

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -882,6 +882,25 @@ body {
   display: inline-flex;
 }
 
+/* Touch targets on the phone viewport. Apple's HIG floor is 44px and HeroUI's
+ * `size="sm"` button is 32, which is the size every table row's actions, every
+ * filter chip and every pagination control is written at: ~180 call sites, and
+ * the next one would start out under the floor again.
+ *
+ * A floor rather than a size, so it raises what is under it and leaves the
+ * larger sizes alone, and it is `min-*` so an explicit `h-8` on a button still
+ * decides the desktop height. `[data-slot="button"]` is only ever HeroUI's
+ * Button, which is why the hook is narrow enough to be safe.
+ *
+ * 767px is the shell's own MOBILE_QUERY boundary (`AppShell`), so the rule
+ * applies exactly where the sidebar has already become a drawer. */
+@media (max-width: 767px) {
+  [data-slot="button"] {
+    min-height: 2.75rem;
+    min-width: 2.75rem;
+  }
+}
+
 /* Modal sizing: v3's default container is sm:w-fit which under-sizes
  * wider modals. Allow growth to content, with a sensible min/max. */
 @media (min-width: 640px) {

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -906,11 +906,11 @@ body {
  *
  * Patched here rather than at the call sites because there are seven of them
  * and a future one would start out wrong again, and rather than in the token
- * because the two backdrops that already pass their own alpha
- * (`WorkspaceSwitcher`'s `/50`, `KeysPage`'s `/40`) would then compound it and
- * come out at a quarter strength. This is the last resort the frontend
- * standards describe, a rule against the library's own class, and it is here
- * because nothing above it reaches the value. */
+ * because the one backdrop that passes its own alpha (`WorkspaceSwitcher`'s
+ * `/50`) would then compound it and come out at a quarter strength. This is
+ * the last resort the frontend standards describe, a rule against the
+ * library's own class, and it is here because nothing above it reaches the
+ * value. */
 .alert-dialog__backdrop--opaque,
 .modal__backdrop--opaque,
 .drawer__backdrop--opaque {


### PR DESCRIPTION
## Description

Clears the dashboard's accessibility debt, worst first.

- **The one-time secret dialog** (`KeysPage`) was hand-rolled: the page behind it was never inerted, focus was never restored, the Tab trap read a `querySelectorAll` snapshot that leaked past its own subtree, and Escape was swallowed with no other exit. It is a HeroUI `Modal` now. The reason it was hand-rolled, that a secret shown once must not be dismissed by accident, is `isDismissable={false}` plus `isKeyboardDismissDisabled`, which is what `ConfirmDialog` already passes the other way round.
- **The two-step confirms** (`InlineConfirm`, `ConfirmButton`) arm by unmounting the button that was pressed, so focus fell to `<body>` at Regenerate, Archive and Delete. A shared `useConfirmationFocus` moves it onto the confirm and back on cancel.
- **Sub-12px text** in five places is back on the scale: both chart axes (a `fontSize` number becomes the class that owns the size, since ticks are SVG `<text>`), the Activity row pill and tool badge, the Models tooltip marker, the Budgets id.
- **The timeline pan rail** was a 10px stripe, so a zoomed window could not be panned by finger. The row is 44px with the stripe drawn inside it; the rail still reads as a hairline.
- **Touch targets**: one floor against `[data-slot="button"]` below the shell's own mobile boundary, rather than a className at each of the ~180 `size="sm"` call sites. A sweep leaves the next call site to remember it; a floor does not.
- **Raw checkboxes**: four `<input type="checkbox">` rendered the browser's own box, system blue in both themes, beside the themed one every other list uses. `Checkbox` gains an `ariaLabel` for the one group whose visible labels repeat.
- **`<th scope>`** on the two hand-rolled tables (`DataTable` gets this from react-aria).
- **aria-live** on the three counts that change under a control that keeps focus: the pager range, the bulk-bar selection count, the copy-button outcome (a tooltip opened by a press is not announced).
- **Card titles**: fifteen were `<div class="text-title">`, leaving most routes with an `<h1>` and nothing under it. They are `<h2>` wearing the same role, so nothing moves visually.

Four sweeps are now enforced in `foundation.test.ts`, so the next regression fails rather than accumulating: no arbitrary font size anywhere in `src`, no raw checkbox, every `<th>` carries a scope, and the touch-target floor stays in the stylesheet.

Not done: the one raw `<input type="radio">` (`RoutingPage`) is a `name`-grouped set rendered per item, and moving it to HeroUI needs a `RadioGroup` around the map, which is a refactor of that form rather than an accessibility patch.

Overlaps #885 (and #871), which touch nearly every file here. Whichever lands second wants a rebase rather than a conflict resolution.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#1938

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Dashboard-only change, so the checks run are `web/`'s: `pnpm lint`, `pnpm exec tsc -b --noEmit`, `pnpm test` (2084 passing). No Python, no API contract, no docs affected.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 5 (1M context), via Claude Code

**Any additional AI details you'd like to share:**

Implemented, tested and self-reviewed by the agent. New coverage: the reveal dialog's dismissal behavior and focus return, the confirm focus swap in both directions, the axis ticks' size source, the two live regions, the pan handle's grab area, plus the four `foundation.test.ts` sweeps.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
