### PR TITLE
docs: unscope the docstring rule and rein in standalone documents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,7 @@ The per-request flow (auth → budget → dispatch → reconciliation) spans sev
 ## Repository Conventions
 - Prefer minimal, targeted edits over broad refactors, and match the import order and typing style of the file you are in (`TYPE_CHECKING` for type-only imports where it helps, as in `routes/_helpers.py`).
 - Add a comment only where the logic is not obvious; keep docstrings concise and meaningful. Do not restate the code, narrate the change, or record what the code used to do: the commit message is where that belongs. Leave the comments around a change shorter than you found them: prune narration, repeated rationale, and implementation history as you touch them.
+- Add a standalone document only for a durable user workflow, a public contract, or a cross-cutting invariant; implementation detail belongs next to the code. Link one canonical source rather than restating it, and fix or delete whatever the change made wrong before it lands.
 - Preserve security-relevant behavior: header parsing, auth checks, and the error-detail boundary. Do not leak internals in public error responses, and never log secrets, tokens, or raw API keys (the one-time bootstrap key print is the deliberate exception).
 - Keep test additions next to the behavior they cover: unit for pure logic, integration for route or database behavior.
 - CI runs Python 3.14 (`.github/workflows/otari-tests.yml`), matching the Docker image; the package still supports 3.13+ (`requires-python = ">=3.13"`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ The per-request flow (auth → budget → dispatch → reconciliation) spans sev
 
 ## Repository Conventions
 - Prefer minimal, targeted edits over broad refactors, and match the import order and typing style of the file you are in (`TYPE_CHECKING` for type-only imports where it helps, as in `routes/_helpers.py`).
-- Add a comment only where the logic is not obvious; keep docstrings concise and meaningful on public functions and classes. Do not restate the code, narrate the change, or record what the code used to do: the commit message is where that belongs. Leave the comments around a change shorter than you found them: prune narration, repeated rationale, and implementation history as you touch them.
+- Add a comment only where the logic is not obvious; keep docstrings concise and meaningful. Do not restate the code, narrate the change, or record what the code used to do: the commit message is where that belongs. Leave the comments around a change shorter than you found them: prune narration, repeated rationale, and implementation history as you touch them.
 - Preserve security-relevant behavior: header parsing, auth checks, and the error-detail boundary. Do not leak internals in public error responses, and never log secrets, tokens, or raw API keys (the one-time bootstrap key print is the deliberate exception).
 - Keep test additions next to the behavior they cover: unit for pure logic, integration for route or database behavior.
 - CI runs Python 3.14 (`.github/workflows/otari-tests.yml`), matching the Docker image; the package still supports 3.13+ (`requires-python = ">=3.13"`).


### PR DESCRIPTION
## Description

Two one-line changes to Repository Conventions.

**Docstrings.** The rule read "concise and meaningful on public functions and classes", so a private helper's docstring was held to nothing. Nothing else in that bullet is scoped, and the carve-out is unearned: across `src/gateway/` private and public docstrings both average 7.4 lines, and the eight longest are all public.

**Documents.** The comment bullet says not to restate, not to narrate, and to prune as you go. Nothing said the same about a document, so a feature inventory or a duplicate guide could land, and the copy a change made wrong could stay. #477, #860 and #874 were each a retroactive pass over that.

## PR Type

- [x] Documentation

## Relevant issues

None.

## Checklist

- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change. Guidance text.
- [ ] I ran the Definition of Done checks locally. No code changed.
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec. No contract change.

## AI Usage

- [x] AI was used for drafting/refactoring.

**AI Model/Tool used:** Claude Opus 5 (1M context) via Claude Code

**Any additional AI details you'd like to share:** Found while reviewing #840. The document bullet is adapted from agent-of-empires' equivalent rule rather than copied, since our doc layering differs.

- [x] I am an AI Agent filling out this form (check box if true)