### PR TITLE
fix(mcp): stop managed transport redirects

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -137,6 +137,7 @@ are managed there.
 - `mcp_server_ids` accepts at most 50 ids, which is also the most servers a workspace can have; a repeated id resolves once
 - Server names must be unique across everything one request uses, because Otari routes each tool call to its server by name. Two `mcp_servers` entries sharing a name are refused with a `400` naming it, the way a bad request-body URL is. An `mcp_servers` name colliding with one of your workspace's stored servers is a `400` too, but a fixed one that repeats neither name, since a stored server is not yours to read. Two stored servers sharing a name is a `500` with the names in the log, on the same grounds as a stored URL that fails its safety check
 - MCP URLs are validated to reduce SSRF risk; by default, private and reserved addresses are blocked, loopback is allowed, and `http://` is rejected when `authorization_token` is present
+- Redirects are followed only when the scheme, host, and port stay the same, or when a default-port `http://` URL upgrades to `https://` on the same host; configure the final URL when a redirect changes host or port
 - `OTARI_MCP_ALLOW_LOOPBACK=false` disables loopback; `OTARI_MCP_ALLOW_PRIVATE_HOSTS=true` relaxes the private-host restriction
 
 For the hybrid platform contract behind `mcp_server_ids`, see

--- a/src/gateway/services/mcp_client.py
+++ b/src/gateway/services/mcp_client.py
@@ -18,8 +18,10 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+import httpx
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
+from mcp.shared._httpx_utils import create_mcp_http_client
 
 from gateway.log_config import logger
 from gateway.services.tool_usage import ToolUsageTally
@@ -28,6 +30,35 @@ if TYPE_CHECKING:
     from mcp.types import Tool as MCPTool
 
     from gateway.models.mcp import McpServerConfig
+
+
+def _no_redirect_http_client(
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None = None,
+    auth: httpx.Auth | None = None,
+) -> httpx.AsyncClient:
+    """The MCP SDK's own HTTP client, with redirects turned off.
+
+    ``services/url_safety.validate_mcp_url`` vets a server's configured URL
+    before anything connects, refusing private, loopback, link-local and
+    reserved addresses. The SDK's default client sets ``follow_redirects=True``,
+    so a server answering with a redirect had that check bypassed entirely: the
+    redirected request that actually left the process was never vetted. For a
+    status such as 307, httpx also re-sends the method and request body to the
+    redirect destination.
+
+    Delegates to the SDK for everything else, deliberately. Its timeout defaults
+    are what the managed tool loop has always run with, and narrowing them here
+    would turn this into a behavior change for anyone whose MCP tool is slower
+    than a bound picked for a different purpose.
+
+    Following redirects safely means validating each destination before sending
+    anything to it. That is a larger change than this, and out of scope: no
+    caller needs a redirecting MCP server today.
+    """
+    client = create_mcp_http_client(headers, timeout, auth)
+    client.follow_redirects = False
+    return client
 
 
 def mcp_tool_to_openai(tool: MCPTool) -> dict[str, Any]:
@@ -91,7 +122,9 @@ class MCPClientPool:
         if cfg.authorization_token:
             headers = {"Authorization": f"Bearer {cfg.authorization_token}"}
 
-        transport = await self._stack.enter_async_context(streamablehttp_client(cfg.url, headers=headers))
+        transport = await self._stack.enter_async_context(
+            streamablehttp_client(cfg.url, headers=headers, httpx_client_factory=_no_redirect_http_client)
+        )
         read, write, _ = transport
         session = await self._stack.enter_async_context(ClientSession(read, write))
         await session.initialize()

--- a/src/gateway/services/mcp_client.py
+++ b/src/gateway/services/mcp_client.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, Any
 import httpx
 from mcp import ClientSession
 from mcp.client.streamable_http import streamablehttp_client
-from mcp.shared._httpx_utils import create_mcp_http_client
 
 from gateway.log_config import logger
 from gateway.services.tool_usage import ToolUsageTally
