### PR TITLE
fix(cli): redact database URL password in migrate and init-db output

### DIFF
--- a/src/gateway/cli.py
+++ b/src/gateway/cli.py
@@ -7,6 +7,7 @@ import sys
 
 import click
 import uvicorn
+from sqlalchemy.engine.url import make_url
 from uvicorn.config import logger
 
 from gateway.core.config import load_config
@@ -165,7 +166,8 @@ def init_db(config: str | None, database_url: str | None) -> None:
     if database_url:
         gateway_config.database_url = database_url
 
-    click.echo(f"Initializing database: {gateway_config.database_url}")
+    safe_url = make_url(gateway_config.database_url).render_as_string(hide_password=True)
+    click.echo(f"Initializing database: {safe_url}")
 
     db_init(gateway_config)
 
@@ -192,7 +194,8 @@ def migrate(config: str | None, database_url: str | None, revision: str) -> None
         click.echo("alembic command not found in PATH", err=True)
         sys.exit(1)
 
-    click.echo(f"Running migrations on: {gateway_config.database_url}")
+    safe_url = make_url(gateway_config.database_url).render_as_string(hide_password=True)
+    click.echo(f"Running migrations on: {safe_url}")
     click.echo(f"Target revision: {revision}")
 
     env = os.environ.copy()


### PR DESCRIPTION
## Description
Redact the database URL password before echoing in `otari migrate` and `otari init-db` using SQLAlchemy's `make_url(...).render_as_string(hide_password=True)`.

## PR Type
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
Fixes #922

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change.
- [ ] I ran the Definition of Done checks locally.
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec.

## AI Usage
- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude

- [x] I am an AI Agent filling out this form