### PR TITLE
feat(dashboard): add an organization-wide usage page for admins

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -77,6 +77,7 @@ The workspace view contains day-to-day gateway operations:
 
 The organization view contains tenant-wide administration:
 
+- Organization-wide usage, in hosted mode
 - Workspaces and organization members
 - Spend and budgets
 - Organization pricing

--- a/src/gateway/api/routes/bootstrap.py
+++ b/src/gateway/api/routes/bootstrap.py
@@ -116,9 +116,17 @@ STANDALONE_SURFACES: tuple[str, ...] = (
 # Dropping the surface is not itself a guard over the table: ``config.yml``'s
 # ``providers:`` block and ``/v1/provider-credentials`` still populate it with no
 # page in front of them, which is #818's to close.
+#
+# ``organization_usage`` appears for a different reason: not a credential's
+# ownership but a question that only exists once tenants do. The router behind it
+# (``/v1/organizations/me/usage``) is mounted on both editions, but on standalone
+# the organization is the deployment and ``/usage`` already answers it whole, so
+# the dashboard's organization-wide Usage page is a destination only where "my
+# organization" is narrower than "everything" (otari-ai#1963).
 HOSTED_SURFACES: tuple[str, ...] = (
     *(surface for surface in STANDALONE_SURFACES if surface != "providers"),
     "organization_providers",
+    "organization_usage",
 )
 
 

--- a/src/gateway/api/routes/bootstrap.py
+++ b/src/gateway/api/routes/bootstrap.py
@@ -95,9 +95,10 @@ STANDALONE_SURFACES: tuple[str, ...] = (
 )
 
 # The same list for a *hosted* deployment: one control plane serving many
-# organizations, rather than one operator's own gateway. Two rows differ, and
-# both differences are the same fact seen from either side, that a credential
-# here belongs to a tenant rather than to the process.
+# organizations, rather than one operator's own gateway. Three rows differ. The
+# first two are the same fact seen from either side, that a credential here
+# belongs to a tenant rather than to the process; the third is not about
+# credentials at all.
 #
 # ``providers`` drops. It is the deployment-instance surface over
 # ``provider_credentials``, whose primary key is the instance name alone, so an

--- a/tests/unit/test_deployment_bootstrap.py
+++ b/tests/unit/test_deployment_bootstrap.py
@@ -219,7 +219,10 @@ def test_mail_ready_turns_on_only_with_a_transport_and_a_public_url(tmp_path: Pa
 # would collapse them into the roster surface, which is a different page with
 # different access. Listed here rather than in the surface tuple itself so the
 # tuple stays the plain list of names the dashboard gates on.
-SURFACE_ROUTE_PREFIXES = {"organization_providers": "/v1/organizations/me/provider-keys"}
+SURFACE_ROUTE_PREFIXES = {
+    "organization_providers": "/v1/organizations/me/provider-keys",
+    "organization_usage": "/v1/organizations/me/usage",
+}
 
 
 @pytest.mark.parametrize(
@@ -251,13 +254,15 @@ def test_every_surface_names_a_route_the_gateway_mounts(
 
 
 def test_hosted_swaps_the_process_wide_provider_page_for_the_per_organization_one(tmp_path: Path) -> None:
-    """The whole point of the hosted surface set, in the two rows that differ.
+    """The whole point of the hosted surface set, in the rows that differ.
 
     ``provider_credentials`` is keyed on the instance name alone, so a credential
     added through ``/providers`` is served to every organization on the
     deployment and shadows that organization's own BYO key. The page is right for
     the single-tenant product and wrong for a control plane, and the
-    organization-scoped one is the other way around.
+    organization-scoped one is the other way around. ``organization_usage`` is
+    the row that exists only where tenants do: standalone's organization is the
+    deployment, so ``/usage`` already answers it whole (otari-ai#1963).
     """
     app = create_app(_hosted(tmp_path))
 
@@ -269,10 +274,15 @@ def test_hosted_swaps_the_process_wide_provider_page_for_the_per_organization_on
     # somebody else's account system, which no build here does.
     assert answered["session_type"] == "local_operator"
     assert "organization_providers" in answered["surfaces"]
+    assert "organization_usage" in answered["surfaces"]
     assert "providers" not in answered["surfaces"]
     # Everything else is standalone's set, so a surface added there is not
     # silently withheld from a control plane.
-    assert set(answered["surfaces"]) ^ set(STANDALONE_SURFACES) == {"organization_providers", "providers"}
+    assert set(answered["surfaces"]) ^ set(STANDALONE_SURFACES) == {
+        "organization_providers",
+        "organization_usage",
+        "providers",
+    }
 
 
 

--- a/web/e2e/screenshots/authenticated.spec.ts
+++ b/web/e2e/screenshots/authenticated.spec.ts
@@ -122,6 +122,32 @@ test.describe("organization rail", () => {
     ).toBeVisible()
     await captureScreenshot(page, "organization-model-pricing")
   })
+
+  test("organization usage", async ({ page }) => {
+    // This gateway is standalone, whose bootstrap does not report the
+    // organization_usage surface (its organization is the deployment, so /usage
+    // already answers it whole). The surface is patched in before the shell
+    // boots, which is why the stub precedes `login` here: `gotoRoute` changes
+    // only the hash, so the boot-time bootstrap read is the one that counts.
+    // Everything behind the route is served for real, because
+    // /v1/organizations/me/usage is mounted on both editions.
+    await page.route("**/v1/bootstrap", async (route) => {
+      const response = await route.fetch()
+      const bootstrap = await response.json()
+      await route.fulfill({
+        json: {
+          ...bootstrap,
+          surfaces: [...bootstrap.surfaces, "organization_usage"],
+        },
+      })
+    })
+    await login(page)
+    await gotoRoute(page, "/organization/usage")
+    await expect(
+      page.getByRole("heading", { name: /organization usage/i }).first(),
+    ).toBeVisible()
+    await captureScreenshot(page, "organization-usage")
+  })
 })
 
 /**

--- a/web/src/app/nav/overlayLabelOverrides.test.ts
+++ b/web/src/app/nav/overlayLabelOverrides.test.ts
@@ -51,10 +51,11 @@ describe("a build that replaces the label-override module", () => {
       "Access",
     ])
     expect(ORG_NAV_SECTIONS.map((section) => section.label)).toEqual([
+      "Observe",
       "People & access",
       "Cost & billing",
       "Gateway",
-      // The one the mocked list renames; the three around it are untouched.
+      // The one the mocked list renames; the four around it are untouched.
       "Deployment",
     ])
   })

--- a/web/src/app/nav/registry.test.ts
+++ b/web/src/app/nav/registry.test.ts
@@ -242,16 +242,24 @@ describe("nav registry", () => {
   })
 
   it("gates every declared-but-unserved destination on a surface", () => {
-    // The design's organization rail draws two rows this gateway has no endpoint
-    // for and still declares. Each is declared so the rail matches on a
-    // deployment that does serve them, and gated on a surface
-    // `STANDALONE_SURFACES` does not report so the row is absent here. Pinned as
-    // the whole set, because the failure mode is silent in both directions: a
-    // missing gate ships a link to a page that cannot work, and a gate on a
-    // surface the bootstrap *does* report hides a page that can.
+    // The organization rail draws three rows this gateway does not offer and
+    // still declares. Each is declared so the rail matches on a deployment that
+    // does serve them, and gated on a surface `STANDALONE_SURFACES` does not
+    // report so the row is absent here. Pinned as the whole set, because the
+    // failure mode is silent in both directions: a missing gate ships a link to
+    // a page that cannot work, and a gate on a surface the bootstrap *does*
+    // report hides a page that can. A typo in a surface name is silent the same
+    // way, since `NavItemBase.surface` is a bare string.
+    //
+    // The first two have no endpoint behind them here. `/organization/usage` is
+    // withheld for a different reason (otari-ai#1963): the router *is* mounted
+    // on standalone, and the row is held back because standalone's organization
+    // is the deployment, so `/usage` already answers the same question whole.
+    // Same mechanism, so it belongs in the same set.
     const unserved = new Map([
       ["/organization/provider-keys", "organization_providers"],
       ["/organization/guardrails", "organization_guardrails"],
+      ["/organization/usage", "organization_usage"],
     ])
     for (const [to, surface] of unserved) {
       expect(navItemForPath(to)?.surface).toBe(surface)

--- a/web/src/app/nav/registry.test.ts
+++ b/web/src/app/nav/registry.test.ts
@@ -1,6 +1,7 @@
 import { FiBox } from "react-icons/fi"
 import { describe, expect, it } from "vitest"
 import { BASE_CAPABILITIES } from "@/shared/hooks/useEntitlements"
+import { HOSTED_SURFACES } from "@/tests/fixtures"
 import { OVERLAY_NAV_LABEL_OVERRIDES } from "./overlayLabelOverrides"
 import { OVERLAY_NAV_ITEMS } from "./overlayNavItems"
 import {
@@ -251,11 +252,13 @@ describe("nav registry", () => {
     // report hides a page that can. A typo in a surface name is silent the same
     // way, since `NavItemBase.surface` is a bare string.
     //
-    // The first two have no endpoint behind them here. `/organization/usage` is
-    // withheld for a different reason (otari-ai#1963): the router *is* mounted
-    // on standalone, and the row is held back because standalone's organization
-    // is the deployment, so `/usage` already answers the same question whole.
-    // Same mechanism, so it belongs in the same set.
+    // Only the guardrail ceiling is an actual absence: no edition here serves
+    // that API. The other two are editorial, with the API mounted either way,
+    // and they differ in what the choice is about. Provider keys is about which
+    // credential table the deployment should be showing at all. Usage is about
+    // a question that only exists once tenants do (otari-ai#1963): standalone's
+    // organization is the deployment, so `/usage` already answers it whole.
+    // One mechanism, three reasons, so the set is worth reading as a list.
     const unserved = new Map([
       ["/organization/provider-keys", "organization_providers"],
       ["/organization/guardrails", "organization_guardrails"],
@@ -284,6 +287,20 @@ describe("nav registry", () => {
     for (const surface of unserved.values()) {
       expect(standalone).not.toContain(surface)
     }
+    // The three are not one category past that point, so the other direction is
+    // asserted per row. Two are served by a hosted deployment and withheld from
+    // standalone, which is what makes their rows appear there; the guardrail
+    // ceiling has no endpoint on *either* edition and is declared for a
+    // deployment that does serve it, so it is absent from both lists.
+    //
+    // Read from the fixture the hosted-shell tests render with, which is what
+    // keeps that fixture honest: a surface added to the backend's
+    // HOSTED_SURFACES and not to the fixture leaves those tests quietly
+    // rendering a rail the product does not have, and fails here instead.
+    for (const surface of ["organization_providers", "organization_usage"]) {
+      expect(HOSTED_SURFACES).toContain(surface)
+    }
+    expect(HOSTED_SURFACES).not.toContain("organization_guardrails")
   })
 
   it("declares no destination an overlay owns", () => {

--- a/web/src/app/nav/registry.test.ts
+++ b/web/src/app/nav/registry.test.ts
@@ -42,6 +42,7 @@ describe("nav registry", () => {
     // The second rail, reached from the sidebar footer. Its own registry, so
     // its order is asserted separately from the workspace one's.
     expect(ORG_NAV_SECTIONS.map((section) => section.id)).toEqual([
+      "org-observe",
       "org-people",
       "org-money",
       "org-gateway",
@@ -65,6 +66,7 @@ describe("nav registry", () => {
       "API keys",
       "Providers",
       "Members",
+      "Usage",
       "Workspaces",
       "Members & roles",
       "Providers",

--- a/web/src/app/nav/registry.ts
+++ b/web/src/app/nav/registry.ts
@@ -259,6 +259,31 @@ const BASE_NAV_SECTIONS = [
  */
 const ORGANIZATION_NAV_SECTIONS = [
   {
+    // The workspace rail's "Observe" question asked one level up. One row for
+    // now, with a heading all the same: unlike the index's headingless section,
+    // this is a category (an organization Activity page would join it), and a
+    // bare "Usage" row above "People & access" would read as a stray.
+    id: "org-observe",
+    label: "Observe",
+    items: [
+      // The organization as a whole, which the workspace rail's Usage page
+      // cannot ask for: its scope is the sidebar's selected workspace, and the
+      // switcher offers only the caller's own memberships (otari-ai#1963).
+      // Gated on a surface only the hosted bootstrap reports, because on a
+      // standalone deployment the organization is the deployment and `/usage`
+      // already answers it whole. No `operatorOnly` and no role gate here: the
+      // organization rail already opens only to a caller who manages the
+      // organization, and the server scopes a member who lands here by URL to
+      // their own workspaces, the same rows `/usage` shows them.
+      {
+        to: "/organization/usage",
+        label: "Usage",
+        surface: "organization_usage",
+        icon: FiBarChart2,
+      },
+    ],
+  },
+  {
     id: "org-people",
     label: "People & access",
     items: [

--- a/web/src/features/usage/OrganizationUsagePage.tsx
+++ b/web/src/features/usage/OrganizationUsagePage.tsx
@@ -1,0 +1,8 @@
+import { UsagePage } from "@/features/usage/UsagePage"
+
+// The organization rail's Usage destination (otari-ai#1963): the same analytics
+// as the workspace rail's, pinned to the organization-wide scope. All the
+// behavior lives on UsagePage, keyed off the one prop.
+export function OrganizationUsagePage() {
+  return <UsagePage scope="organization" />
+}

--- a/web/src/features/usage/OrganizationUsagePage.tsx
+++ b/web/src/features/usage/OrganizationUsagePage.tsx
@@ -1,8 +1,0 @@
-import { UsagePage } from "@/features/usage/UsagePage"
-
-// The organization rail's Usage destination (otari-ai#1963): the same analytics
-// as the workspace rail's, pinned to the organization-wide scope. All the
-// behavior lives on UsagePage, keyed off the one prop.
-export function OrganizationUsagePage() {
-  return <UsagePage scope="organization" />
-}

--- a/web/src/features/usage/UsagePage.test.tsx
+++ b/web/src/features/usage/UsagePage.test.tsx
@@ -347,6 +347,13 @@ describe("UsagePage", () => {
           String(url).includes("workspace_id=ws-1"),
       ),
     ).toBe(true)
+    // The workspace rail takes its scope from the switcher and offers no
+    // workspace picker, so the roster this page never shows is not fetched.
+    expect(
+      fetchMock.mock.calls.some(([url]) =>
+        String(url).includes("/v1/workspaces"),
+      ),
+    ).toBe(false)
   })
 
   it("asks for the whole organization on the organization page, whatever the switcher selects", async () => {
@@ -397,6 +404,10 @@ describe("UsagePage", () => {
     renderPage(<UsagePage scope="organization" />)
     await screen.findByText("$1,240.50")
 
+    // Through the disclosure a person uses. jsdom does not apply Tailwind's
+    // `.hidden`, so the select is reachable without this and the case would
+    // keep passing if the control became unreachable in a browser.
+    await user.click(screen.getByRole("button", { name: "Add filter" }))
     await pickOption(user, "Workspace", "Research")
 
     const summaryCalls = fetchMock.mock.calls

--- a/web/src/features/usage/UsagePage.test.tsx
+++ b/web/src/features/usage/UsagePage.test.tsx
@@ -349,6 +349,68 @@ describe("UsagePage", () => {
     ).toBe(true)
   })
 
+  it("asks for the whole organization on the organization page, whatever the switcher selects", async () => {
+    // The switcher holds a selection and the fixture's caller even operates the
+    // deployment; the organization page must let neither leak in. Narrowed by
+    // the switcher it would repeat the workspace page, and widened to
+    // `/v1/usage` it would title every tenant's traffic as this organization's.
+    const fetchMock = mockApi(summary(), {
+      "/v1/organizations/me": organizationContext({
+        workspace_memberships: [
+          {
+            workspace_id: "ws-1",
+            name: "Platform team",
+            role: "owner",
+          },
+        ],
+      }),
+    })
+    renderPage(<UsagePage scope="organization" />, { scoped: true })
+    await screen.findByText("$1,240.50")
+
+    const reads = fetchMock.mock.calls
+      .map(([url]) => String(url))
+      .filter((url) => url.includes("/usage/"))
+    expect(reads).not.toHaveLength(0)
+    for (const url of reads) {
+      expect(url).toContain("/v1/organizations/me/usage/")
+      expect(url).not.toContain("workspace_id=")
+    }
+  })
+
+  it("narrows the organization page through its own workspace filter", async () => {
+    const user = userEvent.setup()
+    const fetchMock = mockApi(summary(), {
+      "/v1/workspaces": {
+        data: [
+          {
+            id: "ws-2",
+            name: "Research",
+            organization_id: "org-1",
+            created_at: "2026-08-01T00:00:00+00:00",
+            updated_at: "2026-08-01T00:00:00+00:00",
+          },
+        ],
+        count: 1,
+      },
+    })
+    renderPage(<UsagePage scope="organization" />)
+    await screen.findByText("$1,240.50")
+
+    await pickOption(user, "Workspace", "Research")
+
+    const summaryCalls = fetchMock.mock.calls
+      .map(([u]) => String(u))
+      .filter((u) => u.includes("/v1/organizations/me/usage/summary"))
+    expect(summaryCalls.some((u) => u.includes("workspace_id=ws-2"))).toBe(true)
+    // The narrowing is visible and revocable where every other filter is.
+    expect(
+      screen.getByRole("button", {
+        name: "Remove Workspace filter Research",
+      }),
+    ).toBeInTheDocument()
+  })
+
   it("renders totals tiles with compact currency and error rate", async () => {
     mockApi(summary())
     renderPage(<UsagePage />)

--- a/web/src/features/usage/UsagePage.tsx
+++ b/web/src/features/usage/UsagePage.tsx
@@ -639,7 +639,11 @@ export function UsagePage({ scope = "caller" }: { scope?: UsageScope } = {}) {
   // Named on the share card's face. A card whose numbers came from a filtered
   // window has to say so, or a reader takes the figure for the whole gateway.
   const shareScopeSuffix = [
-    workspaceFilter !== undefined ? workspaceLabel(workspaceFilter) : null,
+    // Named, like the counted phrases below it: a bare workspace name among
+    // them reads as a stray token rather than as the scope it states.
+    workspaceFilter !== undefined
+      ? `workspace ${workspaceLabel(workspaceFilter)}`
+      : null,
     userFilters.length > 0
       ? `${userFilters.length} user${userFilters.length > 1 ? "s" : ""}`
       : null,
@@ -1102,7 +1106,7 @@ export function UsagePage({ scope = "caller" }: { scope?: UsageScope } = {}) {
       >
         {orgWide ? (
           <FilterSelect
-            ariaLabel="Workspace"
+            label="Workspace"
             value={workspaceFilter ?? ""}
             onChange={(value) => setWorkspaceFilter(value || undefined)}
             options={[

--- a/web/src/features/usage/UsagePage.tsx
+++ b/web/src/features/usage/UsagePage.tsx
@@ -19,8 +19,10 @@ import {
 import { ApiError } from "@/shared/api/client"
 import {
   NO_BREAKDOWNS,
+  type UsageScope,
   useUsageGroupedSeries,
   useUsageSummary,
+  useWorkspaces,
 } from "@/shared/api/hooks"
 import {
   ChartLegend,
@@ -188,8 +190,11 @@ interface BreakdownProps {
   // has gone missing (a deleted user); a dimension where NULL is a normal state
   // (gateway rows carry no session label) passes its own wording.
   unknownLabel?: string
-  // Turns a row key into the Activity-page filter to drill into.
-  onDrill: (key: string) => void
+  // Turns a row key into the Activity-page filter to drill into. Absent on the
+  // organization-wide page: Activity narrows to the sidebar's selected
+  // workspace, so a jump from an organization-wide row would silently show a
+  // subset of what the row counted.
+  onDrill?: (key: string) => void
   loading: boolean
 }
 
@@ -279,12 +284,16 @@ function BreakdownTable({
         getRowKey={rowKey}
         isLoading={loading}
         emptyContent={emptyLabel}
-        onRowAction={(key) => {
-          // Only real groups drill; the fold and deleted-user rows have no id to filter on.
-          if (key !== OTHER_KEY && key !== UNKNOWN_KEY) {
-            onDrill(key)
-          }
-        }}
+        onRowAction={
+          onDrill
+            ? (key) => {
+                // Only real groups drill; the fold and deleted-user rows have no id to filter on.
+                if (key !== OTHER_KEY && key !== UNKNOWN_KEY) {
+                  onDrill(key)
+                }
+              }
+            : undefined
+        }
       />
       {!loading && hidden > 0 ? (
         <Button size="sm" variant="ghost" onPress={() => setShowAll(true)}>
@@ -312,7 +321,8 @@ function ToolBreakdownTable({
 }: {
   rows: UsageSummary["by_tool"]
   totalCost: number
-  onDrill: (tool: string) => void
+  // Optional for the reason BreakdownTable's is.
+  onDrill?: (tool: string) => void
   loading: boolean
 }) {
   const columns: DataTableColumn<UsageSummary["by_tool"][number]>[] = [
@@ -380,7 +390,7 @@ function ToolBreakdownTable({
       getRowKey={(row) => row.tool}
       isLoading={loading}
       emptyContent="No gateway-run tool calls in this range."
-      onRowAction={(key) => onDrill(String(key))}
+      onRowAction={onDrill ? (key) => onDrill(String(key)) : undefined}
     />
   )
 }
@@ -428,7 +438,15 @@ interface BreakdownDimensionDef {
 
 // ---------- page ----------
 
-export function UsagePage() {
+// One page, two scopes. `"caller"` is the workspace rail's Usage destination:
+// whatever the caller may read, narrowed to the sidebar's selected workspace.
+// `"organization"` is the organization rail's (otari-ai#1963): the same
+// analytics pinned to `/v1/organizations/me/usage` and unnarrowed by default,
+// so an admin can finally ask about the organization as a whole; an explicit
+// workspace filter replaces the sidebar switcher, because the server lets an
+// admin narrow to any workspace in the organization, member of it or not.
+export function UsagePage({ scope = "caller" }: { scope?: UsageScope } = {}) {
+  const orgWide = scope === "organization"
   const navigate = useNavigate()
 
   // The share panel curates presentation only; the data it renders is whatever
@@ -468,19 +486,33 @@ export function UsagePage() {
     : preset.bucket
 
   const { selected: workspace } = useSelectedWorkspace()
+  // The organization page's own workspace narrowing, in place of the sidebar's
+  // switcher (which offers only the caller's memberships).
+  const [workspaceFilter, setWorkspaceFilter] = useState<string | undefined>()
+  const workspaces = useWorkspaces(orgWide)
   const filters: UsageFilters = useMemo(
     () => ({
-      // From the sidebar's switcher, like the request log's. `previousFilters`
+      // From the sidebar's switcher, like the request log's; the organization
+      // page swaps that for its own filter, unset by default. `previousFilters`
       // spreads this, so the period-over-period comparison is scoped to the
       // same workspace as the window it is compared against.
-      workspace_id: workspace?.workspace_id,
+      workspace_id: orgWide ? workspaceFilter : workspace?.workspace_id,
       start_date: winStart,
       end_date: winEnd,
       model: modelFilters.length > 0 ? modelFilters : undefined,
       user_id: userFilters.length > 0 ? userFilters : undefined,
       api_key_id: apiKeyFilters.length > 0 ? apiKeyFilters : undefined,
     }),
-    [workspace, winStart, winEnd, modelFilters, userFilters, apiKeyFilters],
+    [
+      orgWide,
+      workspaceFilter,
+      workspace,
+      winStart,
+      winEnd,
+      modelFilters,
+      userFilters,
+      apiKeyFilters,
+    ],
   )
 
   // The immediately-preceding window of equal length, for period-over-period
@@ -507,16 +539,23 @@ export function UsagePage() {
     }
   }, [customMode, winStart, winEnd, filters, preset.seconds, startDate])
 
-  const summary = useUsageSummary(filters, bucket, PAGE_BREAKDOWNS)
+  const summary = useUsageSummary(filters, bucket, PAGE_BREAKDOWNS, true, scope)
   // Deltas read `totals` only, so the previous window skips every breakdown.
   const previous = useUsageSummary(
     previousFilters ?? filters,
     bucket,
     NO_BREAKDOWNS,
     previousFilters !== null,
+    scope,
   )
   // The per-group stack, fetched only while a dimension is selected.
-  const grouped = useUsageGroupedSeries(filters, bucket, groupBy || null)
+  const grouped = useUsageGroupedSeries(
+    filters,
+    bucket,
+    groupBy || null,
+    true,
+    scope,
+  )
   // A 404 from the grouped endpoint is version skew: a gateway older than this
   // dashboard (most often one not yet restarted onto the build that ships it).
   // Fall back to the ungrouped view with a notice instead of a bare error.
@@ -543,6 +582,8 @@ export function UsagePage() {
     modelSuggestFilters,
     bucket,
     MODEL_BREAKDOWN,
+    true,
+    scope,
   )
   const realGroups = (rows: UsageGroupRow[] | undefined) =>
     (rows ?? []).filter((r) => !r.is_other && r.key !== null)
@@ -558,6 +599,8 @@ export function UsagePage() {
     entitySuggestFilters,
     bucket,
     ENTITY_BREAKDOWNS,
+    true,
+    scope,
   )
   const userOptions = realGroups(entitySuggest.data?.by_user).map((r) => ({
     value: r.key as string,
@@ -572,6 +615,16 @@ export function UsagePage() {
   // the picker hides what is already selected and the chips carry the raw name.
   const modelOptionList = modelOptions.map((m) => ({ value: m, label: m }))
 
+  // Every workspace in the organization, not just the caller's memberships,
+  // which is what separates this filter from the sidebar switcher. Only fetched
+  // on the organization page.
+  const workspaceOptions = (workspaces.data ?? []).map((w) => ({
+    value: w.id,
+    label: w.name,
+  }))
+  const workspaceLabel = (id: string) =>
+    workspaceOptions.find((o) => o.value === id)?.label ?? id
+
   // The default 30d window is the baseline (like the old "All" was), so it does
   // not count as a user-applied time filter: clearing returns to it, and an
   // empty gateway on the default view still reads as onboarding, not "no match".
@@ -580,11 +633,13 @@ export function UsagePage() {
     modelFilters.length > 0 ||
     userFilters.length > 0 ||
     apiKeyFilters.length > 0 ||
+    workspaceFilter !== undefined ||
     timeFiltered
 
   // Named on the share card's face. A card whose numbers came from a filtered
   // window has to say so, or a reader takes the figure for the whole gateway.
   const shareScopeSuffix = [
+    workspaceFilter !== undefined ? workspaceLabel(workspaceFilter) : null,
     userFilters.length > 0
       ? `${userFilters.length} user${userFilters.length > 1 ? "s" : ""}`
       : null,
@@ -609,6 +664,7 @@ export function UsagePage() {
     setModelFilters([])
     setUserFilters([])
     setApiKeyFilters([])
+    setWorkspaceFilter(undefined)
   }
   const valueChips = (
     dimension: string,
@@ -627,6 +683,19 @@ export function UsagePage() {
       onClear: () => setValues(values.filter((v) => v !== value)),
     }))
   const filterChips: FilterChip[] = [
+    // The workspace filter is single-valued (the endpoint takes one id), so its
+    // chip is built directly rather than through valueChips.
+    ...(workspaceFilter !== undefined
+      ? [
+          {
+            key: `workspace:${workspaceFilter}`,
+            label: "Workspace",
+            value: workspaceLabel(workspaceFilter),
+            clearLabel: `Remove Workspace filter ${workspaceLabel(workspaceFilter)}`,
+            onClear: () => setWorkspaceFilter(undefined),
+          },
+        ]
+      : []),
     ...valueChips(
       "user",
       "User",
@@ -984,8 +1053,12 @@ export function UsagePage() {
   return (
     <div className="flex flex-col gap-6">
       <PageHeader
-        title="Usage & analytics"
-        description="Spend, tokens, cache use, and request volume over time. Group the chart by model, user, key, or source, and click a breakdown row to drill into the request log."
+        title={orgWide ? "Organization usage" : "Usage & analytics"}
+        description={
+          orgWide
+            ? "Spend, tokens, cache use, and request volume across every workspace in your organization. Group the chart by model, user, key, or source, or narrow to a single workspace."
+            : "Spend, tokens, cache use, and request volume over time. Group the chart by model, user, key, or source, and click a breakdown row to drill into the request log."
+        }
       />
 
       <ErrorBanner
@@ -1027,6 +1100,17 @@ export function UsagePage() {
           </>
         }
       >
+        {orgWide ? (
+          <FilterSelect
+            ariaLabel="Workspace"
+            value={workspaceFilter ?? ""}
+            onChange={(value) => setWorkspaceFilter(value || undefined)}
+            options={[
+              { value: "", label: "All workspaces" },
+              ...workspaceOptions,
+            ]}
+          />
+        ) : null}
         {/* allowsCustom because the options are the in-window top spenders (a
             breakdown capped at 100): an entity below that rank, or with no traffic
             in the window, is not offered, so Enter has to commit a pasted id. */}
@@ -1352,7 +1436,7 @@ export function UsagePage() {
                     : "No usage recorded yet."
                 }
                 unknownLabel={activePrimary.unknownLabel}
-                onDrill={activePrimary.drill}
+                onDrill={orgWide ? undefined : activePrimary.drill}
                 loading={summary.isLoading}
               />
             </div>
@@ -1385,7 +1469,7 @@ export function UsagePage() {
                     : "No usage recorded yet."
                 }
                 unknownLabel={activeSecondary.unknownLabel}
-                onDrill={activeSecondary.drill}
+                onDrill={orgWide ? undefined : activeSecondary.drill}
                 loading={summary.isLoading}
               />
             </div>
@@ -1408,7 +1492,7 @@ export function UsagePage() {
               <ToolBreakdownTable
                 rows={toolRows}
                 totalCost={totals?.cost ?? 0}
-                onDrill={(tool) => drillTo({ tool })}
+                onDrill={orgWide ? undefined : (tool) => drillTo({ tool })}
                 loading={summary.isLoading}
               />
             </div>

--- a/web/src/features/usage/UsagePage.tsx
+++ b/web/src/features/usage/UsagePage.tsx
@@ -640,10 +640,15 @@ export function UsagePage({ scope = "caller" }: { scope?: UsageScope } = {}) {
   // window has to say so, or a reader takes the figure for the whole gateway.
   const shareScopeSuffix = [
     // Named, like the counted phrases below it: a bare workspace name among
-    // them reads as a stray token rather than as the scope it states.
+    // them reads as a stray token rather than as the scope it states. An
+    // unnarrowed organization card says so rather than staying silent, since
+    // silence is what a workspace-scoped card looks like and the two figures
+    // are worth very different amounts.
     workspaceFilter !== undefined
       ? `workspace ${workspaceLabel(workspaceFilter)}`
-      : null,
+      : orgWide
+        ? "organization-wide"
+        : null,
     userFilters.length > 0
       ? `${userFilters.length} user${userFilters.length > 1 ? "s" : ""}`
       : null,
@@ -1060,7 +1065,12 @@ export function UsagePage({ scope = "caller" }: { scope?: UsageScope } = {}) {
         title={orgWide ? "Organization usage" : "Usage & analytics"}
         description={
           orgWide
-            ? "Spend, tokens, cache use, and request volume across every workspace in your organization. Group the chart by model, user, key, or source, or narrow to a single workspace."
+            ? // "You can see" rather than "every workspace": an admin does read
+              // every one, but the row is only hidden from a member rather than
+              // refused, so a member reaching this by URL reads this sentence
+              // beside their own workspaces alone. True for both, and the page
+              // does not have to know which one is reading it.
+              "Spend, tokens, cache use, and request volume across the workspaces you can see in your organization. Group the chart by model, user, key, or source, or narrow to a single workspace."
             : "Spend, tokens, cache use, and request volume over time. Group the chart by model, user, key, or source, and click a breakdown row to drill into the request log."
         }
       />

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -32,6 +32,7 @@ import { Route as OrganizationGuardrailsRouteImport } from './routes/organizatio
 import { Route as OrganizationMembersRouteImport } from './routes/organization.members'
 import { Route as OrganizationPricingRouteImport } from './routes/organization.pricing'
 import { Route as OrganizationProviderKeysRouteImport } from './routes/organization.provider-keys'
+import { Route as OrganizationUsageRouteImport } from './routes/organization.usage'
 import { Route as ToolsIndexRouteImport } from './routes/tools.index'
 import { Route as ToolsCodeExecutionRouteImport } from './routes/tools.code-execution'
 import { Route as ToolsGuardrailsRouteImport } from './routes/tools.guardrails'
@@ -154,6 +155,11 @@ const OrganizationProviderKeysRoute =
     path: '/provider-keys',
     getParentRoute: () => OrganizationRoute,
   } as any)
+const OrganizationUsageRoute = OrganizationUsageRouteImport.update({
+  id: '/usage',
+  path: '/usage',
+  getParentRoute: () => OrganizationRoute,
+} as any)
 const ToolsIndexRoute = ToolsIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -203,6 +209,7 @@ export interface FileRoutesByFullPath {
   '/organization/members': typeof OrganizationMembersRoute
   '/organization/pricing': typeof OrganizationPricingRoute
   '/organization/provider-keys': typeof OrganizationProviderKeysRoute
+  '/organization/usage': typeof OrganizationUsageRoute
   '/tools/code-execution': typeof ToolsCodeExecutionRoute
   '/tools/guardrails': typeof ToolsGuardrailsRoute
   '/tools/mcp-servers': typeof ToolsMcpServersRoute
@@ -231,6 +238,7 @@ export interface FileRoutesByTo {
   '/organization/members': typeof OrganizationMembersRoute
   '/organization/pricing': typeof OrganizationPricingRoute
   '/organization/provider-keys': typeof OrganizationProviderKeysRoute
+  '/organization/usage': typeof OrganizationUsageRoute
   '/tools/code-execution': typeof ToolsCodeExecutionRoute
   '/tools/guardrails': typeof ToolsGuardrailsRoute
   '/tools/mcp-servers': typeof ToolsMcpServersRoute
@@ -262,6 +270,7 @@ export interface FileRoutesById {
   '/organization/members': typeof OrganizationMembersRoute
   '/organization/pricing': typeof OrganizationPricingRoute
   '/organization/provider-keys': typeof OrganizationProviderKeysRoute
+  '/organization/usage': typeof OrganizationUsageRoute
   '/tools/code-execution': typeof ToolsCodeExecutionRoute
   '/tools/guardrails': typeof ToolsGuardrailsRoute
   '/tools/mcp-servers': typeof ToolsMcpServersRoute
@@ -294,6 +303,7 @@ export interface FileRouteTypes {
     | '/organization/members'
     | '/organization/pricing'
     | '/organization/provider-keys'
+    | '/organization/usage'
     | '/tools/code-execution'
     | '/tools/guardrails'
     | '/tools/mcp-servers'
@@ -322,6 +332,7 @@ export interface FileRouteTypes {
     | '/organization/members'
     | '/organization/pricing'
     | '/organization/provider-keys'
+    | '/organization/usage'
     | '/tools/code-execution'
     | '/tools/guardrails'
     | '/tools/mcp-servers'
@@ -352,6 +363,7 @@ export interface FileRouteTypes {
     | '/organization/members'
     | '/organization/pricing'
     | '/organization/provider-keys'
+    | '/organization/usage'
     | '/tools/code-execution'
     | '/tools/guardrails'
     | '/tools/mcp-servers'
@@ -544,6 +556,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OrganizationProviderKeysRouteImport
       parentRoute: typeof OrganizationRoute
     }
+    '/organization/usage': {
+      id: '/organization/usage'
+      path: '/usage'
+      fullPath: '/organization/usage'
+      preLoaderRoute: typeof OrganizationUsageRouteImport
+      parentRoute: typeof OrganizationRoute
+    }
     '/tools/': {
       id: '/tools/'
       path: '/'
@@ -587,6 +606,7 @@ interface OrganizationRouteChildren {
   OrganizationMembersRoute: typeof OrganizationMembersRoute
   OrganizationPricingRoute: typeof OrganizationPricingRoute
   OrganizationProviderKeysRoute: typeof OrganizationProviderKeysRoute
+  OrganizationUsageRoute: typeof OrganizationUsageRoute
   OrganizationIndexRoute: typeof OrganizationIndexRoute
 }
 
@@ -595,6 +615,7 @@ const OrganizationRouteChildren: OrganizationRouteChildren = {
   OrganizationMembersRoute: OrganizationMembersRoute,
   OrganizationPricingRoute: OrganizationPricingRoute,
   OrganizationProviderKeysRoute: OrganizationProviderKeysRoute,
+  OrganizationUsageRoute: OrganizationUsageRoute,
   OrganizationIndexRoute: OrganizationIndexRoute,
 }
 

--- a/web/src/routes/organization.usage.tsx
+++ b/web/src/routes/organization.usage.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { OrganizationUsagePage } from "@/features/usage/OrganizationUsagePage"
+
+export const Route = createFileRoute("/organization/usage")({
+  component: OrganizationUsagePage,
+})

--- a/web/src/routes/organization.usage.tsx
+++ b/web/src/routes/organization.usage.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 
-import { OrganizationUsagePage } from "@/features/usage/OrganizationUsagePage"
+import { UsagePage } from "@/features/usage/UsagePage"
 
 export const Route = createFileRoute("/organization/usage")({
-  component: OrganizationUsagePage,
+  component: () => <UsagePage scope="organization" />,
 })

--- a/web/src/shared/api/hooks.ts
+++ b/web/src/shared/api/hooks.ts
@@ -1587,16 +1587,26 @@ function usageParams(filters: UsageFilters): URLSearchParams {
 //
 // The base is part of every query key it feeds, so two callers on one browser
 // can never read each other's cached rows.
-export function useUsageScope(): {
+//
+// `"organization"` pins the narrow surface regardless of who is asking. It
+// exists for the organization-wide Usage page (otari-ai#1963), whose question is
+// "this organization", so for an operator the caller-derived scope would answer
+// a different one: `/v1/usage` reads every tenant on the deployment, and a page
+// titled with the organization would silently overstate it. A pinned base needs
+// no context answer to be known, so it is ready on first paint.
+export type UsageScope = "caller" | "organization"
+
+export function useUsageScope(scope: UsageScope = "caller"): {
   base: string
   isReady: boolean
   isDeploymentWide: boolean
 } {
   const context = useOrganizationContext()
-  const isDeploymentWide = context.data?.deployment_operator === true
+  const isDeploymentWide =
+    scope === "caller" && context.data?.deployment_operator === true
   return {
     base: isDeploymentWide ? "/v1/usage" : "/v1/organizations/me/usage",
-    isReady: context.isSuccess || context.isError,
+    isReady: scope === "organization" || context.isSuccess || context.isError,
     isDeploymentWide,
   }
 }
@@ -1845,8 +1855,9 @@ export function useUsageSummary(
   bucket: UsageBucket,
   dimensions?: SummaryDimension[],
   enabled = true,
+  usageScope: UsageScope = "caller",
 ) {
-  const scope = useUsageScope()
+  const scope = useUsageScope(usageScope)
   return useQuery({
     queryKey: [
       USAGE,
@@ -1884,8 +1895,9 @@ export function useUsageGroupedSeries(
   bucket: UsageBucket,
   groupBy: UsageGroupBy | null,
   enabled = true,
+  usageScope: UsageScope = "caller",
 ) {
-  const scope = useUsageScope()
+  const scope = useUsageScope(usageScope)
   return useQuery({
     queryKey: [USAGE, "series", scope.base, filters, bucket, groupBy],
     queryFn: () => {
@@ -2300,11 +2312,14 @@ export function useResetPassword() {
   })
 }
 
-export function useWorkspaces() {
+// `enabled` lets a page that only sometimes offers a workspace control (the
+// organization-wide Usage page's filter) skip the read everywhere else.
+export function useWorkspaces(enabled = true) {
   return useQuery({
     queryKey: [WORKSPACES],
     queryFn: () => fetchAllPaged<Workspace>("/v1/workspaces"),
     staleTime: 60_000,
+    enabled,
   })
 }
 

--- a/web/src/tests/fixtures.ts
+++ b/web/src/tests/fixtures.ts
@@ -103,11 +103,14 @@ const STANDALONE_SURFACES = [
 ]
 
 // The same list for a hosted (multi-tenant) deployment, kept in step with
-// HOSTED_SURFACES beside it: the process-global provider page drops and the
-// organization-scoped one takes its place.
+// HOSTED_SURFACES beside it: the process-global provider page drops, the
+// organization-scoped one takes its place, and the organization-wide Usage page
+// appears, being a destination only where "my organization" is narrower than
+// "everything" (otari-ai#1963).
 export const HOSTED_SURFACES = [
   ...STANDALONE_SURFACES.filter((surface) => surface !== "providers"),
   "organization_providers",
+  "organization_usage",
 ]
 
 /** The deployment bootstrap, standalone by default. See useDeployment. */


### PR DESCRIPTION
## Description

Gives org admins on a multi-tenant deployment a dedicated organization-wide Usage page. The organization rail gains an Observe section whose Usage destination renders the existing analytics pinned to `/v1/organizations/me/usage` (never the deployment-wide surface, even for an operator) and unnarrowed by default, with an explicit workspace filter that can name any workspace in the organization rather than only the caller's memberships.

The page is gated on a new `organization_usage` surface reported only by the hosted bootstrap: standalone's organization is the deployment, so `/usage` already answers it whole. Breakdown-row drill-down into Activity is withheld on the organization page because Activity still narrows to the sidebar's selected workspace and would silently show a subset.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes mozilla-ai/otari-ai#1963

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`); the integration half of `make test` is left to CI because this environment has no Docker, and `tests/unit` (2790 passed) plus the full dashboard suite (2668 passed), `tsc`, and Biome all ran locally.
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Fable 5 (Claude Code)

**Any additional AI details you'd like to share:**

Surface list is runtime data, so regenerating the OpenAPI spec produced no diff.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added an organization-wide Usage page for admins in hosted, multi-tenant deployments.
- Added an **Observe** section with a **Usage** destination in the organization navigation.
- Added workspace filtering for workspaces visible to the caller.
- Updated usage requests to use `/v1/organizations/me/usage` for organization scope.
- Kept organization usage unnarrowed by default and labeled shared data clearly.
- Disabled Activity drill-down for organization-wide breakdown rows.
- Added hosted-surface synchronization, route, navigation, filter, roster, API, and screenshot tests.
- Updated dashboard documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->