### PR TITLE
fix(dashboard): correct two sidebar defects and inline the record copy control

### DIFF
--- a/.github/instructions/frontend-standards.instructions.md
+++ b/.github/instructions/frontend-standards.instructions.md
@@ -25,9 +25,13 @@ full guidance, with worked examples grounded in this dashboard's code, lives in 
    classes the call site names itself, so `cursor-pointer` on a bare `<button>` is correct
    rather than a finding. Then four ways to change how it looks, in order: a variable (ours
    as a token, or one of HeroUI's own aliased onto ours;
-   `--radius` drives its whole radius ramp, and `--cursor-interactive`, `--disabled-opacity`
-   and the rest are in `@heroui/styles/dist/themes/`, none of them aliased in `globals.css`
-   yet, and the alias goes there rather than into a class string of ours), a shared utility
+   `--radius` drives its whole radius ramp, and it, `--disabled-opacity` and
+   `--field-border-width` are the three HeroUI variables `globals.css` already declares.
+   `--cursor-interactive`, `--ring-offset-width`, the `--scrollbar-*` family and the rest
+   are still only in `@heroui/styles/dist/themes/`, and an alias for one of those goes into
+   `globals.css` rather than into a class string of ours. Our variable block is unlayered
+   and has to stay that way: `@heroui/styles` declares many of the same names from inside
+   `@layer`, and an unlayered declaration is what outranks a layered one), a shared utility
    once the look repeats, the component's own prop (`variant`, `size`, `isDisabled`,
    `isPending`, `fullWidth`, `isInvalid`), and only then a rule against HeroUI's
    own classes under the `.otari-*` namespace. HeroUI and Tailwind both permit that last one and

--- a/.github/skills/frontend-standards/design-tokens.md
+++ b/.github/skills/frontend-standards/design-tokens.md
@@ -172,8 +172,12 @@ share is the rule that matters: the value lives in one named place, and a compon
 Never a hex, never a numbered Tailwind palette class, never `bg-white`, because those three do
 not adapt and nothing downstream can make them.
 
-The ones we have not aliased are a gap rather than a decision, and the gap decides how
-much work a visual fix is. A value
+The ones we have not aliased are a gap rather than a decision **where
+`@heroui/styles` still declares and reads them**, and the gap decides how much work a
+visual fix is. Not every unaliased name is one: `globals.css:361` records that upstream's
+`--content1` through `--content4` are deliberately left out because HeroUI v3 neither
+declares nor reads them, so aliasing those would restore four inert lines. Check that a
+variable is live upstream before treating its absence here as a gap. A value
 computed from a variable is one alias away from being ours; the same value chased through the
 rules that read it is a selector to keep in sync with somebody else's internals, forever. A
 table whose body corners are drawn at `min(32px, var(--radius-2xl))`, which is 16px, inside a

--- a/.github/skills/frontend-standards/design-tokens.md
+++ b/.github/skills/frontend-standards/design-tokens.md
@@ -140,9 +140,28 @@ through `--radius-4xl` calculated from it in `dist/themes/shared/theme.css`, so 
 is `calc(var(--radius) * 2)`), `--field-radius`, `--spacing`, `--border-width`,
 `--field-border-width`, `--ring-offset-width`, `--disabled-opacity`, `--cursor-interactive` /
 `--cursor-disabled` and the `--scrollbar-*` family, all declared in
-`dist/themes/default/variables.css`. This repo aliases none of them, so a component's corner
-radius, its disabled dimming and its pointer all come from HeroUI's defaults rather than from
-anything we name.
+`dist/themes/default/variables.css`. This repo declares three of them, all in `globals.css`:
+`--radius` (`0px`, the square corners), `--disabled-opacity` (`0.4`) and `--field-border-width`
+(`1px`, once per theme block). The rest are not aliased, so a component's pointer, its ring
+offset and its scrollbars still come from HeroUI's defaults rather than from anything we name.
+
+**Our variable block must stay unlayered.**
+
+`@heroui/styles` declares many of the same variables we do, from inside `@layer`. Ours are
+declared in a bare `:root` at the end of `globals.css`, and being unlayered is what makes them
+win: an unlayered declaration outranks a layered one regardless of source order, so it is not
+position in the file that is holding this up. Wrap the theme blocks in `@layer` and `--radius`
+goes from `0px` to `8px` (every corner in the app rounds), the weight ladder shifts up a step
+(`medium` 400 to 500, `semibold` 550 to 600, `bold` 600 to 700), the four `--shadow-*` tokens
+stop being `none` so elevation returns on top of the hairline edges that replaced it,
+`--tracking-tight` doubles, and the 12px and 18px line-heights move by 2px each way. The font
+sizes are the trap: `--text-xs` and `--text-sm` revert to `.75rem` and `.875rem`, which compute
+to the same 12px and 14px at our 16px root, so the sizes hold and only the leading around them
+moves. Nothing fails either way: Ruff is silent, the dashboard builds, `foundation.test.ts`
+passes, and the only place the change is visible is the screen.
+
+`--spacing` is the one variable in that set we deliberately do not override; the 4px step is
+Tailwind's own.
 
 **Only the color half belongs in both theme blocks.** A color token is declared twice because
 its whole job is to hold a light value and a dark one, which is what lets a component adapt
@@ -153,7 +172,8 @@ share is the rule that matters: the value lives in one named place, and a compon
 Never a hex, never a numbered Tailwind palette class, never `bg-white`, because those three do
 not adapt and nothing downstream can make them.
 
-That is a gap rather than a decision, and it decides how much work a visual fix is. A value
+The ones we have not aliased are a gap rather than a decision, and the gap decides how
+much work a visual fix is. A value
 computed from a variable is one alias away from being ours; the same value chased through the
 rules that read it is a selector to keep in sync with somebody else's internals, forever. A
 table whose body corners are drawn at `min(32px, var(--radius-2xl))`, which is 16px, inside a

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -175,8 +175,11 @@ review output until the suite becomes a pull-request gate.
 
 ## Measuring the running dashboard
 
