### PR TITLE
fix(dashboard): survive a bootstrap from an older gateway

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -23,6 +23,12 @@ foundations, components with their states, and the page archetypes as artboards.
 `src/main.tsx` fetches unauthenticated `GET /v1/bootstrap` before mounting
 React. Do not guess a deployment when that request fails.
 
+A gateway older than a bootstrap field does not send it, whatever the generated
+type promises, so `App` completes the payload once through
+`shared/helpers/bootstrap.ts` before anything below reads a field. Add a field
+to the bootstrap and that module stops compiling until it is given a default.
+The two fields naming the deployment take none, for the reason above.
+
 The bootstrap selects standalone, hosted, or hybrid presentation and publishes:
 
 - sign-in methods and configured OAuth providers

--- a/web/design/DESIGN.md
+++ b/web/design/DESIGN.md
@@ -52,7 +52,7 @@ classifier and the meter that reads it).
 | `metrics/SeverityMark` | `SeverityMark`, and the `Severity` type |
 | `metrics/TrendChip` | `TrendChip`, `trendState`, and the `Trend*` types |
 | `metrics/charts` | `TrendChart`, `Sparkline`, `ChartLegend`, and the `SeriesDef` / `StackedPoint` types |
-| `feedback/ErrorBanner` · `/InfoBanner` · `/EmptyState` · `/EmptyMessage` · `/PageLoading` · `/ConfirmDialog` · `/ErrorBoundary` · `/errorMessage` | one each |
+| `feedback/ErrorBanner` · `/InfoBanner` · `/EmptyState` · `/EmptyMessage` · `/PageLoading` · `/PageError` · `/ConfirmDialog` · `/ErrorBoundary` · `/errorMessage` | one each |
 | `forms/Field` · `/SecretField` | `Field` · `SecretField` |
 | `forms/FieldMessages` | `FieldMessages`, `ControlField` |
 | `forms/Checkbox` | `Checkbox`, `CheckboxVisual` |

--- a/web/design/DESIGN.md
+++ b/web/design/DESIGN.md
@@ -52,7 +52,7 @@ classifier and the meter that reads it).
 | `metrics/SeverityMark` | `SeverityMark`, and the `Severity` type |
 | `metrics/TrendChip` | `TrendChip`, `trendState`, and the `Trend*` types |
 | `metrics/charts` | `TrendChart`, `Sparkline`, `ChartLegend`, and the `SeriesDef` / `StackedPoint` types |
-| `feedback/ErrorBanner` · `/InfoBanner` · `/EmptyState` · `/EmptyMessage` · `/PageLoading` · `/ConfirmDialog` · `/errorMessage` | one each |
+| `feedback/ErrorBanner` · `/InfoBanner` · `/EmptyState` · `/EmptyMessage` · `/PageLoading` · `/ConfirmDialog` · `/ErrorBoundary` · `/errorMessage` | one each |
 | `forms/Field` · `/SecretField` | `Field` · `SecretField` |
 | `forms/FieldMessages` | `FieldMessages`, `ControlField` |
 | `forms/Checkbox` | `Checkbox`, `CheckboxVisual` |

--- a/web/design/feedback.md
+++ b/web/design/feedback.md
@@ -23,6 +23,8 @@ Is the destination empty?
 Is it loading?
  ├── The whole route -> PageLoading
  └── One section    -> the section's own isLoading, which keeps the heading
