### PR TITLE
feat(dashboard): name the setup-guide step in the telemetry vocabulary

### DIFF
--- a/web/src/shared/telemetry/events.ts
+++ b/web/src/shared/telemetry/events.ts
@@ -40,7 +40,7 @@ export const TELEMETRY_EVENTS = {
   TAB_CHANGED: "Tab Changed",
 
   /**
-   * The post-sign-in setup guide shown to a new account, and dismissed.
+   * The post-sign-in setup guide shown to a new account.
    *
    * Named here and fired by nobody in this build, for the same reason as
    * `CHECKOUT_CANCELLED` below: the guide is a hosted surface an overlay
@@ -51,10 +51,16 @@ export const TELEMETRY_EVENTS = {
    * them, and an overlay that invented a string for it would split the funnel
    * this vocabulary is base-owned to hold together.
    *
-   * The properties the platform sends with them are `workspace_id` and
+   * The properties the platform sends with it are `workspace_id` and
    * `presentation_count`.
    */
   ACTIVATION_GUIDE_SHOWN: "Activation Guide Shown",
+  /**
+   * That guide dismissed, whether by finishing it or by closing it.
+   *
+   * Overlay-fired and base-named for the reason given on
+   * `ACTIVATION_GUIDE_SHOWN` above, and carries the same two properties.
+   */
   ACTIVATION_GUIDE_DISMISSED: "Activation Guide Dismissed",
 
   /**

--- a/web/src/shared/telemetry/events.ts
+++ b/web/src/shared/telemetry/events.ts
@@ -40,14 +40,31 @@ export const TELEMETRY_EVENTS = {
   TAB_CHANGED: "Tab Changed",
 
   /**
+   * The post-sign-in setup guide shown to a new account, and dismissed.
+   *
+   * Named here and fired by nobody in this build, for the same reason as
+   * `CHECKOUT_CANCELLED` below: the guide is a hosted surface an overlay
+   * contributes, and no base page shows it. Naming the step here is what keeps
+   * the activation funnel in one piece. `SIGNUP_STARTED` through
+   * `LOGIN_SUCCESS` are recorded from Otari's own auth pages and the first
+   * settled request is measured server-side, so this is the one step between
+   * them, and an overlay that invented a string for it would split the funnel
+   * this vocabulary is base-owned to hold together.
+   *
+   * The properties the platform sends with them are `workspace_id` and
+   * `presentation_count`.
+   */
+  ACTIVATION_GUIDE_SHOWN: "Activation Guide Shown",
+  ACTIVATION_GUIDE_DISMISSED: "Activation Guide Dismissed",
+
+  /**
    * A wallet top-up abandoned at the payment provider.
    *
-   * Named here and fired by nobody in this build, which is the one deliberate
-   * gap in this list: billing is ARCHITECTURE.md's canonical overlay-only
-   * capability, this gateway meters spend but holds no wallet, and no base page
-   * ever sees the return from a checkout. It is named so the overlay that does
-   * own that return records it under the platform's existing name rather than
-   * inventing a second one.
+   * Named here and fired by nobody in this build: billing is ARCHITECTURE.md's
+   * canonical overlay-only capability, this gateway meters spend but holds no
+   * wallet, and no base page ever sees the return from a checkout. It is named
+   * so the overlay that does own that return records it under the platform's
+   * existing name rather than inventing a second one.
    */
   CHECKOUT_CANCELLED: "Checkout Cancelled",
 } as const

--- a/web/src/shared/telemetry/overlayTelemetry.test.ts
+++ b/web/src/shared/telemetry/overlayTelemetry.test.ts
@@ -120,7 +120,7 @@ describe("the base build's dependencies", () => {
 })
 
 describe("the event catalog", () => {
-  it("carries the twelve names the platform already records under", () => {
+  it("carries the fourteen names the platform already records under", () => {
     // Pinned as strings, not just as keys: a superset build reports into the
     // analytics workspace otari-ai already reports into, so renaming one here
     // splits its funnel in two rather than failing anything.
@@ -136,6 +136,8 @@ describe("the event catalog", () => {
       RESEND_VERIFICATION_CLICKED: "Resend Verification Clicked",
       FORM_VALIDATION_FAILED: "Form Validation Failed",
       TAB_CHANGED: "Tab Changed",
+      ACTIVATION_GUIDE_SHOWN: "Activation Guide Shown",
+      ACTIVATION_GUIDE_DISMISSED: "Activation Guide Dismissed",
       CHECKOUT_CANCELLED: "Checkout Cancelled",
     })
   })
@@ -173,14 +175,18 @@ describe("the wiring behind the catalog", () => {
   const sources = baseSources(join(WEB, "src"))
 
   /**
-   * Named here and fired by nobody, deliberately, and the only such name.
+   * Named here and fired by nobody, deliberately.
    *
    * Listed rather than left silently outside the assertion below: an unfired
    * name reads as dead, and the next person to tidy one away would be breaking
-   * a contract rather than removing a leftover. `events.ts` says why this one
-   * is here.
+   * a contract rather than removing a leftover. `events.ts` says why each of
+   * these is here.
    */
-  const NOT_FIRED_HERE = ["CHECKOUT_CANCELLED"]
+  const NOT_FIRED_HERE = [
+    "ACTIVATION_GUIDE_SHOWN",
+    "ACTIVATION_GUIDE_DISMISSED",
+    "CHECKOUT_CANCELLED",
+  ]
 
   it.each(
     Object.keys(TELEMETRY_EVENTS).filter(


### PR DESCRIPTION
## Description

`web/src/shared/telemetry/events.ts` carried no name for the post-sign-in setup guide, so the hosted onboarding step could record nothing. The step is an overlay contribution, and the vocabulary is base-owned precisely so a replacement cannot invent a string of its own; the result was a hole in the activation funnel, with `Signup Started` through `Login Success` firing, the first settled request measured server-side, and nothing at all in between in any build.

This adds `ACTIVATION_GUIDE_SHOWN` and `ACTIVATION_GUIDE_DISMISSED`, spelled the way the platform's own catalog spells them (`Activation Guide Shown`, `Activation Guide Dismissed`), so a superset build reports into the same funnel rather than splitting it. They follow the `CHECKOUT_CANCELLED` precedent: named in the base vocabulary and fired by nobody here, because the guide itself is a hosted surface. The properties the platform sends with them are `workspace_id` and `presentation_count`, noted in the doc comment.

That makes three deliberately unfired names rather than one, so the note on `CHECKOUT_CANCELLED` no longer claims to be the single gap, and the test's `NOT_FIRED_HERE` list and its docstring cover all three.

No overlay-facing shape changes: `TelemetryEventName` derives from this object, `overlayTelemetry.ts` still names no event, and the base tracker remains a no-op.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #907

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Notes on the checks: the dashboard's own suite is what covers this change, and all three passed (`pnpm --dir web run lint`, `pnpm --dir web run typecheck`, `pnpm --dir web test`: 110 files, 2675 tests). `make lint` and `make typecheck` are green as well. `make test` was not run, because no Python or migration file is touched here. No API contract change, so no generated spec or Postman regeneration was owed; no new page, so no screenshot entry is owed.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code

**Any additional AI details you'd like to share:**

Implemented and self-reviewed against the repo's `pr-cycle` and `review` skills.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added `Activation Guide Shown` and `Activation Guide Dismissed` to the telemetry vocabulary.
- Documented their `workspace_id` and `presentation_count` properties.
- Updated tests and notes to identify all intentionally unfired events, including `CHECKOUT_CANCELLED`.

These names allow the hosted setup guide to use the shared activation funnel without changing overlay APIs or tracker behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->