### PR TITLE
fix(gateway): let the platform health probe reach a route outside base_url's own path

### DIFF
--- a/docs/hybrid-mode-protocol.md
+++ b/docs/hybrid-mode-protocol.md
@@ -527,6 +527,7 @@ flag.
 |---|---|---|
 | `OTARI_AI_TOKEN` | none | Setting this enables hybrid mode. |
 | `PLATFORM_HEALTH_PATH` | `/utils/health-check/` | Path under `base_url` probed to report `platform_reachable` on `GET /health`; `GET /health/readiness` answers `503` when the same probe fails. Only a `2xx` counts as reachable, so point it at a route the peer actually serves: a `404`, a `401`, and a redirect to a login page all report unreachable. The default is an otari.ai route. |
+| `PLATFORM_HEALTH_URL` | none | Full URL probed instead of `base_url` + `PLATFORM_HEALTH_PATH`, for a peer whose health route does not live under `base_url`'s own path (an unversioned `/health` beside a versioned `/v1` API, say). Takes precedence over `PLATFORM_HEALTH_PATH` when set. |
 | `PLATFORM_RESOLVE_TIMEOUT_MS` | `5000` | Per-resolve timeout. |
 | `PLATFORM_USAGE_TIMEOUT_MS` | `5000` | Per-usage-report timeout. |
 | `PLATFORM_USAGE_INLINE_TIMEOUT_MS` | `1500` | Budget for the one usage report the response path waits on to attach inline cost. Expiry ships the response without cost; the report itself continues. |

--- a/src/gateway/api/routes/health.py
+++ b/src/gateway/api/routes/health.py
@@ -26,9 +26,15 @@ async def _check_platform_reachability(config: GatewayConfig) -> bool:
     if not platform_base_url:
         return False
 
-    health_path = config.platform.get("health_path", DEFAULT_PLATFORM_HEALTH_PATH)
     timeout_ms = int(config.platform.get("resolve_timeout_ms", 5000))
-    health_url = f"{platform_base_url.rstrip('/')}/{health_path.lstrip('/')}"
+
+    # health_url, when set, names the peer's health route directly rather than
+    # joining health_path onto base_url -- the only way to reach a health route
+    # that does not live under base_url's own path (see its definition).
+    health_url = config.platform.get("health_url")
+    if not health_url:
+        health_path = config.platform.get("health_path", DEFAULT_PLATFORM_HEALTH_PATH)
+        health_url = f"{platform_base_url.rstrip('/')}/{health_path.lstrip('/')}"
 
     try:
         async with httpx.AsyncClient(timeout=timeout_ms / 1000, follow_redirects=False) as client:

--- a/src/gateway/core/config.py
+++ b/src/gateway/core/config.py
@@ -73,6 +73,12 @@ DEFAULT_PLATFORM_MANAGEMENT_URL = "https://otari.ai"
 # is an otari.ai route, so a deployment resolving against any other peer sets
 # platform.health_path (PLATFORM_HEALTH_PATH) to one that peer serves.
 DEFAULT_PLATFORM_HEALTH_PATH = "/utils/health-check/"
+# health_path is always joined onto base_url, which only works when the peer's
+# health route lives under the same path prefix as the rest of its API. Some
+# peers serve health outside that prefix entirely (an unversioned /health
+# beside a versioned /v1 API): no join of base_url and a relative path reaches
+# that. platform.health_url (PLATFORM_HEALTH_URL) is a full URL that bypasses
+# the join and is checked first, for exactly that peer shape.
 PLATFORM_TOKEN_ENV_VAR = "OTARI_AI_TOKEN"
 # User-facing config env vars use the OTARI_ prefix (e.g. OTARI_MASTER_KEY,
 # OTARI_PORT), which is also the native pydantic prefix below.
@@ -2466,6 +2472,7 @@ def _apply_platform_env_overrides(config: dict[str, Any]) -> None:
         "PLATFORM_BASE_URL": ("base_url", str),
         "PLATFORM_MANAGEMENT_URL": ("management_url", str),
         "PLATFORM_HEALTH_PATH": ("health_path", str),
+        "PLATFORM_HEALTH_URL": ("health_url", str),
         "PLATFORM_RESOLVE_TIMEOUT_MS": ("resolve_timeout_ms", int),
         "PLATFORM_USAGE_TIMEOUT_MS": ("usage_timeout_ms", int),
         # Budget for the one usage report the response path waits on. Expiry

