### PR TITLE
fix(migrations): run otari's chain only against otari's own database

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -3,7 +3,11 @@ import os
 from logging.config import fileConfig
 
 from alembic import context
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
+from alembic.util import CommandError
 from sqlalchemy import engine_from_config, pool
+from sqlalchemy.engine import Engine, make_url
 
 from gateway.core.database import to_sync_url
 
@@ -28,11 +32,15 @@ if config.config_file_name is not None:
 # for 'autogenerate' support
 target_metadata = Base.metadata
 
-# Get database URL from config (if already set programmatically) or environment variables
-# Priority: Programmatically set URL -> OTARI_DATABASE_URL -> DATABASE_URL -> default
-database_url = config.get_main_option("sqlalchemy.url") or (
-    os.getenv("OTARI_DATABASE_URL") or os.getenv("DATABASE_URL") or "sqlite:///./otari.db"
-)
+# Get database URL from config (if already set programmatically) or the environment.
+# Priority: Programmatically set URL -> OTARI_DATABASE_URL -> default
+#
+# A bare `DATABASE_URL` is deliberately not read. `otari serve` and `otari
+# migrate` both take that name as `--database-url` and pass the resolved URL on
+# explicitly, so the only invocation this fallback ever served was a bare
+# `alembic upgrade head` in a process holding another application's
+# `DATABASE_URL`, which aims this chain at that application's database.
+database_url = config.get_main_option("sqlalchemy.url") or os.getenv("OTARI_DATABASE_URL") or "sqlite:///./otari.db"
 # Normalized here rather than at each call site so every entry point is covered:
 # `otari migrate`, auto_migrate on startup, and a bare `alembic upgrade head`
 # reading OTARI_DATABASE_URL. Migrations run on a sync engine, so an async URL
@@ -43,6 +51,41 @@ config.set_main_option("sqlalchemy.url", to_sync_url(database_url))
 # can be acquired:
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
+
+
+def _reject_foreign_history(engine: Engine) -> None:
+    """Refuse a database whose stamped history is not this chain's.
+
+    Otari stamps the default `alembic_version` table, and so does every other
+    Alembic application, so a URL naming someone else's database is accepted as
+    readily as otari's own. Alembic then reports only that it cannot locate the
+    revision it read, which reads as a corrupt database rather than as the URL
+    being wrong, and the next `upgrade` would write otari's schema into that
+    database. Naming the target and the foreign revision is what turns it back
+    into a configuration error.
+
+    On a connection of its own, so that reading the version table leaves no
+    transaction open on the one the migrations run in: Alembic commits its work
+    inside `begin_transaction`, which is a no-op when a transaction is already
+    under way, and the run would then be rolled back when the connection closes.
+    """
+    with engine.connect() as connection:
+        heads = MigrationContext.configure(connection).get_current_heads()
+    if not heads:
+        return
+
+    known = {script.revision for script in ScriptDirectory.from_config(config).walk_revisions()}
+    foreign = sorted(set(heads) - known)
+    if not foreign:
+        return
+
+    target = make_url(config.get_main_option("sqlalchemy.url") or "").render_as_string(hide_password=True)
+    msg = (
+        f"{target} is stamped with alembic revision(s) {', '.join(foreign)}, which are not otari's. "
+        "The database holds another application's migration history, or one written by a newer otari "
+        "than this one. Point OTARI_DATABASE_URL at otari's own database."
+    )
+    raise CommandError(msg)
 
 
 def run_migrations_offline() -> None:
@@ -81,6 +124,8 @@ def run_migrations_online() -> None:
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )
+
+    _reject_foreign_history(connectable)
 
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -33,14 +33,26 @@ if config.config_file_name is not None:
 target_metadata = Base.metadata
 
 # Get database URL from config (if already set programmatically) or the environment.
-# Priority: Programmatically set URL -> OTARI_DATABASE_URL -> default
+# Priority: Programmatically set URL -> OTARI_DATABASE_URL, and nothing else.
 #
 # A bare `DATABASE_URL` is deliberately not read. `otari serve` and `otari
 # migrate` both take that name as `--database-url` and pass the resolved URL on
