### PR TITLE
docs(tenancy): drop the stale "any 403 drops the session" claim

### DIFF
--- a/src/gateway/services/tenancy/errors.py
+++ b/src/gateway/services/tenancy/errors.py
@@ -93,13 +93,12 @@ class NotAuthorizedError(TenancyForbiddenError):
 class DeploymentAdministrationUnavailableError(TenancyNotFoundError):
     """The caller is not an operator of this deployment, so the surface is not there.
 
-    A 404 and not the 403 the condition really is, for two reasons that point the
-    same way. The dashboard's ``apiFetch`` treats a 403 as "this session cannot
-    use the management API" and drops the session, so refusing one page that way
-    signs the caller out of every other page they *are* allowed. And a surface
-    that answers 403 confirms it exists to anyone who asks, which for a
-    deployment-wide account list is a thing worth not confirming. The hosted
-    backends' own admin surface refuses the same way (mozilla-ai/otari-ai#1842).
+    A 404 and not the 403 the condition really is, because a surface that answers
+    403 confirms it exists to anyone who asks, which for a deployment-wide
+    account list is a thing worth not confirming. A caller who is not an operator
+    gets the answer an unentitled deployment gets, which is the one that tells
+    them least. The hosted backends' own admin surface refuses the same way
+    (mozilla-ai/otari-ai#1842).
     """
 
     def __init__(self) -> None:

--- a/web/src/shared/api/hooks.ts
+++ b/web/src/shared/api/hooks.ts
@@ -2171,7 +2171,7 @@ export function useRevokeOrganizationMemberInvitation() {
 // The accept-invitation page's two calls. Both hit routes the server never
 // gates on a session or the master key: the token in the emailed link is the
 // caller's whole credential, and the gateway answers 404/400 for a bad one,
-// never 401, so apiFetch's session-bounce on 401/403 never triggers here.
+// never 401, so apiFetch's session-bounce never triggers here.
 export function useValidateInvitation(token: string) {
   return useQuery({
     queryKey: ["invitation-preview", token],
@@ -2206,7 +2206,7 @@ export function useAcceptInvitation() {
 // master key, because a caller completing a signup or opening an emailed link
 // holds neither. The gateway answers 400 for a bad token, 429 when the shared
 // sign-in limiter fires, and 503 when this deployment cannot send mail, so
-// apiFetch's session-bounce on 401/403 never triggers on any of them.
+// apiFetch's session-bounce never triggers on any of them.
 //
 // None of them invalidates anything. They write to an identity this
 // unauthenticated caller cannot read back, and the cache they would touch


### PR DESCRIPTION
## Description

`apiFetch` drops the session on a 401 alone (`web/src/shared/api/client.ts`); a 403 surfaces as an ordinary error the page reports. Three comments still justified themselves with the older blanket rule.

- `src/gateway/services/tenancy/errors.py` — `DeploymentAdministrationUnavailableError` gave two reasons for answering 404 rather than the 403 the condition really is, and the first was the sign-out. Dropped. The reason that carries the decision stays: a 403 confirms the surface exists to anyone who asks, which for a deployment-wide account list is worth not confirming.
- `web/src/shared/api/hooks.ts` (×2) — "apiFetch's session-bounce on 401/403" is 401-only. The surrounding claim is unaffected; neither status reaches those unauthenticated routes.

Comments only. No behavior change, no API change.

Found while removing the same claim from the overlay's copies in mozilla-ai/otari-ai#1971.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None upstream. Context: mozilla-ai/otari-ai#1935, mozilla-ai/otari-ai#1971.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). — comments only, nothing to cover.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). — ran `ruff check` and `mypy` on the touched Python file and `biome check` on the touched TypeScript file. Did not run the full suite: no executable line changes.
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). — the contract did not change.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code.

**Any additional AI details you'd like to share:**

The stale claim was spotted by @njbrake reviewing mozilla-ai/otari-ai#1971, which removed the overlay-side copies. I verified each site against `client.ts` before editing and left the reasons that still hold.

- [x] I am an AI Agent filling out this form (check box if true)
