### PR TITLE
fix(api): refuse to cap a gateway user at an organization's budget

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -1531,6 +1531,18 @@
             ],
             "title": "Name"
           },
+          "organization_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Organization Id"
+          },
           "reset_alignment": {
             "anyOf": [
               {
@@ -1564,6 +1576,7 @@
         },
         "required": [
           "budget_id",
+          "organization_id",
           "name",
           "max_budget",
           "budget_duration_sec",

--- a/src/gateway/api/routes/budgets.py
+++ b/src/gateway/api/routes/budgets.py
@@ -1,3 +1,4 @@
+import uuid
 from decimal import Decimal
 from typing import Annotated
 
@@ -68,6 +69,11 @@ class BudgetResponse(BaseModel):
     """
 
     budget_id: str
+    # Null for the deployment's own, and a tenant's organization when set. Carried
+    # so a caller can tell the two apart before offering one: an organization's is
+    # listed here for the operator to see, and `POST /v1/users` refuses to cap a
+    # gateway user at it (mozilla-ai/otari#881).
+    organization_id: uuid.UUID | None
     name: str | None
     max_budget: float | None
     budget_duration_sec: int | None
@@ -90,6 +96,7 @@ class BudgetResponse(BaseModel):
         """Create a BudgetResponse from a Budget ORM model and its usage rollup."""
         return cls(
             budget_id=budget.budget_id,
+            organization_id=budget.organization_id,
             name=budget.name,
             # Narrowed on the way out: the cap is exact in the database, while
             # the wire contract and the dashboard client stay float.

--- a/src/gateway/api/routes/users.py
+++ b/src/gateway/api/routes/users.py
@@ -122,6 +122,26 @@ class UsageLogResponse(BaseModel):
         )
 
 
+def _require_assignable_budget(budget: Budget | None, budget_id: str) -> Budget:
+    """The budget a gateway user may be capped at, or the not-found an unknown id gets.
+
+    An organization's budget is not one. A ``users`` row is deployment-wide with
+    no tenancy column, so pointing one at a tenant's budget lets a tenant admin
+    editing their own figure move what a gateway user may spend, and neither side
+    can see the coupling: the admin cannot reach this surface, and the operator
+    sees no sign the budget they picked is a tenant's. Answered as the 404 this
+    route already gives an id naming nothing, because from the deployment
+    surface's point of view a tenant's budget is not one it may assign, and
+    telling the two apart says nothing useful.
+    """
+    if budget is None or budget.organization_id is not None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Budget with id '{budget_id}' not found",
+        )
+    return budget
+
+
 @router.post("")
 async def create_user(
     request: CreateUserRequest,
@@ -145,12 +165,7 @@ async def create_user(
     budget: Budget | None = None
     if request.budget_id:
         budget_result = await db.execute(select(Budget).where(Budget.budget_id == request.budget_id))
-        budget = budget_result.scalar_one_or_none()
-        if not budget:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Budget with id '{request.budget_id}' not found",
-            )
+        budget = _require_assignable_budget(budget_result.scalar_one_or_none(), request.budget_id)
 
     if existing_user and existing_user.deleted_at is not None:
         user = existing_user
@@ -264,12 +279,7 @@ async def update_user(
             user.next_budget_reset_at = None
         else:
             budget_result = await db.execute(select(Budget).where(Budget.budget_id == request.budget_id))
-            budget = budget_result.scalar_one_or_none()
-            if not budget:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"Budget with id '{request.budget_id}' not found",
-                )
+            budget = _require_assignable_budget(budget_result.scalar_one_or_none(), request.budget_id)
 
             user.budget_id = request.budget_id
             now = datetime.now(UTC)

--- a/src/gateway/services/tenancy/errors.py
+++ b/src/gateway/services/tenancy/errors.py
@@ -847,10 +847,12 @@ class OrganizationBudgetHeldElsewhereError(TenancyConflictError):
     """Something outside this organization's own surface still names the budget.
 
     ``users.budget_id`` and ``budget_reset_logs.budget_id``, neither of which is
-    a tenant's to see: an operator can assign a gateway user to any budget
-    ``GET /v1/budgets`` lists, tenant-owned ones included. Left unchecked the
-    first is nulled out by the ORM and the second fails at the commit, so the
-    refusal says the budget is held without naming the rows holding it.
+    a tenant's to see. Since otari#881 neither assignment site will point a
+    gateway user at a tenant's budget, so a live hold is one made before that,
+    and a reset record outlives the assignment that produced it either way. Left
+    unchecked the first is nulled out by the ORM and the second fails at the
+    commit, so the refusal says the budget is held without naming the rows
+    holding it.
     """
 
     def __init__(self, budget_id: object):

--- a/src/gateway/services/tenancy/organization_budget_service.py
+++ b/src/gateway/services/tenancy/organization_budget_service.py
@@ -596,13 +596,13 @@ class OrganizationBudgetService:
         so the refusal can say which.
 
         ``users.budget_id`` is counted but not named. It can hold a tenant's
-        budget, because ``GET /v1/budgets`` is unfiltered and ``POST /v1/users``
-        accepts any id it lists, and ``Budget.users`` is a plain relationship, so
-        deleting the budget would not refuse: the ORM nulls the column out and
-        the assignment an operator made disappears with no refusal to either of
-        them. The count is what stops that, and it says only that the budget is
-        held, because saying "3 users" to an admin who cannot see the users page
-        would name a thing they cannot act on.
+        budget: the assignment sites refuse one since otari#881, so what remains
+        is a row assigned before that, and ``Budget.users`` is a plain
+        relationship, so deleting the budget would not refuse. The ORM nulls the
+        column out and the assignment an operator made disappears with no refusal
+        to either of them. The count is what stops that, and it says only that
+        the budget is held, because saying "3 users" to an admin who cannot see
+        the users page would name a thing they cannot act on.
 
         ``budget_reset_logs.budget_id`` is the same shape with a NOT NULL column,
         so its null-out fails instead, as an ``IntegrityError`` at the commit.

--- a/tests/integration/test_organization_budgets.py
+++ b/tests/integration/test_organization_budgets.py
@@ -205,35 +205,55 @@ def test_every_recognized_alignment_is_accepted(
         assert created.json()["reset_alignment"] == alignment
 
 
-def test_a_budget_a_gateway_user_holds_is_refused_rather_than_unassigned(
+def test_a_gateway_user_may_not_be_created_on_an_organizations_budget(
     client: TestClient,
     master_key_header: dict[str, str],
 ) -> None:
-    """The delete refuses instead of silently clearing ``users.budget_id``.
+    """404, the same one an id naming nothing gets.
 
-    An operator can assign a gateway user to any budget ``GET /v1/budgets``
-    lists, tenant-owned ones included. ``Budget.users`` is a plain relationship,
-    so an unchecked delete does not fail: the ORM nulls the column out, and an
-    admin who cannot see that table removes the operator's assignment with it.
+    A ``users`` row is deployment-wide with no tenancy column, so a tenant's
+    budget is never the right cap for one: the admin editing its figure would be
+    moving what a gateway user may spend, and neither side can see the coupling.
     """
-    budget = client.post(_BUDGETS, json=_budget_body(), headers=master_key_header).json()
+    tenant = client.post(_BUDGETS, json=_budget_body(), headers=master_key_header).json()
+    user_id = f"holder-{uuid.uuid4().hex[:8]}"
+
+    refused = client.post(
+        "/v1/users",
+        json={"user_id": user_id, "budget_id": tenant["budget_id"]},
+        headers=master_key_header,
+    )
+    assert refused.status_code == status.HTTP_404_NOT_FOUND, refused.text
+    assert refused.json()["detail"] == f"Budget with id '{tenant['budget_id']}' not found"
+
+    # Refused whole, rather than the user landing uncapped.
+    assert client.get(f"/v1/users/{user_id}", headers=master_key_header).status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_a_gateway_user_may_not_be_moved_onto_an_organizations_budget(
+    client: TestClient,
+    master_key_header: dict[str, str],
+) -> None:
+    """The other assignment site, and the cap it already had survives the refusal."""
+    deployment = client.post("/v1/budgets", json={"max_budget": 10.0}, headers=master_key_header).json()
+    tenant = client.post(_BUDGETS, json=_budget_body(), headers=master_key_header).json()
     user_id = f"holder-{uuid.uuid4().hex[:8]}"
     created = client.post(
         "/v1/users",
-        json={"user_id": user_id, "budget_id": budget["budget_id"]},
+        json={"user_id": user_id, "budget_id": deployment["budget_id"]},
         headers=master_key_header,
     )
-    assert created.status_code in {status.HTTP_200_OK, status.HTTP_201_CREATED}, created.text
+    assert created.status_code == status.HTTP_200_OK, created.text
 
-    refused = client.delete(f"{_BUDGETS}/{budget['budget_id']}", headers=master_key_header)
-    assert refused.status_code == status.HTTP_409_CONFLICT, refused.text
-    assert "still in use" in refused.json()["detail"]
+    refused = client.patch(
+        f"/v1/users/{user_id}",
+        json={"budget_id": tenant["budget_id"]},
+        headers=master_key_header,
+    )
+    assert refused.status_code == status.HTTP_404_NOT_FOUND, refused.text
 
-    # The assignment is still the operator's, and the budget is still there.
-    still_assigned = client.get(f"/v1/users/{user_id}", headers=master_key_header)
-    assert still_assigned.status_code == status.HTTP_200_OK, still_assigned.text
-    assert still_assigned.json()["budget_id"] == budget["budget_id"]
-    assert client.get(_BUDGETS, headers=master_key_header).json()["count"] == 1
+    still_capped = client.get(f"/v1/users/{user_id}", headers=master_key_header)
+    assert still_capped.json()["budget_id"] == deployment["budget_id"]
 
 
 def test_an_unknown_budget_is_not_found(client: TestClient, master_key_header: dict[str, str]) -> None:
@@ -441,6 +461,11 @@ def test_the_deployment_budget_list_is_not_this_one(
         deployment.json()["budget_id"],
         tenant["budget_id"],
     }
+    # And each row says which it is, so the operator's assignment control can
+    # withhold the one `POST /v1/users` would refuse.
+    owners = {row["budget_id"]: row["organization_id"] for row in everything}
+    assert owners[deployment.json()["budget_id"]] is None
+    assert owners[tenant["budget_id"]] == tenant["organization_id"]
 
 
 def test_a_ceiling_may_not_name_a_deployment_budget(
@@ -1023,6 +1048,27 @@ async def test_an_explicit_null_clears_the_cap_as_the_schema_says(async_db: Asyn
     )
     assert renamed.max_budget is None
     assert renamed.name == "Uncapped"
+
+@pytest.mark.asyncio
+async def test_a_delete_is_refused_while_a_gateway_user_holds_the_budget(async_db: AsyncSession) -> None:
+    """The hold the assignment sites no longer create, and still have to refuse.
+
+    Since otari#881 neither `/v1/users` site will point a gateway user at a
+    tenant's budget, so a row in this shape was assigned before that. Seeded
+    directly for the same reason. `Budget.users` is a plain relationship, so an
+    unchecked delete does not fail on it: the ORM nulls the column out, and an
+    admin who cannot see that table removes the operator's assignment with it.
+    """
+    organization = await _organization(async_db, slug="acme-user-hold")
+    owner = await _member(async_db, organization, role="owner", full_name="Owner")
+    service = OrganizationBudgetService(async_db)
+    budget = await service.create_budget(user=owner, request=_create())
+    async_db.add(ApiUser(user_id="capped-user", budget_id=budget.budget_id))
+    await async_db.flush()
+
+    with pytest.raises(OrganizationBudgetHeldElsewhereError):
+        await service.delete_budget(user=owner, budget_id=budget.budget_id)
+
 
 @pytest.mark.asyncio
 async def test_a_delete_is_refused_while_a_reset_record_names_the_budget(async_db: AsyncSession) -> None:

--- a/tests/unit/test_shared_helpers_pure.py
+++ b/tests/unit/test_shared_helpers_pure.py
@@ -1,5 +1,6 @@
 """Unit tests for pure helper behavior shared by route handlers."""
 
+import uuid
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
@@ -195,6 +196,7 @@ def test_resolve_user_id_empty_string_treated_as_missing() -> None:
 def test_budget_response_from_model() -> None:
     budget = MagicMock()
     budget.budget_id = "budget-1"
+    budget.organization_id = None
     budget.name = "team-free"
     budget.max_budget = 100.0
     budget.budget_duration_sec = 86400
@@ -212,11 +214,31 @@ def test_budget_response_from_model() -> None:
     # A freshly serialized budget has no assigned users yet.
     assert resp.user_count == 0
     assert resp.total_spend == 0.0
+    # No organization, so this is the deployment's own and assignable to a
+    # gateway user.
+    assert resp.organization_id is None
+
+
+def test_budget_response_carries_the_owning_organization() -> None:
+    """A tenant's budget is marked as one, which is what keeps a caller from offering it."""
+    organization_id = uuid.uuid4()
+    budget = MagicMock()
+    budget.budget_id = "budget-3"
+    budget.organization_id = organization_id
+    budget.name = "Engineering monthly"
+    budget.max_budget = 250.0
+    budget.budget_duration_sec = None
+    budget.reset_alignment = "calendar_month"
+    budget.created_at = datetime(2025, 1, 1, tzinfo=UTC)
+    budget.updated_at = datetime(2025, 1, 2, tzinfo=UTC)
+
+    assert BudgetResponse.from_model(budget).organization_id == organization_id
 
 
 def test_budget_response_from_model_nullable_fields() -> None:
     budget = MagicMock()
     budget.budget_id = "budget-2"
+    budget.organization_id = None
     budget.name = None
     budget.max_budget = None
     budget.budget_duration_sec = None

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -4846,6 +4846,8 @@ export interface components {
             max_budget: number | null;
             /** Name */
             name: string | null;
+            /** Organization Id */
+            organization_id: string | null;
             /** Reset Alignment */
             reset_alignment: string | null;
             /**

--- a/web/src/features/budgets/BudgetsPage.test.tsx
+++ b/web/src/features/budgets/BudgetsPage.test.tsx
@@ -34,6 +34,7 @@ function testUser(user_id: string): User {
 function budget(overrides: Partial<Budget> = {}): Budget {
   return {
     budget_id: "11111111-2222-3333-4444-555555555555",
+    organization_id: null,
     name: null,
     max_budget: 100,
     reset_alignment: null,
@@ -490,6 +491,45 @@ describe("BudgetsPage", () => {
       await screen.findByRole("button", { name: "Save changes" }),
     ).toBeInTheDocument()
     expect(screen.getByLabelText("Spending limit (USD)")).toHaveValue("42")
+  })
+
+  it("marks a budget an organization owns and withholds assignment on it", async () => {
+    // `/v1/users` refuses to cap a gateway user at a tenant's budget, so offering
+    // the multiselect would be offering a save that answers 404.
+    mockApi({
+      budgets: [
+        budget({ organization_id: "99999999-8888-7777-6666-555555555555" }),
+      ],
+      users: [testUser("alice")],
+    })
+    const user = userEvent.setup()
+    renderPage(<BudgetsPage />)
+
+    const row = (await screen.findByText("11111111")).closest("tr")!
+    expect(
+      within(row).getByText("Owned by an organization"),
+    ).toBeInTheDocument()
+
+    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    expect(
+      await screen.findByRole("button", { name: "Save changes" }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText("Assign to people (optional)")).toBeNull()
+    expect(screen.getByText(/belongs to an organization/)).toBeInTheDocument()
+  })
+
+  it("keeps the assignment control on the deployment's own budget", async () => {
+    mockApi({ budgets: [budget()], users: [testUser("alice")] })
+    const user = userEvent.setup()
+    renderPage(<BudgetsPage />)
+
+    const row = (await screen.findByText("11111111")).closest("tr")!
+    expect(within(row).queryByText("Owned by an organization")).toBeNull()
+
+    await user.click(within(row).getByRole("button", { name: "Edit" }))
+    expect(
+      await screen.findByText("Assign to people (optional)"),
+    ).toBeInTheDocument()
   })
 
   it("reveals per-user reset history on demand", async () => {

--- a/web/src/features/budgets/BudgetsPage.tsx
+++ b/web/src/features/budgets/BudgetsPage.tsx
@@ -211,6 +211,7 @@ function BudgetForm({
   onClose,
   assignUsers,
   assignedUserIds,
+  assignmentNote,
 }: {
   title: string
   submitLabel: string
@@ -231,6 +232,9 @@ function BudgetForm({
   // Who already holds this budget, so edit opens with them selected rather than
   // reading as an empty assignment that would clear them on save.
   assignedUserIds?: string[]
+  // Why the multiselect is absent, where its absence is a rule rather than a
+  // failed read. The failed-roster case is explained by the page's banner.
+  assignmentNote?: string
 }) {
   const [name, setName] = useState(initial.name ?? "")
   const [limit, setLimit] = useState(
@@ -299,6 +303,8 @@ function BudgetForm({
             onChange={setUserIds}
             users={assignUsers}
           />
+        ) : assignmentNote ? (
+          <p className="text-caption">{assignmentNote}</p>
         ) : null}
         <div className="flex gap-2">
           <Button variant="primary" isDisabled={!canSubmit} onPress={submit}>
@@ -492,6 +498,14 @@ function budgetLabel(budget: Budget): string {
   return budget.name ?? shortId(budget.budget_id)
 }
 
+// Whose budget a row is: a tenant's carries an organization, the deployment's own
+// carries none. `/v1/users` refuses to cap a gateway user at a tenant's
+// (otari#881), so the page marks the row and withholds the assignment control
+// rather than offering a save the API answers 404.
+function isOrganizationOwned(budget: Budget): boolean {
+  return budget.organization_id !== null
+}
+
 /**
  * The deployment's own budgets page, which is what an operator sees.
  *
@@ -603,6 +617,15 @@ function DeploymentBudgetsPage() {
             <span className="font-medium text-foreground">
               {b.name ?? <span className="text-muted">(unnamed)</span>}
             </span>
+            {isOrganizationOwned(b) ? (
+              // Not a warning: the budget is a real one this page may still
+              // relabel and refigure, it is simply not one a gateway user can be
+              // held to. The mirror of the tenant page's "Set at the deployment
+              // level".
+              <Chip className="self-start" size="sm" variant="secondary">
+                Owned by an organization
+              </Chip>
+            ) : null}
             {/* Only a prefix is rendered, so the id an API call needs is not on the
               page in full; the copy hands over the whole thing. */}
             <CopyableValue value={b.budget_id} label="budget id">
@@ -862,7 +885,16 @@ function DeploymentBudgetsPage() {
           }}
           error={updateBudget.error ?? assignmentError}
           isPending={updateBudget.isPending || assigningUsers}
-          assignUsers={rosterReady ? (users.data ?? []) : undefined}
+          assignUsers={
+            rosterReady && !isOrganizationOwned(editingBudget)
+              ? (users.data ?? [])
+              : undefined
+          }
+          assignmentNote={
+            isOrganizationOwned(editingBudget)
+              ? "This budget belongs to an organization, so people here cannot be held to it. Its limit and reset are still the deployment's to change."
+              : undefined
+          }
           assignedUserIds={(users.data ?? [])
             .filter((u) => u.budget_id === editingBudget.budget_id)
             .map((u) => u.user_id)}

--- a/web/src/features/overview/overview.test.ts
+++ b/web/src/features/overview/overview.test.ts
@@ -12,6 +12,7 @@ import { usageTotals } from "@/tests/fixtures"
 function budget(over: Partial<Budget>): Budget {
   return {
     budget_id: "b",
+    organization_id: null,
     name: null,
     max_budget: 100,
     reset_alignment: null,

--- a/web/src/tests/fixtures.ts
+++ b/web/src/tests/fixtures.ts
@@ -344,6 +344,9 @@ export function scopedBudget(
 export function budget(overrides: Partial<Budget> = {}): Budget {
   return {
     budget_id: "77777777-7777-7777-7777-777777777777",
+    // The deployment's own. A tenant's carries its organization, and no gateway
+    // user may be held to one.
+    organization_id: null,
     name: "Team standard",
     max_budget: 100,
     budget_duration_sec: 2_592_000,


### PR DESCRIPTION
## Description

`POST /v1/users` and `PATCH /v1/users/{id}` validated `budget_id` for existence, not for ownership. Since `b7e1c4a9d2f5` a budget can belong to a tenant, so an operator could cap a gateway user at one. A `users` row is deployment-wide with no tenancy column, so while that stood a tenant admin editing their own figure moved what a gateway user may spend, and neither party could see the coupling: the admin cannot reach the users surface, and the operator saw no sign the budget they picked was a tenant's.

#875 closed the data-loss half (deleting such a budget used to null `users.budget_id` out silently; it now refuses with a 409). This is the authority half it deliberately held back.

**What changed**

- `_require_assignable_budget` at both assignment sites answers the 404 an id naming nothing already gets. From the deployment surface's point of view a tenant's budget is not one it may assign, and telling the two apart says nothing useful.
- `BudgetResponse` now carries `organization_id` (null for the deployment's own). The list stays unfiltered, so an operator still sees and can still refigure a tenant's budget; what changes is that the row now says whose it is.
- The operator's Budgets page marks such a row ("Owned by an organization", mirroring the tenant page's "Set at the deployment level") and withholds its assignment control with a line saying why, so the UI stops offering a save the API refuses.

**Contract narrowing**, stated plainly: a request that used to succeed now answers 404. That is the whole point of the issue, and it is why it was not folded into #875.

**Legacy rows.** Nothing migrates an assignment made before this. `b7e1c4a9d2f5` is a day old and unreleased, so a row in that shape can only exist in a tree that ran it unreleased, and rewriting live `users.budget_id` values on upgrade is the worse trade. Worth knowing if one does exist: the assignment multiselect is the only dashboard control that writes `users.budget_id`, and this PR withholds it on exactly the rows that would carry such an assignment, while the People column goes on counting them. `PATCH /v1/users/{id}` with `budget_id: null` detaches, and #875's 409 keeps the tenant from deleting the budget out from under the user in the meantime.

**Not in scope**, and reachable after this merges: `POST /v1/scoped-budgets` validates a `budget_id` for existence only (`scoped_budgets.py:173`), and the workspace-member ceiling picker offers the same unfiltered list (`OrganizationMembersPage.tsx:480`), so a ceiling on a tenant's budget still saves with a 200. And `DELETE /v1/budgets/{id}` still removes a tenant's budget and nulls its holders. Filed as #901 and #902, so that closing #881 does not read as closing the class.

The delete-refusal guard from #875 still matters for rows assigned before this, so its test moved to the service layer and seeds the assignment directly; the comments in `errors.py` and `organization_budget_service.py` that described the assignment as possible were updated with it.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #881

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Dashboard checks were run too (`pnpm --dir web run lint`, `typecheck`, `test`). `make test` is green: the two unit assertions on `BudgetResponse` needed the new field and were updated. The OSS-edition smoke gate fails identically on an unmodified tree in this environment (its local `/health` probe never answers), so it was not usable as a signal here.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code

**Any additional AI details you'd like to share:**

Implemented from the issue's suggested fix, which the issue notes was already written and tested.

- [x] I am an AI Agent filling out this form (check box if true)