-# explicitly, so the only invocation this fallback ever served was a bare
+# explicitly, so the only invocation that fallback ever served was a bare
 # `alembic upgrade head` in a process holding another application's
 # `DATABASE_URL`, which aims this chain at that application's database.
-database_url = config.get_main_option("sqlalchemy.url") or os.getenv("OTARI_DATABASE_URL") or "sqlite:///./otari.db"
+#
+# Nor is there a default. The `sqlite:///./otari.db` that stood here turned the
+# same run into a silent success: the chain migrated a throwaway file in the
+# working directory, reported "Running upgrade" and exited 0, while the database
+# the operator believed they were migrating went untouched.
+database_url = config.get_main_option("sqlalchemy.url") or os.getenv("OTARI_DATABASE_URL")
+if not database_url:
+    no_url = (
+        "No database URL to migrate. Set OTARI_DATABASE_URL, or go through `otari migrate`, which "
+        "resolves one and passes it on. A bare DATABASE_URL is not read here: it belongs to whichever "
+        "application put it in this environment."
+    )
+    raise CommandError(no_url)
 # Normalized here rather than at each call site so every entry point is covered:
 # `otari migrate`, auto_migrate on startup, and a bare `alembic upgrade head`
 # reading OTARI_DATABASE_URL. Migrations run on a sync engine, so an async URL
@@ -81,6 +93,15 @@ def _reject_foreign_history(engine: Engine) -> None:
     transaction open on the one the migrations run in: Alembic commits its work
     inside `begin_transaction`, which is a no-op when a transaction is already
     under way, and the run would then be rolled back when the connection closes.
+
+    Scoped to a neighbor that keeps its history in this same `alembic_version`
+    table. One that keeps it anywhere else, under a custom `version_table` or in
+    `django_migrations` or `flyway_schema_history`, leaves nothing here to read
+    and is accepted. Refusing those too would take a positive signal that the
+    database is otari's, and "has tables, none of them otari's" is the shape of a
+    legitimate first migration into a database an edition's own chain populated
+    first. Stamping a version table of otari's own is the structural answer, and
+    it is a migration for every deployment that exists.
     """
     if _is_stamp_command():
         return
@@ -95,12 +116,19 @@ def _reject_foreign_history(engine: Engine) -> None:
     if not foreign:
         return
 
+    # Host and database, not the URL: `render_as_string(hide_password=True)` masks
+    # the password field and not credentials passed as query parameters, which is
+    # how libpq takes `password` and `sslpassword`, and this string is echoed by
+    # `otari migrate`.
+    url = engine.url
+    target = f"{url.host}/{url.database}" if url.host else str(url.database)
     msg = (
-        f"{engine.url.render_as_string(hide_password=True)} is stamped with alembic revision(s) "
-        f"{', '.join(foreign)}, which are not otari's. The database holds another application's migration "
-        "history, or one written by a newer otari than this one. Point OTARI_DATABASE_URL at otari's own "
-        "database, or, where this database is otari's and the row is wrong, rewrite it with "
-        "`alembic stamp --purge <revision>`."
+        f"{target} is stamped with alembic revision(s) {', '.join(foreign)}, which are not otari's. "
+        "The database holds another application's migration history, or one written by a newer otari "
+        "than this one. Point OTARI_DATABASE_URL at otari's own database first. Once it is established "
+        "that this database is otari's and the row is the wrong one, `alembic stamp --purge <revision>` "
+        "rewrites it, replacing whatever the version table holds: run against a neighbor's database it "
+        "destroys that application's history."
     )
     raise CommandError(msg)
 

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -7,7 +7,7 @@ from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
 from alembic.util import CommandError
 from sqlalchemy import engine_from_config, pool
-from sqlalchemy.engine import Engine, make_url
+from sqlalchemy.engine import Engine
 
 from gateway.core.database import to_sync_url
 
@@ -53,6 +53,19 @@ config.set_main_option("sqlalchemy.url", to_sync_url(database_url))
 # ... etc.
 
 
+def _is_stamp_command() -> bool:
+    """Whether this run is `alembic stamp`, which the check below has to let through.
+
+    Rewriting the version table is how an operator repairs the state that check
+    refuses (`alembic stamp --purge <revision>`), so refusing to run it would
+    take away the fix along with the failure. `config.cmd_opts` is set by the
+    CLI and absent when alembic is driven programmatically, which is the
+    gateway's own path and never a stamp.
+    """
+    cmd = getattr(getattr(config, "cmd_opts", None), "cmd", None)
+    return bool(cmd) and getattr(cmd[0], "__name__", "") == "stamp"
+
+
 def _reject_foreign_history(engine: Engine) -> None:
     """Refuse a database whose stamped history is not this chain's.
 