-Three ways a probe reports a real number that answers the wrong question. Each
-has produced a wrong finding here more than once, and none of them errors.
+Ways a probe reports a real number that answers the wrong question. Each has
+produced a wrong finding here more than once, and none of them errors. Left
+uncounted deliberately: the sentence said "three" while eight followed it,
+because a total in the prose has to be edited by every later addition and was
+not.
 
 **Check which bundle the tab is on first.** A gateway serves the last bundle
 built into `src/gateway/static/dashboard/`, and a browser tab holds the one it
@@ -227,6 +230,13 @@ nothing. Reproduced on a two-file project: a real `TS2322` is reported alone and
 disappears entirely once one unresolved file is added. Resolve the last conflict
 before believing a typecheck, and treat lint and per-file test runs as the only
 checks that hold before that.
+
+**A bare `tsc --noEmit` checks nothing.** The root `tsconfig.json` is
+`{"files": [], "references": [...]}`, so invoking `tsc` without `-b` resolves a
+config that owns no files and exits clean over a tree the real typecheck rejects,
+test files included. Use the command in Checks above. The tell that found this:
+an `@ts-expect-error` whose error had been deliberately removed still reported
+success, where `pnpm --dir web run typecheck` reports `TS2578`.
 
 **And absence from the built CSS proves nothing on its own.** Tailwind emits
 only the utilities something in the tree asks for, so checking whether a

--- a/web/src/app/AppShell.test.tsx
+++ b/web/src/app/AppShell.test.tsx
@@ -484,6 +484,40 @@ describe("AppShell responsive layout", () => {
   })
 })
 
