### PR TITLE
fix(api): refuse a blank provider narrowing on POST /v1/scoped-budgets

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -2942,13 +2942,15 @@
             "anyOf": [
               {
                 "maxLength": 255,
+                "minLength": 1,
+                "pattern": "^\\S+$",
                 "type": "string"
               },
               {
                 "type": "null"
               }
             ],
-            "description": "Narrow the cap to one provider instance; null caps spend across every provider",
+            "description": "Narrow the cap to one provider instance; omit or null to cap spend across every provider. Must name a real instance: a blank value would store a ceiling that never binds",
             "title": "Provider Key Id"
           },
           "scope_id": {

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -2950,7 +2950,7 @@
                 "type": "null"
               }
             ],
-            "description": "Narrow the cap to one provider instance; omit or null to cap spend across every provider. Must name a real instance: a blank value would store a ceiling that never binds",
+            "description": "Narrow the cap to one provider instance; omit or null to cap spend across every provider. A blank value would store a ceiling that never binds, so it is refused; this does not check that the value names a configured provider instance",
             "title": "Provider Key Id"
           },
           "scope_id": {

--- a/src/gateway/api/routes/scoped_budgets.py
+++ b/src/gateway/api/routes/scoped_budgets.py
@@ -47,10 +47,20 @@ class CreateScopedBudgetRequest(BaseModel):
         max_length=255,
         description="Id of the capped identity: an organization, workspace, membership row, or API key",
     )
+    # Absent means every provider; a present value must name a real instance.
+    # Resolution matches `provider_key_id == provider_instance OR IS NULL`, and a
+    # blank string is neither, so it would store, list, and never bind. Refused
+    # rather than folded into null, because null is the *wider* cap and coercing
+    # would silently cap more than the caller asked for.
     provider_key_id: str | None = Field(
         default=None,
+        min_length=1,
         max_length=255,
-        description="Narrow the cap to one provider instance; null caps spend across every provider",
+        pattern=r"^\S+$",
+        description=(
+            "Narrow the cap to one provider instance; omit or null to cap spend across every provider. "
+            "Must name a real instance: a blank value would store a ceiling that never binds"
+        ),
     )
     budget_id: str = Field(
         min_length=1,

--- a/src/gateway/api/routes/scoped_budgets.py
+++ b/src/gateway/api/routes/scoped_budgets.py
@@ -47,11 +47,13 @@ class CreateScopedBudgetRequest(BaseModel):
         max_length=255,
         description="Id of the capped identity: an organization, workspace, membership row, or API key",
     )