@@ -69,6 +82,9 @@ def _reject_foreign_history(engine: Engine) -> None:
     inside `begin_transaction`, which is a no-op when a transaction is already
     under way, and the run would then be rolled back when the connection closes.
     """
+    if _is_stamp_command():
+        return
+
     with engine.connect() as connection:
         heads = MigrationContext.configure(connection).get_current_heads()
     if not heads:
@@ -79,11 +95,12 @@ def _reject_foreign_history(engine: Engine) -> None:
     if not foreign:
         return
 
-    target = make_url(config.get_main_option("sqlalchemy.url") or "").render_as_string(hide_password=True)
     msg = (
-        f"{target} is stamped with alembic revision(s) {', '.join(foreign)}, which are not otari's. "
-        "The database holds another application's migration history, or one written by a newer otari "
-        "than this one. Point OTARI_DATABASE_URL at otari's own database."
+        f"{engine.url.render_as_string(hide_password=True)} is stamped with alembic revision(s) "
+        f"{', '.join(foreign)}, which are not otari's. The database holds another application's migration "
+        "history, or one written by a newer otari than this one. Point OTARI_DATABASE_URL at otari's own "
+        "database, or, where this database is otari's and the row is wrong, rewrite it with "
+        "`alembic stamp --purge <revision>`."
     )
     raise CommandError(msg)
 

--- a/tests/unit/test_alembic_target_database.py
+++ b/tests/unit/test_alembic_target_database.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 from alembic import command
 from alembic.config import Config
+from alembic.script import ScriptDirectory
 from alembic.util import CommandError
 from sqlalchemy import create_engine, inspect
 
@@ -48,6 +49,26 @@ def _stamp(db_path: Path, revision: str) -> None:
         connection.close()
 
 
+def _version_rows(db_path: Path) -> list[tuple[str]]:
+    connection = sqlite3.connect(db_path)
+    try:
+        return connection.execute("SELECT version_num FROM alembic_version").fetchall()
+    finally:
+        connection.close()
+
+
+def _run_alembic(args: list[str], cwd: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    """Drive the CLI, which is the entry point an operator has."""
+    return subprocess.run(  # noqa: S603
+        [sys.executable, "-m", "alembic", "-c", str(_REPO_ROOT / "alembic.ini"), *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
 def test_upgrade_refuses_a_database_stamped_by_another_chain(tmp_path: Path) -> None:
     """The error names the target and the revision, not just the revision.
 
@@ -65,8 +86,31 @@ def test_upgrade_refuses_a_database_stamped_by_another_chain(tmp_path: Path) -> 
     assert _FOREIGN_REVISION in message
     assert "platform.db" in message
     assert "OTARI_DATABASE_URL" in message
-    # Refused before writing: the foreign database still holds only its own row.
-    assert inspect(create_engine(f"sqlite:///{db_path}")).get_table_names() == ["alembic_version"]
+    # Refused before writing: the foreign database still holds only its own table.
+    engine = create_engine(f"sqlite:///{db_path}")
+    try:
+        assert inspect(engine).get_table_names() == ["alembic_version"]
+    finally:
+        engine.dispose()
+
+
+def test_stamp_still_rewrites_a_foreign_version_table(tmp_path: Path) -> None:
+    """The refusal must not take the repair for it away.
+
+    ``alembic stamp --purge`` is what an operator runs on a version table that
+    holds the wrong row, so a check that refused to run it would leave a
+    database that can only be fixed by hand.
+    """
+    db_path = tmp_path / "platform.db"
+    _stamp(db_path, _FOREIGN_REVISION)
+    env = {key: value for key, value in os.environ.items() if key != "DATABASE_URL"}
+    env["OTARI_DATABASE_URL"] = f"sqlite:///{db_path}"
+
+    result = _run_alembic(["stamp", "head", "--purge"], cwd=tmp_path, env=env)
+
+    assert result.returncode == 0, result.stderr
+    head = ScriptDirectory.from_config(_alembic_config("sqlite://")).get_current_head()
+    assert _version_rows(db_path) == [(head,)]
 
 
 def test_a_bare_alembic_run_ignores_a_foreign_database_url(tmp_path: Path) -> None:
@@ -80,14 +124,7 @@ def test_a_bare_alembic_run_ignores_a_foreign_database_url(tmp_path: Path) -> No
     env = {key: value for key, value in os.environ.items() if key != "OTARI_DATABASE_URL"}
     env["DATABASE_URL"] = f"sqlite:///{foreign}"
 
-    result = subprocess.run(  # noqa: S603
-        [sys.executable, "-m", "alembic", "-c", str(_REPO_ROOT / "alembic.ini"), "current"],
-        cwd=tmp_path,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    result = _run_alembic(["current"], cwd=tmp_path, env=env)
 
     assert result.returncode == 0, result.stderr
     assert not foreign.exists(), "DATABASE_URL selected the database this chain connected to"

--- a/tests/unit/test_alembic_target_database.py
+++ b/tests/unit/test_alembic_target_database.py
@@ -1,0 +1,93 @@
+"""Which database otari's migration chain is willing to run against.
+
+Otari stamps the default ``alembic_version`` table, the same one every other
+Alembic application stamps, so nothing about a URL says whose database it names.
+Two ways a deployment ends up pointed at someone else's, both seen in practice
+when otari's control plane runs beside an older application: the process
+inherits that application's ``DATABASE_URL``, or it is handed one outright.
+Alembic's own report of that is "Can't locate revision identified by ...", which
+reads as a corrupt database rather than as a URL naming the wrong one.
+"""
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from alembic.util import CommandError
+from sqlalchemy import create_engine, inspect
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ALEMBIC_DIR = _REPO_ROOT / "alembic"
+
+# A revision from otari-ai's platform chain, which is exactly the history a
+# control plane sharing that deployment's environment can be aimed at.
+_FOREIGN_REVISION = "a5f83c1d6e07"
+
+
+def _alembic_config(database_url: str) -> Config:
+    config = Config()
+    config.set_main_option("script_location", str(_ALEMBIC_DIR))
+    config.set_main_option("sqlalchemy.url", database_url)
+    config.attributes["configure_logger"] = False
+    return config
+
+
+def _stamp(db_path: Path, revision: str) -> None:
+    """Give a database an ``alembic_version`` row from another chain."""
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)")
+        connection.execute("INSERT INTO alembic_version (version_num) VALUES (?)", (revision,))
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def test_upgrade_refuses_a_database_stamped_by_another_chain(tmp_path: Path) -> None:
+    """The error names the target and the revision, not just the revision.
+
+    This is the path ``auto_migrate`` and ``otari migrate`` both take, so the
+    refusal is what a control plane boots into rather than a schema written over
+    another application's tables.
+    """
+    db_path = tmp_path / "platform.db"
+    _stamp(db_path, _FOREIGN_REVISION)
+
+    with pytest.raises(CommandError) as excinfo:
+        command.upgrade(_alembic_config(f"sqlite:///{db_path}"), "head")
+
+    message = str(excinfo.value)
+    assert _FOREIGN_REVISION in message
+    assert "platform.db" in message
+    assert "OTARI_DATABASE_URL" in message
+    # Refused before writing: the foreign database still holds only its own row.
+    assert inspect(create_engine(f"sqlite:///{db_path}")).get_table_names() == ["alembic_version"]
+
+
+def test_a_bare_alembic_run_ignores_a_foreign_database_url(tmp_path: Path) -> None:
+    """``DATABASE_URL`` alone does not select a database for this chain.
+
+    ``otari serve`` and ``otari migrate`` read that name themselves and pass the
+    URL on explicitly, so a bare ``alembic`` invocation reading it too only ever
+    picked up the value some other application left in the environment.
+    """
+    foreign = tmp_path / "platform.db"
+    env = {key: value for key, value in os.environ.items() if key != "OTARI_DATABASE_URL"}
+    env["DATABASE_URL"] = f"sqlite:///{foreign}"
+
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-m", "alembic", "-c", str(_REPO_ROOT / "alembic.ini"), "current"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not foreign.exists(), "DATABASE_URL selected the database this chain connected to"

