### PR TITLE
fix(dashboard): decide the Overview's variant from the organization context

### DIFF
--- a/web/src/features/overview/OverviewPage.test.tsx
+++ b/web/src/features/overview/OverviewPage.test.tsx
@@ -650,20 +650,19 @@ describe("OverviewIndex routing", () => {
   })
 })
 
-// The wire for a caller who does not operate the deployment: `/v1/admin/access`
-// answers an explicit no, the organization context agrees, and the usage hooks
-// therefore read `/v1/organizations/me/usage` (otari#837). Everything else is
-// an endpoint this caller must never be asked to read, so it refuses the way
-// the server would; a leak fails the assertions loudly instead of rendering a
-// plausible tile. Every URL is recorded so the tests can say so.
+// The wire for a caller who does not operate the deployment: the organization
+// context says so, and the usage hooks therefore read
+// `/v1/organizations/me/usage` (otari#837). Everything else is an endpoint this
+// caller must never be asked to read, so it refuses the way the server would; a
+// leak fails the assertions loudly instead of rendering a plausible tile. Every
+// URL is recorded so the tests can say so, `/v1/admin/access` included: this
+// page decides from the context alone, so asking it at all is the bug
+// otari-ai#1936 is about.
 function mockScopedApi(b: Bodies): string[] {
   const requested: string[] = []
   vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
     const url = String(input)
     requested.push(url)
-    if (url.endsWith("/v1/admin/access")) {
-      return jsonResponse({ granted: false })
-    }
     if (url.endsWith("/v1/organizations/me")) {
       return jsonResponse(organizationContext({ deployment_operator: false }))
     }
@@ -718,14 +717,15 @@ describe("OverviewIndex for a caller who does not operate the deployment", () =>
     expect(screen.queryByText("Budget health")).not.toBeInTheDocument()
     expect(screen.queryByText("Active keys")).not.toBeInTheDocument()
     expect(screen.queryByText("Active members")).not.toBeInTheDocument()
-    // And nothing left the scoped surface: beyond the gate and the context,
-    // every request this page made names /v1/organizations/me/usage. A bare
-    // /v1/usage read here would be a cross-tenant read the server refuses, so
-    // the page must not even attempt it.
+    // And nothing left the scoped surface: beyond the context, every request
+    // this page made names /v1/organizations/me/usage. A bare /v1/usage read
+    // here would be a cross-tenant read the server refuses, so the page must
+    // not even attempt it.
+    expect(requested.some((url) => url.endsWith("/v1/admin/access"))).toBe(
+      false,
+    )
     const scoped = requested.filter(
-      (url) =>
-        !url.endsWith("/v1/admin/access") &&
-        !url.endsWith("/v1/organizations/me"),
+      (url) => !url.endsWith("/v1/organizations/me"),
     )
     expect(scoped.length).toBeGreaterThan(0)
     for (const url of scoped) {
@@ -773,9 +773,6 @@ describe("OverviewIndex for a caller who does not operate the deployment", () =>
     // every "vs prev" chip and look like there was nothing to compare.
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = String(input)
-      if (url.endsWith("/v1/admin/access")) {
-        return jsonResponse({ granted: false })
-      }
       if (url.endsWith("/v1/organizations/me")) {
         return jsonResponse(organizationContext({ deployment_operator: false }))
       }
@@ -801,9 +798,6 @@ describe("OverviewIndex for a caller who does not operate the deployment", () =>
   it("reports a failed scoped summary instead of a silent wall of dashes", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = String(input)
-      if (url.endsWith("/v1/admin/access")) {
-        return jsonResponse({ granted: false })
-      }
       if (url.endsWith("/v1/organizations/me")) {
         return jsonResponse(organizationContext({ deployment_operator: false }))
       }
@@ -818,5 +812,105 @@ describe("OverviewIndex for a caller who does not operate the deployment", () =>
     renderPage(<OverviewIndex />)
 
     expect(await screen.findByText(/usage exploded/)).toBeInTheDocument()
+  })
+})
+
+// One question, one source. The page picks its variant and the usage hooks pick
+// their surface off the same `deployment_operator` field, so the operator panels
+// can never end up beside tiles reading the other one (otari-ai#1936).
+describe("OverviewIndex operator-ness", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("renders the operator page off the context, without asking /v1/admin/access", async () => {
+    const requested: string[] = []
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input)
+      requested.push(url)
+      if (url.endsWith("/v1/organizations/me")) {
+        return jsonResponse(organizationContext())
+      }
+      if (url.includes("/v1/usage/summary")) {
+        return jsonResponse(summary({ cost: 200, request_count: 2000 }))
+      }
+      if (url.includes("/v1/providers/health")) {
+        return jsonResponse({
+          providers: [],
+          healthy: 1,
+          total: 1,
+          checked_at: null,
+        })
+      }
+      if (url.includes("/v1/providers")) {
+        return jsonResponse({ providers: [{ provider: "openai" }] })
+      }
+      return jsonResponse([])
+    })
+    renderPage(<OverviewIndex />)
+
+    expect(
+      await screen.findByText(
+        "At-a-glance spend, traffic, and health across the gateway.",
+      ),
+    ).toBeInTheDocument()
+    expect(requested.some((url) => url.endsWith("/v1/admin/access"))).toBe(
+      false,
+    )
+  })
+
+  it("lands a failed context on the scoped page, where its tiles already read", async () => {
+    // The failure the two sources used to disagree about: the context read is
+    // what the usage hooks scope off, so a page that decided operator-ness some
+    // other way would render the deployment-wide panels above tiles quietly
+    // serving this caller's own organization, with nothing on screen to say so.
+    const requested: string[] = []
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input)
+      requested.push(url)
+      if (url.endsWith("/v1/organizations/me")) {
+        return jsonResponse({ detail: "context exploded" }, 500)
+      }
+      if (url.includes("/v1/organizations/me/usage/summary")) {
+        if (url.includes("bucket=hour"))
+          return jsonResponse(summary({ cost: 5 }))
+        return jsonResponse(summary({ cost: 200, request_count: 2000 }))
+      }
+      if (url.includes("/v1/organizations/me/usage")) {
+        return jsonResponse([])
+      }
+      return jsonResponse({ detail: "forbidden" }, 403)
+    })
+    renderPage(<OverviewIndex />)
+
+    // The scoped page, rendering scoped numbers: an errored context is an
+    // answer, so the page is not stranded on its loading state either.
+    expect(await screen.findByText("$200.00")).toBeInTheDocument()
+    expect(screen.getByText("$5.00")).toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        "At-a-glance spend, traffic, and health across the gateway.",
+      ),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText("Budget health")).not.toBeInTheDocument()
+
+    // And it settled there. The usage hooks behind those tiles observe the same
+    // errored context, and their mount asks it to refetch; a page reading the
+    // transient pending state would flip back to its spinner, unmount them, and
+    // ask again without end. The tiles asserted above are what such a page never
+    // reaches, and this is the request storm underneath it.
+    expect(
+      requested.filter((url) => url.endsWith("/v1/organizations/me")).length,
+    ).toBeLessThan(4)
+
+    // And it asked nothing the deployment-wide page would have: not the gate,
+    // and no endpoint outside the surface the hooks fell back to.
+    const asked = requested.filter(
+      (url) => !url.endsWith("/v1/organizations/me"),
+    )
+    expect(asked.length).toBeGreaterThan(0)
+    for (const url of asked) {
+      expect(url).toContain("/v1/organizations/me/usage")
+    }
   })
 })

