### PR TITLE
refactor(dashboard): cut seven button variants to three

### DIFF
--- a/web/e2e/screenshots/public.spec.ts
+++ b/web/e2e/screenshots/public.spec.ts
@@ -13,6 +13,23 @@ test("sign-in screen", async ({ page }) => {
   await captureScreenshot(page, "sign-in")
 })
 
+test("sign-in screen offering a passkey and OAuth", async ({ page }) => {
+  // The one sign-in state this fixture cannot reach on its own: `e2e/otari.yml`
+  // configures no passkey relying party and no OAuth client, so the buttons
+  // below never render against it, and they are the two controls on this screen
+  // that carry a variant rather than being the primary. Stubbed on the one
+  // response the shell reads before it mounts, the way the OAuth callback
+  // captures below already do it, rather than changing the fixture underneath
+  // `parity.bootstrap.spec.ts`, which asserts the empty lists as part of what
+  // this deployment IS.
+  await withPasskeyAndOauth(page)
+  await page.goto("/")
+  await expect(
+    page.getByRole("button", { name: "Use a passkey" }),
+  ).toBeVisible()
+  await captureScreenshot(page, "sign-in-alternatives")
+})
+
 test("sign-in screen with a rejected key", async ({ page }) => {
   await page.goto("/")
   const key = page.locator('input[type="password"]')
@@ -49,6 +66,25 @@ async function withMailReady(page: Page): Promise<void> {
     await route.fulfill({
       response,
       json: { ...bootstrap, mail_ready: true },
+    })
+  })
+}
+
+// The sign-in screen's alternatives: a passkey needs `passkeys_ready` and a
+// relying party, and each OAuth button needs its provider configured. Same
+// treatment and same reason as the two stubs below it.
+async function withPasskeyAndOauth(page: Page): Promise<void> {
+  await page.route("**/v1/bootstrap", async (route) => {
+    const response = await route.fetch()
+    const bootstrap = await response.json()
+    await route.fulfill({
+      response,
+      json: {
+        ...bootstrap,
+        sign_in_methods: [...bootstrap.sign_in_methods, "passkey"],
+        passkeys_ready: true,
+        oauth_providers: ["google", "github"],
+      },
     })
   })
 }