+describe("the rail's closing rules", () => {
+  // The footer block and the closing band each draw a rule. Between them sits
+  // one row, the way onto the organization rail, and on that rail it is gated
+  // out: the two rules then land 4px apart and read as a single doubled
+  // hairline, which is what a reader reported. The band's rule is the
+  // unconditional one, mirroring the scope band at the head of the rail, so the
+  // footer's is the one that gives way.
+  const footerOf = (container: HTMLElement) =>
+    container.querySelector('[class*="pb-[env(safe-area-inset-bottom)]"]')
+
+  it("keeps the footer rule where a row sits below it", async () => {
+    mockMatchMedia(false)
+    const { container } = await renderShell(bootstrap(), { url: "/" })
+
+    expect(
+      await screen.findByRole("link", { name: "Organization" }),
+    ).toBeInTheDocument()
+    expect(footerOf(container)).toHaveClass("border-t")
+  })
+
+  it("drops it on the organization rail, where that row is gone", async () => {
+    mockMatchMedia(false)
+    const { container } = await renderShell(bootstrap(), {
+      url: "/organization/members",
+    })
+
+    expect(
+      await screen.findByRole("link", { name: /^Back to/ }),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: "Organization" })).toBeNull()
+    expect(footerOf(container)).not.toHaveClass("border-t")
+  })
+})
+
 describe("AppShell surface gating", () => {
   afterEach(() => {
     vi.restoreAllMocks()

--- a/web/src/app/AppShell.tsx
+++ b/web/src/app/AppShell.tsx
@@ -526,6 +526,12 @@ function AppShellChrome() {
   // where the drawer can be one level down inside the organization rail while
   // the page behind it is still a workspace page.
   const showOrganizationRail = inOrganization || (isMobile && mobileOrgNavOpen)
+  // Whether the footer holds a row above its closing band. The organization row
+  // is the only one left in there, so when it is gated out the footer's own rule
+  // and the band's rule land 4px apart and read as one doubled hairline. The
+  // band's rule is the unconditional one (it mirrors the scope band at the top
+  // of the rail), so it is the footer's that gives way.
+  const footerHasRowAboveBand = !showOrganizationRail && managesOrganization
   // Filtered before it is indexed, so the divider and top margin below key off
   // the first *rendered* section rather than the first registered one.
   const visibleSections = visibleNavSections(
@@ -869,7 +875,11 @@ function AppShellChrome() {
               right border, while the rows inside keep the rail's padding. A
               divider that stops short of the edge reads as a box's top border
               rather than as a division of the rail. */}
-            <div className="-mx-3 flex flex-col gap-1 border-t border-border px-3 pt-1 pb-[env(safe-area-inset-bottom)]">
+            <div
+              className={`-mx-3 flex flex-col gap-1 px-3 pt-1 pb-[env(safe-area-inset-bottom)] ${
+                footerHasRowAboveBand ? "border-t border-border" : ""
+              }`}
+            >
               {/* The way into the organization rail. Only in the workspace
                 context, since the organization one has its own way back, and
                 only for someone who manages the organization: it is the single
@@ -894,7 +904,7 @@ function AppShellChrome() {
                 and a destination in it is what dismisses the drawer. That is
                 also what earns the trailing chevron back: it promises a submenu
                 only where one now opens. */}
-              {!showOrganizationRail && managesOrganization ? (
+              {footerHasRowAboveBand ? (
                 isMobile ? (
                   // `cursor-pointer` because a bare button resolves to the default
                   // arrow, which is the one thing `navRowClass` leaves to its call

--- a/web/src/app/nav/AccountMenu.tsx
+++ b/web/src/app/nav/AccountMenu.tsx
@@ -303,9 +303,16 @@ export function AccountMenu({ collapsed }: { collapsed: boolean }) {
         // place it could reach anybody there. `AppearanceControl` folds its own
         // visible state in for the same reason.
         aria-label={`Account: ${identity.name}`}
-        className={`${navRowClass({ collapsed, band: true })} justify-start`}
+        // `expandedJustify` rather than a `justify-start` appended here: this is
+        // a HeroUI `Button`, which arrives centered, and the collapsed rail
+        // wants the monogram in the icon column instead.
+        className={navRowClass({
+          collapsed,
+          band: true,
+          expandedJustify: "start",
+        })}
       >
-        <span className="flex h-[1.625rem] w-[1.625rem] shrink-0 items-center justify-center border border-control-border bg-surface-alt text-chrome-initials font-semibold text-muted">
+        <span className="flex h-[1.625rem] w-[1.625rem] shrink-0 items-center justify-center border border-control-border bg-surface-alt text-shell-monogram font-semibold text-muted">
           {identity.initials}
         </span>
         {collapsed ? null : (

--- a/web/src/app/nav/rowStyles.test.ts
+++ b/web/src/app/nav/rowStyles.test.ts
@@ -131,6 +131,30 @@ describe("navRowClass", () => {
     }
   })
 
+  describe("expandedJustify", () => {
+    it("start-aligns an expanded row that asks for it", () => {
+      expect(navRowClass({ expandedJustify: "start" })).toContain(
+        "justify-start",
+      )
+    })
+
+    it("still centers that row when the rail is collapsed", () => {
+      // The collapsed icon column outranks the request: a monogram or icon sits
+      // in the same lane as every other collapsed row.
+      const collapsed = navRowClass({
+        collapsed: true,
+        expandedJustify: "start",
+      })
+      expect(collapsed).toContain("justify-center")
+      expect(collapsed).not.toContain("justify-start")
+    })
+
+    it("adds no justification when it is left unset", () => {
+      expect(navRowClass()).not.toContain("justify-")
+      expect(navRowClass({ band: true })).not.toContain("justify-")
+    })
+  })
+
   it("keeps the 44px floor and the shared shape on every variant", () => {
     for (const row of [
       resting,

--- a/web/src/app/nav/rowStyles.ts
+++ b/web/src/app/nav/rowStyles.ts
@@ -231,6 +231,7 @@ export function navRowClass({
   collapsed = false,
   nested = false,
   band = false,
+  expandedJustify,
 }: {
   isActive?: boolean
   /** This row is the group holding the selected row, not the selected row. */
@@ -239,12 +240,30 @@ export function navRowClass({
   nested?: boolean
   /** This row is the whole of a chrome band rather than one row in a list. */
   band?: boolean
+  /**
+   * How the row's contents sit along its main axis while the rail is expanded.
+   * Collapsed rows are always centered, so the icon column holds whether or not
+   * a row asks for anything here.
+   *
+   * Only a row whose element arrives already centered needs it: HeroUI's
+   * `Button` carries `justify-content: center`, so the account control's name
+   * and chevron would sit mid-rail without `"start"`. Left unset the row adds
+   * no justification of its own, which is what every plain link and button in
+   * the rail wants. Asking at the helper rather than appending a utility at the
+   * call site is deliberate: both land on the element, and the later-emitted one
+   * wins regardless of the order they are written in.
+   */
+  expandedJustify?: "start"
 } = {}): string {
   return [
     ROW_BASE,
     isActive ? ROW_SELECTED : ancestor ? ROW_ANCESTOR : ROW_RESTING,
     nested ? "pl-[3.125rem]" : "",
-    collapsed ? "min-w-11 justify-center" : "",
+    collapsed
+      ? "min-w-11 justify-center"
+      : expandedJustify === "start"
+        ? "justify-start"
+        : "",
     band ? navBandRowClass({ collapsed }) : collapsed ? "px-0" : "px-3",
   ]
     .filter(Boolean)

--- a/web/src/features/organization/OrganizationDomainsPage.tsx
+++ b/web/src/features/organization/OrganizationDomainsPage.tsx
@@ -166,19 +166,23 @@ function PendingProof({ row }: { row: OrganizationDomain }) {
         </p>
       </div>
       <ErrorBanner error={verify.error} />
+      {/* The verify action sits in the field's row rather than under it: the
+          record is one line an operator copies and then acts on, so the copy
+          affordance moved inside the field and the button it hands off to is
+          beside it. */}
       <CopyField
         label={`TXT record for ${row.domain}`}
         value={row.verification_record}
+        action={
+          <Button
+            variant="primary"
+            isPending={verify.isPending}
+            onPress={() => verify.mutate(row.id)}
+          >
+            {expired ? "Re-verify domain" : "Verify domain"}
+          </Button>
+        }
       />
-      <div>
-        <Button
-          variant="primary"
-          isPending={verify.isPending}
-          onPress={() => verify.mutate(row.id)}
-        >
-          {expired ? "Re-verify domain" : "Verify domain"}
-        </Button>
-      </div>
     </Section>
   )
 }

--- a/web/src/shared/components/actions/CopyButton.test.tsx
+++ b/web/src/shared/components/actions/CopyButton.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { useRef } from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { CopyButton } from "@/shared/components/actions/CopyButton"
 
@@ -117,5 +118,60 @@ describe("CopyButton", () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it("selects a field it was given only after a failed attempt", async () => {
+    const user = userEvent.setup()
+    // Both paths refused: the async API throws, and the legacy fallback fails on
+    // its own because jsdom defines no `document.execCommand`. The attempt is
+    // recorded so the ordering can be asserted, not just the end state.
+    const order: string[] = []
+    vi.spyOn(navigator.clipboard, "writeText").mockImplementation(() => {
+      order.push("attempt")
+      return Promise.reject(new Error("not a secure context"))
+    })
+
+    function Harness() {
+      const ref = useRef<HTMLInputElement | null>(null)
+      return (
+        <>
+          <input ref={ref} readOnly defaultValue="otari-verify=abc" />
+          <CopyButton
+            value="otari-verify=abc"
+            label="TXT record"
+            selectOnFailure={ref}
+          />
+        </>
+      )
+    }
+    render(<Harness />)
+    const field = screen.getByDisplayValue(
+      "otari-verify=abc",
+    ) as HTMLInputElement
+    field.addEventListener("focus", () => order.push("focus"))
+
+    await user.click(screen.getByRole("button", { name: "Copy TXT record" }))
+
+    await waitFor(() => expect(document.activeElement).toBe(field))
+    expect(field.selectionStart).toBe(0)
+    expect(field.selectionEnd).toBe("otari-verify=abc".length)
+    // The order is the point: the legacy path restores the selection and focus
+    // it found on its way out, so selecting before the attempt is undone by it.
+    expect(order).toEqual(["attempt", "focus"])
+  })
+
+  it("leaves focus alone when no field was given", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockRejectedValue(
+      new Error("not a secure context"),
+    )
+    render(<CopyButton value="openai:gpt-4o" label="model id" />)
+    const button = screen.getByRole("button", { name: "Copy model id" })
+
+    await user.click(button)
+    await screen.findByText(/Copy blocked/)
+
+    // The default: a table cell has no field to select, so nothing is moved.
+    expect(document.activeElement).toBe(button)
   })
 })

--- a/web/src/shared/components/actions/CopyButton.tsx
+++ b/web/src/shared/components/actions/CopyButton.tsx
@@ -17,7 +17,22 @@ import { copyToClipboard } from "@/shared/helpers/clipboard"
 // controlled (never hover-opened) because it reports an event, not a hint, and it
 // renders in an overlay so it is not clipped by the table's scroll container and
 // does not reflow the row it reports on.
-export function CopyButton({ value, label }: { value: string; label: string }) {
+export function CopyButton({
+  value,
+  label,
+  selectOnFailure,
+}: {
+  value: string
+  label: string
+  /**
+   * A field to focus and select if the copy fails, so the operator can reach
+   * Ctrl/Cmd-C without hunting for the value. Off by default: a table cell has
+   * no field to select, which is the majority of this button's call sites.
+   */
+  selectOnFailure?: React.RefObject<
+    HTMLInputElement | HTMLTextAreaElement | null
+  >
+}) {
   const [state, setState] = useState<"idle" | "copied" | "failed">("idle")
   const resetTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
@@ -27,6 +42,13 @@ export function CopyButton({ value, label }: { value: string; label: string }) {
 
   const copy = async () => {
     const copied = await copyToClipboard(value)
+    if (!copied) {
+      // After the attempt, never before it: `copyToClipboard`'s legacy path
+      // restores the selection and focus it found on the way out, so a
+      // selection made first is undone by the very fallback this exists for.
+      selectOnFailure?.current?.focus()
+      selectOnFailure?.current?.select()
+    }
     setState(copied ? "copied" : "failed")
     clearTimeout(resetTimer.current)
     // A failure has something to read and act on, so it lingers longer.

--- a/web/src/shared/components/actions/CopyField.test.tsx
+++ b/web/src/shared/components/actions/CopyField.test.tsx
@@ -1,7 +1,180 @@
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { describe, expect, it, vi } from "vitest"
-import { CopyableValue } from "@/shared/components/actions/CopyField"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { CopyableValue, CopyField } from "@/shared/components/actions/CopyField"
+
+describe("CopyField", () => {
+  // Scoped like CopyButton's above: the failure case spies on
+  // `navigator.clipboard`, and without this it would leak into the describes
+  // that follow.
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // Written against the arrangement that shipped before the in-field control
+  // existed, so it is a regression guard for the six call sites that keep it
+  // rather than a description of the newer branch.
+  it("keeps the Copy button in the label row by default", () => {
+    render(<CopyField label="Secret key" value="sk-test-000" />)
+
+    const field = screen.getByLabelText("Secret key")
+    expect(field.tagName).toBe("INPUT")
+    expect(field).toHaveAttribute("readonly")
+    // The default arrangement's button is the field's sibling in the label row,
+    // named by its own text, and there is no control inside the field.
+    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Copy Secret key" }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders the multiline variant as a textarea", () => {
+    render(<CopyField label="curl" value={"line one\nline two"} multiline />)
+
+    const field = screen.getByLabelText("curl")
+    expect(field.tagName).toBe("TEXTAREA")
+    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument()
+  })
+
+  it("moves the copy affordance into the field when given an action", () => {
+    render(
+      <CopyField
+        label="TXT record for example.com"
+        value="otari-verify=abc"
+        action={<button type="button">Verify domain</button>}
+      />,
+    )
+
+    const field = screen.getByLabelText("TXT record for example.com")
+    expect(field.tagName).toBe("INPUT")
+    expect(field).toHaveAttribute("readonly")
+    // The label row's button is gone, and the control inside the field is named
+    // by the label rather than by bare text, so a screen reader hears which
+    // field it copies.
+    expect(
+      screen.queryByRole("button", { name: "Copy" }),
+    ).not.toBeInTheDocument()
+    const copy = screen.getByRole("button", {
+      name: "Copy TXT record for example.com",
+    })
+    // The control is inside the field's wrapper; the action is its sibling.
+    expect(copy.closest("div")).toContainElement(field)
+    expect(
+      screen.getByRole("button", { name: "Verify domain" }),
+    ).toBeInTheDocument()
+  })
+
+  it("keeps the confirmation out of the row, so the action cannot shift", async () => {
+    const user = userEvent.setup()
+    const { container } = render(
+      <CopyField
+        label="TXT record for example.com"
+        value="otari-verify=abc"
+        action={<button type="button">Verify domain</button>}
+      />,
+    )
+    // `sr-only` is clipped and out of flow, so it is not part of what the row
+    // lays out. Everything else here would be, including a confirmation line.
+    const laidOut = () => {
+      const clone = container.cloneNode(true) as HTMLElement
+      for (const node of clone.querySelectorAll(".sr-only")) node.remove()
+      return clone.textContent
+    }
+    const before = laidOut()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Copy TXT record for example.com",
+      }),
+    )
+    await screen.findByText("Copied!")
+
+    // The acknowledgement is an overlay, so the Verify button does not move.
+    expect(laidOut()).toBe(before)
+  })
+
+  it("selects the value when a copy fails, so Ctrl/Cmd-C still works", async () => {
+    const user = userEvent.setup()
+    // Both clipboard paths refused, which is the case this fallback exists for.
+    // The async API is made to throw; the legacy path then fails on its own,
+    // because jsdom defines no `document.execCommand` and `legacyCopy` reports
+    // false when the call throws. That is what the existing "announces a
+    // blocked copy" case above relies on too.
+    vi.spyOn(navigator.clipboard, "writeText").mockRejectedValue(
+      new Error("not a secure context"),
+    )
+    render(
+      <CopyField
+        label="TXT record for example.com"
+        value="otari-verify=abc"
+        action={<button type="button">Verify domain</button>}
+      />,
+    )
+    const field = screen.getByLabelText(
+      "TXT record for example.com",
+    ) as HTMLInputElement
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Copy TXT record for example.com",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(field)
+      expect(field.selectionStart).toBe(0)
+      expect(field.selectionEnd).toBe("otari-verify=abc".length)
+    })
+  })
+
+  it("selects only after the copy attempt, not before it", async () => {
+    const user = userEvent.setup()
+    // The order is the thing under test, not just the end state. The legacy
+    // fallback restores the selection and focus it found on its way out, so a
+    // selection made before the attempt is undone by the fallback itself. That
+    // does not reproduce in jsdom (there is no `execCommand` for the fallback
+    // to get that far), so the end state alone passes either way and the
+    // sequence has to be asserted directly.
+    const order: string[] = []
+    vi.spyOn(navigator.clipboard, "writeText").mockImplementation(() => {
+      order.push("attempt")
+      return Promise.reject(new Error("not a secure context"))
+    })
+    render(
+      <CopyField
+        label="TXT record for example.com"
+        value="otari-verify=abc"
+        action={<button type="button">Verify domain</button>}
+      />,
+    )
+    const field = screen.getByLabelText("TXT record for example.com")
+    field.addEventListener("focus", () => order.push("focus"))
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Copy TXT record for example.com",
+      }),
+    )
+
+    await waitFor(() => expect(order).toContain("focus"))
+    expect(order).toEqual(["attempt", "focus"])
+  })
+
+  it("rejects an action on the multiline variant at the type level", () => {
+    render(
+      // @ts-expect-error a textarea's right padding indents every line, so the
+      // in-field arrangement is not available to the multiline variant. The
+      // union rejects the pair at the element, which is where the error lands.
+      <CopyField
+        label="curl"
+        value="one"
+        multiline
+        action={<button type="button">Verify domain</button>}
+      />,
+    )
+    expect(screen.getByLabelText("curl")).toBeInTheDocument()
+  })
+})
 
 describe("CopyableValue", () => {
   it("copies the value, which need not be what is displayed", async () => {

--- a/web/src/shared/components/actions/CopyField.test.tsx
+++ b/web/src/shared/components/actions/CopyField.test.tsx
@@ -160,6 +160,23 @@ describe("CopyField", () => {
     expect(order).toEqual(["attempt", "focus"])
   })
 
+  it("rejects a falsy action at the type level", () => {
+    // `ReactNode` admitted `false`, so `action={enabled && <Button />}`
+    // compiled and then fell back to the default arrangement through
+    // `if (action)`. `ReactElement` rejects it where it is written.
+    const enabled = false
+    render(
+      <CopyField
+        label="TXT record"
+        value="otari-verify=abc"
+        // @ts-expect-error a conditional action is a falsy action, which would
+        // silently render the label-row button and the clipboard-only path.
+        action={enabled && <button type="button">Verify</button>}
+      />,
+    )
+    expect(screen.getByLabelText("TXT record")).toBeInTheDocument()
+  })
+
   it("rejects an action on the multiline variant at the type level", () => {
     render(
       // @ts-expect-error a textarea's right padding indents every line, so the

--- a/web/src/shared/components/actions/CopyField.tsx
+++ b/web/src/shared/components/actions/CopyField.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@heroui/react"
-import type { ReactNode } from "react"
+import type { ReactElement, ReactNode } from "react"
 import { useEffect, useId, useRef, useState } from "react"
 import { CopyButton } from "@/shared/components/actions/CopyButton"
 
@@ -89,8 +89,12 @@ type CopyFieldProps = {
        * A control to sit beside the field, which moves the copy affordance
        * inside the field and drops the button from the label row. Absent, the
        * field renders the arrangement it always has.
+       *
+       * `ReactElement` rather than `ReactNode`: the latter admits `false`, so
+       * `action={enabled && <Button />}` compiled and then silently fell back
+       * to the default arrangement, which is the one this exists to replace.
        */
-      action: ReactNode
+      action: ReactElement
     }
 )
 
@@ -140,7 +144,7 @@ export function CopyField({
   const shared =
     "w-full rounded-lg border border-border bg-surface-alt px-3 py-2 font-mono text-xs text-foreground"
 
-  if (action) {
+  if (action !== undefined) {
     return (
       <div className="flex flex-col gap-1">
         {/* The label keeps its own row and stays a real `<label>`: it is what

--- a/web/src/shared/components/actions/CopyField.tsx
+++ b/web/src/shared/components/actions/CopyField.tsx
@@ -68,17 +68,39 @@ export function CopyableValue({
 // values are handed over in pairs and threes (a key and two snippets), so
 // "which field is this" has to be answerable by a screen reader and by a test
 // that queries the way an operator reads.
+type CopyFieldProps = {
+  label: string
+  value: string
+  fieldRef?: React.RefObject<HTMLInputElement | HTMLTextAreaElement | null>
+} & (
+  | {
+      multiline?: boolean
+      /**
+       * Excluded here rather than guarded at runtime, so a call site that passes
+       * both fails to compile. The multiline field is a `<textarea>`, where the
+       * right padding an in-field control needs indents every line instead of
+       * making room on the first, which is a different design.
+       */
+      action?: never
+    }
+  | {
+      multiline?: false
+      /**
+       * A control to sit beside the field, which moves the copy affordance
+       * inside the field and drops the button from the label row. Absent, the
+       * field renders the arrangement it always has.
+       */
+      action: ReactNode
+    }
+)
+
 export function CopyField({
   label,
   value,
   multiline = false,
   fieldRef,
-}: {
-  label: string
-  value: string
-  multiline?: boolean
-  fieldRef?: React.RefObject<HTMLInputElement | HTMLTextAreaElement | null>
-}) {
+  action,
+}: CopyFieldProps) {
   const internalRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(
     null,
   )
@@ -117,6 +139,47 @@ export function CopyField({
 
   const shared =
     "w-full rounded-lg border border-border bg-surface-alt px-3 py-2 font-mono text-xs text-foreground"
+
+  if (action) {
+    return (
+      <div className="flex flex-col gap-1">
+        {/* The label keeps its own row and stays a real `<label>`: it is what
+            names the in-field control to a screen reader ("Copy TXT record for
+            example.com"), not just a caption over the value. */}
+        <label htmlFor={fieldId} className="text-caption">
+          {label}
+        </label>
+        {/* Wraps below `xl`, where 757px of content does not fit beside the
+            rail, so `action` drops to its own line rather than squeezing the
+            field below the width the whole record needs. */}
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="relative w-full xl:w-[37.5rem] xl:shrink-0">
+            <input
+              id={fieldId}
+              ref={ref as React.RefObject<HTMLInputElement>}
+              readOnly
+              value={value}
+              onFocus={(e) => e.currentTarget.select()}
+              // Right padding clears the control rather than the value running
+              // under it, and the field grows below `md` so the 44px touch
+              // floor fits between its borders. The value is never truncated:
+              // it scrolls inside the input and stays wholly selectable.
+              className={`${shared} min-h-[2.875rem] pr-14 md:min-h-0 md:pr-11`}
+            />
+            {/* `CopyButton` rather than this component's own button: it falls
+                back to `execCommand`, so it actually copies on the plain-HTTP
+                origins where the async Clipboard API does not exist. It owns the
+                acknowledgement too, which is why the field's own `aria-live`
+                line and select hint are absent from this arrangement. */}
+            <span className="absolute top-1/2 right-1 -translate-y-1/2">
+              <CopyButton value={value} label={label} selectOnFailure={ref} />
+            </span>
+          </div>
+          {action}
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="flex flex-col gap-1">

--- a/web/src/styles/foundation.test.ts
+++ b/web/src/styles/foundation.test.ts
@@ -1062,6 +1062,25 @@ describe("the shell chrome's type roles", () => {
     // produces no CSS, on text that looks merely unstyled rather than broken.
     expect(CSS).toContain(`@utility ${role} {`)
   })
+
+  it.each(SHELL_ROLES)("uses %s somewhere in the chrome", (role) => {
+    // The other half, and the one that was promised above but missing. A
+    // declared role with no call site is half of the failure that shipped:
+    // `text-chrome-initials` reached main because the declaration was renamed
+    // to `text-shell-monogram` and the call site was moved back to the old
+    // name, so the span carried a class that produces no CSS. Asserting the
+    // declaration could not catch that, because the declaration was fine.
+    const APP = join(WEB, "src", "app")
+    const users = readdirSync(APP, { recursive: true })
+      .map((name) => String(name).replaceAll("\\", "/"))
+      .filter((name) => /\.tsx$/.test(name) && !/\.test\.tsx$/.test(name))
+      .filter((name) => readFileSync(join(APP, name), "utf8").includes(role))
+
+    expect(
+      users,
+      `${role} is declared but never used; a class that produces no CSS reads as unstyled rather than broken`,
+    ).not.toEqual([])
+  })
 })
 
 // The scale's smallest step is 12px (`--text-xs`), so a size written at a call


### PR DESCRIPTION
## Description

Three changes to the dashboard, all reported or approved from use: two visual
defects in the sidebar, and the verify block on the organization email-domain
page rearranged so the record and the action it feeds sit on one row.

**The account monogram rendered at the wrong size.** The initials span at
`AccountMenu.tsx` carried `text-chrome-initials`, a class that is defined
nowhere. It was defined in #638, renamed to `text-shell-monogram` with identical
values in #892 (the old definition being deleted), and #934 moved the call site
back to the old name. Since #934 the span has had no font size of its own and
has inherited the nav row's, so a monogram sized for a 26px tile rendered at
14px instead of 9px. The fix is the current name. Verified on a running
instance: computed `font-size` is 9px, and removing the fix live in the DOM puts
it back to 14px, so the rename is load bearing rather than cosmetic.

**The monogram tile was not centered on the collapsed rail.** `navRowClass`
contributes `justify-center` when the rail is collapsed, and the call site
appended an unconditional `justify-start` on top of it. Both landed on the
element with equal specificity, so the later emitted one won: in the built
stylesheet `.justify-center` sits at byte 424928 and `.justify-start` at 425005.
The tile centered at x=14.0 in a 72px rail whose center, and whose every other
collapsed icon, sits at 35.5 to 36.5. That is 21.5px off, and it is what a
reader sees as the icon being off center.

Rather than make the appended utility conditional at the call site, this gives
`navRowClass` an optional `expandedJustify` parameter, because the missing
affordance is the cause: a row that needs a justification other than the
collapsed default had no way to say so through the helper, so it had to append
and then lose. The parameter is additive. It is unset by default, all seven
existing call sites and the helper's own tests are untouched, and only
`AccountMenu` passes it. Confirmed by importing `navRowClass` from the base
commit alongside the new one and comparing output across ten call site shapes:
byte identical on all ten.

After the fix the tile centers at x=35.5, matching the rail center and the other
collapsed icons. Expanded, the row is still start aligned, with the tile's left
edge at x=25 alongside the other rows' icons at 25 and 26.

**Two dividers at the foot of the rail on the organization pages.** The footer
block and the rail's closing band each draw a rule, and the only row between
them is the way onto the organization rail, which is gated out once you are on
it. With that row absent the two rules were separated by `pt-1` alone, so 4px of
gap and 6px from outer edge to outer edge, which reads as one doubled hairline.
Reproduced in the DOM before fixing: two painted rules, both
`rgba(255, 255, 255, 0.08)`, with tops at y=784 and y=789.

The band's rule is deliberately unconditional, since it mirrors the scope band
at the head of the rail so that both ends of the rail are the same shape, so the
footer's rule is the one that gives way. The condition is now a single named
constant shared with the row's own gate, so the two cannot drift apart: them
drifting apart is the defect, not this one instance of it.

After the fix, one rule on the organization rail. In the workspace context,
still a rule, then the row, then a rule.

**The verify block on the email-domain page put the record and its action on
separate rows.** The TXT record an operator has to publish took a full-width
field, the copy affordance sat above it in the label row, and the Verify button
sat in a row of its own below. The record is one line that is copied and then
acted on, so the copy control moves inside the field and the button moves beside
it.

`CopyField` takes one optional prop, `action`, and its presence selects the
arrangement. Absent, the field renders exactly what it always has. The prop is
excluded from the multiline variant at the type level rather than guarded at
runtime, through a discriminated union on the props type, so a call site cannot
pass both: the multiline field is a `<textarea>`, where the right padding an
in-field control needs indents every line instead of clearing the first.

In the inline arrangement the control is `CopyButton`, the same component the
models table uses. That is an improvement beyond the layout, and it is the
reason the swap is worth making rather than restyling the existing button:
`CopyField`'s own copy path only ever tried `navigator.clipboard`, which does
not exist on the plain-HTTP origins this dashboard is routinely served from, so
it could not actually copy there and instead selected the value and asked for
Ctrl/Cmd-C. `CopyButton` goes through `copyToClipboard`, which falls back to
`execCommand`, the only clipboard write such an origin has. So the common
non-secure case now copies.

The one case that would have got worse is when `execCommand` also fails, where
the old field at least left the value selected. `CopyButton` therefore takes an
optional `selectOnFailure` ref, defaulted off so `CopyableValue` and the models
table are untouched, and focuses and selects the field on a failed copy. It does
that **after** the attempt resolves, not before: `copyToClipboard`'s legacy path
deliberately restores the selection and focus it found on its way out
(`clipboard.ts:55-59`), so a selection made first is undone by the very fallback
it exists to serve. Selecting first would look correct and do nothing on exactly
the path that needs it.

Scope: the shared `CopyField` has seven call sites, and this changes one. The
master key field on Settings is a separate local component declared at
`SettingsPage.tsx:281`, not this one. The
other six, including the four multiline ones, render byte-identically, and that
is proved rather than eyeballed: `CopyField` was imported from the base commit
alongside the new one and both were rendered for every distinct prop shape those
six use, comparing markup with only `useId` values normalized away. Identical on
all of them, and the comparison was itself checked by confirming it fails on a
single added class.

### Numbers, measured on the running instance

| Quantity | Value |
| --- | --- |
| Record length | 74 characters, all three blocks |
| Fira Code advance | 7.20px at the field's 12px, so 0.600 em |
| Glyph run | 532.79px |
| Field, xl and up | 600px, height 36px, right padding 44px |
| Control, xl and up | 32 x 32px, 4px inset, vertically centered to 0.00px |
| Whole value visible | yes, `scrollWidth` 598 against `clientWidth` 598 |
| Row content, Verify domain | 735.65px |
| Row content, Re-verify domain | 757.13px |
| Field, below md | height 46px, right padding 56px |
| Control, below md | 44 x 44px, fits inside the field's borders |

The control renders 32 x 32, not the 36 x 32 its declared width suggests, which
is why the right padding is 44px and not 46px.

### What this does not do

It does not touch the `!` appends in the nav, `navBandRowClass`, or the two
findings below, all of which are real and each of which is going to its own
issue:

- `border-border-strong` matches no utility in the bundle. The variable itself is
  fine: `--color-border-strong` is emitted in both theme blocks and is consumed
  at `globals.css:2062`. Only the utility class is missing, and nothing in
  `web/src` writes that name, so it is a latent gap rather than a live defect.
- `.border-emerald-200` reaches the bundle because Tailwind scans it out of a
  comment in `foundation.test.ts`.
- The `!` appends elsewhere in the nav are a related shape but not this bug.
  `AppShell.tsx:278` is the same helper versus call site collision, resolved with
  a bang instead of a parameter. `navBandRowClass`'s own bang may simply be
  unnecessary. Whether the nav helpers should own width the way they now own
  justification is worth deciding on its own, not in passing here.

`text-shell-monogram` is now the only type role in the file with a call site
pointing at it, and `text-emphasis` remains without one by design.

The organization domains page has an existing screenshot entry and its baseline
changes. Those PNGs are gitignored and the suite runs on demand, so there is
nothing to commit, but the baseline should be retaken.

### Verification

Measured on a running dashboard, confirming the served asset hash before each
measurement, and reading numbers only after a full reload. Two things about that
are worth stating, because both nearly produced a wrong number: an automated tab
reports `visibilityState: "hidden"`, so the rail's `transition-[width]` never
advances and a width read mid transition is the frozen start value rather than
the collapsed width; and navigating to a `#/` route from the same origin does not
reload, so it can be measured against a stale bundle.

**One thing could not be verified here, and it is the press itself.** An
automated tab reports `document.hasFocus()` as false and `visibilityState` as
hidden, so react-aria never registers the press: clicking the in-field control
opened no tooltip and wrote to no live region. The tooltip's strings, its 1500ms
and 5000ms timings and its self-clearing are covered by the existing
`CopyButton` cases, and the failure string was checked against the two candidate
stylesheet rules for the tooltip box (`.tooltip`, capped at `--container-xs` with
12px text, and `.tooltip__content`, capped at `min(22rem, 100vw - 2rem)` with
13px text). It overruns its content box under both, 309px against 302px and
334.8px against 328px, so it wraps to two lines either way. Which rule the
rendered box uses could not be settled without opening it.

Checks on this exact tree: `pnpm --dir web run lint` clean over 387 files,
`pnpm --dir web run typecheck` (`tsc -b --noEmit`) clean,
`pnpm --dir web test` 3858 passed across 135 files. The baseline was measured on
a pristine checkout of the base commit rather than assumed: 3844 passed across
the same 135 files, so the delta is exactly the fourteen added cases and no test
moved from pass to fail. `make lint` clean (architecture, alembic heads, Ruff),
`make typecheck` clean over 567 files, `make test-unit` 2881 passed and 3
skipped.

Use `pnpm --dir web run typecheck` and not a bare `tsc --noEmit` to reproduce
this. The package script is `tsc -b --noEmit`, and the root `tsconfig.json`
carries `"files": []` with project references, so a bare `tsc --noEmit` resolves
that root config and checks almost nothing, including none of the test files. It
reports success on a tree the real typecheck rejects.

The narrow-width numbers are from a 606px viewport, which is the narrowest this
browser window would go, and every rule below `md` is confirmed there: 46px
field, 56px right padding, a 44 x 44 control inside the borders, the action
wrapping to its own line, and the value scrolling rather than truncating. The
390px case is computed from the measured 7.20px advance and the live 16px page
padding, giving a 358px field, a 288px content box and 40 of the 74 characters
visible. Computed, not measured, because the window would not reach 390px.

### About the tests

Fourteen cases are added and nine of them are checks. Each fix was removed and the
suite re-run to see which cases actually fail without it, because a case that
passes either way is a regression guard and not evidence:

- `rowStyles.test.ts`: "start-aligns an expanded row that asks for it" fails
  without the fix. "still centers that row when the rail is collapsed" and "adds
  no justification when it is left unset" pass either way.
- `AppShell.test.tsx`: both cases are checks, and neither covers the other.
  Suppressing the band's rule instead of the footer's fails "drops it on the
  organization rail, where that row is gone". Inverting
  `footerHasRowAboveBand` fails "keeps the footer rule where a row sits below
  it" at its own assertion. Neither break fails the other case, so together they
  cover both regressions and separately they cover one each.
- `actions/CopyField.test.tsx`: the three inline-arrangement cases fail without
  the `action` branch. "selects only after the copy attempt, not before it"
  fails when the selection is moved back before the attempt, printing
  `expected [ 'focus', 'attempt' ] to deeply equal [ 'attempt', 'focus' ]`. The
  two default-arrangement cases pass either way by design: they were written
  against `main` first, so they guard the six untouched call sites rather than
  describe the new code.
- `actions/CopyButton.test.tsx`: "selects a field it was given only after a
  failed attempt" fails the same way, and "leaves focus alone when no field was
  given" guards the default.
- The `@ts-expect-error` case for `action` with `multiline` is a check too, and
  a compile-time one: relaxing the union to allow both produces
  `TS2578: Unused '@ts-expect-error' directive` from
  `pnpm --dir web run typecheck`. It reports nothing under a bare
  `tsc --noEmit`, for the reason given above.

Worth knowing about one of them. "selects the value when a copy fails" asserts
the end state, and it passes whether the selection happens before or after the
copy, because the legacy fallback needs a `document.execCommand` that jsdom does
not define and so never reaches the code that would undo an early selection.
That is why the ordering is asserted separately and directly. The end-state case
was kept, but on its own it would have let the ordering bug through.

The `AppShell` pair asserts a class name rather than a rendered rule, which is
the weaker kind of test; there is precedent for that in the file, and the
rendered result was confirmed by measuring the page instead.

A note on how the classification was arrived at, because it changed one answer.
Removing a fix and re-running is only informative if the break is aimed at the
regression the case claims to prevent. The first break tried on the `AppShell`
pair was aimed at something neither case claims, and it produced a pass that
looked exactly like the pass it was meant to test. The same trap sits under
"selects the value when a copy fails": it asserts the end state and passes
whether the selection happens before or after the copy, because jsdom never
reaches the code that would undo an early one. Both were only settled by
breaking the specific thing each case names.

## PR Type
<!-- Check all that apply -->

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None. Both defects were reported directly from use rather than filed.

## Checklist
<!-- If you delete this checklist, your PR will be automatically closed -->

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

Notes on the checklist:

- Tests are in `web/`, not `tests/unit` or `tests/integration`, because the
  change is entirely in the dashboard. They are `rowStyles.test.ts` and
  `AppShell.test.tsx`, next to the behavior they cover.
- `make lint` and `make typecheck` are clean and `make test-unit` passes.
  `make test` as a whole was not run: the integration suite needs PostgreSQL,
  either Docker or `TEST_DATABASE_URL`, and neither was available here. Nothing
  outside `web/` changed, so there is no `src/gateway/` behavior for it to cover,
  but the box is left unticked rather than ticked on a partial run.
- `.github/skills/frontend-standards/design-tokens.md` is corrected here. It
  claimed this repo aliases none of HeroUI's non-color variables, which is wrong
  about `--radius`, `--disabled-opacity` and `--field-border-width`, and it now
  also records that our variable block has to stay unlayered, with what breaks
  if it is wrapped in `@layer`. Verified against `globals.css` before applying:
  `--radius: 0px` at 877, `--disabled-opacity: 0.4` at 894, and
  `--field-border-width: 1px` at 425 and 634, once per theme block. Beyond that,
  the mechanism behind each fix is explained in a comment at its site, which is
  where this repo asks for it.
- No API contract changed and no route or docstring was touched, so no generated
  artifact went stale. The dashboard bundle is generated and not committed, and
  the committed generated files (`web/src/client/schema.ts` and
  `web/src/routeTree.gen.ts`) are unaffected.

## AI Usage
<!-- Check one -->

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

The diagnosis, the fixes, the tests and this description were all written by the
model. Several claims made along the way were wrong and were corrected by
measuring rather than by reasoning, which is worth stating because it is the
reason the numbers above are quoted rather than described: a supposed vertical
offset in the monogram did not reproduce and measures 0.000px; a first set of
collapsed-rail measurements was invalid because it was read while a CSS width
transition sat frozen in an automated tab; one measurement was taken against a
stale bundle because a `#/` route change does not reload the page; a sweep for
dead utility classes returned three different wrong answers before it was
checked against known positives; and a claim that the repo had three alembic
heads was wrong, as `scripts/check_alembic_heads.py` reports one.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed account navigation alignment and monogram styling.
- Removed the duplicate organization sidebar divider.
- Placed email-domain verification controls on one row.
- Added clipboard fallback behavior for plain-HTTP origins and copy failures.
- Updated design-token and dashboard typecheck guidance.

## Technical notes

- Added `expandedJustify` to `navRowClass`.
- Added a typed `action` slot to `CopyField`.
- Added selection fallback support to `CopyButton`.
- Added tests for navigation, sidebar dividers, copy behavior, layout states, and shell role usage.
- Dashboard and backend lint, typecheck, and unit tests pass. Integration tests were not run because PostgreSQL was unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->