### PR TITLE
refactor(dashboard): adopt the type roles and enforce them

### DIFF
--- a/.github/skills/frontend-standards/components.md
+++ b/.github/skills/frontend-standards/components.md
@@ -99,7 +99,7 @@ owner is usually a component: HeroUI's styling guide points at a wrapper built w
 heavy-handed". `DataTable` is exactly that wrapper: pages declare columns and rows and never
 style a table. A value-shaped decision, rather than a markup-shaped one, is where a utility or a
 shared class string comes in: the `@utility text-heading` family in `globals.css` carries the
-type roles, and `navRowClass` and `NAV_TRANSITION` in `app/nav/rowStyles.ts` carry a chrome row.
+type roles, and `navRowClass` and `NAV_TRANSITION` in `app/nav/rowStyles.ts` carry a shell row.
 Two copies of a class list are two surfaces that are meant to match and will stop matching one
 fix at a time, and the copy that missed the fix is the one somebody notices.
 

--- a/.github/skills/frontend-standards/design-tokens.md
+++ b/.github/skills/frontend-standards/design-tokens.md
@@ -201,16 +201,16 @@ identifier does not belong in it.
 The shell chrome is the other scale: the rails, the account menu and the top bar, which read a
 step below the content roles because they are furniture around a page rather than part of one.
 
-`text-chrome-row` (13px, the caption step: a row label in either rail, the menu, or the top bar)
-· `text-chrome-meta` (12px, `--text-xs`: the second line under one of those labels) ·
-`text-chrome-initials` (9px, sized to a 26px avatar).
+`text-shell-label` (13px, the caption step: a row label in either rail, the menu, or the top bar)
+· `text-shell-secondary` (12px, `--text-xs`: the second line under one of those labels) ·
+`text-shell-monogram` (9px, sized to a 26px avatar).
 
 These three carry metrics only. No weight and no ink, because one menu row is `text-foreground`
 resting and `text-muted` disabled and an identity line is medium over semibold, so the call site
-is where the weight and the colour belong: `text-chrome-meta text-muted` is the shape to write,
-not a wart to clean up. That is the opposite of the content contract above, so check which scale
-a role belongs to before deciding a class beside it is redundant. `text-chrome-initials` is the
-one documented off-scale size, and globals.css says why: two letters in a 26px avatar are
+is where the weight and the colour belong: `text-shell-secondary text-muted` is the shape to
+write, not a wart to clean up. That is the opposite of the content contract above, so check which
+scale a role belongs to before deciding a class beside it is redundant. `text-shell-monogram` is
+the one documented off-scale size, and globals.css says why: two letters in a 26px avatar are
 recognized rather than read.
 
 Zilla Slab is spent on `text-display` alone; every other content role, `text-heading`

--- a/.github/skills/frontend-standards/design-tokens.md
+++ b/.github/skills/frontend-standards/design-tokens.md
@@ -173,8 +173,8 @@ through.
 
 ## Type scale
 
-Seven roles, each an `@utility` in the same file. Pick the one whose **meaning** matches the
-text, not its size:
+Two scales, each role an `@utility` in the same file. Seven roles carry the content of a page.
+Pick the one whose **meaning** matches the text, not its size:
 
 `text-display` (one per route) · `text-heading` (section) · `text-title` (card/dialog) ·
 `text-body` (default, matches `<body>`) · `text-emphasis` (rare) · `text-caption` (metadata) ·
@@ -189,20 +189,36 @@ card title nested two sections deep may be an `<h3>` or an `<h4>` and still wear
 `text-title`. Pick the level that keeps the outline unbroken, then the role that matches the
 meaning.
 
-A role carries family, size, line-height, tracking, weight and ink together, so writing any of
-those beside one is a bug rather than a refinement: `@utility` definitions are emitted ahead of
-the theme's own utilities, so the `text-xs` in `text-caption text-xs` wins the size and the role
-compiles, emits and does nothing. `text-xs text-muted` is the caption role spelled that way, a
-point small and repeating an ink the role already sets. `src/styles/foundation.test.ts` sweeps
-`src` for both. The single deliberate pairing is `font-mono`, because a role sets the body face
-and an identifier does not belong in it.
+A content role carries family, size, line-height, tracking, weight and ink together, so writing
+any of those beside one is a bug rather than a refinement. `@utility` definitions are emitted
+ahead of the theme's own utilities, so the `text-xs` in `text-caption text-xs` wins the size and
+the role compiles, emits and does nothing, and the `text-muted` in `text-caption text-muted`
+repeats an ink the role already sets. `text-xs text-muted` is that role hand-rolled, a point
+small and stating an ink twice. `src/styles/foundation.test.ts` sweeps `src` for all three. The
+one deliberate pairing is `font-mono`, because a content role sets the body face and an
+identifier does not belong in it.
 