@@ -47,18 +46,21 @@ def _no_redirect_http_client(
     status such as 307, httpx also re-sends the method and request body to the
     redirect destination.
 
-    Delegates to the SDK for everything else, deliberately. Its timeout defaults
-    are what the managed tool loop has always run with, and narrowing them here
-    would turn this into a behavior change for anyone whose MCP tool is slower
-    than a bound picked for a different purpose.
+    The SDK transport passes its headers, authentication and effective timeout
+    into this factory. Preserving those values keeps the managed tool loop's
+    existing behavior; the fallback matches the SDK's 30-second default for
+    direct callers that omit a timeout.
 
     Following redirects safely means validating each destination before sending
     anything to it. That is a larger change than this, and out of scope: no
     caller needs a redirecting MCP server today.
     """
-    client = create_mcp_http_client(headers, timeout, auth)
-    client.follow_redirects = False
-    return client
+    return httpx.AsyncClient(
+        headers=headers,
+        timeout=timeout if timeout is not None else httpx.Timeout(30.0),
+        auth=auth,
+        follow_redirects=False,
+    )
 
 
 def mcp_tool_to_openai(tool: MCPTool) -> dict[str, Any]:

--- a/src/gateway/services/mcp_client.py
+++ b/src/gateway/services/mcp_client.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
+from functools import partial
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -31,35 +32,46 @@ if TYPE_CHECKING:
     from gateway.models.mcp import McpServerConfig
 
 
-def _no_redirect_http_client(
+def _effective_port(url: httpx.URL) -> int | None:
+    if url.port is not None:
+        return url.port
+    return {"http": 80, "https": 443}.get(url.scheme)
+
+
+def _is_allowed_mcp_redirect(base: httpx.URL, target: httpx.URL) -> bool:
+    same_host = base.host == target.host
+    same_origin = (
+        same_host and base.scheme == target.scheme and _effective_port(base) == _effective_port(target)
+    )
+    https_upgrade = (
+        same_host
+        and base.scheme == "http"
+        and _effective_port(base) == 80
+        and target.scheme == "https"
+        and _effective_port(target) == 443
+    )
+    return same_origin or https_upgrade
+
+
+def _origin_bound_http_client(
+    base_url: str,
     headers: dict[str, str] | None = None,
     timeout: httpx.Timeout | None = None,
     auth: httpx.Auth | None = None,
 ) -> httpx.AsyncClient:
-    """The MCP SDK's own HTTP client, with redirects turned off.
+    """Create an MCP HTTP client that refuses redirects outside the vetted origin."""
+    base = httpx.URL(base_url)
 
-    ``services/url_safety.validate_mcp_url`` vets a server's configured URL
-    before anything connects, refusing private, loopback, link-local and
-    reserved addresses. The SDK's default client sets ``follow_redirects=True``,
-    so a server answering with a redirect had that check bypassed entirely: the
-    redirected request that actually left the process was never vetted. For a
-    status such as 307, httpx also re-sends the method and request body to the
-    redirect destination.
+    async def enforce_origin(request: httpx.Request) -> None:
+        if not _is_allowed_mcp_redirect(base, request.url):
+            raise httpx.RequestError("MCP redirect target is outside the validated origin", request=request)
 
-    The SDK transport passes its headers, authentication and effective timeout
-    into this factory. Preserving those values keeps the managed tool loop's
-    existing behavior; the fallback matches the SDK's 30-second default for
-    direct callers that omit a timeout.
-
-    Following redirects safely means validating each destination before sending
-    anything to it. That is a larger change than this, and out of scope: no
-    caller needs a redirecting MCP server today.
-    """
     return httpx.AsyncClient(
         headers=headers,
         timeout=timeout if timeout is not None else httpx.Timeout(30.0),
         auth=auth,
-        follow_redirects=False,
+        follow_redirects=True,
+        event_hooks={"request": [enforce_origin]},
     )
 
 
@@ -125,7 +137,11 @@ class MCPClientPool:
             headers = {"Authorization": f"Bearer {cfg.authorization_token}"}
 
         transport = await self._stack.enter_async_context(
-            streamablehttp_client(cfg.url, headers=headers, httpx_client_factory=_no_redirect_http_client)
+            streamablehttp_client(
+                cfg.url,
+                headers=headers,
+                httpx_client_factory=partial(_origin_bound_http_client, cfg.url),
+            )
         )
         read, write, _ = transport
         session = await self._stack.enter_async_context(ClientSession(read, write))

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock
 
 import httpx
 import pytest
-from mcp.shared._httpx_utils import create_mcp_http_client
 
 from gateway.models.mcp import McpServerConfig
 from gateway.services.mcp_client import MCPClientPool, _ConnectedServer
@@ -188,13 +187,16 @@ async def test_the_transport_keeps_the_sdk_timeout_defaults(
     async with MCPClientPool([config]):
         pass
 
-    ours = captured["httpx_client_factory"](None, None, None)
-    theirs = create_mcp_http_client(None, None, None)
+    factory = captured["httpx_client_factory"]
+    default_client = factory(None, None, None)
+    transport_timeout = httpx.Timeout(30.0, read=300.0)
+    configured_client = factory(None, transport_timeout, None)
     try:
-        assert ours.timeout == theirs.timeout
+        assert default_client.timeout == httpx.Timeout(30.0)
+        assert configured_client.timeout == transport_timeout
     finally:
-        await ours.aclose()
-        await theirs.aclose()
+        await default_client.aclose()
+        await configured_client.aclose()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -148,39 +148,9 @@ def _capture_transport(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
 
 
 @pytest.mark.asyncio
-async def test_connect_opens_the_transport_with_redirects_disabled(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The SDK's default client follows redirects, and this transport must not.
-
-    ``validate_mcp_url`` vets the configured URL, so a followed redirect is a
-    request that leaves the process having never been vetted. A 307 also
-    replays the MCP request body to the destination.
-    """
-    captured = _capture_transport(monkeypatch)
-    config = McpServerConfig(name="tools", url="https://93.184.216.34/mcp", authorization_token="ghp_token")
-
-    async with MCPClientPool([config]):
-        pass
-
-    factory = captured["httpx_client_factory"]
-    client = factory({"Authorization": "Bearer ghp_token"}, None, None)
-    try:
-        assert client.follow_redirects is False
-    finally:
-        await client.aclose()
-
-
-@pytest.mark.asyncio
 async def test_the_transport_keeps_the_sdk_timeout_defaults(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Only redirects change.
-
-    The managed tool loop serves live completions, so narrowing its timeouts
-    here would turn a security fix into a behavior change for anyone whose MCP
-    tool is slower than the new bound.
-    """
     captured = _capture_transport(monkeypatch)
     config = McpServerConfig(name="tools", url="https://93.184.216.34/mcp")
 
@@ -200,18 +170,63 @@ async def test_the_transport_keeps_the_sdk_timeout_defaults(
 
 
 @pytest.mark.asyncio
-async def test_a_redirect_is_not_followed(
+@pytest.mark.parametrize(
+    ("base_url", "location"),
+    [
+        ("https://93.184.216.34/mcp", "/mcp/"),
+        ("http://93.184.216.34/mcp", "https://93.184.216.34/mcp/"),
+    ],
+)
+async def test_safe_redirect_is_followed(
     monkeypatch: pytest.MonkeyPatch,
+    base_url: str,
+    location: str,
 ) -> None:
-    """The redirect is returned as a response, so nothing is re-sent anywhere."""
     seen: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         seen.append(request)
-        return httpx.Response(307, headers={"location": "http://169.254.169.254/"})
+        if len(seen) == 1:
+            return httpx.Response(307, headers={"location": location})
+        return httpx.Response(200)
 
     captured = _capture_transport(monkeypatch)
-    config = McpServerConfig(name="tools", url="https://93.184.216.34/mcp", authorization_token="ghp_token")
+    config = McpServerConfig(name="tools", url=base_url)
+
+    async with MCPClientPool([config]):
+        pass
+
+    client = captured["httpx_client_factory"](None, None, None)
+    client._transport = httpx.MockTransport(handler)  # noqa: SLF001
+    async with client:
+        response = await client.post(base_url, json={"method": "tools/list"})
+
+    assert response.status_code == 200
+    assert len(seen) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "location",
+    [
+        "http://169.254.169.254/",
+        "http://93.184.216.34/mcp",
+        "https://93.184.216.34:8443/mcp",
+    ],
+)
+async def test_unsafe_redirect_is_blocked_before_sending(
+    monkeypatch: pytest.MonkeyPatch,
+    location: str,
+) -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(307, headers={"location": location})
+
+    base_url = "https://93.184.216.34/mcp"
+    captured = _capture_transport(monkeypatch)
+    config = McpServerConfig(name="tools", url=base_url, authorization_token="ghp_token")
 
     async with MCPClientPool([config]):
         pass
@@ -219,8 +234,8 @@ async def test_a_redirect_is_not_followed(
     client = captured["httpx_client_factory"]({"Authorization": "Bearer ghp_token"}, None, None)
     client._transport = httpx.MockTransport(handler)  # noqa: SLF001
     async with client:
-        response = await client.post("https://93.184.216.34/mcp", json={"method": "tools/list"})
+        with pytest.raises(httpx.RequestError, match="outside the validated origin"):
+            await client.post(base_url, json={"method": "tools/list"})
 
-    assert response.status_code == 307
     assert len(seen) == 1
     assert seen[0].url.host == "93.184.216.34"

--- a/tests/unit/test_mcp_client.py
+++ b/tests/unit/test_mcp_client.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
+from mcp.shared._httpx_utils import create_mcp_http_client
 
 from gateway.models.mcp import McpServerConfig
 from gateway.services.mcp_client import MCPClientPool, _ConnectedServer
@@ -104,3 +107,118 @@ async def test_call_tool_sanitizes_transport_failure(
     assert warnings == [("MCP tool %s execution failed: %s", "lookup", "RuntimeError")]
     assert "internal.test" not in str(warnings)
     assert "secret" not in str(warnings)
+
+
+# --------------------------------------------------------------------------- #
+# Transport safety
+# --------------------------------------------------------------------------- #
+
+
+class _FakeSession:
+    """Enough of a ``ClientSession`` for ``_connect`` to finish."""
+
+    def __init__(self, *args: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> _FakeSession:
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    async def initialize(self) -> None:
+        return None
+
+    async def list_tools(self) -> SimpleNamespace:
+        return SimpleNamespace(tools=[])
+
+
+def _capture_transport(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Substitute the MCP transport and record the kwargs the pool opens it with."""
+    captured: dict[str, Any] = {}
+
+    @asynccontextmanager
+    async def fake_transport(url: str, **kwargs: Any) -> Any:
+        captured["url"] = url
+        captured.update(kwargs)
+        yield (None, None, None)
+
+    monkeypatch.setattr("gateway.services.mcp_client.streamablehttp_client", fake_transport)
+    monkeypatch.setattr("gateway.services.mcp_client.ClientSession", _FakeSession)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_connect_opens_the_transport_with_redirects_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The SDK's default client follows redirects, and this transport must not.
+
+    ``validate_mcp_url`` vets the configured URL, so a followed redirect is a
+    request that leaves the process having never been vetted. A 307 also
+    replays the MCP request body to the destination.
+    """
+    captured = _capture_transport(monkeypatch)
+    config = McpServerConfig(name="tools", url="https://93.184.216.34/mcp", authorization_token="ghp_token")
+
+    async with MCPClientPool([config]):
+        pass
+
+    factory = captured["httpx_client_factory"]
+    client = factory({"Authorization": "Bearer ghp_token"}, None, None)
+    try:
+        assert client.follow_redirects is False
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_the_transport_keeps_the_sdk_timeout_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only redirects change.
+
+    The managed tool loop serves live completions, so narrowing its timeouts
+    here would turn a security fix into a behavior change for anyone whose MCP
+    tool is slower than the new bound.
+    """
+    captured = _capture_transport(monkeypatch)
+    config = McpServerConfig(name="tools", url="https://93.184.216.34/mcp")
+
+    async with MCPClientPool([config]):
+        pass
+
+    ours = captured["httpx_client_factory"](None, None, None)
+    theirs = create_mcp_http_client(None, None, None)
+    try:
+        assert ours.timeout == theirs.timeout
+    finally:
+        await ours.aclose()
+        await theirs.aclose()
+
+
+@pytest.mark.asyncio
+async def test_a_redirect_is_not_followed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The redirect is returned as a response, so nothing is re-sent anywhere."""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(307, headers={"location": "http://169.254.169.254/"})
+
+    captured = _capture_transport(monkeypatch)
+    config = McpServerConfig(name="tools", url="https://93.184.216.34/mcp", authorization_token="ghp_token")
+
+    async with MCPClientPool([config]):
+        pass
+
+    client = captured["httpx_client_factory"]({"Authorization": "Bearer ghp_token"}, None, None)
+    client._transport = httpx.MockTransport(handler)  # noqa: SLF001
+    async with client:
+        response = await client.post("https://93.184.216.34/mcp", json={"method": "tools/list"})
+
+    assert response.status_code == 307
+    assert len(seen) == 1
+    assert seen[0].url.host == "93.184.216.34"


### PR DESCRIPTION
## Description

Restricts managed MCP redirects to the validated origin or a same-host HTTP-to-HTTPS upgrade, preventing requests to unvalidated hosts while preserving common endpoint canonicalization. Adds regression coverage and documents the constraint.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 5 and OpenAI Codex GPT-5.6 Sol

**Any additional AI details you'd like to share:** Implemented and verified under user direction.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

