### PR TITLE
docs(otlp): document export response schemas

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -5238,6 +5238,17 @@
             ],
             "title": "Prompt Cache Key"
           },
+          "service_tier": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Service Tier"
+          },
           "session_label": {
             "anyOf": [
               {
@@ -5902,6 +5913,141 @@
           "active_organization_id"
         ],
         "title": "OAuthSessionResponse",
+        "type": "object"
+      },
+      "OTLPLogsPartialSuccess": {
+        "properties": {
+          "errorMessage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Errormessage"
+          },
+          "rejectedLogRecords": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Rejected log record count, encoded as an int64 string by OTLP JSON.",
+            "title": "Rejectedlogrecords"
+          }
+        },
+        "title": "OTLPLogsPartialSuccess",
+        "type": "object"
+      },
+      "OTLPLogsServiceResponse": {
+        "properties": {
+          "partialSuccess": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OTLPLogsPartialSuccess"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "title": "OTLPLogsServiceResponse",
+        "type": "object"
+      },
+      "OTLPMetricsPartialSuccess": {
+        "properties": {
+          "errorMessage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Errormessage"
+          },
+          "rejectedDataPoints": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Rejected data point count, encoded as an int64 string by OTLP JSON.",
+            "title": "Rejecteddatapoints"
+          }
+        },
+        "title": "OTLPMetricsPartialSuccess",
+        "type": "object"
+      },
+      "OTLPMetricsServiceResponse": {
+        "properties": {
+          "partialSuccess": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OTLPMetricsPartialSuccess"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "title": "OTLPMetricsServiceResponse",
+        "type": "object"
+      },
+      "OTLPTracePartialSuccess": {
+        "properties": {
+          "errorMessage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Errormessage"
+          },
+          "rejectedSpans": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Rejected span count, encoded as an int64 string by OTLP JSON.",
+            "title": "Rejectedspans"
+          }
+        },
+        "title": "OTLPTracePartialSuccess",
+        "type": "object"
+      },
+      "OTLPTraceServiceResponse": {
+        "properties": {
+          "partialSuccess": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OTLPTracePartialSuccess"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "title": "OTLPTraceServiceResponse",
         "type": "object"
       },
       "OrgProviderKeyCreateRequest": {
@@ -17916,10 +18062,17 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/OTLPLogsServiceResponse"
+                }
+              },
+              "application/x-protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/OTLPLogsServiceResponse"
+                }
               }
             },
-            "description": "Successful Response"
+            "description": "OTLP export response. A partial success still returns HTTP 200; the rejected count is present only when the gateway rejected part of the export."
           }
         },
         "security": [
@@ -18042,10 +18195,17 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/OTLPMetricsServiceResponse"
+                }
+              },
+              "application/x-protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/OTLPMetricsServiceResponse"
+                }
               }
             },
-            "description": "Successful Response"
+            "description": "OTLP export response. A partial success still returns HTTP 200; the rejected count is present only when the gateway rejected part of the export."
           }
         },
         "security": [
@@ -25168,10 +25328,17 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/OTLPTraceServiceResponse"
+                }
+              },
+              "application/x-protobuf": {
+                "schema": {
+                  "$ref": "#/components/schemas/OTLPTraceServiceResponse"
+                }
               }
             },
-            "description": "Successful Response"
+            "description": "OTLP export response. A partial success still returns HTTP 200; the rejected count is present only when the gateway rejected part of the export."
           }
         },
         "security": [

--- a/src/gateway/api/routes/otlp.py
+++ b/src/gateway/api/routes/otlp.py
@@ -59,6 +59,7 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceResponse,
 )
 from opentelemetry.proto.metrics.v1.metrics_pb2 import AggregationTemporality
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from gateway.api.deps import TelemetryStoragePortDep, get_config, get_db, verify_api_key_or_master_key
@@ -86,6 +87,67 @@ router = APIRouter(tags=["otel"])
 _JSON = "application/json"
 _PROTOBUF = ("application/x-protobuf", "application/octet-stream")
 _DEFAULT_SOURCE = "otel"
+
+_OTLP_RESPONSE_DESCRIPTION = (
+    "OTLP export response. A partial success still returns HTTP 200; the rejected count "
+    "is present only when the gateway rejected part of the export."
+)
+
+
+class _OTLPModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class OTLPTracePartialSuccess(_OTLPModel):
+    rejected_spans: str | None = Field(
+        default=None,
+        alias="rejectedSpans",
+        description="Rejected span count, encoded as an int64 string by OTLP JSON.",
+    )
+    error_message: str | None = Field(default=None, alias="errorMessage")
+
+
+class OTLPTraceServiceResponse(_OTLPModel):
+    partial_success: OTLPTracePartialSuccess | None = Field(default=None, alias="partialSuccess")
+
+
+class OTLPLogsPartialSuccess(_OTLPModel):
+    rejected_log_records: str | None = Field(
+        default=None,
+        alias="rejectedLogRecords",
+        description="Rejected log record count, encoded as an int64 string by OTLP JSON.",
+    )
+    error_message: str | None = Field(default=None, alias="errorMessage")
+
+
+class OTLPLogsServiceResponse(_OTLPModel):
+    partial_success: OTLPLogsPartialSuccess | None = Field(default=None, alias="partialSuccess")
+
+
+class OTLPMetricsPartialSuccess(_OTLPModel):
+    rejected_data_points: str | None = Field(
+        default=None,
+        alias="rejectedDataPoints",
+        description="Rejected data point count, encoded as an int64 string by OTLP JSON.",
+    )
+    error_message: str | None = Field(default=None, alias="errorMessage")
+
+
+class OTLPMetricsServiceResponse(_OTLPModel):
+    partial_success: OTLPMetricsPartialSuccess | None = Field(default=None, alias="partialSuccess")
+
+
+def _otlp_response_docs(response_model: type[BaseModel]) -> dict[int | str, dict[str, Any]]:
+    """Add the protobuf representation beside FastAPI's JSON response schema."""
+    return {
+        200: {
+            "content": {
+                "application/x-protobuf": {
+                    "schema": {"$ref": f"#/components/schemas/{response_model.__name__}"}
+                }
+            }
+        }
+    }
 
 # Request bounds. OTLP exporters batch to a few MiB per export; the cap keeps one
 # request from expanding without bound in memory (gzip bombs decompress fully