--- a/tests/unit/test_alembic_target_database.py
+++ b/tests/unit/test_alembic_target_database.py
@@ -113,12 +113,15 @@ def test_stamp_still_rewrites_a_foreign_version_table(tmp_path: Path) -> None:
     assert _version_rows(db_path) == [(head,)]
 
 
-def test_a_bare_alembic_run_ignores_a_foreign_database_url(tmp_path: Path) -> None:
-    """``DATABASE_URL`` alone does not select a database for this chain.
+def test_a_bare_alembic_run_refuses_a_foreign_database_url(tmp_path: Path) -> None:
+    """``DATABASE_URL`` alone selects nothing, and selecting nothing is an error.
 
     ``otari serve`` and ``otari migrate`` read that name themselves and pass the
     URL on explicitly, so a bare ``alembic`` invocation reading it too only ever
-    picked up the value some other application left in the environment.
+    picked up the value some other application left in the environment. Falling
+    back to the SQLite default instead would be the same wrong-database run with
+    the failure taken out of it: a throwaway file migrated in the working
+    directory, exit 0, and the operator's database untouched.
     """
     foreign = tmp_path / "platform.db"
     env = {key: value for key, value in os.environ.items() if key != "OTARI_DATABASE_URL"}
@@ -126,5 +129,7 @@ def test_a_bare_alembic_run_ignores_a_foreign_database_url(tmp_path: Path) -> No
 
     result = _run_alembic(["current"], cwd=tmp_path, env=env)
 
-    assert result.returncode == 0, result.stderr
+    assert result.returncode != 0
+    assert "OTARI_DATABASE_URL" in result.stderr
     assert not foreign.exists(), "DATABASE_URL selected the database this chain connected to"
+    assert list(tmp_path.iterdir()) == [], "a default URL migrated a database nobody named"


### PR DESCRIPTION
## Description

Otari's Alembic chain stamps the default `alembic_version` table, the same table every other Alembic application
stamps, so a URL naming a different application's database is accepted as readily as otari's own. All Alembic says
then is `Can't locate revision identified by ...`, which reads as a corrupt database rather than as a URL naming the
wrong one.

Three changes:

- Before migrating, refuse a database stamped with a revision this chain does not own, naming the target (password
  masked) and the revision. That covers both readings: another application's database, or one written by a newer
  otari than this process, which is the shape a rolled-back deploy leaves behind.
- Let `alembic stamp` through the check. Rewriting the version table is how an operator repairs the state the
  check refuses, and `alembic stamp --purge` works on such a database today, so refusing to run it would take the
  fix away along with the failure.
- Stop falling back to a bare `DATABASE_URL`, and stop defaulting to `sqlite:///./otari.db` behind it. `otari
  serve` and `otari migrate` both take that name as `--database-url` and pass the resolved URL on explicitly, so
  the only invocation the fallback ever served was a bare `alembic upgrade head` in a process holding another
  application's `DATABASE_URL`. Keeping the SQLite default under it would have turned that run into a silent
  success: a throwaway file migrated in the working directory, exit 0, the operator's database untouched. A run
  that resolves no URL now raises before it connects.

The refusal names host and database rather than the URL: `render_as_string(hide_password=True)` masks the password
field but not credentials passed as query parameters, and `otari migrate` echoes that string (#922).

Found while diagnosing a deploy where this chain met another application's `alembic_version` table. The general
case, a neighbor whose history lives anywhere but this `alembic_version` table, is out of reach of any
revision-set check and needs a version table of otari's own: #921.

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None. Filed from an incident in `mozilla-ai/otari-ai`.

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

`make lint`, `make typecheck`, `tests/unit` (2834 passed) and the OSS-edition smoke ran locally. The integration
suite needs PostgreSQL and runs in CI. No API contract or documentation change: the refusal message is what a
misconfigured deployment reads.

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context) via Claude Code.

**Any additional AI details you'd like to share:**

Written at @khaledosman's request while diagnosing the deploy failure this fixes. Both tests were confirmed to fail
without the change.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
