### PR TITLE
fix(api): gate the deployment-wide routers on the router, not per route

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -17559,7 +17559,7 @@
     },
     "/v1/models/discoverable": {
       "get": {
-        "description": "List every model the configured provider credentials can reach.\n\nOperator-facing counterpart to GET /v1/models, which serves a curated catalog\nto API callers. This reports each provider separately and keeps its error, so\na provider with a bad key is distinguishable from one with no models. It is\nmaster-key gated because a provider error message describes the gateway's own\nconfiguration.\n\nAnswers from the discovery cache, which a background refresher keeps warm, so\nthe call does not wait on a slow or unreachable provider. Each provider\ncarries the ``checked_at`` its result was produced at; a null one has not been\ndialed yet. Pass ``refresh=true`` to force a live re-dial of every provider.",
+        "description": "List every model the configured provider credentials can reach.\n\nOperator-facing counterpart to GET /v1/models, which serves a curated catalog\nto API callers. This reports each provider separately and keeps its error, so\na provider with a bad key is distinguishable from one with no models. It is\noperator-gated because a provider error message describes the gateway's own\nconfiguration.\n\nAnswers from the discovery cache, which a background refresher keeps warm, so\nthe call does not wait on a slow or unreachable provider. Each provider\ncarries the ``checked_at`` its result was produced at; a null one has not been\ndialed yet. Pass ``refresh=true`` to force a live re-dial of every provider.",
         "operationId": "list_discoverable_models_v1_models_discoverable_get",
         "parameters": [
           {
@@ -17613,7 +17613,7 @@
     },
     "/v1/models/metadata": {
       "get": {
-        "description": "Per-model metadata for the dashboard's detail view, from models.dev.\n\nCovers every model models.dev lists under a configured provider, keyed by the\n``instance:model`` selector the dashboard uses. ``available`` is false when\nenrichment is disabled (``models_dev_metadata``) or models.dev could not be\nreached; the response is then empty and the UI falls back to bundled data.\nMaster-key gated: it describes the gateway's configured providers.\n\nAnswers from the cached catalog, kept warm by a background refresher, so the\ndashboard never waits on the models.dev fetch timeout.",
+        "description": "Per-model metadata for the dashboard's detail view, from models.dev.\n\nCovers every model models.dev lists under a configured provider, keyed by the\n``instance:model`` selector the dashboard uses. ``available`` is false when\nenrichment is disabled (``models_dev_metadata``) or models.dev could not be\nreached; the response is then empty and the UI falls back to bundled data.\nOperator-gated: it describes the gateway's configured providers.\n\nAnswers from the cached catalog, kept warm by a background refresher, so the\ndashboard never waits on the models.dev fetch timeout.",
         "operationId": "list_model_metadata_v1_models_metadata_get",
         "responses": {
           "200": {
@@ -22143,7 +22143,7 @@
     },
     "/v1/providers": {
       "get": {
-        "description": "List static metadata for every configured provider.\n\nOperator-facing: reports each provider's capabilities, documentation and\npricing links, and display name from the bundled any-llm and genai-prices\ndatasets. No provider is contacted, so this is cheap and always available.\nMaster-key gated because it describes the gateway's own configuration.",
+        "description": "List static metadata for every configured provider.\n\nOperator-facing: reports each provider's capabilities, documentation and\npricing links, and display name from the bundled any-llm and genai-prices\ndatasets. No provider is contacted, so this is cheap and always available.",
         "operationId": "list_providers_v1_providers_get",
         "responses": {
           "200": {
@@ -22173,7 +22173,7 @@
     },
     "/v1/providers/catalog": {
       "get": {
-        "description": "List every known provider for the add-provider picker: id and name only.\n\nLightweight by design so the picker never lags: provider ids come from the\nany-llm registry and names from the bundled genai-prices dataset, so no\nprovider SDK is imported. The autofill hints for a chosen provider come from\nGET /v1/providers/catalog/{provider_id}, which imports only that one SDK.\nMaster-key gated because it is operator-facing dashboard data.",
+        "description": "List every known provider for the add-provider picker: id and name only.\n\nLightweight by design so the picker never lags: provider ids come from the\nany-llm registry and names from the bundled genai-prices dataset, so no\nprovider SDK is imported. The autofill hints for a chosen provider come from\nGET /v1/providers/catalog/{provider_id}, which imports only that one SDK.",
         "operationId": "provider_catalog_v1_providers_catalog_get",
         "responses": {
           "200": {
@@ -22207,7 +22207,7 @@
     },
     "/v1/providers/catalog/{provider_id}": {
       "get": {
-        "description": "Autofill hints for one provider the add-provider form has selected.\n\nImports only the selected provider's any-llm module (not the whole catalog)\nto report its credential env var, default endpoint, whether a key is required,\nand whether that env var is already set on the server. Returns 404 for an\nunknown provider id. Master-key gated because it is operator-facing.\n\nThe SDK import is offloaded to a worker thread: the first fetch for a given\nprovider imports that provider's module, which would otherwise block the event\nloop (and thus every concurrent request) for the import's duration.",
+        "description": "Autofill hints for one provider the add-provider form has selected.\n\nImports only the selected provider's any-llm module (not the whole catalog)\nto report its credential env var, default endpoint, whether a key is required,\nand whether that env var is already set on the server. Returns 404 for an\nunknown provider id.\n\nThe SDK import is offloaded to a worker thread: the first fetch for a given\nprovider imports that provider's module, which would otherwise block the event\nloop (and thus every concurrent request) for the import's duration.",
         "operationId": "provider_catalog_detail_v1_providers_catalog__provider_id__get",
         "parameters": [
           {
@@ -22258,7 +22258,7 @@
     },
     "/v1/providers/health": {
       "get": {
-        "description": "Report every configured provider's reachability, with a last-checked time.\n\nReuses the per-provider model-discovery test path, so a provider is healthy\nwhen its credentials can list models. Results are served from the discovery\ncache (cheap enough to poll), so ``checked_at`` reflects when each provider\nwas actually dialed. Pass ``refresh=true`` to force a live re-dial of every\nprovider. Master-key gated because it describes the gateway's own providers.\n\nA provider whose backend serves no model-listing endpoint cannot be verified\nthis way, but it is not unreachable either: it is reported with\n``discovery_unsupported`` and counted under ``degraded`` rather than as a\nreachability failure.",
+        "description": "Report every configured provider's reachability, with a last-checked time.\n\nReuses the per-provider model-discovery test path, so a provider is healthy\nwhen its credentials can list models. Results are served from the discovery\ncache (cheap enough to poll), so ``checked_at`` reflects when each provider\nwas actually dialed. Pass ``refresh=true`` to force a live re-dial of every\nprovider.\n\nA provider whose backend serves no model-listing endpoint cannot be verified\nthis way, but it is not unreachable either: it is reported with\n``discovery_unsupported`` and counted under ``degraded`` rather than as a\nreachability failure.",
         "operationId": "provider_health_v1_providers_health_get",
         "parameters": [
           {
@@ -22519,7 +22519,7 @@
     },
     "/v1/routing/policies/explain": {
       "post": {
-        "description": "Compile a policy and return the plan, without dispatching anything.\n\nMaster-key gated, and deliberately so: the response enumerates the policy's\ntargets, which is exactly the information a policy exists to keep off the wire.\nIt is a management surface, not a caller-facing one.\n\nAccepts an unsaved ``spec`` as well as a saved ``name``, so a form can validate\nwhat the operator is about to save. The response includes dropped candidates\nwith reasons, which is the part that catches a \"failover\" policy that has\nquietly compiled down to a single attempt.",
+        "description": "Compile a policy and return the plan, without dispatching anything.\n\nOperator-gated, and deliberately so: the response enumerates the policy's\ntargets, which is exactly the information a policy exists to keep off the wire.\nIt is a management surface, not a caller-facing one.\n\nAccepts an unsaved ``spec`` as well as a saved ``name``, so a form can validate\nwhat the operator is about to save. The response includes dropped candidates\nwith reasons, which is the part that catches a \"failover\" policy that has\nquietly compiled down to a single attempt.",
         "operationId": "explain_policy_v1_routing_policies_explain_post",
         "requestBody": {
           "content": {
@@ -23467,7 +23467,7 @@
         ]
       },
       "patch": {
-        "description": "Persist and apply runtime setting changes.\n\nEach provided field is stored as an override (winning over config/env) and\napplied to the running gateway immediately. Master-key gated: these change\nhow the gateway meters and lists models.",
+        "description": "Persist and apply runtime setting changes.\n\nEach provided field is stored as an override (winning over config/env) and\napplied to the running gateway immediately. Operator-gated: these change\nhow the gateway meters and lists models.",
         "operationId": "update_settings_v1_settings_patch",
         "requestBody": {
           "content": {
@@ -23733,7 +23733,7 @@
         ]
       },
       "patch": {
-        "description": "Persist and apply tool/guardrail setting changes.\n\nUses ``model_fields_set`` so an explicit ``null`` clears a field while an\nomitted field is left unchanged. Master-key gated and standalone-only.",
+        "description": "Persist and apply tool/guardrail setting changes.\n\nUses ``model_fields_set`` so an explicit ``null`` clears a field while an\nomitted field is left unchanged. Operator-gated and standalone-only.",
         "operationId": "update_tool_settings_v1_tool_settings_patch",
         "requestBody": {
           "content": {

--- a/docs/public/otari.postman_collection.json
+++ b/docs/public/otari.postman_collection.json
@@ -2159,7 +2159,7 @@
         {
           "name": "List Discoverable Models",
           "request": {
-            "description": "List every model the configured provider credentials can reach.\n\nOperator-facing counterpart to GET /v1/models, which serves a curated catalog\nto API callers. This reports each provider separately and keeps its error, so\na provider with a bad key is distinguishable from one with no models. It is\nmaster-key gated because a provider error message describes the gateway's own\nconfiguration.\n\nAnswers from the discovery cache, which a background refresher keeps warm, so\nthe call does not wait on a slow or unreachable provider. Each provider\ncarries the ``checked_at`` its result was produced at; a null one has not been\ndialed yet. Pass ``refresh=true`` to force a live re-dial of every provider.",
+            "description": "List every model the configured provider credentials can reach.\n\nOperator-facing counterpart to GET /v1/models, which serves a curated catalog\nto API callers. This reports each provider separately and keeps its error, so\na provider with a bad key is distinguishable from one with no models. It is\noperator-gated because a provider error message describes the gateway's own\nconfiguration.\n\nAnswers from the discovery cache, which a background refresher keeps warm, so\nthe call does not wait on a slow or unreachable provider. Each provider\ncarries the ``checked_at`` its result was produced at; a null one has not been\ndialed yet. Pass ``refresh=true`` to force a live re-dial of every provider.",
             "header": [],
             "method": "GET",
             "url": {
@@ -2186,7 +2186,7 @@
         {
           "name": "List Model Metadata",
           "request": {
-            "description": "Per-model metadata for the dashboard's detail view, from models.dev.\n\nCovers every model models.dev lists under a configured provider, keyed by the\n``instance:model`` selector the dashboard uses. ``available`` is false when\nenrichment is disabled (``models_dev_metadata``) or models.dev could not be\nreached; the response is then empty and the UI falls back to bundled data.\nMaster-key gated: it describes the gateway's configured providers.\n\nAnswers from the cached catalog, kept warm by a background refresher, so the\ndashboard never waits on the models.dev fetch timeout.",
+            "description": "Per-model metadata for the dashboard's detail view, from models.dev.\n\nCovers every model models.dev lists under a configured provider, keyed by the\n``instance:model`` selector the dashboard uses. ``available`` is false when\nenrichment is disabled (``models_dev_metadata``) or models.dev could not be\nreached; the response is then empty and the UI falls back to bundled data.\nOperator-gated: it describes the gateway's configured providers.\n\nAnswers from the cached catalog, kept warm by a background refresher, so the\ndashboard never waits on the models.dev fetch timeout.",
             "header": [],
             "method": "GET",
             "url": {
@@ -3937,7 +3937,7 @@
               },
               "raw": "{\n  \"allowed_models\": [\n    \"string\"\n  ],\n  \"budget_remaining_usd\": 0,\n  \"budget_used_pct\": 0,\n  \"key_id\": \"string\",\n  \"name\": \"string\",\n  \"spec\": {},\n  \"user_id\": \"string\",\n  \"workspace_id\": \"00000000-0000-0000-0000-000000000000\"\n}"
             },
-            "description": "Compile a policy and return the plan, without dispatching anything.\n\nMaster-key gated, and deliberately so: the response enumerates the policy's\ntargets, which is exactly the information a policy exists to keep off the wire.\nIt is a management surface, not a caller-facing one.\n\nAccepts an unsaved ``spec`` as well as a saved ``name``, so a form can validate\nwhat the operator is about to save. The response includes dropped candidates\nwith reasons, which is the part that catches a \"failover\" policy that has\nquietly compiled down to a single attempt.",
+            "description": "Compile a policy and return the plan, without dispatching anything.\n\nOperator-gated, and deliberately so: the response enumerates the policy's\ntargets, which is exactly the information a policy exists to keep off the wire.\nIt is a management surface, not a caller-facing one.\n\nAccepts an unsaved ``spec`` as well as a saved ``name``, so a form can validate\nwhat the operator is about to save. The response includes dropped candidates\nwith reasons, which is the part that catches a \"failover\" policy that has\nquietly compiled down to a single attempt.",
             "header": [
               {
                 "key": "Content-Type",
@@ -4997,7 +4997,7 @@
         {
           "name": "List Providers",
           "request": {
-            "description": "List static metadata for every configured provider.\n\nOperator-facing: reports each provider's capabilities, documentation and\npricing links, and display name from the bundled any-llm and genai-prices\ndatasets. No provider is contacted, so this is cheap and always available.\nMaster-key gated because it describes the gateway's own configuration.",
+            "description": "List static metadata for every configured provider.\n\nOperator-facing: reports each provider's capabilities, documentation and\npricing links, and display name from the bundled any-llm and genai-prices\ndatasets. No provider is contacted, so this is cheap and always available.",
             "header": [],
             "method": "GET",
             "url": {
@@ -5015,7 +5015,7 @@
         {
           "name": "Provider Catalog",
           "request": {
-            "description": "List every known provider for the add-provider picker: id and name only.\n\nLightweight by design so the picker never lags: provider ids come from the\nany-llm registry and names from the bundled genai-prices dataset, so no\nprovider SDK is imported. The autofill hints for a chosen provider come from\nGET /v1/providers/catalog/{provider_id}, which imports only that one SDK.\nMaster-key gated because it is operator-facing dashboard data.",
+            "description": "List every known provider for the add-provider picker: id and name only.\n\nLightweight by design so the picker never lags: provider ids come from the\nany-llm registry and names from the bundled genai-prices dataset, so no\nprovider SDK is imported. The autofill hints for a chosen provider come from\nGET /v1/providers/catalog/{provider_id}, which imports only that one SDK.",
             "header": [],
             "method": "GET",
             "url": {
@@ -5034,7 +5034,7 @@
         {
           "name": "Provider Catalog Detail",
           "request": {
-            "description": "Autofill hints for one provider the add-provider form has selected.\n\nImports only the selected provider's any-llm module (not the whole catalog)\nto report its credential env var, default endpoint, whether a key is required,\nand whether that env var is already set on the server. Returns 404 for an\nunknown provider id. Master-key gated because it is operator-facing.\n\nThe SDK import is offloaded to a worker thread: the first fetch for a given\nprovider imports that provider's module, which would otherwise block the event\nloop (and thus every concurrent request) for the import's duration.",
+            "description": "Autofill hints for one provider the add-provider form has selected.\n\nImports only the selected provider's any-llm module (not the whole catalog)\nto report its credential env var, default endpoint, whether a key is required,\nand whether that env var is already set on the server. Returns 404 for an\nunknown provider id.\n\nThe SDK import is offloaded to a worker thread: the first fetch for a given\nprovider imports that provider's module, which would otherwise block the event\nloop (and thus every concurrent request) for the import's duration.",
             "header": [],
             "method": "GET",
             "url": {
@@ -5061,7 +5061,7 @@
         {
           "name": "Provider Health",
           "request": {
-            "description": "Report every configured provider's reachability, with a last-checked time.\n\nReuses the per-provider model-discovery test path, so a provider is healthy\nwhen its credentials can list models. Results are served from the discovery\ncache (cheap enough to poll), so ``checked_at`` reflects when each provider\nwas actually dialed. Pass ``refresh=true`` to force a live re-dial of every\nprovider. Master-key gated because it describes the gateway's own providers.\n\nA provider whose backend serves no model-listing endpoint cannot be verified\nthis way, but it is not unreachable either: it is reported with\n``discovery_unsupported`` and counted under ``degraded`` rather than as a\nreachability failure.",
+            "description": "Report every configured provider's reachability, with a last-checked time.\n\nReuses the per-provider model-discovery test path, so a provider is healthy\nwhen its credentials can list models. Results are served from the discovery\ncache (cheap enough to poll), so ``checked_at`` reflects when each provider\nwas actually dialed. Pass ``refresh=true`` to force a live re-dial of every\nprovider.\n\nA provider whose backend serves no model-listing endpoint cannot be verified\nthis way, but it is not unreachable either: it is reported with\n``discovery_unsupported`` and counted under ``degraded`` rather than as a\nreachability failure.",
             "header": [],
             "method": "GET",
             "url": {
@@ -5603,7 +5603,7 @@
               },
               "raw": "{\n  \"budget_estimate_default_output_tokens\": 0,\n  \"default_pricing\": false,\n  \"file_understanding_enabled\": false,\n  \"model_cache_ttl_seconds\": 0,\n  \"model_discovery\": false,\n  \"model_discovery_negative_ttl_seconds\": 0,\n  \"model_discovery_timeout_seconds\": 0,\n  \"models_dev_cache_ttl_seconds\": 0,\n  \"models_dev_metadata\": false,\n  \"reject_user_mismatch\": false,\n  \"require_pricing\": false,\n  \"stream_missing_usage_policy\": \"estimate\",\n  \"vision_describe_max_tokens\": 0,\n  \"vision_describe_model\": \"string\",\n  \"vision_strategy\": \"describe\"\n}"
             },
-            "description": "Persist and apply runtime setting changes.\n\nEach provided field is stored as an override (winning over config/env) and\napplied to the running gateway immediately. Master-key gated: these change\nhow the gateway meters and lists models.",
+            "description": "Persist and apply runtime setting changes.\n\nEach provided field is stored as an override (winning over config/env) and\napplied to the running gateway immediately. Operator-gated: these change\nhow the gateway meters and lists models.",
             "header": [
               {
                 "key": "Content-Type",
@@ -5783,7 +5783,7 @@
               },
               "raw": "{\n  \"web_search_max_results\": 5,\n  \"web_search_url\": \"http://searxng:8080\"\n}"
             },
-            "description": "Persist and apply tool/guardrail setting changes.\n\nUses ``model_fields_set`` so an explicit ``null`` clears a field while an\nomitted field is left unchanged. Master-key gated and standalone-only.",
+            "description": "Persist and apply tool/guardrail setting changes.\n\nUses ``model_fields_set`` so an explicit ``null`` clears a field while an\nomitted field is left unchanged. Operator-gated and standalone-only.",
             "header": [
               {
                 "key": "Content-Type",

--- a/src/gateway/AGENTS.md
+++ b/src/gateway/AGENTS.md
@@ -50,8 +50,11 @@ handler.
 `verify_master_key` authenticates either a header master key or an active
 dashboard session. It does not prove that the session may act deployment-wide.
 
-- Deployment-wide management routes declare
-  `require_deployment_operator`.
+- Deployment-wide management routers declare
+  `require_deployment_operator` on the router, not per route, so a route added
+  to one inherits it. Where such a router holds a route with a different rule
+  (a catalog read, external usage ingestion), that route goes on a router of its
+  own rather than overriding the gate in place.
 - Tenant routes authenticate, resolve `CurrentIdentity`, and authorize the
   organization or workspace in `services/tenancy/authorization.py`.
 - Data-plane routes use `verify_api_key_or_master_key`, which never accepts a

--- a/src/gateway/api/deps.py
+++ b/src/gateway/api/deps.py
@@ -360,18 +360,20 @@ async def require_deployment_operator(
     """Refuse a deployment-wide management request from a non-operator identity.
 
     ``verify_master_key`` answers *authenticated*, not *authorized*: a dashboard
-    session clears it for any active, email-verified identity. That is right for
-    the tenant-scoped routers (`organizations.py`, `workspaces.py`,
-    `org_provider_keys.py`, `admin.py`), which declare it as their authentication
-    gate and then re-check the caller's role against the organization, workspace
-    or deployment they are acting on. It is wrong for the deployment-wide
-    routers, where clearing it *is* the whole authorization: `/v1/keys` mints a
-    key into any workspace, `/v1/provider-credentials` holds process-global
-    provider secrets, and `POST /v1/settings/master-key/rotate` replaces the
-    deployment credential. On a single-operator deployment every login is that
-    operator and the distinction is invisible; once mutually-untrusting tenants
-    sign in to one process, a member of one organization holding master-key
-    authority is a cross-organization breach (otari-ai#1880).
+    session clears it for any identity still active. (Address verification is a
+    condition of minting a session, not of resolving one, so it says nothing
+    about authority either way.) That is right for the tenant-scoped routers
+    (`organizations.py`, `workspaces.py`, `org_provider_keys.py`, `admin.py`),
+    which declare it as their authentication gate and then re-check the caller's
+    role against the organization, workspace or deployment they are acting on.
+    It is wrong for the deployment-wide routers, where clearing it *is* the
+    whole authorization: `/v1/keys` mints a key into any workspace,
+    `/v1/provider-credentials` holds process-global provider secrets, and
+    `POST /v1/settings/master-key/rotate` replaces the deployment credential. On
+    a single-operator deployment every login is that operator and the
+    distinction is invisible; once mutually-untrusting tenants sign in to one
+    process, a member of one organization holding master-key authority is a
+    cross-organization breach (otari-ai#1880).
 
     A **header master key** is the deployment credential itself, so it passes; it
     names nobody, and ``get_current_identity`` resolves it to the bootstrap
@@ -382,10 +384,16 @@ async def require_deployment_operator(
     than re-derived so the routers guarded here and the account administration
     that can grant the authority cannot come to disagree about who holds it.
 
-    Declared as a dependency and not a check inside each handler so it composes
-    the way the router it guards already declares auth, and so ``Depends``
-    caching means the master-key verification underneath runs once per request
-    however many of these a route pulls in.
+    Declared on the router rather than per route, and as a dependency rather
+    than a check inside each handler: a route added to one of those routers
+    later inherits the gate instead of being reachable with no credential at
+    all until someone notices the missing decorator. ``Depends`` caching means
+    the master-key verification underneath still runs once per request however
+    many of these a route pulls in. The three modules that hold an exception
+    (``models.py`` and ``pricing.py`` for the catalog reads, ``usage.py`` for
+    external-event ingestion) put it on a router of its own, so admitting a
+    non-operator is spelled at a router instead of hidden in one route's
+    decorator.
     """
     if session_identity is not None and not await DeploymentUserService(db).has_administration_access(
         session_identity
@@ -455,8 +463,10 @@ async def verify_catalog_reader(
     deployment-wide costs a signed-in caller's own organization nothing.
 
     Split out rather than left as a branch inside the other dependency so that
-    adding a route to this plane defaults to refusing the cookie, and admitting
-    one is a decision spelled at the route.
+    adding a route to this plane defaults to refusing the cookie. The three
+    routers that serve these reads declare it on the router for the same reason,
+    so admitting a session is spelled where the route is mounted rather than in
+    one route's decorator.
     """
     if session_identity is not None:
         return None, True

--- a/src/gateway/api/main.py
+++ b/src/gateway/api/main.py
@@ -161,10 +161,14 @@ def _register_core_routers(app: FastAPI, config: GatewayConfig) -> None:
         app.include_router(search.router)
         app.include_router(batches.router)
         app.include_router(moderations.router)
-    # Not gated: /v1/models is discovery, not dispatch. A control plane needs it
-    # to tell a tenant which models their gateway could route to, and "models"
-    # is one of the surfaces bootstrap publishes for a hosted deployment.
-    app.include_router(models.router)
+    # The catalog reads are not operator-gated: /v1/models is discovery, not
+    # dispatch. A control plane needs it to tell a tenant which models their
+    # gateway could route to, and "models" is one of the surfaces bootstrap
+    # publishes for a hosted deployment. The operator router goes first so
+    # /v1/models/discoverable and /v1/models/metadata stay ahead of the
+    # /v1/models/{model_id:path} catch-all the catalog router ends with.
+    app.include_router(models.operator_router)
+    app.include_router(models.catalog_router)
     app.include_router(providers.router)
     app.include_router(keys.router)
     app.include_router(users.router)
@@ -175,7 +179,7 @@ def _register_core_routers(app: FastAPI, config: GatewayConfig) -> None:
     app.include_router(organization_guardrails.router)
     # The tenant-scoped read over the same rows ``/v1/usage`` serves to an
     # operator. Mounted with the rest of the ``/v1/organizations/me`` surface
-    # rather than beside ``usage.router``, because what it is scoped to is what
+    # rather than beside the usage routers, because what it is scoped to is what
     # decides who may call it (otari#837).
     app.include_router(organization_usage.router)
     # The tenant-scoped read over the same table ``/v1/routing/policies`` serves
@@ -200,8 +204,14 @@ def _register_core_routers(app: FastAPI, config: GatewayConfig) -> None:
     app.include_router(aliases.router)
     app.include_router(routing.router)
     app.include_router(routing_memory.router)
-    app.include_router(pricing.router)
-    app.include_router(usage.router)
+    # Both prefixed /v1/pricing, split by who may call them; operator first, so
+    # its DELETE /{model_key:path} does not sit behind the catalog catch-all.
+    app.include_router(pricing.operator_router)
+    app.include_router(pricing.catalog_router)
+    # Both prefixed /v1/usage. POST /external-events authenticates with an API
+    # key rather than operator standing, so it is mounted on its own router.
+    app.include_router(usage.operator_router)
+    app.include_router(usage.ingest_router)
     app.include_router(agent_telemetry.router)
     app.include_router(otlp.router)
     app.include_router(settings.router)

--- a/src/gateway/api/routes/agent_telemetry.py
+++ b/src/gateway/api/routes/agent_telemetry.py
@@ -60,7 +60,11 @@ from gateway.services.agent_telemetry_service import (
     series_point_increments,
 )
 
-router = APIRouter(prefix="/v1/agent-telemetry", tags=["agent-telemetry"])
+router = APIRouter(
+    prefix="/v1/agent-telemetry",
+    tags=["agent-telemetry"],
+    dependencies=[Depends(require_deployment_operator)],
+)
 
 TelemetryGroupBy = Literal["user_id", "api_key_id"]
 
@@ -368,7 +372,7 @@ def _fold_behavior(counts: BehaviorCounts) -> AgentTelemetryBehavior:
     return behavior
 
 
-@router.get("/summary", dependencies=[Depends(require_deployment_operator)])
+@router.get("/summary")
 async def agent_telemetry_summary(
     db: Annotated[AsyncSession, Depends(get_db)],
     storage: TelemetryStoragePortDep,
@@ -518,7 +522,7 @@ async def _summary_series(
     )
 
 
-@router.get("/count", dependencies=[Depends(require_deployment_operator)])
+@router.get("/count")
 async def count_agent_telemetry(
     storage: TelemetryStoragePortDep,
     start_date: datetime | None = Query(default=None, description=_START_DESC),
@@ -539,7 +543,7 @@ async def count_agent_telemetry(
     return AgentTelemetryCount(total=await storage.count(filters=scope))
 
 
-@router.get("/series", dependencies=[Depends(require_deployment_operator)])
+@router.get("/series")
 async def agent_telemetry_series(
     storage: TelemetryStoragePortDep,
     group_by: TelemetryGroupBy = Query(description="Dimension to split the series by"),
@@ -600,7 +604,7 @@ async def agent_telemetry_series(
     )
 
 
-@router.delete("", dependencies=[Depends(require_deployment_operator)])
+@router.delete("")
 async def delete_agent_telemetry_rows(
     request: AgentTelemetryDeleteRequest,
     storage: TelemetryStoragePortDep,

--- a/src/gateway/api/routes/aliases.py
+++ b/src/gateway/api/routes/aliases.py
@@ -36,7 +36,11 @@ from gateway.repositories.users_repository import get_active_user
 from gateway.services.alias_service import all_alias_names, refresh_alias_cache
 from gateway.services.policy_store import all_policy_names
 
-router = APIRouter(prefix="/v1/aliases", tags=["aliases"])
+router = APIRouter(
+    prefix="/v1/aliases",
+    tags=["aliases"],
+    dependencies=[Depends(require_deployment_operator)],
+)
 
 
 class AliasRequest(BaseModel):
@@ -150,7 +154,7 @@ async def _require_user(db: AsyncSession, user_id: str) -> None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"User '{user_id}' not found")
 
 
-@router.get("", dependencies=[Depends(require_deployment_operator)])
+@router.get("")
 async def list_aliases(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
@@ -195,7 +199,7 @@ async def list_aliases(
     )
 
 
-@router.post("", dependencies=[Depends(require_deployment_operator)])
+@router.post("")
 async def set_alias(
     request: AliasRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -250,11 +254,7 @@ async def set_alias(
     return AliasResponse.from_model(alias)
 
 
-@router.delete(
-    "/{name:path}",
-    status_code=status.HTTP_204_NO_CONTENT,
-    dependencies=[Depends(require_deployment_operator)],
-)
+@router.delete("/{name:path}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_alias(
     name: str,
     db: Annotated[AsyncSession, Depends(get_db)],

--- a/src/gateway/api/routes/budgets.py
+++ b/src/gateway/api/routes/budgets.py
@@ -15,7 +15,11 @@ from gateway.models.tenancy import Workspace
 from gateway.services.budget_retiming import cadence_of, retime_ceilings_for_budget
 from gateway.services.scoped_budget_service import ResetAlignment
 
-router = APIRouter(prefix="/v1/budgets", tags=["budgets"])
+router = APIRouter(
+    prefix="/v1/budgets",
+    tags=["budgets"],
+    dependencies=[Depends(require_deployment_operator)],
+)
 
 # The rollup below sums exact counters, so its coalesce default is exact too.
 _ZERO = Decimal(0)
@@ -149,7 +153,7 @@ async def _budget_usage(db: AsyncSession, budget_id: str) -> tuple[int, float, f
     return int(row[0]), float(row[1]), float(row[2])
 
 
-@router.post("", dependencies=[Depends(require_deployment_operator)])
+@router.post("")
 async def create_budget(
     request: CreateBudgetRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -178,7 +182,7 @@ async def create_budget(
     return BudgetResponse.from_model(budget)
 
 
-@router.get("", dependencies=[Depends(require_deployment_operator)])
+@router.get("")
 async def list_budgets(
     db: Annotated[AsyncSession, Depends(get_db)],
     skip: Annotated[int, Query(ge=0)] = 0,
@@ -218,7 +222,7 @@ async def list_budgets(
     ]
 
 
-@router.get("/{budget_id}", dependencies=[Depends(require_deployment_operator)])
+@router.get("/{budget_id}")
 async def get_budget(
     budget_id: str,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -239,7 +243,7 @@ async def get_budget(
     )
 
 
-@router.patch("/{budget_id}", dependencies=[Depends(require_deployment_operator)])
+@router.patch("/{budget_id}")
 async def update_budget(
     budget_id: str,
     request: UpdateBudgetRequest,
@@ -316,11 +320,7 @@ async def update_budget(
     )
 
 
-@router.delete(
-    "/{budget_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
-    dependencies=[Depends(require_deployment_operator)],
-)
+@router.delete("/{budget_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_budget(
     budget_id: str,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -392,7 +392,7 @@ async def delete_budget(
         ) from None
 
 
-@router.get("/{budget_id}/reset-logs", dependencies=[Depends(require_deployment_operator)])
+@router.get("/{budget_id}/reset-logs")
 async def list_budget_reset_logs(
     budget_id: str,
     db: Annotated[AsyncSession, Depends(get_db)],

--- a/src/gateway/api/routes/keys.py
+++ b/src/gateway/api/routes/keys.py
@@ -26,7 +26,11 @@ _KEY_EXCEEDS_USER_DETAIL = (
     "the user's model access, not broaden it."
 )
 
-router = APIRouter(prefix="/v1/keys", tags=["keys"])
+router = APIRouter(
+    prefix="/v1/keys",
+    tags=["keys"],
+    dependencies=[Depends(require_deployment_operator)],
+)
 
 
 async def _caller_organization_id(
@@ -216,7 +220,7 @@ class UpdateKeyRequest(BaseModel):
     metadata: dict[str, Any] | None = None
 
 
-@router.post("", dependencies=[Depends(require_deployment_operator)])
+@router.post("")
 async def create_key(
     request: CreateKeyRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -336,7 +340,7 @@ async def create_key(
     )
 
 
-@router.get("", dependencies=[Depends(require_deployment_operator)])
+@router.get("")
 async def list_keys(
     db: Annotated[AsyncSession, Depends(get_db)],
     organization_id: CallerOrganization,
@@ -363,7 +367,7 @@ async def list_keys(
     return [KeyInfo.from_model(key) for key in keys]
 
 
-@router.get("/{key_id}", dependencies=[Depends(require_deployment_operator)])
+@router.get("/{key_id}")
 async def get_key(
     key_id: str,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -378,7 +382,7 @@ async def get_key(
     return KeyInfo.from_model(key)
 
 
-@router.patch("/{key_id}", dependencies=[Depends(require_deployment_operator)])
+@router.patch("/{key_id}")
 async def update_key(
     key_id: str,
     request: UpdateKeyRequest,
@@ -440,7 +444,7 @@ async def update_key(
     return KeyInfo.from_model(key)
 
 
-@router.post("/{key_id}/rotate", dependencies=[Depends(require_deployment_operator)])
+@router.post("/{key_id}/rotate")
 async def rotate_key(
     key_id: str,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -479,7 +483,7 @@ async def rotate_key(
     )
 
 
-@router.delete("/{key_id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(require_deployment_operator)])
+@router.delete("/{key_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_key(
     key_id: str,
     db: Annotated[AsyncSession, Depends(get_db)],

--- a/src/gateway/api/routes/mail.py
+++ b/src/gateway/api/routes/mail.py
@@ -1,6 +1,6 @@
 """Outgoing mail settings, and the operator's way to prove they work.
 
-Two endpoints under ``/v1/settings``, master-key gated and standalone-only like
+Two endpoints under ``/v1/settings``, operator-gated and standalone-only like
 the rest of the management API:
 
 * ``GET /v1/settings/mail`` reports which transport (if any) this deployment
@@ -28,7 +28,11 @@ from gateway.core.config import GatewayConfig
 from gateway.log_config import logger
 from gateway.services.mail import Mailer, MailNotConfiguredError, normalized_address
 
-router = APIRouter(prefix="/v1/settings/mail", tags=["settings"])
+router = APIRouter(
+    prefix="/v1/settings/mail",
+    tags=["settings"],
+    dependencies=[Depends(require_deployment_operator)],
+)
 
 
 class MailSettings(BaseModel):
@@ -100,13 +104,13 @@ def _settings(config: GatewayConfig) -> MailSettings:
     )
 
 
-@router.get("", dependencies=[Depends(require_deployment_operator)])
+@router.get("")
 async def get_mail_settings(config: Annotated[GatewayConfig, Depends(get_config)]) -> MailSettings:
     """Report the effective outgoing-mail configuration."""
     return _settings(config)
 
 
-@router.post("/test", dependencies=[Depends(require_deployment_operator)])
+@router.post("/test")
 async def send_test_mail(
     request: SendTestMailRequest,
     config: Annotated[GatewayConfig, Depends(get_config)],

--- a/src/gateway/api/routes/maintenance_mode.py
+++ b/src/gateway/api/routes/maintenance_mode.py
@@ -1,6 +1,6 @@
 """The maintenance-mode switch: freeze and unfreeze dashboard sign-ins.
 
-Two endpoints under ``/v1/settings``, master-key gated and standalone-only like
+Two endpoints under ``/v1/settings``, operator-gated and standalone-only like
 the rest of the management API. The state itself, and why it is stored the way
 it is, belongs to ``services/maintenance_mode_service.py``.
 
@@ -29,7 +29,11 @@ from gateway.api.deps import get_db, require_deployment_operator
 from gateway.log_config import logger
 from gateway.services.maintenance_mode_service import is_maintenance_mode, stage_maintenance_mode
 
-router = APIRouter(prefix="/v1/settings/maintenance-mode", tags=["settings"])
+router = APIRouter(
+    prefix="/v1/settings/maintenance-mode",
+    tags=["settings"],
+    dependencies=[Depends(require_deployment_operator)],
+)
 
 
 class MaintenanceMode(BaseModel):
@@ -51,13 +55,13 @@ class UpdateMaintenanceModeRequest(BaseModel):
     enabled: bool = Field(description="True to freeze new dashboard sign-ins, false to allow them again.")
 
 
-@router.get("", dependencies=[Depends(require_deployment_operator)])
+@router.get("")
 async def get_maintenance_mode(db: Annotated[AsyncSession, Depends(get_db)]) -> MaintenanceMode:
     """Report whether new dashboard sign-ins are frozen."""
     return MaintenanceMode(enabled=await is_maintenance_mode(db))
 
 
-@router.patch("", dependencies=[Depends(require_deployment_operator)])
+@router.patch("")
 async def update_maintenance_mode(
     request: UpdateMaintenanceModeRequest,
     db: Annotated[AsyncSession, Depends(get_db)],

--- a/src/gateway/api/routes/models.py
+++ b/src/gateway/api/routes/models.py
@@ -44,7 +44,22 @@ from gateway.services.provider_kwargs import normalize_pricing_key
 if TYPE_CHECKING:
     from any_llm.types.model import Model
 
-router = APIRouter(prefix="/v1", tags=["models"])
+# Two routers under one prefix, one per authorization rule, so that adding a
+# route defaults to refusing a caller who is not a deployment operator and
+# opening one up to any catalog reader has to be spelled by the router it is
+# declared on. The catalog reads name ``verify_catalog_reader`` a second time as
+# a parameter because they use what it resolves; ``Depends`` caching means it
+# still runs once per request.
+operator_router = APIRouter(
+    prefix="/v1",
+    tags=["models"],
+    dependencies=[Depends(require_deployment_operator)],
+)
+catalog_router = APIRouter(
+    prefix="/v1",
+    tags=["models"],
+    dependencies=[Depends(verify_catalog_reader)],
+)
 
 # ``owned_by`` reported for alias entries. Aliases intentionally hide the
 # underlying provider, so the gateway itself is named as the owner rather than
@@ -418,7 +433,7 @@ async def _get_pricing_map(
     return {p.model_key: p for p in pricings}
 
 
-@router.get("/models")
+@catalog_router.get("/models")
 async def list_models(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
@@ -580,12 +595,13 @@ async def list_models(
     return ModelListResponse(data=sorted_models)
 
 
-# Declared before GET /models/{model_id:path}: FastAPI matches routes in
-# registration order, so a later declaration would be shadowed and "discoverable"
-# would arrive as a model id. The corollary is that a provider model literally
-# named "discoverable" is unreachable via GET /v1/models/discoverable; that is
-# accepted, and such a model is still listed by GET /v1/models.
-@router.get("/models/discoverable", dependencies=[Depends(require_deployment_operator)])
+# Served before GET /models/{model_id:path}, which FastAPI would otherwise match
+# first and hand "discoverable" to as a model id. The two are now on different
+# routers, so what keeps this true is the order ``api/main.py`` mounts them in,
+# not the order they are declared in here. The corollary is that a provider model
+# literally named "discoverable" is unreachable via GET /v1/models/discoverable;
+# that is accepted, and such a model is still listed by GET /v1/models.
+@operator_router.get("/models/discoverable")
 async def list_discoverable_models(
     config: Annotated[GatewayConfig, Depends(get_config)],
     refresh: Annotated[
@@ -598,7 +614,7 @@ async def list_discoverable_models(
     Operator-facing counterpart to GET /v1/models, which serves a curated catalog
     to API callers. This reports each provider separately and keeps its error, so
     a provider with a bad key is distinguishable from one with no models. It is
-    master-key gated because a provider error message describes the gateway's own
+    operator-gated because a provider error message describes the gateway's own
     configuration.
 
     Answers from the discovery cache, which a background refresher keeps warm, so
@@ -629,9 +645,8 @@ async def list_discoverable_models(
     return DiscoverableModelsResponse(providers=sorted(providers, key=lambda p: p.provider))
 
 
-# Declared before GET /models/{model_id:path} for the same route-order reason as
-# /models/discoverable above.
-@router.get("/models/metadata", dependencies=[Depends(require_deployment_operator)])
+# Ahead of GET /models/{model_id:path} for the same reason as /models/discoverable.
+@operator_router.get("/models/metadata")
 async def list_model_metadata(
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> ModelMetadataResponse:
@@ -641,7 +656,7 @@ async def list_model_metadata(
     ``instance:model`` selector the dashboard uses. ``available`` is false when
     enrichment is disabled (``models_dev_metadata``) or models.dev could not be
     reached; the response is then empty and the UI falls back to bundled data.
-    Master-key gated: it describes the gateway's configured providers.
+    Operator-gated: it describes the gateway's configured providers.
 
     Answers from the cached catalog, kept warm by a background refresher, so the
     dashboard never waits on the models.dev fetch timeout.
@@ -654,7 +669,7 @@ async def list_model_metadata(
     )
 
 
-@router.get("/models/{model_id:path}")
+@catalog_router.get("/models/{model_id:path}")
 async def get_model(
     model_id: str,
     db: Annotated[AsyncSession, Depends(get_db)],

--- a/src/gateway/api/routes/pricing.py
+++ b/src/gateway/api/routes/pricing.py
@@ -24,7 +24,21 @@ from gateway.services.pricing_refresh_service import (
 from gateway.services.pricing_service import normalize_effective_at
 from gateway.services.provider_kwargs import normalize_pricing_key, provider_key, split_selector
 
-router = APIRouter(prefix="/v1/pricing", tags=["pricing"])
+# Two routers under one prefix, one per authorization rule, so that adding a
+# route defaults to refusing a caller who is not a deployment operator and
+# opening one up to any catalog reader has to be spelled by the router it is
+# declared on. See ``api/deps.verify_catalog_reader`` for why the reads are open
+# at all.
+operator_router = APIRouter(
+    prefix="/v1/pricing",
+    tags=["pricing"],
+    dependencies=[Depends(require_deployment_operator)],
+)
+catalog_router = APIRouter(
+    prefix="/v1/pricing",
+    tags=["pricing"],
+    dependencies=[Depends(verify_catalog_reader)],
+)
 
 
 class PricingTier(BaseModel):
@@ -174,11 +188,7 @@ def _candidate_model_keys(raw_key: str) -> list[str]:
     return candidates
 
 
-@router.post(
-    "/refresh",
-    response_model=PricingRefreshPreviewResponse,
-    dependencies=[Depends(require_deployment_operator)],
-)
+@operator_router.post("/refresh", response_model=PricingRefreshPreviewResponse)
 async def preview_pricing_refresh(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> PricingRefreshPreviewResponse:
@@ -209,11 +219,7 @@ async def preview_pricing_refresh(
     )
 
 
-@router.post(
-    "/refresh/confirm",
-    response_model=PricingRefreshConfirmationResponse,
-    dependencies=[Depends(require_deployment_operator)],
-)
+@operator_router.post("/refresh/confirm", response_model=PricingRefreshConfirmationResponse)
 async def confirm_pricing_refresh(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> PricingRefreshConfirmationResponse:
@@ -231,11 +237,7 @@ async def confirm_pricing_refresh(
     return PricingRefreshConfirmationResponse()
 
 
-@router.post(
-    "/refresh/reject",
-    status_code=status.HTTP_204_NO_CONTENT,
-    dependencies=[Depends(require_deployment_operator)],
-)
+@operator_router.post("/refresh/reject", status_code=status.HTTP_204_NO_CONTENT)
 async def reject_pricing_refresh(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> None:
@@ -314,7 +316,7 @@ def _policy_pricing_detail(config: GatewayConfig, request: SetPricingRequest) ->
     )
 
 
-@router.post("", dependencies=[Depends(require_deployment_operator)])
+@operator_router.post("")
 async def set_pricing(
     request: SetPricingRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -433,7 +435,7 @@ async def set_pricing(
     return PricingResponse.from_model(pricing)
 
 
-@router.get("", dependencies=[Depends(verify_catalog_reader)])
+@catalog_router.get("")
 async def list_pricing(
     db: Annotated[AsyncSession, Depends(get_db)],
     skip: Annotated[int, Query(ge=0)] = 0,
@@ -452,7 +454,7 @@ async def list_pricing(
     return [PricingResponse.from_model(pricing) for pricing in pricings]
 
 
-@router.get("/{model_key:path}/history", dependencies=[Depends(verify_catalog_reader)])
+@catalog_router.get("/{model_key:path}/history")
 async def get_pricing_history(
     model_key: str,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -470,7 +472,7 @@ async def get_pricing_history(
     return [PricingResponse.from_model(pricing) for pricing in pricings]
 
 
-@router.get("/{model_key:path}", dependencies=[Depends(verify_catalog_reader)])
+@catalog_router.get("/{model_key:path}")
 async def get_pricing(
     model_key: str,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -490,11 +492,7 @@ async def get_pricing(
     return PricingResponse.from_model(pricing)
 
 
-@router.delete(
-    "/{model_key:path}",
-    status_code=status.HTTP_204_NO_CONTENT,
-    dependencies=[Depends(require_deployment_operator)],
-)
+@operator_router.delete("/{model_key:path}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_pricing(
     model_key: str,
     db: Annotated[AsyncSession, Depends(get_db)],

--- a/src/gateway/api/routes/providers.py
+++ b/src/gateway/api/routes/providers.py
@@ -3,8 +3,9 @@
 The ``/v1/providers`` endpoint reports static, network-free metadata for every
 configured provider. The ``/v1/provider-credentials`` endpoints manage the
 ``provider_credentials`` table: providers an operator adds at runtime through the
-dashboard, encrypted at rest and merged over config.yml providers. All routes are
-master-key gated and standalone-mode only (the router is not mounted in hybrid).
+dashboard, encrypted at rest and merged over config.yml providers. Every route
+here describes or changes the gateway's own configuration, so the router is
+operator-gated; standalone-mode only (it is not mounted in hybrid).
 """
 
 import asyncio
@@ -52,7 +53,11 @@ from gateway.services.secret_box import (
 )
 from gateway.services.url_safety import UnsafeURLError, validate_provider_api_base
 
-router = APIRouter(prefix="/v1", tags=["providers"])
+router = APIRouter(
+    prefix="/v1",
+    tags=["providers"],
+    dependencies=[Depends(require_deployment_operator)],
+)
 
 
 class ProviderCapabilitiesSchema(BaseModel):
@@ -116,7 +121,7 @@ def _to_schema(info: ProviderInfo) -> ProviderInfoSchema:
     )
 
 
-@router.get("/providers", dependencies=[Depends(require_deployment_operator)])
+@router.get("/providers")
 async def list_providers(
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> ProvidersResponse:
@@ -125,7 +130,6 @@ async def list_providers(
     Operator-facing: reports each provider's capabilities, documentation and
     pricing links, and display name from the bundled any-llm and genai-prices
     datasets. No provider is contacted, so this is cheap and always available.
-    Master-key gated because it describes the gateway's own configuration.
     """
     return ProvidersResponse(providers=[_to_schema(info) for info in list_provider_info(config)])
 
@@ -166,7 +170,7 @@ def _to_known_schema(provider: KnownProvider) -> KnownProviderSchema:
     )
 
 
-@router.get("/providers/catalog", dependencies=[Depends(require_deployment_operator)])
+@router.get("/providers/catalog")
 async def provider_catalog() -> list[KnownProviderSummarySchema]:
     """List every known provider for the add-provider picker: id and name only.
 
@@ -174,19 +178,18 @@ async def provider_catalog() -> list[KnownProviderSummarySchema]:
     any-llm registry and names from the bundled genai-prices dataset, so no
     provider SDK is imported. The autofill hints for a chosen provider come from
     GET /v1/providers/catalog/{provider_id}, which imports only that one SDK.
-    Master-key gated because it is operator-facing dashboard data.
     """
     return [_to_summary_schema(summary) for summary in list_known_provider_summaries()]
 
 
-@router.get("/providers/catalog/{provider_id}", dependencies=[Depends(require_deployment_operator)])
+@router.get("/providers/catalog/{provider_id}")
 async def provider_catalog_detail(provider_id: str) -> KnownProviderSchema:
     """Autofill hints for one provider the add-provider form has selected.
 
     Imports only the selected provider's any-llm module (not the whole catalog)
     to report its credential env var, default endpoint, whether a key is required,
     and whether that env var is already set on the server. Returns 404 for an
-    unknown provider id. Master-key gated because it is operator-facing.
+    unknown provider id.
 
     The SDK import is offloaded to a worker thread: the first fetch for a given
     provider imports that provider's module, which would otherwise block the event
@@ -253,7 +256,7 @@ def _to_health_schema(health: ProviderHealth) -> ProviderHealthSchema:
     )
 
 
-@router.get("/providers/health", dependencies=[Depends(require_deployment_operator)])
+@router.get("/providers/health")
 async def provider_health(
     config: Annotated[GatewayConfig, Depends(get_config)],
     refresh: bool = False,
@@ -264,7 +267,7 @@ async def provider_health(
     when its credentials can list models. Results are served from the discovery
     cache (cheap enough to poll), so ``checked_at`` reflects when each provider
     was actually dialed. Pass ``refresh=true`` to force a live re-dial of every
-    provider. Master-key gated because it describes the gateway's own providers.
+    provider.
 
     A provider whose backend serves no model-listing endpoint cannot be verified
     this way, but it is not unreachable either: it is reported with
@@ -454,7 +457,7 @@ async def _apply_write(db: AsyncSession, config: GatewayConfig, instance: str) -
         logger.warning("Provider overlay refresh failed after writing '%s'; converges within TTL", instance)
 
 
-@router.post("/provider-credentials/test", dependencies=[Depends(require_deployment_operator)])
+@router.post("/provider-credentials/test")
 async def test_provider_connection(
     request: TestProviderRequest,
     config: Annotated[GatewayConfig, Depends(get_config)],
@@ -491,7 +494,7 @@ async def test_provider_connection(
     )
 
 
-@router.post("/provider-credentials/reencrypt", dependencies=[Depends(require_deployment_operator)])
+@router.post("/provider-credentials/reencrypt")
 async def reencrypt_stored_provider_keys(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
@@ -520,7 +523,7 @@ async def reencrypt_stored_provider_keys(
     return ReencryptProviderCredentialsResponse(reencrypted=reencrypted, unreadable=unreadable)
 
 
-@router.get("/provider-credentials", dependencies=[Depends(require_deployment_operator)])
+@router.get("/provider-credentials")
 async def list_stored_providers(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> list[StoredProviderResponse]:
@@ -530,11 +533,7 @@ async def list_stored_providers(
     ]
 
 
-@router.post(
-    "/provider-credentials",
-    status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(require_deployment_operator)],
-)
+@router.post("/provider-credentials", status_code=status.HTTP_201_CREATED)
 async def create_stored_provider(
     request: CreateStoredProviderRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -574,7 +573,7 @@ async def create_stored_provider(
     return StoredProviderResponse.from_model(row)
 
 
-@router.patch("/provider-credentials/{instance}", dependencies=[Depends(require_deployment_operator)])
+@router.patch("/provider-credentials/{instance}")
 async def update_stored_provider(
     instance: str,
     request: UpdateStoredProviderRequest,
@@ -620,11 +619,7 @@ async def update_stored_provider(
     return StoredProviderResponse.from_model(row)
 
 
-@router.delete(
-    "/provider-credentials/{instance}",
-    status_code=status.HTTP_204_NO_CONTENT,
-    dependencies=[Depends(require_deployment_operator)],
-)
+@router.delete("/provider-credentials/{instance}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_stored_provider(
     instance: str,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -640,7 +635,7 @@ async def delete_stored_provider(
     await _apply_write(db, config, instance)
 
 
-@router.post("/provider-credentials/{instance}/test", dependencies=[Depends(require_deployment_operator)])
+@router.post("/provider-credentials/{instance}/test")
 async def test_stored_provider(
     instance: str,
     db: Annotated[AsyncSession, Depends(get_db)],

--- a/src/gateway/api/routes/routing.py
+++ b/src/gateway/api/routes/routing.py
@@ -12,7 +12,7 @@ who is then the only caller that resolves it. Omitting ``workspace_id`` means th
 deployment's default workspace, so a single-workspace deployment never names one.
 See ``services/policy_store`` for precedence between the layers.
 
-Master-key gated on every verb, like alias management. That is what makes a policy
+Operator-gated on every verb, like alias management. That is what makes a policy
 safe as a unit of access: only an operator can decide which models a name reaches,
 so a caller cannot widen their own access by writing a policy.
 """
@@ -48,7 +48,11 @@ from gateway.services.routing import (
 from gateway.services.routing.decide import explain_router_ordering
 from gateway.services.routing.knn import unpriced_router_candidates
 
-router = APIRouter(prefix="/v1/routing/policies", tags=["routing"])
+router = APIRouter(
+    prefix="/v1/routing/policies",
+    tags=["routing"],
+    dependencies=[Depends(require_deployment_operator)],
+)
 
 
 class PolicyRequest(BaseModel):
@@ -372,7 +376,7 @@ async def _refresh_quietly(db: AsyncSession, name: str) -> None:
         logger.warning("Policy cache refresh failed after writing '%s'; converges within TTL", name)
 
 
-@router.get("", dependencies=[Depends(require_deployment_operator)])
+@router.get("")
 async def list_policies(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
@@ -427,7 +431,7 @@ async def list_policies(
     )
 
 
-@router.post("", dependencies=[Depends(require_deployment_operator)])
+@router.post("")
 async def set_policy(
     request: PolicyRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -542,11 +546,7 @@ async def set_policy(
     return PolicyResponse.from_model(policy, is_dynamic=spec.is_dynamic)
 
 
-@router.delete(
-    "/{name:path}",
-    status_code=status.HTTP_204_NO_CONTENT,
-    dependencies=[Depends(require_deployment_operator)],
-)
+@router.delete("/{name:path}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_policy(
     name: str,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -594,7 +594,7 @@ async def delete_policy(
     await _refresh_quietly(db, name)
 
 
-@router.post("/explain", dependencies=[Depends(require_deployment_operator)])
+@router.post("/explain")
 async def explain_policy(
     request: ExplainRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -602,7 +602,7 @@ async def explain_policy(
 ) -> ExplainResponse:
     """Compile a policy and return the plan, without dispatching anything.
 
-    Master-key gated, and deliberately so: the response enumerates the policy's
+    Operator-gated, and deliberately so: the response enumerates the policy's
     targets, which is exactly the information a policy exists to keep off the wire.
     It is a management surface, not a caller-facing one.
 

--- a/src/gateway/api/routes/routing_memory.py
+++ b/src/gateway/api/routes/routing_memory.py
@@ -17,7 +17,7 @@ are budget-checked and land in the usage log like all other provider spend. A
 convenience endpoint that skipped both would be the only unmetered way to spend
 money through this gateway.
 
-Master-key gated, like ``/v1/routing/policies``, with ``user_id`` naming whose
+Operator-gated, like ``/v1/routing/policies``, with ``user_id`` naming whose
 memory is being taught rather than taking it from the calling key: which model
 serves a caller is an operator decision, exactly as a policy's targets are.
 
@@ -59,7 +59,11 @@ from gateway.services.provider_kwargs import resolve_provider_selector
 from gateway.services.routing import KNN_BACKEND, backend_pool_is_teachable, get_router_backend
 from gateway.services.routing.knn import KnnRoutingMemory
 
-router = APIRouter(prefix="/v1/routing", tags=["routing"])
+router = APIRouter(
+    prefix="/v1/routing",
+    tags=["routing"],
+    dependencies=[Depends(require_deployment_operator)],
+)
 
 # One request may not teach more than this. Each example costs an embedding call,
 # so a batch is a loop with a bound rather than an unbounded fan-out.
@@ -373,7 +377,7 @@ async def _pool_counts(
     return total, [(str(task_id), int(count)) for task_id, count in rows]
 
 
-@router.post("/preferences/rank", dependencies=[Depends(require_deployment_operator)])
+@router.post("/preferences/rank")
 async def rank_candidates(
     request: RankRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -489,7 +493,7 @@ async def rank_candidates(
     return RankResponse(recorded=recorded, seed_count=backend.seed_count, pools=pools)
 
 
-@router.get("/status", dependencies=[Depends(require_deployment_operator)])
+@router.get("/status")
 async def routing_memory_status(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],

--- a/src/gateway/api/routes/scoped_budgets.py
+++ b/src/gateway/api/routes/scoped_budgets.py
@@ -1,6 +1,6 @@
 """Manage the tenancy-scoped USD ceilings in ``scoped_budgets``.
 
-Standalone-mode only, and master-key authed on the router itself.
+Standalone-mode only, and operator-gated on the router itself.
 Deliberately minimal: a scope's ceiling is created, listed, retimed and removed
 here, and everything about how one is enforced lives in
 ``services/scoped_budget_service.py``.

--- a/src/gateway/api/routes/search_tools.py
+++ b/src/gateway/api/routes/search_tools.py
@@ -12,7 +12,7 @@ Config-file tools stay honored and stay read-only here; they are reported by the
 list endpoint so the dashboard can show every tool a request could name, not just
 the editable ones.
 
-Master-key gated and standalone-only (the router is not mounted in hybrid). URL
+Operator-gated and standalone-only (the router is not mounted in hybrid). URL
 validation is structural, matching ``/v1/tool-settings`` rather than the provider
 SSRF gate: the backend this most often points at is a SearXNG sidecar on a
 private address, which a deny-private gate would refuse.
@@ -55,7 +55,11 @@ from gateway.services.secret_box import (
 )
 from gateway.services.tool_settings_service import validate_url
 
-router = APIRouter(prefix="/v1/search-tools", tags=["search-tools"])
+router = APIRouter(
+    prefix="/v1/search-tools",
+    tags=["search-tools"],
+    dependencies=[Depends(require_deployment_operator)],
+)
 
 
 class SearchProviderSchema(BaseModel):
@@ -228,7 +232,7 @@ async def _apply_write(db: AsyncSession, config: GatewayConfig, name: str) -> No
         logger.warning("Search tool overlay refresh failed after writing '%s'; converges within TTL", name)
 
 
-@router.get("/providers", dependencies=[Depends(require_deployment_operator)])
+@router.get("/providers")
 async def list_search_providers(
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> list[SearchProviderSchema]:
@@ -249,7 +253,7 @@ async def list_search_providers(
     ]
 
 
-@router.get("", dependencies=[Depends(require_deployment_operator)])
+@router.get("")
 async def list_all_search_tools(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
@@ -285,7 +289,7 @@ async def list_all_search_tools(
     )
 
 
-@router.post("/reencrypt", dependencies=[Depends(require_deployment_operator)])
+@router.post("/reencrypt")
 async def reencrypt_stored_search_tool_keys(
     db: Annotated[AsyncSession, Depends(get_db)],
     config: Annotated[GatewayConfig, Depends(get_config)],
@@ -313,7 +317,7 @@ async def reencrypt_stored_search_tool_keys(
     return ReencryptSearchToolsResponse(reencrypted=reencrypted, unreadable=unreadable)
 
 
-@router.post("", status_code=status.HTTP_201_CREATED, dependencies=[Depends(require_deployment_operator)])
+@router.post("", status_code=status.HTTP_201_CREATED)
 async def create_search_tool(
     request: CreateSearchToolRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -361,7 +365,7 @@ async def create_search_tool(
     return StoredSearchToolSchema.from_model(row, shadows_config=shadows_config)
 
 
-@router.patch("/{name}", dependencies=[Depends(require_deployment_operator)])
+@router.patch("/{name}")
 async def update_search_tool(
     name: str,
     request: UpdateSearchToolRequest,
@@ -423,7 +427,7 @@ async def update_search_tool(
     return StoredSearchToolSchema.from_model(row, shadows_config=name in config_file_search_tools(config))
 
 
-@router.delete("/{name}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(require_deployment_operator)])
+@router.delete("/{name}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_stored_search_tool(
     name: str,
     db: Annotated[AsyncSession, Depends(get_db)],

--- a/src/gateway/api/routes/settings.py
+++ b/src/gateway/api/routes/settings.py
@@ -49,7 +49,11 @@ from gateway.services.secret_box import secret_box_configured
 from gateway.services.url_safety import redact_url_secrets
 from gateway.version import __version__
 
-router = APIRouter(prefix="/v1/settings", tags=["settings"])
+router = APIRouter(
+    prefix="/v1/settings",
+    tags=["settings"],
+    dependencies=[Depends(require_deployment_operator)],
+)
 
 # The effective-config view, in display order. Each entry is a group label and
 # the config field names shown under it. Only non-secret scalar fields appear;
@@ -376,7 +380,7 @@ def _current_settings(config: GatewayConfig) -> GatewaySettings:
     )
 
 
-@router.get("", dependencies=[Depends(require_deployment_operator)])
+@router.get("")
 async def get_settings(
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> GatewaySettings:
@@ -384,7 +388,7 @@ async def get_settings(
     return _current_settings(config)
 
 
-@router.patch("", dependencies=[Depends(require_deployment_operator)])
+@router.patch("")
 async def update_settings(
     request: UpdateSettingsRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -393,7 +397,7 @@ async def update_settings(
     """Persist and apply runtime setting changes.
 
     Each provided field is stored as an override (winning over config/env) and
-    applied to the running gateway immediately. Master-key gated: these change
+    applied to the running gateway immediately. Operator-gated: these change
     how the gateway meters and lists models.
     """
     # Every field on the request maps 1:1 onto a settable key. Use the set of
@@ -425,7 +429,7 @@ async def update_settings(
     return _current_settings(config)
 
 
-@router.post("/master-key/rotate", dependencies=[Depends(require_deployment_operator)])
+@router.post("/master-key/rotate")
 async def rotate_master_key(
     request: Request,
     response: Response,

--- a/src/gateway/api/routes/tool_settings.py
+++ b/src/gateway/api/routes/tool_settings.py
@@ -39,7 +39,11 @@ from gateway.services.tool_settings_service import (
 )
 from gateway.services.url_safety import redact_url_secrets
 
-router = APIRouter(prefix="/v1/tool-settings", tags=["tool-settings"])
+router = APIRouter(
+    prefix="/v1/tool-settings",
+    tags=["tool-settings"],
+    dependencies=[Depends(require_deployment_operator)],
+)
 
 _URL_FIELDS = frozenset(SERVICE_URL_FIELD.values())
 
@@ -121,7 +125,7 @@ def _current_fields(config: GatewayConfig) -> ToolSettingsResponse:
     return ToolSettingsResponse(fields=fields)
 
 
-@router.get("", dependencies=[Depends(require_deployment_operator)])
+@router.get("")
 async def get_tool_settings(
     config: Annotated[GatewayConfig, Depends(get_config)],
 ) -> ToolSettingsResponse:
@@ -129,7 +133,7 @@ async def get_tool_settings(
     return _current_fields(config)
 
 
-@router.patch("", dependencies=[Depends(require_deployment_operator)])
+@router.patch("")
 async def update_tool_settings(
     request: UpdateToolSettingsRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -138,7 +142,7 @@ async def update_tool_settings(
     """Persist and apply tool/guardrail setting changes.
 
     Uses ``model_fields_set`` so an explicit ``null`` clears a field while an
-    omitted field is left unchanged. Master-key gated and standalone-only.
+    omitted field is left unchanged. Operator-gated and standalone-only.
     """
     updates: dict[str, SettingValue] = {
         key: getattr(request, key) for key in request.model_fields_set if key in TOOL_SETTABLE_KEYS
@@ -169,7 +173,7 @@ async def update_tool_settings(
     return _current_fields(config)
 
 
-@router.post("/{service}/test", dependencies=[Depends(require_deployment_operator)])
+@router.post("/{service}/test")
 async def test_service(
     service: str,
     request: TestServiceRequest,

--- a/src/gateway/api/routes/tools.py
+++ b/src/gateway/api/routes/tools.py
@@ -31,7 +31,11 @@ from gateway.core.env import otari_env
 from gateway.services.sandbox_backend import code_execution_tool_definition
 from gateway.services.web_search_backend import web_search_tool_definition
 
-router = APIRouter(prefix="/v1", tags=["tools"])
+router = APIRouter(
+    prefix="/v1",
+    tags=["tools"],
+    dependencies=[Depends(verify_catalog_reader)],
+)
 
 
 class ManagedTool(BaseModel):
@@ -93,7 +97,7 @@ def _managed_tools(config: GatewayConfig) -> list[ManagedTool]:
     ]
 
 
-@router.get("/tools", dependencies=[Depends(verify_catalog_reader)])
+@router.get("/tools")
 async def list_tools(config: Annotated[GatewayConfig, Depends(get_config)]) -> ToolsResponse:
     """List the tools Otari runs itself, with the declaration forms it accepts.
 

--- a/src/gateway/api/routes/usage.py
+++ b/src/gateway/api/routes/usage.py
@@ -47,7 +47,24 @@ from gateway.services.usage_admin_service import (
 )
 from gateway.services.web_search_backend import WEB_SEARCH_TOOL_NAME
 
-router = APIRouter(prefix="/v1/usage", tags=["usage"])
+# Two routers under one prefix, because the two planes that meet here
+# authenticate differently. Reading or amending every tenant's usage rows is
+# deployment-wide, so that gate is declared on the router and a route added later
+# inherits it; ``POST /external-events`` files rows on behalf of the API key that
+# holds them, and is split onto a router of its own rather than left as a
+# route-level override so that admitting a non-operator is spelled here. Each
+# router names its own rule, so adding a route to either one inherits a gate
+# rather than none.
+operator_router = APIRouter(
+    prefix="/v1/usage",
+    tags=["usage"],
+    dependencies=[Depends(require_deployment_operator)],
+)
+ingest_router = APIRouter(
+    prefix="/v1/usage",
+    tags=["usage"],
+    dependencies=[Depends(verify_api_key_or_master_key)],
+)
 
 # The analytics summary is range-bounded, unlike the raw list. Absent a start_date
 # it looks back this far; a wider explicit window is clamped to the hard cap so a
@@ -439,7 +456,7 @@ def _usage_filters(
     return conditions
 
 
-@router.get("", dependencies=[Depends(require_deployment_operator)])
+@operator_router.get("")
 async def list_usage(
     db: Annotated[AsyncSession, Depends(get_db)],
     start_date: datetime | None = Query(default=None, description=_START_DESC),
@@ -514,7 +531,7 @@ async def list_usage(
     ]
 
 
-@router.post("/external-events")
+@ingest_router.post("/external-events")
 async def ingest_external_usage(
     request: ExternalEventsRequest,
     auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
@@ -543,7 +560,7 @@ async def ingest_external_usage(
     )
 
 
-@router.get("/count", dependencies=[Depends(require_deployment_operator)])
+@operator_router.get("/count")
 async def count_usage(
     db: Annotated[AsyncSession, Depends(get_db)],
     start_date: datetime | None = Query(default=None, description=_START_DESC),
@@ -599,7 +616,7 @@ async def count_usage(
     return UsageCount(total=total)
 
 
-@router.get("/in-flight", dependencies=[Depends(require_deployment_operator)])
+@operator_router.get("/in-flight")
 async def list_in_flight(raw_request: Request) -> InFlightResponse:
     """Requests the gateway is currently serving, longest-running first.
 
@@ -639,7 +656,7 @@ async def list_in_flight(raw_request: Request) -> InFlightResponse:
     )
 
 
-@router.delete("", dependencies=[Depends(require_deployment_operator)])
+@operator_router.delete("")
 async def delete_usage_rows(
     request: UsageDeleteRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -656,7 +673,7 @@ async def delete_usage_rows(
     return await delete_usage(db, request)
 
 
-@router.post("/set-price", dependencies=[Depends(require_deployment_operator)])
+@operator_router.post("/set-price")
 async def set_usage_price_rows(
     request: UsageSetPriceRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -1438,7 +1455,7 @@ async def _summary_response(
     )
 
 
-@router.get("/summary", dependencies=[Depends(require_deployment_operator)])
+@operator_router.get("/summary")
 async def usage_summary(
     db: Annotated[AsyncSession, Depends(get_db)],
     start_date: datetime | None = Query(default=None, description=_START_DESC),
@@ -1600,7 +1617,7 @@ async def _grouped_series_response(
     )
 
 
-@router.get("/series", dependencies=[Depends(require_deployment_operator)])
+@operator_router.get("/series")
 async def usage_series(
     db: Annotated[AsyncSession, Depends(get_db)],
     group_by: SeriesGroupBy = Query(description="Dimension to split the series by"),

--- a/src/gateway/api/routes/users.py
+++ b/src/gateway/api/routes/users.py
@@ -17,7 +17,11 @@ from gateway.repositories.users_repository import get_active_user
 from gateway.services.budget_periods import budget_window
 from gateway.services.model_access import validate_allowed_models
 
-router = APIRouter(prefix="/v1/users", tags=["users"])
+router = APIRouter(
+    prefix="/v1/users",
+    tags=["users"],
+    dependencies=[Depends(require_deployment_operator)],
+)
 
 
 class CreateUserRequest(BaseModel):
@@ -118,7 +122,7 @@ class UsageLogResponse(BaseModel):
         )
 
 
-@router.post("", dependencies=[Depends(require_deployment_operator)])
+@router.post("")
 async def create_user(
     request: CreateUserRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -190,7 +194,7 @@ async def create_user(
     return UserResponse.from_model(user)
 
 
-@router.get("", dependencies=[Depends(require_deployment_operator)])
+@router.get("")
 async def list_users(
     db: Annotated[AsyncSession, Depends(get_db)],
     skip: Annotated[int, Query(ge=0)] = 0,
@@ -203,7 +207,7 @@ async def list_users(
     return [UserResponse.from_model(user) for user in users]
 
 
-@router.get("/{user_id}", dependencies=[Depends(require_deployment_operator)])
+@router.get("/{user_id}")
 async def get_user(
     user_id: str,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -220,7 +224,7 @@ async def get_user(
     return UserResponse.from_model(user)
 
 
-@router.patch("/{user_id}", dependencies=[Depends(require_deployment_operator)])
+@router.patch("/{user_id}")
 async def update_user(
     user_id: str,
     request: UpdateUserRequest,
@@ -291,11 +295,7 @@ async def update_user(
     return UserResponse.from_model(user)
 
 
-@router.delete(
-    "/{user_id}",
-    status_code=status.HTTP_204_NO_CONTENT,
-    dependencies=[Depends(require_deployment_operator)],
-)
+@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_user(
     user_id: str,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -356,7 +356,7 @@ async def delete_user(
         ) from None
 
 
-@router.get("/{user_id}/usage", dependencies=[Depends(require_deployment_operator)])
+@router.get("/{user_id}/usage")
 async def get_user_usage(
     user_id: str,
     db: Annotated[AsyncSession, Depends(get_db)],

--- a/tests/integration/test_deployment_operator_gate.py
+++ b/tests/integration/test_deployment_operator_gate.py
@@ -17,6 +17,10 @@ and drives the three credential-test endpoints at a URL of its choosing.
 Both halves are asserted here, and the second half is the point: the control
 cases at the bottom are what catches a fix that swung too wide and took the
 tenant-scoped routers with it.
+
+What the gate does over HTTP is this file. Where it is declared, and that it
+covers every route on every deployment-wide router rather than the roster of
+paths probed below, is `tests/unit/test_operator_gate_declarations.py`.
 """
 
 import uuid

--- a/tests/integration/test_hybrid_mode_surface.py
+++ b/tests/integration/test_hybrid_mode_surface.py
@@ -142,9 +142,10 @@ def test_hybrid_mode_disables_dashboard_management_endpoints(monkeypatch: pytest
 
 
 def test_hybrid_mode_omits_model_management_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
-    # models.router is standalone-only (register_routers returns early in hybrid),
-    # so the dashboard's model-management reads have no route at all. Guards
-    # against re-mounting models.router in hybrid, which would expose them.
+    # The models routers are standalone-only (register_routers returns early in
+    # hybrid), so the dashboard's model-management reads have no route at all.
+    # Guards against re-mounting either of them in hybrid, which would expose
+    # them.
     monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
 
     config = GatewayConfig(

--- a/tests/unit/test_operator_gate_declarations.py
+++ b/tests/unit/test_operator_gate_declarations.py
@@ -1,0 +1,241 @@
+"""The deployment-wide routers declare the operator gate on themselves.
+
+`tests/integration/test_deployment_operator_gate.py` asserts what the gate does
+over HTTP, and why it exists at all (otari-ai#1880). This file asserts where it
+is declared, which is the other half: the gate used to be a decorator on each
+route, every one of them correct, and the hazard was the next route someone
+added. One forgotten `dependencies=[...]` and a deployment-wide handler is
+reachable with no credential at all, which no roster of probes can notice
+because the probes name paths and the missing path is the one nobody wrote
+(otari-ai#1937).
+
+Read from the routers rather than from a running app: this is a claim about the
+declarations, it needs no database, and a route that never reached the app is
+still a route somebody will mount.
+"""
+
+import importlib
+import pkgutil
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import pytest
+from fastapi import APIRouter
+from fastapi.dependencies.models import Dependant
+from fastapi.routing import APIRoute
+
+import gateway.api.routes
+from gateway.api.deps import (
+    require_deployment_operator,
+    verify_api_key_or_master_key,
+    verify_catalog_reader,
+    verify_master_key,
+)
+from gateway.api.routes import (
+    agent_telemetry,
+    aliases,
+    budgets,
+    keys,
+    mail,
+    maintenance_mode,
+    models,
+    pricing,
+    providers,
+    routing,
+    routing_memory,
+    scoped_budgets,
+    search_tools,
+    settings,
+    tool_settings,
+    tools,
+    usage,
+    users,
+)
+
+# Every router whose whole surface is deployment-wide: a read or write over
+# every tenant's rows, or over the deployment's own configuration.
+_DEPLOYMENT_WIDE_ROUTERS: list[tuple[str, APIRouter]] = [
+    ("agent_telemetry", agent_telemetry.router),
+    ("aliases", aliases.router),
+    ("budgets", budgets.router),
+    ("keys", keys.router),
+    ("mail", mail.router),
+    ("maintenance_mode", maintenance_mode.router),
+    ("models", models.operator_router),
+    ("pricing", pricing.operator_router),
+    ("providers", providers.router),
+    ("routing", routing.router),
+    ("routing_memory", routing_memory.router),
+    ("scoped_budgets", scoped_budgets.router),
+    ("search_tools", search_tools.router),
+    ("settings", settings.router),
+    ("tool_settings", tool_settings.router),
+    ("usage", usage.operator_router),
+    ("users", users.router),
+]
+
+# The routers a caller reaches without operator standing, and the dependency
+# each admits them with instead. Listed so the gate can be asserted *off* them:
+# putting it on the whole of `models.py`, `pricing.py` or `usage.py` is the
+# plausible wrong fix, and it would take the dashboard's Models and Pricing
+# pages and a data-plane gateway's usage report with it.
+_NON_OPERATOR_ROUTERS: list[tuple[str, APIRouter, Callable[..., Any]]] = [
+    ("models.catalog", models.catalog_router, verify_catalog_reader),
+    ("pricing.catalog", pricing.catalog_router, verify_catalog_reader),
+    ("tools", tools.router, verify_catalog_reader),
+    ("usage.ingest", usage.ingest_router, verify_api_key_or_master_key),
+]
+
+
+# Why each remaining router declares nothing at the router level. Everything not
+# listed has to carry a router-level dependency, which is what extends "a new
+# route starts gated" to "a new router does too": the partial-gating case below
+# cannot see a router with no gate anywhere on it, because it has no gated route
+# to compare against.
+_DATA_PLANE = "data plane: an API key or the master key, checked per route or inside the handler"
+_PUBLIC_AUTH = "public auth: reached before the caller holds any credential"
+
+_UNGATED_ROUTERS: dict[str, str] = {
+    "audio.router": _DATA_PLANE,
+    "batches.router": _DATA_PLANE,
+    "chat.router": _DATA_PLANE,
+    "embeddings.router": _DATA_PLANE,
+    "files.router": _DATA_PLANE,
+    "images.router": _DATA_PLANE,
+    "messages.router": _DATA_PLANE,
+    "moderations.router": _DATA_PLANE,
+    "otlp.router": _DATA_PLANE,
+    "rerank.router": _DATA_PLANE,
+    "responses.router": _DATA_PLANE,
+    "search.router": _DATA_PLANE,
+    "auth_oauth.router": _PUBLIC_AUTH,
+    "auth_password_reset.router": _PUBLIC_AUTH,
+    "auth_session.router": _PUBLIC_AUTH,
+    "auth_signup.router": _PUBLIC_AUTH,
+    "auth_webauthn.router": _PUBLIC_AUTH,
+    "invitations.router": "the invitation token is the credential, and the invitee has no account yet",
+    "bootstrap.router": "unauthenticated on purpose: how a browser learns which mode it reached",
+    "health.router": "unauthenticated liveness and readiness",
+    "web_search_backend.router": "its own X-Gateway-Token, checked in the handler",
+    "hosted_mode.router": "mode stub: a 404 naming why the prefix is absent on this deployment",
+    "hybrid_mode.router": "mode stub, as above",
+}
+
+
+# What counts as a gate when a router declares it. Named rather than taken as
+# "declares any dependency at all": a router-level ``Depends(get_db)`` is a
+# convenience, and reading it as authorization would let a router satisfy the
+# classification below while every route on it stayed open.
+# ``verify_master_key`` is here because the tenant-scoped routers declare it and
+# then authorize the caller against the organization or workspace themselves.
+_ROUTER_LEVEL_GATES: frozenset[Callable[..., Any]] = frozenset(
+    {
+        require_deployment_operator,
+        verify_api_key_or_master_key,
+        verify_catalog_reader,
+        verify_master_key,
+    }
+)
+
+
+def _exposed_routers() -> dict[str, APIRouter]:
+    """Every router the routes package exposes, keyed ``module.attribute``."""
+    found: dict[str, APIRouter] = {}
+    for module_info in pkgutil.iter_modules(gateway.api.routes.__path__):
+        module = importlib.import_module(f"gateway.api.routes.{module_info.name}")
+        for attribute, value in vars(module).items():
+            if isinstance(value, APIRouter):
+                found[f"{module_info.name}.{attribute}"] = value
+    return found
+
+
+def _resolves(dependant: Dependant, gate: Callable[..., Any]) -> bool:
+    """Whether a route reaches ``gate``, by way of its router or its own signature."""
+    return any(sub.call is gate or _resolves(sub, gate) for sub in dependant.dependencies)
+
+
+def _route_id(name: str, route: APIRoute) -> str:
+    return f"{name} {'/'.join(sorted(route.methods))} {route.path or '/'}"
+
+
+def _routes(routers: list[tuple[str, APIRouter]]) -> Iterator[Any]:
+    for name, router in routers:
+        for route in router.routes:
+            if isinstance(route, APIRoute):
+                yield pytest.param(route, id=_route_id(name, route))
+
+
+def _non_operator_routes() -> Iterator[Any]:
+    for name, router, gate in _NON_OPERATOR_ROUTERS:
+        for route in router.routes:
+            if isinstance(route, APIRoute):
+                yield pytest.param(route, gate, id=_route_id(name, route))
+
+
+@pytest.mark.parametrize(("name", "router"), _DEPLOYMENT_WIDE_ROUTERS, ids=[n for n, _ in _DEPLOYMENT_WIDE_ROUTERS])
+def test_each_deployment_wide_router_declares_the_gate_itself(name: str, router: APIRouter) -> None:
+    """On the router, so a route added to it later inherits the gate."""
+    assert any(dependency.dependency is require_deployment_operator for dependency in router.dependencies), name
+
+
+@pytest.mark.parametrize("route", _routes(_DEPLOYMENT_WIDE_ROUTERS))
+def test_every_route_on_a_deployment_wide_router_resolves_the_gate(route: APIRoute) -> None:
+    """The declaration above, read back per route as FastAPI resolves it."""
+    assert _resolves(route.dependant, require_deployment_operator)
+
+
+@pytest.mark.parametrize(("route", "gate"), _non_operator_routes())
+def test_the_non_operator_routers_admit_their_own_caller_instead(route: APIRoute, gate: Callable[..., Any]) -> None:
+    """Both directions: the route keeps the dependency it takes, and gains no operator gate."""
+    assert _resolves(route.dependant, gate)
+    assert not _resolves(route.dependant, require_deployment_operator)
+
+
+def test_every_router_declares_a_gate_or_says_why_it_does_not() -> None:
+    """The hazard this change moved rather than removed: the next *router*.
+
+    Declaring the gate on the router makes a new route inherit it, so the gap
+    walks up one level. A wholly ungated new router is invisible to every other
+    case in this file, including the partial-gating one below, which needs a
+    gated route on the same router to compare against.
+
+    So every router is classified: it declares a router-level dependency, or it
+    is named in ``_UNGATED_ROUTERS`` with the reason. A new management router
+    fails this until it does one or the other, which is the decision being
+    forced. What counts as a gate is the roster in ``_ROUTER_LEVEL_GATES``, not
+    any dependency at all, so a router-level ``Depends(get_db)`` does not read as
+    one. The second assertion keeps the list from going stale once a listed
+    router gains a gate.
+    """
+    routers = _exposed_routers()
+    declares_a_gate = {
+        name
+        for name, router in routers.items()
+        if any(dependency.dependency in _ROUTER_LEVEL_GATES for dependency in router.dependencies)
+    }
+
+    unclassified = sorted(set(routers) - declares_a_gate - set(_UNGATED_ROUTERS))
+    listed_but_gated = sorted(declares_a_gate & set(_UNGATED_ROUTERS))
+
+    assert unclassified == []
+    assert listed_but_gated == []
+
+
+def test_no_router_gates_some_of_its_routes_and_not_the_rest() -> None:
+    """The old shape: a gate on some routes of a router and not the others.
+
+    If any route on a router resolves the gate then every route on it must,
+    which is what declaring it on the router gets you and what a per-route
+    decorator gives up. A router with a genuine exception splits it off (see
+    ``_NON_OPERATOR_ROUTERS``) rather than mixing the two. This says nothing
+    about a router with no gate anywhere; that is the case above.
+    """
+    partly_gated: list[str] = []
+    for name, router in _exposed_routers().items():
+        routes = [route for route in router.routes if isinstance(route, APIRoute)]
+        gated = [route for route in routes if _resolves(route.dependant, require_deployment_operator)]
+        if gated and len(gated) != len(routes):
+            ungated = sorted({route.path for route in routes if route not in gated})
+            partly_gated.append(f"{name}: ungated {ungated}")
+
+    assert partly_gated == []

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -1446,7 +1446,7 @@ export interface paths {
          *     Operator-facing counterpart to GET /v1/models, which serves a curated catalog
          *     to API callers. This reports each provider separately and keeps its error, so
          *     a provider with a bad key is distinguishable from one with no models. It is
-         *     master-key gated because a provider error message describes the gateway's own
+         *     operator-gated because a provider error message describes the gateway's own
          *     configuration.
          *
          *     Answers from the discovery cache, which a background refresher keeps warm, so
@@ -1478,7 +1478,7 @@ export interface paths {
          *     ``instance:model`` selector the dashboard uses. ``available`` is false when
          *     enrichment is disabled (``models_dev_metadata``) or models.dev could not be
          *     reached; the response is then empty and the UI falls back to bundled data.
-         *     Master-key gated: it describes the gateway's configured providers.
+         *     Operator-gated: it describes the gateway's configured providers.
          *
          *     Answers from the cached catalog, kept warm by a background refresher, so the
          *     dashboard never waits on the models.dev fetch timeout.
@@ -2577,7 +2577,6 @@ export interface paths {
          *     Operator-facing: reports each provider's capabilities, documentation and
          *     pricing links, and display name from the bundled any-llm and genai-prices
          *     datasets. No provider is contacted, so this is cheap and always available.
-         *     Master-key gated because it describes the gateway's own configuration.
          */
         get: operations["list_providers_v1_providers_get"];
         put?: never;
@@ -2603,7 +2602,6 @@ export interface paths {
          *     any-llm registry and names from the bundled genai-prices dataset, so no
          *     provider SDK is imported. The autofill hints for a chosen provider come from
          *     GET /v1/providers/catalog/{provider_id}, which imports only that one SDK.
-         *     Master-key gated because it is operator-facing dashboard data.
          */
         get: operations["provider_catalog_v1_providers_catalog_get"];
         put?: never;
@@ -2628,7 +2626,7 @@ export interface paths {
          *     Imports only the selected provider's any-llm module (not the whole catalog)
          *     to report its credential env var, default endpoint, whether a key is required,
          *     and whether that env var is already set on the server. Returns 404 for an
-         *     unknown provider id. Master-key gated because it is operator-facing.
+         *     unknown provider id.
          *
          *     The SDK import is offloaded to a worker thread: the first fetch for a given
          *     provider imports that provider's module, which would otherwise block the event
@@ -2658,7 +2656,7 @@ export interface paths {
          *     when its credentials can list models. Results are served from the discovery
          *     cache (cheap enough to poll), so ``checked_at`` reflects when each provider
          *     was actually dialed. Pass ``refresh=true`` to force a live re-dial of every
-         *     provider. Master-key gated because it describes the gateway's own providers.
+         *     provider.
          *
          *     A provider whose backend serves no model-listing endpoint cannot be verified
          *     this way, but it is not unreachable either: it is reported with
@@ -2777,7 +2775,7 @@ export interface paths {
          * Explain Policy
          * @description Compile a policy and return the plan, without dispatching anything.
          *
-         *     Master-key gated, and deliberately so: the response enumerates the policy's
+         *     Operator-gated, and deliberately so: the response enumerates the policy's
          *     targets, which is exactly the information a policy exists to keep off the wire.
          *     It is a management surface, not a caller-facing one.
          *
@@ -3138,7 +3136,7 @@ export interface paths {
          * @description Persist and apply runtime setting changes.
          *
          *     Each provided field is stored as an override (winning over config/env) and
-         *     applied to the running gateway immediately. Master-key gated: these change
+         *     applied to the running gateway immediately. Operator-gated: these change
          *     how the gateway meters and lists models.
          */
         patch: operations["update_settings_v1_settings_patch"];
@@ -3274,7 +3272,7 @@ export interface paths {
          * @description Persist and apply tool/guardrail setting changes.
          *
          *     Uses ``model_fields_set`` so an explicit ``null`` clears a field while an
-         *     omitted field is left unchanged. Master-key gated and standalone-only.
+         *     omitted field is left unchanged. Operator-gated and standalone-only.
          */
         patch: operations["update_tool_settings_v1_tool_settings_patch"];
         trace?: never;


### PR DESCRIPTION
## Description

Sixteen routers spelled `require_deployment_operator` once per route. Every declared route was gated, so no answer the API gives today changes: the set of gates enforced behind every mounted route is identical before and after, checked in all three runtime modes (211 method-and-path pairs standalone, 343 hosted, 162 hybrid). What changes is the next route, which was reachable with no credential at all if someone forgot the decorator.

Three routes gain a duplicate dependency node rather than none, because the router-level declaration sits alongside a parameter the handler still consumes: `GET /v1/models` and `GET /v1/models/{model_id}` name `verify_catalog_reader` twice, `POST /v1/usage/external-events` names `verify_api_key_or_master_key` twice. Both halves carry `use_cache=True`, so each resolver runs once per request. The handlers need the value and the routers need the default-deny, so the duplicate is the price.

The gate now sits on the router. Three routers hold a route it must not cover, and each splits that route onto a router of its own instead of overriding the gate in place: the catalog reads in `models.py` and `pricing.py` that the dashboard's Models and Pricing pages are built on, and `POST /v1/usage/external-events`, which a data-plane gateway calls with an API key. `api/main.py` mounts the operator router first in each pair, so `/v1/models/discoverable`, `/v1/models/metadata` and `DELETE /v1/pricing/{model_key}` stay ahead of the catch-alls the catalog routers end with. That mount order is load-bearing: reversed, `GET /v1/models/discoverable` would reach `get_model` and drop from operator to catalog reader.

Registration order therefore moves: three routes relocate and shift eleven others by one, fourteen indices in all. Every shift stays inside its prefix group and none crosses a path-parameter catch-all, so each route still resolves to the same endpoint under the same gates.

Each of those split-off routers names its own rule on the router for the same reason the gated ones do, and `tools.py` joins them: it is the third catalog surface, it carried `verify_catalog_reader` on its one route, and the argument for the router-level form does not depend on which dependency is being held.

`tests/unit/test_operator_gate_declarations.py` is the widened check: 103 route-and-method pairs instead of one probe per family, plus two cases guarding the roster itself. Every router the routes package exposes either declares a router-level dependency or is named in `_UNGATED_ROUTERS` with the reason, so a new management router fails until someone decides which it is; and no router gates some of its routes and not the others. The first of those matters because declaring the gate on the router moves the hazard from the next route up to the next router, and the partial-gating case cannot see a router with no gate anywhere on it.

Also corrects the wording the gate made stale. `verify_master_key` admits any identity still active, not an "email-verified" one: address verification is a condition of minting a session, not of resolving one. And "master-key gated" was the wrong phrase on eleven routers now behind `require_deployment_operator`, since clearing the master-key check is what `deps.py` argues is not operator authority; seven of those were published OpenAPI descriptions, so the spec, the Postman collection and `web/src/client/schema.ts` are regenerated with them.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#1937

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

`make lint`, `make typecheck`, `make openapi-check`, `make postman-check`, `git diff --exit-code -- web/src/client/schema.ts` and `tests/unit` are green locally. The integration suite needs Docker, which is not up on this machine, so `tests/integration` is left to CI.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Code (Opus 5, 1M context)

**Any additional AI details you'd like to share:**

The behavior-preserving claim was checked mechanically, not by reading: a script walks every mounted route and records which `deps` gates its dependency tree resolves, deduplicated, and the output is identical on `main` and on this branch in standalone, hosted and hybrid. Each test case was mutation-checked against the defect it claims to catch, including the ungated `zz_probe` router from the review.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Moved deployment-wide authorization from individual routes to router-level declarations.
- Split catalog reads and external usage ingestion into separate routers with their existing access rules.
- Preserved route matching and runtime-mode behavior.
- Added comprehensive authorization checks for all exposed routers and route-method pairs.
- Updated authorization terminology and regenerated API documentation and client artifacts.

## Benefits

- New routes inherit the correct authorization by default.
- Router configuration is easier to review and maintain.
- Tests detect missing, partial, or incorrectly classified authorization coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->