### PR TITLE
fix(auth): default oauth providers to empty array so sign-in survives an older gateway

### DIFF
--- a/web/src/features/auth/oauthProviders.ts
+++ b/web/src/features/auth/oauthProviders.ts
@@ -55,7 +55,7 @@ export function isOAuthProvider(value: string): value is OAuthProvider {
 
 /** The providers from a bootstrap that this dashboard can render, in its order. */
 export function renderableOAuthProviders(
-  configured: readonly string[],
+  configured: readonly string[] = [],
 ): OAuthProvider[] {
   return configured.filter(isOAuthProvider)
 }


### PR DESCRIPTION
## Description
`renderableOAuthProviders` now defaults its `configured` parameter to an empty array, so a gateway whose `/v1/bootstrap` omits `oauth_providers` no longer throws in `.filter()` and white-screens the sign-in page.

## PR Type
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
Fixes #806

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change.
- [ ] I ran the Definition of Done checks locally.
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec.

## AI Usage
- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude

- [x] I am an AI Agent filling out this form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Default `renderableOAuthProviders` to an empty list when `oauth_providers` is missing.
- Prevent the sign-in page from failing during rendering with older gateways.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->