### PR TITLE
feat(cli): add otari import claude-code to backfill transcript usage

### DIFF
--- a/docs/external-usage.md
+++ b/docs/external-usage.md
@@ -32,6 +32,13 @@ analytics would count the session twice.
 Prefer a dedicated API key for each importer. It limits attribution mistakes and
 keeps the master key out of collectors.
 
+## Backfill Claude Code from local transcripts
+
+For Claude Code specifically, the bundled `otari import claude-code` reads the
+transcripts already on disk and posts them here, which is how history from before
+any exporter was configured gets in. See
+[Use with Claude Code](use-with-claude-code.md#backfill-history-from-local-transcripts).
+
 ## Import normalized events
 
 ```bash

--- a/docs/use-with-claude-code.md
+++ b/docs/use-with-claude-code.md
@@ -87,3 +87,34 @@ Imported events are priced for analytics and never count toward budgets. Do not
 both route and export one session, or its cost will appear twice. See
 [Importing external usage](external-usage.md) for attribution, privacy,
 idempotency, and pricing behavior.
+
+## Backfill history from local transcripts
+
+The exporter above carries sessions that run after it is configured. Everything
+Claude Code did before that is already on disk, one JSONL transcript per session
+under `~/.claude/projects`. `otari import claude-code` reads those transcripts and
+posts them to the same import endpoint:
+
+```bash
+export OTARI_URL="https://otari.example.com"
+export OTARI_API_KEY="gw-your-import-key"
+otari import claude-code --user-id alice
+```
+
+The key must be budget-exempt (`exclude_from_budget: true`), the same requirement
+every import has. Use `--dry-run` first to see the event and token counts without
+sending anything, and `--since 7d` (or an ISO date) to read only recently modified
+transcripts.
+
+Only token counts and identifiers are read. Prompts, completions, and tool
+payloads are never opened out of a transcript, and the endpoint rejects them.
+
+Rows are unique on `(source, source_event_id)`, and the source event id here is the
+Anthropic response id, so re-running imports only what is new and reports the rest
+as duplicates. A single reply spans several transcript lines under one response id;
+those collapse to the one API call they were.
+
+The same warning applies as above, and it matters more for a backfill: do not
+import sessions that were routed through Otari. Those are already recorded, and the
+proxied and imported rows cannot be correlated, so the cost would count twice.
+

--- a/docs/use-with-claude-code.md
+++ b/docs/use-with-claude-code.md
@@ -97,17 +97,43 @@ posts them to the same import endpoint:
 
 ```bash
 export OTARI_URL="https://otari.example.com"
+
+# Preview what is on disk. No credential needed: a dry run sends nothing.
+otari import claude-code --dry-run
+
+# Then import it, with a budget-exempt API key. Usage binds to that key's own
+# user, so do not pass --user-id here.
 export OTARI_API_KEY="gw-your-import-key"
-otari import claude-code --user-id alice
+otari import claude-code
 ```
 
 The key must be budget-exempt (`exclude_from_budget: true`), the same requirement
-every import has. Use `--dry-run` first to see the event and token counts without
-sending anything, and `--since 7d` (or an ISO date) to read only recently modified
-transcripts.
+every import has.
+
+The master key works too, and it is the only credential that can import on behalf
+of somebody else. It requires `--user-id`, and that user must already exist
+(create one with `POST /v1/users` first):
+
+```bash
+export OTARI_MASTER_KEY="your-master-key"
+otari import claude-code --user-id alice
+```
+
+Passing `--user-id` with an ordinary API key does not do this: usage always binds
+to the key's own user, and naming a different one is rejected. Prefer a per-user
+API key where you can, and keep the master key for a one-off backfill you are
+running on someone's behalf.
+
+The first event is posted on its own, so a rejection (an unknown user, a key that
+is not budget-exempt) is reported before the rest of the history is uploaded. Use
+`--since 7d` (or an ISO date) to read only recently modified transcripts.
 
 Only token counts and identifiers are read. Prompts, completions, and tool
 payloads are never opened out of a transcript, and the endpoint rejects them.
+
+Each event carries a `session_label` of `<hostname>:<project>`, where the project
+is the session's working directory with the home-directory prefix dropped, so
+usage can be grouped per repository. Filter on it in Activity and Usage.
 
 Rows are unique on `(source, source_event_id)`, and the source event id here is the
 Anthropic response id, so re-running imports only what is new and reports the rest

--- a/src/gateway/cli.py
+++ b/src/gateway/cli.py
@@ -4,6 +4,7 @@ import re
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 import click
 import uvicorn
@@ -384,6 +385,125 @@ def routing_explain(
             "/v1/chat/completions, /v1/messages and /v1/responses; on the other model-taking endpoints "
             "(embeddings, images, moderations, rerank, batches) it is not a resolvable model name."
         )
+
+
+@cli.group(name="import")
+def import_group() -> None:
+    """Import usage that Otari did not proxy."""
+
+
+@import_group.command(name="claude-code")
+@click.option("--url", envvar="OTARI_URL", default="http://localhost:8000", help="Base URL of the Otari gateway.")
+@click.option(
+    "--api-key",
+    envvar="OTARI_API_KEY",
+    required=True,
+    help="A budget-exempt API key (exclude_from_budget: true). Imported usage is never enforceable.",
+)
+@click.option(
+    "--projects-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path.home() / ".claude" / "projects",
+    show_default=True,
+    help="Where Claude Code keeps its transcripts.",
+)
+@click.option(
+    "--since",
+    default=None,
+    help="Only read transcripts modified since this ISO date or duration (7d, 24h, 2w).",
+)
+@click.option(
+    "--user-id",
+    default=None,
+    help="Default user for the batch. Required when authenticating with the master key.",
+)
+@click.option(
+    "--label-prefix",
+    default=None,
+    help="First half of session_label. Defaults to this machine's short hostname.",
+)
+@click.option("--batch-size", type=click.IntRange(1, 1000), default=1000, show_default=True, help="Events per request.")
+@click.option("--dry-run", is_flag=True, help="Parse and summarize without sending anything.")
+def import_claude_code(
+    url: str,
+    api_key: str,
+    projects_dir: Path,
+    since: str | None,
+    user_id: str | None,
+    label_prefix: str | None,
+    batch_size: int,
+    dry_run: bool,
+) -> None:
+    """Backfill historical Claude Code usage from this machine's transcripts.
+
+    The OTLP exporter documented in docs/use-with-claude-code.md only carries
+    sessions that run after it is configured. This reads the transcripts Claude
+    Code has already written and posts them to /v1/usage/external-events, which
+    is idempotent on (source, source_event_id): re-running imports only what is
+    new and reports the rest as duplicates.
+
+    Do not backfill sessions that were routed through Otari. Their usage is
+    already recorded, and the proxied and imported rows cannot be correlated, so
+    the cost would appear twice.
+    """
+    import socket
+
+    import httpx
+
+    from gateway.services.claude_code_import import parse_since, scan_transcripts
+
+    try:
+        cutoff = parse_since(since) if since is not None else None
+    except ValueError as exc:
+        raise click.BadParameter(str(exc), param_hint="--since") from exc
+
+    prefix = label_prefix or socket.gethostname().split(".")[0]
+    result = scan_transcripts(projects_dir, label_prefix=prefix, since=cutoff)
+    if not result.events:
+        click.echo(f"No usage found in {projects_dir}. Nothing to import.")
+        return
+
+    click.echo(
+        f"Scanned {result.files_scanned} transcript(s): {len(result.events)} event(s), "
+        f"{result.duplicates_skipped} repeated response id(s) collapsed."
+    )
+    for model, tokens in sorted(result.tokens_by_model.items(), key=lambda item: -item[1]):
+        click.echo(f"  {model}: {tokens:,} tokens")
+    if dry_run:
+        click.echo("Dry run: nothing was sent.")
+        return
+
+    endpoint = f"{url.rstrip('/')}/v1/usage/external-events"
+    accepted = duplicate = rejected = 0
+    with httpx.Client(timeout=120.0) as client:
+        for start in range(0, len(result.events), batch_size):
+            body: dict[str, object] = {
+                "source": "claude_code",
+                "events": [event.as_payload() for event in result.events[start : start + batch_size]],
+            }
+            if user_id is not None:
+                body["user_id"] = user_id
+            response = client.post(endpoint, json=body, headers={"Authorization": f"Bearer {api_key}"})
+            if response.status_code >= 400:
+                # The whole batch failed validation or auth. Show what the server
+                # said rather than a count, because the reason is the fix.
+                click.echo(
+                    f"Batch starting at event {start} was refused "
+                    f"({response.status_code}): {response.text[:500]}"
+                )
+                rejected += len(body["events"]) if isinstance(body["events"], list) else 0
+                continue
+            outcome = response.json()
+            accepted += int(outcome.get("accepted", 0))
+            duplicate += int(outcome.get("duplicate", 0))
+            rejected += int(outcome.get("rejected", 0))
+            for error in outcome.get("errors", [])[:5]:
+                click.echo(f"  rejected: {error.get('detail')}")
+
+    click.echo(f"Imported {accepted} event(s); {duplicate} already present; {rejected} rejected.")
+    if rejected:
+        raise SystemExit(1)
+
 
 
 def main() -> None:

--- a/src/gateway/cli.py
+++ b/src/gateway/cli.py
@@ -396,9 +396,13 @@ def import_group() -> None:
 @click.option("--url", envvar="OTARI_URL", default="http://localhost:8000", help="Base URL of the Otari gateway.")
 @click.option(
     "--api-key",
-    envvar="OTARI_API_KEY",
-    required=True,
-    help="A budget-exempt API key (exclude_from_budget: true). Imported usage is never enforceable.",
+    envvar=["OTARI_API_KEY", "OTARI_MASTER_KEY"],
+    default=None,
+    help=(
+        "Credential for the import endpoint: a budget-exempt API key "
+        "(exclude_from_budget: true) or the master key. Imported usage is never "
+        "budget-enforceable. Not needed with --dry-run."
+    ),
 )
 @click.option(
     "--projects-dir",
@@ -415,23 +419,31 @@ def import_group() -> None:
 @click.option(
     "--user-id",
     default=None,
-    help="Default user for the batch. Required when authenticating with the master key.",
+    help=(
+        "Default user for the batch. Required when authenticating with the master key, and the user "
+        "must already exist. Ignored with an API key, which binds usage to its own user."
+    ),
 )
 @click.option(
     "--label-prefix",
     default=None,
     help="First half of session_label. Defaults to this machine's short hostname.",
 )
-@click.option("--batch-size", type=click.IntRange(1, 1000), default=1000, show_default=True, help="Events per request.")
+@click.option(
+    "--batch-size",
+    type=click.IntRange(1),
+    default=None,
+    help="Events per request. Defaults to the endpoint's own maximum.",
+)
 @click.option("--dry-run", is_flag=True, help="Parse and summarize without sending anything.")
 def import_claude_code(
     url: str,
-    api_key: str,
+    api_key: str | None,
     projects_dir: Path,
     since: str | None,
     user_id: str | None,
     label_prefix: str | None,
-    batch_size: int,
+    batch_size: int | None,
     dry_run: bool,
 ) -> None:
     """Backfill historical Claude Code usage from this machine's transcripts.
@@ -451,14 +463,33 @@ def import_claude_code(
     import httpx
 
     from gateway.services.claude_code_import import parse_since, scan_transcripts
+    from gateway.services.external_usage_service import MAX_EVENTS_PER_BATCH
 
     try:
         cutoff = parse_since(since) if since is not None else None
     except ValueError as exc:
         raise click.BadParameter(str(exc), param_hint="--since") from exc
 
+    # The endpoint owns the cap, so it is read rather than restated on the option:
+    # a decorator default would need the constant at import time, and importing the
+    # ingest service to build the CLI would load the API stack for every command.
+    if batch_size is None:
+        batch_size = MAX_EVENTS_PER_BATCH
+    elif batch_size > MAX_EVENTS_PER_BATCH:
+        raise click.BadParameter(
+            f"the endpoint accepts at most {MAX_EVENTS_PER_BATCH} events per request.",
+            param_hint="--batch-size",
+        )
+
     prefix = label_prefix or socket.gethostname().split(".")[0]
     result = scan_transcripts(projects_dir, label_prefix=prefix, since=cutoff)
+    if result.unparsable_lines:
+        # Reported before the empty check: a truncated transcript is exactly the
+        # case that finds nothing to import, and silence there reads as "no usage".
+        click.echo(
+            f"Warning: {result.unparsable_lines} line(s) could not be decoded and were skipped. "
+            "Any usage they carried was not imported."
+        )
     if not result.events:
         click.echo(f"No usage found in {projects_dir}. Nothing to import.")
         return
@@ -474,32 +505,65 @@ def import_claude_code(
         click.echo("Dry run: nothing was sent.")
         return
 
+    if not api_key:
+        raise click.UsageError(
+            "A credential is required to send events: a budget-exempt API key, or the master key. "
+            "Pass --api-key, or set OTARI_API_KEY or OTARI_MASTER_KEY. "
+            "Re-run with --dry-run to preview a scan without one."
+        )
+
     endpoint = f"{url.rstrip('/')}/v1/usage/external-events"
+    headers = {"Authorization": f"Bearer {api_key}"}
+    # The first event is posted alone, so a mistake that will reject every event
+    # (an unknown --user-id, a key that is not budget-exempt) costs one request and
+    # one error line instead of the whole history and a truncated list of identical
+    # rejections. The rest follow in full batches.
+    batches = [result.events[:1]]
+    batches += [result.events[start : start + batch_size] for start in range(1, len(result.events), batch_size)]
+
     accepted = duplicate = rejected = 0
     with httpx.Client(timeout=120.0) as client:
-        for start in range(0, len(result.events), batch_size):
+        for position, batch in enumerate(batches):
             body: dict[str, object] = {
                 "source": "claude_code",
-                "events": [event.as_payload() for event in result.events[start : start + batch_size]],
+                "events": [event.as_payload() for event in batch],
             }
             if user_id is not None:
                 body["user_id"] = user_id
-            response = client.post(endpoint, json=body, headers={"Authorization": f"Bearer {api_key}"})
+            try:
+                response = client.post(endpoint, json=body, headers=headers)
+            except httpx.HTTPError as exc:
+                click.echo(
+                    f"Import stopped after {accepted} event(s): {exc}. "
+                    "Re-running is safe: what already landed comes back as duplicates."
+                )
+                rejected += len(batch)
+                break
             if response.status_code >= 400:
                 # The whole batch failed validation or auth. Show what the server
                 # said rather than a count, because the reason is the fix.
                 click.echo(
-                    f"Batch starting at event {start} was refused "
+                    f"Batch {position + 1} of {len(batches)} was refused "
                     f"({response.status_code}): {response.text[:500]}"
                 )
-                rejected += len(body["events"]) if isinstance(body["events"], list) else 0
+                rejected += len(batch)
+                if position == 0:
+                    click.echo("Nothing else was sent. Fix the above and re-run.")
+                    break
                 continue
             outcome = response.json()
             accepted += int(outcome.get("accepted", 0))
             duplicate += int(outcome.get("duplicate", 0))
-            rejected += int(outcome.get("rejected", 0))
+            batch_rejected = int(outcome.get("rejected", 0))
+            rejected += batch_rejected
             for error in outcome.get("errors", [])[:5]:
                 click.echo(f"  rejected: {error.get('detail')}")
+            if position == 0 and batch_rejected:
+                click.echo(
+                    f"The first event was rejected, so the remaining {len(result.events) - len(batch)} "
+                    "were not sent. Fix the above and re-run."
+                )
+                break
 
     click.echo(f"Imported {accepted} event(s); {duplicate} already present; {rejected} rejected.")
     if rejected:

--- a/src/gateway/cli.py
+++ b/src/gateway/cli.py
@@ -465,7 +465,8 @@ def import_claude_code(
 
     click.echo(
         f"Scanned {result.files_scanned} transcript(s): {len(result.events)} event(s), "
-        f"{result.duplicates_skipped} repeated response id(s) collapsed."
+        f"{result.duplicates_skipped} repeated response id(s) collapsed, "
+        f"{result.synthetic_skipped} local (non-API) message(s) skipped."
     )
     for model, tokens in sorted(result.tokens_by_model.items(), key=lambda item: -item[1]):
         click.echo(f"  {model}: {tokens:,} tokens")

--- a/src/gateway/services/claude_code_import.py
+++ b/src/gateway/services/claude_code_import.py
@@ -201,8 +201,6 @@ def _usage_event(record: dict[str, Any], label: str) -> UsageEvent | None:
     timestamp = record.get("timestamp")
     if not isinstance(usage, dict) or not isinstance(response_id, str) or not isinstance(timestamp, str):
         return None
-    if message.get("model") == _SYNTHETIC_MODEL:
-        return None
     # Anthropic splits cache writes by TTL. ``cache_creation_input_tokens`` is the
     # total; the 1h share is priced differently, so it is reported separately and
     # subtracted rather than counted twice.

--- a/src/gateway/services/claude_code_import.py
+++ b/src/gateway/services/claude_code_import.py
@@ -41,11 +41,10 @@ _IDENT_ALLOWED = re.compile(r"[^A-Za-z0-9._:/\-]")
 # priced model, so it is stripped: keeping it would leave every such event
 # unpriced under a model id no price list has.
 _CONTEXT_TAG = re.compile(r"\[[^\]]*\]")
-# A project directory is the session's working directory with separators
-# replaced by dashes ("-Users-alice-Projects-otari"). Only the last segment is
-# meaningful as a label, and reconstructing the original path is impossible
-# anyway, because a dash in a real directory name is indistinguishable from a
-# separator.
+# A project directory is the session's working directory with separators and dots
+# replaced by dashes ("-Users-alice-Projects-otari"). Reconstructing the original
+# path is impossible, because a dash in a real directory name is
+# indistinguishable from a separator.
 _LEADING_DASH = re.compile(r"^-+")
 # Claude Code writes an assistant line with this model for text it produced
 # locally rather than fetched, most often an API error notice shown in the
@@ -165,12 +164,33 @@ def provider_for_model(model: str) -> str:
     return UNKNOWN_PROVIDER
 
 
-def session_label(project_dir: str, prefix: str) -> str:
-    """Build ``<prefix>:<project>`` from a transcript's project directory name."""
+def mangle_path(path: Path) -> str:
+    """Encode a path the way Claude Code names its project directories.
+
+    Not a path operation, which is why pathlib cannot do it: the encoding flattens
+    a path into one directory name, replacing dots as well as separators, so
+    ``~/.claude/worktrees`` arrives as ``-Users-alice--claude-worktrees``. Only the
+    separators are pathlib's business, and ``as_posix`` is what makes them one
+    character to replace on Windows too.
+    """
+    return path.as_posix().replace("/", "-").replace(".", "-")
+
+
+def session_label(project_dir: str, prefix: str, *, home: Path | None = None) -> str:
+    """Build ``<prefix>:<project>`` from a transcript's project directory name.
+
+    The home directory's own prefix is dropped, which keeps a username out of the
+    label; what remains is kept whole rather than reduced to its last segment,
+    because the last segment collides badly in practice. Sessions run from
+    worktrees under ``.claude/worktrees`` would all label as a bare branch name,
+    identical across every repository on the machine.
+    """
     trimmed = _LEADING_DASH.sub("", project_dir)
-    project = trimmed.rsplit("-", 1)[-1] if trimmed else ""
+    home_prefix = _LEADING_DASH.sub("", mangle_path(home if home is not None else Path.home()))
+    if home_prefix and trimmed.startswith(f"{home_prefix}-"):
+        trimmed = trimmed[len(home_prefix) + 1 :]
     host = _IDENT_ALLOWED.sub("-", prefix).strip("-") or "local"
-    name = _IDENT_ALLOWED.sub("-", project).strip("-") or "unknown"
+    name = _IDENT_ALLOWED.sub("-", trimmed).strip("-") or "unknown"
     return f"{host}:{name}"[:256]
 
 
@@ -186,8 +206,15 @@ def iter_transcripts(projects_dir: Path, since: datetime | None = None) -> Itera
         return
     cutoff = since.timestamp() if since is not None else None
     for path in sorted(projects_dir.rglob("*.jsonl")):
-        if cutoff is not None and path.stat().st_mtime < cutoff:
-            continue
+        if cutoff is not None:
+            try:
+                if path.stat().st_mtime < cutoff:
+                    continue
+            except OSError:
+                # Tolerated for the same reason the read loop tolerates one: a
+                # transcript that vanished or cannot be read is not a reason to
+                # abandon the scan.
+                continue
         yield path
 
 

--- a/src/gateway/services/claude_code_import.py
+++ b/src/gateway/services/claude_code_import.py
@@ -13,7 +13,9 @@ Claude Code writes one JSONL transcript per session under
 the API response id, the model, and the Anthropic usage block. The same response
 id repeats once per content block of a single reply, so the walk is deduplicated
 by response id: counting every line would multiply a session's tokens by the
-number of blocks its replies happened to contain.
+number of blocks its replies happened to contain. Lines whose model is
+``<synthetic>`` are dropped: those are messages Claude Code wrote itself, such as
+an API error notice, and no request was ever sent for them.
 
 Pure and offline. No network, no database, and no prompt or completion text is
 read out of a transcript: a line is decoded, its usage numbers and identifiers
@@ -45,6 +47,12 @@ _CONTEXT_TAG = re.compile(r"\[[^\]]*\]")
 # anyway, because a dash in a real directory name is indistinguishable from a
 # separator.
 _LEADING_DASH = re.compile(r"^-+")
+# Claude Code writes an assistant line with this model for text it produced
+# locally rather than fetched, most often an API error notice shown in the
+# transcript. It carries a usage block like any other line, but no request was
+# ever made, so importing one invents a call that never happened and puts a
+# model nobody can price into the breakdown.
+_SYNTHETIC_MODEL = "<synthetic>"
 _DURATION = re.compile(r"^(\d+)([hdw])$")
 _DURATION_UNITS = {"h": "hours", "d": "days", "w": "weeks"}
 
@@ -106,6 +114,7 @@ class ScanResult:
     files_scanned: int = 0
     duplicates_skipped: int = 0
     unparsable_lines: int = 0
+    synthetic_skipped: int = 0
 
     @property
     def tokens_by_model(self) -> dict[str, int]:
@@ -192,6 +201,8 @@ def _usage_event(record: dict[str, Any], label: str) -> UsageEvent | None:
     timestamp = record.get("timestamp")
     if not isinstance(usage, dict) or not isinstance(response_id, str) or not isinstance(timestamp, str):
         return None
+    if message.get("model") == _SYNTHETIC_MODEL:
+        return None
     # Anthropic splits cache writes by TTL. ``cache_creation_input_tokens`` is the
     # total; the 1h share is priced differently, so it is reported separately and
     # subtracted rather than counted twice.
@@ -213,6 +224,12 @@ def _usage_event(record: dict[str, Any], label: str) -> UsageEvent | None:
         cache_write_1h_tokens=write_1h,
         session_label=label,
     )
+
+
+def _is_synthetic(record: dict[str, Any]) -> bool:
+    """Whether a line is Claude Code's own text rather than a provider response."""
+    message = record.get("message")
+    return isinstance(message, dict) and message.get("model") == _SYNTHETIC_MODEL
 
 
 def _int(value: Any) -> int:
@@ -244,6 +261,9 @@ def scan_transcripts(projects_dir: Path, *, label_prefix: str, since: datetime |
                         result.unparsable_lines += 1
                         continue
                     if not isinstance(record, dict):
+                        continue
+                    if _is_synthetic(record):
+                        result.synthetic_skipped += 1
                         continue
                     event = _usage_event(record, label)
                     if event is None:

--- a/src/gateway/services/claude_code_import.py
+++ b/src/gateway/services/claude_code_import.py
@@ -1,0 +1,261 @@
+"""Read Claude Code's local transcripts into importable usage events.
+
+Claude Code speaks the Anthropic Messages API, but a subscription-backed session
+never routes through Otari, so its spend is invisible here. `Importing external
+usage <../../docs/external-usage.md>`_ closes that gap going forward: point the
+OTLP exporter at a gateway and new sessions arrive. What the exporter cannot
+reach is the history already on disk from before it was configured, which for a
+daily Claude Code user is most of the usage there has ever been. This module
+reads that history so it can be posted to ``POST /v1/usage/external-events``.
+
+Claude Code writes one JSONL transcript per session under
+``~/.claude/projects/<mangled-cwd>/<session-id>.jsonl``. An assistant line carries
+the API response id, the model, and the Anthropic usage block. The same response
+id repeats once per content block of a single reply, so the walk is deduplicated
+by response id: counting every line would multiply a session's tokens by the
+number of blocks its replies happened to contain.
+
+Pure and offline. No network, no database, and no prompt or completion text is
+read out of a transcript: a line is decoded, its usage numbers and identifiers
+are taken, and the rest is dropped. The caller posts what this returns.
+"""
+
+import json
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+# The endpoint's identifier grammar (``_IDENT_PATTERN`` in
+# ``external_usage_service``). Anything outside it is a 422 for the whole batch,
+# so model names and labels are folded into it here rather than discovered to be
+# unpostable a thousand events later.
+_IDENT_ALLOWED = re.compile(r"[^A-Za-z0-9._:/\-]")
+# Claude Code appends a context-window tag to the model it reports, e.g.
+# ``claude-sonnet-4-5[1m]`` for the 1M-context variant. The brackets are outside
+# the grammar above, and the tag names a context window rather than a distinct
+# priced model, so it is stripped: keeping it would leave every such event
+# unpriced under a model id no price list has.
+_CONTEXT_TAG = re.compile(r"\[[^\]]*\]")
+# A project directory is the session's working directory with separators
+# replaced by dashes ("-Users-alice-Projects-otari"). Only the last segment is
+# meaningful as a label, and reconstructing the original path is impossible
+# anyway, because a dash in a real directory name is indistinguishable from a
+# separator.
+_LEADING_DASH = re.compile(r"^-+")
+_DURATION = re.compile(r"^(\d+)([hdw])$")
+_DURATION_UNITS = {"h": "hours", "d": "days", "w": "weeks"}
+
+# Claude Code is an Anthropic client, but ``ANTHROPIC_BASE_URL`` points it at
+# anything that speaks the Messages API, and the transcript records whatever
+# model that backend named. Mapping only families we can identify, and admitting
+# "unknown" otherwise, keeps a mispriced guess out of the usage log: an unpriced
+# row is visibly unpriced, while one priced as Anthropic is silently wrong.
+_PROVIDER_BY_PREFIX: tuple[tuple[str, str], ...] = (
+    ("claude", "anthropic"),
+    ("gpt", "openai"),
+    ("o1", "openai"),
+    ("o3", "openai"),
+    ("gemini", "google"),
+    ("kimi", "moonshot"),
+)
+UNKNOWN_PROVIDER = "unknown"
+
+
+@dataclass(frozen=True)
+class UsageEvent:
+    """One API call, shaped for ``POST /v1/usage/external-events``."""
+
+    source_event_id: str
+    timestamp: str
+    provider: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_write_tokens: int
+    cache_write_1h_tokens: int
+    session_label: str
+
+    def as_payload(self) -> dict[str, Any]:
+        """The event as the endpoint's JSON body wants it."""
+        return {
+            "source_event_id": self.source_event_id,
+            "timestamp": self.timestamp,
+            "provider": self.provider,
+            "model": self.model,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "cache_write_tokens": self.cache_write_tokens,
+            "cache_write_1h_tokens": self.cache_write_1h_tokens,
+            # Claude Code reports the Anthropic shape, where the cache buckets are
+            # additive rather than a subset of the input count.
+            "cache_tokens_in_prompt": False,
+            "session_label": self.session_label,
+        }
+
+
+@dataclass
+class ScanResult:
+    """Everything a scan found, plus the counts a caller reports."""
+
+    events: list[UsageEvent] = field(default_factory=list)
+    files_scanned: int = 0
+    duplicates_skipped: int = 0
+    unparsable_lines: int = 0
+
+    @property
+    def tokens_by_model(self) -> dict[str, int]:
+        """Total tokens per model, for the summary a run prints."""
+        totals: dict[str, int] = {}
+        for event in self.events:
+            totals[event.model] = totals.get(event.model, 0) + (
+                event.input_tokens
+                + event.output_tokens
+                + event.cache_read_tokens
+                + event.cache_write_tokens
+                + event.cache_write_1h_tokens
+            )
+        return totals
+
+
+def parse_since(value: str) -> datetime:
+    """Read ``--since`` as an ISO-8601 timestamp or a duration like ``7d``.
+
+    Returns an aware UTC datetime. A bare date is taken as midnight UTC.
+    """
+    match = _DURATION.match(value.strip().lower())
+    if match is not None:
+        amount, unit = int(match.group(1)), _DURATION_UNITS[match.group(2)]
+        return datetime.now(timezone.utc) - timedelta(**{unit: amount})
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(
+            f"{value!r} is neither an ISO-8601 date/time nor a duration like '7d', '24h', or '2w'."
+        ) from exc
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def normalize_model(raw: str | None) -> str:
+    """Fold a reported model id into the endpoint's identifier grammar."""
+    stripped = _CONTEXT_TAG.sub("", raw or "")
+    cleaned = _IDENT_ALLOWED.sub("-", stripped).strip("-")
+    return cleaned or "unknown"
+
+
+def provider_for_model(model: str) -> str:
+    """The provider a model id belongs to, or ``unknown`` when it is not ours to guess."""
+    lowered = model.lower()
+    for prefix, provider in _PROVIDER_BY_PREFIX:
+        if lowered.startswith(prefix):
+            return provider
+    return UNKNOWN_PROVIDER
+
+
+def session_label(project_dir: str, prefix: str) -> str:
+    """Build ``<prefix>:<project>`` from a transcript's project directory name."""
+    trimmed = _LEADING_DASH.sub("", project_dir)
+    project = trimmed.rsplit("-", 1)[-1] if trimmed else ""
+    host = _IDENT_ALLOWED.sub("-", prefix).strip("-") or "local"
+    name = _IDENT_ALLOWED.sub("-", project).strip("-") or "unknown"
+    return f"{host}:{name}"[:256]
+
+
+def iter_transcripts(projects_dir: Path, since: datetime | None = None) -> Iterator[Path]:
+    """Yield every transcript under ``projects_dir``, optionally filtered by ``since``.
+
+    ``since`` is compared against file modification time rather than the timestamps
+    inside, so a run can skip whole files without opening them. A session appended
+    to after the cutoff is therefore read in full and its older events are
+    re-submitted, which the endpoint absorbs as duplicates.
+    """
+    if not projects_dir.is_dir():
+        return
+    cutoff = since.timestamp() if since is not None else None
+    for path in sorted(projects_dir.rglob("*.jsonl")):
+        if cutoff is not None and path.stat().st_mtime < cutoff:
+            continue
+        yield path
+
+
+def _usage_event(record: dict[str, Any], label: str) -> UsageEvent | None:
+    """Turn one decoded transcript line into an event, or None when it carries no usage."""
+    message = record.get("message")
+    if not isinstance(message, dict):
+        return None
+    usage = message.get("usage")
+    response_id = message.get("id")
+    timestamp = record.get("timestamp")
+    if not isinstance(usage, dict) or not isinstance(response_id, str) or not isinstance(timestamp, str):
+        return None
+    # Anthropic splits cache writes by TTL. ``cache_creation_input_tokens`` is the
+    # total; the 1h share is priced differently, so it is reported separately and
+    # subtracted rather than counted twice.
+    cache_creation = usage.get("cache_creation")
+    write_1h = 0
+    if isinstance(cache_creation, dict):
+        write_1h = _int(cache_creation.get("ephemeral_1h_input_tokens"))
+    write_total = _int(usage.get("cache_creation_input_tokens"))
+    model = normalize_model(message.get("model"))
+    return UsageEvent(
+        source_event_id=response_id,
+        timestamp=timestamp,
+        provider=provider_for_model(model),
+        model=model,
+        input_tokens=_int(usage.get("input_tokens")),
+        output_tokens=_int(usage.get("output_tokens")),
+        cache_read_tokens=_int(usage.get("cache_read_input_tokens")),
+        cache_write_tokens=max(write_total - write_1h, 0),
+        cache_write_1h_tokens=write_1h,
+        session_label=label,
+    )
+
+
+def _int(value: Any) -> int:
+    """Read a token count, treating a missing or non-numeric one as zero."""
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
+
+
+def scan_transcripts(projects_dir: Path, *, label_prefix: str, since: datetime | None = None) -> ScanResult:
+    """Walk every transcript under ``projects_dir`` and collect its usage events.
+
+    Deduplicated by response id across the whole scan, not per file: a resumed
+    session can repeat a reply in a second transcript, and the endpoint would
+    reject neither, it would simply record the first and call the second a
+    duplicate. Doing it here keeps the batch honest and the summary accurate.
+    """
+    result = ScanResult()
+    seen: set[str] = set()
+    for path in iter_transcripts(projects_dir, since):
+        result.files_scanned += 1
+        label = session_label(path.relative_to(projects_dir).parts[0], label_prefix)
+        try:
+            with path.open(encoding="utf-8", errors="replace") as handle:
+                for line in handle:
+                    if '"usage"' not in line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except ValueError:
+                        result.unparsable_lines += 1
+                        continue
+                    if not isinstance(record, dict):
+                        continue
+                    event = _usage_event(record, label)
+                    if event is None:
+                        continue
+                    if event.source_event_id in seen:
+                        result.duplicates_skipped += 1
+                        continue
+                    seen.add(event.source_event_id)
+                    result.events.append(event)
+        except OSError:
+            # A transcript being rewritten, or one this user cannot read, is not a
+            # reason to abandon the other several thousand.
+            continue
+    result.events.sort(key=lambda event: event.timestamp)
+    return result

--- a/tests/unit/test_claude_code_import.py
+++ b/tests/unit/test_claude_code_import.py
@@ -145,6 +145,41 @@ def test_locally_generated_messages_are_not_imported(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
+    "line",
+    [
+        json.dumps(
+            {"message": "a string, not an object", "usage": {"input_tokens": 1}, "timestamp": "2026-07-22T12:34:56Z"}
+        ),
+        json.dumps({"message": {"id": "msg_01", "usage": "not-a-dict"}, "timestamp": "2026-07-22T12:34:56Z"}),
+        json.dumps({"message": {"usage": {"input_tokens": 1}}, "timestamp": "2026-07-22T12:34:56Z"}),
+        json.dumps({"message": {"id": 17, "usage": {"input_tokens": 1}}, "timestamp": "2026-07-22T12:34:56Z"}),
+        json.dumps({"message": {"id": "msg_01", "usage": {"input_tokens": 1}}}),
+        json.dumps(["usage", "in a list rather than an object"]),
+    ],
+)
+def test_malformed_usage_lines_are_skipped_without_failing_the_scan(tmp_path: Path, line: str) -> None:
+    """A transcript is a log, not a schema. One odd line must not cost the other thousands."""
+    _write_transcript(tmp_path, "-Users-alice-Projects-otari", "session-a", [line, _assistant_line("msg_ok")])
+
+    result = scan_transcripts(tmp_path, label_prefix="host")
+
+    assert [event.source_event_id for event in result.events] == ["msg_ok"]
+
+
+def test_an_unreadable_transcript_does_not_abort_the_scan(tmp_path: Path) -> None:
+    """One file being rewritten or unreadable must not lose the rest of the corpus."""
+    (tmp_path / "-Users-alice-Projects-otari").mkdir(parents=True)
+    # A directory named like a transcript: rglob matches it, opening it raises OSError.
+    (tmp_path / "-Users-alice-Projects-otari" / "unreadable.jsonl").mkdir()
+    _write_transcript(tmp_path, "-Users-alice-Projects-otari", "session-a", [_assistant_line("msg_01")])
+
+    result = scan_transcripts(tmp_path, label_prefix="host")
+
+    assert [event.source_event_id for event in result.events] == ["msg_01"]
+    assert result.files_scanned == 2
+
+
+@pytest.mark.parametrize(
     ("raw", "expected"),
     [
         ("claude-sonnet-4-5[1m]", "claude-sonnet-4-5"),

--- a/tests/unit/test_claude_code_import.py
+++ b/tests/unit/test_claude_code_import.py
@@ -1,5 +1,6 @@
 """Unit tests for reading Claude Code transcripts into importable usage events."""
 
+import errno
 import json
 import os
 import time
@@ -41,6 +42,15 @@ def _assistant_line(
             },
         }
     )
+
+
+_HOME = Path("/Users/alice")
+
+
+@pytest.fixture(autouse=True)
+def pinned_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A label drops the home directory's prefix, so these tests fix a home to compare against."""
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: _HOME))
 
 
 def _write_transcript(projects_dir: Path, project: str, session: str, lines: list[str]) -> Path:
@@ -213,15 +223,26 @@ def test_provider_is_admitted_unknown_rather_than_guessed(model: str, expected: 
 @pytest.mark.parametrize(
     ("project_dir", "expected"),
     [
-        ("-Users-alice-Projects-otari", "box:otari"),
-        ("-home-alice-src-my-app", "box:app"),
+        ("-Users-alice-Projects-otari", "box:Projects-otari"),
+        # The last segment alone would label this "box:files", naming a project it
+        # is not, and every worktree under .claude/worktrees after its branch.
+        ("-Users-alice-otari-files", "box:otari-files"),
+        ("-Users-alice-otari--claude-worktrees-issue-42", "box:otari--claude-worktrees-issue-42"),
+        # Outside the home directory there is no prefix to drop.
+        ("-opt-src-app", "box:opt-src-app"),
         ("plain", "box:plain"),
         ("", "box:unknown"),
     ],
 )
-def test_session_label_uses_the_last_path_segment(project_dir: str, expected: str) -> None:
-    """The directory name is a mangled path; only its last segment survives as a label."""
-    assert session_label(project_dir, "box") == expected
+def test_session_label_drops_the_home_prefix_and_keeps_the_rest(project_dir: str, expected: str) -> None:
+    """The directory name is a mangled path: the home prefix is noise, the rest identifies the project."""
+    assert session_label(project_dir, "box", home=_HOME) == expected
+
+
+def test_session_label_stays_within_the_endpoints_length_bound() -> None:
+    """A deeply nested working directory must not push the label past max_length=256."""
+    label = session_label("-opt" + "-segment" * 100, "box")
+    assert len(label) == 256
 
 
 def test_since_skips_transcripts_by_modification_time(tmp_path: Path) -> None:
@@ -293,6 +314,8 @@ class _FakeClient:
 
     posted: list[dict[str, Any]] = []
     response = _FakeResponse(200, {"accepted": 1, "duplicate": 0, "rejected": 0, "errors": []})
+    # Consumed one per post when set, for a run whose batches must answer differently.
+    responses: list[Any] = []
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         pass
@@ -305,7 +328,11 @@ class _FakeClient:
 
     def post(self, url: str, *, json: dict[str, Any], headers: dict[str, str]) -> _FakeResponse:
         type(self).posted.append({"url": url, "body": json, "headers": headers})
-        return type(self).response
+        queued = type(self).responses
+        outcome = queued.pop(0) if queued else type(self).response
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
 
 
 @pytest.fixture
@@ -313,6 +340,7 @@ def fake_httpx(monkeypatch: pytest.MonkeyPatch) -> type[_FakeClient]:
     import httpx
 
     _FakeClient.posted = []
+    _FakeClient.responses = []
     _FakeClient.response = _FakeResponse(200, {"accepted": 1, "duplicate": 0, "rejected": 0, "errors": []})
     monkeypatch.setattr(httpx, "Client", _FakeClient)
     return _FakeClient
@@ -362,7 +390,7 @@ def test_a_run_posts_the_batch_to_the_external_events_endpoint(
     assert sent["headers"]["Authorization"] == "Bearer gw-test"
     assert sent["body"]["source"] == "claude_code"
     assert sent["body"]["user_id"] == "alice"
-    assert sent["body"]["events"][0]["session_label"] == "box:otari"
+    assert sent["body"]["events"][0]["session_label"] == "box:Projects-otari"
     assert "prompt" not in sent["body"]["events"][0]
 
 
@@ -415,3 +443,184 @@ def test_a_bad_since_is_a_usage_error(tmp_path: Path, fake_httpx: type[_FakeClie
 
     assert result.exit_code == 2
     assert "--since" in result.output
+
+
+def test_a_credential_is_only_required_to_send(tmp_path: Path, fake_httpx: type[_FakeClient]) -> None:
+    """A dry run reaches nothing, so it must not demand a key to preview a scan."""
+    _write_transcript(tmp_path, "-Users-alice-Projects-otari", "session-a", [_assistant_line("msg_01")])
+
+    preview = CliRunner().invoke(cli, ["import", "claude-code", "--projects-dir", str(tmp_path), "--dry-run"])
+    send = CliRunner().invoke(cli, ["import", "claude-code", "--projects-dir", str(tmp_path)])
+
+    assert preview.exit_code == 0, preview.output
+    assert fake_httpx.posted == []
+    assert send.exit_code == 2
+    assert "OTARI_MASTER_KEY" in send.output
+
+
+def test_the_master_key_env_var_also_supplies_the_credential(
+    tmp_path: Path, fake_httpx: type[_FakeClient]
+) -> None:
+    """Either credential the endpoint accepts should be readable from its own env var."""
+    _write_transcript(tmp_path, "-Users-alice-Projects-otari", "session-a", [_assistant_line("msg_01")])
+
+    result = CliRunner(env={"OTARI_MASTER_KEY": "master-secret"}).invoke(
+        cli, ["import", "claude-code", "--projects-dir", str(tmp_path), "--user-id", "alice"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert fake_httpx.posted[0]["headers"]["Authorization"] == "Bearer master-secret"
+
+
+def test_the_first_event_is_posted_alone_before_the_rest(tmp_path: Path, fake_httpx: type[_FakeClient]) -> None:
+    """A mistake that rejects every event should cost one request to discover, not all of them."""
+    _write_transcript(
+        tmp_path,
+        "-Users-alice-Projects-otari",
+        "session-a",
+        [_assistant_line(f"msg_{index:02d}") for index in range(5)],
+    )
+    fake_httpx.responses = [
+        _FakeResponse(200, {"accepted": 1, "duplicate": 0, "rejected": 0, "errors": []}),
+        _FakeResponse(200, {"accepted": 4, "duplicate": 0, "rejected": 0, "errors": []}),
+    ]
+
+    result = CliRunner().invoke(
+        cli, ["import", "claude-code", "--projects-dir", str(tmp_path), "--api-key", "gw-test"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert [len(post["body"]["events"]) for post in fake_httpx.posted] == [1, 4]
+    assert "Imported 5 event(s)" in result.output
+
+
+def test_a_rejected_first_event_stops_the_import(tmp_path: Path, fake_httpx: type[_FakeClient]) -> None:
+    """An unknown user_id rejects every event, so the rest must not be sent to learn that twice."""
+    _write_transcript(
+        tmp_path,
+        "-Users-alice-Projects-otari",
+        "session-a",
+        [_assistant_line(f"msg_{index:02d}") for index in range(5)],
+    )
+    fake_httpx.response = _FakeResponse(
+        200,
+        {
+            "accepted": 0,
+            "duplicate": 0,
+            "rejected": 1,
+            "errors": [{"index": 0, "detail": "user_id 'ghost' not found."}],
+        },
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["import", "claude-code", "--projects-dir", str(tmp_path), "--api-key", "gw-test", "--user-id", "ghost"],
+    )
+
+    assert result.exit_code == 1
+    assert len(fake_httpx.posted) == 1
+    assert "not found" in result.output
+    assert "remaining 4" in result.output
+
+
+def test_a_refused_first_batch_stops_the_import(tmp_path: Path, fake_httpx: type[_FakeClient]) -> None:
+    """A 403 on the preflight is the whole run's answer; sending the rest only repeats it."""
+    _write_transcript(
+        tmp_path,
+        "-Users-alice-Projects-otari",
+        "session-a",
+        [_assistant_line(f"msg_{index:02d}") for index in range(5)],
+    )
+    fake_httpx.response = _FakeResponse(403, {"detail": "key is not budget-exempt"})
+
+    result = CliRunner().invoke(
+        cli, ["import", "claude-code", "--projects-dir", str(tmp_path), "--api-key", "gw-test"]
+    )
+
+    assert result.exit_code == 1
+    assert len(fake_httpx.posted) == 1
+    assert "Batch 1 of 2 was refused" in result.output
+    assert "Nothing else was sent" in result.output
+
+
+def test_a_transport_failure_stops_with_a_message_rather_than_a_traceback(
+    tmp_path: Path, fake_httpx: type[_FakeClient]
+) -> None:
+    """A long backfill can lose its connection; re-running it is safe and should say so."""
+    import httpx
+
+    _write_transcript(
+        tmp_path,
+        "-Users-alice-Projects-otari",
+        "session-a",
+        [_assistant_line(f"msg_{index:02d}") for index in range(3)],
+    )
+    fake_httpx.responses = [
+        _FakeResponse(200, {"accepted": 1, "duplicate": 0, "rejected": 0, "errors": []}),
+        httpx.ConnectError("connection reset"),
+    ]
+
+    result = CliRunner().invoke(
+        cli, ["import", "claude-code", "--projects-dir", str(tmp_path), "--api-key", "gw-test"]
+    )
+
+    assert result.exit_code == 1
+    assert "Import stopped after 1 event(s)" in result.output
+    assert "duplicates" in result.output
+
+
+def test_a_batch_size_above_the_endpoints_cap_is_a_usage_error(
+    tmp_path: Path, fake_httpx: type[_FakeClient]
+) -> None:
+    """The cap belongs to the endpoint, so the CLI reads it rather than restating a number."""
+    from gateway.services.external_usage_service import MAX_EVENTS_PER_BATCH
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "import",
+            "claude-code",
+            "--projects-dir",
+            str(tmp_path),
+            "--api-key",
+            "gw-test",
+            "--batch-size",
+            str(MAX_EVENTS_PER_BATCH + 1),
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert str(MAX_EVENTS_PER_BATCH) in result.output
+
+
+def test_undecodable_lines_are_reported_rather_than_silently_dropped(
+    tmp_path: Path, fake_httpx: type[_FakeClient]
+) -> None:
+    """A truncated transcript finds nothing to import, and silence there reads as no usage."""
+    _write_transcript(tmp_path, "-Users-alice-Projects-otari", "session-a", ['{"message": {"usage": {"input'])
+
+    result = CliRunner().invoke(cli, ["import", "claude-code", "--projects-dir", str(tmp_path), "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "1 line(s) could not be decoded" in result.output
+    assert "Nothing to import." in result.output
+
+
+def test_a_transcript_that_vanishes_mid_scan_does_not_abort_the_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--since stats every file, and one that cannot be stat'd is not a reason to stop."""
+    _write_transcript(tmp_path, "-Users-alice-Projects-a", "session-a", [_assistant_line("msg_01")])
+    kept = _write_transcript(tmp_path, "-Users-alice-Projects-b", "session-b", [_assistant_line("msg_02")])
+    real_stat = Path.stat
+
+    def exploding_stat(self: Path, **kwargs: Any) -> os.stat_result:
+        if self.suffix == ".jsonl" and self != kept:
+            raise OSError(errno.ENOENT, "gone")
+        return real_stat(self, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", exploding_stat)
+
+    result = scan_transcripts(tmp_path, label_prefix="host", since=datetime.now(timezone.utc) - timedelta(days=1))
+
+    assert [event.source_event_id for event in result.events] == ["msg_02"]

--- a/tests/unit/test_claude_code_import.py
+++ b/tests/unit/test_claude_code_import.py
@@ -1,0 +1,363 @@
+"""Unit tests for reading Claude Code transcripts into importable usage events."""
+
+import json
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from gateway.cli import cli
+from gateway.services.claude_code_import import (
+    normalize_model,
+    parse_since,
+    provider_for_model,
+    scan_transcripts,
+    session_label,
+)
+
+
+def _assistant_line(
+    response_id: str,
+    *,
+    model: str = "claude-sonnet-4-5",
+    timestamp: str = "2026-07-22T12:34:56.000Z",
+    usage: dict[str, Any] | None = None,
+) -> str:
+    """One assistant line as Claude Code writes it, with only the fields read back."""
+    return json.dumps(
+        {
+            "type": "assistant",
+            "timestamp": timestamp,
+            "message": {
+                "id": response_id,
+                "model": model,
+                "usage": usage
+                if usage is not None
+                else {"input_tokens": 10, "output_tokens": 5, "cache_read_input_tokens": 0},
+            },
+        }
+    )
+
+
+def _write_transcript(projects_dir: Path, project: str, session: str, lines: list[str]) -> Path:
+    path = projects_dir / project / f"{session}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def test_repeated_response_ids_are_counted_once(tmp_path: Path) -> None:
+    """A reply spans several transcript lines under one response id; that is one API call."""
+    _write_transcript(
+        tmp_path,
+        "-Users-alice-Projects-otari",
+        "session-a",
+        [_assistant_line("msg_01"), _assistant_line("msg_01"), _assistant_line("msg_02")],
+    )
+
+    result = scan_transcripts(tmp_path, label_prefix="host")
+
+    assert [event.source_event_id for event in result.events] == ["msg_01", "msg_02"]
+    assert result.duplicates_skipped == 1
+
+
+def test_a_response_id_repeated_across_sessions_is_still_one_event(tmp_path: Path) -> None:
+    """A resumed session re-records earlier replies; the scan is deduplicated globally."""
+    _write_transcript(tmp_path, "-Users-alice-Projects-otari", "session-a", [_assistant_line("msg_01")])
+    _write_transcript(tmp_path, "-Users-alice-Projects-otari", "session-b", [_assistant_line("msg_01")])
+
+    result = scan_transcripts(tmp_path, label_prefix="host")
+
+    assert len(result.events) == 1
+    assert result.files_scanned == 2
+
+
+def test_cache_writes_split_by_ttl(tmp_path: Path) -> None:
+    """The 1h share is priced separately, so it is reported apart from the 5m share."""
+    _write_transcript(
+        tmp_path,
+        "-Users-alice-Projects-otari",
+        "session-a",
+        [
+            _assistant_line(
+                "msg_01",
+                usage={
+                    "input_tokens": 100,
+                    "output_tokens": 20,
+                    "cache_read_input_tokens": 900,
+                    "cache_creation_input_tokens": 500,
+                    "cache_creation": {"ephemeral_1h_input_tokens": 200, "ephemeral_5m_input_tokens": 300},
+                },
+            )
+        ],
+    )
+
+    event = scan_transcripts(tmp_path, label_prefix="host").events[0]
+
+    assert (event.cache_write_tokens, event.cache_write_1h_tokens) == (300, 200)
+    assert (event.input_tokens, event.output_tokens, event.cache_read_tokens) == (100, 20, 900)
+    assert event.as_payload()["cache_tokens_in_prompt"] is False
+
+
+def test_a_cache_total_below_its_1h_share_never_goes_negative(tmp_path: Path) -> None:
+    """Token counts are unsigned at the endpoint, so an inconsistent transcript clamps to zero."""
+    _write_transcript(
+        tmp_path,
+        "-Users-alice-Projects-otari",
+        "session-a",
+        [
+            _assistant_line(
+                "msg_01",
+                usage={
+                    "cache_creation_input_tokens": 100,
+                    "cache_creation": {"ephemeral_1h_input_tokens": 400},
+                },
+            )
+        ],
+    )
+
+    event = scan_transcripts(tmp_path, label_prefix="host").events[0]
+
+    assert event.cache_write_tokens == 0
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("claude-sonnet-4-5[1m]", "claude-sonnet-4-5"),
+        ("claude-opus-4-6", "claude-opus-4-6"),
+        ("openai/gpt-5-mini", "openai/gpt-5-mini"),
+        ("weird model!name", "weird-model-name"),
+        ("[1m]", "unknown"),
+        (None, "unknown"),
+    ],
+)
+def test_model_ids_are_folded_into_the_endpoint_grammar(raw: str | None, expected: str) -> None:
+    """A bracketed context tag names a window, not a priced model, and the grammar rejects it anyway."""
+    assert normalize_model(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("claude-opus-4-6", "anthropic"),
+        ("gpt-5-mini", "openai"),
+        ("gemini-2-5-pro", "google"),
+        ("kimi-k2", "moonshot"),
+        ("something-local", "unknown"),
+    ],
+)
+def test_provider_is_admitted_unknown_rather_than_guessed(model: str, expected: str) -> None:
+    """An unpriced row is visibly unpriced; one priced as the wrong provider is silently wrong."""
+    assert provider_for_model(model) == expected
+
+
+@pytest.mark.parametrize(
+    ("project_dir", "expected"),
+    [
+        ("-Users-alice-Projects-otari", "box:otari"),
+        ("-home-alice-src-my-app", "box:app"),
+        ("plain", "box:plain"),
+        ("", "box:unknown"),
+    ],
+)
+def test_session_label_uses_the_last_path_segment(project_dir: str, expected: str) -> None:
+    """The directory name is a mangled path; only its last segment survives as a label."""
+    assert session_label(project_dir, "box") == expected
+
+
+def test_since_skips_transcripts_by_modification_time(tmp_path: Path) -> None:
+    """A run can skip whole files without opening them."""
+    old = _write_transcript(tmp_path, "-Users-alice-Projects-old", "session-old", [_assistant_line("msg_old")])
+    _write_transcript(tmp_path, "-Users-alice-Projects-new", "session-new", [_assistant_line("msg_new")])
+    stale = time.time() - timedelta(days=30).total_seconds()
+    os.utime(old, (stale, stale))
+
+    result = scan_transcripts(tmp_path, label_prefix="host", since=datetime.now(timezone.utc) - timedelta(days=1))
+
+    assert [event.source_event_id for event in result.events] == ["msg_new"]
+    assert result.files_scanned == 1
+
+
+def test_lines_without_usage_are_ignored_and_bad_json_is_counted(tmp_path: Path) -> None:
+    """A transcript carries user turns and tool results too, and can be truncated mid-write."""
+    _write_transcript(
+        tmp_path,
+        "-Users-alice-Projects-otari",
+        "session-a",
+        [
+            json.dumps({"type": "user", "message": {"role": "user"}}),
+            '{"message": {"usage": {"input_tokens": 1}',
+            _assistant_line("msg_01"),
+        ],
+    )
+
+    result = scan_transcripts(tmp_path, label_prefix="host")
+
+    assert len(result.events) == 1
+    assert result.unparsable_lines == 1
+
+
+def test_a_missing_projects_directory_is_empty_not_an_error(tmp_path: Path) -> None:
+    assert scan_transcripts(tmp_path / "absent", label_prefix="host").events == []
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_delta"),
+    [("24h", timedelta(hours=24)), ("7d", timedelta(days=7)), ("2w", timedelta(weeks=2))],
+)
+def test_since_accepts_durations(value: str, expected_delta: timedelta) -> None:
+    parsed = parse_since(value)
+    assert abs((datetime.now(timezone.utc) - parsed) - expected_delta) < timedelta(seconds=5)
+
+
+def test_since_accepts_a_bare_date_as_utc_midnight() -> None:
+    assert parse_since("2026-07-22") == datetime(2026, 7, 22, tzinfo=timezone.utc)
+
+
+def test_since_rejects_nonsense() -> None:
+    with pytest.raises(ValueError, match="neither an ISO-8601"):
+        parse_since("last tuesday")
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict[str, Any]) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeClient:
+    """Stands in for httpx.Client, recording what a run would have sent."""
+
+    posted: list[dict[str, Any]] = []
+    response = _FakeResponse(200, {"accepted": 1, "duplicate": 0, "rejected": 0, "errors": []})
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def __enter__(self) -> "_FakeClient":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        return None
+
+    def post(self, url: str, *, json: dict[str, Any], headers: dict[str, str]) -> _FakeResponse:
+        type(self).posted.append({"url": url, "body": json, "headers": headers})
+        return type(self).response
+
+
+@pytest.fixture
+def fake_httpx(monkeypatch: pytest.MonkeyPatch) -> type[_FakeClient]:
+    import httpx
+
+    _FakeClient.posted = []
+    _FakeClient.response = _FakeResponse(200, {"accepted": 1, "duplicate": 0, "rejected": 0, "errors": []})
+    monkeypatch.setattr(httpx, "Client", _FakeClient)
+    return _FakeClient
+
+
+def test_dry_run_reports_totals_and_sends_nothing(tmp_path: Path, fake_httpx: type[_FakeClient]) -> None:
+    _write_transcript(tmp_path, "-Users-alice-Projects-otari", "session-a", [_assistant_line("msg_01")])
+
+    result = CliRunner().invoke(
+        cli,
+        ["import", "claude-code", "--projects-dir", str(tmp_path), "--api-key", "gw-test", "--dry-run"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "1 event(s)" in result.output
+    assert "Dry run: nothing was sent." in result.output
+    assert fake_httpx.posted == []
+
+
+def test_a_run_posts_the_batch_to_the_external_events_endpoint(
+    tmp_path: Path, fake_httpx: type[_FakeClient]
+) -> None:
+    _write_transcript(tmp_path, "-Users-alice-Projects-otari", "session-a", [_assistant_line("msg_01")])
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "import",
+            "claude-code",
+            "--projects-dir",
+            str(tmp_path),
+            "--url",
+            "http://gateway.test/",
+            "--api-key",
+            "gw-test",
+            "--user-id",
+            "alice",
+            "--label-prefix",
+            "box",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(fake_httpx.posted) == 1
+    sent = fake_httpx.posted[0]
+    assert sent["url"] == "http://gateway.test/v1/usage/external-events"
+    assert sent["headers"]["Authorization"] == "Bearer gw-test"
+    assert sent["body"]["source"] == "claude_code"
+    assert sent["body"]["user_id"] == "alice"
+    assert sent["body"]["events"][0]["session_label"] == "box:otari"
+    assert "prompt" not in sent["body"]["events"][0]
+
+
+def test_an_empty_scan_sends_nothing(tmp_path: Path, fake_httpx: type[_FakeClient]) -> None:
+    result = CliRunner().invoke(
+        cli, ["import", "claude-code", "--projects-dir", str(tmp_path), "--api-key", "gw-test"]
+    )
+
+    assert result.exit_code == 0
+    assert "Nothing to import." in result.output
+    assert fake_httpx.posted == []
+
+
+def test_a_refused_batch_exits_non_zero(tmp_path: Path, fake_httpx: type[_FakeClient]) -> None:
+    """A silent success on a refused import would leave a gap nobody goes looking for."""
+    _write_transcript(tmp_path, "-Users-alice-Projects-otari", "session-a", [_assistant_line("msg_01")])
+    fake_httpx.response = _FakeResponse(403, {"detail": "key is not budget-exempt"})
+
+    result = CliRunner().invoke(
+        cli, ["import", "claude-code", "--projects-dir", str(tmp_path), "--api-key", "gw-test"]
+    )
+
+    assert result.exit_code == 1
+    assert "403" in result.output
+    assert "key is not budget-exempt" in result.output
+
+
+def test_events_rejected_individually_also_exit_non_zero(
+    tmp_path: Path, fake_httpx: type[_FakeClient]
+) -> None:
+    _write_transcript(tmp_path, "-Users-alice-Projects-otari", "session-a", [_assistant_line("msg_01")])
+    fake_httpx.response = _FakeResponse(
+        200,
+        {"accepted": 0, "duplicate": 0, "rejected": 1, "errors": [{"index": 0, "detail": "no price"}]},
+    )
+
+    result = CliRunner().invoke(
+        cli, ["import", "claude-code", "--projects-dir", str(tmp_path), "--api-key", "gw-test"]
+    )
+
+    assert result.exit_code == 1
+    assert "no price" in result.output
+
+
+def test_a_bad_since_is_a_usage_error(tmp_path: Path, fake_httpx: type[_FakeClient]) -> None:
+    result = CliRunner().invoke(
+        cli,
+        ["import", "claude-code", "--projects-dir", str(tmp_path), "--api-key", "gw-test", "--since", "yesterday"],
+    )
+
+    assert result.exit_code == 2
+    assert "--since" in result.output

--- a/tests/unit/test_claude_code_import.py
+++ b/tests/unit/test_claude_code_import.py
@@ -125,6 +125,25 @@ def test_a_cache_total_below_its_1h_share_never_goes_negative(tmp_path: Path) ->
     assert event.cache_write_tokens == 0
 
 
+def test_locally_generated_messages_are_not_imported(tmp_path: Path) -> None:
+    """Claude Code writes an API error notice itself, with a usage block and no request behind it."""
+    _write_transcript(
+        tmp_path,
+        "-Users-alice-Projects-otari",
+        "session-a",
+        [
+            _assistant_line("msg_01"),
+            _assistant_line("msg_syn", model="<synthetic>", usage={"input_tokens": 0, "output_tokens": 0}),
+        ],
+    )
+
+    result = scan_transcripts(tmp_path, label_prefix="host")
+
+    assert [event.source_event_id for event in result.events] == ["msg_01"]
+    assert result.synthetic_skipped == 1
+    assert all(event.model != "synthetic" for event in result.events)
+
+
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [


### PR DESCRIPTION
## Description

`docs/use-with-claude-code.md` shows how to send Claude Code usage to Otari over OTLP. That export only carries sessions which run *after* it is configured, so for anyone who installs Otari today, every token they have already burned stays invisible. For a daily Claude Code user that is most of the usage there has ever been.

Claude Code has already written it all down. It keeps one JSONL transcript per session under `~/.claude/projects`, and each assistant line carries the API response id, the model, and the Anthropic usage block. This adds `otari import claude-code`, which reads those transcripts and posts them to the existing `POST /v1/usage/external-events`. No new endpoint, no schema change, no new dependency.

```bash
otari import claude-code --dry-run                 # counts only, sends nothing
otari import claude-code --user-id alice           # backfill everything
otari import claude-code --since 7d                # top up, e.g. from cron
```

Three details drove the shape of it:

- **A response id repeats.** One reply spans several transcript lines, one per content block, each carrying the same id and the same usage block. Counting lines multiplies a session's tokens by however many blocks its replies happened to contain, so the scan deduplicates on the response id. Using that id as `source_event_id` also means the endpoint's existing `(source, source_event_id)` uniqueness does the rest: re-running imports only what is new and reports the remainder as duplicates.
- **Claude Code appends a context tag to the model**, e.g. `claude-sonnet-4-5[1m]`. Brackets are outside the endpoint's identifier grammar, so an untouched value 422s the whole batch, and the tag names a context window rather than a separately priced model, so keeping it would leave those events unpriced under a model id no price list has. It is stripped.
- **Cache writes are split by TTL.** `cache_creation_input_tokens` is the total and the 1h share is priced differently, so the 1h part is reported separately and subtracted rather than counted twice.

Provider is mapped only for model families that can be identified and is left `unknown` otherwise, since `ANTHROPIC_BASE_URL` points Claude Code at anything speaking the Messages API. An unpriced row is visibly unpriced; one priced as the wrong provider is silently wrong.

Parsing lives in `services/claude_code_import.py` as a pure module with no network and no database, so all of the above is unit-testable. The click command only wires options, calls it, and posts in batches. Prompt, completion, and tool payloads are never read out of a transcript, matching the content-free contract the endpoint already enforces.

A refused batch exits non-zero and prints what the server said, because a silent success on a failed import leaves a gap nobody goes looking for.

The docs section repeats the existing double-count warning, which matters more for a backfill than for live export: do not import sessions that were already routed through Otari.

### Validation

Beyond the unit tests, this was run against a real corpus of 14,820 transcripts spanning eight weeks. It parsed 271,506 API calls, and a second run reported the previously imported events as duplicates and created no new rows, which is the behaviour the uniqueness constraint promises.

Happy to split the docs out or open an issue first if you would rather align on the approach.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Relevant issues

None open that I could find. This extends the workflow documented in `docs/use-with-claude-code.md` and `docs/external-usage.md`.

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [x] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`).
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`). Not applicable: no route or schema changed, this is a client of the existing endpoint.

`make lint` and `make typecheck` (mypy --strict, 569 files) are clean. `tests/unit` is 2918 passed, 2 skipped.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [ ] This is fully AI-generated.

**AI Model/Tool used:**


**Any additional AI details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added `otari import claude-code` to backfill Claude Code usage from local transcripts.
- Added dry-run mode, date filtering, user IDs, labels, batching, and safe reruns.
- Handles malformed records, duplicate events, unreadable files, and transport errors.
- Excludes content payloads and documents the workflow.
- Added comprehensive parser and CLI tests.

## Technical notes

- Splits cache usage by TTL.
- Maps recognized model families to providers.
- Leaves unknown models unpriced.
- Supports budget-exempt API keys and master keys.
- Reports undecodable transcript lines and stops safely when the first batch fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->