-Zilla Slab is spent on `text-display` alone; every other role, `text-heading` included, is set
-in Mozilla Text, because at 18px a slab serif competes with the page title instead of sitting
-under it (mozilla-ai/otari#807). Keys, IDs, and code are Fira Code. A bare `h1`-`h6` still defaults to the
-display face through the `@layer base` rule in the same file, which is why a heading always
-wears a role: left bare it renders serif, and at any size but the display's that reads as an
-accident. The faces are self-hosted in `web/public/fonts/` under
+The shell chrome is the other scale: the rails, the account menu and the top bar, which read a
+step below the content roles because they are furniture around a page rather than part of one.
+
+`text-chrome-row` (13px, the caption step: a row label in either rail, the menu, or the top bar)
+· `text-chrome-meta` (12px, `--text-xs`: the second line under one of those labels) ·
+`text-chrome-initials` (9px, sized to a 26px avatar).
+
+These three carry metrics only. No weight and no ink, because one menu row is `text-foreground`
+resting and `text-muted` disabled and an identity line is medium over semibold, so the call site
+is where the weight and the colour belong: `text-chrome-meta text-muted` is the shape to write,
+not a wart to clean up. That is the opposite of the content contract above, so check which scale
+a role belongs to before deciding a class beside it is redundant. `text-chrome-initials` is the
+one documented off-scale size, and globals.css says why: two letters in a 26px avatar are
+recognized rather than read.
+
+Zilla Slab is spent on `text-display` alone; every other content role, `text-heading`
+included, is set in Mozilla Text, because at 18px a slab serif competes with the page title
+instead of sitting under it (mozilla-ai/otari#807). Keys, IDs, and code are Fira Code. A bare
+`h1`-`h6` still defaults to the display face through the `@layer base` rule in the same file,
+which is why a heading always wears a role: left bare it renders serif, and at any size but the
+display's that reads as an accident. The faces are self-hosted in `web/public/fonts/` under
 SIL OFL 1.1, with each family's license shipped beside it (see the README there), so the
 dashboard's typography needs no third-party request and an air-gapped gateway looks like a
 connected one. Adding a family means adding its license in the same commit;

--- a/.github/skills/frontend-standards/design-tokens.md
+++ b/.github/skills/frontend-standards/design-tokens.md
@@ -189,6 +189,14 @@ card title nested two sections deep may be an `<h3>` or an `<h4>` and still wear
 `text-title`. Pick the level that keeps the outline unbroken, then the role that matches the
 meaning.
 
+A role carries family, size, line-height, tracking, weight and ink together, so writing any of
+those beside one is a bug rather than a refinement: `@utility` definitions are emitted ahead of
+the theme's own utilities, so the `text-xs` in `text-caption text-xs` wins the size and the role
+compiles, emits and does nothing. `text-xs text-muted` is the caption role spelled that way, a
+point small and repeating an ink the role already sets. `src/styles/foundation.test.ts` sweeps
+`src` for both. The single deliberate pairing is `font-mono`, because a role sets the body face
+and an identifier does not belong in it.
+
 Zilla Slab is spent on `text-display` alone; every other role, `text-heading` included, is set
 in Mozilla Text, because at 18px a slab serif competes with the page title instead of sitting
 under it (mozilla-ai/otari#807). Keys, IDs, and code are Fira Code. A bare `h1`-`h6` still defaults to the

--- a/web/src/app/HybridLanding.tsx
+++ b/web/src/app/HybridLanding.tsx
@@ -80,7 +80,7 @@ export function HybridLanding() {
             <CopyableValue
               value={baseUrl}
               label="gateway base URL"
-              className="font-mono text-sm text-foreground"
+              className="font-mono text-body"
             />
             <p className="text-sm text-muted">
               Use it as the base URL of any OpenAI-compatible client, with an

--- a/web/src/app/nav/AccountMenu.tsx
+++ b/web/src/app/nav/AccountMenu.tsx
@@ -58,7 +58,7 @@ const THEME_LABELS: Record<ThemePreference, string> = {
 // That 36px is a desk figure. This menu also renders inside the mobile drawer,
 // where these rows are tapped, so below `md` they take the 44px touch floor and
 // the menu's own scale resumes at the breakpoint.
-const MENU_ROW = `flex min-h-11 w-full items-center gap-2.5 rounded-md px-2.5 text-left text-chrome-row font-medium md:min-h-9 ${NAV_TRANSITION}`
+const MENU_ROW = `flex min-h-11 w-full items-center gap-2.5 rounded-md px-2.5 text-left text-shell-label font-medium md:min-h-9 ${NAV_TRANSITION}`
 const MENU_ROW_RESTING = "text-foreground hover:bg-surface-alt"
 const MENU_ROW_DISABLED = "cursor-not-allowed text-muted opacity-60"
 // No vertical margin: the dialog's own 6px gap is the menu's rhythm, and a
@@ -175,7 +175,7 @@ function MenuItem({
           takes, so the one row that carries a value does not push its own label
           out of the column the others sit in. */}
       {trailing ? (
-        <span className="w-11 shrink-0 text-right text-chrome-meta font-normal text-muted">
+        <span className="w-11 shrink-0 text-right text-shell-secondary font-normal text-muted">
           {trailing}
         </span>
       ) : (
@@ -305,7 +305,7 @@ export function AccountMenu({ collapsed }: { collapsed: boolean }) {
         aria-label={`Account: ${identity.name}`}
         className={`${navRowClass({ collapsed })} w-auto! justify-start`}
       >
-        <span className="flex h-[1.625rem] w-[1.625rem] shrink-0 items-center justify-center rounded-full border border-border bg-surface-alt text-chrome-initials font-semibold text-muted">
+        <span className="flex h-[1.625rem] w-[1.625rem] shrink-0 items-center justify-center rounded-full border border-border bg-surface-alt text-shell-monogram font-semibold text-muted">
           {identity.initials}
         </span>
         {collapsed ? null : (

--- a/web/src/app/nav/AccountMenu.tsx
+++ b/web/src/app/nav/AccountMenu.tsx
@@ -175,7 +175,7 @@ function MenuItem({
           takes, so the one row that carries a value does not push its own label
           out of the column the others sit in. */}
       {trailing ? (
-        <span className="w-11 shrink-0 text-right text-xs font-normal text-muted">
+        <span className="w-11 shrink-0 text-right text-chrome-meta font-normal text-muted">
           {trailing}
         </span>
       ) : (

--- a/web/src/app/nav/TopBarActions.tsx
+++ b/web/src/app/nav/TopBarActions.tsx
@@ -23,7 +23,7 @@ import { useDeployment } from "@/shared/hooks/useDeployment"
 // file to fill. It renders nothing here.
 
 const ACTION =
-  "flex min-h-[2.125rem] items-center rounded-md px-1 text-chrome-row font-medium text-muted transition-colors hover:text-foreground"
+  "flex min-h-[2.125rem] items-center rounded-md px-1 text-shell-label font-medium text-muted transition-colors hover:text-foreground"
 
 export function TopBarActions() {
   const { docs_url } = useDeployment()

--- a/web/src/app/nav/WorkspaceSwitcher.tsx
+++ b/web/src/app/nav/WorkspaceSwitcher.tsx
@@ -143,7 +143,7 @@ export function WorkspaceSwitcher({
                 <span className="truncate text-sm leading-[1.125rem] font-semibold tracking-[-0.01em] text-foreground">
                   {workspaceName}
                 </span>
-                <span className="truncate text-chrome-meta font-medium text-muted">
+                <span className="truncate text-shell-secondary font-medium text-muted">
                   {organizationName}
                 </span>
               </span>
@@ -225,11 +225,11 @@ export function WorkspaceSwitcher({
               Workspaces ({memberships.length})
             </p>
             {isLoading ? (
-              <p className="px-2.5 py-1 text-chrome-meta text-muted">
+              <p className="px-2.5 py-1 text-shell-secondary text-muted">
                 Loading workspaces…
               </p>
             ) : memberships.length === 0 ? (
-              <p className="px-2.5 py-1 text-chrome-meta text-muted">
+              <p className="px-2.5 py-1 text-shell-secondary text-muted">
                 You do not belong to a workspace yet.
               </p>
             ) : (

--- a/web/src/app/nav/WorkspaceSwitcher.tsx
+++ b/web/src/app/nav/WorkspaceSwitcher.tsx
@@ -225,11 +225,11 @@ export function WorkspaceSwitcher({
               Workspaces ({memberships.length})
             </p>
             {isLoading ? (
-              <p className="px-2.5 py-1 text-xs text-muted">
+              <p className="px-2.5 py-1 text-chrome-meta text-muted">
                 Loading workspaces…
               </p>
             ) : memberships.length === 0 ? (
-              <p className="px-2.5 py-1 text-xs text-muted">
+              <p className="px-2.5 py-1 text-chrome-meta text-muted">
                 You do not belong to a workspace yet.
               </p>
             ) : (

--- a/web/src/features/account/PasskeysCard.tsx
+++ b/web/src/features/account/PasskeysCard.tsx
@@ -67,7 +67,7 @@ function PasskeyRow({
           <p className="truncate text-sm font-medium text-foreground">
             {passkey.name}
           </p>
-          <p className="text-xs text-muted">
+          <p className="text-caption">
             {passkey.backed_up
               ? "Synced to your credential manager"
               : "Stored on one device"}
@@ -310,7 +310,7 @@ export function PasskeysCard() {
                   placeholder="Work laptop"
                   maxLength={MAX_PASSKEY_NAME_LENGTH}
                 />
-                <Description className="text-xs text-muted">
+                <Description className="text-caption">
                   Optional. It is only a label, so you can tell this passkey
                   from the others.
                 </Description>

--- a/web/src/features/account/PasskeysCard.tsx
+++ b/web/src/features/account/PasskeysCard.tsx
@@ -64,9 +64,7 @@ function PasskeyRow({
           <FiKey aria-hidden className="mt-0.5 size-4 shrink-0 text-muted" />
         )}
         <div className="min-w-0">
-          <p className="truncate text-sm font-medium text-foreground">
-            {passkey.name}
-          </p>
+          <p className="truncate text-body">{passkey.name}</p>
           <p className="text-caption">
             {passkey.backed_up
               ? "Synced to your credential manager"
@@ -303,9 +301,7 @@ export function PasskeysCard() {
                 onChange={setNewName}
                 className="flex max-w-md flex-1 flex-col gap-1"
               >
-                <Label className="text-sm font-medium text-foreground">
-                  Name
-                </Label>
+                <Label className="text-body">Name</Label>
                 <Input
                   placeholder="Work laptop"
                   maxLength={MAX_PASSKEY_NAME_LENGTH}
@@ -349,7 +345,7 @@ export function PasskeysCard() {
             isRequired
             className="flex flex-col gap-1"
           >
-            <Label className="text-sm font-medium text-foreground">Name</Label>
+            <Label className="text-body">Name</Label>
             <Input autoFocus maxLength={MAX_PASSKEY_NAME_LENGTH} />
           </TextField>
         }

--- a/web/src/features/account/PasswordCard.tsx
+++ b/web/src/features/account/PasswordCard.tsx
@@ -43,7 +43,7 @@ function PasswordField({
       isRequired
       className="flex max-w-md flex-col gap-1"
     >
-      <Label className="text-sm font-medium text-foreground">{label}</Label>
+      <Label className="text-body">{label}</Label>
       <Input autoComplete={autoComplete} />
       {description ? (
         // HeroUI's Description renders through the TextField's "description"
@@ -225,9 +225,7 @@ export function PasswordCard() {
                 isRequired
                 className="flex max-w-md flex-col gap-1"
               >
-                <Label className="text-sm font-medium text-foreground">
-                  Email
-                </Label>
+                <Label className="text-body">Email</Label>
                 {/* autoComplete="username" and not "email": this is the handle
                     the sign-in form will ask for, so a password manager should
                     file it against the credential it is being set beside. */}

--- a/web/src/features/account/PasswordCard.tsx
+++ b/web/src/features/account/PasswordCard.tsx
@@ -50,7 +50,7 @@ function PasswordField({
         // slot, so it reaches the input as aria-describedby; a raw span does
         // not, and a policy the field states only to sighted users is a policy
         // half the people typing into it cannot read.
-        <Description className="text-xs text-muted">{description}</Description>
+        <Description className="text-caption">{description}</Description>
       ) : null}
     </TextField>
   )
@@ -236,7 +236,7 @@ export function PasswordCard() {
                     explanation above it before the operator has asked to
                     type. */}
                 <Input placeholder="you@example.com" autoComplete="username" />
-                <Description className="text-xs text-muted">
+                <Description className="text-caption">
                   Changing this address later is not supported yet, so pick the
                   one you will keep.
                 </Description>

--- a/web/src/features/activity/ActivityPage.tsx
+++ b/web/src/features/activity/ActivityPage.tsx
@@ -812,7 +812,7 @@ function RoutingPlan({ entry }: { entry: UsageEntry }) {
   return (
     <div className="flex flex-col gap-2">
       <span className="text-overline">Routing plan · {entry.policy_name}</span>
-      <span className="text-sm text-foreground">{summary}</span>
+      <span className="text-body">{summary}</span>
       <div className="overflow-x-auto rounded-lg border border-border">
         <table
           className="w-full text-xs"
@@ -919,12 +919,12 @@ function DetailField({
         <CopyableValue
           value={copyValue}
           label={copyLabel ?? label.toLowerCase()}
-          className="text-sm text-foreground break-all"
+          className="text-body break-all"
         >
           {children}
         </CopyableValue>
       ) : (
-        <span className="text-sm text-foreground break-all">{children}</span>
+        <span className="text-body break-all">{children}</span>
       )}
     </div>
   )
@@ -1745,9 +1745,7 @@ export function ActivityPage() {
     (entry: UsageEntry) => (
       <div>
         <div className="flex items-center justify-between border-b border-border px-4 py-2">
-          <span className="text-sm font-medium text-foreground">
-            Request detail
-          </span>
+          <span className="text-body">Request detail</span>
           <Button size="sm" variant="ghost" onPress={() => setExpandedId(null)}>
             Close
           </Button>

--- a/web/src/features/activity/ActivityPage.tsx
+++ b/web/src/features/activity/ActivityPage.tsx
@@ -226,7 +226,7 @@ function InFlightControl({
         <Popover.Dialog>
           <div className="flex w-80 flex-col gap-2">
             <Popover.Heading className="text-title">In flight</Popover.Heading>
-            <p className="text-xs text-muted">
+            <p className="text-caption">
               Running right now, across the whole gateway; longest-running
               first. Not narrowed by the filters above.
             </p>
@@ -244,7 +244,7 @@ function InFlightControl({
                   >
                     <span className="min-w-0">
                       <span className="block truncate">{request.model}</span>
-                      <span className="block truncate text-xs text-muted">
+                      <span className="block truncate text-caption">
                         {request.user_id ?? "—"}
                         {request.policy_name ? ` · ${request.policy_name}` : ""}
                       </span>
@@ -259,7 +259,7 @@ function InFlightControl({
             {/* Only when the endpoint's cap actually bit, which takes more
                 concurrency than a live list can usefully show anyway. */}
             {hidden > 0 ? (
-              <p className="text-xs text-muted">
+              <p className="text-caption">
                 {hidden.toLocaleString()} further{" "}
                 {hidden === 1 ? "request is" : "requests are"} in flight beyond
                 the {shown.length.toLocaleString()} listed.
@@ -745,7 +745,7 @@ function RoutingCell({
           the model that served), and a qualified target is routinely longer than
           the column. The Model column wraps for the same reason. */}
       {sentence ? (
-        <span className="text-xs break-words text-muted">{sentence}</span>
+        <span className="text-caption break-words">{sentence}</span>
       ) : null}
     </span>
   )
@@ -888,7 +888,7 @@ function RoutingPlan({ entry }: { entry: UsageEntry }) {
           </tbody>
         </table>
       </div>
-      <span className="text-xs text-muted">
+      <span className="text-caption">
         Cost and tool charges settle on the attempt that served, so a failed
         attempt carries its tokens and no charge.
       </span>
@@ -1070,7 +1070,7 @@ function RequestDetail({
               Price this model
             </Button>
           ) : null}
-          <span className="text-xs text-muted">
+          <span className="text-caption">
             {onPriceModel ? (
               <>
                 This request carries no cost. Set a price for{" "}
@@ -2044,7 +2044,7 @@ export function ActivityPage() {
               ) : null}
               {newRowsUnknown ? (
                 <span
-                  className="text-xs text-muted"
+                  className="text-caption"
                   title="The row count could not be read, so this page cannot tell whether newer requests have landed. Refresh to load whatever is there."
                 >
                   Newer rows unknown

--- a/web/src/features/activity/ActivityTimeline.tsx
+++ b/web/src/features/activity/ActivityTimeline.tsx
@@ -267,7 +267,7 @@ export function ActivityTimeline({
           </Button>
         ))}
         <div className="ml-auto flex items-center gap-3">
-          <span className="text-xs text-muted">Showing {label} · UTC</span>
+          <span className="text-caption">Showing {label} · UTC</span>
           {action}
         </div>
       </div>
@@ -281,7 +281,7 @@ export function ActivityTimeline({
             <ChartLegend series={chartSeries} />
           </span>
           <div className="flex items-center gap-1.5">
-            <span className="hidden text-xs text-muted sm:inline">
+            <span className="hidden text-caption sm:inline">
               drag across the chart to zoom
             </span>
             <Button
@@ -339,7 +339,7 @@ export function ActivityTimeline({
             <Spinner size="sm" />
           </div>
         ) : n === 0 ? (
-          <div className="flex h-[90px] items-center justify-center text-xs text-muted">
+          <div className="flex h-[90px] items-center justify-center text-caption">
             No activity in this range.
           </div>
         ) : (

--- a/web/src/features/admin/DeploymentAccountsPage.tsx
+++ b/web/src/features/admin/DeploymentAccountsPage.tsx
@@ -86,7 +86,7 @@ export function DeploymentAccountsPage() {
                 only whitespace falls back to the email up there, so testing the
                 untrimmed value here would print the same address twice. */}
             {account.full_name?.trim() && account.email ? (
-              <span className="text-xs text-muted">{account.email}</span>
+              <span className="text-caption">{account.email}</span>
             ) : null}
           </div>
         ),

--- a/web/src/features/admin/DeploymentAccountsPage.tsx
+++ b/web/src/features/admin/DeploymentAccountsPage.tsx
@@ -79,9 +79,7 @@ export function DeploymentAccountsPage() {
         isRowHeader: true,
         cell: (account) => (
           <div className="flex flex-col gap-0.5">
-            <span className="text-sm text-foreground">
-              {accountLabel(account)}
-            </span>
+            <span className="text-body">{accountLabel(account)}</span>
             {/* `full_name?.trim()`, matching `accountLabel`: a name that is
                 only whitespace falls back to the email up there, so testing the
                 untrimmed value here would print the same address twice. */}

--- a/web/src/features/auth/AuthFields.tsx
+++ b/web/src/features/auth/AuthFields.tsx
@@ -61,7 +61,7 @@ export function AuthEmailField({
       {description ? (
         // HeroUI's Description reaches the input as aria-describedby through
         // the TextField's "description" slot, which a raw span does not.
-        <Description className="text-xs text-muted">{description}</Description>
+        <Description className="text-caption">{description}</Description>
       ) : null}
     </TextField>
   )
@@ -91,7 +91,7 @@ export function AuthPasswordField({
       <Label className="text-sm font-medium text-foreground">{label}</Label>
       <Input autoComplete={autoComplete} />
       {description ? (
-        <Description className="text-xs text-muted">{description}</Description>
+        <Description className="text-caption">{description}</Description>
       ) : null}
     </TextField>
   )
@@ -119,7 +119,7 @@ export function AuthTextField({
       <Label className="text-sm font-medium text-foreground">{label}</Label>
       <Input autoComplete={autoComplete} />
       {description ? (
-        <Description className="text-xs text-muted">{description}</Description>
+        <Description className="text-caption">{description}</Description>
       ) : null}
     </TextField>
   )

--- a/web/src/features/auth/AuthFields.tsx
+++ b/web/src/features/auth/AuthFields.tsx
@@ -38,7 +38,7 @@ export function AuthEmailField({
       isReadOnly={isReadOnly}
       className="flex flex-col gap-1"
     >
-      <Label className="text-sm font-medium text-foreground">{label}</Label>
+      <Label className="text-body">{label}</Label>
       {/* autoComplete="username" and not "email": this is the handle the
           sign-in form asks for, so a password manager should file it against
           the credential it is being set beside. */}
@@ -88,7 +88,7 @@ export function AuthPasswordField({
       isRequired
       className="flex flex-col gap-1"
     >
-      <Label className="text-sm font-medium text-foreground">{label}</Label>
+      <Label className="text-body">{label}</Label>
       <Input autoComplete={autoComplete} />
       {description ? (
         <Description className="text-caption">{description}</Description>
@@ -116,7 +116,7 @@ export function AuthTextField({
       onChange={onChange}
       className="flex flex-col gap-1"
     >
-      <Label className="text-sm font-medium text-foreground">{label}</Label>
+      <Label className="text-body">{label}</Label>
       <Input autoComplete={autoComplete} />
       {description ? (
         <Description className="text-caption">{description}</Description>

--- a/web/src/features/auth/CheckEmailPage.tsx
+++ b/web/src/features/auth/CheckEmailPage.tsx
@@ -37,7 +37,7 @@ export function CheckEmailPage({ hash }: { hash: string }) {
         Open the link in that message to confirm the address. Signing in is
         blocked until you do.
       </p>
-      <p className="text-center text-xs text-muted">
+      <p className="text-center text-caption">
         The link expires, and a new one can be sent at any time.
       </p>
     </PublicAuthLayout>

--- a/web/src/features/auth/CheckEmailPage.tsx
+++ b/web/src/features/auth/CheckEmailPage.tsx
@@ -33,7 +33,7 @@ export function CheckEmailPage({ hash }: { hash: string }) {
         </>
       }
     >
-      <p className="text-center text-sm text-foreground">
+      <p className="text-center text-body">
         Open the link in that message to confirm the address. Signing in is
         blocked until you do.
       </p>

--- a/web/src/features/auth/Login.tsx
+++ b/web/src/features/auth/Login.tsx
@@ -832,10 +832,7 @@ export function Login() {
                   and an unlabeled line reads as the latter. One rule for both
                   groups, however many buttons follow it, because they are all
                   the same alternative: another way to prove the same thing. */}
-              <div
-                className="flex items-center gap-3 text-xs text-muted"
-                aria-hidden
-              >
+              <div className="flex items-center gap-3 text-caption" aria-hidden>
                 <span className="h-px flex-1 bg-border" />
                 or
                 <span className="h-px flex-1 bg-border" />
@@ -892,7 +889,7 @@ export function Login() {
           ) : null}
 
           <div className="flex flex-col items-center gap-3">
-            <p className="text-center text-xs text-balance text-muted">
+            <p className="text-center text-caption text-balance">
               Sent once and exchanged for a session cookie. Never stored in the
               browser.
             </p>

--- a/web/src/features/auth/OAuthCallbackPage.tsx
+++ b/web/src/features/auth/OAuthCallbackPage.tsx
@@ -190,7 +190,7 @@ export function OAuthCallbackPage({
       title="That sign-in did not complete"
       footer={<PublicAuthLink to="#/">Back to sign in</PublicAuthLink>}
     >
-      <p className="text-center text-sm text-foreground">{failure}</p>
+      <p className="text-center text-body">{failure}</p>
     </PublicAuthLayout>
   )
 }

--- a/web/src/features/auth/RecoverPasswordPage.tsx
+++ b/web/src/features/auth/RecoverPasswordPage.tsx
@@ -48,7 +48,7 @@ export function RecoverPasswordPage() {
         description="If that address has a password on this gateway, a reset link is on its way."
         footer={<PublicAuthLink to="#/">Back to sign in</PublicAuthLink>}
       >
-        <p className="text-center text-xs text-muted">
+        <p className="text-center text-caption">
           The link is single-use and expires. Requesting another replaces the
           one before it.
         </p>

--- a/web/src/features/budgets/BudgetsPage.tsx
+++ b/web/src/features/budgets/BudgetsPage.tsx
@@ -134,7 +134,7 @@ function PeriodPicker({
 
   return (
     <div className="flex flex-col gap-2">
-      <span className="text-sm font-medium text-foreground">Reset period</span>
+      <span className="text-body">Reset period</span>
       <div className="flex flex-wrap gap-2">
         {PERIOD_PRESETS.map((preset) => (
           <Button
@@ -927,7 +927,7 @@ function DeploymentBudgetsPage() {
         <Card>
           <Card.Content className="p-0">
             <div className="flex items-center justify-between border-b border-border px-4 py-2">
-              <span className="text-sm font-medium text-foreground">
+              <span className="text-body">
                 Reset history — {budgetLabel(historyBudget)}
               </span>
               <Button

--- a/web/src/features/budgets/BudgetsPage.tsx
+++ b/web/src/features/budgets/BudgetsPage.tsx
@@ -191,7 +191,7 @@ function PeriodPicker({
           />
         </div>
       ) : null}
-      <span className="text-xs text-muted">
+      <span className="text-caption">
         Spend returns to zero each period. A user&rsquo;s clock starts when the
         budget is assigned to them.
       </span>
@@ -320,7 +320,7 @@ function BudgetForm({
 // collectively allowed (cap × users). A bar only when both are meaningful.
 function UsageCell({ budget }: { budget: Budget }) {
   if (budget.user_count === 0) {
-    return <span className="text-xs text-muted">No users assigned</span>
+    return <span className="text-caption">No users assigned</span>
   }
   const spent = budget.total_spend
   if (budget.max_budget === null) {
@@ -606,7 +606,7 @@ function DeploymentBudgetsPage() {
             {/* Only a prefix is rendered, so the id an API call needs is not on the
               page in full; the copy hands over the whole thing. */}
             <CopyableValue value={b.budget_id} label="budget id">
-              <code className="text-caption" title={b.budget_id}>
+              <code className="font-mono text-caption" title={b.budget_id}>
                 {shortId(b.budget_id)}
               </code>
             </CopyableValue>
@@ -643,7 +643,7 @@ function DeploymentBudgetsPage() {
         cell: (b) => {
           const holders = defaultFor.get(b.budget_id)
           if (!holders || holders.length === 0) {
-            return <span className="text-xs text-muted">&mdash;</span>
+            return <span className="text-caption">&mdash;</span>
           }
           return (
             <div className="flex flex-wrap gap-1">

--- a/web/src/features/budgets/OrganizationBudgetsCard.tsx
+++ b/web/src/features/budgets/OrganizationBudgetsCard.tsx
@@ -62,9 +62,7 @@ export function OrganizationBudgetsCard() {
       id: "name",
       header: "Budget",
       isRowHeader: true,
-      cell: (row) => (
-        <span className="text-sm text-foreground">{budgetLabel(row)}</span>
-      ),
+      cell: (row) => <span className="text-body">{budgetLabel(row)}</span>,
     },
     {
       id: "limit",

--- a/web/src/features/budgets/SpendCeilingDialog.tsx
+++ b/web/src/features/budgets/SpendCeilingDialog.tsx
@@ -161,7 +161,7 @@ export function SpendCeilingDialog({
                         ? `, on ${editing.provider_key_id}`
                         : ", on every provider"}
                     </span>
-                    <span className="text-xs text-muted">
+                    <span className="text-caption">
                       What a ceiling caps cannot be changed. Delete it and add
                       one for the other identity.
                     </span>

--- a/web/src/features/budgets/SpendCeilingDialog.tsx
+++ b/web/src/features/budgets/SpendCeilingDialog.tsx
@@ -152,9 +152,7 @@ export function SpendCeilingDialog({
                 <ErrorBanner error={error} />
                 {editing ? (
                   <div className="flex flex-col gap-1">
-                    <span className="text-sm font-medium text-foreground">
-                      Capping
-                    </span>
+                    <span className="text-body">Capping</span>
                     <span className="text-sm text-muted">
                       {scopeLabel(editing, { organizationName, workspaces })}
                       {editing.provider_key_id

--- a/web/src/features/budgets/SpendCeilingsCard.tsx
+++ b/web/src/features/budgets/SpendCeilingsCard.tsx
@@ -96,9 +96,7 @@ export function SpendCeilingsCard({
           <span className="text-sm text-foreground">
             {scopeLabel(row, { organizationName, workspaces: workspaceRows })}
           </span>
-          {row.name ? (
-            <span className="text-xs text-muted">{row.name}</span>
-          ) : null}
+          {row.name ? <span className="text-caption">{row.name}</span> : null}
         </div>
       ),
     },
@@ -138,7 +136,7 @@ export function SpendCeilingsCard({
         <div className="flex flex-col gap-0.5">
           <span>{periodLabel(row)}</span>
           {row.period_end ? (
-            <span className="text-xs text-muted">
+            <span className="text-caption">
               Next on {formatDate(row.period_end)}
             </span>
           ) : null}

--- a/web/src/features/budgets/SpendCeilingsCard.tsx
+++ b/web/src/features/budgets/SpendCeilingsCard.tsx
@@ -93,7 +93,7 @@ export function SpendCeilingsCard({
       isRowHeader: true,
       cell: (row) => (
         <div className="flex flex-col gap-0.5">
-          <span className="text-sm text-foreground">
+          <span className="text-body">
             {scopeLabel(row, { organizationName, workspaces: workspaceRows })}
           </span>
           {row.name ? <span className="text-caption">{row.name}</span> : null}

--- a/web/src/features/invitations/AcceptInvitationPage.tsx
+++ b/web/src/features/invitations/AcceptInvitationPage.tsx
@@ -114,7 +114,7 @@ export function AcceptInvitationPage() {
             <>
               {/* No article before the role: two of the three ("a owner", "a
                   admin") read wrong, and the roles are the server's words. */}
-              <p className="text-center text-sm text-foreground">
+              <p className="text-center text-body">
                 You're now a member of{" "}
                 <strong>{accept.data.organization_name}</strong>, with the{" "}
                 <strong>{accept.data.role}</strong> role.
@@ -194,7 +194,7 @@ export function AcceptInvitationPage() {
             </>
           ) : preview.data ? (
             <>
-              <p className="text-center text-sm text-foreground">
+              <p className="text-center text-body">
                 <strong>{preview.data.organization_name}</strong> has invited{" "}
                 <strong>{preview.data.email}</strong> to join with the{" "}
                 <strong>{preview.data.role}</strong> role.

--- a/web/src/features/invitations/AcceptInvitationPage.tsx
+++ b/web/src/features/invitations/AcceptInvitationPage.tsx
@@ -121,7 +121,7 @@ export function AcceptInvitationPage() {
               </p>
               {isAuthenticated ? (
                 <>
-                  <p className="text-center text-xs text-muted">
+                  <p className="text-center text-caption">
                     You're already signed in, so there is nothing left to set
                     up.
                   </p>
@@ -144,7 +144,7 @@ export function AcceptInvitationPage() {
                 </>
               ) : offersClaim ? (
                 <>
-                  <p className="text-center text-xs text-muted">
+                  <p className="text-center text-caption">
                     Next, set your password to sign in.
                   </p>
                   <Button
@@ -168,7 +168,7 @@ export function AcceptInvitationPage() {
                       no endpoint for that. `PUT /v1/auth/password` only ever
                       acts on the caller's own identity, so that advice named
                       something nobody on this deployment can do. */}
-                  <p className="text-center text-xs text-muted">
+                  <p className="text-center text-caption">
                     {offersProviderSignIn
                       ? "Setting a password works by emailing you a link, and this deployment sends no mail. Sign in with one of the providers on the sign-in screen instead."
                       : "Setting a password works by emailing you a link, and this deployment sends no mail. An operator can turn that on by configuring outgoing mail and a public base URL for this gateway."}

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -184,7 +184,7 @@ function RevealSecretModal({
                 be retrieved later. If you lose it, use Regenerate to issue a
                 new secret.
               </InfoBanner>
-              <p className="text-xs text-muted">
+              <p className="text-caption">
                 Model access: {accessLabel(result.allowed_models).text}.
               </p>
               <CopyField
@@ -198,7 +198,7 @@ function RevealSecretModal({
                   {snippets === undefined ? (
                     <MissingGatewayAddressNotice />
                   ) : (
-                    <p className="text-xs text-muted">
+                    <p className="text-caption">
                       Replace <code>{SNIPPET_MODEL_PLACEHOLDER}</code> with a
                       model from the Models page.
                     </p>
@@ -293,7 +293,7 @@ function OwnerAccessNote({ userId, users }: { userId: string; users: User[] }) {
   const id = userId.trim()
   if (id === "") {
     return (
-      <p className="text-xs text-muted">
+      <p className="text-caption">
         Choose an owner above to see the models this key can inherit.
       </p>
     )
@@ -301,7 +301,7 @@ function OwnerAccessNote({ userId, users }: { userId: string; users: User[] }) {
   const owner = users.find((u) => u.user_id === id)
   if (!owner) {
     return (
-      <p className="text-xs text-muted">
+      <p className="text-caption">
         New user <code>{id}</code> starts unrestricted, so this key may allow
         any model.
       </p>
@@ -313,7 +313,7 @@ function OwnerAccessNote({ userId, users }: { userId: string; users: User[] }) {
       ? owner.allowed_models.join(", ")
       : null
   return (
-    <p className="text-xs text-muted">
+    <p className="text-caption">
       Owner <code>{id}</code> allows{" "}
       <span className="font-medium text-foreground">{text.toLowerCase()}</span>
       {entries ? (
@@ -345,7 +345,7 @@ function BudgetExemptToggle({
       <Checkbox isSelected={checked} onChange={onChange}>
         <span className="font-medium text-foreground">Exempt from budget</span>
       </Checkbox>
-      <p className="text-xs text-muted">
+      <p className="text-caption">
         Requests on this key are logged with their cost but never counted toward
         the owner&apos;s budget or spend, and never blocked by it.
       </p>
@@ -385,7 +385,7 @@ function UserMismatchPicker({
           { value: "accept", label: "Always accept" },
         ]}
       />
-      <span className="text-xs text-muted">
+      <span className="text-caption">
         What happens when a request on this key names a different{" "}
         <code>user</code> than its owner. Accept it for clients that send
         telemetry there rather than an identity, such as Claude Code. Spend
@@ -514,7 +514,7 @@ function CreateKeyForm({
             memberLabels={memberLabels}
           />
         ) : (
-          <p className="text-xs text-muted">
+          <p className="text-caption">
             This key is yours: requests on it are billed to you and count
             against your budget.
           </p>
@@ -891,7 +891,9 @@ export function KeysPage() {
                   )
                 }
                 return (
-                  <code className="text-xs text-muted">{k.user_id ?? "—"}</code>
+                  <code className="font-mono text-caption">
+                    {k.user_id ?? "—"}
+                  </code>
                 )
               },
             } satisfies DataTableColumn<ApiKey>,
@@ -901,7 +903,7 @@ export function KeysPage() {
         id: "key",
         header: "Key",
         cell: (k) => (
-          <code className="text-xs text-muted">
+          <code className="font-mono text-caption">
             {k.key_prefix ? `${k.key_prefix}…` : "—"}
           </code>
         ),

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -369,7 +369,7 @@ function UserMismatchPicker({
       {/* The label carries markup (`user` as code), which FilterSelect's own
           `label` cannot, so it stays here with `htmlFor` on the trigger and
           `ariaLabel` naming the control for assistive tech. */}
-      <label htmlFor={selectId} className="text-sm font-medium text-foreground">
+      <label htmlFor={selectId} className="text-body">
         Mismatched <code>user</code> field
       </label>
       <FilterSelect
@@ -882,10 +882,7 @@ export function KeysPage() {
                   : undefined
                 if (member) {
                   return (
-                    <span
-                      className="text-sm text-foreground"
-                      title={k.user_id ?? ""}
-                    >
+                    <span className="text-body" title={k.user_id ?? ""}>
                       {member}
                     </span>
                   )

--- a/web/src/features/models/ModelComboBox.tsx
+++ b/web/src/features/models/ModelComboBox.tsx
@@ -110,7 +110,7 @@ export function ModelComboBox({
       className="flex max-w-md flex-col gap-1"
     >
       {/* HeroUI marks a required field's label through CSS; see Field. */}
-      <Label className="text-sm font-medium text-foreground">{label}</Label>
+      <Label className="text-body">{label}</Label>
       <ComboBox.InputGroup>
         <Input placeholder={placeholder} autoFocus={autoFocus} />
         <ComboBox.Trigger />

--- a/web/src/features/models/ModelComboBox.tsx
+++ b/web/src/features/models/ModelComboBox.tsx
@@ -126,7 +126,7 @@ export function ModelComboBox({
           )}
         </ListBox>
       </ComboBox.Popover>
-      {hint ? <span className="text-xs text-muted">{hint}</span> : null}
+      {hint ? <span className="text-caption">{hint}</span> : null}
     </ComboBox.Root>
   )
 }

--- a/web/src/features/models/ModelScopeControl.tsx
+++ b/web/src/features/models/ModelScopeControl.tsx
@@ -139,7 +139,7 @@ export function ModelScopeControl({
     <div className="flex flex-col gap-3">
       <div>
         <span className="text-sm font-medium text-foreground">{title}</span>
-        <p className="text-xs text-muted">
+        <p className="text-caption">
           {description ??
             "Which models this key may list and call. The master key is never restricted, so blocking a key cannot lock you out of the dashboard."}
         </p>
@@ -161,7 +161,7 @@ export function ModelScopeControl({
         <div className="flex flex-col gap-2">
           <div className="flex flex-wrap gap-1.5">
             {entries.length === 0 ? (
-              <span className="text-xs text-muted">
+              <span className="text-caption">
                 Pick at least one model below, or choose “Block all”.
               </span>
             ) : (
@@ -184,7 +184,7 @@ export function ModelScopeControl({
             )}
           </div>
           {catalogEmpty ? (
-            <span className="text-xs text-muted">
+            <span className="text-caption">
               No providers or models discovered yet. Configure a provider first,
               then scope this key.
             </span>

--- a/web/src/features/models/ModelScopeControl.tsx
+++ b/web/src/features/models/ModelScopeControl.tsx
@@ -124,8 +124,8 @@ export function ModelScopeControl({
       onClick={() => chooseMode(value)}
       className={
         mode === value
-          ? "rounded-md bg-surface px-3 py-1.5 text-sm font-medium text-foreground shadow-sm"
-          : "rounded-md px-3 py-1.5 text-sm text-muted hover:text-foreground"
+          ? "rounded-md bg-surface px-3 py-1.5 text-body shadow-sm"
+          : "rounded-md px-3 py-1.5 text-body text-muted hover:text-foreground"
       }
     >
       {label}
@@ -138,7 +138,7 @@ export function ModelScopeControl({
   return (
     <div className="flex flex-col gap-3">
       <div>
-        <span className="text-sm font-medium text-foreground">{title}</span>
+        <span className="text-body">{title}</span>
         <p className="text-caption">
           {description ??
             "Which models this key may list and call. The master key is never restricted, so blocking a key cannot lock you out of the dashboard."}

--- a/web/src/features/models/ModelsPage.tsx
+++ b/web/src/features/models/ModelsPage.tsx
@@ -403,7 +403,7 @@ function PricingTierEditor({
           <div className="text-xs font-medium text-foreground">
             Long-context price tiers
           </div>
-          <p className="text-xs text-muted">
+          <p className="text-caption">
             At a threshold, listed rates replace the base rate for the whole
             request.
           </p>
@@ -417,7 +417,7 @@ function PricingTierEditor({
           key={tier.id}
           className="flex flex-wrap items-end gap-2 border-t border-border pt-2"
         >
-          <label className="flex flex-col gap-1 text-xs text-muted">
+          <label className="flex flex-col gap-1 text-caption">
             Context ≥ tokens
             <input
               type="number"
@@ -432,7 +432,7 @@ function PricingTierEditor({
               className="w-28 rounded-md border border-field-border bg-field px-2 py-1 text-right text-sm tabular-nums focus:border-accent focus:outline-none"
             />
           </label>
-          <label className="flex flex-col gap-1 text-xs text-muted">
+          <label className="flex flex-col gap-1 text-caption">
             Input
             <MoneyInput
               value={tier.input}
@@ -440,7 +440,7 @@ function PricingTierEditor({
               ariaLabel="Tier input price"
             />
           </label>
-          <label className="flex flex-col gap-1 text-xs text-muted">
+          <label className="flex flex-col gap-1 text-caption">
             Output
             <MoneyInput
               value={tier.output}
@@ -448,7 +448,7 @@ function PricingTierEditor({
               ariaLabel="Tier output price"
             />
           </label>
-          <label className="flex flex-col gap-1 text-xs text-muted">
+          <label className="flex flex-col gap-1 text-caption">
             Cache read
             <MoneyInput
               value={tier.cacheRead}
@@ -456,7 +456,7 @@ function PricingTierEditor({
               ariaLabel="Tier cache read price"
             />
           </label>
-          <label className="flex flex-col gap-1 text-xs text-muted">
+          <label className="flex flex-col gap-1 text-caption">
             Cache write
             <MoneyInput
               value={tier.cacheWrite}
@@ -464,7 +464,7 @@ function PricingTierEditor({
               ariaLabel="Tier cache write price"
             />
           </label>
-          <label className="flex flex-col gap-1 text-xs text-muted">
+          <label className="flex flex-col gap-1 text-caption">
             1h write
             <MoneyInput
               value={tier.cacheWrite1h}
@@ -503,9 +503,9 @@ function SourceChip({ source }: { source: PriceSource }) {
     )
   }
   if (source === "unknown") {
-    return <span className="text-xs text-muted">rate unknown</span>
+    return <span className="text-caption">rate unknown</span>
   }
-  return <span className="text-xs text-muted">not priced</span>
+  return <span className="text-caption">not priced</span>
 }
 
 // A small info affordance: an "i" bubble that reveals a tooltip on hover or
@@ -586,7 +586,7 @@ function PricingInfo() {
 function Spec({ label, value }: { label: string; value: ReactNode }) {
   return (
     <div className="flex items-baseline justify-between gap-3">
-      <span className="text-xs text-muted">{label}</span>
+      <span className="text-caption">{label}</span>
       <span className="text-right text-sm text-foreground tabular-nums">
         {value}
       </span>
@@ -674,7 +674,7 @@ function PanelPriceEditor({
     return (
       <div className="flex flex-col gap-2">
         <div className="flex items-center justify-between gap-2">
-          <span className="text-xs text-muted">Input $ / 1M</span>
+          <span className="text-caption">Input $ / 1M</span>
           <MoneyInput
             value={input}
             onChange={setInput}
@@ -682,7 +682,7 @@ function PanelPriceEditor({
           />
         </div>
         <div className="flex items-center justify-between gap-2">
-          <span className="text-xs text-muted">Output $ / 1M</span>
+          <span className="text-caption">Output $ / 1M</span>
           <MoneyInput
             value={output}
             onChange={setOutput}
@@ -690,7 +690,7 @@ function PanelPriceEditor({
           />
         </div>
         <div className="flex items-center justify-between gap-2">
-          <span className="text-xs text-muted">Cache read $ / 1M</span>
+          <span className="text-caption">Cache read $ / 1M</span>
           <MoneyInput
             value={cacheRead}
             onChange={setCacheRead}
@@ -698,7 +698,7 @@ function PanelPriceEditor({
           />
         </div>
         <div className="flex items-center justify-between gap-2">
-          <span className="text-xs text-muted">Cache write $ / 1M</span>
+          <span className="text-caption">Cache write $ / 1M</span>
           <MoneyInput
             value={cacheWrite}
             onChange={setCacheWrite}
@@ -706,7 +706,7 @@ function PanelPriceEditor({
           />
         </div>
         <div className="flex items-center justify-between gap-2">
-          <span className="text-xs text-muted">1h cache write $ / 1M</span>
+          <span className="text-caption">1h cache write $ / 1M</span>
           <MoneyInput
             value={cacheWrite1h}
             onChange={setCacheWrite1h}
@@ -858,14 +858,14 @@ function ModelDetailPanel({
                 </Chip>
               ) : null}
             </div>
-            <p className="mt-1 text-xs break-all text-muted">
+            <p className="mt-1 text-caption break-all">
               Selector:{" "}
               <CopyableValue value={row.key} label="model id">
                 <code>{row.key}</code>
               </CopyableValue>
             </p>
             {metadata?.family ? (
-              <p className="text-xs text-muted">{metadata.family}</p>
+              <p className="text-caption">{metadata.family}</p>
             ) : null}
           </div>
           <button
@@ -886,7 +886,7 @@ function ModelDetailPanel({
           <div className="flex items-center gap-2">
             <SourceChip source={row.source} />
             {row.isDiscovered || !discoveryKnown ? null : (
-              <span className="text-xs text-muted">not discovered</span>
+              <span className="text-caption">not discovered</span>
             )}
           </div>
           <PanelPriceEditor
@@ -923,7 +923,7 @@ function ModelDetailPanel({
           {inputModalities.length === 0 && outputModalities.length === 0 ? (
             <span className="text-sm text-muted">Unknown.</span>
           ) : (
-            <div className="flex flex-col gap-1.5 text-xs text-muted">
+            <div className="flex flex-col gap-1.5 text-caption">
               <div className="flex flex-wrap items-center gap-1">
                 <span>In:</span>
                 {inputModalities.map((m) => (
@@ -1077,10 +1077,8 @@ function InlinePriceForm({
   return (
     <div className="flex flex-col gap-3 px-4 py-3">
       <div className="flex flex-wrap items-center gap-3">
-        <span className="text-xs font-medium break-all text-muted">
-          {row.key}
-        </span>
-        <label className="flex items-center gap-1.5 text-xs text-muted">
+        <span className="text-caption break-all">{row.key}</span>
+        <label className="flex items-center gap-1.5 text-caption">
           Input $ / 1M
           <MoneyInput
             value={input}
@@ -1088,7 +1086,7 @@ function InlinePriceForm({
             ariaLabel={`Input price for ${row.key}`}
           />
         </label>
-        <label className="flex items-center gap-1.5 text-xs text-muted">
+        <label className="flex items-center gap-1.5 text-caption">
           Output $ / 1M
           <MoneyInput
             value={output}
@@ -1096,7 +1094,7 @@ function InlinePriceForm({
             ariaLabel={`Output price for ${row.key}`}
           />
         </label>
-        <label className="flex items-center gap-1.5 text-xs text-muted">
+        <label className="flex items-center gap-1.5 text-caption">
           Cache read $ / 1M
           <MoneyInput
             value={cacheRead}
@@ -1104,7 +1102,7 @@ function InlinePriceForm({
             ariaLabel={`Cache read price for ${row.key}`}
           />
         </label>
-        <label className="flex items-center gap-1.5 text-xs text-muted">
+        <label className="flex items-center gap-1.5 text-caption">
           Cache write $ / 1M
           <MoneyInput
             value={cacheWrite}
@@ -1112,7 +1110,7 @@ function InlinePriceForm({
             ariaLabel={`Cache write price for ${row.key}`}
           />
         </label>
-        <label className="flex items-center gap-1.5 text-xs text-muted">
+        <label className="flex items-center gap-1.5 text-caption">
           1h cache write $ / 1M
           <MoneyInput
             value={cacheWrite1h}
@@ -1237,7 +1235,7 @@ function CachingCell({
   const label = entries.length > 0 ? entries.join(" · ") : "Input-rate fallback"
   if (onEdit === undefined) {
     return (
-      <span className="inline-block max-w-44 text-right text-xs leading-5 text-muted">
+      <span className="inline-block max-w-44 text-right text-caption">
         {label}
       </span>
     )
@@ -1246,7 +1244,7 @@ function CachingCell({
     <button
       type="button"
       aria-label={`Edit caching price for ${rowKey}`}
-      className="max-w-44 text-right text-xs leading-5 text-muted hover:text-link hover:underline"
+      className="max-w-44 text-right text-caption hover:text-link hover:underline"
       onClick={(event) => {
         event.stopPropagation()
         onEdit()
@@ -1274,7 +1272,7 @@ function PricingPolicyCell({
       : `${thresholds.length} tier${thresholds.length === 1 ? "" : "s"} · ≥ ${thresholds.join(", ")}`
   if (onEdit === undefined) {
     return (
-      <span className="inline-block max-w-40 text-right text-xs leading-5 text-muted">
+      <span className="inline-block max-w-40 text-right text-caption">
         {label}
       </span>
     )
@@ -1283,7 +1281,7 @@ function PricingPolicyCell({
     <button
       type="button"
       aria-label={`Edit pricing policy for ${row.key}`}
-      className="max-w-40 text-right text-xs leading-5 text-muted hover:text-link hover:underline"
+      className="max-w-40 text-right text-caption hover:text-link hover:underline"
       onClick={(event) => {
         event.stopPropagation()
         onEdit()
@@ -2017,7 +2015,7 @@ export function ModelsPage() {
             ? "No models yet. Add a provider on the Providers page."
             : "No models yet. A deployment operator adds providers."}
       </span>
-      <span className="text-xs text-muted">
+      <span className="text-caption">
         A provider that serves no model listing still answers requests, so a
         model you can call may not be listed here.
       </span>

--- a/web/src/features/models/ModelsPage.tsx
+++ b/web/src/features/models/ModelsPage.tsx
@@ -587,9 +587,7 @@ function Spec({ label, value }: { label: string; value: ReactNode }) {
   return (
     <div className="flex items-baseline justify-between gap-3">
       <span className="text-caption">{label}</span>
-      <span className="text-right text-sm text-foreground tabular-nums">
-        {value}
-      </span>
+      <span className="text-right text-body tabular-nums">{value}</span>
     </div>
   )
 }
@@ -879,7 +877,7 @@ function ModelDetailPanel({
         </div>
 
         {metadata?.description ? (
-          <p className="text-sm text-foreground">{metadata.description}</p>
+          <p className="text-body">{metadata.description}</p>
         ) : null}
 
         <PanelSection title="Pricing">
@@ -2189,9 +2187,7 @@ export function ModelsPage() {
             <Card>
               <Card.Content className="p-0">
                 <div className="flex items-center justify-between border-b border-border px-4 py-2">
-                  <span className="text-sm font-medium text-foreground">
-                    Edit pricing
-                  </span>
+                  <span className="text-body">Edit pricing</span>
                   <Button
                     size="sm"
                     variant="ghost"

--- a/web/src/features/models/SetPriceDialog.tsx
+++ b/web/src/features/models/SetPriceDialog.tsx
@@ -36,7 +36,7 @@ function RateField({
       isRequired={isRequired}
       className="flex flex-col gap-1"
     >
-      <Label className="text-sm font-medium text-foreground">{label}</Label>
+      <Label className="text-body">{label}</Label>
       <Input inputMode="decimal" placeholder="0.00" autoFocus={autoFocus} />
     </TextField>
   )

--- a/web/src/features/onboarding/SetupGuideCard.tsx
+++ b/web/src/features/onboarding/SetupGuideCard.tsx
@@ -324,7 +324,7 @@ function ListeningRow({
           </>
         ) : (
           <>
-            <span className="text-sm font-medium text-foreground">
+            <span className="text-body">
               {checkFailed
                 ? "The gateway could not be checked"
                 : "Listening for your first request"}

--- a/web/src/features/onboarding/SetupGuideCard.tsx
+++ b/web/src/features/onboarding/SetupGuideCard.tsx
@@ -183,7 +183,7 @@ function SetupGuide({
             >
               Create a setup key
             </Button>
-            <span className="text-xs text-muted">
+            <span className="text-caption">
               An API key for this workspace, shown once. It appears on the API
               keys page as “Setup guide”.
             </span>
@@ -242,7 +242,7 @@ function IssuedKey({ issued }: { issued: ActivationApiKey }) {
       <CopyField label="API key" value={issued.key} />
       {snippetInput === undefined ? <MissingGatewayAddressNotice /> : null}
       {snippetInput !== undefined && model === undefined ? (
-        <p className="text-xs text-muted">
+        <p className="text-caption">
           No model is being served yet, so the snippets name{" "}
           <code>{SNIPPET_MODEL_PLACEHOLDER}</code>. Replace it with a model from
           the{" "}
@@ -307,7 +307,7 @@ function ListeningRow({
             <span className="text-sm font-medium text-danger">
               Request failed: {failure.cause}
             </span>
-            <span className="text-xs text-muted">
+            <span className="text-caption">
               Still listening. Fix it and send the request again.
               {attempt?.occurred_at
                 ? ` Last attempt ${formatRelative(attempt.occurred_at)}.`
@@ -329,7 +329,7 @@ function ListeningRow({
                 ? "The gateway could not be checked"
                 : "Listening for your first request"}
             </span>
-            <span className="text-xs text-muted">
+            <span className="text-caption">
               {checkFailed
                 ? "Leave this page open and try again."
                 : "This page notices it within a few seconds."}
@@ -380,9 +380,7 @@ function SetupComplete({
             fill in from here.
           </p>
           {receipt.length > 0 ? (
-            <p className="font-mono text-xs text-muted">
-              {receipt.join(" · ")}
-            </p>
+            <p className="font-mono text-caption">{receipt.join(" · ")}</p>
           ) : null}
         </div>
         <div className="flex flex-wrap items-center gap-2">

--- a/web/src/features/organization/OrganizationGeneralPage.tsx
+++ b/web/src/features/organization/OrganizationGeneralPage.tsx
@@ -52,7 +52,7 @@ function OrganizationDetails({
           description="What this deployment's tenant is called across the dashboard. The slug below is set when the organization is provisioned and does not follow a rename."
         />
         <div className="flex flex-col gap-1">
-          <span className="text-sm font-medium text-foreground">Slug</span>
+          <span className="text-body">Slug</span>
           <CopyableValue value={slug} label="organization slug">
             <code className="font-mono text-caption">{slug}</code>
           </CopyableValue>

--- a/web/src/features/organization/OrganizationGeneralPage.tsx
+++ b/web/src/features/organization/OrganizationGeneralPage.tsx
@@ -54,7 +54,7 @@ function OrganizationDetails({
         <div className="flex flex-col gap-1">
           <span className="text-sm font-medium text-foreground">Slug</span>
           <CopyableValue value={slug} label="organization slug">
-            <code className="text-xs text-muted">{slug}</code>
+            <code className="font-mono text-caption">{slug}</code>
           </CopyableValue>
         </div>
         <div>

--- a/web/src/features/organization/OrganizationMembersPage.tsx
+++ b/web/src/features/organization/OrganizationMembersPage.tsx
@@ -231,9 +231,7 @@ function AddMemberForm({ onClose }: { onClose: () => void }) {
         </div>
         {workspaces.data && workspaces.data.length > 0 ? (
           <fieldset className="flex flex-col gap-2">
-            <legend className="text-sm font-medium text-foreground">
-              Workspaces (optional)
-            </legend>
+            <legend className="text-body">Workspaces (optional)</legend>
             <span className="text-caption">
               Joined as a member of each, in the same request, so someone never
               exists without the access they were added for. Workspace roles are
@@ -393,9 +391,7 @@ function InviteMemberForm({ onClose }: { onClose: () => void }) {
         </div>
         {workspaces.data && workspaces.data.length > 0 ? (
           <fieldset className="flex flex-col gap-2">
-            <legend className="text-sm font-medium text-foreground">
-              Workspaces (optional)
-            </legend>
+            <legend className="text-body">Workspaces (optional)</legend>
             <span className="text-caption">
               Granted once the invitation is accepted, not before.
             </span>
@@ -658,9 +654,7 @@ function MemberEditor({
         )}
 
         <div className="flex flex-col gap-2">
-          <span className="text-sm font-medium text-foreground">
-            Workspace access
-          </span>
+          <span className="text-body">Workspace access</span>
           <div className="max-w-3xl overflow-x-auto">
             <table className="w-full min-w-lg text-sm">
               <thead>
@@ -850,9 +844,7 @@ export function OrganizationMembersPage() {
         isRowHeader: true,
         cell: (member) => (
           <div className="flex flex-col gap-0.5">
-            <span className="text-sm text-foreground">
-              {memberLabel(member)}
-            </span>
+            <span className="text-body">{memberLabel(member)}</span>
             {member.email && member.full_name ? (
               <span className="text-caption">{member.email}</span>
             ) : null}
@@ -991,9 +983,7 @@ export function OrganizationMembersPage() {
           }
           return (
             <div className="flex flex-col items-end gap-0.5">
-              <span className="text-sm text-foreground">
-                {usd.format(spendRow.spend)}
-              </span>
+              <span className="text-body">{usd.format(spendRow.spend)}</span>
               {spendRow.reserved > 0 ? (
                 <span className="text-caption">
                   {usd.format(spendRow.reserved)} in flight

--- a/web/src/features/organization/OrganizationMembersPage.tsx
+++ b/web/src/features/organization/OrganizationMembersPage.tsx
@@ -234,7 +234,7 @@ function AddMemberForm({ onClose }: { onClose: () => void }) {
             <legend className="text-sm font-medium text-foreground">
               Workspaces (optional)
             </legend>
-            <span className="text-xs text-muted">
+            <span className="text-caption">
               Joined as a member of each, in the same request, so someone never
               exists without the access they were added for. Workspace roles are
               changed afterwards on the Workspaces page.
@@ -396,7 +396,7 @@ function InviteMemberForm({ onClose }: { onClose: () => void }) {
             <legend className="text-sm font-medium text-foreground">
               Workspaces (optional)
             </legend>
-            <span className="text-xs text-muted">
+            <span className="text-caption">
               Granted once the invitation is accepted, not before.
             </span>
             {workspaces.data.map((workspace) => (
@@ -651,7 +651,7 @@ function MemberEditor({
             }}
           />
         ) : (
-          <span className="text-xs text-muted">
+          <span className="text-caption">
             No spend row yet, so there is no model access to set. One is minted
             when a key is issued to this member.
           </span>
@@ -664,7 +664,7 @@ function MemberEditor({
           <div className="max-w-3xl overflow-x-auto">
             <table className="w-full min-w-lg text-sm">
               <thead>
-                <tr className="text-left text-xs text-muted">
+                <tr className="text-left text-caption">
                   <th scope="col" className="py-1 font-medium">
                     Workspace
                   </th>
@@ -727,7 +727,7 @@ function MemberEditor({
             </table>
           </div>
           {operates ? (
-            <span className="max-w-2xl text-xs text-muted">
+            <span className="max-w-2xl text-caption">
               Each workspace holds its own allowance, so someone in two
               workspaces has two. The amount and the reset period belong to the
               budget, so editing one moves everyone held to it; pick a different
@@ -854,7 +854,7 @@ export function OrganizationMembersPage() {
               {memberLabel(member)}
             </span>
             {member.email && member.full_name ? (
-              <span className="text-xs text-muted">{member.email}</span>
+              <span className="text-caption">{member.email}</span>
             ) : null}
           </div>
         ),
@@ -933,17 +933,17 @@ export function OrganizationMembersPage() {
             ? userByAttribution.get(member.attribution_user_id)
             : undefined
           if (!spendRow) {
-            return <span className="text-xs text-muted">&mdash;</span>
+            return <span className="text-caption">&mdash;</span>
           }
           const { text, tone } = accessLabel(spendRow.allowed_models)
           return (
             <span
               className={
                 tone === "danger"
-                  ? "text-xs text-danger"
+                  ? "text-caption text-danger"
                   : tone === "muted"
-                    ? "text-xs text-muted"
-                    : "text-xs text-foreground"
+                    ? "text-caption"
+                    : "text-caption text-foreground"
               }
             >
               {text}
@@ -962,7 +962,7 @@ export function OrganizationMembersPage() {
             ? (placementsByUser.get(member.user_id) ?? [])
             : []
           if (placements.length === 0) {
-            return <span className="text-xs text-muted">None</span>
+            return <span className="text-caption">None</span>
           }
           return (
             <div className="flex flex-wrap gap-1">
@@ -987,7 +987,7 @@ export function OrganizationMembersPage() {
             ? userByAttribution.get(member.attribution_user_id)
             : undefined
           if (!spendRow) {
-            return <span className="text-xs text-muted">&mdash;</span>
+            return <span className="text-caption">&mdash;</span>
           }
           return (
             <div className="flex flex-col items-end gap-0.5">
@@ -995,7 +995,7 @@ export function OrganizationMembersPage() {
                 {usd.format(spendRow.spend)}
               </span>
               {spendRow.reserved > 0 ? (
-                <span className="text-xs text-muted">
+                <span className="text-caption">
                   {usd.format(spendRow.reserved)} in flight
                 </span>
               ) : null}

--- a/web/src/features/organization/OrganizationProviderKeysPage.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.tsx
@@ -144,9 +144,7 @@ function KeyForm({
           // uniqueness constraint and the whole of what dispatch matches on),
           // and the API's update body cannot change it.
           <div className="flex flex-col gap-1">
-            <span className="text-sm font-medium text-foreground">
-              Provider
-            </span>
+            <span className="text-body">Provider</span>
             <span className="text-sm text-muted">
               {editing.provider}. Create a second key to use another provider.
             </span>

--- a/web/src/features/organization/PricingOverrideDialog.tsx
+++ b/web/src/features/organization/PricingOverrideDialog.tsx
@@ -50,7 +50,7 @@ function RateField({
       isRequired={isRequired}
       className="flex flex-col gap-1"
     >
-      <Label className="text-sm font-medium text-foreground">{label}</Label>
+      <Label className="text-body">{label}</Label>
       <Input inputMode="decimal" placeholder="0.00" />
       {description ? <span className="text-caption">{description}</span> : null}
     </TextField>
@@ -211,9 +211,7 @@ export function PricingOverrideDialog({
                 <ErrorBanner error={error} />
                 {editing ? (
                   <div className="flex flex-col gap-1">
-                    <span className="text-sm font-medium text-foreground">
-                      Model
-                    </span>
+                    <span className="text-body">Model</span>
                     <code className="font-mono text-caption">
                       {editing.model_key}
                     </code>
@@ -272,9 +270,7 @@ export function PricingOverrideDialog({
                     isRequired={editing !== undefined}
                     className="flex flex-col gap-1"
                   >
-                    <Label className="text-sm font-medium text-foreground">
-                      Applies from
-                    </Label>
+                    <Label className="text-body">Applies from</Label>
                     <Input type="datetime-local" />
                     <span className="text-caption">
                       {editing
@@ -287,9 +283,7 @@ export function PricingOverrideDialog({
                     onChange={setTo}
                     className="flex flex-col gap-1"
                   >
-                    <Label className="text-sm font-medium text-foreground">
-                      Applies until
-                    </Label>
+                    <Label className="text-body">Applies until</Label>
                     <Input type="datetime-local" />
                     <span className="text-caption">
                       Blank leaves it open ended. The end is exclusive, so the

--- a/web/src/features/organization/PricingOverrideDialog.tsx
+++ b/web/src/features/organization/PricingOverrideDialog.tsx
@@ -52,9 +52,7 @@ function RateField({
     >
       <Label className="text-sm font-medium text-foreground">{label}</Label>
       <Input inputMode="decimal" placeholder="0.00" />
-      {description ? (
-        <span className="text-xs text-muted">{description}</span>
-      ) : null}
+      {description ? <span className="text-caption">{description}</span> : null}
     </TextField>
   )
 }
@@ -216,10 +214,10 @@ export function PricingOverrideDialog({
                     <span className="text-sm font-medium text-foreground">
                       Model
                     </span>
-                    <code className="text-xs text-muted">
+                    <code className="font-mono text-caption">
                       {editing.model_key}
                     </code>
-                    <span className="text-xs text-muted">
+                    <span className="text-caption">
                       A model cannot be changed here. Delete this override and
                       add one for the other model.
                     </span>
@@ -278,7 +276,7 @@ export function PricingOverrideDialog({
                       Applies from
                     </Label>
                     <Input type="datetime-local" />
-                    <span className="text-xs text-muted">
+                    <span className="text-caption">
                       {editing
                         ? "Required when editing: a replacement states the whole period."
                         : "Blank starts it now."}
@@ -293,7 +291,7 @@ export function PricingOverrideDialog({
                       Applies until
                     </Label>
                     <Input type="datetime-local" />
-                    <span className="text-xs text-muted">
+                    <span className="text-caption">
                       Blank leaves it open ended. The end is exclusive, so the
                       next period may start at the same moment.
                     </span>

--- a/web/src/features/organization/RateOverridesCard.tsx
+++ b/web/src/features/organization/RateOverridesCard.tsx
@@ -143,7 +143,7 @@ export function RateOverridesCard() {
     {
       id: "period",
       header: "Period",
-      cell: (row) => <span className="text-xs text-muted">{period(row)}</span>,
+      cell: (row) => <span className="text-caption">{period(row)}</span>,
     },
     {
       id: "status",

--- a/web/src/features/pricing/ModelPricingPage.tsx
+++ b/web/src/features/pricing/ModelPricingPage.tsx
@@ -99,7 +99,7 @@ function PricingRefreshDialog({
               </ul>
             ) : null}
             {preview.changes_truncated ? (
-              <p className="text-xs text-muted">
+              <p className="text-caption">
                 Only the first 100 changes are shown.
               </p>
             ) : null}

--- a/web/src/features/pricing/ModelPricingPage.tsx
+++ b/web/src/features/pricing/ModelPricingPage.tsx
@@ -90,7 +90,7 @@ function PricingRefreshDialog({
               {preview.protected_model_count === 1 ? "" : "s"} remain unchanged.
             </p>
             {preview.changes.length > 0 ? (
-              <ul className="max-h-60 list-disc overflow-auto pl-5 text-sm text-foreground">
+              <ul className="max-h-60 list-disc overflow-auto pl-5 text-body">
                 {preview.changes.map((change) => (
                   <li key={change.model_key}>
                     {change.model_key}: {change.change}
@@ -140,9 +140,7 @@ function PricingRefreshSection() {
         <Card.Content className="flex flex-col gap-4 p-5">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div className="min-w-0">
-              <div className="text-sm font-medium text-foreground">
-                genai-prices defaults
-              </div>
+              <div className="text-body">genai-prices defaults</div>
               <p className="mt-1 max-w-3xl text-sm text-muted">
                 Fetch the latest upstream catalog, review the proposed change
                 summary, then accept or reject it. Accepted data is stored as{" "}
@@ -264,9 +262,7 @@ const COLUMNS: DataTableColumn<PriceRow>[] = [
     id: "modelKey",
     header: "Model",
     isRowHeader: true,
-    cell: (row) => (
-      <span className="font-mono text-sm text-foreground">{row.modelKey}</span>
-    ),
+    cell: (row) => <span className="font-mono text-body">{row.modelKey}</span>,
   },
   {
     id: "input",

--- a/web/src/features/providers/ProvidersPage.tsx
+++ b/web/src/features/providers/ProvidersPage.tsx
@@ -393,8 +393,8 @@ function AddProviderForm({ onClose }: { onClose: () => void }) {
                 onClick={() => setTab(id)}
                 className={
                   tab === id
-                    ? "rounded-md bg-surface px-3 py-1.5 text-sm font-medium text-foreground shadow-sm"
-                    : "rounded-md px-3 py-1.5 text-sm text-muted hover:text-foreground"
+                    ? "rounded-md bg-surface px-3 py-1.5 text-body shadow-sm"
+                    : "rounded-md px-3 py-1.5 text-body text-muted hover:text-foreground"
                 }
               >
                 {label}

--- a/web/src/features/providers/ProvidersPage.tsx
+++ b/web/src/features/providers/ProvidersPage.tsx
@@ -576,7 +576,7 @@ function TestOutcome({ state }: { state: TestState | undefined }) {
   if (!state) return null
   if (state.status === "pending") {
     return (
-      <span className="inline-flex items-center gap-1.5 text-xs text-muted">
+      <span className="inline-flex items-center gap-1.5 text-caption">
         {/* Hidden rather than left as HeroUI's own role="status": its
             "Loading" name would contradict the "Testing…" beside it. */}
         <Spinner size="sm" aria-hidden="true" /> Testing…
@@ -623,7 +623,7 @@ function TestOutcome({ state }: { state: TestState | undefined }) {
 // warning state rather than the red one (issue #447).
 function HealthPill({ health }: { health: ProviderHealth | undefined }) {
   if (!health) {
-    return <span className="text-xs text-muted">—</span>
+    return <span className="text-caption">—</span>
   }
   const degraded = !health.ok && health.discovery_unsupported
   const styles = health.ok
@@ -1018,7 +1018,7 @@ export function ProvidersPage() {
             <TestOutcome state={tests[row.instance]} />
           </div>
         ) : (
-          <span className="block text-right text-xs text-muted">
+          <span className="block text-right text-caption">
             managed in config.yml
           </span>
         ),

--- a/web/src/features/providers/providerFields.tsx
+++ b/web/src/features/providers/providerFields.tsx
@@ -85,7 +85,7 @@ export function ClientArgsField({
         className="font-mono text-xs"
       />
       <Description
-        className={error ? "text-xs text-danger" : "text-xs text-muted"}
+        className={error ? "text-caption text-danger" : "text-caption"}
       >
         {error ??
           // Unlike the API key, these are stored and returned unencrypted, so say

--- a/web/src/features/providers/providerFields.tsx
+++ b/web/src/features/providers/providerFields.tsx
@@ -197,9 +197,7 @@ export function ProviderComboBox({
           )}
         </ListBox>
       </ComboBox.Popover>
-      {description ? (
-        <span className="text-xs text-muted">{description}</span>
-      ) : null}
+      {description ? <span className="text-caption">{description}</span> : null}
     </ComboBox.Root>
   )
 }

--- a/web/src/features/providers/providerFields.tsx
+++ b/web/src/features/providers/providerFields.tsx
@@ -75,9 +75,7 @@ export function ClientArgsField({
       isInvalid={error !== null}
       className="flex max-w-md flex-col gap-1"
     >
-      <Label className="text-sm font-medium text-foreground">
-        Client options (JSON)
-      </Label>
+      <Label className="text-body">Client options (JSON)</Label>
       <TextArea
         rows={3}
         placeholder={'{"timeout": 1800}'}
@@ -174,7 +172,7 @@ export function ProviderComboBox({
       }}
       className="flex max-w-md flex-col gap-1"
     >
-      <Label className="text-sm font-medium text-foreground">{label}</Label>
+      <Label className="text-body">{label}</Label>
       <ComboBox.InputGroup>
         {/* Not a credential field: keep browser password managers from offering to fill it.
             Select the text on focus so typing replaces the current selection instead of

--- a/web/src/features/routing/RouterReadiness.tsx
+++ b/web/src/features/routing/RouterReadiness.tsx
@@ -28,7 +28,7 @@ function Warmth({
           style={{ width: `${pct}%` }}
         />
       </div>
-      <span className="text-sm text-foreground">
+      <span className="text-body">
         {records} / {seed} examples
       </span>
       <Chip size="sm" color={warm ? "accent" : "default"}>
@@ -75,7 +75,7 @@ export function RouterReadiness({
   return (
     <div>
       <div className="flex items-center justify-between border-b border-border px-4 py-2">
-        <span className="text-sm font-medium text-foreground">
+        <span className="text-body">
           Examples for <code>{policyName}</code>
         </span>
         <Button size="sm" variant="ghost" onPress={onClose}>
@@ -86,7 +86,7 @@ export function RouterReadiness({
       <div className="flex flex-col gap-5 px-4 py-4">
         <div className="flex flex-col gap-1">
           <span className="text-caption">Candidates</span>
-          <span className="text-sm text-foreground">
+          <span className="text-body">
             <code>{backend}</code> ranks {candidates.join(", ")} for each
             request.
           </span>
@@ -131,9 +131,7 @@ export function RouterReadiness({
           ) : status.data ? (
             <div className="flex flex-col gap-2">
               <div className="flex flex-wrap items-center gap-3">
-                <span className="text-sm font-medium text-foreground">
-                  Default pool
-                </span>
+                <span className="text-body">Default pool</span>
                 <Warmth
                   records={status.data.default_pool.records}
                   seed={status.data.seed_count}
@@ -145,9 +143,7 @@ export function RouterReadiness({
                   key={pool.task_id}
                   className="flex flex-wrap items-center gap-3"
                 >
-                  <code className="text-sm text-foreground">
-                    {pool.task_id}
-                  </code>
+                  <code className="font-mono text-body">{pool.task_id}</code>
                   <Warmth
                     records={pool.records}
                     seed={status.data.seed_count}

--- a/web/src/features/routing/RouterReadiness.tsx
+++ b/web/src/features/routing/RouterReadiness.tsx
@@ -85,12 +85,12 @@ export function RouterReadiness({
 
       <div className="flex flex-col gap-5 px-4 py-4">
         <div className="flex flex-col gap-1">
-          <span className="text-xs font-medium text-muted">Candidates</span>
+          <span className="text-caption">Candidates</span>
           <span className="text-sm text-foreground">
             <code>{backend}</code> ranks {candidates.join(", ")} for each
             request.
           </span>
-          <span className="text-xs text-muted">
+          <span className="text-caption">
             <code>{defaultTarget}</code> serves whenever it declines: too few
             examples, a weakly supported pick, a request carrying tools, or{" "}
             <code>Otari-Router: off</code>.
@@ -98,7 +98,7 @@ export function RouterReadiness({
         </div>
 
         <div className="flex flex-col gap-2">
-          <span className="text-xs font-medium text-muted">Examples</span>
+          <span className="text-caption">Examples</span>
           {scopedUserId === null ? (
             <UserComboBox
               label="Whose memory"
@@ -114,7 +114,7 @@ export function RouterReadiness({
               }
             />
           ) : (
-            <span className="text-xs text-muted">
+            <span className="text-caption">
               Scoped to user <code>{scopedUserId}</code>, so that is the only
               memory it can use.
             </span>
@@ -156,13 +156,13 @@ export function RouterReadiness({
                 </div>
               ))}
               {status.data.tasks.length > 0 ? (
-                <span className="text-xs text-muted">
+                <span className="text-caption">
                   The default pool counts every example this user has, including
                   the ones filed under a task, so it can be warm while a task
                   partition is not.
                 </span>
               ) : null}
-              <span className="text-xs text-muted">
+              <span className="text-caption">
                 Scoring with <code>{status.data.embedding_model}</code>,{" "}
                 {status.data.k} nearest examples per decision, cost dial{" "}
                 {status.data.alpha}, deciding once per{" "}
@@ -177,10 +177,8 @@ export function RouterReadiness({
         </div>
 
         <div className="flex flex-col gap-1">
-          <span className="text-xs font-medium text-muted">
-            Adding examples
-          </span>
-          <span className="text-xs text-muted">
+          <span className="text-caption">Adding examples</span>
+          <span className="text-caption">
             Examples are recorded over the API, with{" "}
             <code>POST /v1/routing/preferences/rank</code>. Score a batch of
             prompts from 0 (bad) to 1 (great) per candidate; two good answers is

--- a/web/src/features/routing/RoutingPage.tsx
+++ b/web/src/features/routing/RoutingPage.tsx
@@ -316,7 +316,7 @@ function ScopePicker({
     <div className="flex flex-col gap-3">
       <div>
         <span className="text-sm font-medium text-foreground">Applies to</span>
-        <p className="text-xs text-muted">
+        <p className="text-caption">
           A global policy resolves for every caller. A user-scoped one resolves
           only for that user, and takes precedence over a global policy of the
           same name.
@@ -381,9 +381,7 @@ function ModeToggle({
           </button>
         ))}
       </div>
-      {hint === undefined ? null : (
-        <span className="text-xs text-muted">{hint}</span>
-      )}
+      {hint === undefined ? null : <span className="text-caption">{hint}</span>}
     </div>
   )
 }
@@ -648,7 +646,7 @@ function PolicyForm({
                   Alias name
                 </span>
                 <code className="text-sm text-muted">{previousName}</code>
-                <span className="text-xs text-muted">
+                <span className="text-caption">
                   An alias name is its key and cannot be changed here. Delete
                   and recreate to change it.
                 </span>
@@ -697,7 +695,7 @@ function PolicyForm({
                     <code>{effectiveTarget}</code>
                   )}
                 </span>
-                <span className="text-xs text-muted">
+                <span className="text-caption">
                   {weighted
                     ? "The split picks per request, so this policy has no single target. The model marked below is what serves a caller who opts out."
                     : "A router picks per request, so this policy has no single target. The model marked below is what serves when the router does not choose."}
@@ -715,7 +713,7 @@ function PolicyForm({
           </div>
 
           {editing ? (
-            <p className="text-xs text-muted">
+            <p className="text-caption">
               Who this applies to is the other half of the key. It cannot be
               changed here: delete and recreate to move it between scopes.
             </p>
@@ -730,7 +728,7 @@ function PolicyForm({
                 <span className="text-sm font-medium text-foreground">
                   Instead, when the budget fills up
                 </span>
-                <p className="text-xs text-muted">
+                <p className="text-caption">
                   Checked before the model above. A threshold must be under 100:
                   the budget gate refuses a request before selection once the
                   cap is reached, so a rule at 100 could never fire.
@@ -796,7 +794,7 @@ function PolicyForm({
                     ? "Split traffic between"
                     : "The router chooses between"}
                 </span>
-                <p className="text-xs text-muted">
+                <p className="text-caption">
                   {weighted
                     ? "Each request goes to one of these, drawn in proportion to its share. Shares are relative, so 70 and 30 mean the same as 7 and 3. No pricing needed."
                     : "For each request, the cheapest of these that past scoring says is good enough. Every model here needs pricing, because the router weighs quality against cost."}
@@ -869,7 +867,7 @@ function PolicyForm({
                   </Button>
                 </div>
               ))}
-              <p className="text-xs text-muted">
+              <p className="text-caption">
                 {weighted ? (
                   <>
                     The marked model serves a caller who sends{" "}
@@ -933,7 +931,7 @@ function PolicyForm({
                   + Another model
                 </button>
                 {atCandidateCap ? (
-                  <span className="text-xs text-muted">
+                  <span className="text-caption">
                     A policy dispatches at most {MAX_CANDIDATES} models,
                     counting the fallback chain. Remove a fallback to add
                     another.
@@ -950,7 +948,7 @@ function PolicyForm({
                 <span className="text-sm font-medium text-foreground">
                   If that fails, try
                 </span>
-                <p className="text-xs text-muted">
+                <p className="text-caption">
                   Tried in order after a retryable failure. Not tried once
                   tokens have started streaming, or after a 400/401/403, which
                   every provider would reject the same way.
@@ -994,7 +992,7 @@ function PolicyForm({
                   + Another fallback
                 </button>
                 {atCandidateCap ? (
-                  <span className="text-xs text-muted">
+                  <span className="text-caption">
                     A policy dispatches at most {MAX_CANDIDATES} models in
                     total.
                   </span>
@@ -1010,7 +1008,7 @@ function PolicyForm({
                 <span className="text-sm font-medium text-foreground">
                   Always check
                 </span>
-                <p className="text-xs text-muted">
+                <p className="text-caption">
                   Runs on every request through this policy. Callers can add
                   their own guardrails but cannot weaken these.
                 </p>
@@ -1175,10 +1173,7 @@ function PolicyForm({
                   + Add guardrails
                 </button>
                 {guardrails_.configured ? null : (
-                  <span
-                    id="guardrails-unavailable"
-                    className="text-xs text-muted"
-                  >
+                  <span id="guardrails-unavailable" className="text-caption">
                     No guardrails service is configured, so there would be
                     nothing to call.{" "}
                     <Link to="/tools" className="text-accent hover:underline">
@@ -1202,11 +1197,11 @@ function PolicyForm({
             <Button variant="ghost" onPress={onClose}>
               Cancel
             </Button>
-            <span className="text-xs text-muted">
+            <span className="text-caption">
               In effect for new requests within 30s.
             </span>
             {routed && !weighted ? (
-              <span className="text-xs text-muted">
+              <span className="text-caption">
                 A new router serves the model above until it has scored
                 examples. Recording them is an API job for now (
                 <code>POST /v1/routing/preferences/rank</code>); open{" "}
@@ -1214,7 +1209,7 @@ function PolicyForm({
               </span>
             ) : null}
             {weighted ? (
-              <span className="text-xs text-muted">
+              <span className="text-caption">
                 Each request is drawn independently, so the shares hold over
                 traffic rather than over any ten requests, and they behave the
                 same behind any number of replicas.
@@ -1433,7 +1428,7 @@ export function RoutingPage() {
         return policy.source === "config" ? (
           <div className="flex items-center justify-end gap-2">
             {readiness}
-            <span className="text-xs text-muted">set in config.yml</span>
+            <span className="text-caption">set in config.yml</span>
           </div>
         ) : (
           <div className="flex items-center justify-end gap-2">
@@ -1454,7 +1449,7 @@ export function RoutingPage() {
                 Edit
               </Button>
             ) : (
-              <span className="text-xs text-muted">
+              <span className="text-caption">
                 Uses options this form cannot show yet. Edit it through the API
                 so nothing is lost.
               </span>

--- a/web/src/features/routing/RoutingPage.tsx
+++ b/web/src/features/routing/RoutingPage.tsx
@@ -304,8 +304,8 @@ function ScopePicker({
       onClick={() => onChange(value ? "" : null)}
       className={
         scoped === value
-          ? "rounded-md bg-surface px-3 py-1.5 text-sm font-medium text-foreground shadow-sm"
-          : "rounded-md px-3 py-1.5 text-sm text-muted hover:text-foreground"
+          ? "rounded-md bg-surface px-3 py-1.5 text-body shadow-sm"
+          : "rounded-md px-3 py-1.5 text-body text-muted hover:text-foreground"
       }
     >
       {label}
@@ -315,7 +315,7 @@ function ScopePicker({
   return (
     <div className="flex flex-col gap-3">
       <div>
-        <span className="text-sm font-medium text-foreground">Applies to</span>
+        <span className="text-body">Applies to</span>
         <p className="text-caption">
           A global policy resolves for every caller. A user-scoped one resolves
           only for that user, and takes precedence over a global policy of the
@@ -363,7 +363,7 @@ function ModeToggle({
 }) {
   return (
     <div className="flex flex-col gap-1">
-      <span className="text-sm font-medium text-foreground">{label}</span>
+      <span className="text-body">{label}</span>
       <div className="flex w-fit items-center gap-1 rounded-lg bg-surface-alt p-1">
         {MODE_VALUES.map((mode) => (
           <button
@@ -373,8 +373,8 @@ function ModeToggle({
             onClick={() => onChange(mode)}
             className={
               value === mode
-                ? "rounded-md bg-surface px-3 py-1 text-sm font-medium text-foreground shadow-sm"
-                : "rounded-md px-3 py-1 text-sm text-muted hover:text-foreground"
+                ? "rounded-md bg-surface px-3 py-1 text-body shadow-sm"
+                : "rounded-md px-3 py-1 text-body text-muted hover:text-foreground"
             }
           >
             {mode}
@@ -642,9 +642,7 @@ function PolicyForm({
           <div className="grid gap-4 sm:grid-cols-2">
             {editingAlias ? (
               <div className="flex flex-col gap-1">
-                <span className="text-sm font-medium text-foreground">
-                  Alias name
-                </span>
+                <span className="text-body">Alias name</span>
                 <code className="text-sm text-muted">{previousName}</code>
                 <span className="text-caption">
                   An alias name is its key and cannot be changed here. Delete
@@ -683,10 +681,8 @@ function PolicyForm({
             )}
             {routed ? (
               <div className="flex flex-col gap-1">
-                <span className="text-sm font-medium text-foreground">
-                  Serves
-                </span>
-                <span className="text-sm text-foreground">
+                <span className="text-body">Serves</span>
+                <span className="text-body">
                   {effectiveTarget.trim() === "" ? (
                     <span className="text-muted">
                       whichever model you mark below
@@ -725,7 +721,7 @@ function PolicyForm({
           {conditions.length > 0 ? (
             <div className="flex flex-col gap-3 rounded-lg border border-border p-3">
               <div>
-                <span className="text-sm font-medium text-foreground">
+                <span className="text-body">
                   Instead, when the budget fills up
                 </span>
                 <p className="text-caption">
@@ -789,7 +785,7 @@ function PolicyForm({
           {candidates.length > 0 ? (
             <div className="flex flex-col gap-3 rounded-lg border border-border p-3">
               <div>
-                <span className="text-sm font-medium text-foreground">
+                <span className="text-body">
                   {weighted
                     ? "Split traffic between"
                     : "The router chooses between"}
@@ -945,9 +941,7 @@ function PolicyForm({
           {chain.length > 0 ? (
             <div className="flex flex-col gap-3 rounded-lg border border-border p-3">
               <div>
-                <span className="text-sm font-medium text-foreground">
-                  If that fails, try
-                </span>
+                <span className="text-body">If that fails, try</span>
                 <p className="text-caption">
                   Tried in order after a retryable failure. Not tried once
                   tokens have started streaming, or after a 400/401/403, which
@@ -1005,9 +999,7 @@ function PolicyForm({
           {guardrails.length > 0 ? (
             <div className="flex flex-col gap-3 rounded-lg border border-border p-3">
               <div>
-                <span className="text-sm font-medium text-foreground">
-                  Always check
-                </span>
+                <span className="text-body">Always check</span>
                 <p className="text-caption">
                   Runs on every request through this policy. Callers can add
                   their own guardrails but cannot weaken these.
@@ -1334,9 +1326,7 @@ export function RoutingPage() {
         header: "Serves",
         cell: (policy) => (
           <div className="flex items-center gap-2">
-            <span className="text-sm text-foreground">
-              {servesSummary(policy)}
-            </span>
+            <span className="text-body">{servesSummary(policy)}</span>
             {candidatesOf(policy.spec).length > 0 ? (
               <Chip size="sm" color="accent">
                 {routerLabelOf(policy.spec)}
@@ -1357,7 +1347,7 @@ export function RoutingPage() {
           if (guardrails.length === 0)
             return <span className="text-muted">–</span>
           return (
-            <span className="text-sm text-foreground">
+            <span className="text-body">
               {guardrails
                 .map((guardrail) => `${guardrail.profile} (${guardrail.mode})`)
                 .join(", ")}

--- a/web/src/features/settings/MailDeliveryCard.tsx
+++ b/web/src/features/settings/MailDeliveryCard.tsx
@@ -92,9 +92,7 @@ export function MailDeliveryCard() {
 
           <div className="flex flex-col gap-4 py-4">
             <div className="min-w-0">
-              <p className="text-sm font-medium text-foreground">
-                Send a test email
-              </p>
+              <p className="text-body">Send a test email</p>
               <p className="mt-1 max-w-3xl text-sm text-muted">
                 {loading
                   ? "Checking whether this deployment can send mail…"

--- a/web/src/features/settings/MaintenanceModeCard.tsx
+++ b/web/src/features/settings/MaintenanceModeCard.tsx
@@ -37,9 +37,7 @@ export function MaintenanceModeCard() {
             {data ? (
               <div className="flex flex-wrap items-start justify-between gap-4">
                 <div className="min-w-0">
-                  <p className="text-sm font-medium text-foreground">
-                    Freeze new dashboard sign-ins
-                  </p>
+                  <p className="text-body">Freeze new dashboard sign-ins</p>
                   <p className="mt-1 max-w-3xl text-sm text-muted">
                     {enabled
                       ? "Nobody can start a new dashboard session. Sessions already open keep working, and the API and management endpoints still answer the master key, so you can turn this back off from here or with your key."

--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -195,7 +195,7 @@ function SettingControl({
         <span className="text-sm tabular-nums text-foreground">
           {formatValue(field)}
         </span>
-        <span className="rounded-full border border-border px-2 py-0.5 text-xs text-muted">
+        <span className="rounded-full border border-border px-2 py-0.5 text-caption">
           startup-only
         </span>
       </div>
@@ -303,7 +303,7 @@ function CopyField({
   return (
     <div className="flex flex-col gap-1">
       <div className="flex items-center justify-between">
-        <span className="text-xs font-medium text-muted">New master key</span>
+        <span className="text-caption">New master key</span>
         <Button size="sm" variant="outline" onPress={copy}>
           {copied ? "Copied" : "Copy"}
         </Button>
@@ -324,7 +324,7 @@ function CopyField({
         {copied ? "Copied to clipboard." : ""}
       </span>
       {selectHint ? (
-        <span className="text-xs text-muted">
+        <span className="text-caption">
           Selected. Press Ctrl/Cmd-C to copy.
         </span>
       ) : null}
@@ -665,7 +665,7 @@ export function SettingsPage() {
       </div>
 
       {data ? (
-        <p className="text-xs text-muted">
+        <p className="text-caption">
           Showing {filtered.length} of {allFields.length} settings
         </p>
       ) : null}
@@ -708,7 +708,7 @@ export function SettingsPage() {
       <MaintenanceModeCard />
 
       {data ? (
-        <p className="text-xs text-muted">
+        <p className="text-caption">
           Mode: {data.mode} · Version {data.version}
           {data.require_pricing ? " · require_pricing on" : ""}
         </p>

--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -192,9 +192,7 @@ function SettingControl({
   if (!field.settable) {
     return (
       <div className="flex items-center gap-2">
-        <span className="text-sm tabular-nums text-foreground">
-          {formatValue(field)}
-        </span>
+        <span className="text-body tabular-nums">{formatValue(field)}</span>
         <span className="rounded-full border border-border px-2 py-0.5 text-caption">
           startup-only
         </span>
@@ -259,7 +257,7 @@ function ConfigRow({
   return (
     <div className="flex items-start justify-between gap-6 py-4">
       <div className="min-w-0">
-        <code className="text-sm font-medium text-foreground">{field.key}</code>
+        <code className="font-mono text-body">{field.key}</code>
         {field.description ? (
           <p className="mt-1 text-sm text-muted">{field.description}</p>
         ) : null}
@@ -457,9 +455,7 @@ function MasterKeyRow({ source }: { source: "configured" | "generated" }) {
     <div className="flex flex-col gap-4 py-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
-          <code className="text-sm font-medium text-foreground">
-            master_key
-          </code>
+          <code className="font-mono text-body">master_key</code>
           <p className="mt-1 max-w-3xl text-sm text-muted">
             {isGenerated
               ? "This gateway uses its first-run generated dashboard key. Regeneration invalidates the current key immediately."
@@ -507,9 +503,7 @@ function SecretKeyRow() {
     <div className="flex flex-col gap-4 py-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
-          <code className="text-sm font-medium text-foreground">
-            OTARI_SECRET_KEY
-          </code>
+          <code className="font-mono text-body">OTARI_SECRET_KEY</code>
           <p className="mt-1 max-w-3xl text-sm text-muted">
             Generate a new key with <code>uv run otari gen-secret-key</code>,
             then restart with{" "}
@@ -657,7 +651,7 @@ export function SettingsPage() {
           onKeyDown={(event) => {
             if (event.key === "Escape") setSearch("")
           }}
-          className="min-w-0 flex-1 rounded-lg border border-border bg-surface-alt px-3 py-2 text-sm text-foreground focus:border-accent focus:outline-none"
+          className="min-w-0 flex-1 rounded-lg border border-border bg-surface-alt px-3 py-2 text-body focus:border-accent focus:outline-none"
         />
         <Checkbox isSelected={settableOnly} onChange={setSettableOnly}>
           Settable only

--- a/web/src/features/tools/McpServerDialog.tsx
+++ b/web/src/features/tools/McpServerDialog.tsx
@@ -236,7 +236,7 @@ export function McpServerDialog({
                   <Checkbox isSelected={enabled} onChange={setEnabled}>
                     Enabled
                   </Checkbox>
-                  <span className="text-xs text-muted">
+                  <span className="text-caption">
                     A disabled server keeps its row and its token. A request
                     that names it skips it rather than failing.
                   </span>

--- a/web/src/features/tools/OrganizationGuardrailsCard.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.tsx
@@ -108,7 +108,7 @@ function WorkspaceScope({
             </Checkbox>
           ))}
           {workspaces.length === 0 ? (
-            <span className="text-xs text-muted">
+            <span className="text-caption">
               No workspaces to choose from yet.
             </span>
           ) : null}
@@ -425,7 +425,7 @@ function AddGuardrailForm({
           {create.isPending ? "Adding…" : "Add"}
         </Button>
       </div>
-      <span className="text-xs text-muted">
+      <span className="text-caption">
         The profile has to exist on the guardrails service. A caller can tighten
         a mandated guardrail but never weaken it. A credential needs an https
         endpoint of its own, since the URL above may be a plain-http sidecar,

--- a/web/src/features/tools/OrganizationGuardrailsCard.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.tsx
@@ -212,9 +212,7 @@ function GuardrailRow({
   return (
     <div className="flex flex-col gap-2 py-4">
       <div className="flex flex-wrap items-center gap-2">
-        <code className="text-sm font-medium text-foreground">
-          {guardrail.profile}
-        </code>
+        <code className="font-mono text-body">{guardrail.profile}</code>
         <Badge tone="muted">{scopeLabel(guardrail, workspaces)}</Badge>
         {guardrail.url ? <Badge tone="muted">own endpoint</Badge> : null}
         {guardrail.has_credential ? (
@@ -359,9 +357,7 @@ function AddGuardrailForm({
 
   return (
     <div className="flex flex-col gap-2 py-4">
-      <span className="text-sm font-medium text-foreground">
-        Mandate a guardrail
-      </span>
+      <span className="text-body">Mandate a guardrail</span>
       <div className="flex flex-wrap items-end gap-2">
         <input
           type="text"

--- a/web/src/features/tools/SearchToolsCard.tsx
+++ b/web/src/features/tools/SearchToolsCard.tsx
@@ -161,7 +161,7 @@ function ConfigToolRow({ tool }: { tool: ConfigSearchTool }) {
       {tool.shadowed ? (
         <Badge tone="warn">Overridden by the stored tool of this name</Badge>
       ) : null}
-      <span className="text-xs text-muted">
+      <span className="text-caption">
         {tool.api_base ?? "no api_base declared"} · editable only where the
         config file is defined
       </span>
@@ -280,7 +280,7 @@ function AddToolForm({
           {create.isPending ? "Adding…" : "Add"}
         </Button>
       </div>
-      <span className="text-xs text-muted">
+      <span className="text-caption">
         Callers name the tool in{" "}
         <code className="font-mono">search_tool_name</code>, or in the{" "}
         <code className="font-mono">POST /v1/search/{"{tool}"}</code> path.

--- a/web/src/features/tools/SearchToolsCard.tsx
+++ b/web/src/features/tools/SearchToolsCard.tsx
@@ -88,7 +88,7 @@ function StoredToolRow({
   return (
     <div className="flex flex-col gap-2 py-4">
       <div className="flex flex-wrap items-center gap-2">
-        <code className="text-sm font-medium text-foreground">{tool.name}</code>
+        <code className="font-mono text-body">{tool.name}</code>
         <Badge tone="muted">{tool.provider}</Badge>
         {tool.last4 ? (
           <Badge tone="muted">{`key ····${tool.last4}`}</Badge>
@@ -154,7 +154,7 @@ function StoredToolRow({
 function ConfigToolRow({ tool }: { tool: ConfigSearchTool }) {
   return (
     <div className="flex flex-wrap items-center gap-2 py-4">
-      <code className="text-sm font-medium text-foreground">{tool.name}</code>
+      <code className="font-mono text-body">{tool.name}</code>
       <Badge tone="muted">{tool.provider}</Badge>
       <Badge tone="muted">Config file</Badge>
       {tool.has_api_key ? <Badge tone="muted">key set</Badge> : null}
@@ -220,9 +220,7 @@ function AddToolForm({
 
   return (
     <div className="flex flex-col gap-2 py-4">
-      <span className="text-sm font-medium text-foreground">
-        Add a search tool
-      </span>
+      <span className="text-body">Add a search tool</span>
       <div className="flex flex-wrap items-end gap-2">
         <input
           type="text"

--- a/web/src/features/tools/ToolsGuardrailsPage.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.tsx
@@ -164,7 +164,7 @@ function FieldLabel({
       {field.description ? (
         <p className="mt-1 text-sm text-muted">{field.description}</p>
       ) : null}
-      {help ? <p className="mt-1 text-xs text-muted">{help}</p> : null}
+      {help ? <p className="mt-1 text-caption">{help}</p> : null}
     </div>
   )
 }
@@ -428,7 +428,7 @@ function ToolPriceRow({
         <span className="text-sm font-medium text-foreground">
           Price per call
         </span>
-        <span className="text-xs text-muted">
+        <span className="text-caption">
           {configured === null ? (
             <>
               Not priced. Calls are recorded but billed nothing, and with{" "}
@@ -445,7 +445,7 @@ function ToolPriceRow({
         </span>
       </div>
       <div className="flex items-center gap-1.5 sm:col-start-2 sm:justify-self-end">
-        <span className="text-xs text-muted">USD</span>
+        <span className="text-caption">USD</span>
         <input
           type="number"
           min="0"

--- a/web/src/features/tools/ToolsGuardrailsPage.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.tsx
@@ -160,7 +160,7 @@ function FieldLabel({
 }) {
   return (
     <div className="min-w-0 sm:col-start-1">
-      <code className="text-sm font-medium text-foreground">{field.key}</code>
+      <code className="font-mono text-body">{field.key}</code>
       {field.description ? (
         <p className="mt-1 text-sm text-muted">{field.description}</p>
       ) : null}
@@ -425,9 +425,7 @@ function ToolPriceRow({
   return (
     <div className={ROW_CLASS}>
       <div className="flex flex-col gap-0.5">
-        <span className="text-sm font-medium text-foreground">
-          Price per call
-        </span>
+        <span className="text-body">Price per call</span>
         <span className="text-caption">
           {configured === null ? (
             <>
@@ -537,7 +535,7 @@ function HowToCallCard({ tool }: { tool: ManagedTool }) {
   return (
     <div className="flex flex-col gap-3 py-4">
       <div className="flex flex-wrap items-center gap-2">
-        <code className="text-sm font-medium text-foreground">{tool.id}</code>
+        <code className="font-mono text-body">{tool.id}</code>
         {tool.available ? null : (
           <span className="rounded-full border border-warning bg-warning-subtle px-2 py-0.5 text-xs font-medium text-warning">
             No backend configured

--- a/web/src/features/tools/WorkspaceCodeExecutionPolicyCard.tsx
+++ b/web/src/features/tools/WorkspaceCodeExecutionPolicyCard.tsx
@@ -322,14 +322,14 @@ export function WorkspaceCodeExecutionPolicyCard({
                   operator to restore it.
                 </p>
               ) : (
-                <p className="text-xs text-muted">
+                <p className="text-caption">
                   The image this workspace's code runs in, from the list the
                   operator has approved.
                 </p>
               )}
             </div>
           ) : (
-            <p className="text-xs text-muted">
+            <p className="text-caption">
               This deployment has approved no sandbox images, so this workspace
               runs whatever the sandbox runs. An operator adds them with
               sandbox_allowed_session_images.
@@ -338,10 +338,8 @@ export function WorkspaceCodeExecutionPolicyCard({
 
           {availableTools.length > 1 || staleTools.length > 0 ? (
             <fieldset className="flex flex-col gap-2">
-              <legend className="text-xs font-medium text-muted">
-                Code-execution tools
-              </legend>
-              <p className="text-xs text-muted">
+              <legend className="text-caption">Code-execution tools</legend>
+              <p className="text-caption">
                 Which of the tools this deployment's sandbox serves the
                 workspace may use. Leaving them all ticked narrows nothing; use
                 Blocked above to refuse code execution outright.
@@ -373,7 +371,7 @@ export function WorkspaceCodeExecutionPolicyCard({
             // control that cannot express anything is worse than a sentence
             // saying so. The checkboxes appear on their own the day a backend
             // serves a second kind.
-            <p className="text-xs text-muted">
+            <p className="text-caption">
               This deployment's sandbox serves{" "}
               {availableTools.length === 1 ? availableTools[0] : "no tools"}, so
               there is no tool subset to choose. Use Blocked above to refuse

--- a/web/src/features/usage/ShareDialog.tsx
+++ b/web/src/features/usage/ShareDialog.tsx
@@ -260,7 +260,7 @@ export function ShareDialog(props: ShareDialogProps) {
               </AlertDialog.Heading>
             </AlertDialog.Header>
             <AlertDialog.Body className="flex max-h-[70vh] flex-col gap-4 overflow-y-auto">
-              <p className="text-xs text-muted">
+              <p className="text-caption">
                 The card shows the window and filters currently applied above.
                 Change them on the page to change what it says.
               </p>
@@ -284,7 +284,7 @@ export function ShareDialog(props: ShareDialogProps) {
                       className="h-auto w-full rounded-md border border-border"
                     />
                   ) : (
-                    <div className="flex aspect-square w-full items-center justify-center rounded-md border border-dashed border-border text-xs text-muted">
+                    <div className="flex aspect-square w-full items-center justify-center rounded-md border border-dashed border-border text-caption">
                       Rendering preview…
                     </div>
                   )}
@@ -469,7 +469,7 @@ function Field({
 }) {
   return (
     <div className="flex flex-col gap-1">
-      <span className="text-xs font-medium text-muted">{label}</span>
+      <span className="text-caption">{label}</span>
       {children}
     </div>
   )

--- a/web/src/features/usage/UsagePage.tsx
+++ b/web/src/features/usage/UsagePage.tsx
@@ -1016,7 +1016,7 @@ export function UsagePage() {
         ))}
         end={
           <>
-            <span className="text-xs text-muted">
+            <span className="text-caption">
               Showing {formatWindowLabel(effectiveStart, effectiveEnd)} · UTC
             </span>
             <RefreshButton
@@ -1256,7 +1256,7 @@ export function UsagePage() {
                     area is TrendChart's drag-to-zoom target and a button there
                     would swallow the drag. Only rendered inside this branch, so a
                     range with no data offers no share affordance at all. */}
-                <figcaption className="flex items-start justify-between gap-3 text-xs text-muted">
+                <figcaption className="flex items-start justify-between gap-3 text-caption">
                   <span>
                     {formatValue(peak)} peak · {chart.data.length}{" "}
                     {bucket === "hour" ? "hours" : "days"} (times in UTC) · drag
@@ -1399,7 +1399,7 @@ export function UsagePage() {
             <div className="rounded-2xl border border-border bg-surface p-4">
               <div className="mb-3 flex flex-col gap-1">
                 <h2 className="text-title">Gateway-run tools</h2>
-                <p className="text-xs text-muted">
+                <p className="text-caption">
                   Tools Otari ran itself, billed per call. MCP tools are not
                   listed here: their names come from your own server, so they
                   appear on each request instead.

--- a/web/src/features/users/UserComboBox.tsx
+++ b/web/src/features/users/UserComboBox.tsx
@@ -152,7 +152,7 @@ export function UserComboBox({
           )}
         </ListBox>
       </ComboBox.Popover>
-      <Description className="text-xs text-muted">{creatingHint}</Description>
+      <Description className="text-caption">{creatingHint}</Description>
     </ComboBox.Root>
   )
 }

--- a/web/src/features/users/UserComboBox.tsx
+++ b/web/src/features/users/UserComboBox.tsx
@@ -130,7 +130,7 @@ export function UserComboBox({
       // reach instead of stretching across a wide form.
       className="flex max-w-md flex-col gap-1"
     >
-      <Label className="text-sm font-medium text-foreground">{label}</Label>
+      <Label className="text-body">{label}</Label>
       <ComboBox.InputGroup>
         {/* Not a credential field: keep password managers out, and select on focus
             so typing replaces the current value rather than appending. */}

--- a/web/src/features/users/UserMultiSelect.tsx
+++ b/web/src/features/users/UserMultiSelect.tsx
@@ -81,9 +81,7 @@ export function UserMultiSelect({
     <div className="flex flex-col gap-2">
       <div>
         <span className="text-sm font-medium text-foreground">{label}</span>
-        {description ? (
-          <p className="text-xs text-muted">{description}</p>
-        ) : null}
+        {description ? <p className="text-caption">{description}</p> : null}
       </div>
       {value.length > 0 ? (
         <div className="flex flex-wrap gap-1.5">
@@ -106,7 +104,7 @@ export function UserMultiSelect({
         </div>
       ) : null}
       {options.length === 0 ? (
-        <span className="text-xs text-muted">
+        <span className="text-caption">
           Nobody to assign yet. Add people under Members &amp; roles, or issue a
           key, and they can be assigned here.
         </span>

--- a/web/src/features/users/UserMultiSelect.tsx
+++ b/web/src/features/users/UserMultiSelect.tsx
@@ -80,7 +80,7 @@ export function UserMultiSelect({
   return (
     <div className="flex flex-col gap-2">
       <div>
-        <span className="text-sm font-medium text-foreground">{label}</span>
+        <span className="text-body">{label}</span>
         {description ? <p className="text-caption">{description}</p> : null}
       </div>
       {value.length > 0 ? (

--- a/web/src/features/workspaces/WorkspaceMembersPanel.tsx
+++ b/web/src/features/workspaces/WorkspaceMembersPanel.tsx
@@ -162,7 +162,7 @@ export function WorkspaceMembersPanel({
               key={member.id}
               className="flex flex-wrap items-center gap-3 rounded-lg border border-border bg-surface-alt px-3 py-2"
             >
-              <span className="text-sm text-foreground">
+              <span className="text-body">
                 {nameByUserId.get(member.user_id) ??
                   `Identity ${member.user_id.slice(0, 8)}`}
               </span>

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -134,7 +134,7 @@ function NarrowedDefaults({
         }
       />
       {narrowed.length === 0 ? (
-        <span className="text-xs text-muted">
+        <span className="text-caption">
           None. The budget above applies on every provider.
         </span>
       ) : (
@@ -569,7 +569,7 @@ function EditWorkspaceForm({
               value={selectedBudget}
               onChange={setBudgetId}
             />
-            <span className="max-w-md text-xs text-muted">
+            <span className="max-w-md text-caption">
               Every member of this workspace is held to this budget, each with
               their own allowance. Changing it applies to members who join
               afterwards; members already here keep the budget they were given,
@@ -686,9 +686,7 @@ export function WorkspacesPage() {
               {workspace.name}
             </span>
             {workspace.description ? (
-              <span className="text-xs text-muted">
-                {workspace.description}
-              </span>
+              <span className="text-caption">{workspace.description}</span>
             ) : null}
           </div>
         ),
@@ -708,7 +706,7 @@ export function WorkspacesPage() {
           return name ? (
             <Chip size="sm">{name}</Chip>
           ) : (
-            <span className="text-xs text-muted">None</span>
+            <span className="text-caption">None</span>
           )
         },
       },

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -125,9 +125,7 @@ function NarrowedDefaults({
 
   return (
     <div className="flex flex-col gap-2">
-      <span className="text-sm font-medium text-foreground">
-        Per-provider defaults
-      </span>
+      <span className="text-body">Per-provider defaults</span>
       <ErrorBanner
         error={
           createDefault.error ?? updateDefault.error ?? deleteDefault.error
@@ -682,9 +680,7 @@ export function WorkspacesPage() {
         isRowHeader: true,
         cell: (workspace) => (
           <div className="flex flex-col gap-0.5">
-            <span className="text-sm font-medium text-foreground">
-              {workspace.name}
-            </span>
+            <span className="text-body">{workspace.name}</span>
             {workspace.description ? (
               <span className="text-caption">{workspace.description}</span>
             ) : null}

--- a/web/src/shared/components/Field.tsx
+++ b/web/src/shared/components/Field.tsx
@@ -44,7 +44,7 @@ export function Field({
       {description ? (
         // HeroUI's Description renders through the TextField's "description" slot,
         // so it is wired to the input via aria-describedby (a raw span is not).
-        <Description className="text-xs text-muted">{description}</Description>
+        <Description className="text-caption">{description}</Description>
       ) : null}
       {/* Same reasoning one step further: `FieldError` renders through the
           field's error slot, so the message is announced *on* the input rather

--- a/web/src/shared/components/Field.tsx
+++ b/web/src/shared/components/Field.tsx
@@ -39,7 +39,7 @@ export function Field({
     >
       {/* No manual "*": HeroUI marks a required field's label through CSS
           ([data-required=true] > .label::after), so adding one renders two. */}
-      <Label className="text-sm font-medium text-foreground">{label}</Label>
+      <Label className="text-body">{label}</Label>
       <Input type={type} placeholder={placeholder} autoFocus={autoFocus} />
       {description ? (
         // HeroUI's Description renders through the TextField's "description" slot,

--- a/web/src/shared/components/MissingGatewayAddressNotice.tsx
+++ b/web/src/shared/components/MissingGatewayAddressNotice.tsx
@@ -9,7 +9,7 @@
 // them rather than in either feature.
 export function MissingGatewayAddressNotice() {
   return (
-    <p className="text-xs text-muted">
+    <p className="text-caption">
       This deployment has not published the gateway address to send requests to,
       so there is no example to show here. Ask whoever runs it for the base URL,
       then call <code>/v1/chat/completions</code> with this key in an{" "}

--- a/web/src/shared/components/SecretField.tsx
+++ b/web/src/shared/components/SecretField.tsx
@@ -30,7 +30,7 @@ export function SecretField({
       onChange={onChange}
       className="flex max-w-md flex-col gap-1"
     >
-      <Label className="text-sm font-medium text-foreground">{label}</Label>
+      <Label className="text-body">{label}</Label>
       <Input
         type="password"
         placeholder={placeholder ?? "sk-…"}

--- a/web/src/shared/components/SecretField.tsx
+++ b/web/src/shared/components/SecretField.tsx
@@ -42,7 +42,7 @@ export function SecretField({
         data-lpignore="true"
       />
       {description ? (
-        <Description className="text-xs text-muted">{description}</Description>
+        <Description className="text-caption">{description}</Description>
       ) : null}
     </TextField>
   )

--- a/web/src/shared/components/TablePagination.tsx
+++ b/web/src/shared/components/TablePagination.tsx
@@ -151,7 +151,7 @@ export function TablePagination({
                 }
               }}
               onBlur={commitPage}
-              className="w-12 rounded-lg border border-border bg-surface-alt px-2 py-1 text-center text-sm text-foreground tabular-nums focus:border-accent focus:outline-none"
+              className="w-12 rounded-lg border border-border bg-surface-alt px-2 py-1 text-center text-body tabular-nums focus:border-accent focus:outline-none"
             />
             {pageCount != null ? (
               <span className="tabular-nums">

--- a/web/src/shared/components/charts.tsx
+++ b/web/src/shared/components/charts.tsx
@@ -137,10 +137,7 @@ export function ChartLegend({ series }: { series: SeriesDef[] }) {
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
       {series.map((s) => (
-        <span
-          key={s.key}
-          className="flex items-center gap-1.5 text-xs text-muted"
-        >
+        <span key={s.key} className="flex items-center gap-1.5 text-caption">
           <SeriesMarker color={s.color} />
           {s.label}
         </span>

--- a/web/src/shared/components/ui.tsx
+++ b/web/src/shared/components/ui.tsx
@@ -251,7 +251,7 @@ export function StatCard({
           misalignment visible; a tile with no chart and nothing to say reserves
           nothing, so a lone tile carries no dead space. */}
       {trend || hint || chart ? (
-        <span className="flex min-h-10.5 flex-wrap items-center gap-x-2 gap-y-1 text-xs tabular-nums text-muted">
+        <span className="flex min-h-10.5 flex-wrap items-center gap-x-2 gap-y-1 text-caption tabular-nums">
           {trend}
           {/* Its own element, not a bare text node beside the chip: the two
               are separate statements, and a node keeps the hint addressable
@@ -413,7 +413,7 @@ export function RefreshButton({
   return (
     <span className="inline-flex items-center gap-2">
       {freshness ? (
-        <span className="text-xs text-muted">Updated {freshness}</span>
+        <span className="text-caption">Updated {freshness}</span>
       ) : null}
       <Button
         variant="outline"
@@ -561,7 +561,7 @@ export function CopyField({
   return (
     <div className="flex flex-col gap-1">
       <div className="flex items-center justify-between">
-        <label htmlFor={fieldId} className="text-xs font-medium text-muted">
+        <label htmlFor={fieldId} className="text-caption">
           {label}
         </label>
         <Button size="sm" variant="outline" onPress={copy}>
@@ -593,7 +593,7 @@ export function CopyField({
         {copied ? "Copied to clipboard." : ""}
       </span>
       {selectHint ? (
-        <span className="text-xs text-muted">
+        <span className="text-caption">
           Selected. Press Ctrl/Cmd-C to copy.
         </span>
       ) : null}
@@ -905,9 +905,7 @@ export function FilterSelect({
         if (key != null) onChange(optionValue(String(key)))
       }}
     >
-      {label ? (
-        <Label className="text-xs font-medium text-muted">{label}</Label>
-      ) : null}
+      {label ? <Label className="text-caption">{label}</Label> : null}
       <Select.Trigger id={id}>
         <Select.Value />
         <Select.Indicator />
@@ -1014,7 +1012,7 @@ export function FilterMultiComboBox({
       }}
       className="flex flex-col gap-1"
     >
-      <Label className="text-xs font-medium text-muted">{label}</Label>
+      <Label className="text-caption">{label}</Label>
       <ComboBox.InputGroup>
         <Input
           placeholder={

--- a/web/src/shared/components/ui.tsx
+++ b/web/src/shared/components/ui.tsx
@@ -123,7 +123,7 @@ export function Checkbox({
       isSelected={isSelected}
       onChange={onChange}
       isDisabled={isDisabled}
-      className="group flex w-fit items-center gap-2 text-sm text-foreground"
+      className="group flex w-fit items-center gap-2 text-body"
     >
       {({ isSelected: selected, isDisabled: disabled }) => (
         <>

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -567,13 +567,26 @@ describe("content text wears a type role", () => {
     "text-caption",
     "text-overline",
   ] as const
-  const ANY_ROLE = `text-(?:${ROLES.map((role) => role.slice(5)).join("|")})`
+  const ANY_ROLE = `text-(?:${ROLES.map((role) => role.slice("text-".length)).join("|")})`
   // The ink each role sets for itself, and therefore the one a call site wearing
   // it never repeats.
   const ROLE_INK: Array<[string, string]> = [
     ["text-(?:caption|overline)", "text-muted"],
     ["text-(?:display|heading|title|body|emphasis)", "text-foreground"],
   ]
+
+  it("gives every role an ink it must not repeat", () => {
+    // ROLE_INK spells the role names a second time, so one added above and
+    // missed below would go unchecked rather than fail. This is the guard on
+    // that guard.
+    const covered = ROLE_INK.flatMap(([roles]) =>
+      roles
+        .replace(/^text-\(\?:|\)$/g, "")
+        .split("|")
+        .map((name) => `text-${name}`),
+    )
+    expect(covered.sort()).toEqual([...ROLES].sort())
+  })
 
   it.each(ROLES)("declares %s in globals.css", (role) => {
     // Same failure the documented-utilities list guards against: a role named in

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -543,6 +543,109 @@ describe("headings wear a type role", () => {
   })
 })
 
+// The content scale's roles, and the spelling that kept them empty. Before this
+// sweep `text-caption` had one consumer, `text-body`, `text-emphasis` and
+// `text-overline` between them a handful, and 174 sites wrote the caption role
+// out as `text-xs text-muted`: a size a point under the role's own and an ink
+// the role already sets. A scale nobody uses is documentation, so the roles are
+// enforced here the way the chrome's are below.
+//
+// A role sets family, size, line-height, tracking, weight and ink together, and
+// each of those is a utility somebody can write beside it. That pairing is not a
+// style preference: Tailwind emits `@utility` definitions ahead of its own
+// theme-derived utilities, so a `text-xs` beside `text-caption` wins the size
+// and leaves the role compiling, emitting, and doing nothing. `font-mono` is the
+// one pairing deliberately left alone, because a role sets the body face and an
+// identifier does not belong in it.
+describe("content text wears a type role", () => {
+  const ROLES = [
+    "text-display",
+    "text-heading",
+    "text-title",
+    "text-body",
+    "text-emphasis",
+    "text-caption",
+    "text-overline",
+  ] as const
+  const ANY_ROLE = `text-(?:${ROLES.map((role) => role.slice(5)).join("|")})`
+  // The ink each role sets for itself, and therefore the one a call site wearing
+  // it never repeats.
+  const ROLE_INK: Array<[string, string]> = [
+    ["text-(?:caption|overline)", "text-muted"],
+    ["text-(?:display|heading|title|body|emphasis)", "text-foreground"],
+  ]
+
+  it.each(ROLES)("declares %s in globals.css", (role) => {
+    // Same failure the documented-utilities list guards against: a role named in
+    // the scale's comment but never declared is a className that produces no CSS.
+    expect(CSS).toContain(`@utility ${role} {`)
+  })
+
+  /**
+   * Two utilities inside one class list. The span between them may not cross a
+   * quote, so `className={ok ? "text-caption" : "text-xs text-muted"}` reads as
+   * the two lists it is rather than as one. Each name is anchored against a
+   * variant prefix and against a longer name, which leaves `sm:text-xs` and
+   * `hover:text-muted` the deliberate overrides they look like.
+   */
+  const together = (first: string, second: string): RegExp => {
+    const alone = (name: string) => `(?<![:\\w-])(?:${name})(?![\\w-])`
+    return new RegExp(
+      `${alone(first)}[^"'\`\\n]*${alone(second)}|${alone(second)}[^"'\`\\n]*${alone(first)}`,
+    )
+  }
+
+  const SRC = join(WEB, "src")
+  const sources = readdirSync(SRC, { recursive: true })
+    .map((name) => String(name).replaceAll("\\", "/"))
+    .filter((name) => /\.tsx?$/.test(name) && !/\.test\.tsx?$/.test(name))
+  // Block comments go first, for the reason the heading sweep drops them:
+  // `ActivityPage` explains in a JSX comment, in backticks, why a `<th>` on
+  // `text-overline` carries no `text-muted`.
+  const read = (name: string) =>
+    readFileSync(join(SRC, name), "utf8").replace(/\/\*[\s\S]*?\*\//g, "")
+
+  it("covers the source tree", () => {
+    // Same guard as the sweeps above: an empty list passes vacuously.
+    expect(sources.length).toBeGreaterThan(30)
+  })
+
+  it.each(sources)("spells the caption role in %s as text-caption", (name) => {
+    expect(
+      read(name),
+      `${name} hand-rolls the caption role as \`text-xs text-muted\`: 12px where the role is 13, plus the ink it already sets. Use text-caption`,
+    ).not.toMatch(together("text-xs", "text-muted"))
+  })
+
+  it.each(sources)("overrides no type role's own metrics in %s", (name) => {
+    const source = read(name)
+    for (const [what, utility] of [
+      ["a font size", "text-(?:xs|sm|base|lg|xl|2xl)"],
+      [
+        "a font weight",
+        "font-(?:thin|extralight|light|normal|medium|semibold|bold|extrabold|black)",
+      ],
+      ["a line height", String.raw`leading-[\w./%\[\]-]+`],
+      ["a tracking", String.raw`tracking-[\w./%\[\]-]+`],
+    ]) {
+      expect(
+        source,
+        `${name} puts ${what} beside a type role; the role carries its own, and the utility beside it wins with nothing to show for it`,
+      ).not.toMatch(together(ANY_ROLE, utility))
+    }
+  })
+
+  it.each(sources)("repeats no type role's own ink in %s", (name) => {
+    const source = read(name)
+    for (const [role, ink] of ROLE_INK) {
+      expect(
+        source,
+        `${name} pairs a type role with \`${ink}\`, which that role already sets`,
+      ).not.toMatch(together(role, ink))
+    }
+  })
+})
+
 // The chrome's own type roles, added because the nav files had grown six
 // arbitrary sizes between them (13.5px twice, 13px, 11.5px, 11px, 9px), which is
 // a scale with no single place to read it and nothing to keep it from growing a

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -664,13 +664,13 @@ describe("content text wears a type role", () => {
 // a scale with no single place to read it and nothing to keep it from growing a
 // seventh. Both halves are asserted: the roles exist, and the chrome uses them.
 describe("the shell chrome's type roles", () => {
-  const CHROME_ROLES = [
-    "text-chrome-row",
-    "text-chrome-meta",
-    "text-chrome-initials",
+  const SHELL_ROLES = [
+    "text-shell-label",
+    "text-shell-secondary",
+    "text-shell-monogram",
   ]
 
-  it.each(CHROME_ROLES)("declares %s in globals.css", (role) => {
+  it.each(SHELL_ROLES)("declares %s in globals.css", (role) => {
     // The same failure the documented-utilities list guards against: a role
     // named in the scale's comment but never declared is a className that
     // produces no CSS, on text that looks merely unstyled rather than broken.
@@ -695,7 +695,7 @@ describe("no font size is written at a call site", () => {
 
     expect(
       offenders,
-      "use a type role (text-caption, text-overline, …) or a text-chrome-* one, or add one",
+      "use a type role (text-caption, text-overline, …) or a text-shell-* one, or add one",
     ).toEqual([])
   })
 })

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -620,7 +620,7 @@
      `-step` rather than `--text-caption` on purpose: a `--text-*` key generates
      a same-named utility that would outrank `@utility text-caption` in the same
      layer and silently kill the role's own metrics. Nothing consumes this but
-     that role and `text-chrome-row`, so it needs no utility of its own. */
+     that role and `text-shell-label`, so it needs no utility of its own. */
   --text-caption-step: 13px;
   --text-caption-step--line-height: 19px;
   --text-caption-step--letter-spacing: 0.0075em;
@@ -681,9 +681,9 @@
  * size repeated inline in a component is a scale nobody can see the whole of,
  * and these were six arbitrary values across four nav files before.
  *
- *   text-chrome-row      — a row label in the rail, the menu, or the top bar.
- *   text-chrome-meta     — the second line under one of those labels.
- *   text-chrome-initials — initials in an avatar.
+ *   text-shell-label     — a row label in the rail, the menu, or the top bar.
+ *   text-shell-secondary — the second line under one of those labels.
+ *   text-shell-monogram  — the initials in an avatar.
  *
  * These three carry metrics only, no color and no weight: one menu row is
  * `text-foreground` resting and `text-muted` disabled, and an identity line is
@@ -769,17 +769,17 @@
   text-transform: uppercase;
   color: var(--color-text-muted);
 }
-@utility text-chrome-row {
+@utility text-shell-label {
   font-size: var(--text-caption-step);
   line-height: var(--text-caption-step--line-height);
   letter-spacing: var(--text-caption-step--letter-spacing);
 }
-@utility text-chrome-meta {
+@utility text-shell-secondary {
   font-size: var(--text-xs);
   line-height: var(--text-xs--line-height);
   letter-spacing: var(--text-xs--letter-spacing);
 }
-@utility text-chrome-initials {
+@utility text-shell-monogram {
   /* Deliberately off-scale, and the one documented exception. Two letters in a
      26px avatar are recognized, not read, so putting them on the scale would
      either overflow the avatar or drag a real text step down to 9px to suit a


### PR DESCRIPTION
## Description

The base-repo half of mozilla-ai/otari-ai#1939: the type scale had roles nobody
used. `text-caption` had one consumer against 174 sites spelling it `text-xs
text-muted`, and `text-body` had none against 92 spelling it `text-sm font-medium
text-foreground`. Nothing enforced any of it outside `app/nav/`.

- **Caption sweep, 174 sites.** Metadata text moves 12px to 13px, which is the
  point of the role, and drops the `text-muted` the role already sets plus a
  `font-medium` that has resolved to 400 since the weight axis was cut to two
  values.
- **Body sweep, 92 sites.** Only the sites that already stated size, weight and
  ink move; body text that merely inherits from `<body>` stays classless.
- **Enforcement.** Four sweeps in `foundation.test.ts`, shaped like the chrome
  roles' and the heading sweep's: the seven roles are declared, no class list
  spells `text-xs text-muted`, none puts a size, weight, line-height or tracking
  beside a role, and none repeats a role's own ink. Each was watched failing on a
  planted violation before it was trusted green.

The shell's three roles are renamed in the same PR, because the sweep put the
docs in front of them and `chrome` did not survive the reading: it reads as a
metal or as the browser, which is the case `design-tokens.md`'s own "name by
role, not appearance" rule rejects with two metals as its counterexamples, and
`meta` was not parallel to `row`, so nothing in the pair said they are the first
and second line of one row.

| Now | Was |
|---|---|
| `text-shell-label` | `text-chrome-row` |
| `text-shell-secondary` | `text-chrome-meta` |
| `text-shell-monogram` | `text-chrome-initials` |

Same metrics in the same order, and all three still emit ahead of the weight and
ink utilities their call sites rely on, so nothing moves on screen. The 9px
literal and the question of whether a shell role should own its ink the way a
content role does are both on mozilla-ai/otari-ai#1977.

Worth a look in review:

- **`<code>` gains `font-mono`.** A type role sets `font-family`, so an
  identifier on one would come off the mono face onto the body one. Ten sites
  gain it, including `BudgetsPage`'s budget id, which was the caption role's only
  consumer and was already losing the face that way. They move from the browser's
  default monospace to Fira Code, which the type-scale docs already call the face
  for keys, IDs and code.
- **Three lines in the account menu and the workspace switcher** move to
  `text-chrome-meta` rather than `text-caption`. Same 12px step, so it is a
  rename onto the scale the surrounding rows already wear.
- **Two raw `<input>`s** (Settings search, TablePagination) now carry the body
  face rather than the browser's form font.
- **`text-emphasis` gains no consumer.** Every candidate is a `<strong>` in a
  banner or a value in a tooltip that sets its own ink or size, which the role
  would overwrite. Not manufacturing one.
- **Two sites resisted conversion and kept `text-xs`.** `ModelsPage`'s round "i"
  badge is a glyph in a 16px circle, where the extra point overflows; the
  workspace switcher's identity line hand-rolls its leading and tracking and
  belongs to the chrome rather than the content scale, and `text-emphasis` would
  flatten both. The other ~85 remaining `text-xs` sites are pills, tone-coloured
  status text, `<pre>` blocks and links, which are not the caption role.
- **`text-subtle` is not a type role.** `--color-text-subtle` is declared in both
  theme blocks and registered in no `@theme`, so no utility exists and nothing
  but the contrast assertion reads it. Left alone here.

Screenshots: `otari-dashboard.yml`'s `screenshots` job is `workflow_dispatch`
only and no baselines are committed, so nothing to regenerate. Draft #885
(`feat/dashboard-divided-surface`, 80 files) touches most of the same files, so
whoever merges second wants a deliberate rebase.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Base-repo half of mozilla-ai/otari-ai#1939. The overlay half is otari-ai#1973,
which carries the closing keyword and ships alongside this.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Code (Claude Opus 5, 1M context)

**Any additional AI details you'd like to share:**

The sweep was scripted and reviewed site by site; the judgment calls are the
bulleted list above. Every enforcement rule was planted with a violation and
watched go red before it was trusted green.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
