### PR TITLE
refactor(budgets): hoist duplicated provider_key_id field into a shared type

### DIFF
--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -7450,7 +7450,7 @@
                 "type": "null"
               }
             ],
-            "description": "Narrow the cap to one provider instance; omit or null to cap spend across every provider. Must name a real instance: a blank value would store a ceiling that never binds",
+            "description": "Narrow the cap to one provider instance; omit or null to cap spend across every provider. A blank value would store a ceiling that never binds, so it is refused; this does not check that the value names a configured provider instance",
             "title": "Provider Key Id"
           },
           "scope_id": {
@@ -13868,7 +13868,7 @@
                 "type": "null"
               }
             ],
-            "description": "Narrow the default to one provider instance; omit or null to apply to every provider. Must name a real instance: a blank value would materialize ceilings that never bind",
+            "description": "Narrow the cap to one provider instance; omit or null to cap spend across every provider. A blank value would store a ceiling that never binds, so it is refused; this does not check that the value names a configured provider instance",
             "title": "Provider Key Id"
           }
         },

--- a/src/gateway/api/routes/scoped_budgets.py
+++ b/src/gateway/api/routes/scoped_budgets.py
@@ -25,6 +25,7 @@ from gateway.models.tenancy import Organization, OrganizationMember, Workspace, 
 # here: the ``Literal`` is what puts the allowed values in the OpenAPI schema,
 # and a second roster would eventually let a client create a scope enforcement
 # does not know.
+from gateway.services.budget_periods import ProviderNarrowing
 from gateway.services.scoped_budget_service import ScopeType, period_window
 
 # Auth is declared on the router, not repeated on each handler, following
@@ -47,24 +48,10 @@ class CreateScopedBudgetRequest(BaseModel):
         max_length=255,
         description="Id of the capped identity: an organization, workspace, membership row, or API key",
     )
