### PR TITLE
fix(lint): strip block comments before matching arbitrary font-size rule

### DIFF
--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -690,7 +690,7 @@ describe("no font size is written at a call site", () => {
       .filter((name) =>
         // `text-[` followed by a digit: an arbitrary size, as opposed to an
         // arbitrary color, which the token rules above already cover.
-        /text-\[\d/.test(readFileSync(join(SRC, name), "utf8")),
+        /text-\[\d/.test(readFileSync(join(SRC, name), "utf8").replace(/\/\*[\s\S]*?\*\//g, "")),
       )
 
     expect(

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -690,7 +690,12 @@ describe("no font size is written at a call site", () => {
       .filter((name) =>
         // `text-[` followed by a digit: an arbitrary size, as opposed to an
         // arbitrary color, which the token rules above already cover.
-        /text-\[\d/.test(readFileSync(join(SRC, name), "utf8").replace(/\/\*[\s\S]*?\*\//g, "")),
+        /text-\[\d/.test(
+          readFileSync(join(SRC, name), "utf8").replace(
+            /\/\*[\s\S]*?\*\//g,
+            "",
+          ),
+        ),
       )
 
     expect(


### PR DESCRIPTION
## Description
Strip block comments before matching the arbitrary font-size rule in `foundation.test.ts`, consistent with all sibling rules.

## PR Type
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
Fixes #931

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change.
- [ ] I ran the Definition of Done checks locally.
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec.

## AI Usage
- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the arbitrary font-size lint rule to ignore block comments before matching.
- Prevents quoted patterns in comments or docstrings from causing false positives.
- Aligns the rule with its sibling rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->