@@ -433,7 +495,12 @@ def _otlp_response(content_type: str, response: Message) -> Response:
     return Response(content=response.SerializeToString(), media_type="application/x-protobuf")
 
 
-@router.post("/v1/traces")
+@router.post(
+    "/v1/traces",
+    response_model=OTLPTraceServiceResponse,
+    response_description=_OTLP_RESPONSE_DESCRIPTION,
+    responses=_otlp_response_docs(OTLPTraceServiceResponse),
+)
 async def receive_traces(
     request: Request,
     auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
@@ -472,7 +539,12 @@ async def receive_traces(
     return _otlp_response(content_type, response)
 
 
-@router.post("/v1/logs")
+@router.post(
+    "/v1/logs",
+    response_model=OTLPLogsServiceResponse,
+    response_description=_OTLP_RESPONSE_DESCRIPTION,
+    responses=_otlp_response_docs(OTLPLogsServiceResponse),
+)
 async def receive_logs(
     request: Request,
     auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],
@@ -531,7 +603,12 @@ async def receive_logs(
     return _otlp_response(content_type, response)
 
 
-@router.post("/v1/metrics")
+@router.post(
+    "/v1/metrics",
+    response_model=OTLPMetricsServiceResponse,
+    response_description=_OTLP_RESPONSE_DESCRIPTION,
+    responses=_otlp_response_docs(OTLPMetricsServiceResponse),
+)
 async def receive_metrics(
     request: Request,
     auth_result: Annotated[tuple[APIKey | None, bool], Depends(verify_api_key_or_master_key)],

--- a/tests/unit/test_otlp_openapi.py
+++ b/tests/unit/test_otlp_openapi.py
@@ -1,0 +1,35 @@
+"""Keep the published OTLP export response contract typed and complete."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+_SPEC_PATH = Path(__file__).resolve().parents[2] / "docs/public/openapi.json"
+
+
+def test_otlp_export_responses_describe_json_and_protobuf_shapes() -> None:
+    spec: dict[str, Any] = json.loads(_SPEC_PATH.read_text())
+    schemas = spec["components"]["schemas"]
+    expected = {
+        "/v1/traces": ("OTLPTraceServiceResponse", "OTLPTracePartialSuccess", "rejectedSpans"),
+        "/v1/logs": ("OTLPLogsServiceResponse", "OTLPLogsPartialSuccess", "rejectedLogRecords"),
+        "/v1/metrics": ("OTLPMetricsServiceResponse", "OTLPMetricsPartialSuccess", "rejectedDataPoints"),
+    }
+
+    for path, (response_name, partial_name, rejected_name) in expected.items():
+        response = spec["paths"][path]["post"]["responses"]["200"]
+        assert "partial success" in response["description"].lower()
+        assert set(response["content"]) == {"application/json", "application/x-protobuf"}
+        for media_type in response["content"]:
+            assert response["content"][media_type]["schema"] == {
+                "$ref": f"#/components/schemas/{response_name}"
+            }
+
+        response_schema = schemas[response_name]
+        assert set(response_schema["properties"]) == {"partialSuccess"}
+        assert response_schema["properties"]["partialSuccess"]["anyOf"][0] == {
+            "$ref": f"#/components/schemas/{partial_name}"
+        }
+
+        partial_schema = schemas[partial_name]
+        assert set(partial_schema["properties"]) == {rejected_name, "errorMessage"}


### PR DESCRIPTION
## Description

Document the response contract for the OTLP trace, log, and metrics ingestion endpoints. Each endpoint now publishes its typed OTLP export response for both `application/json` and `application/x-protobuf`, including the lowerCamelCase partial-success fields emitted by protobuf JSON.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #900

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). The repository's uv lockfile excludes Windows, so I ran the equivalent Python 3.14 checks directly where possible.
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). The generated spec and Postman collection both pass their direct checks.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** GPT-5 Codex

**Any additional AI details you'd like to share:** Implemented the typed FastAPI response models and the generated-spec regression test from the issue requirements.

- [x] I am an AI Agent filling out this form (check box if true)

## Verification

- `py -3.14 -m pytest tests/unit/test_otlp_openapi.py tests/unit/test_sdk_endpoint_coverage.py -q` passed, 4 tests.
- `py -3.14 -m ruff check src tests scripts` passed.
- `py -3.14 -m mypy src/gateway/api/routes/otlp.py tests/unit/test_otlp_openapi.py` passed.
- Architecture, migration-head, OpenAPI, and Postman checks passed.
- The focused OTLP integration run was blocked by a Testcontainers timeout while pulling `postgres:17`; the local Docker daemon did not have that image available. Full unit collection also hit pre-existing environment dependency mismatches involving `any-llm` types and the uninstalled `moto` package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Documented typed successful responses for the OTLP traces, logs, and metrics endpoints.
- Added JSON and protobuf response formats with partial-success details.
- Added OpenAPI regression tests for all three endpoints and response schemas.

These changes improve API accuracy and help prevent future documentation regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->