--- a/web/src/app/AppShell.tsx
+++ b/web/src/app/AppShell.tsx
@@ -696,7 +696,10 @@ function AppShellChrome() {
           tabIndex={-1}
           inert={isMobile && !mobileNavOpen ? true : undefined}
           className={clsx(
-            "flex flex-col border-r border-border bg-background focus:outline-none",
+            // `otari-rail`: the rail is a named place, the way the toolbar and
+            // the tables already are, and a ghost control inside it drops its
+            // edge rather than each of them remembering to.
+            "otari-rail flex flex-col border-r border-border bg-background focus:outline-none",
             isMobile
               ? clsx(
                   // Full width, starting below the top bar: `top-14` pairs with

--- a/web/src/features/activity/ActivityPage.tsx
+++ b/web/src/features/activity/ActivityPage.tsx
@@ -198,7 +198,7 @@ function InFlightControl({
   if (data.total === 0 && !isOpen) return null
   return (
     <Popover isOpen={isOpen} onOpenChange={setIsOpen}>
-      <Button size="sm" variant="outline">
+      <Button size="sm" variant="ghost">
         {/* Decorative: the count beside it carries the same meaning in text, so
             nothing is encoded in motion alone. That is also why it can stop
             outright under `prefers-reduced-motion`, being the one element on the
@@ -1072,7 +1072,7 @@ function RequestDetail({
           {onPriceModel ? (
             <Button
               size="sm"
-              variant="outline"
+              variant="ghost"
               onPress={() => onPriceModel(pricingKey)}
             >
               Price this model
@@ -2068,7 +2068,7 @@ export function ActivityPage() {
               {newRows > 0 ? (
                 <Button
                   size="sm"
-                  variant="outline"
+                  variant="ghost"
                   onPress={refresh}
                   isDisabled={usage.isFetching}
                 >

--- a/web/src/features/auth/Login.tsx
+++ b/web/src/features/auth/Login.tsx
@@ -780,7 +780,7 @@ export function Login() {
             {offersPasskey ? (
               <Button
                 type="button"
-                variant="secondary"
+                variant="ghost"
                 fullWidth
                 isDisabled={
                   isSubmitting || isSigningOut || pendingProvider !== null
@@ -800,7 +800,7 @@ export function Login() {
                 <Button
                   key={provider}
                   type="button"
-                  variant="secondary"
+                  variant="ghost"
                   fullWidth
                   isDisabled={
                     isSubmitting ||

--- a/web/src/features/invitations/PendingInvitationsPage.tsx
+++ b/web/src/features/invitations/PendingInvitationsPage.tsx
@@ -129,7 +129,7 @@ export function PendingInvitationsPage() {
                     Accept
                   </Button>
                   <Button
-                    variant="outline"
+                    variant="ghost"
                     aria-label={`Decline invitation to ${invitation.organization_name}`}
                     onPress={() => setDeclining(invitation)}
                   >

--- a/web/src/features/keys/KeysPage.tsx
+++ b/web/src/features/keys/KeysPage.tsx
@@ -1258,7 +1258,7 @@ export function KeysPage() {
         >
           <Button
             size="sm"
-            variant="outline"
+            variant="ghost"
             isDisabled={bulkPending}
             onPress={() =>
               void runBulk(selectedKeys, (k) =>
@@ -1273,7 +1273,7 @@ export function KeysPage() {
           {isDeploymentWide ? (
             <Button
               size="sm"
-              variant="outline"
+              variant="ghost"
               isDisabled={bulkPending}
               onPress={() =>
                 void runBulk(selectedKeys, (k) =>

--- a/web/src/features/models/ModelsPage.tsx
+++ b/web/src/features/models/ModelsPage.tsx
@@ -438,7 +438,7 @@ function PricingTierEditor({
             request.
           </p>
         </div>
-        <Button size="sm" variant="outline" onPress={add}>
+        <Button size="sm" variant="ghost" onPress={add}>
           Add tier
         </Button>
       </div>
@@ -844,7 +844,7 @@ function PanelPriceEditor({
       />
       {readOnly ? null : (
         <div className="flex items-center gap-2 pt-1">
-          <Button size="sm" variant="outline" onPress={startEdit}>
+          <Button size="sm" variant="ghost" onPress={startEdit}>
             {row.source === "configured" ? "Edit price" : "Set price"}
           </Button>
           {row.source === "configured" ? (
@@ -1603,7 +1603,7 @@ function DiscoveredErrors({
               the wrong provider without saying so. */}
             <Button
               size="sm"
-              variant="outline"
+              variant="ghost"
               className="mt-2"
               onPress={() =>
                 onPriceModel(
@@ -2221,7 +2221,7 @@ export function ModelsPage() {
       {isOperator ? (
         <Button
           size="sm"
-          variant="outline"
+          variant="ghost"
           onPress={() => setCustomPriceKey(searchedSelector ?? "")}
         >
           {searchedSelector

--- a/web/src/features/models/ModelsPage.tsx
+++ b/web/src/features/models/ModelsPage.tsx
@@ -850,11 +850,11 @@ function PanelPriceEditor({
           {row.source === "configured" ? (
             <>
               <ConfirmButton
-                confirmLabel="Reset"
+                confirmLabel="Reset to default"
                 isPending={deletePricing.isPending}
                 onConfirm={() => deletePricing.mutate(row.key)}
               >
-                Reset
+                Reset price
               </ConfirmButton>
               <InfoTooltip label="What reset does">
                 Removes the custom price. The model reverts to the default rate
@@ -1184,13 +1184,13 @@ function InlinePriceForm({
         {row.source === "configured" ? (
           <span className="inline-flex items-center gap-1">
             <ConfirmButton
-              confirmLabel="Reset"
+              confirmLabel="Reset to default"
               isPending={deletePricing.isPending}
               onConfirm={() =>
                 deletePricing.mutate(row.key, { onSuccess: onClose })
               }
             >
-              Reset
+              Reset price
             </ConfirmButton>
             <InfoTooltip label="What reset does">
               Removes the custom price. The model reverts to the default rate

--- a/web/src/features/onboarding/SetupGuideCard.tsx
+++ b/web/src/features/onboarding/SetupGuideCard.tsx
@@ -338,7 +338,7 @@ function ListeningRow({
         )}
       </div>
       <Button
-        variant="outline"
+        variant="ghost"
         size="sm"
         isPending={isChecking}
         onPress={onCheckNow}

--- a/web/src/features/organization/OrganizationDomainsPage.test.tsx
+++ b/web/src/features/organization/OrganizationDomainsPage.test.tsx
@@ -91,7 +91,9 @@ describe("OrganizationDomainsPage", () => {
       await screen.findByRole("rowheader", { name: "acme.example" }),
     ).toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Pause" })).toBeNull()
-    expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Remove domain" }),
+    ).toBeInTheDocument()
   })
 
   it("shows a verified, enabled claim as active and pausable", async () => {

--- a/web/src/features/organization/OrganizationDomainsPage.tsx
+++ b/web/src/features/organization/OrganizationDomainsPage.tsx
@@ -256,7 +256,7 @@ export function OrganizationDomainsPage() {
           {row.verified_at !== null ? (
             <Button
               size="sm"
-              variant="outline"
+              variant="ghost"
               isDisabled={update.isPending}
               onPress={() =>
                 update.mutate({

--- a/web/src/features/organization/OrganizationDomainsPage.tsx
+++ b/web/src/features/organization/OrganizationDomainsPage.tsx
@@ -269,11 +269,11 @@ export function OrganizationDomainsPage() {
             </Button>
           ) : null}
           <ConfirmButton
-            confirmLabel="Remove"
+            confirmLabel="Remove claim"
             isPending={remove.isPending}
             onConfirm={() => remove.mutate(row.id)}
           >
-            Remove
+            Remove domain
           </ConfirmButton>
         </div>
       ),

--- a/web/src/features/pricing/ModelPricingPage.tsx
+++ b/web/src/features/pricing/ModelPricingPage.tsx
@@ -154,7 +154,7 @@ function PricingRefreshSection() {
           </div>
           <Button
             size="sm"
-            variant="outline"
+            variant="ghost"
             isDisabled={previewRefresh.isPending || isPending}
             onPress={() => previewRefresh.mutate()}
           >

--- a/web/src/features/providers/ProvidersPage.tsx
+++ b/web/src/features/providers/ProvidersPage.tsx
@@ -62,7 +62,7 @@ function ConnectionTest({
   return (
     <div className="flex flex-col gap-1.5">
       <Button
-        variant="outline"
+        variant="ghost"
         isDisabled={payload === null || test.isPending}
         onPress={() => {
           if (payload) test.mutate(payload)
@@ -507,7 +507,7 @@ function EditProviderForm({
             </span>
             <Button
               size="sm"
-              variant="outline"
+              variant="ghost"
               onPress={() => setReplacingKey(true)}
             >
               Replace key

--- a/web/src/features/settings/MailDeliveryCard.tsx
+++ b/web/src/features/settings/MailDeliveryCard.tsx
@@ -110,7 +110,7 @@ export function MailDeliveryCard() {
           />
           <Button
             size="sm"
-            variant="outline"
+            variant="ghost"
             isDisabled={!ready || to.trim() === "" || sendTest.isPending}
             onPress={() => sendTest.mutate({ to: to.trim() })}
           >

--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -314,7 +314,7 @@ function CopyField({
     <div className="flex flex-col gap-1">
       <div className="flex items-center justify-between">
         <span className="text-caption">New master key</span>
-        <Button size="sm" variant="outline" onPress={copy}>
+        <Button size="sm" variant="ghost" onPress={copy}>
           {copied ? "Copied" : "Copy"}
         </Button>
       </div>
@@ -532,7 +532,7 @@ function SecretKeyRow() {
         <div className="shrink-0">
           <Button
             size="sm"
-            variant="outline"
+            variant="ghost"
             isDisabled={!hasStoredKeys || reencrypt.isPending}
             onPress={() => reencrypt.mutate()}
           >

--- a/web/src/features/settings/SettingsPage.tsx
+++ b/web/src/features/settings/SettingsPage.tsx
@@ -479,12 +479,12 @@ function MasterKeyRow({ source }: { source: "configured" | "generated" }) {
         <AlertDialog isOpen={dialogOpen} onOpenChange={onOpenChange}>
           {isGenerated ? (
             <AlertDialog.Trigger
-              className={buttonVariants({ size: "sm", variant: "danger-soft" })}
+              className={buttonVariants({ size: "sm", variant: "danger" })}
             >
               Regenerate
             </AlertDialog.Trigger>
           ) : (
-            <Button size="sm" variant="danger-soft" isDisabled>
+            <Button size="sm" variant="danger" isDisabled>
               Managed in configuration
             </Button>
           )}

--- a/web/src/features/tools/OrganizationGuardrailsCard.tsx
+++ b/web/src/features/tools/OrganizationGuardrailsCard.tsx
@@ -300,7 +300,7 @@ function GuardrailRow({
           {update.isPending ? "Saving…" : "Save"}
         </Button>
         <ConfirmButton
-          confirmLabel="Remove"
+          confirmLabel="Remove permanently"
           isPending={busy}
           onConfirm={() => {
             setError("")
@@ -310,7 +310,7 @@ function GuardrailRow({
             })
           }}
         >
-          Remove
+          Remove guardrail
         </ConfirmButton>
       </div>
       {error ? (

--- a/web/src/features/tools/SearchToolsCard.test.tsx
+++ b/web/src/features/tools/SearchToolsCard.test.tsx
@@ -216,8 +216,10 @@ describe("SearchToolsCard", () => {
     renderWithClient(<SearchToolsCard onSaved={() => {}} />)
     await screen.findByText("local")
 
-    await user.click(screen.getByRole("button", { name: "Remove" }))
-    await user.click(screen.getByRole("button", { name: "Remove" }))
+    // The two steps read differently now: the trigger names the object and the
+    // armed confirm names the consequence, which is what the second click does.
+    await user.click(screen.getByRole("button", { name: "Remove tool" }))
+    await user.click(screen.getByRole("button", { name: "Remove permanently" }))
 
     await waitFor(() => {
       const call = fetchMock.mock.calls.find(

--- a/web/src/features/tools/SearchToolsCard.tsx
+++ b/web/src/features/tools/SearchToolsCard.tsx
@@ -132,7 +132,7 @@ function StoredToolRow({
           {update.isPending ? "Saving…" : "Save"}
         </Button>
         <ConfirmButton
-          confirmLabel="Remove"
+          confirmLabel="Remove permanently"
           isPending={busy}
           onConfirm={() => {
             setError("")
@@ -142,7 +142,7 @@ function StoredToolRow({
             })
           }}
         >
-          Remove
+          Remove tool
         </ConfirmButton>
       </div>
       {error ? (

--- a/web/src/features/tools/ToolsGuardrailsPage.tsx
+++ b/web/src/features/tools/ToolsGuardrailsPage.tsx
@@ -222,7 +222,7 @@ function UrlRow({
         </Button>
         <Button
           size="sm"
-          variant="outline"
+          variant="ghost"
           aria-label={`Test ${field.service}`}
           isDisabled={trimmed === "" || test.isPending}
           onPress={() => {

--- a/web/src/features/workspaces/WorkspaceMembersPanel.tsx
+++ b/web/src/features/workspaces/WorkspaceMembersPanel.tsx
@@ -191,7 +191,7 @@ export function WorkspaceMembersPanel({
                 />
                 <Button
                   size="sm"
-                  variant="danger-soft"
+                  variant="danger"
                   isDisabled={!canManageWorkspace}
                   onPress={() => setRemoving(member)}
                 >

--- a/web/src/features/workspaces/WorkspacesPage.tsx
+++ b/web/src/features/workspaces/WorkspacesPage.tsx
@@ -163,7 +163,7 @@ function NarrowedDefaults({
               />
               <Button
                 size="sm"
-                variant="danger-soft"
+                variant="danger"
                 isDisabled={pending}
                 onPress={() =>
                   deleteDefault.mutate({ workspaceId, defaultId: row.id })

--- a/web/src/shared/components/FilterChips.tsx
+++ b/web/src/shared/components/FilterChips.tsx
@@ -52,7 +52,7 @@ export function FilterChips({
         {start}
         <Button
           size="sm"
-          variant="outline"
+          variant="ghost"
           onPress={() => setOpen((prev) => !prev)}
           aria-expanded={open}
           aria-controls={regionId}

--- a/web/src/shared/components/TablePagination.tsx
+++ b/web/src/shared/components/TablePagination.tsx
@@ -124,7 +124,7 @@ export function TablePagination({
         <div className="otari-pagination__pager flex items-center gap-1">
           <Button
             size="sm"
-            variant="outline"
+            variant="ghost"
             aria-label="First page"
             isDisabled={isFirst}
             onPress={() => onPageChange(0)}
@@ -133,7 +133,7 @@ export function TablePagination({
           </Button>
           <Button
             size="sm"
-            variant="outline"
+            variant="ghost"
             aria-label="Previous page"
             isDisabled={isFirst}
             onPress={() => onPageChange(page - 1)}
@@ -170,7 +170,7 @@ export function TablePagination({
           </span>
           <Button
             size="sm"
-            variant="outline"
+            variant="ghost"
             aria-label="Next page"
             isDisabled={isLast}
             onPress={() => onPageChange(page + 1)}
@@ -179,7 +179,7 @@ export function TablePagination({
           </Button>
           <Button
             size="sm"
-            variant="outline"
+            variant="ghost"
             aria-label="Last page"
             isDisabled={pageCount == null || isLast}
             onPress={() => pageCount != null && onPageChange(pageCount - 1)}

--- a/web/src/shared/components/ui.tsx
+++ b/web/src/shared/components/ui.tsx
@@ -807,7 +807,7 @@ export function ConfirmButton({
     <Button
       ref={triggerRef}
       size="sm"
-      variant="danger-soft"
+      variant="danger"
       onPress={() => setArmed(true)}
     >
       {children}

--- a/web/src/shared/components/ui.tsx
+++ b/web/src/shared/components/ui.tsx
@@ -763,8 +763,27 @@ export function UnavailableHere({ title }: { title: string }) {
   )
 }
 
-// A destructive button that requires a second click to confirm, avoiding a
-// modal dependency for revoke/delete actions.
+/**
+ * A destructive button that requires a second click to confirm, avoiding a
+ * modal dependency for revoke/delete actions.
+ *
+ * Neutral, then danger. The first click is SAFE: it arms this control and
+ * destroys nothing, so spending the danger hue on it would spend the loudest
+ * signal in the product on a reversible action. Color marks the irreversible
+ * step. That is also what keeps the two steps apart now that `danger-soft` is
+ * gone: as two shades of danger they were the same variant at the same size,
+ * and the only difference was the label.
+ *
+ * THE CANCEL THAT APPEARS WHEN ARMED IS LOAD-BEARING. Do not simplify it away.
+ * The escalation this control now carries is hue-only, and hue is the one
+ * channel a red-green deficiency removes: measured, the ghost edge against the
+ * danger edge is 1.17 in light and 1.11 in dark, which is no luminance
+ * difference at all, and under simulated protanopia in light it is 1.03, so the
+ * armed and resting states are indistinguishable. What survives is structural:
+ * a second control appears and the row's layout changes, which no color
+ * deficiency hides. Drop the Cancel and the escalation goes to zero for those
+ * operators and close to it for everyone.
+ */
 export function ConfirmButton({
   children,
   confirmLabel,
@@ -807,7 +826,7 @@ export function ConfirmButton({
     <Button
       ref={triggerRef}
       size="sm"
-      variant="danger"
+      variant="ghost"
       onPress={() => setArmed(true)}
     >
       {children}

--- a/web/src/shared/components/ui.tsx
+++ b/web/src/shared/components/ui.tsx
@@ -437,7 +437,7 @@ export function RefreshButton({
         <span className="text-caption">Updated {freshness}</span>
       ) : null}
       <Button
-        variant="outline"
+        variant="ghost"
         size="sm"
         isIconOnly
         isDisabled={isFetching}
@@ -574,7 +574,7 @@ export function CopyField({
         <label htmlFor={fieldId} className="text-caption">
           {label}
         </label>
-        <Button size="sm" variant="outline" onPress={copy}>
+        <Button size="sm" variant="ghost" onPress={copy}>
           {copied ? "Copied" : "Copy"}
         </Button>
       </div>

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -1095,3 +1095,75 @@ describe("a field's trailing glyph is spaced once", () => {
     )
   })
 })
+
+// Three button variants, and the only thing that can hold them to three.
+//
+// `Button` is HeroUI's, re-exported directly from shared/components/ui, so its
+// `variant` prop is typed by HeroUI's union and still accepts the four names
+// this product retired. Removing our CSS for them does not make
+// `variant="secondary"` a type error; it makes it a silently unstyled button,
+// which is why the reduction needs a check rather than a convention.
+//
+// Keyed on the HOST rather than on the word, which is load-bearing: `Chip` has
+// its own variant union that happens to share `secondary`, and two legitimate
+// `<Chip variant="secondary">` render on the Budgets page. A scan for the word
+// alone would fail on correct code the first time anyone ran it, and a gate
+// that fails on correct code is one people learn to suppress.
+describe("buttons come in three variants", () => {
+  const SRC = join(WEB, "src")
+  const RETIRED = ["outline", "secondary", "tertiary", "danger-soft"]
+  const sources = readdirSync(SRC, { recursive: true })
+    .map((name) => String(name).replaceAll("\\", "/"))
+    .filter((name) => name.endsWith(".tsx") && !name.endsWith(".test.tsx"))
+
+  /** Every retired variant a `Button` carries in one file, with its line. */
+  function offenders(source: string): string[] {
+    const found: string[] = []
+    const text = source.replace(/\/\*[\s\S]*?\*\//g, "")
+    for (const match of text.matchAll(/variant\s*[=:]\s*"([a-z-]+)"/g)) {
+      const name = match[1]
+      if (!RETIRED.includes(name)) continue
+      const before = text.slice(0, match.index)
+      // The nearest opening tag before the prop is the component it is on.
+      const host = [...before.matchAll(/<([A-Z][A-Za-z0-9]*)/g)].pop()?.[1]
+      // `buttonVariants({ variant: … })` builds a button's className without a
+      // JSX host, so it is matched on the call rather than on a tag.
+      const call = /buttonVariants\s*\(\s*\{[^}]*$/.test(before)
+      if (host === "Button" || call) {
+        const line = before.split("\n").length
+        found.push(`line ${line}: ${match[0]}`)
+      }
+    }
+    return found
+  }
+
+  it("covers the source tree", () => {
+    expect(sources.length).toBeGreaterThan(30)
+  })
+
+  it.each(sources)("uses no retired button variant in %s", (name) => {
+    const source = readFileSync(join(SRC, name), "utf8")
+    expect(
+      offenders(source),
+      `${name} gives a Button a retired variant; use primary, ghost or danger`,
+    ).toEqual([])
+  })
+
+  it("still reads a retired variant on a Button as an offence", () => {
+    // The scan's own mutation check: this is what a reintroduced variant looks
+    // like, and it has to be caught by the same code the sweep above runs.
+    expect(
+      offenders('<Button size="sm" variant="secondary">Go</Button>'),
+    ).toEqual(['line 1: variant="secondary"'])
+    expect(
+      offenders('buttonVariants({ size: "sm", variant: "danger-soft" })'),
+    ).toEqual(['line 1: variant: "danger-soft"'])
+  })
+
+  it("leaves another component's identically named variant alone", () => {
+    // Chip's own vocabulary, which the product uses and must keep.
+    expect(
+      offenders('<Chip size="sm" variant="secondary">soft</Chip>'),
+    ).toEqual([])
+  })
+})

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1676,9 +1676,17 @@ main {
    button. `.otari-toolbar`, `.otari-pagination`, `.otari-table` and the
    per-page table classes already work this way for inputs and pagination
    controls; `.otari-bulk-bar` and `.otari-breakdown` already exist too.
-   `.otari-rail` and `.otari-row` are new class names for two places the
-   approved prototype declared (`place-nav` and `place-row`) and this
-   stylesheet had no word for.
+   `.otari-rail` is a new class name, for the place the approved prototype
+   declared as `place-nav` and this stylesheet had no word for. Its `place-row`
+   is deliberately NOT here: measured page by page, every candidate for it was
+   already covered or wanted the edge. A table row's ghosts are inside
+   `.otari-table`; the prototype demonstrated `place-row` only as a container
+   for icon-only ghosts, which the last selector below covers by what the
+   control is; a form row's single trailing action reads better WITH the edge
+   beside the bordered fields it sits with (compared on /routing, both ways);
+   and a table row's Edit and Delete are `RowAction`, a plain caption button
+   that is not part of this family at all. A place nobody consumes is a place
+   that goes stale, so it is not carried.
    The last selector is the one exception to place, and it is deliberate: an
    icon-only ghost never takes the edge, wherever it renders. `CopyButton` is
    why. It appears inside tables, inside the models detail panel, inside
@@ -1690,7 +1698,6 @@ main {
 .otari-bulk-bar .button--ghost,
 .otari-breakdown .button--ghost,
 .otari-rail .button--ghost,
-.otari-row .button--ghost,
 .button--ghost.button--icon-only {
   border-color: transparent;
 }

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1725,35 +1725,17 @@ main {
   border-color: transparent;
 }
 
-/* An outlined button is an object, so it takes the object edge. HeroUI gives it
-   `--color-border`, the 0.08 divider alpha, which is tuned to separate two
-   surfaces of nearly the same value and leaves a button on the page ground with
-   no edge to speak of in dark. Select triggers already took the control edge in
-   the block above, so one control family had the rule and the other did not. */
-.button--outline {
-  border-color: var(--color-control-border);
-}
-
-/* And an object's edge is drawn INSIDE its box, so the border eats a pixel of
-   the inset that every other variant spends on air. Measured beside each
-   other: an outline sm put its label 13px from the edge where a primary sm put
-   its label at 12, which is a visible step between two controls that sit in
-   the same row. The padding gives the pixel back.
-   Written at both sizes even though only sm renders an outline today, because
-   the rule is about the border rather than about which sizes happen to be in
-   use, and md would acquire the same 1px the first time someone reaches for it.
-   Icon-only is excluded: it has no label to inset and HeroUI zeroes its
-   padding to keep it square.
-   Ghost and danger join it because they carry a 1px edge now too, and measured
-   beside a primary in the same dialog footer, a bordered button without this
-   puts its label 13px from the edge at sm and 17px at md where a primary puts
-   it at 12 and 16. */
-.button--outline.button--sm:not(.button--icon-only),
+/* An edge is drawn INSIDE the box, so it eats a pixel of the inset the other
+   variants spend on air. Measured beside a primary in the same dialog footer,
+   a bordered button without this puts its label 13px from the edge at sm and
+   17px at md where a primary puts it at 12 and 16. The padding gives the pixel
+   back. Both sizes, because the rule is about the border rather than about
+   which sizes happen to be in use today. Icon-only is excluded: it has no
+   label to inset and HeroUI zeroes its padding to keep it square. */
 .button--ghost.button--sm:not(.button--icon-only),
 .button--danger.button--sm:not(.button--icon-only) {
   padding-inline: 11px;
 }
-.button--outline:not(.button--sm):not(.button--icon-only),
 .button--ghost:not(.button--sm):not(.button--icon-only),
 .button--danger:not(.button--sm):not(.button--icon-only) {
   padding-inline: 15px;

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1468,6 +1468,29 @@ main {
   transform: scale(0.98);
 }
 
+/* And the pressed FILL, which has never rendered under a pointer.
+ *
+ * HeroUI declares the two in one layer at equal specificity and puts hover
+ * last: measured in the emitted stylesheet, `.button:active,
+ * .button[data-pressed="true"]` sets `background-color: var(--button-bg-pressed)`
+ * at byte 74094 and `.button:hover, .button[data-hovered="true"]` sets the
+ * hover fill at 74220. A pointer that is down is also hovering, so hover won
+ * and the pressed step was unreachable for every variant, primary included.
+ * It was never a broken step: pressing WITHOUT hovering (focus the control,
+ * hold Space) paints `--color-surface-subtle` on a ghost with
+ * `data-pressed="true"` and matching neither `:hover` nor `:active`, which is
+ * the third step exactly as specified.
+ *
+ * Restating it here wins by being unlayered rather than by being later, which
+ * is the mechanism this file already relies on elsewhere. It matters more than
+ * a missing state: the flat 0.98 press above is justified BY this fill, so
+ * without it the transform carries the acknowledgement alone at 1.27px where
+ * the size-stepped ladder it replaced gave 1.90px, and the press would be
+ * quieter than what it replaced on the interaction most people use. */
+.button:is(:active, [data-pressed="true"]) {
+  background-color: var(--button-bg-pressed);
+}
+
 /* `.button--full-width` alongside the two utilities: a button is also a row
    when HeroUI's own `fullWidth` prop puts it there, and that prop emits this
    class rather than either utility. Measured at 471px, the widest of them

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1414,7 +1414,6 @@ main {
    2px of `--background`. Setting only ours would recolor every ringed control
    except the buttons, which are the ones this ruling is mostly about. */
 .button--primary,
-.button--danger,
 .bg-accent,
 .bg-control-indicator,
 .bg-success,
@@ -1455,7 +1454,28 @@ main {
   transition-duration: 100ms;
   transition-timing-function: var(--ease-out, ease-out);
 }
-.button:is(.w-full, .w-full\!):is(:active, [data-pressed="true"]) {
+/* One value at every rung, replacing the ladder above.
+ *
+ * The ladder deepened with size, so a wider button displaced more on a deeper
+ * value: measured per edge, 0.57px at sm, 1.90px at md, 2.78px at lg. It ran
+ * that way because the press had no color answer and the transform was
+ * carrying the whole acknowledgement alone. Ghost has a real color step now
+ * (below), so 0.98 everywhere is enough: 1.27px at md, 1.39px at lg. If the
+ * ghost ramp is ever dropped, the ladder comes back with it. */
+.button:is(:active, [data-pressed="true"]),
+.button--sm:is(:active, [data-pressed="true"]),
+.button--lg:is(:active, [data-pressed="true"]) {
+  transform: scale(0.98);
+}
+
+/* `.button--full-width` alongside the two utilities: a button is also a row
+   when HeroUI's own `fullWidth` prop puts it there, and that prop emits this
+   class rather than either utility. Measured at 471px, the widest of them
+   displaced 7.07px. */
+.button:is(.w-full, .w-full\!, .button--full-width):is(
+  :active,
+  [data-pressed="true"]
+) {
   transform: none;
 }
 
@@ -1598,6 +1618,83 @@ main {
   --button-fg: var(--color-primary-button-foreground);
 }
 
+/* =============================================================
+ * Three variants: primary, ghost, danger.
+ *
+ * `secondary`, `tertiary`, `danger-soft` and `outline` are retired at the call
+ * sites; ghost carries the opaque edge outline had, and danger absorbs
+ * danger-soft. HeroUI still declares all seven, so nothing here can stop a
+ * retired name from being typed: `foundation.test.ts` is what does that.
+ *
+ * GHOST'S EDGE NEEDS A WIDTH, not just a color, and this is the one place the
+ * spec for this change was wrong. Ghost reads as edgeless today because HeroUI
+ * gives `.button--outline` `border-width: 1px` and gives ghost none: measured
+ * on the page, a ghost button's computed `border-top-width` is 0px while its
+ * border-color is already set to the divider alpha. Setting only the color
+ * would have compiled, linted, shipped and painted nothing.
+ *
+ * The color is `--color-text-subtle`, opaque, which measures 6.01 against the
+ * page in light and 6.13 in dark, where the divider alpha it replaces measured
+ * 1.14 and 1.18. No new token: the same one, in a job it was not being given.
+ *
+ * The press ramp gives ghost three steps where it had two, and it is not a new
+ * idea in this stylesheet: `.list-box-item` below already uses this exact pair
+ * for hover and selection. Rest to pressed goes from 1.05 to 1.22 in dark and
+ * from 1.06 to 1.14 in light. The light half is marginal and stated rather
+ * than trimmed; no neutral fill in this palette does better, the whole ramp
+ * spans 1.05 to 1.22.
+ * ============================================================= */
+.button--ghost {
+  border-style: var(--tw-border-style, solid);
+  border-width: 1px;
+  border-color: var(--color-text-subtle);
+  --button-bg: transparent;
+  --button-bg-hover: var(--color-surface-alt);
+  --button-bg-pressed: var(--color-surface-subtle);
+}
+
+/* Danger, once, unfilled: transparent ground, danger ink, danger edge, filling
+   to the subtle danger on hover. A filled destructive button read as a second
+   primary, which is what absorbing `danger-soft` into it is for. The ink
+   measures 5.15 on the page ground in light and 5.54 in dark, both clearing
+   4.5 as text.
+   Hover and pressed share the one subtle danger fill, because that is the only
+   subtle danger value in the palette and inventing a second is a token change
+   rather than a role change. The press is carried by the transform above and by
+   the ink, not by a third fill. */
+.button--danger {
+  border-style: var(--tw-border-style, solid);
+  border-width: 1px;
+  border-color: var(--color-danger);
+  --button-bg: transparent;
+  --button-bg-hover: var(--color-danger-subtle);
+  --button-bg-pressed: var(--color-danger-subtle);
+  --button-fg: var(--color-danger);
+}
+
+/* Where an edge is too loud, named as a place rather than remembered per
+   button. `.otari-toolbar`, `.otari-pagination`, `.otari-table` and the
+   per-page table classes already work this way for inputs and pagination
+   controls; `.otari-bulk-bar` and `.otari-breakdown` already exist too.
+   `.otari-rail` and `.otari-row` are new class names for two places the
+   approved prototype declared (`place-nav` and `place-row`) and this
+   stylesheet had no word for.
+   The last selector is the one exception to place, and it is deliberate: an
+   icon-only ghost never takes the edge, wherever it renders. `CopyButton` is
+   why. It appears inside tables, inside the models detail panel, inside
+   banners and standalone on a page, so no container can reach it, and a rule
+   keyed on what the control IS cannot be forgotten by a call site either. */
+.otari-toolbar .button--ghost,
+.otari-pagination .button--ghost,
+.otari-table .button--ghost,
+.otari-bulk-bar .button--ghost,
+.otari-breakdown .button--ghost,
+.otari-rail .button--ghost,
+.otari-row .button--ghost,
+.button--ghost.button--icon-only {
+  border-color: transparent;
+}
+
 /* An outlined button is an object, so it takes the object edge. HeroUI gives it
    `--color-border`, the 0.08 divider alpha, which is tuned to separate two
    surfaces of nearly the same value and leaves a button on the page ground with
@@ -1616,12 +1713,30 @@ main {
    the rule is about the border rather than about which sizes happen to be in
    use, and md would acquire the same 1px the first time someone reaches for it.
    Icon-only is excluded: it has no label to inset and HeroUI zeroes its
-   padding to keep it square. */
-.button--outline.button--sm:not(.button--icon-only) {
+   padding to keep it square.
+   Ghost and danger join it because they carry a 1px edge now too, and measured
+   beside a primary in the same dialog footer, a bordered button without this
+   puts its label 13px from the edge at sm and 17px at md where a primary puts
+   it at 12 and 16. */
+.button--outline.button--sm:not(.button--icon-only),
+.button--ghost.button--sm:not(.button--icon-only),
+.button--danger.button--sm:not(.button--icon-only) {
   padding-inline: 11px;
 }
-.button--outline:not(.button--sm):not(.button--icon-only) {
+.button--outline:not(.button--sm):not(.button--icon-only),
+.button--ghost:not(.button--sm):not(.button--icon-only),
+.button--danger:not(.button--sm):not(.button--icon-only) {
   padding-inline: 15px;
+}
+
+/* The rail is the exception, and it has to be one: its two band controls set
+   their own lane so their mark and their label line up with the nav rows'
+   icon lane, which is a call-site decision this rule would otherwise outrank
+   (an unlayered rule beats `@layer utilities`, so `px-6` cannot win on its
+   own). `revert-layer` hands the value back to the utility rather than
+   restating the number here, so the lane stays declared in exactly one place. */
+.otari-rail .button--ghost:not(.button--icon-only) {
+  padding-inline: revert-layer;
 }
 
 /* =============================================================


### PR DESCRIPTION
## Description

Cuts the dashboard's seven button variants to three (primary, ghost, danger), makes the press one value everywhere, and makes the pressed fill reach a pointer press for the first time. 176 Button call sites, ten commits, and every number below was measured on the running dashboard rather than derived from the stylesheet.

Stacked deliberately on `feat/dashboard-redesign` (#934) rather than on `main`, and kept separate from it for one reason: this change touches controls on every page, and it has to be revertible on its own. Because this repository squash-merges, a single sha is what makes that possible.

**To undo this entire change:** `git revert <squash sha of this PR>`. That restores the seven variants, the size-stepped press ladder, the filled danger, ghost's edgeless rest state, the focus-ring list and the old confirm labels, and removes the place rules, the new place class and the enforcement scan. It does not touch #934's work, which is why the two are separate PRs.

**The revert is rehearsed, not asserted.** On a scratch branch I squash-merged this PR onto the base the way GitHub will, reverted that single commit, and checked what came back:

- `git diff feat/dashboard-redesign` against the reverted tree is **empty**. Nothing is left behind.
- `lint`, `typecheck` and `test` are all green on the reverted state, at 3057 tests (the pre-scan count, since the scan reverts with the change).
- The bundle rebuilds from the reverted tree to **`index-CNLUdEUK.js` / `index-5YVrOLEX.css`**, byte-identical filenames to the bundle before this work started.
- That build boots and renders with **zero page errors and zero console errors**: `variant="outline"` is back on the pager with its 1px `rgb(90, 95, 107)` edge, ghost is back to `border-width: 0px`, the `.button--lg` press is back to `scale(.96)`, and our unlayered pressed-fill rule is absent from the emitted CSS.
- No generated artifact moves in either direction: `git status` is clean after the revert and after the rebuild.

### The three variants

| from | count | to |
|---|---|---|
| `primary` | 73 | `primary`, unchanged |
| `ghost` | 64 | `ghost`, new edge and press ramp |
| `outline` | 26 | `ghost` |
| `secondary` | 2 | `ghost` |
| `danger` | 6 | `danger`, unfilled |
| `danger-soft` | 4 | `danger` |
| `tertiary` | 0 | declared, never used |

**176 Button call sites, not 178.** `variant="…"` returns 177 matches, of which two are `<Chip variant="secondary">` (`features/budgets/SpendCeilingsCard.tsx:119`, `features/budgets/BudgetsPage.tsx:642`) and not Buttons at all; the one a prop grep misses is `features/settings/SettingsPage.tsx:482`, which calls `buttonVariants({ variant: "danger-soft" })` to build a className.

**Outline to ghost is an identity outside a place, and that is a fact about the tokens rather than luck.** `--color-control-border` IS `--color-text-subtle`, in both theme blocks, so the edge outline drew and the edge ghost now draws are the same value. Measured before and after on the three converted sites that render outside any place (/settings' "Re-encrypt provider credentials" and "Send test email", /providers' "Re-check all"): 1px `rgb(90, 95, 107)`, padding 11px, height 32px, both ways. A reviewer looking at 26 converted call sites should read them as an identity rather than as 26 chances to drift; the ones that change are the ones inside a place, where the edge is suppressed on purpose.

### Ghost's edge needed three properties where the design named one

HeroUI gives `.button--outline` `border-width: 1px` and gives ghost **none**. Measured on the running page before any edit, a ghost button's computed `border-top-width` was `0px` while its `border-color` was already set to the divider alpha. So setting only the colour, which is what the design asked for, would have compiled, linted, passed every gate, shipped and painted nothing. The rule sets `border-style`, `border-width` and `border-color` together for that reason.

The colour is `--color-text-subtle`, opaque: **6.01** against the page in light and **6.13** in dark, where the divider alpha it replaces measured **1.14** and **1.18**. No new token; the same one in a job it was not being given.

### Ghost's press ramp, and the coupling that justifies the flat press

Ghost gains a third step, from the pair `.list-box-item` already uses: transparent, `--color-surface-alt` on hover, `--color-surface-subtle` pressed. Rest to pressed goes 1.05 to **1.22** in dark and 1.06 to **1.14** in light. The light half is marginal and stated rather than trimmed: no neutral fill in this palette does better, the whole ramp spans 1.05 to 1.22.

**The press is 0.98 at every rung**, replacing a ladder that deepened with size, and **`.button--full-width` now stops pressing at all** (HeroUI's own `fullWidth` prop emits that class, which the existing exclusion did not name). Measured on the sign-in button at 471px: `transform: none` under a real press, where the ladder moved it 7.07px per edge.

**These two are coupled and neither is defensible alone.** The flat 0.98 is justified by the pressed fill existing, because a flat transform is a smaller acknowledgement than the ladder it replaces (1.27px at md against 1.90px). And the pressed fill has never rendered under a pointer: HeroUI declares the pressed and hover backgrounds in one layer at equal specificity with hover last (byte 74094 against 74220 in the emitted stylesheet), so a pointer that is down is also hovering and hover won. The step itself was never broken, which is what makes this a cascade fix rather than a state fix: pressing without hovering (focus a control, hold Space) already painted `--color-surface-subtle`, with `data-pressed="true"` and matching neither `:hover` nor `:active`. Restating the declaration unlayered fixes it, and this is the first time anyone has seen that fill paint under a pointer:

| control | rest | hover | pressed |
|---|---|---|---|
| primary | `rgb(0, 128, 138)` | `rgb(0, 109, 118)` | `rgb(0, 91, 98)` |
| ghost, in a place | transparent | `rgb(240, 241, 242)` | `rgb(232, 233, 235)` |
| ghost, no place | transparent | `rgb(240, 241, 242)` | `rgb(232, 233, 235)` |
| danger | transparent | `rgb(255, 236, 233)` | `rgb(255, 236, 233)` |

All measured with `:active`, `:hover` and `data-pressed="true"` all true at the moment of reading. **Danger is the asymmetry:** the palette has one subtle danger value, so danger's press is carried by the ink and the transform rather than by a third fill. That is a consequence of the palette rather than an oversight, and it is why the row above reads the same twice.

Consequence worth stating plainly: the pressed fill now renders for pointer users on **all** variants including primary, which is a state nobody has seen in the shipped app. It matches the approved prototype, so it is restoration, but restoration describes its relation to the approved artifact and not to what anyone's eyes are used to.

### Danger, once, unfilled

Transparent ground, danger ink, danger edge, filling to `--color-danger-subtle` on hover. A filled destructive button read as a second primary, which is what absorbing `danger-soft` is for. Measured at rest: transparent with a `rgb(203, 37, 38)` edge and ink; `--color-danger` on the page ground is 5.15 in light and 5.54 in dark, both clearing 4.5 as text.

It also **leaves the filled-control focus-ring list**, which that rule's own comment asks for since it names fills rather than components. Measured on the button, `--focus` now reads `#00848f` where the list would have made it near-black in light and near-white in dark.

### Places, and why one class name is new

Where an edge would be too loud it is suppressed by naming the place, not by remembering a modifier at each call site: `.otari-toolbar`, `.otari-pagination`, `.otari-table` and the per-page table classes already work this way for inputs and pagination controls, and `.otari-bulk-bar` and `.otari-breakdown` already existed.

`.otari-rail` is new, and it is a **correction rather than an addition**: the approved prototype declared four places (`place-toolbar`, `place-row`, `place-cell`, `place-nav`) and this stylesheet had a word for only three. `WorkspaceSwitcher`'s own comment records that the artboard removed its border because it "made the rail open with an outlined card sitting above a list of flat rows", so an opaque edge there would undo a decision already taken.

`place-row` deliberately has no counterpart here. Every candidate for it was already covered or wanted the edge: a table row's ghosts are inside `.otari-table`; the prototype demonstrates `place-row` in exactly one spot, as the container for its four icon-only ghosts, which the rule below covers by what the control is; a form row's single trailing action reads better WITH the edge, compared both ways on /routing; and a table row's Edit and Delete are `RowAction`, a plain caption button outside this family. A place nobody consumes is a place that goes stale.

One rule is not a place, deliberately: **an icon-only ghost never takes the edge.** `CopyButton` renders inside tables, inside the models detail panel, inside banners and standalone on a page, so no container can reach it, and a rule keyed on what the control *is* cannot be forgotten by a call site either.

### The reduction is enforced, and the scan is mutation-checked

`Button` is HeroUI's, re-exported directly, so its `variant` prop is typed by HeroUI's union and still accepts every retired name: deleting our CSS for `secondary` does not make `variant="secondary"` a type error, it makes it a silently unstyled button.

The scan in `foundation.test.ts` is keyed on the **host** rather than on the word, which is load-bearing: `Chip` has its own variant union that shares `secondary`, and two legitimate `<Chip variant="secondary">` render on the Budgets page, so a scan for the word alone would have failed on correct code the first time anyone ran it. A gate that fails on correct code is one people learn to suppress.

Three mutation checks, because a scan that cannot fail is worse than no scan:

1. One real `variant="ghost"` in `features/keys/KeysPage.tsx` changed to `variant="secondary"`: the sweep fails and names the file and the line.
2. Restored: green, 124 files and 3201 tests.
3. Green with the two Chips in place, and the host keying is pinned by two assertions in the block, so a future edit that loosened it to a word match fails its own test.

### The two-step destructive confirm

`ConfirmButton`'s resting trigger was `danger-soft` and its armed confirm `danger`; with danger-soft absorbed they became the same variant at the same size. The first click is safe, so the resting trigger is now neutral and the danger hue marks the irreversible step. Measured at rest: resting is a ghost with `rgb(8, 9, 10)` ink and a `rgb(90, 95, 107)` edge; armed is danger, ink and edge `rgb(203, 37, 38)`, with the ghost Cancel beside it.

**What gives, and it is a regression against what ships today.** The escalation is hue-only and slightly quieter rather than louder: the ghost edge measures 6.01/6.13 and the danger edge 5.15/5.54, so arming *changes* edge contrast by -0.86 in light and -0.59 in dark. Ghost edge against danger edge is 1.17 light and 1.11 dark, which is no luminance difference at all, and under simulated protanopia in light it is **1.03**. Today's escalation is a pale filled box to a saturated filled box, a fill and luminance change that survives colour deficiency; ours replaces it with a hue change that does not. The user chose this with those figures in front of them.

What carries it instead is structural, and the component's docstring now says so: **the Cancel appearing when armed is load-bearing, not decorative.** A second control appearing and the layout changing is the one cue no colour deficiency hides. Anybody simplifying the armed state by dropping it takes the escalation to zero for those operators.

The labels are part of that answer rather than a tidy-up. All five call sites passed the same word twice, so the two-step pattern carried no information in its labels anywhere it was used; the armed label is what an affected operator reads to learn what the second click does. Now: `Remove domain` then `Remove claim`; `Remove tool` and `Remove guardrail` then `Remove permanently`; `Reset price` then `Reset to default`. Domains is deliberately not "permanently": `delete_domain_for_user` drops a claim row that can be re-added, and its docstring records that memberships already auto-joined through the claim are left alone on purpose, so "permanently" would overstate it in two directions at once.

### The sign-in screen

`e2e/otari.yml` configures no passkey relying party and no OAuth client, so "Use a passkey" and the per-provider buttons never render against this fixture and were the only surface here shipping on a CSS-level claim. `e2e/screenshots/public.spec.ts` now stubs the bootstrap the way its OAuth callback captures already do and takes one capture of that state.

Measured on it: each of the three is a full-width ghost at 471x44, transparent, ink `rgb(8, 9, 10)`, edge 1px `rgb(90, 95, 107)`, padding 15px, beside the filled primary at 471x44 and padding 16px. A press hovers, presses and does not scale, which is the full-width exclusion demonstrated on the widest buttons in the product. **One filled primary above three edged alternatives reads as a hierarchy, where three filled greys would have read as four primaries** — that is the argument for the conversion rather than a consolation for it.

### Regressions and costs, in one place

- **The pager's disabled arrows lose a channel.** With the boxes gone, "which arrows can I press" rests on opacity alone (0.4 against 1.0) at glyph size, where it used to be a box and opacity. Put to the user with that cost stated; they chose bare.
- **The refresh control loses its box everywhere.** It is icon-only, so the icon rule reaches it regardless of place. Same trade as the pager, on three pages.
- **The confirm's escalation is hue-only** and measurably quieter, carried structurally by the Cancel (above).
- **Danger has no third press fill**, because the palette has one subtle danger value (above).
- **The pressed fill now paints for pointer users on every variant**, primary included, which no shipped build has done (above).

### Not in this change

Loading is a capability rather than a repair and ships as its own PR afterwards, so a revert of this one cannot take it out. No colour value moves; roles are reassigned and not one hex changes. Sizes stay at 32/36/40 and `features/auth/Login.tsx`'s `h-11` override stays, flagged separately. Brand teal on primary is measured, unapplied and left with the user. The two-layer focus ring, square corners, both typefaces and the 100ms timing are untouched. The disabled cursor is its own item. A filled armed confirm was offered and declined. `RowActions` is noted as the latent home if a row place is ever wanted.

`globals.css` stays recognisably `otari-ai/frontend/src/index.css`: every change here is a rule in a variant block or the utilities layer, not a token value, so the cross-repo cost is low.

## PR Type

- [x] Refactor
- [ ] New Feature
- [ ] Bug Fix
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None filed; this comes from a design review of the shipped button set.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change. The enforcement scan in `src/styles/foundation.test.ts`, mutation-checked three ways above; a screenshot capture of the sign-in screen's alternatives; and two component tests updated to the new confirm labels. What is deliberately NOT tested is the appearance itself: jsdom renders none of this CSS, so a component test asserting it would pin class strings rather than behaviour, which is a test that cannot fail for the reason we care about.
- [x] I ran the Definition of Done checks locally. The dashboard's four, which are the ones this touches: `pnpm --dir web run lint`, `run typecheck`, `test` (124 files, 3201 tests) and `run build`. No Python changed, so `make lint` and `make test` cover nothing in this diff.
- [ ] Documentation was updated where necessary. Nothing to update: no user-facing behaviour beyond the appearance described here, and no contract change.
- [ ] If the API contract changed, I regenerated the OpenAPI spec. No API change; `client/schema.ts` and `routeTree.gen.ts` both come back clean.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 via Claude Code.

**Any additional AI details you'd like to share:**

Every figure here was read off the running dashboard or the emitted stylesheet, and three of them corrected the plan this started from: ghost's zero border-width, a padding compensation danger needed that only appeared beside a ghost of the same size, and the pressed fill that no pointer press has ever painted. The place audit that produced `.otari-rail` and deleted `.otari-row` was done by reading all 64 ghost call sites and their rendered containers rather than by grep.

- [x] I am an AI Agent filling out this form (check box if true)