-    # Absent means every provider; a present value must name a real instance.
-    # Resolution matches `provider_key_id == provider_instance OR IS NULL`, and a
-    # blank string is neither, so it would store, list, and never bind. Refused
-    # rather than folded into null, because null is the *wider* cap and coercing
-    # would silently cap more than the caller asked for.
+    # Absent means every provider. Resolution matches `provider_key_id ==
+    # provider_instance OR IS NULL`, and a blank string is neither, so it would
+    # store, list, and never bind. Refused rather than folded into null, because
+    # null is the *wider* cap and coercing would silently cap more than the
+    # caller asked for. This only refuses the blank/whitespace shape, not an
+    # unresolvable value: unlike `scope_id` and `budget_id` above, a present
+    # `provider_key_id` naming no configured instance is not checked here (#918).
     provider_key_id: str | None = Field(
         default=None,
         min_length=1,
@@ -59,7 +61,8 @@ class CreateScopedBudgetRequest(BaseModel):
         pattern=r"^\S+$",
         description=(
             "Narrow the cap to one provider instance; omit or null to cap spend across every provider. "
-            "Must name a real instance: a blank value would store a ceiling that never binds"
+            "A blank value would store a ceiling that never binds, so it is refused; this does not check "
+            "that the value names a configured provider instance"
         ),
     )
     budget_id: str = Field(

--- a/tests/integration/test_scoped_budgets.py
+++ b/tests/integration/test_scoped_budgets.py
@@ -912,6 +912,57 @@ def test_unknown_scope_type_is_refused(client: Any, master_key_header: dict[str,
     assert response.status_code == 422
 
 
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_a_blank_provider_narrowing_is_refused(
+    client: Any,
+    master_key_header: dict[str, str],
+    blank: str,
+) -> None:
+    """A ceiling narrowed to nothing would be created, listed, and never enforced.
+
+    ``applicable_budgets`` matches ``provider_key_id == provider_instance OR IS
+    NULL``, and a blank string is neither: it would store as a narrowed row
+    under ``uq_scoped_budgets_scope_with_key`` and bind to no request ever. That
+    is the same permissive-direction failure a scope naming nothing has, so it
+    is refused at the schema rather than normalized, since folding it into null
+    would quietly cap *more* than the caller asked for. Mirrors
+    ``test_organization_budgets.py::test_a_blank_provider_narrowing_is_refused``.
+    """
+    workspace_id = _a_workspace_id(client, master_key_header)
+
+    refused = client.post(
+        "/v1/scoped-budgets",
+        json={
+            "scope_type": "workspace",
+            "scope_id": workspace_id,
+            "provider_key_id": blank,
+            "budget_id": _a_budget_id(client, master_key_header, max_budget=1.0),
+        },
+        headers=master_key_header,
+    )
+    assert refused.status_code == 422, refused.text
+
+
+def test_an_omitted_provider_narrowing_still_caps_every_provider(
+    client: Any,
+    master_key_header: dict[str, str],
+) -> None:
+    """The other half of the rule above: absent is the aggregate cap, and stays so."""
+    workspace_id = _a_workspace_id(client, master_key_header)
+
+    created = client.post(
+        "/v1/scoped-budgets",
+        json={
+            "scope_type": "workspace",
+            "scope_id": workspace_id,
+            "budget_id": _a_budget_id(client, master_key_header, max_budget=1.0),
+        },
+        headers=master_key_header,
+    )
+    assert created.status_code == 200, created.text
+    assert created.json()["provider_key_id"] is None
+
+
 @pytest.mark.asyncio
 async def test_token_ceiling_holds_the_estimate_and_records_the_measured_total(
     async_db: AsyncSession, tenancy: Fixture

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -5477,7 +5477,7 @@ export interface components {
             name?: string | null;
             /**
              * Provider Key Id
-             * @description Narrow the cap to one provider instance; omit or null to cap spend across every provider. Must name a real instance: a blank value would store a ceiling that never binds
+             * @description Narrow the cap to one provider instance; omit or null to cap spend across every provider. A blank value would store a ceiling that never binds, so it is refused; this does not check that the value names a configured provider instance
              */
             provider_key_id?: string | null;
             /**

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -5477,7 +5477,7 @@ export interface components {
             name?: string | null;
             /**
              * Provider Key Id
-             * @description Narrow the cap to one provider instance; null caps spend across every provider
+             * @description Narrow the cap to one provider instance; omit or null to cap spend across every provider. Must name a real instance: a blank value would store a ceiling that never binds
              */
             provider_key_id?: string | null;
             /**


### PR DESCRIPTION
## Description
`CreateScopedBudgetRequest.provider_key_id` on `POST /v1/scoped-budgets` was length-checked but not constrained, so an empty or whitespace-only value was accepted. NULL means "cap spend across every provider" and a value means "cap only this instance"; a blank string satisfies neither:

- It is `NOT NULL`, so the partial unique index `uq_scoped_budgets_scope_no_key` (declared `WHERE provider_key_id IS NULL`) does not cover it, and the "one aggregate cap per scope" rule silently stops applying to that row.
- `applicable_budgets` matches `provider_key_id == provider_instance OR provider_key_id IS NULL`. A blank string satisfies neither, so the ceiling never binds.

The result: a ceiling created, listed, and enforced against nothing, with no error anywhere — the same permissive-direction failure `test_a_ceiling_on_a_scope_that_does_not_exist_is_refused` already guards against for an unresolvable scope.

Mirrors the fix #875 applied to the two tenant-facing siblings (`OrganizationScopedBudgetCreate`, `WorkspaceMemberBudgetPolicyCreate`): `min_length=1` plus `pattern=r"^\S+$"`, refusing rather than coercing to null, since null is the *wider* cap and coercion would silently cap more than the caller asked for. This router is gated on `require_deployment_operator`, reached by a smaller audience than those two, which is why #878 filed it separately and lower priority rather than folding it into #875.

Also regenerated `docs/public/openapi.json` for the changed field (the Postman collection doesn't embed this field's schema, so it didn't need regenerating).

## PR Type

- [x] Bug Fix

## Relevant issues
Fixes #878

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test` — ran `ruff check` directly and confirmed it's clean; verified the Pydantic validation logic in isolation (blank/whitespace/tab all rejected, `None` and a real value accepted) since I couldn't run the full suite through `uv sync` on this machine, same platform constraint as #699).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`) — done by hand, matching the already-correct sibling schema exactly (confirmed identical shape/description text).

## AI Usage

- [x] AI was used for drafting/refactoring.

**AI Model/Tool used:** Claude Sonnet 5 (Claude Code)

**Any additional AI details you'd like to share:** Picked this up off the issue directly — it's fully specified with the exact fix and a pointer to the sibling pattern already in the codebase, so there was no design decision to make, just verifying the mirror was exact and adding the matching test and OpenAPI update. I confirmed the validation behavior directly before opening this rather than trusting the diff alone.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Reject blank or whitespace-only `provider_key_id` values for `POST /v1/scoped-budgets`.
- Preserve omitted or `null` values as aggregate provider caps.
- Add tests for invalid and aggregate inputs.
- Update the OpenAPI documentation and generated client schema.

This prevents ceilings that never apply to provider spending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->