--- a/web/src/features/overview/OverviewPage.tsx
+++ b/web/src/features/overview/OverviewPage.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate } from "@tanstack/react-router"
 import { useEffect, useMemo, useState } from "react"
 import type { UsageEntry } from "@/client"
 import { SetupGuideCard } from "@/features/onboarding/SetupGuideCard"
+import { isDeploymentOperator } from "@/features/organization/roles"
 import {
   budgetHealth,
   errorRateHealth,
@@ -13,8 +14,8 @@ import {
 import {
   NO_BREAKDOWNS,
   useBudgets,
-  useDeploymentAdminAccess,
   useKeys,
+  useOrganizationContext,
   useOrganizationMembers,
   useProviderHealth,
   useProviders,
@@ -262,20 +263,33 @@ function UsageStatTiles({
  * a component that is not rendered runs none of them: that is what keeps a
  * tenant's first page from being a row of failed requests.
  *
- * It fails toward the operator view on purpose. Only an explicit `false` shows
- * the organization-scoped page, so a deployment with no operator surface to ask
- * (hybrid) and a transient failure of the question both land on the panels,
- * which report their own errors, rather than telling a real operator this page
- * is not theirs.
+ * Decided from the organization context, which is where `useUsageScope` and the
+ * nav rail take the same answer from, so nothing on screen can hold a different
+ * one (otari-ai#1936). Two sources compose into a page that reports nothing
+ * while being wrong: the deployment-wide panels beside usage tiles quietly
+ * reading `/v1/organizations/me/usage`, every number disagreeing with its
+ * neighbor and each query happy with its own. It also costs no request, since
+ * the shell reads this context before it paints.
+ *
+ * So it fails toward the scoped page, the direction the hooks behind those tiles
+ * already fail in: the narrower surface understates rather than refusing, and
+ * reports its own error where this page can show it. An errored context is an
+ * answer, not a wait, for `useUsageScope`'s reason: holding the page on a
+ * loading state that no retry clears renders nothing at all.
  */
 export function OverviewIndex() {
-  const access = useDeploymentAdminAccess()
+  const context = useOrganizationContext()
 
-  if (access.data === false) {
-    return <OrganizationOverview />
-  }
-  if (access.isLoading) {
+  // `isFetched`, not `isPending`: a query that errored with no data goes back to
+  // pending on its next fetch, and the page below this line mounts a second
+  // observer of the same context (the usage hooks), whose mount is what asks for
+  // that fetch. Reading the transient state would swing the page back to this
+  // spinner, unmount the observer, and start the round again forever.
+  if (!context.isFetched) {
     return <PageLoading />
+  }
+  if (!isDeploymentOperator(context.data)) {
+    return <OrganizationOverview />
   }
   return <OperatorOverviewIndex />
 }

--- a/web/src/shared/api/hooks.ts
+++ b/web/src/shared/api/hooks.ts
@@ -3237,12 +3237,11 @@ export function useDeleteOrganizationSpendCeiling() {
 // 404: a gate cannot be built on a failed request, and hiding a destination
 // grants nothing either way.
 //
-// Read by the two pages that decide in their own words what the caller sees (the
-// deployment accounts page's refusal, the Overview's member view), and no longer
-// by the sidebar: the rail needs the same answer before its first paint, so it
-// takes `deployment_operator` off the organization context instead, which is the
-// same server-side predicate on a read the shell already makes (otari#836). Both
-// pages hold their decision until this lands, so neither pays what the rail did.
+// Read by the deployment accounts page alone, to word its own refusal, and it
+// holds that decision until this lands. Nothing else asks: the rail and the
+// Overview index need the answer before their first paint, so they take
+// `deployment_operator` off the organization context, which is the same
+// server-side predicate on a read the shell already makes (otari#836).
 // ---------------------------------------------------------------------------
 
 export function useDeploymentAdminAccess() {
@@ -3253,15 +3252,12 @@ export function useDeploymentAdminAccess() {
         (body) => body.granted,
       ),
     staleTime: 60_000,
-    // No `enabled` parameter any more: it existed for the rail alone, so it could
-    // withhold the request on a gateway that does not host `/v1/admin` and keep
-    // that 404 from becoming a second reading of `surfaces`. Neither remaining
-    // caller ever passed one. The accounts page does not need to, being behind a
-    // route that declares `surface: "admin"`; the Overview index has no surface
-    // of its own, is the deployment's front page, and already asked
-    // unconditionally. Deliberately still not inferred from a 404 here, which is
-    // the scattered mode check the surface axis replaced; the ordinary retry
-    // policy applies, and a failure is a failure.
+    // No `enabled` parameter: the one caller sits behind a route declaring
+    // `surface: "admin"`, so a deployment that does not host `/v1/admin` never
+    // renders it and the 404 never becomes a second reading of `surfaces`.
+    // Deliberately not inferred from a 404 here either, which is the scattered
+    // mode check the surface axis replaced; the ordinary retry policy applies,
+    // and a failure is a failure.
   })
 }
 


### PR DESCRIPTION
## Description

The Overview landing page asked `GET /v1/admin/access` to pick its variant while every usage hook scoped off the organization context's `deployment_operator`, and the two failed in opposite directions: an operator whose context read failed got the deployment-wide panels above tiles quietly serving their own organization, and a member whose gate read failed got the operator page's wall of 403s.

Both now read the context, through `isDeploymentOperator` like the nav rail, so the page and its tiles cannot disagree and the landing page makes one request fewer. The gate is `isFetched` rather than the pending state: an errored query with no data returns to pending on its next fetch, and the scoped page mounts a second observer of the same context, so reading the transient state would loop the page between spinner and content.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#1936

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). Frontend-only change: `pnpm lint`, `pnpm typecheck` and `pnpm test` are green, as are `make lint`, `make typecheck` and `tests/unit`; the Python integration suite is left to CI.
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). No API contract change.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code

**Any additional AI details you'd like to share:**

The `isFetched` gate came out of the change itself: the first version used `isSuccess || isError` and hung the page in a refetch loop, which the failed-context test pins.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated Overview page selection to use the organization context.
- Removed the separate access request from Overview.
- Kept the page variant and tiles consistent when requests fail or reload.
- Added and updated tests for operator and scoped views.

## Technical notes

- `OverviewIndex` now uses `isDeploymentOperator` and `isFetched`.
- Updated `useDeploymentAdminAccess` documentation.
- Frontend lint, typecheck, and tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->