--- a/tests/integration/test_config_env_loading.py
+++ b/tests/integration/test_config_env_loading.py
@@ -397,6 +397,7 @@ def test_load_config_platform_env_overrides(tmp_path: Path, monkeypatch: pytest.
     monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
     monkeypatch.setenv("PLATFORM_BASE_URL", "http://localhost:8100/api/v1")
     monkeypatch.setenv("PLATFORM_HEALTH_PATH", "/healthz")
+    monkeypatch.setenv("PLATFORM_HEALTH_URL", "http://localhost:8100/health")
     monkeypatch.setenv("PLATFORM_RESOLVE_TIMEOUT_MS", "1234")
     monkeypatch.setenv("PLATFORM_USAGE_TIMEOUT_MS", "2345")
     monkeypatch.setenv("PLATFORM_USAGE_INLINE_TIMEOUT_MS", "150")
@@ -410,6 +411,7 @@ def test_load_config_platform_env_overrides(tmp_path: Path, monkeypatch: pytest.
     assert config.is_hybrid_mode
     assert config.platform["base_url"] == "http://localhost:8100/api/v1"
     assert config.platform["health_path"] == "/healthz"
+    assert config.platform["health_url"] == "http://localhost:8100/health"
     assert config.platform["resolve_timeout_ms"] == 1234
     assert config.platform["usage_timeout_ms"] == 2345
     assert config.platform["usage_inline_timeout_ms"] == 150

--- a/tests/unit/test_platform_reachability_probe.py
+++ b/tests/unit/test_platform_reachability_probe.py
@@ -56,16 +56,28 @@ def _isolated_platform_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> N
     ``load_config`` reads a ``.env`` from the working directory, which would put
     a contributor's local ``PLATFORM_*`` values back after the deletes below.
     """
-    for name in ("OTARI_AI_TOKEN", "PLATFORM_BASE_URL", "PLATFORM_HEALTH_PATH", "OTARI_MODE"):
+    for name in (
+        "OTARI_AI_TOKEN",
+        "PLATFORM_BASE_URL",
+        "PLATFORM_HEALTH_PATH",
+        "PLATFORM_HEALTH_URL",
+        "OTARI_MODE",
+    ):
         monkeypatch.delenv(name, raising=False)
     monkeypatch.chdir(tmp_path)
 
 
-def _hybrid_config(monkeypatch: pytest.MonkeyPatch, health_path: str | None = None) -> Any:
+def _hybrid_config(
+    monkeypatch: pytest.MonkeyPatch,
+    health_path: str | None = None,
+    health_url: str | None = None,
+) -> Any:
     monkeypatch.setenv("OTARI_AI_TOKEN", "gw_test_token")
     monkeypatch.setenv("PLATFORM_BASE_URL", "http://platform.test/v1")
     if health_path is not None:
         monkeypatch.setenv("PLATFORM_HEALTH_PATH", health_path)
+    if health_url is not None:
+        monkeypatch.setenv("PLATFORM_HEALTH_URL", health_url)
     return load_config()
 
 
@@ -76,6 +88,28 @@ async def test_health_path_env_var_moves_the_probe(monkeypatch: pytest.MonkeyPat
 
     assert await _check_platform_reachability(config) is True
     assert [str(url) for url in stub.requested] == ["http://platform.test/v1/healthz"]
+
+
+@pytest.mark.asyncio
+async def test_health_url_env_var_bypasses_the_join(monkeypatch: pytest.MonkeyPatch, probe: Any) -> None:
+    """A peer whose health route sits outside base_url's own path (an
+    unversioned /health beside a versioned /v1 base) has no health_path that
+    joining onto base_url can reach; health_url names it directly instead.
+    """
+    stub = probe()
+    config = _hybrid_config(monkeypatch, health_url="http://platform.test/health")
+
+    assert await _check_platform_reachability(config) is True
+    assert [str(url) for url in stub.requested] == ["http://platform.test/health"]
+
+
+@pytest.mark.asyncio
+async def test_health_url_takes_precedence_over_health_path(monkeypatch: pytest.MonkeyPatch, probe: Any) -> None:
+    stub = probe()
+    config = _hybrid_config(monkeypatch, health_path="/healthz", health_url="http://platform.test/health")
+
+    assert await _check_platform_reachability(config) is True
+    assert [str(url) for url in stub.requested] == ["http://platform.test/health"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

A hybrid-mode gateway's `platform_reachable` probe (`GET /health`, `GET /health/readiness`) always builds its check URL by joining `PLATFORM_HEALTH_PATH` onto `PLATFORM_BASE_URL`:

```python
health_url = f"{platform_base_url.rstrip('/')}/{health_path.lstrip('/')}"
```

That only reaches a peer whose health route lives *under* `base_url`'s own path. A peer that serves its health route outside that path entirely — an unversioned `/health` beside a versioned `/v1` API, say — has no relative `health_path` a join onto `/v1` can reach: the probe 404s every interval, and `platform_reachable` reports `no` even when the peer is healthy.

Adds `platform.health_url` (`PLATFORM_HEALTH_URL`): a full URL, checked first, that bypasses the `base_url` + `health_path` join entirely. Unset, behavior is unchanged — falls back to the existing join.

## PR Type

- [x] Bug Fix

## Relevant issues

None filed — found via log review, not tracked elsewhere.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
  - `make lint` and `make typecheck` pass clean. `make test` (full suite) not run: this environment has no Docker, which most of `tests/integration/` needs (testcontainers Postgres, per `AGENTS.md`). Ran the specific unit file for the changed behavior (`tests/unit/test_platform_reachability_probe.py`, 15 passed) instead.
- [x] Documentation was updated where necessary.
- [ ] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). — not applicable, no request/response schema changed.

## AI Usage

- [x] This is fully AI-generated.

**AI Model/Tool used:** Claude Sonnet 5 (Claude Code)

**Any additional AI details you'd like to share:** Diagnosed from gateway source after being pointed at a repeating 404 in an operator's logs; implementation, tests, and docs all written by the agent.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `platform.health_url` (`PLATFORM_HEALTH_URL`) for hybrid-mode health probes.
- Health probes use the full URL when configured, then fall back to the existing base URL and health path.
- Updated configuration documentation and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->