+Did the page fail to render at all?
+ └── PageError             (a catch boundary's panel; no page reaches for it)
 Is the action destructive and does it need more than a second click?
  └── ConfirmDialog          (otherwise ConfirmButton; see actions.md)
 ```

--- a/web/design/feedback.md
+++ b/web/design/feedback.md
@@ -38,7 +38,12 @@ EmptyMessage: { children, minHeight? }
 PageLoading: { label = "Loading…" }
 ConfirmDialog: { isOpen, onOpenChange, heading, body, confirmLabel, onConfirm,
   confirmVariant = "danger", isPending?, error? }
+ErrorBoundary: { children }
 ```
+
+`ErrorBoundary` is not one a page reaches for: it is the catch above the router in
+`App.tsx`, and the only one the pre-session screens have. Everything inside
+`RouterProvider` is already covered by TanStack Router's own catch boundary.
 
 `EmptyState` takes `actionLabel` plus `onAction`, not a rendered button:
 it owns the variant so no empty state can pick the wrong one. `ErrorBanner` takes the

--- a/web/design/feedback.md
+++ b/web/design/feedback.md
@@ -36,14 +36,20 @@ EmptyState: { title, description?, actionLabel?, onAction?, isActionDisabled?,
   children? }
 EmptyMessage: { children, minHeight? }
 PageLoading: { label = "Loading…" }
+PageError: { error: unknown, children? }
 ConfirmDialog: { isOpen, onOpenChange, heading, body, confirmLabel, onConfirm,
   confirmVariant = "danger", isPending?, error? }
 ErrorBoundary: { children }
 ```
 
+`PageError` is `PageLoading`'s counterpart, for a failure that took the whole page
+rather than a band inside one: a gateway that never answered, and the two catch
+boundaries below. Its `children` is the sentence about what to do next.
+
 `ErrorBoundary` is not one a page reaches for: it is the catch above the router in
 `App.tsx`, and the only one the pre-session screens have. Everything inside
-`RouterProvider` is already covered by TanStack Router's own catch boundary.
+`RouterProvider` is covered by TanStack Router's own catch boundary, which
+`router.tsx` points at the same `PageError` so the two look like one product.
 
 `EmptyState` takes `actionLabel` plus `onAction`, not a rendered button:
 it owns the variant so no empty state can pick the wrong one. `ErrorBanner` takes the

--- a/web/design/feedback.md
+++ b/web/design/feedback.md
@@ -39,7 +39,7 @@ PageLoading: { label = "Loading…" }
 PageError: { error: unknown, children? }
 ConfirmDialog: { isOpen, onOpenChange, heading, body, confirmLabel, onConfirm,
   confirmVariant = "danger", isPending?, error? }
-ErrorBoundary: { children }
+ErrorBoundary: { children, resetKey? }
 ```
 
 `PageError` is `PageLoading`'s counterpart, for a failure that took the whole page

--- a/web/design/feedback.md
+++ b/web/design/feedback.md
@@ -24,7 +24,7 @@ Is it loading?
  ├── The whole route -> PageLoading
  └── One section    -> the section's own isLoading, which keeps the heading
 Did the page fail to render at all?
- └── PageError             (a catch boundary's panel; no page reaches for it)
+ └── PageError             (the catch boundaries' panel; see below)
 Is the action destructive and does it need more than a second click?
  └── ConfirmDialog          (otherwise ConfirmButton; see actions.md)
 ```

--- a/web/src/app/App.test.tsx
+++ b/web/src/app/App.test.tsx
@@ -222,3 +222,72 @@ describe("App", () => {
     expect(screen.queryByText("ada@example.com")).toBeNull()
   })
 })
+
+// otari#806: a dashboard from `main` served by a gateway built before a field
+// was added. The field is absent rather than null, the generated type says it is
+// always there, and every one of these pages renders above the router's own
+// catch boundary, so a throw here is a blank document with no error text in it.
+describe("a bootstrap from an older gateway", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    window.localStorage.clear()
+    window.location.hash = ""
+  })
+
+  // Deleting from the current fixture rather than writing a literal: the case
+  // is "this key never arrived", and it should keep meaning that as the
+  // bootstrap grows fields.
+  function older(...absent: string[]) {
+    const wire = { ...bootstrap() } as Record<string, unknown>
+    for (const field of absent) {
+      delete wire[field]
+    }
+    return wire as Parameters<typeof App>[0]["bootstrap"]
+  }
+
+  it("still renders the sign-in screen without oauth_providers", () => {
+    const { container } = renderApp(older("oauth_providers"))
+
+    expect(
+      screen.getByRole("heading", { name: "Otari Dashboard" }),
+    ).toBeInTheDocument()
+    expect(container).not.toBeEmptyDOMElement()
+  })
+
+  it("says so, rather than blanking, without sign_in_methods", () => {
+    // The field Login reads three times, 25 lines before it reads
+    // oauth_providers, so a guard on the second one alone never runs here.
+    // An empty list is the honest completion (naming a credential the gateway
+    // never published would be the guess), and Login already has a screen for
+    // a deployment that offers none.
+    const { container } = renderApp(older("sign_in_methods"))
+
+    expect(container).not.toBeEmptyDOMElement()
+    expect(
+      screen.getByRole("heading", { name: "Otari sign-in is unavailable" }),
+    ).toBeInTheDocument()
+  })
+
+  it("still renders the invitation page, which reads the same field", () => {
+    vi.mocked(apiFetch).mockImplementation(async () => [] as never)
+    window.location.hash = "#/accept-invitation?token=some-token"
+
+    const { container } = renderApp(older("oauth_providers"))
+
+    expect(container).not.toBeEmptyDOMElement()
+    expect(
+      screen.getByRole("heading", { name: "Organization invitation" }),
+    ).toBeInTheDocument()
+  })
+
+  it("still renders a public auth page, which reads it on the no-mail path", () => {
+    window.location.hash = "#/recover-password"
+
+    const { container } = renderApp(older("oauth_providers", "mail_ready"))
+
+    expect(container).not.toBeEmptyDOMElement()
+    expect(
+      screen.getByRole("heading", { name: "Not available on this gateway" }),
+    ).toBeInTheDocument()
+  })
+})

--- a/web/src/app/App.test.tsx
+++ b/web/src/app/App.test.tsx
@@ -280,6 +280,22 @@ describe("a bootstrap from an older gateway", () => {
     ).toBeInTheDocument()
   })
 
+  it("shows the boundary's panel when a page above the router throws", () => {
+    // React logs a caught render error whatever catches it, so the assertion is
+    // about what is on screen rather than about silence.
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    // Present but not the shape the type promises, which is the half of skew a
+    // default cannot complete: `Login` throws where only the boundary in `App`
+    // can catch it, and without one the document is empty.
+    const { container } = renderApp({
+      ...bootstrap(),
+      oauth_providers: 3 as unknown as string[],
+    })
+
+    expect(container).not.toBeEmptyDOMElement()
+    expect(screen.getByRole("alert")).toBeInTheDocument()
+  })
+
   it("still renders a public auth page, which reads it on the no-mail path", () => {
     window.location.hash = "#/recover-password"
 

--- a/web/src/app/App.test.tsx
+++ b/web/src/app/App.test.tsx
@@ -225,8 +225,8 @@ describe("App", () => {
 
 // otari#806: a dashboard from `main` served by a gateway built before a field
 // was added. The field is absent rather than null, the generated type says it is
-// always there, and every one of these pages renders above the router's own
-// catch boundary, so a throw here is a blank document with no error text in it.
+// always there, and these pages render above the router's own catch boundary, so
+// a throw here was a blank document.
 describe("a bootstrap from an older gateway", () => {
   afterEach(() => {
     vi.restoreAllMocks()

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -2,13 +2,15 @@ import { RouterProvider } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
 import { HybridLanding } from "@/app/HybridLanding"
 import { router } from "@/app/router"
-import type { DeploymentBootstrap } from "@/client"
 import { useAuth } from "@/features/auth/AuthContext"
 import { Login } from "@/features/auth/Login"
 import { PublicAuthPage } from "@/features/auth/PublicAuthPage"
 import { publicAuthPath } from "@/features/auth/publicAuthPaths"
 import { AcceptInvitationPage } from "@/features/invitations/AcceptInvitationPage"
 import { ErrorBanner } from "@/shared/components/feedback/ErrorBanner"
+import { ErrorBoundary } from "@/shared/components/feedback/ErrorBoundary"
+import type { WireBootstrap } from "@/shared/helpers/bootstrap"
+import { normalizeBootstrap } from "@/shared/helpers/bootstrap"
 import { SelectedWorkspaceProvider } from "@/shared/hooks/SelectedWorkspace"
 import { DeploymentProvider, useDeployment } from "@/shared/hooks/useDeployment"
 
@@ -31,7 +33,11 @@ function useHashPath(): string {
 export default function App({
   bootstrap,
 }: {
-  bootstrap: DeploymentBootstrap | null
+  // `WireBootstrap`, not `DeploymentBootstrap`: this is the one component that
+  // takes the payload as it came off the wire, and an older gateway sends fewer
+  // fields than the generated type promises. `normalizeBootstrap` below is
+  // where it becomes the complete shape everything under here reads.
+  bootstrap: WireBootstrap | null
 }) {
   // Null means /v1/bootstrap did not answer (see main.tsx). The app deliberately
   // has no fallback deployment to assume: rendering a management dashboard at a
@@ -53,10 +59,15 @@ export default function App({
     )
   }
 
+  // Outside the provider rather than inside it, because the provider's own
+  // correction memo reads `sign_in_methods` and is therefore one of the things
+  // that can throw on a bootstrap this dashboard did not expect.
   return (
-    <DeploymentProvider value={bootstrap}>
-      <DeploymentRoot />
-    </DeploymentProvider>
+    <ErrorBoundary>
+      <DeploymentProvider value={normalizeBootstrap(bootstrap)}>
+        <DeploymentRoot />
+      </DeploymentProvider>
+    </ErrorBoundary>
   )
 }
 

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -7,8 +7,8 @@ import { Login } from "@/features/auth/Login"
 import { PublicAuthPage } from "@/features/auth/PublicAuthPage"
 import { publicAuthPath } from "@/features/auth/publicAuthPaths"
 import { AcceptInvitationPage } from "@/features/invitations/AcceptInvitationPage"
-import { ErrorBanner } from "@/shared/components/feedback/ErrorBanner"
 import { ErrorBoundary } from "@/shared/components/feedback/ErrorBoundary"
+import { PageError } from "@/shared/components/feedback/PageError"
 import type { WireBootstrap } from "@/shared/helpers/bootstrap"
 import { normalizeBootstrap } from "@/shared/helpers/bootstrap"
 import { SelectedWorkspaceProvider } from "@/shared/hooks/SelectedWorkspace"
@@ -17,8 +17,10 @@ import { DeploymentProvider, useDeployment } from "@/shared/hooks/useDeployment"
 /**
  * The hash path, live: it changes without a reload (following an emailed
  * link while a tab is already open, or the accept page navigating away when
- * it is done), and `DeploymentRoot` has to notice, unlike the bootstrap and
- * auth state everything else here reads once per load.
+ * it is done), and both `App` and `DeploymentRoot` have to notice, unlike the
+ * bootstrap and auth state everything else here reads once per load. Read once
+ * in `App` and passed down rather than called in both, so one listener decides
+ * which branch renders and when the boundary around it resets.
  */
 function useHashPath(): string {
   const [hash, setHash] = useState(() => window.location.hash)
@@ -39,23 +41,24 @@ export default function App({
   // where it becomes the complete shape everything under here reads.
   bootstrap: WireBootstrap | null
 }) {
+  // Read here rather than only in `DeploymentRoot` because the boundary below
+  // resets on it: which branch renders is a function of the hash, so a throw in
+  // one of them must not outlive the navigation away from it.
+  const hash = useHashPath()
+
   // Null means /v1/bootstrap did not answer (see main.tsx). The app deliberately
   // has no fallback deployment to assume: rendering a management dashboard at a
   // gateway that does not serve one is the failure this contract exists to
   // prevent, so say what happened instead.
   if (!bootstrap) {
     return (
-      <div className="flex min-h-full items-center justify-center p-6">
-        <div className="w-full max-w-md">
-          <ErrorBanner
-            error={
-              new Error(
-                "Could not reach the gateway, so the dashboard does not know what it is connected to. Check that it is running, then reload.",
-              )
-            }
-          />
-        </div>
-      </div>
+      <PageError
+        error={
+          new Error(
+            "Could not reach the gateway, so the dashboard does not know what it is connected to. Check that it is running, then reload.",
+          )
+        }
+      />
     )
   }
 
@@ -63,9 +66,9 @@ export default function App({
   // correction memo reads `sign_in_methods` and is therefore one of the things
   // that can throw on a bootstrap this dashboard did not expect.
   return (
-    <ErrorBoundary>
+    <ErrorBoundary resetKey={hash}>
       <DeploymentProvider value={normalizeBootstrap(bootstrap)}>
-        <DeploymentRoot />
+        <DeploymentRoot hash={hash} />
       </DeploymentProvider>
     </ErrorBoundary>
   )
@@ -78,10 +81,9 @@ export default function App({
  * *session* gets to require. No page below here reads the deployment mode
  * again.
  */
-function DeploymentRoot() {
+function DeploymentRoot({ hash }: { hash: string }) {
   const { deployment_type, session_type } = useDeployment()
   const { isAuthenticated } = useAuth()
-  const hash = useHashPath()
 
   // A hybrid gateway is data-plane only: otari.ai owns its organizations,
   // credentials, routing, budgets and usage, and a second management UI beside

--- a/web/src/app/router.test.tsx
+++ b/web/src/app/router.test.tsx
@@ -1,0 +1,54 @@
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { router } from "@/app/router"
+
+// Which boundary catches a routed throw is not obvious from the config, and it
+// decides whether the failure wears the design system or the library's own
+// inline-styled red `<pre>`. Two paths exist in @tanstack/react-router: the
+// global one (`Matches.tsx`) renders its CatchBoundary with no errorComponent
+// and therefore always falls back to the built-in, while the per-match one
+// (`Match.tsx`) wraps each match only when `errorComponent ?? defaultErrorComponent`
+// is set, and sits inside the global one so it catches first. Setting
+// `defaultErrorComponent` is what turns the inner boundary on, and this asserts
+// the outcome rather than the config, so a library upgrade that rewires it fails
+// here instead of silently returning the red `<pre>`.
+const rootRoute = createRootRoute()
+const throwingRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  component: () => {
+    throw new Error("routed page blew up")
+  },
+})
+
+describe("router error handling", () => {
+  it("renders a routed throw on our own panel", async () => {
+    // React logs a caught render error whatever catches it, and the router
+    // warns about an uncaught one in development.
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    const probe = createRouter({
+      routeTree: rootRoute.addChildren([throwingRoute]),
+      history: createMemoryHistory({ initialEntries: ["/"] }),
+      // The real one, so this tests the app's configuration and not a copy of it.
+      defaultErrorComponent: router.options.defaultErrorComponent,
+    })
+    render(<RouterProvider router={probe} />)
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "routed page blew up",
+    )
+    // The built-in component's heading, which is what renders when the inner
+    // boundary is off and the global one answers instead.
+    expect(screen.queryByText("Something went wrong!")).toBeNull()
+  })
+})

--- a/web/src/app/router.test.tsx
+++ b/web/src/app/router.test.tsx
@@ -10,16 +10,15 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { router } from "@/app/router"
 
-// Which boundary catches a routed throw is not obvious from the config, and it
-// decides whether the failure wears the design system or the library's own
-// inline-styled red `<pre>`. Two paths exist in @tanstack/react-router: the
-// global one (`Matches.tsx`) renders its CatchBoundary with no errorComponent
-// and therefore always falls back to the built-in, while the per-match one
-// (`Match.tsx`) wraps each match only when `errorComponent ?? defaultErrorComponent`
-// is set, and sits inside the global one so it catches first. Setting
-// `defaultErrorComponent` is what turns the inner boundary on, and this asserts
-// the outcome rather than the config, so a library upgrade that rewires it fails
-// here instead of silently returning the red `<pre>`.
+// Which boundary catches a routed throw, kept here because this is what breaks
+// when a library upgrade rewires it, and because reading the config gets it
+// backwards. @tanstack/react-router has two: the global one (`Matches.tsx`)
+// renders its CatchBoundary with no `errorComponent` and so always falls back to
+// the built-in, while the per-match one (`Match.tsx`) wraps a match only when
+// `errorComponent ?? defaultErrorComponent` is set, and sits inside the global
+// one, so it catches first. Setting `defaultErrorComponent` is therefore what
+// turns a usable boundary on rather than what styles an existing one. Asserted
+// as a rendered outcome for the same reason.
 const rootRoute = createRootRoute()
 const throwingRoute = createRoute({
   getParentRoute: () => rootRoute,

--- a/web/src/app/router.test.tsx
+++ b/web/src/app/router.test.tsx
@@ -6,7 +6,7 @@ import {
   RouterProvider,
 } from "@tanstack/react-router"
 import { render, screen } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { router } from "@/app/router"
 
@@ -30,6 +30,10 @@ const throwingRoute = createRoute({
 })
 
 describe("router error handling", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it("renders a routed throw on our own panel", async () => {
     // React logs a caught render error whatever catches it, and the router
     // warns about an uncaught one in development.

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -1,6 +1,7 @@
 import { createHashHistory, createRouter } from "@tanstack/react-router"
 import { PendingPage } from "@/app/PendingPage"
 import { routeTree } from "@/routeTree.gen"
+import { PageError } from "@/shared/components/feedback/PageError"
 import { parseSearch, stringifySearch } from "@/shared/helpers/search"
 
 export const router = createRouter({
@@ -19,6 +20,18 @@ export const router = createRouter({
   defaultPendingComponent: PendingPage,
   defaultPendingMs: 0,
   defaultPendingMinMs: 0,
+  // The router wraps its whole match tree in a catch boundary already, so a
+  // throw inside the shell was never a blank page. What it fell back to was
+  // TanStack's built-in `ErrorComponent`, which paints its own inline-styled
+  // box and a red `<pre>` of the raw error: outside the design system, and the
+  // one thing `feedback.md` says never to render. Same panel as the boundary
+  // above the router now, so the two failures look like one product.
+  defaultErrorComponent: ({ error }) => (
+    <PageError error={error}>
+      This page could not finish rendering. Try another destination from the
+      sidebar, or reload.
+    </PageError>
+  ),
 })
 
 declare module "@tanstack/react-router" {

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -25,9 +25,10 @@ export const router = createRouter({
   // thing `design/feedback.md` says never to render. `router.test.tsx` covers
   // why setting it is what makes a boundary catch the throw at all.
   defaultErrorComponent: ({ error }) => (
+    // No mention of the sidebar: this serves the root match too, and a throw in
+    // `AppShell` itself replaces the shell the sidebar lives in.
     <PageError error={error}>
-      This page could not finish rendering. Try another destination from the
-      sidebar, or reload.
+      This page could not finish rendering. Reload to try again.
     </PageError>
   ),
 })

--- a/web/src/app/router.tsx
+++ b/web/src/app/router.tsx
@@ -20,12 +20,10 @@ export const router = createRouter({
   defaultPendingComponent: PendingPage,
   defaultPendingMs: 0,
   defaultPendingMinMs: 0,
-  // The router wraps its whole match tree in a catch boundary already, so a
-  // throw inside the shell was never a blank page. What it fell back to was
-  // TanStack's built-in `ErrorComponent`, which paints its own inline-styled
-  // box and a red `<pre>` of the raw error: outside the design system, and the
-  // one thing `feedback.md` says never to render. Same panel as the boundary
-  // above the router now, so the two failures look like one product.
+  // Without this a routed throw lands on TanStack's built-in component, which
+  // paints its own inline-styled box and a red `<pre>` of the raw error: the one
+  // thing `design/feedback.md` says never to render. `router.test.tsx` covers
+  // why setting it is what makes a boundary catch the throw at all.
   defaultErrorComponent: ({ error }) => (
     <PageError error={error}>
       This page could not finish rendering. Try another destination from the

--- a/web/src/client/index.ts
+++ b/web/src/client/index.ts
@@ -18,14 +18,19 @@ export type { components, operations, paths } from "./schema"
 type Schemas = components["schemas"]
 
 /**
- * Make the fields the gateway defaults optional on the way in.
+ * Make a named set of fields optional, where the generator promised them.
  *
  * The generator marks a property with a schema default as always present, which
  * is true of a response and false of a request body: the point of a default is
  * that a client may omit it. Applied only where the dashboard actually omits
  * one, so it stays a correction rather than a blanket loosening.
+ *
+ * Exported because the response side has the same problem from the other
+ * direction: a gateway older than a field does not send it, whatever the
+ * current schema says. `WireBootstrap` in `shared/helpers/bootstrap.ts` is that
+ * case, and reuses this rather than restating it.
  */
-type Defaulted<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
+export type Defaulted<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
 // ---------------------------------------------------------------------------
 // Deployment bootstrap

--- a/web/src/features/auth/Login.tsx
+++ b/web/src/features/auth/Login.tsx
@@ -537,10 +537,18 @@ export function Login() {
       <AuthPageShell>
         <div className={CARD_FLAT}>
           <h1 className={HEADING}>Otari sign-in is unavailable</h1>
+          {/* Two causes, because reloading only answers one of them. An empty
+              `sign_in_methods` is what the gateway sends when it cannot reach
+              its database, and also what `normalizeBootstrap` fills in for a
+              gateway too old to publish the field at all (otari#806). Naming
+              only the first sends an operator to restart a database that was
+              never the problem. */}
           <p className="text-sm text-muted">
-            This gateway cannot start a session at the moment, which usually
-            means it cannot reach its database. It reports which credentials it
-            accepts once it recovers, so reload this page to try again.
+            This gateway published no sign-in method. That usually means it
+            cannot reach its database, and it says which credentials it accepts
+            once it recovers, so reloading is worth a try. It can also mean the
+            gateway is older than the dashboard it is serving, and reloading
+            will not settle that: the two have to be brought back into step.
           </p>
           <p className="text-sm text-muted">
             The management API is unaffected by this screen and still accepts

--- a/web/src/features/auth/Login.tsx
+++ b/web/src/features/auth/Login.tsx
@@ -225,10 +225,12 @@ export function Login() {
     useDeployment()
   const usesPassword = sign_in_methods.includes("password")
   // An empty list is the gateway saying it cannot mint a session at all right
-  // now, which is what `/v1/bootstrap` answers when it cannot reach its
-  // database. Falling through to a credential form would offer the operator a
-  // box whose only possible outcome is a refusal, and on a claimed deployment
-  // it would be the *master-key* box, whose refusal reads as "wrong key".
+  // now. Two ways to get there: `/v1/bootstrap` answers [] when it cannot reach
+  // its database, and `normalizeBootstrap` fills the same [] in for a gateway
+  // too old to publish the field (otari#806). Falling through to a credential
+  // form would offer the operator a box whose only possible outcome is a
+  // refusal, and on a claimed deployment it would be the *master-key* box,
+  // whose refusal reads as "wrong key".
   const signInUnavailable = sign_in_methods.length === 0
   // Every flow below the form begins with an email, so none of them can work
   // on a gateway that cannot send one. The two recovery links need one thing

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,8 +3,8 @@ import { createRoot } from "react-dom/client"
 
 import App from "@/app/App"
 import { Provider } from "@/app/provider"
-import type { DeploymentBootstrap } from "@/client"
 import { apiFetch } from "@/shared/api/client"
+import type { WireBootstrap } from "@/shared/helpers/bootstrap"
 import "@/styles/globals.css"
 
 const container = document.getElementById("root")
@@ -30,8 +30,8 @@ if (!container) {
 // decides. Both land on the same screen, which says the gateway is unreachable.
 const BOOTSTRAP_TIMEOUT_MS = 8_000
 
-function loadBootstrap(): Promise<DeploymentBootstrap | null> {
-  return apiFetch<DeploymentBootstrap>("/v1/bootstrap", {
+function loadBootstrap(): Promise<WireBootstrap | null> {
+  return apiFetch<WireBootstrap>("/v1/bootstrap", {
     signal: AbortSignal.timeout(BOOTSTRAP_TIMEOUT_MS),
   }).catch(() => null)
 }

--- a/web/src/shared/components/feedback/ErrorBoundary.test.tsx
+++ b/web/src/shared/components/feedback/ErrorBoundary.test.tsx
@@ -89,7 +89,9 @@ describe("ErrorBoundary", () => {
   // throw. A boundary keyed on the thrown value's own truthiness renders the
   // child again, and React answers the second throw by blanking the document; a
   // banner keyed on it renders nothing, leaving a panel with no error in it.
-  // `null` alone exercises neither, being the one case a nullish coalesce covers.
+  // Every case here exercises the first. Only the three below `undefined`
+  // exercise the second, since a nullish coalesce already stood in for the two
+  // above it, which is how that half stayed broken behind a passing test.
   it.each([
     ["null", null],
     ["undefined", undefined],

--- a/web/src/shared/components/feedback/ErrorBoundary.test.tsx
+++ b/web/src/shared/components/feedback/ErrorBoundary.test.tsx
@@ -3,12 +3,14 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { ErrorBoundary } from "@/shared/components/feedback/ErrorBoundary"
 
-function Throws(): never {
+function Thrower(): never {
   throw new Error("the bootstrap said nothing about oauth")
 }
 
-function ThrowsNothing(): never {
-  throw null
+function throwing(value: unknown) {
+  return function Throws(): never {
+    throw value
+  }
 }
 
 describe("ErrorBoundary", () => {
@@ -33,7 +35,7 @@ describe("ErrorBoundary", () => {
 
     const { container } = render(
       <ErrorBoundary>
-        <Throws />
+        <Thrower />
       </ErrorBoundary>,
     )
 
@@ -50,7 +52,7 @@ describe("ErrorBoundary", () => {
 
     const { rerender } = render(
       <ErrorBoundary resetKey="#/verify-email">
-        <Throws />
+        <Thrower />
       </ErrorBoundary>,
     )
     expect(screen.getByRole("alert")).toBeInTheDocument()
@@ -70,7 +72,7 @@ describe("ErrorBoundary", () => {
 
     const { rerender } = render(
       <ErrorBoundary resetKey="#/verify-email">
-        <Throws />
+        <Thrower />
       </ErrorBoundary>,
     )
     rerender(
@@ -83,14 +85,24 @@ describe("ErrorBoundary", () => {
     expect(screen.queryByText("never reached")).toBeNull()
   })
 
-  it("catches a falsy thrown value rather than re-rendering the thrower", () => {
-    // A boundary keyed on the thrown value's truthiness renders the child
-    // again, and React answers a second throw by blanking the document.
+  // Two hazards meet in a falsy throw, and every one of these values is legal to
+  // throw. A boundary keyed on the thrown value's own truthiness renders the
+  // child again, and React answers the second throw by blanking the document; a
+  // banner keyed on it renders nothing, leaving a panel with no error in it.
+  // `null` alone exercises neither, being the one case a nullish coalesce covers.
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["an empty string", ""],
+    ["zero", 0],
+    ["false", false],
+  ])("shows a panel when the thrown value was %s", (_name, thrown) => {
     vi.spyOn(console, "error").mockImplementation(() => {})
+    const Throws = throwing(thrown)
 
     const { container } = render(
       <ErrorBoundary>
-        <ThrowsNothing />
+        <Throws />
       </ErrorBoundary>,
     )
 

--- a/web/src/shared/components/feedback/ErrorBoundary.test.tsx
+++ b/web/src/shared/components/feedback/ErrorBoundary.test.tsx
@@ -43,6 +43,46 @@ describe("ErrorBoundary", () => {
     expect(container).not.toBeEmptyDOMElement()
   })
 
+  it("clears the panel when the reset key changes", () => {
+    // The panel would otherwise latch: App picks its branch from the hash, so a
+    // throw on one public-auth link would survive following the next one.
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const { rerender } = render(
+      <ErrorBoundary resetKey="#/verify-email">
+        <Throws />
+      </ErrorBoundary>,
+    )
+    expect(screen.getByRole("alert")).toBeInTheDocument()
+
+    rerender(
+      <ErrorBoundary resetKey="#/reset-password">
+        <p>the next link</p>
+      </ErrorBoundary>,
+    )
+
+    expect(screen.queryByRole("alert")).toBeNull()
+    expect(screen.getByText("the next link")).toBeInTheDocument()
+  })
+
+  it("keeps the panel while the reset key holds", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const { rerender } = render(
+      <ErrorBoundary resetKey="#/verify-email">
+        <Throws />
+      </ErrorBoundary>,
+    )
+    rerender(
+      <ErrorBoundary resetKey="#/verify-email">
+        <p>never reached</p>
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByRole("alert")).toBeInTheDocument()
+    expect(screen.queryByText("never reached")).toBeNull()
+  })
+
   it("catches a falsy thrown value rather than re-rendering the thrower", () => {
     // A boundary keyed on the thrown value's truthiness renders the child
     // again, and React answers a second throw by blanking the document.

--- a/web/src/shared/components/feedback/ErrorBoundary.test.tsx
+++ b/web/src/shared/components/feedback/ErrorBoundary.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { ErrorBoundary } from "@/shared/components/feedback/ErrorBoundary"
+
+function Throws(): never {
+  throw new Error("the bootstrap said nothing about oauth")
+}
+
+describe("ErrorBoundary", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("renders its children while nothing throws", () => {
+    render(
+      <ErrorBoundary>
+        <p>the sign-in screen</p>
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByText("the sign-in screen")).toBeInTheDocument()
+  })
+
+  it("shows the error instead of unmounting to a blank document", () => {
+    // React logs a caught render error through console.error regardless of the
+    // boundary, so the assertion is about what is on screen, not about silence.
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const { container } = render(
+      <ErrorBoundary>
+        <Throws />
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "the bootstrap said nothing about oauth",
+    )
+    expect(container).not.toBeEmptyDOMElement()
+  })
+})

--- a/web/src/shared/components/feedback/ErrorBoundary.test.tsx
+++ b/web/src/shared/components/feedback/ErrorBoundary.test.tsx
@@ -7,6 +7,10 @@ function Throws(): never {
   throw new Error("the bootstrap said nothing about oauth")
 }
 
+function ThrowsNothing(): never {
+  throw null
+}
+
 describe("ErrorBoundary", () => {
   afterEach(() => {
     vi.restoreAllMocks()
@@ -36,6 +40,21 @@ describe("ErrorBoundary", () => {
     expect(screen.getByRole("alert")).toHaveTextContent(
       "the bootstrap said nothing about oauth",
     )
+    expect(container).not.toBeEmptyDOMElement()
+  })
+
+  it("catches a falsy thrown value rather than re-rendering the thrower", () => {
+    // A boundary keyed on the thrown value's truthiness renders the child
+    // again, and React answers a second throw by blanking the document.
+    vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const { container } = render(
+      <ErrorBoundary>
+        <ThrowsNothing />
+      </ErrorBoundary>,
+    )
+
+    expect(screen.getByRole("alert")).toBeInTheDocument()
     expect(container).not.toBeEmptyDOMElement()
   })
 })

--- a/web/src/shared/components/feedback/ErrorBoundary.tsx
+++ b/web/src/shared/components/feedback/ErrorBoundary.tsx
@@ -5,15 +5,13 @@ import { PageError } from "./PageError"
 /**
  * The catch above the router, and the only one the pre-session pages have.
  *
- * TanStack Router wraps its whole match tree in a `CatchBoundary` of its own
- * (`Matches.tsx`, unless `disableGlobalCatchBoundary`), so a throw inside the
- * shell already renders `router.tsx`'s `defaultErrorComponent`. `App`'s four
- * branches above `RouterProvider` (the sign-in screen, the public auth pages,
- * the invitation page, and the hybrid landing page) sit outside that, and a
- * throw in any of them unmounts to a blank document with nothing in it but a
- * console line. That is the worst place in the app to lose, because the sign-in
- * screen is the only page an operator can reach before every other one
- * (otari#806).
+ * Everything inside `RouterProvider` is already caught, so this covers only
+ * `App`'s four branches above it: the sign-in screen, the public auth pages,
+ * the invitation page, and the hybrid landing page. A throw in one of those
+ * unmounts to a blank document with nothing in it but a console line, which is
+ * the worst place in the app to lose, because the sign-in screen is the only
+ * page an operator can reach before every other one (otari#806).
+ * `router.test.tsx` has which boundary answers where.
  *
  * A class because React offers no hook for this; `getDerivedStateFromError` and
  * `componentDidCatch` are still the only way to catch a render.

--- a/web/src/shared/components/feedback/ErrorBoundary.tsx
+++ b/web/src/shared/components/feedback/ErrorBoundary.tsx
@@ -20,18 +20,22 @@ import { ErrorBanner } from "./ErrorBanner"
  * Nothing is logged here on purpose: `src/` writes to no console anywhere, and
  * the error is on screen, which is the whole point of the panel.
  */
-export class ErrorBoundary extends Component<
-  { children: ReactNode },
-  { error: unknown }
-> {
-  state: { error: unknown } = { error: null }
+type Caught = { caught: boolean; error: unknown }
 
-  static getDerivedStateFromError(error: unknown): { error: unknown } {
-    return { error }
+// `throw null` is legal, and a boundary that keys on the thrown value's truthiness
+// re-renders the child that threw it, which React answers by giving up and
+// blanking the document: the failure this file exists to prevent.
+const UNTYPED_FAILURE = new Error("Something went wrong.")
+
+export class ErrorBoundary extends Component<{ children: ReactNode }, Caught> {
+  state: Caught = { caught: false, error: undefined }
+
+  static getDerivedStateFromError(error: unknown): Caught {
+    return { caught: true, error }
   }
 
   render() {
-    if (!this.state.error) {
+    if (!this.state.caught) {
       return this.props.children
     }
     // The same shape as `App`'s unreachable-gateway panel, because they are the
@@ -40,7 +44,7 @@ export class ErrorBoundary extends Component<
     return (
       <div className="flex min-h-full items-center justify-center p-6">
         <div className="flex w-full max-w-md flex-col gap-3">
-          <ErrorBanner error={this.state.error} />
+          <ErrorBanner error={this.state.error ?? UNTYPED_FAILURE} />
           <p className="text-caption">
             The dashboard could not finish rendering this page. Reload to try
             again. If it keeps happening, this gateway and the dashboard it

--- a/web/src/shared/components/feedback/ErrorBoundary.tsx
+++ b/web/src/shared/components/feedback/ErrorBoundary.tsx
@@ -1,0 +1,54 @@
+import { Component, type ReactNode } from "react"
+
+import { ErrorBanner } from "./ErrorBanner"
+
+/**
+ * The catch above the router, and the only one the pre-session pages have.
+ *
+ * TanStack Router wraps every routed page in a `CatchBoundary` of its own, so a
+ * throw inside the shell already renders its "Something went wrong!" panel.
+ * `App`'s four branches above `RouterProvider` (the sign-in screen, the public
+ * auth pages, the invitation page, and the hybrid landing page) sit outside
+ * that, and a throw in any of them unmounts to a blank document with nothing in
+ * it but a console line. That is the worst place in the app to lose, because
+ * the sign-in screen is the only page an operator can reach before every other
+ * one (otari#806).
+ *
+ * A class because React offers no hook for this; `getDerivedStateFromError` and
+ * `componentDidCatch` are still the only way to catch a render.
+ *
+ * Nothing is logged here on purpose: `src/` writes to no console anywhere, and
+ * the error is on screen, which is the whole point of the panel.
+ */
+export class ErrorBoundary extends Component<
+  { children: ReactNode },
+  { error: unknown }
+> {
+  state: { error: unknown } = { error: null }
+
+  static getDerivedStateFromError(error: unknown): { error: unknown } {
+    return { error }
+  }
+
+  render() {
+    if (!this.state.error) {
+      return this.props.children
+    }
+    // The same shape as `App`'s unreachable-gateway panel, because they are the
+    // same situation to the person reading one: the dashboard is up and cannot
+    // show them the deployment.
+    return (
+      <div className="flex min-h-full items-center justify-center p-6">
+        <div className="flex w-full max-w-md flex-col gap-3">
+          <ErrorBanner error={this.state.error} />
+          <p className="text-caption">
+            The dashboard could not finish rendering this page. Reload to try
+            again. If it keeps happening, this gateway and the dashboard it
+            serves may be out of step, and restarting the gateway on a matching
+            build is what puts them back.
+          </p>
+        </div>
+      </div>
+    )
+  }
+}

--- a/web/src/shared/components/feedback/ErrorBoundary.tsx
+++ b/web/src/shared/components/feedback/ErrorBoundary.tsx
@@ -1,18 +1,19 @@
 import { Component, type ReactNode } from "react"
 
-import { ErrorBanner } from "./ErrorBanner"
+import { PageError } from "./PageError"
 
 /**
  * The catch above the router, and the only one the pre-session pages have.
  *
- * TanStack Router wraps every routed page in a `CatchBoundary` of its own, so a
- * throw inside the shell already renders its "Something went wrong!" panel.
- * `App`'s four branches above `RouterProvider` (the sign-in screen, the public
- * auth pages, the invitation page, and the hybrid landing page) sit outside
- * that, and a throw in any of them unmounts to a blank document with nothing in
- * it but a console line. That is the worst place in the app to lose, because
- * the sign-in screen is the only page an operator can reach before every other
- * one (otari#806).
+ * TanStack Router wraps its whole match tree in a `CatchBoundary` of its own
+ * (`Matches.tsx`, unless `disableGlobalCatchBoundary`), so a throw inside the
+ * shell already renders `router.tsx`'s `defaultErrorComponent`. `App`'s four
+ * branches above `RouterProvider` (the sign-in screen, the public auth pages,
+ * the invitation page, and the hybrid landing page) sit outside that, and a
+ * throw in any of them unmounts to a blank document with nothing in it but a
+ * console line. That is the worst place in the app to lose, because the sign-in
+ * screen is the only page an operator can reach before every other one
+ * (otari#806).
  *
  * A class because React offers no hook for this; `getDerivedStateFromError` and
  * `componentDidCatch` are still the only way to catch a render.
@@ -20,39 +21,56 @@ import { ErrorBanner } from "./ErrorBanner"
  * Nothing is logged here on purpose: `src/` writes to no console anywhere, and
  * the error is on screen, which is the whole point of the panel.
  */
-type Caught = { caught: boolean; error: unknown }
 
-// `throw null` is legal, and a boundary that keys on the thrown value's truthiness
-// re-renders the child that threw it, which React answers by giving up and
-// blanking the document: the failure this file exists to prevent.
+interface Props {
+  children: ReactNode
+  /**
+   * Clears the caught state when it changes, the way the router's own boundary
+   * takes `getResetKey`. Without one the panel latches: `App` picks the branch
+   * to render from the hash, so following a second emailed link after one of
+   * them threw would keep showing the first link's failure.
+   */
+  resetKey?: string
+}
+
+interface State {
+  caught: boolean
+  error: unknown
+  /** The key the current caught state belongs to, to compare the next one against. */
+  seenKey: string | undefined
+}
+
+// `throw null` is legal, and a boundary that keys on the thrown value's own
+// truthiness renders the child that threw it a second time, which React answers
+// by unmounting to the root: the failure this file exists to prevent. So the
+// flag is what decides, and this stands in where there is nothing to show.
 const UNTYPED_FAILURE = new Error("Something went wrong.")
 
-export class ErrorBoundary extends Component<{ children: ReactNode }, Caught> {
-  state: Caught = { caught: false, error: undefined }
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { caught: false, error: undefined, seenKey: undefined }
 
-  static getDerivedStateFromError(error: unknown): Caught {
+  static getDerivedStateFromError(error: unknown): Partial<State> {
     return { caught: true, error }
+  }
+
+  static getDerivedStateFromProps(props: Props, state: State): State | null {
+    if (props.resetKey === state.seenKey) {
+      return null
+    }
+    return { caught: false, error: undefined, seenKey: props.resetKey }
   }
 
   render() {
     if (!this.state.caught) {
       return this.props.children
     }
-    // The same shape as `App`'s unreachable-gateway panel, because they are the
-    // same situation to the person reading one: the dashboard is up and cannot
-    // show them the deployment.
     return (
-      <div className="flex min-h-full items-center justify-center p-6">
-        <div className="flex w-full max-w-md flex-col gap-3">
-          <ErrorBanner error={this.state.error ?? UNTYPED_FAILURE} />
-          <p className="text-caption">
-            The dashboard could not finish rendering this page. Reload to try
-            again. If it keeps happening, this gateway and the dashboard it
-            serves may be out of step, and restarting the gateway on a matching
-            build is what puts them back.
-          </p>
-        </div>
-      </div>
+      <PageError error={this.state.error ?? UNTYPED_FAILURE}>
+        The dashboard could not finish rendering this page. Reload to try again.
+        If it keeps happening, this gateway and the dashboard it serves may be
+        out of step, and restarting the gateway on a matching build is what puts
+        them back.
+      </PageError>
     )
   }
 }

--- a/web/src/shared/components/feedback/ErrorBoundary.tsx
+++ b/web/src/shared/components/feedback/ErrorBoundary.tsx
@@ -38,11 +38,10 @@ interface State {
   seenKey: string | undefined
 }
 
-// `throw null` is legal, and a boundary that keys on the thrown value's own
+// A falsy throw is legal, and a boundary that keys on the thrown value's own
 // truthiness renders the child that threw it a second time, which React answers
 // by unmounting to the root: the failure this file exists to prevent. So the
-// flag is what decides, and this stands in where there is nothing to show.
-const UNTYPED_FAILURE = new Error("Something went wrong.")
+// flag is what decides. Showing such a value is `PageError`'s end.
 
 export class ErrorBoundary extends Component<Props, State> {
   state: State = { caught: false, error: undefined, seenKey: undefined }
@@ -63,7 +62,7 @@ export class ErrorBoundary extends Component<Props, State> {
       return this.props.children
     }
     return (
-      <PageError error={this.state.error ?? UNTYPED_FAILURE}>
+      <PageError error={this.state.error}>
         The dashboard could not finish rendering this page. Reload to try again.
         If it keeps happening, this gateway and the dashboard it serves may be
         out of step, and restarting the gateway on a matching build is what puts

--- a/web/src/shared/components/feedback/PageError.test.tsx
+++ b/web/src/shared/components/feedback/PageError.test.tsx
@@ -16,6 +16,22 @@ describe("PageError", () => {
     expect(container.querySelector("p")).toBeNull()
   })
 
+  // The banner renders nothing for a falsy value, so every one of these would
+  // otherwise be a panel with an explanation and no error in it. `null` is the
+  // only one a nullish coalesce would have caught.
+  it.each([
+    ["empty string", ""],
+    ["zero", 0],
+    ["false", false],
+    ["NaN", Number.NaN],
+    ["null", null],
+    ["undefined", undefined],
+  ])("still shows a banner when the thrown value was %s", (_name, thrown) => {
+    render(<PageError error={thrown} />)
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Something went wrong")
+  })
+
   it("renders what to do next beside the banner", () => {
     render(
       <PageError error={new Error("bare")}>Reload to try again.</PageError>,

--- a/web/src/shared/components/feedback/PageError.test.tsx
+++ b/web/src/shared/components/feedback/PageError.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { PageError } from "@/shared/components/feedback/PageError"
+
+describe("PageError", () => {
+  it("renders the caught value through the banner", () => {
+    render(<PageError error={new Error("the gateway said no")} />)
+
+    expect(screen.getByRole("alert")).toHaveTextContent("the gateway said no")
+  })
+
+  it("omits the paragraph when there is nothing to add", () => {
+    const { container } = render(<PageError error={new Error("bare")} />)
+
+    expect(container.querySelector("p")).toBeNull()
+  })
+
+  it("renders what to do next beside the banner", () => {
+    render(
+      <PageError error={new Error("bare")}>Reload to try again.</PageError>,
+    )
+
+    expect(screen.getByText("Reload to try again.")).toBeInTheDocument()
+  })
+})

--- a/web/src/shared/components/feedback/PageError.test.tsx
+++ b/web/src/shared/components/feedback/PageError.test.tsx
@@ -17,8 +17,9 @@ describe("PageError", () => {
   })
 
   // The banner renders nothing for a falsy value, so every one of these would
-  // otherwise be a panel with an explanation and no error in it. `null` is the
-  // only one a nullish coalesce would have caught.
+  // otherwise be a panel with an explanation and no error in it. The list runs
+  // past `null` and `undefined` deliberately: a nullish coalesce covers those
+  // two, so a case picked from them passes whether or not the other four work.
   it.each([
     ["empty string", ""],
     ["zero", 0],

--- a/web/src/shared/components/feedback/PageError.tsx
+++ b/web/src/shared/components/feedback/PageError.tsx
@@ -11,6 +11,14 @@ import { ErrorBanner } from "./ErrorBanner"
  * box. `children` is the sentence about what to do next, which the gateway case
  * puts in the banner itself and the two throwing cases cannot.
  */
+
+// `ErrorBanner` renders nothing at all for a falsy value, and both catch
+// boundaries hand over whatever was thrown: `throw ""` and `throw 0` are as
+// legal as `throw null`, and none of them carries a message to show. Substituted
+// here rather than at each caller, so neither can reach the panel with an empty
+// banner in it.
+const UNTYPED_FAILURE = new Error("Something went wrong.")
+
 export function PageError({
   error,
   children,
@@ -21,7 +29,7 @@ export function PageError({
   return (
     <div className="flex min-h-full items-center justify-center p-6">
       <div className="flex w-full max-w-md flex-col gap-3">
-        <ErrorBanner error={error} />
+        <ErrorBanner error={error || UNTYPED_FAILURE} />
         {children ? <p className="text-caption">{children}</p> : null}
       </div>
     </div>

--- a/web/src/shared/components/feedback/PageError.tsx
+++ b/web/src/shared/components/feedback/PageError.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react"
+
+import { ErrorBanner } from "./ErrorBanner"
+
+/**
+ * A failure that took the whole page rather than a band inside one.
+ *
+ * `PageLoading`'s counterpart, and for the same reason it exists: three places
+ * reach this state (a gateway that never answered, a throw above the router,
+ * and a throw inside it) and none of them should be drawing its own centered
+ * box. `children` is the sentence about what to do next, which the gateway case
+ * puts in the banner itself and the two throwing cases cannot.
+ */
+export function PageError({
+  error,
+  children,
+}: {
+  error: unknown
+  children?: ReactNode
+}) {
+  return (
+    <div className="flex min-h-full items-center justify-center p-6">
+      <div className="flex w-full max-w-md flex-col gap-3">
+        <ErrorBanner error={error} />
+        {children ? <p className="text-caption">{children}</p> : null}
+      </div>
+    </div>
+  )
+}

--- a/web/src/shared/helpers/bootstrap.test.ts
+++ b/web/src/shared/helpers/bootstrap.test.ts
@@ -76,7 +76,7 @@ describe("normalizeBootstrap", () => {
 
   it("does not invent the two fields that say what the deployment is", () => {
     // web/AGENTS.md: do not guess a deployment. Absent here means absent below,
-    // where it selects no mode rather than the wrong one.
+    // rather than a deployment identity this file made up.
     const completed = normalizeBootstrap(
       omitting("deployment_type", "session_type"),
     )

--- a/web/src/shared/helpers/bootstrap.test.ts
+++ b/web/src/shared/helpers/bootstrap.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+
+import type { WireBootstrap } from "@/shared/helpers/bootstrap"
+import { normalizeBootstrap } from "@/shared/helpers/bootstrap"
+import { bootstrap } from "@/tests/fixtures"
+
+// A payload from a gateway that predates a field: the key is absent, not null.
+// Built by deleting rather than by writing a literal, so the case stays the one
+// the wire produces even as the bootstrap grows fields.
+function omitting(...fields: string[]): WireBootstrap {
+  const wire = { ...bootstrap() } as Record<string, unknown>
+  for (const field of fields) {
+    delete wire[field]
+  }
+  return wire as WireBootstrap
+}
+
+describe("normalizeBootstrap", () => {
+  it("leaves a current gateway's answer alone", () => {
+    const current = bootstrap({
+      surfaces: ["settings"],
+      sign_in_methods: ["password"],
+      oauth_providers: ["github"],
+      docs_url: "https://docs.example.com",
+      mail_ready: true,
+    })
+
+    expect(normalizeBootstrap(current)).toEqual(current)
+  })
+
+  it("empties a collection the gateway did not publish", () => {
+    const completed = normalizeBootstrap(
+      omitting("surfaces", "sign_in_methods", "oauth_providers"),
+    )
+
+    expect(completed.surfaces).toEqual([])
+    expect(completed.sign_in_methods).toEqual([])
+    expect(completed.oauth_providers).toEqual([])
+  })
+
+  it("reads an absent flag as off and an absent link as none", () => {
+    const completed = normalizeBootstrap(
+      omitting(
+        "mail_ready",
+        "passkeys_ready",
+        "maintenance_mode",
+        "docs_url",
+        "management_url",
+        "data_plane_url",
+        "terms_url",
+        "privacy_url",
+      ),
+    )
+
+    expect(completed.mail_ready).toBe(false)
+    expect(completed.passkeys_ready).toBe(false)
+    expect(completed.maintenance_mode).toBe(false)
+    expect(completed.docs_url).toBeNull()
+    expect(completed.management_url).toBeNull()
+    expect(completed.data_plane_url).toBeNull()
+    expect(completed.terms_url).toBeNull()
+    expect(completed.privacy_url).toBeNull()
+  })
+
+  it("keeps a false flag rather than treating it as absent", () => {
+    // The trap `??` exists to avoid and `||` would fall into: a gateway that
+    // publishes `maintenance_mode: false` has answered, and an empty
+    // `sign_in_methods` is an answer too.
+    const completed = normalizeBootstrap(
+      bootstrap({ maintenance_mode: false, sign_in_methods: [] }),
+    )
+
+    expect(completed.maintenance_mode).toBe(false)
+    expect(completed.sign_in_methods).toEqual([])
+  })
+
+  it("does not invent the two fields that say what the deployment is", () => {
+    // web/AGENTS.md: do not guess a deployment. Absent here means absent below,
+    // where it selects no mode rather than the wrong one.
+    const completed = normalizeBootstrap(
+      omitting("deployment_type", "session_type"),
+    )
+
+    expect(completed.deployment_type).toBeUndefined()
+    expect(completed.session_type).toBeUndefined()
+  })
+})

--- a/web/src/shared/helpers/bootstrap.test.ts
+++ b/web/src/shared/helpers/bootstrap.test.ts
@@ -63,9 +63,8 @@ describe("normalizeBootstrap", () => {
   })
 
   it("keeps a false flag rather than treating it as absent", () => {
-    // The trap `??` exists to avoid and `||` would fall into: a gateway that
-    // publishes `maintenance_mode: false` has answered, and an empty
-    // `sign_in_methods` is an answer too.
+    // A published `false` and a published empty list are answers, not absences,
+    // and neither may be overwritten by the default that stands in for one.
     const completed = normalizeBootstrap(
       bootstrap({ maintenance_mode: false, sign_in_methods: [] }),
     )

--- a/web/src/shared/helpers/bootstrap.ts
+++ b/web/src/shared/helpers/bootstrap.ts
@@ -15,10 +15,18 @@
  * where the crash was seen leaves the same field unguarded three lines up.
  *
  * `deployment_type` and `session_type` take no default, because they say what
- * this deployment *is* and `web/AGENTS.md` is explicit that the app must not
- * guess that. Both have been on this route since it was added, so no gateway
- * that answers it at all omits one; a payload missing them is passed through as
- * it arrived, and `DeploymentRoot` falls through to the sign-in screen.
+ * this deployment *is*, and `web/AGENTS.md` refuses to guess that for a
+ * bootstrap that never arrived. The same refusal is the right one for a
+ * bootstrap that arrived without them, though that file states only the first
+ * case. Both have been on this route since it was added (`88c24ac13`), so no
+ * gateway that answers it at all omits one; a payload missing them is passed
+ * through as it came, and `DeploymentRoot` falls through to the sign-in screen,
+ * where `Login` says the gateway published no way in.
+ *
+ * That last part is a claim about this gateway only. `bootstrap.py` says the
+ * contract is shared with otari.ai, which serves the same shape from its own
+ * codebase, so the cast in `normalizeBootstrap`'s return type is guarded by
+ * history rather than by the compiler.
  */
 
 import type { Defaulted, DeploymentBootstrap } from "@/client"

--- a/web/src/shared/helpers/bootstrap.ts
+++ b/web/src/shared/helpers/bootstrap.ts
@@ -21,7 +21,7 @@
  * it arrived, and `DeploymentRoot` falls through to the sign-in screen.
  */
 
-import type { DeploymentBootstrap } from "@/client"
+import type { Defaulted, DeploymentBootstrap } from "@/client"
 
 /**
  * The fields whose absence has a safe reading, which is the same reading in
@@ -45,13 +45,12 @@ type SkewProne =
 /**
  * A bootstrap as received rather than as promised.
  *
- * The response-side twin of `Defaulted` in `src/client/index.ts`: that one
- * loosens a request body the dashboard may send partially, this one loosens a
- * response an older server may send partially. Both exist because the generator
- * emits one shape for a contract that has two.
+ * `Defaulted` itself, applied to a response rather than to a request body: that
+ * use loosens what the dashboard may send partially, this one what an older
+ * gateway may answer partially. Both exist because the generator emits one
+ * shape for a contract that has two.
  */
-export type WireBootstrap = Omit<DeploymentBootstrap, SkewProne> &
-  Partial<Pick<DeploymentBootstrap, SkewProne>>
+export type WireBootstrap = Defaulted<DeploymentBootstrap, SkewProne>
 
 /** Complete a received bootstrap, so nothing below reads an absent field. */
 export function normalizeBootstrap(wire: WireBootstrap): DeploymentBootstrap {

--- a/web/src/shared/helpers/bootstrap.ts
+++ b/web/src/shared/helpers/bootstrap.ts
@@ -1,0 +1,75 @@
+/**
+ * The bootstrap as an older gateway can actually send it, and how to read one.
+ *
+ * `DeploymentBootstrap` describes the gateway this dashboard was built beside,
+ * where every field is present. A gateway built before a field was added does
+ * not send it, and nothing on the wire says so: the generated type promises
+ * `oauth_providers: string[]`, the payload carries no `oauth_providers`, and
+ * the first `.filter` on it throws (otari#806). Version skew is a normal
+ * condition while developing and an ordinary one in production, where the
+ * dashboard is served by whichever gateway an operator has deployed.
+ *
+ * So the payload is read as the possibly older shape it is and completed once,
+ * here, rather than guarded at each call site that would otherwise have to
+ * remember. The alternative was tried and is what #806 is about: a guard added
+ * where the crash was seen leaves the same field unguarded three lines up.
+ *
+ * `deployment_type` and `session_type` take no default, because they say what
+ * this deployment *is* and `web/AGENTS.md` is explicit that the app must not
+ * guess that. A payload missing them is passed through as it arrived, where it
+ * selects no mode rather than the wrong one.
+ */
+
+import type { DeploymentBootstrap } from "@/client"
+
+/**
+ * The fields whose absence has a safe reading, which is the same reading in
+ * every case: offer nothing, claim nothing, link nowhere. A gateway too old to
+ * publish a field is a gateway that cannot serve what the field describes, so
+ * the empty answer is not a guess about it.
+ */
+type SkewProne =
+  | "surfaces"
+  | "sign_in_methods"
+  | "oauth_providers"
+  | "management_url"
+  | "data_plane_url"
+  | "docs_url"
+  | "terms_url"
+  | "privacy_url"
+  | "maintenance_mode"
+  | "passkeys_ready"
+  | "mail_ready"
+
+/**
+ * A bootstrap as received rather than as promised.
+ *
+ * The response-side twin of `Defaulted` in `src/client/index.ts`: that one
+ * loosens a request body the dashboard may send partially, this one loosens a
+ * response an older server may send partially. Both exist because the generator
+ * emits one shape for a contract that has two.
+ */
+export type WireBootstrap = Omit<DeploymentBootstrap, SkewProne> &
+  Partial<Pick<DeploymentBootstrap, SkewProne>>
+
+/** Complete a received bootstrap, so nothing below reads an absent field. */
+export function normalizeBootstrap(wire: WireBootstrap): DeploymentBootstrap {
+  return {
+    ...wire,
+    surfaces: wire.surfaces ?? [],
+    // Empty rather than `["master_key"]`, which is what a gateway old enough to
+    // omit this would in fact have accepted. Naming a credential the server
+    // never published is the guess this file exists to avoid, and the sign-in
+    // screen already has a sentence for a deployment offering none.
+    sign_in_methods: wire.sign_in_methods ?? [],
+    oauth_providers: wire.oauth_providers ?? [],
+    management_url: wire.management_url ?? null,
+    data_plane_url: wire.data_plane_url ?? null,
+    docs_url: wire.docs_url ?? null,
+    terms_url: wire.terms_url ?? null,
+    privacy_url: wire.privacy_url ?? null,
+    maintenance_mode: wire.maintenance_mode ?? false,
+    passkeys_ready: wire.passkeys_ready ?? false,
+    mail_ready: wire.mail_ready ?? false,
+  }
+}

--- a/web/src/shared/helpers/bootstrap.ts
+++ b/web/src/shared/helpers/bootstrap.ts
@@ -16,8 +16,9 @@
  *
  * `deployment_type` and `session_type` take no default, because they say what
  * this deployment *is* and `web/AGENTS.md` is explicit that the app must not
- * guess that. A payload missing them is passed through as it arrived, where it
- * selects no mode rather than the wrong one.
+ * guess that. Both have been on this route since it was added, so no gateway
+ * that answers it at all omits one; a payload missing them is passed through as
+ * it arrived, and `DeploymentRoot` falls through to the sign-in screen.
  */
 
 import type { DeploymentBootstrap } from "@/client"

--- a/web/src/shared/helpers/bootstrap.ts
+++ b/web/src/shared/helpers/bootstrap.ts
@@ -28,19 +28,17 @@ import type { Defaulted, DeploymentBootstrap } from "@/client"
  * every case: offer nothing, claim nothing, link nowhere. A gateway too old to
  * publish a field is a gateway that cannot serve what the field describes, so
  * the empty answer is not a guess about it.
+ *
+ * Derived rather than listed, because a listed one is the same bug again: the
+ * next field added to the bootstrap would be absent from an older gateway,
+ * absent from the list, and dereferenced unguarded, with nothing failing to say
+ * so. Subtracting instead means a new field arrives in `WireBootstrap` optional
+ * and `normalizeBootstrap` stops compiling until it is given a default.
  */
-type SkewProne =
-  | "surfaces"
-  | "sign_in_methods"
-  | "oauth_providers"
-  | "management_url"
-  | "data_plane_url"
-  | "docs_url"
-  | "terms_url"
-  | "privacy_url"
-  | "maintenance_mode"
-  | "passkeys_ready"
-  | "mail_ready"
+type SkewProne = Exclude<
+  keyof DeploymentBootstrap,
+  "deployment_type" | "session_type"
+>
 
 /**
  * A bootstrap as received rather than as promised.


### PR DESCRIPTION
## Description

An older gateway omits bootstrap fields the generated type promises, so the first read throws above the router and blanks the document (#806).

Guarding the reported call site does not fix that. `Login.tsx` reads `sign_in_methods` 25 lines before it reaches `oauth_providers`, and two other pre-router pages read `oauth_providers` again. So the payload is completed once on the way in: `WireBootstrap` is `Defaulted` applied to a response instead of a request body. `deployment_type` and `session_type` take no default, both having been required since the route's first commit.

The second half is the boundary above `RouterProvider`, which is all that was missing, since TanStack already catches routed throws. `PageError` is now the panel for both, and for a gateway that never answered.

Verified rather than argued: the five skew cases in `App.test.tsx` fail on `main`, and `router.test.tsx` asserts the rendered outcome because `defaultErrorComponent` reaches the per-match boundary, not the global one.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Fixes #806

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Opus 5, via Claude Code, from a review of #950 and a follow-up review of this PR.

- [x] I am an AI Agent filling out this form

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYy2GK8YP8v8vXvBtdZjDe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added compatibility handling for bootstrap responses from older gateways.
- Added fallback pages for render and routing failures.
- Added tests for compatibility, error handling, and affected pages.
- Documented the new feedback components.

These changes prevent blank dashboard screens and provide clear recovery guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