-    # Absent means every provider. Resolution matches `provider_key_id ==
-    # provider_instance OR IS NULL`, and a blank string is neither, so it would
-    # store, list, and never bind. Refused rather than folded into null, because
-    # null is the *wider* cap and coercing would silently cap more than the
-    # caller asked for. This only refuses the blank/whitespace shape, not an
-    # unresolvable value: unlike `scope_id` and `budget_id` above, a present
-    # `provider_key_id` naming no configured instance is not checked here (#918).
-    provider_key_id: str | None = Field(
-        default=None,
-        min_length=1,
-        max_length=255,
-        pattern=r"^\S+$",
-        description=(
-            "Narrow the cap to one provider instance; omit or null to cap spend across every provider. "
-            "A blank value would store a ceiling that never binds, so it is refused; this does not check "
-            "that the value names a configured provider instance"
-        ),
-    )
+    # Absent means every provider; a blank value is refused rather than folded
+    # into null. Constraint and wording live on `ProviderNarrowing`, and #918
+    # notes a present value naming no configured instance is still not checked.
+    provider_key_id: ProviderNarrowing
     budget_id: str = Field(
         min_length=1,
         max_length=255,

--- a/src/gateway/services/budget_periods.py
+++ b/src/gateway/services/budget_periods.py
@@ -15,7 +15,9 @@ Nothing here imports from the gateway, so both sides can depend on it and
 """
 
 from datetime import UTC, datetime, timedelta
-from typing import Literal, get_args
+from typing import Annotated, Literal, get_args
+
+from pydantic import Field
 
 ALIGN_DAY = "calendar_day"
 ALIGN_WEEK = "calendar_week"
@@ -36,6 +38,35 @@ RESET_ALIGNMENTS: tuple[ResetAlignment, ...] = get_args(ResetAlignment)
 # raises ``OverflowError`` (a 500) instead of the 422 an out-of-range period
 # should be.
 MAX_BUDGET_DURATION_SEC = 10 * 365 * 24 * 3600
+
+
+# The resource axis a ceiling can be narrowed to, and the one place its
+# constraint is written. A request either omits it (null, the wider cap across
+# every provider) or names one provider instance. The three create-request
+# models that carry it — the deployment route's ``CreateScopedBudgetRequest``,
+# ``OrganizationScopedBudgetCreate`` and ``WorkspaceMemberBudgetPolicyCreate`` —
+# used to spell the same ``min_length``/``pattern`` and description out three
+# times, and the two tenant-facing copies claimed the value "must name a real
+# instance" while no code resolves it (otari#918). Hoisted here, a leaf both the
+# route and the tenancy services already import, so the constraint cannot drift
+# and the description says only what the blank/whitespace refusal actually
+# guarantees. The refusal is of a blank or whitespace value, which resolution
+# (``provider_key_id == provider_instance OR IS NULL``) would store, list, and
+# never bind; it is deliberately not an existence check.
+ProviderNarrowing = Annotated[
+    str | None,
+    Field(
+        default=None,
+        min_length=1,
+        max_length=255,
+        pattern=r"^\S+$",
+        description=(
+            "Narrow the cap to one provider instance; omit or null to cap spend across every provider. "
+            "A blank value would store a ceiling that never binds, so it is refused; this does not check "
+            "that the value names a configured provider instance"
+        ),
+    ),
+]
 
 
 def aligned_window(alignment: str, now: datetime) -> tuple[datetime, datetime]:
@@ -99,6 +130,7 @@ __all__ = [
     "ALIGN_MONTH",
     "ALIGN_WEEK",
     "MAX_BUDGET_DURATION_SEC",
+    "ProviderNarrowing",
     "RESET_ALIGNMENTS",
     "ResetAlignment",
     "aligned_window",

--- a/src/gateway/services/tenancy/organization_budget_service.py
+++ b/src/gateway/services/tenancy/organization_budget_service.py
@@ -248,7 +248,7 @@ class OrganizationScopedBudgetCreate(BaseModel):
     # Absent means every provider; a blank value is refused rather than folded
     # into null. Constraint and wording live on `ProviderNarrowing`; #918 notes a
     # present value naming no configured instance is still not checked here.
-    provider_key_id: ProviderNarrowing
+    provider_key_id: ProviderNarrowing = None
     budget_id: str = Field(
         min_length=1,
         max_length=255,

--- a/src/gateway/services/tenancy/organization_budget_service.py
+++ b/src/gateway/services/tenancy/organization_budget_service.py
@@ -67,7 +67,7 @@ from gateway.models.entities import MAX_COUNT_LIMIT, APIKey, Budget, ScopedBudge
 from gateway.models.entities import User as GatewayUser
 from gateway.models.money import MAX_USD_LIMIT, as_float, to_usd_or_none
 from gateway.models.tenancy import Organization, OrganizationMember, User, Workspace, WorkspaceMember
-from gateway.services.budget_periods import ResetAlignment, period_window
+from gateway.services.budget_periods import ProviderNarrowing, ResetAlignment, period_window
 from gateway.services.budget_retiming import cadence_of, retime_ceilings_for_budget
 from gateway.services.tenancy.errors import (
     OrganizationBudgetHeldElsewhereError,
@@ -245,21 +245,10 @@ class OrganizationScopedBudgetCreate(BaseModel):
             "a membership in either, or an API key in one"
         ),
     )
-    # Absent means every provider; a present value must name a real instance.
-    # Resolution matches `provider_key_id == provider_instance OR IS NULL`, and a
-    # blank string is neither, so it would store, list, and never bind. Refused
-    # rather than folded into null, because null is the *wider* cap and coercing
-    # would silently cap more than the caller asked for.
-    provider_key_id: str | None = Field(
-        default=None,
-        min_length=1,
-        max_length=255,
-        pattern=r"^\S+$",
-        description=(
-            "Narrow the cap to one provider instance; omit or null to cap spend across every provider. "
-            "Must name a real instance: a blank value would store a ceiling that never binds"
-        ),
-    )
+    # Absent means every provider; a blank value is refused rather than folded
+    # into null. Constraint and wording live on `ProviderNarrowing`; #918 notes a
+    # present value naming no configured instance is still not checked here.
+    provider_key_id: ProviderNarrowing
     budget_id: str = Field(
         min_length=1,
         max_length=255,

--- a/src/gateway/services/tenancy/workspace_budget_default_service.py
+++ b/src/gateway/services/tenancy/workspace_budget_default_service.py
@@ -79,7 +79,7 @@ class WorkspaceMemberBudgetPolicyCreate(BaseModel):
     # ceiling per member, and a blank one would bind to nothing for every one of
     # them. Constraint and wording live on `ProviderNarrowing`; #918 notes a
     # present value naming no configured instance is still not checked here.
-    provider_key_id: ProviderNarrowing
+    provider_key_id: ProviderNarrowing = None
 
 
 class WorkspaceMemberBudgetPolicyUpdate(BaseModel):

--- a/src/gateway/services/tenancy/workspace_budget_default_service.py
+++ b/src/gateway/services/tenancy/workspace_budget_default_service.py
@@ -36,7 +36,7 @@ from gateway.models.entities import Budget, ScopedBudget, WorkspaceBudgetDefault
 from gateway.models.money import as_float
 from gateway.models.tenancy import User, Workspace, WorkspaceMember
 from gateway.repositories.tenancy import WorkspaceMemberRepository, WorkspaceRepository
-from gateway.services.budget_periods import period_window
+from gateway.services.budget_periods import ProviderNarrowing, period_window
 from gateway.services.tenancy import authorization
 from gateway.services.tenancy.errors import (
     WorkspaceBudgetDefaultAlreadyExistsError,
@@ -74,24 +74,12 @@ class WorkspaceMemberBudgetPolicyCreate(BaseModel):
         max_length=255,
         description="The budget this workspace hands to every member",
     )
-    # Absent means every provider; a present value must name a real instance.
-    # Constrained rather than only length-checked because this template is
-    # materialized verbatim into a ceiling per member, and a ceiling whose
-    # `provider_key_id` is a blank string binds to nothing: resolution matches
-    # `provider_key_id == provider_instance OR IS NULL` and blank is neither, so
-    # every member would get a cap that is stored, listed, and never enforced.
-    # Reachable by an organization or workspace owner/admin, not only an operator,
-    # which is why it is refused here rather than left to the dashboard.
-    provider_key_id: str | None = Field(
-        default=None,
-        min_length=1,
-        max_length=255,
-        pattern=r"^\S+$",
-        description=(
-            "Narrow the default to one provider instance; omit or null to apply to every provider. "
-            "Must name a real instance: a blank value would materialize ceilings that never bind"
-        ),
-    )
+    # Absent means every provider; a blank value is refused rather than folded
+    # into null. Constrained because this template is materialized verbatim into a
+    # ceiling per member, and a blank one would bind to nothing for every one of
+    # them. Constraint and wording live on `ProviderNarrowing`; #918 notes a
+    # present value naming no configured instance is still not checked here.
+    provider_key_id: ProviderNarrowing
 
 
 class WorkspaceMemberBudgetPolicyUpdate(BaseModel):

--- a/web/src/client/schema.ts
+++ b/web/src/client/schema.ts
@@ -7814,7 +7814,7 @@ export interface components {
             name?: string | null;
             /**
              * Provider Key Id
-             * @description Narrow the cap to one provider instance; omit or null to cap spend across every provider. Must name a real instance: a blank value would store a ceiling that never binds
+             * @description Narrow the cap to one provider instance; omit or null to cap spend across every provider. A blank value would store a ceiling that never binds, so it is refused; this does not check that the value names a configured provider instance
              */
             provider_key_id?: string | null;
             /**
@@ -10424,7 +10424,7 @@ export interface components {
             budget_id: string;
             /**
              * Provider Key Id
-             * @description Narrow the default to one provider instance; omit or null to apply to every provider. Must name a real instance: a blank value would materialize ceilings that never bind
+             * @description Narrow the cap to one provider instance; omit or null to cap spend across every provider. A blank value would store a ceiling that never binds, so it is refused; this does not check that the value names a configured provider instance
              */
             provider_key_id?: string | null;
         };


### PR DESCRIPTION
## Description

Hoists the `provider_key_id` `Field` (constraint + description), duplicated verbatim across `CreateScopedBudgetRequest`, `OrganizationScopedBudgetCreate`, and `WorkspaceMemberBudgetPolicyCreate`, into one shared `ProviderNarrowing` type in `gateway.services.budget_periods` (the existing leaf both the route and the tenancy services already import, so no import cycle). The two tenant-facing copies claimed the value "must name a real instance" while nothing resolves it; they now share the honest wording #878 already gave `scoped_budgets.py`. This intentionally addresses only item 2 (the safe dedup / description alignment); item 1 (resolving `provider_key_id` against configured providers) is left for a maintainer design decision since it changes what the shared type must express.

## PR Type
- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
Fixes #918

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change.
- [ ] I ran the Definition of Done checks locally.
- [ ] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec.

## AI Usage
- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude

- [x] I am an AI Agent filling out this form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a shared `ProviderNarrowing` type for `provider_key_id`.
- Reused the type across scoped, organization, and workspace budget requests.
- Centralized length and whitespace validation.
- Updated the description to clarify that provider existence is not validated.
- Reduced duplicated field definitions and improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->