### PR TITLE
fix(a11y): stop sidebar nav disclosures from emitting document headings

### DIFF
--- a/web/src/app/AppShell.tsx
+++ b/web/src/app/AppShell.tsx
@@ -325,7 +325,13 @@ function NavGroup({
       onExpandedChange={setOpen}
       className={clsx("flex flex-col", open && "gap-0.5")}
     >
-      <Disclosure.Heading>
+      {/* A plain wrapper rather than `Disclosure.Heading`: HeroUI renders that
+          as an <h3>, which put every group's label ("Routing", "Tools") into the
+          document outline of every page, so a screen-reader user navigating by
+          heading landed on nav chrome between a page's own sections. The toggle
+          is the `Disclosure.Trigger` button below, which carries its own
+          `aria-expanded` and needs no heading role to work. */}
+      <div>
         {/* `ancestor`, not `isActive`: the selected row is the child below,
               which is visible whenever this trigger is expanded. The collapsed
               rail's trigger a few lines up keeps the full selected marker,
@@ -340,7 +346,7 @@ function NavGroup({
             className={navIndicatorClass({ open })}
           />
         </Disclosure.Trigger>
-      </Disclosure.Heading>
+      </div>
       {/* The rows sit straight in the panel rather than in a `Disclosure.Body`,
           which wraps its children in a div carrying 0.5rem of padding that no
           className can reach: it would inset these rows from the lane their


### PR DESCRIPTION
## Description
The sidebar `NavGroup` disclosure toggles rendered via `Disclosure.Heading` (an `<h3>`), putting "Routing" and "Tools" into every page's document outline; this swaps that wrapper for a plain `<div>` so the labels leave the outline while the `Disclosure.Trigger` button keeps the toggle working.

## PR Type
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues
Fixes #808

## Checklist
- [x] I understand the code I am submitting.
- [ ] I have added or updated tests that cover my change.
- [ ] I ran the Definition of Done checks locally.
- [ ] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec.

## AI Usage
- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude

- [x] I am an AI Agent filling out this form


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Replaced the sidebar group heading wrapper with a neutral container. `Routing` and `Tools` no longer appear in page heading outlines, while their expand and collapse controls continue to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->