### PR TITLE
ci: run unit and integration tests as separate parallel jobs

### DIFF
--- a/.github/workflows/otari-tests.yml
+++ b/.github/workflows/otari-tests.yml
@@ -28,7 +28,6 @@ on:
 jobs:
   test-unit:
     runs-on: ubuntu-latest
-    environment: integration-tests
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -43,8 +42,6 @@ jobs:
          uv sync --dev --frozen
 
     - name: Run Otari unit tests
-      env:
-        GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       run: |
         uv run pytest tests/unit -v --cov --cov-report=xml -n auto
 

--- a/.github/workflows/otari-tests.yml
+++ b/.github/workflows/otari-tests.yml
@@ -26,7 +26,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  test-unit:
     runs-on: ubuntu-latest
     environment: integration-tests
 
@@ -48,16 +48,40 @@ jobs:
       run: |
         uv run pytest tests/unit -v --cov --cov-report=xml -n auto
 
+    - name: Upload coverage
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      with:
+        file: ./coverage.xml
+        flags: unit
+        fail_ci_if_error: false
+
+  test-integration:
+    runs-on: ubuntu-latest
+    environment: integration-tests
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        python-version: 3.14
+        activate-environment: true
+
+    - name: Install dependencies
+      run: |
+         uv sync --dev --frozen
+
     - name: Run Otari integration tests
       env:
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       run: |
-        uv run pytest tests/integration -v --cov --cov-report=xml --cov-append -n auto
+        uv run pytest tests/integration -v --cov --cov-report=xml -n auto
 
     - name: Upload coverage
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         file: ./coverage.xml
+        flags: integration
         fail_ci_if_error: false
 
   openapi-spec:

--- a/.github/workflows/otari-tests.yml
+++ b/.github/workflows/otari-tests.yml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
@@ -48,7 +50,7 @@ jobs:
     - name: Upload coverage
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: unit
         fail_ci_if_error: false
 
@@ -58,6 +60,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:
@@ -77,7 +81,7 @@ jobs:
     - name: Upload coverage
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: integration
         fail_ci_if_error: false
 
@@ -86,6 +90,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,15 @@
 ignore:
   - tests/
+
+# unit and integration now upload from separate parallel jobs (#903), so a job
+# that fails uploads nothing for its flag on that commit. Without carryforward,
+# Codecov reports whatever flag *did* upload as the whole project's coverage,
+# which reads as a coverage cliff on a routine partial failure - integration
+# tests failing without network egress, per AGENTS.md, is exactly that case.
+# carryforward keeps a flag's last known value instead of treating a missing
+# upload as zero.
+flags:
+  unit:
+    carryforward: true
+  integration:
+    carryforward: true


### PR DESCRIPTION
## Description
The `test` job ran `tests/unit` then `tests/integration` sequentially in one job, with `--cov-append` merging the integration run's coverage onto the unit run's. Every PR waited for the full serial time even though the two suites don't depend on each other — the example run linked in the issue shows this.

Split into `test-unit` and `test-integration`. Since neither declares a `needs:` on the other, GitHub Actions runs them in parallel by default. Each now uploads its own `coverage.xml` as a separate Codecov flag (`unit`/`integration`) rather than relying on `--cov-append` to merge them in a single job — Codecov merges multiple uploads against the same commit on its own.

Checked before renaming the job away from `test`: queried the `protect-main` ruleset directly (`gh api repos/mozilla-ai/otari/rulesets/15597390`) and confirmed it has no `required_status_checks` rule — only `deletion`, `non_fast_forward`, and `pull_request`/review rules — so there's no required check tied to the old job name that would need updating elsewhere. The README's CI badge references the workflow file, not a job name, so it's unaffected too.

## PR Type

- [x] Infrastructure / CI

## Relevant issues
Fixes #903

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`). — N/A, pure CI workflow change; no test code touched.
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`) — validated the workflow YAML parses correctly and structures into the expected three jobs (`test-unit`, `test-integration`, `openapi-spec`); couldn't run the actual GitHub Actions job locally, so this PR's own CI run is the real verification.
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). — N/A, no API contract change.

## AI Usage

- [x] AI was used for drafting/refactoring.

**AI Model/Tool used:** Claude Sonnet 5 (Claude Code)

**Any additional AI details you'd like to share:** Straightforward split off the issue's own description. Had Claude Code verify the branch-protection ruleset directly before renaming the job, rather than assuming it was safe, since a required-status-check tied to the old job name would have made this change break mergeability instead of just being a refactor.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Split CI tests into parallel unit and integration jobs.
- Upload coverage separately with `unit` and `integration` flags.
- Enable Codecov carryforward to prevent incomplete workflows from showing false coverage drops.

This reduces CI feedback time and keeps coverage reporting reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->