### PR TITLE
feat(dashboard): give a member their organization's roster

### DIFF
--- a/web/e2e/screenshots/authenticated.spec.ts
+++ b/web/e2e/screenshots/authenticated.spec.ts
@@ -20,6 +20,9 @@ const WORKSPACE_ROUTES: ReadonlyArray<{
   { route: "/routing", name: "routing", heading: /routing/i },
   { route: "/providers", name: "providers", heading: /provider/i },
   { route: "/keys", name: "keys", heading: /keys/i },
+  // The selected workspace's roster, which is not the organization one below:
+  // this page is on the workspace rail and stops at the workspace it names.
+  { route: "/members", name: "members", heading: /members/i },
   { route: "/budgets", name: "budgets", heading: /budgets/i },
   // The member roster now carries what the users page used to: model access,
   // blocking, and per-person spend. It is on the organization rail, which this
@@ -229,6 +232,38 @@ async function stubAdminSpendView(page: Page): Promise<void> {
     })
   })
 }
+
+/**
+ * The member view of the workspace Members page.
+ *
+ * The organization's own roster is read-only there for a caller who does not
+ * manage the organization (otari-ai#1960), because Members & roles is on the
+ * organization rail and the shell opens that rail to nobody else. `login` is the
+ * bootstrap operator, who is an owner, so the only way to capture the other
+ * caller is to stub their context, as `stubAdminSpendView` does above and for
+ * the same reason. The roster itself is served for real.
+ */
+test.describe("organization member", () => {
+  test("workspace members", async ({ page }) => {
+    await login(page)
+    await page.route("**/v1/organizations/me", async (route) => {
+      const response = await route.fetch()
+      const context = await response.json()
+      await route.fulfill({
+        json: { ...context, role: "member", deployment_operator: false },
+      })
+    })
+    await gotoRoute(page, "/members")
+    await expect(
+      page.getByRole("heading", { name: /^members$/i }).first(),
+    ).toBeVisible()
+    // Awaited past the loading rows, so the capture is the populated table.
+    await expect(
+      page.getByRole("heading", { name: "Organization members" }),
+    ).toBeVisible()
+    await captureScreenshot(page, "members-organization-roster")
+  })
+})
 
 test.describe("organization admin", () => {
   test("organization spend and budgets", async ({ page }) => {

--- a/web/src/features/organization/MembershipStatusChip.tsx
+++ b/web/src/features/organization/MembershipStatusChip.tsx
@@ -1,0 +1,33 @@
+import { Chip } from "@heroui/react"
+
+import { membershipLabel } from "./roles"
+
+/**
+ * A membership status as a chip, shared by the rosters that show one.
+ *
+ * `"blocked"` is not a membership status and no roster row carries it: it is the
+ * gateway refusing this person's keys, which the organization roster passes in
+ * place of the status because the membership is active while every request the
+ * person makes fails.
+ */
+export function MembershipStatusChip({ status }: { status: string }) {
+  if (status === "blocked") {
+    return (
+      <Chip size="sm" color="danger">
+        Blocked
+      </Chip>
+    )
+  }
+  if (status === "active") {
+    return (
+      <Chip size="sm" color="accent">
+        Active
+      </Chip>
+    )
+  }
+  return (
+    <Chip size="sm" color={status === "suspended" ? "warning" : "default"}>
+      {membershipLabel(status)}
+    </Chip>
+  )
+}

--- a/web/src/features/organization/OrganizationMembersPage.tsx
+++ b/web/src/features/organization/OrganizationMembersPage.tsx
@@ -20,6 +20,7 @@ import {
   accessLabel,
   ModelScopeControl,
 } from "@/features/models/ModelScopeControl"
+import { MembershipStatusChip } from "@/features/organization/MembershipStatusChip"
 import {
   useAddOrganizationMember,
   useAddWorkspaceMember,
@@ -62,6 +63,7 @@ import {
   isDeploymentOperator,
   MEMBERSHIP_ROLES,
   memberLabel,
+  memberRowKey,
   membershipChangeBlockedReason,
   membershipLabel,
 } from "./roles"
@@ -113,42 +115,6 @@ const ROLE_OPTIONS = MEMBERSHIP_ROLES.map((role) => ({
   value: role,
   label: membershipLabel(role),
 }))
-
-// A membership row is keyed by its own id, and a pending invitation has none
-// yet, so those fall back to the identity or the address they name.
-function memberRowKey(member: OrganizationMember): string {
-  return (
-    member.organization_member_id ??
-    member.invitation_id ??
-    member.user_id ??
-    member.email ??
-    "unknown"
-  )
-}
-
-function StatusChip({ status }: { status: string }) {
-  // Not a membership status: it is the gateway refusing this person's keys, and
-  // it is shown here because the membership is active while every request fails.
-  if (status === "blocked") {
-    return (
-      <Chip size="sm" color="danger">
-        Blocked
-      </Chip>
-    )
-  }
-  if (status === "active") {
-    return (
-      <Chip size="sm" color="accent">
-        Active
-      </Chip>
-    )
-  }
-  return (
-    <Chip size="sm" color={status === "suspended" ? "warning" : "default"}>
-      {membershipLabel(status)}
-    </Chip>
-  )
-}
 
 // Adding someone is an address plus a role, and optionally the workspaces to
 // drop them into in the same request. A local identity is created for an address
@@ -909,9 +875,9 @@ export function OrganizationMembersPage() {
           // active, and every request the person makes is still refused, which
           // is what someone reading this column wants to know.
           return spendRow?.blocked ? (
-            <StatusChip status="blocked" />
+            <MembershipStatusChip status="blocked" />
           ) : (
-            <StatusChip status={member.status} />
+            <MembershipStatusChip status={member.status} />
           )
         },
       },

--- a/web/src/features/organization/OrganizationRosterCard.tsx
+++ b/web/src/features/organization/OrganizationRosterCard.tsx
@@ -1,0 +1,83 @@
+import { Card } from "@heroui/react"
+
+import type { OrganizationMember } from "@/client"
+import { MembershipStatusChip } from "@/features/organization/MembershipStatusChip"
+import {
+  memberLabel,
+  memberRowKey,
+  membershipLabel,
+} from "@/features/organization/roles"
+import { DataTable, type DataTableColumn } from "@/shared/components/DataTable"
+
+// Who belongs to the caller's organization, read-only, for a caller who is not
+// offered Organization > Members & roles: the roles matrix has the members list
+// at View for a member (otari-ai#1960), and that page sits on the organization
+// rail, which the shell opens only to someone who manages the organization.
+// Rendered on the workspace Members page, beside the roster of the workspace
+// itself, which is the subset.
+//
+// Three columns of the management page's seven. The rest are either a control a
+// member cannot use or a deployment-wide read the server refuses them.
+export function OrganizationRosterCard({
+  members,
+  isLoading,
+  organizationName,
+}: {
+  members: OrganizationMember[]
+  isLoading: boolean
+  organizationName: string | undefined
+}) {
+  const columns: DataTableColumn<OrganizationMember>[] = [
+    {
+      id: "member",
+      header: "Member",
+      isRowHeader: true,
+      cell: (member) => (
+        <div className="flex flex-col gap-0.5">
+          <span className="text-body">{memberLabel(member)}</span>
+          {member.email && member.full_name ? (
+            <span className="text-caption">{member.email}</span>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      id: "role",
+      header: "Role",
+      cell: (member) => (
+        <span className="text-body">{membershipLabel(member.role)}</span>
+      ),
+    },
+    {
+      id: "status",
+      header: "Status",
+      cell: (member) => <MembershipStatusChip status={member.status} />,
+    },
+  ]
+
+  return (
+    <section className="flex flex-col gap-2">
+      <h2 className="text-title">Organization members</h2>
+      <p className="text-sm text-muted">
+        Everyone in {organizationName ?? "this organization"} and the role they
+        hold in it. Roles are set by an owner or admin, and a workspace's
+        members are always a subset of this list.
+      </p>
+      <Card>
+        <Card.Content className="p-0">
+          <DataTable
+            ariaLabel="Organization members"
+            columns={columns}
+            rows={members}
+            getRowKey={memberRowKey}
+            isLoading={isLoading}
+            // Says nothing about the organization: an empty table is also what a
+            // failed read leaves behind, and the page's banner is the only thing
+            // that knows which happened.
+            emptyContent="No members to show."
+          />
+        </Card.Content>
+      </Card>
+    </section>
+  )
+}

--- a/web/src/features/organization/roles.ts
+++ b/web/src/features/organization/roles.ts
@@ -190,6 +190,21 @@ export function membershipChangeBlockedReason({
   return undefined
 }
 
+/**
+ * The key a roster row is listed under: its own membership id, falling back to
+ * the identity or the address a pending invitation names, since that row has no
+ * membership yet.
+ */
+export function memberRowKey(member: OrganizationMember): string {
+  return (
+    member.organization_member_id ??
+    member.invitation_id ??
+    member.user_id ??
+    member.email ??
+    "unknown"
+  )
+}
+
 /** How a member is named on screen: their name, then their email, then their id. */
 export function memberLabel(member: OrganizationMember): string {
   return (

--- a/web/src/features/workspaces/WorkspaceMembersPage.test.tsx
+++ b/web/src/features/workspaces/WorkspaceMembersPage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { render, screen } from "@testing-library/react"
+import { screen, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { WorkspaceMembersPage } from "@/features/workspaces/WorkspaceMembersPage"
@@ -9,6 +9,7 @@ import {
   organizationMember,
   workspaceMember,
 } from "@/tests/fixtures"
+import { renderWithRouter } from "@/tests/router"
 import { pickOption } from "@/tests/select"
 
 const ALPHA = "11111111-1111-1111-1111-111111111111"
@@ -53,16 +54,19 @@ function mockApi({
   return requests
 }
 
+// In a router, because the page links to Organization > Members & roles for a
+// caller who manages the organization.
 function renderPage() {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   })
-  return render(
+  return renderWithRouter(
     <QueryClientProvider client={client}>
       <SelectedWorkspaceProvider>
         <WorkspaceMembersPage />
       </SelectedWorkspaceProvider>
     </QueryClientProvider>,
+    { url: "/members" },
   )
 }
 
@@ -74,7 +78,7 @@ describe("WorkspaceMembersPage", () => {
 
   it("shows the roster of the selected workspace, named by the organization", async () => {
     mockApi()
-    renderPage()
+    await renderPage()
 
     // The page is about the selected workspace, and says which one.
     expect(await screen.findByText("Members of Alpha")).toBeInTheDocument()
@@ -82,7 +86,7 @@ describe("WorkspaceMembersPage", () => {
 
   it("says so rather than showing an empty roster when there is no workspace", async () => {
     mockApi({ memberships: [] })
-    renderPage()
+    await renderPage()
 
     // An empty roster would read as "this workspace has nobody in it", which is
     // a different fact from "you are in no workspace".
@@ -96,7 +100,7 @@ describe("WorkspaceMembersPage", () => {
     mockApi({
       memberships: [{ workspace_id: ALPHA, name: "Alpha", role: "owner" }],
     })
-    renderPage()
+    await renderPage()
 
     await screen.findByText("Members of Alpha")
     expect(await screen.findByRole("button", { name: "Remove" })).toBeEnabled()
@@ -111,7 +115,7 @@ describe("WorkspaceMembersPage", () => {
     // The one organization member is already in the workspace, which in a
     // standalone deployment is the permanent state until sign-in lands.
     mockApi()
-    renderPage()
+    await renderPage()
 
     expect(
       await screen.findByText(/already in this workspace/),
@@ -123,7 +127,7 @@ describe("WorkspaceMembersPage", () => {
     // An empty candidate list is only "everyone is already here" once the
     // roster has answered; a failed one has to say so instead.
     mockApi({ rosterFails: true })
-    renderPage()
+    await renderPage()
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Roster unavailable",
@@ -144,7 +148,7 @@ describe("WorkspaceMembersPage", () => {
       ],
     })
     const user = userEvent.setup()
-    renderPage()
+    await renderPage()
 
     await pickOption(user, "Organization member", "Analyst")
     await pickOption(user, "Role", "Admin")
@@ -168,9 +172,73 @@ describe("WorkspaceMembersPage", () => {
       context: organizationContext({ role: "viewer" }),
       memberships: [{ workspace_id: ALPHA, name: "Alpha", role: "viewer" }],
     })
-    renderPage()
+    await renderPage()
 
     await screen.findByText("Members of Alpha")
     expect(await screen.findByRole("button", { name: "Remove" })).toBeDisabled()
+  })
+
+  // otari-ai#1960: the organization's roster is Members & roles, on a rail the
+  // shell opens only to a caller who manages the organization, so a member had
+  // nowhere to read who else is in their organization.
+
+  it("shows a member the organization roster they have no other page for", async () => {
+    mockApi({
+      context: organizationContext({ role: "member" }),
+      memberships: [{ workspace_id: ALPHA, name: "Alpha", role: "member" }],
+      orgMembers: [
+        organizationMember({
+          user_id: USER,
+          full_name: "Alex Avery",
+          role: "member",
+        }),
+        organizationMember({
+          organization_member_id: "owner-membership",
+          user_id: "77777777-7777-7777-7777-777777777777",
+          full_name: "Bea Brooks",
+          role: "owner",
+        }),
+      ],
+    })
+    await renderPage()
+
+    const roster = await screen.findByRole("grid", {
+      name: "Organization members",
+    })
+    // Someone the workspace roster above does not name: the point of the card is
+    // the organization beyond this workspace.
+    expect(within(roster).getByText("Bea Brooks")).toBeInTheDocument()
+    expect(within(roster).getByText("Owner")).toBeInTheDocument()
+    // Read-only: the roles and the removals are the management page's.
+    expect(within(roster).queryByRole("button")).toBeNull()
+  })
+
+  it("shows the organization roster to a member who is in no workspace yet", async () => {
+    // The caller with the most use for it: nothing else on this page answers
+    // for them, and who to ask about a workspace is on the list.
+    mockApi({
+      context: organizationContext({ role: "member" }),
+      memberships: [],
+    })
+    await renderPage()
+
+    expect(await screen.findByText("No workspace selected")).toBeInTheDocument()
+    expect(
+      await screen.findByRole("grid", { name: "Organization members" }),
+    ).toBeInTheDocument()
+  })
+
+  it("points a manager at the organization page instead of repeating its roster", async () => {
+    // An owner or admin has Members & roles, which lists the same people and
+    // can change them, so the read-only copy would be the same table twice.
+    mockApi()
+    await renderPage()
+
+    expect(
+      await screen.findByRole("link", { name: /Members & roles/ }),
+    ).toHaveAttribute("href", "/organization/members")
+    expect(
+      screen.queryByRole("grid", { name: "Organization members" }),
+    ).toBeNull()
   })
 })

--- a/web/src/features/workspaces/WorkspaceMembersPage.test.tsx
+++ b/web/src/features/workspaces/WorkspaceMembersPage.test.tsx
@@ -184,7 +184,10 @@ describe("WorkspaceMembersPage", () => {
 
   it("shows a member the organization roster they have no other page for", async () => {
     mockApi({
-      context: organizationContext({ role: "member" }),
+      context: organizationContext({
+        role: "member",
+        deployment_operator: false,
+      }),
       memberships: [{ workspace_id: ALPHA, name: "Alpha", role: "member" }],
       orgMembers: [
         organizationMember({
@@ -217,7 +220,10 @@ describe("WorkspaceMembersPage", () => {
     // The caller with the most use for it: nothing else on this page answers
     // for them, and who to ask about a workspace is on the list.
     mockApi({
-      context: organizationContext({ role: "member" }),
+      context: organizationContext({
+        role: "member",
+        deployment_operator: false,
+      }),
       memberships: [],
     })
     await renderPage()
@@ -226,6 +232,28 @@ describe("WorkspaceMembersPage", () => {
     expect(
       await screen.findByRole("grid", { name: "Organization members" }),
     ).toBeInTheDocument()
+  })
+
+  it("reports a failed roster to a member rather than an empty organization", async () => {
+    // The card cannot tell an empty organization from an unanswered read, so the
+    // page's banner is what says which happened.
+    mockApi({
+      context: organizationContext({
+        role: "member",
+        deployment_operator: false,
+      }),
+      memberships: [{ workspace_id: ALPHA, name: "Alpha", role: "member" }],
+      rosterFails: true,
+    })
+    await renderPage()
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Roster unavailable",
+    )
+    const roster = await screen.findByRole("grid", {
+      name: "Organization members",
+    })
+    expect(within(roster).getByText("No members to show.")).toBeInTheDocument()
   })
 
   it("points a manager at the organization page instead of repeating its roster", async () => {

--- a/web/src/features/workspaces/WorkspaceMembersPage.tsx
+++ b/web/src/features/workspaces/WorkspaceMembersPage.tsx
@@ -1,4 +1,7 @@
-import { canManageWorkspace } from "@/features/organization/roles"
+import { Link } from "@tanstack/react-router"
+
+import { OrganizationRosterCard } from "@/features/organization/OrganizationRosterCard"
+import { canManage, canManageWorkspace } from "@/features/organization/roles"
 import { WorkspaceMembersPanel } from "@/features/workspaces/WorkspaceMembersPanel"
 import {
   useOrganizationContext,
@@ -13,9 +16,13 @@ import { useSelectedWorkspace } from "@/shared/hooks/SelectedWorkspace"
 // The rest of the context is still deployment-wide until the request plane
 // carries a workspace.
 //
-// Distinct from Organization > Members & roles, which is who belongs to the
-// tenant. A workspace's members are always a subset of that, so someone is
-// added to the organization first and assigned here second.
+// Also where a member reads the *organization's* roster (otari-ai#1960). The
+// tenant-wide list has a page of its own, Organization > Members & roles, and it
+// is on the organization rail, which the shell opens only to a caller who
+// manages the organization: the design hides that row from a member outright
+// rather than degrading it. So the two callers are answered differently here. A
+// manager is pointed at that page, where the roster can also be changed, and
+// everyone else reads it below, which is the View the roles matrix asks for.
 export function WorkspaceMembersPage() {
   const { selected, isLoading } = useSelectedWorkspace()
   const context = useOrganizationContext()
@@ -25,14 +32,43 @@ export function WorkspaceMembersPage() {
   // does an owner/admin of this workspace specifically, which is the rule the
   // workspace service enforces server-side.
   const manages = canManageWorkspace(context.data, selected?.role)
+  // Withheld until the context answers, rather than treating a pending read as
+  // "does not manage": an owner would otherwise be shown a roster they have a
+  // better page for and have it swapped for the pointer to it one paint later.
+  // A context that *failed* does read as "does not manage", which offers the
+  // roster rather than withholding it, and the server authorizes that read
+  // either way.
+  const organizationAnswered = !context.isLoading
+  const managesOrganization = canManage(context.data)
 
-  if (!selected) {
-    return (
-      <div className="flex flex-col gap-6">
-        <PageHeader
-          title="Members"
-          description="People assigned to this workspace and their role in it."
+  return (
+    <div className="flex flex-col gap-6">
+      <PageHeader
+        title="Members"
+        description={
+          selected
+            ? `People assigned to ${selected.name} and their role in it. A workspace's members are a subset of the organization's, so someone joins the organization first.`
+            : "People assigned to this workspace and their role in it."
+        }
+      />
+      {/* The organization roster is what the panel picks candidates from, and
+          what the card below lists, so a failure there is reported rather than
+          left to read as "everyone is already in this workspace", which is what
+          an empty candidate list otherwise looks like. */}
+      <ErrorBanner error={orgMembers.error} />
+      {selected ? (
+        <WorkspaceMembersPanel
+          workspaceId={selected.workspace_id}
+          workspaceName={selected.name}
+          orgMembers={orgMembers.data ?? []}
+          rosterResolved={orgMembers.isSuccess}
+          canManageWorkspace={manages}
         />
+      ) : (
+        // An empty roster would read as "this workspace has nobody in it",
+        // which is a different fact from "you are in no workspace". The
+        // organization roster below still renders: who else is in the tenant is
+        // the answer someone in no workspace yet most needs.
         <EmptyState
           title={isLoading ? "Loading…" : "No workspace selected"}
           description={
@@ -41,28 +77,26 @@ export function WorkspaceMembersPage() {
               : "You do not belong to a workspace in this organization yet. An owner or admin can add you to one on the Workspaces page."
           }
         />
-      </div>
-    )
-  }
-
-  return (
-    <div className="flex flex-col gap-6">
-      <PageHeader
-        title="Members"
-        description={`People assigned to ${selected.name} and their role in it. A workspace's members are a subset of the organization's, so someone joins the organization first.`}
-      />
-      {/* The organization roster is what the panel picks candidates from, so a
-          failure there is reported rather than left to read as "everyone is
-          already in this workspace", which is what an empty candidate list
-          otherwise looks like. */}
-      <ErrorBanner error={orgMembers.error} />
-      <WorkspaceMembersPanel
-        workspaceId={selected.workspace_id}
-        workspaceName={selected.name}
-        orgMembers={orgMembers.data ?? []}
-        rosterResolved={orgMembers.isSuccess}
-        canManageWorkspace={manages}
-      />
+      )}
+      {organizationAnswered && !managesOrganization ? (
+        <OrganizationRosterCard
+          members={orgMembers.data ?? []}
+          isLoading={orgMembers.isPending && !orgMembers.data}
+          organizationName={context.data?.organization?.name}
+        />
+      ) : null}
+      {organizationAnswered && managesOrganization ? (
+        <p className="text-sm text-muted">
+          Everyone in the organization, and the role each of them holds, is on{" "}
+          <Link
+            to="/organization/members"
+            className="font-medium text-link hover:text-link-hover"
+          >
+            Organization → Members &amp; roles
+          </Link>
+          .
+        </p>
+      ) : null}
     </div>
   )
 }

--- a/web/src/features/workspaces/WorkspaceMembersPage.tsx
+++ b/web/src/features/workspaces/WorkspaceMembersPage.tsx
@@ -31,15 +31,18 @@ export function WorkspaceMembersPage() {
   // An organization's owners and admins manage every workspace in it, and so
   // does an owner/admin of this workspace specifically, which is the rule the
   // workspace service enforces server-side.
-  const manages = canManageWorkspace(context.data, selected?.role)
+  const canManageSelectedWorkspace = canManageWorkspace(
+    context.data,
+    selected?.role,
+  )
   // Withheld until the context answers, rather than treating a pending read as
   // "does not manage": an owner would otherwise be shown a roster they have a
   // better page for and have it swapped for the pointer to it one paint later.
   // A context that *failed* does read as "does not manage", which offers the
   // roster rather than withholding it, and the server authorizes that read
   // either way.
-  const organizationAnswered = !context.isLoading
-  const managesOrganization = canManage(context.data)
+  const hasOrganizationAnswered = !context.isLoading
+  const canManageOrganization = canManage(context.data)
 
   return (
     <div className="flex flex-col gap-6">
@@ -62,7 +65,7 @@ export function WorkspaceMembersPage() {
           workspaceName={selected.name}
           orgMembers={orgMembers.data ?? []}
           rosterResolved={orgMembers.isSuccess}
-          canManageWorkspace={manages}
+          canManageWorkspace={canManageSelectedWorkspace}
         />
       ) : (
         // An empty roster would read as "this workspace has nobody in it",
@@ -78,14 +81,14 @@ export function WorkspaceMembersPage() {
           }
         />
       )}
-      {organizationAnswered && !managesOrganization ? (
+      {hasOrganizationAnswered && !canManageOrganization ? (
         <OrganizationRosterCard
           members={orgMembers.data ?? []}
           isLoading={orgMembers.isPending && !orgMembers.data}
           organizationName={context.data?.organization?.name}
         />
       ) : null}
-      {organizationAnswered && managesOrganization ? (
+      {hasOrganizationAnswered && canManageOrganization ? (
         <p className="text-sm text-muted">
           Everyone in the organization, and the role each of them holds, is on{" "}
           <Link


### PR DESCRIPTION
## Description

The base-repo half of mozilla-ai/otari-ai#1960. The 11 Aug roles matrix puts the members list at View for a member. The workspace roster already matched; the organization one is Members & roles on the organization rail, and the shell opens that rail only to a caller who manages the organization, which the design intends (its member artboard drops the row rather than degrading it). A plain member therefore had nowhere to read who else is in their organization, though `GET /v1/organizations/me/members` has always served them the list.

- **The workspace Members page answers both callers.** A caller who does not manage the organization reads the roster there, read-only, in the three columns that are theirs (member, role, status); a manager is pointed at Members & roles, which lists the same people and can change them. The roster read is the one the page already made for the panel's candidate picker, so this costs no request.
- **The card renders whether or not a workspace is selected.** Someone in no workspace yet is the caller with the most use for it, and the empty state above it still reports its own fact.
- **The choice waits for the context read**, so an owner is not shown a roster and then has it swapped for the pointer one paint later. A context that failed reads as "does not manage" and offers the roster, which the server authorizes either way.
- `memberRowKey` and the status chip move out of the management page so both rosters key and label a row the same way.
- Screenshots: `/members` had no entry at all, so the matrix gets one, plus the member variant through the context stub `stubAdminSpendView` established.

No API or authorization change: the read was already open to any active member.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#1960

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Dashboard-only, so the checks that ran are the dashboard's: `pnpm --dir web run lint`, `run typecheck`, and `test` (110 files, 2648 tests). No route, schema, or OpenAPI artifact changed.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Claude Opus 5, 1M context)

**Any additional AI details you'd like to share:**

Written and self-reviewed by the agent; a human owns the review.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
