### PR TITLE
feat(dashboard): ask each provider for the credential fields it needs

### DIFF
--- a/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
@@ -308,10 +308,11 @@ describe("OrganizationProviderKeysPage", () => {
     ).not.toBeInTheDocument()
   })
 
-  it("keeps a stored client_args secret the form was never shown", async () => {
-    // The gateway masks a credential-shaped option on read, so there is nothing
-    // to prefill the box with. Sending the mask back is what tells the gateway
-    // to keep what it holds.
+  it("keeps a stored client_args credential the form was never shown", async () => {
+    // The gateway masks a credential-shaped option on read, by key name, so
+    // both halves of the IAM pair come back as the mask and neither has a value
+    // to prefill with. Sending the mask back is what tells the gateway to keep
+    // what it holds.
     const requests = mockApi({
       catalog: [{ id: "bedrock", name: "Bedrock" }],
       keys: [
@@ -319,7 +320,7 @@ describe("OrganizationProviderKeysPage", () => {
           provider: "bedrock",
           client_args: {
             region_name: "us-east-1",
-            aws_access_key_id: "AKIAIOSFODNN7EXAMPLE",
+            aws_access_key_id: "***",
             aws_secret_access_key: "***",
             timeout: 1800,
           },
@@ -333,13 +334,23 @@ describe("OrganizationProviderKeysPage", () => {
     expect(
       await screen.findByRole("textbox", { name: /AWS region/ }),
     ).toHaveValue("us-east-1")
-    // Never prefilled with the mask: three characters in a password box read as
-    // a real value.
+    // Never prefilled with the mask: three characters in a control read as a
+    // real value, whether or not the control is a password box.
     expect(screen.getByLabelText(/AWS secret access key/)).toHaveValue("")
+    const accessKeyId = screen.getByRole("textbox", {
+      name: /AWS access key ID/,
+    })
+    expect(accessKeyId).toHaveValue("")
+    expect(
+      screen.getAllByText(/Set already, and never shown again/),
+    ).toHaveLength(2)
     // Only what has no typed field of its own is left in the JSON escape hatch.
     expect(
       screen.getByRole("textbox", { name: "Client options (JSON)" }),
     ).toHaveValue('{\n  "timeout": 1800\n}')
+
+    // A stored half counts as filled in, so the pair does not read as half done.
+    expect(screen.queryByText(/is required alongside/)).not.toBeInTheDocument()
 
     await user.click(screen.getByRole("button", { name: "Save" }))
 
@@ -351,7 +362,7 @@ describe("OrganizationProviderKeysPage", () => {
     ).toMatchObject({
       client_args: {
         region_name: "us-east-1",
-        aws_access_key_id: "AKIAIOSFODNN7EXAMPLE",
+        aws_access_key_id: "***",
         aws_secret_access_key: "***",
         timeout: 1800,
       },

--- a/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
@@ -24,6 +24,7 @@ function jsonResponse(body: unknown, status = 200): Response {
 interface MockOpts {
   keys?: OrgProviderKey[]
   context?: OrganizationContext
+  catalog?: { id: string; name: string }[]
 }
 
 function mockApi(opts: MockOpts = {}) {
@@ -54,7 +55,9 @@ function mockApi(opts: MockOpts = {}) {
       return jsonResponse({ detail: "Not authorized" }, 403)
     }
     if (url.includes("/v1/providers/catalog")) {
-      return jsonResponse([{ id: "anthropic", name: "Anthropic" }])
+      return jsonResponse(
+        opts.catalog ?? [{ id: "anthropic", name: "Anthropic" }],
+      )
     }
     return jsonResponse(opts.context ?? organizationContext())
   })
@@ -151,6 +154,168 @@ describe("OrganizationProviderKeysPage", () => {
       provider: "anthropic",
       name: "Production",
       api_key: "sk-secret",
+    })
+  })
+
+  it("asks Bedrock for its region by name and sends it in client_args", async () => {
+    const requests = mockApi({ catalog: [{ id: "bedrock", name: "Bedrock" }] })
+    const user = userEvent.setup()
+    renderPage(<OrganizationProviderKeysPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Add provider key" }),
+    )
+    await user.click(screen.getByRole("combobox", { name: "Provider" }))
+    await user.click(await screen.findByRole("option", { name: "Bedrock" }))
+    await user.type(screen.getByRole("textbox", { name: /Name/ }), "Prod")
+    // Not called an API key here: Bedrock's credential is a bearer token or an
+    // IAM secret, depending on which shape the organization uses.
+    await user.type(screen.getByLabelText(/Bedrock API key/), "bearer-token")
+    await user.type(
+      screen.getByRole("textbox", { name: /AWS region/ }),
+      "us-east-1",
+    )
+    await user.click(
+      screen.getByRole("button", { name: "Add provider key", hidden: false }),
+    )
+
+    await waitFor(() => {
+      expect(requests.some((request) => request.method === "POST")).toBe(true)
+    })
+    expect(
+      requests.find((request) => request.method === "POST")?.body,
+    ).toMatchObject({
+      provider: "bedrock",
+      api_key: "bearer-token",
+      client_args: { region_name: "us-east-1" },
+    })
+  })
+
+  it("will not add a Bedrock key until the region is there and looks like one", async () => {
+    const requests = mockApi({ catalog: [{ id: "bedrock", name: "Bedrock" }] })
+    const user = userEvent.setup()
+    renderPage(<OrganizationProviderKeysPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Add provider key" }),
+    )
+    await user.click(screen.getByRole("combobox", { name: "Provider" }))
+    await user.click(await screen.findByRole("option", { name: "Bedrock" }))
+    await user.type(screen.getByRole("textbox", { name: /Name/ }), "Prod")
+
+    const submit = screen.getByRole("button", {
+      name: "Add provider key",
+      hidden: false,
+    })
+    expect(submit).toBeDisabled()
+    expect(
+      screen.getByText("AWS region is required for this provider."),
+    ).toBeInTheDocument()
+
+    const region = screen.getByRole("textbox", { name: /AWS region/ })
+    await user.type(region, "US East 1")
+    expect(
+      screen.getByText(
+        "A region is lowercase letters, digits and hyphens, like us-east-1.",
+      ),
+    ).toBeInTheDocument()
+    expect(submit).toBeDisabled()
+
+    await user.clear(region)
+    await user.type(region, "us-east-1")
+    await waitFor(() => expect(submit).toBeEnabled())
+    expect(requests.some((request) => request.method === "POST")).toBe(false)
+  })
+
+  it("does not advise against the credential Bedrock's IAM shape requires", async () => {
+    // The old copy said to keep secrets out of client_args, which is the only
+    // supported place for Bedrock's aws_secret_access_key.
+    mockApi()
+    const user = userEvent.setup()
+    renderPage(<OrganizationProviderKeysPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Add provider key" }),
+    )
+
+    expect(screen.queryByText(/keep secrets out/)).not.toBeInTheDocument()
+    expect(
+      screen.getByText(
+        /masked when read back, but nothing here is encrypted at rest/,
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it("does not offer a provider whose stored credential can never authenticate", async () => {
+    mockApi({
+      catalog: [
+        { id: "anthropic", name: "Anthropic" },
+        { id: "sagemaker", name: "SageMaker" },
+      ],
+    })
+    const user = userEvent.setup()
+    renderPage(<OrganizationProviderKeysPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Add provider key" }),
+    )
+    await user.click(screen.getByRole("combobox", { name: "Provider" }))
+
+    expect(
+      await screen.findByRole("option", { name: "Anthropic" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("option", { name: "SageMaker" }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("keeps a stored client_args secret the form was never shown", async () => {
+    // The gateway masks a credential-shaped option on read, so there is nothing
+    // to prefill the box with. Sending the mask back is what tells the gateway
+    // to keep what it holds.
+    const requests = mockApi({
+      catalog: [{ id: "bedrock", name: "Bedrock" }],
+      keys: [
+        orgProviderKey({
+          provider: "bedrock",
+          client_args: {
+            region_name: "us-east-1",
+            aws_access_key_id: "AKIAIOSFODNN7EXAMPLE",
+            aws_secret_access_key: "***",
+            timeout: 1800,
+          },
+        }),
+      ],
+    })
+    const user = userEvent.setup()
+    renderPage(<OrganizationProviderKeysPage />)
+
+    await user.click(await screen.findByRole("button", { name: "Edit" }))
+    expect(
+      await screen.findByRole("textbox", { name: /AWS region/ }),
+    ).toHaveValue("us-east-1")
+    // Never prefilled with the mask: three characters in a password box read as
+    // a real value.
+    expect(screen.getByLabelText(/AWS secret access key/)).toHaveValue("")
+    // Only what has no typed field of its own is left in the JSON escape hatch.
+    expect(
+      screen.getByRole("textbox", { name: "Client options (JSON)" }),
+    ).toHaveValue('{\n  "timeout": 1800\n}')
+
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(requests.some((request) => request.method === "PATCH")).toBe(true)
+    })
+    expect(
+      requests.find((request) => request.method === "PATCH")?.body,
+    ).toMatchObject({
+      client_args: {
+        region_name: "us-east-1",
+        aws_access_key_id: "AKIAIOSFODNN7EXAMPLE",
+        aws_secret_access_key: "***",
+        timeout: 1800,
+      },
     })
   })
 

--- a/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.test.tsx
@@ -227,6 +227,45 @@ describe("OrganizationProviderKeysPage", () => {
     expect(requests.some((request) => request.method === "POST")).toBe(false)
   })
 
+  it("will not add a Bedrock key with half of an IAM key pair", async () => {
+    const requests = mockApi({ catalog: [{ id: "bedrock", name: "Bedrock" }] })
+    const user = userEvent.setup()
+    renderPage(<OrganizationProviderKeysPage />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Add provider key" }),
+    )
+    await user.click(screen.getByRole("combobox", { name: "Provider" }))
+    await user.click(await screen.findByRole("option", { name: "Bedrock" }))
+    await user.type(screen.getByRole("textbox", { name: /Name/ }), "Prod")
+    await user.type(
+      screen.getByRole("textbox", { name: /AWS region/ }),
+      "us-east-1",
+    )
+
+    const submit = screen.getByRole("button", {
+      name: "Add provider key",
+      hidden: false,
+    })
+    // The region alone is the bearer-token shape, which is complete.
+    await waitFor(() => expect(submit).toBeEnabled())
+
+    await user.type(
+      screen.getByRole("textbox", { name: /AWS access key ID/ }),
+      "AKIAIOSFODNN7EXAMPLE",
+    )
+    expect(
+      screen.getByText(
+        "AWS secret access key is required alongside AWS access key ID.",
+      ),
+    ).toBeInTheDocument()
+    expect(submit).toBeDisabled()
+
+    await user.type(screen.getByLabelText(/AWS secret access key/), "s3cret")
+    await waitFor(() => expect(submit).toBeEnabled())
+    expect(requests.some((request) => request.method === "POST")).toBe(false)
+  })
+
   it("does not advise against the credential Bedrock's IAM shape requires", async () => {
     // The old copy said to keep secrets out of client_args, which is the only
     // supported place for Bedrock's aws_secret_access_key.

--- a/web/src/features/organization/OrganizationProviderKeysPage.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.tsx
@@ -7,9 +7,19 @@ import type {
   UpdateOrgProviderKeyRequest,
 } from "@/client"
 import {
+  BYO_UNSUPPORTED_PROVIDERS,
+  type CredentialFieldValues,
+  credentialFieldsFor,
+  credentialSpecFor,
+  mergeCredentialFields,
+  splitClientArgs,
+  validateCredentialFields,
+} from "@/features/providers/providerCredentialFields"
+import {
   ClientArgsField,
   formatClientArgs,
   ProviderComboBox,
+  ProviderCredentialFields,
   parseClientArgs,
 } from "@/features/providers/providerFields"
 import {
@@ -65,7 +75,12 @@ interface KeyDraft {
   name: string
   apiKey: string
   apiBase: string
+  /** The JSON escape hatch: whatever the provider's typed fields do not own. */
   clientArgs: string
+  /** The typed `client_args` entries, keyed by SDK keyword argument. */
+  credentials: CredentialFieldValues
+  /** Typed secrets already stored, so blank means "keep it" rather than "clear it". */
+  redacted: string[]
 }
 
 const EMPTY_DRAFT: KeyDraft = {
@@ -74,9 +89,17 @@ const EMPTY_DRAFT: KeyDraft = {
   apiKey: "",
   apiBase: "",
   clientArgs: "",
+  credentials: {},
+  redacted: [],
 }
 
 function draftFrom(key: OrgProviderKey): KeyDraft {
+  // The registry's fields come out of the stored JSON and into their own
+  // controls; everything else stays in the textarea it was entered in.
+  const { typed, rest, redacted } = splitClientArgs(
+    credentialFieldsFor(key.provider),
+    key.client_args,
+  )
   return {
     provider: key.provider,
     name: key.name,
@@ -84,7 +107,9 @@ function draftFrom(key: OrgProviderKey): KeyDraft {
     // so there is nothing to prefill with. Blank on save means "leave it".
     apiKey: "",
     apiBase: key.api_base ?? "",
-    clientArgs: formatClientArgs(key.client_args),
+    clientArgs: formatClientArgs(rest),
+    credentials: typed,
+    redacted,
   }
 }
 
@@ -104,20 +129,36 @@ function KeyForm({
 
   const parsedClientArgs = parseClientArgs(draft.clientArgs)
   const clientArgsError = parsedClientArgs.ok ? null : parsedClientArgs.error
+  const credentialFields = credentialFieldsFor(draft.provider)
+  const credentialErrors = validateCredentialFields(
+    credentialFields,
+    draft.credentials,
+    draft.redacted,
+  )
+  const spec = credentialSpecFor(draft.provider)
   const pending = create.isPending || update.isPending
   const canSubmit =
     parsedClientArgs.ok &&
+    Object.keys(credentialErrors).length === 0 &&
     draft.name.trim() !== "" &&
     (editing !== null || draft.provider !== "")
 
   const submit = () => {
     if (!parsedClientArgs.ok) return
     const apiBase = draft.apiBase.trim()
+    // The typed fields and the textarea are two views of one `client_args`
+    // object, so they are recombined before it goes out.
+    const clientArgs = mergeCredentialFields(
+      credentialFields,
+      draft.credentials,
+      parsedClientArgs.value,
+      draft.redacted,
+    )
     if (editing) {
       const body: UpdateOrgProviderKeyRequest = {
         name: draft.name.trim(),
         api_base: apiBase === "" ? null : apiBase,
-        client_args: parsedClientArgs.value,
+        client_args: clientArgs,
       }
       // Omitted rather than sent as null when it was left blank: an explicit
       // null clears the stored credential, and "I did not retype the secret" is
@@ -131,7 +172,7 @@ function KeyForm({
       name: draft.name.trim(),
       api_key: draft.apiKey === "" ? null : draft.apiKey,
       api_base: apiBase === "" ? null : apiBase,
-      client_args: parsedClientArgs.value,
+      client_args: clientArgs,
     }
     create.mutate(body, { onSuccess: onClose })
   }
@@ -160,7 +201,12 @@ function KeyForm({
         <ProviderComboBox
           label="Provider"
           value={draft.provider}
-          onChange={(provider) => setDraft({ ...draft, provider })}
+          // The typed fields belong to the provider, so a change to it drops
+          // values that no longer have a field to sit in.
+          onChange={(provider) =>
+            setDraft({ ...draft, provider, credentials: {}, redacted: [] })
+          }
+          excludeIds={BYO_UNSUPPORTED_PROVIDERS}
           description="Which upstream this credential is for. The gateway matches it against the provider half of a model name."
         />
       )}
@@ -175,14 +221,19 @@ function KeyForm({
       />
 
       <SecretField
-        label="API key"
+        // Named for what the provider actually calls its credential, where that
+        // is not an opaque API key (Bedrock's is a bearer token).
+        label={spec?.apiKeyLabel ?? "API key"}
         value={draft.apiKey}
         onChange={(apiKey) => setDraft({ ...draft, apiKey })}
-        description={
+        description={[
           editing
             ? "Encrypted at rest and never shown again. Leave blank to keep the current key."
-            : "Encrypted at rest and never shown again; only the last 4 characters come back."
-        }
+            : "Encrypted at rest and never shown again; only the last 4 characters come back.",
+          spec?.apiKeyHelpText,
+        ]
+          .filter(Boolean)
+          .join(" ")}
       />
 
       <Field
@@ -191,6 +242,16 @@ function KeyForm({
         onChange={(apiBase) => setDraft({ ...draft, apiBase })}
         placeholder="https://api.example.com/v1"
         description="Optional. Point this key at a compatible endpoint of your own instead of the provider's default."
+      />
+
+      {/* What this provider needs beyond a key, asked for by name rather than
+          left to the JSON below. */}
+      <ProviderCredentialFields
+        provider={draft.provider}
+        values={draft.credentials}
+        onChange={(credentials) => setDraft({ ...draft, credentials })}
+        errors={credentialErrors}
+        redacted={draft.redacted}
       />
 
       <ClientArgsField

--- a/web/src/features/organization/OrganizationProviderKeysPage.tsx
+++ b/web/src/features/organization/OrganizationProviderKeysPage.tsx
@@ -149,7 +149,6 @@ function KeyForm({
     // The typed fields and the textarea are two views of one `client_args`
     // object, so they are recombined before it goes out.
     const clientArgs = mergeCredentialFields(
-      credentialFields,
       draft.credentials,
       parsedClientArgs.value,
       draft.redacted,

--- a/web/src/features/providers/ProvidersPage.test.tsx
+++ b/web/src/features/providers/ProvidersPage.test.tsx
@@ -402,6 +402,88 @@ describe("ProvidersPage", () => {
     ).not.toBeInTheDocument()
   })
 
+  it("asks a known provider for its own fields and sends them in client_args", async () => {
+    const fetchMock = mockApi({
+      stored: [storedProvider("anthropic", "0000")],
+      catalog: [
+        {
+          id: "bedrock",
+          name: "Bedrock",
+          env_key: "AWS_BEARER_TOKEN_BEDROCK",
+          default_api_base: null,
+          requires_api_key: true,
+          env_key_present: false,
+        },
+      ],
+    })
+    const user = userEvent.setup()
+    renderPage(<ProvidersPage />)
+
+    await screen.findByText("••••0000")
+    await user.click(screen.getByRole("button", { name: "Add provider" }))
+    await user.click(screen.getByPlaceholderText("Search providers…"))
+    await user.click(await screen.findByRole("option", { name: "Bedrock" }))
+
+    const add = screen.getByRole("button", { name: "Add provider" })
+    await user.type(screen.getByLabelText(/Bedrock API key/), "bearer-token")
+    // The region is required and outside Advanced, so nothing that blocks the
+    // submit is hidden behind a collapsed section.
+    expect(add).toBeDisabled()
+    await user.type(
+      screen.getByRole("textbox", { name: /AWS region/ }),
+      "eu-central-1",
+    )
+    await waitFor(() => expect(add).toBeEnabled())
+    await user.click(add)
+
+    const post = await waitFor(() => {
+      const call = fetchMock.mock.calls.find(
+        ([u, init]) =>
+          String(u).endsWith("/v1/provider-credentials") &&
+          (init?.method ?? "") === "POST",
+      )
+      expect(call).toBeDefined()
+      return call!
+    })
+    expect(JSON.parse(String(post[1]?.body))).toMatchObject({
+      instance: "bedrock",
+      api_key: "bearer-token",
+      client_args: { region_name: "eu-central-1" },
+    })
+  })
+
+  it("splits a stored provider's registered options out of the JSON box on edit", async () => {
+    mockApi({
+      stored: [
+        storedProvider("bedrock", "0000", true, {
+          region_name: "us-east-1",
+          timeout: 1800,
+        }),
+      ],
+      catalog: [
+        {
+          id: "bedrock",
+          name: "Bedrock",
+          env_key: "AWS_BEARER_TOKEN_BEDROCK",
+          default_api_base: null,
+          requires_api_key: true,
+          env_key_present: false,
+        },
+      ],
+    })
+    const user = userEvent.setup()
+    renderPage(<ProvidersPage />)
+
+    await user.click(await screen.findByRole("button", { name: "Edit" }))
+
+    expect(
+      await screen.findByRole("textbox", { name: /AWS region/ }),
+    ).toHaveValue("us-east-1")
+    expect(
+      screen.getByRole("textbox", { name: "Client options (JSON)" }),
+    ).toHaveValue('{\n  "timeout": 1800\n}')
+  })
+
   it("fetches provider autofill hints lazily, only after one is selected", async () => {
     const fetchMock = mockApi({
       stored: [storedProvider("anthropic", "0000")],

--- a/web/src/features/providers/ProvidersPage.test.tsx
+++ b/web/src/features/providers/ProvidersPage.test.tsx
@@ -484,6 +484,58 @@ describe("ProvidersPage", () => {
     ).toHaveValue('{\n  "timeout": 1800\n}')
   })
 
+  it("keeps a split-out option when the provider type is retyped mid-edit", async () => {
+    // The field list follows the provider type, which is an editable box here,
+    // while the values were split out of client_args at mount. A field that
+    // stops rendering must not take the stored option with it.
+    const fetchMock = mockApi({
+      stored: [
+        storedProvider("bedrock", "0000", true, {
+          region_name: "us-east-1",
+          aws_secret_access_key: "***",
+        }),
+      ],
+      catalog: [
+        {
+          id: "bedrock",
+          name: "Bedrock",
+          env_key: "AWS_BEARER_TOKEN_BEDROCK",
+          default_api_base: null,
+          requires_api_key: true,
+          env_key_present: false,
+        },
+      ],
+    })
+    const user = userEvent.setup()
+    renderPage(<ProvidersPage />)
+
+    await user.click(await screen.findByRole("button", { name: "Edit" }))
+    await screen.findByRole("textbox", { name: /AWS region/ })
+    await user.type(
+      screen.getByRole("textbox", { name: "Provider type" }),
+      "openai",
+    )
+    expect(
+      screen.queryByRole("textbox", { name: /AWS region/ }),
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Save changes" }))
+
+    const patch = await waitFor(() => {
+      const call = fetchMock.mock.calls.find(
+        ([, init]) => (init?.method ?? "") === "PATCH",
+      )
+      expect(call).toBeDefined()
+      return call!
+    })
+    expect(JSON.parse(String(patch[1]?.body))).toMatchObject({
+      client_args: {
+        region_name: "us-east-1",
+        aws_secret_access_key: "***",
+      },
+    })
+  })
+
   it("fetches provider autofill hints lazily, only after one is selected", async () => {
     const fetchMock = mockApi({
       stored: [storedProvider("anthropic", "0000")],

--- a/web/src/features/providers/ProvidersPage.tsx
+++ b/web/src/features/providers/ProvidersPage.tsx
@@ -173,7 +173,9 @@ function KnownProviderForm({ onClose }: { onClose: () => void }) {
   // object, so the request body is built in one place for both the save and the
   // connection test.
   const buildPayload = (): CreateStoredProviderRequest | null =>
-    providerId === "" || !clientArgs.ok
+    providerId === "" ||
+    !clientArgs.ok ||
+    Object.keys(credentialErrors).length > 0
       ? null
       : {
           instance: renamed ? name.trim() : providerId,
@@ -182,11 +184,7 @@ function KnownProviderForm({ onClose }: { onClose: () => void }) {
           provider_type: renamed ? providerId : null,
           api_base: apiBase.trim() || null,
           api_key: apiKey.trim() || null,
-          client_args: mergeCredentialFields(
-            credentialFields,
-            credentials,
-            clientArgs.value,
-          ),
+          client_args: mergeCredentialFields(credentials, clientArgs.value),
         }
 
   const submit = () => {
@@ -498,7 +496,6 @@ function EditProviderForm({
       api_base: apiBase.trim() || null,
       // Sent on every save, so emptying the field clears the stored options.
       client_args: mergeCredentialFields(
-        credentialFields,
         credentials,
         clientArgs.value,
         stored.redacted,

--- a/web/src/features/providers/ProvidersPage.tsx
+++ b/web/src/features/providers/ProvidersPage.tsx
@@ -44,9 +44,18 @@ import { Tab, TabRow } from "@/shared/components/navigation/TabRow"
 import { formatRelative } from "@/shared/helpers/format"
 
 import {
+  type CredentialFieldValues,
+  credentialFieldsFor,
+  credentialSpecFor,
+  mergeCredentialFields,
+  splitClientArgs,
+  validateCredentialFields,
+} from "./providerCredentialFields"
+import {
   ClientArgsField,
   formatClientArgs,
   ProviderComboBox,
+  ProviderCredentialFields,
   parseClientArgs,
 } from "./providerFields"
 
@@ -121,7 +130,14 @@ function KnownProviderForm({ onClose }: { onClose: () => void }) {
   const [apiBase, setApiBase] = useState("")
   const [name, setName] = useState("")
   const [clientArgsText, setClientArgsText] = useState("")
+  const [credentials, setCredentials] = useState<CredentialFieldValues>({})
   const clientArgs = parseClientArgs(clientArgsText)
+  const credentialFields = credentialFieldsFor(providerId)
+  const credentialErrors = validateCredentialFields(
+    credentialFields,
+    credentials,
+  )
+  const credentialSpec = credentialSpecFor(providerId)
 
   // Autofill hints are fetched lazily for just the selected provider, so the
   // picker itself never imports every provider SDK (issue #365).
@@ -146,28 +162,37 @@ function KnownProviderForm({ onClose }: { onClose: () => void }) {
     !nameHasDelimiter &&
     (!needsKey || apiKey.trim() !== "") &&
     clientArgs.ok &&
+    Object.keys(credentialErrors).length === 0 &&
     !create.isPending
   // Hold the section open while something inside it is what's blocking submit,
   // so collapsing it can't leave a disabled button with its reason off screen.
   // A hide requested meanwhile is remembered and applies once the field is fixed.
   const advancedOpen = showAdvanced || !clientArgs.ok || nameHasDelimiter
 
+  // The typed fields and the JSON textarea are two views of one `client_args`
+  // object, so the request body is built in one place for both the save and the
+  // connection test.
+  const buildPayload = (): CreateStoredProviderRequest | null =>
+    providerId === "" || !clientArgs.ok
+      ? null
+      : {
+          instance: renamed ? name.trim() : providerId,
+          // A renamed instance is no longer named after its provider, so record
+          // the provider it is so routing still resolves.
+          provider_type: renamed ? providerId : null,
+          api_base: apiBase.trim() || null,
+          api_key: apiKey.trim() || null,
+          client_args: mergeCredentialFields(
+            credentialFields,
+            credentials,
+            clientArgs.value,
+          ),
+        }
+
   const submit = () => {
-    // The clientArgs.ok half is already covered by canSubmit; it is repeated to
-    // narrow the union so `.value` is reachable.
-    if (!canSubmit || !clientArgs.ok) return
-    create.mutate(
-      {
-        instance: renamed ? name.trim() : providerId,
-        // A renamed instance is no longer named after its provider, so record the
-        // provider it is so routing still resolves.
-        provider_type: renamed ? providerId : null,
-        api_base: apiBase.trim() || null,
-        api_key: apiKey.trim() || null,
-        client_args: clientArgs.value,
-      },
-      { onSuccess: onClose },
-    )
+    const payload = buildPayload()
+    if (!canSubmit || payload === null) return
+    create.mutate(payload, { onSuccess: onClose })
   }
 
   return (
@@ -182,22 +207,43 @@ function KnownProviderForm({ onClose }: { onClose: () => void }) {
           // Clear the API base; the effect above refills it from the provider's
           // built-in default once this provider's detail loads.
           setApiBase("")
+          // The typed fields belong to the provider, so a change to it drops
+          // values that no longer have a field to sit in.
+          setCredentials({})
         }}
         description="Its endpoint is built in."
       />
       <SecretField
         value={apiKey}
         onChange={setApiKey}
-        label={selected && !needsKey ? "API key (optional)" : "API key"}
-        description={
+        // The registry names the credential where the provider does not call it
+        // an API key; the optional suffix still tracks whether one is needed.
+        label={
+          selected && !needsKey
+            ? `${credentialSpec?.apiKeyLabel ?? "API key"} (optional)`
+            : (credentialSpec?.apiKeyLabel ?? "API key")
+        }
+        description={[
           selected
             ? needsKey
               ? `${selected.name}'s endpoint is built in — just add your key.`
               : envKeyPresent
                 ? `${selected.env_key} is set on the server, so a key is optional here. Paste one to override it.`
                 : `${selected.name} needs no API key.`
-            : "Stored encrypted. Requires OTARI_SECRET_KEY on the server."
-        }
+            : "Stored encrypted. Requires OTARI_SECRET_KEY on the server.",
+          credentialSpec?.apiKeyHelpText,
+        ]
+          .filter(Boolean)
+          .join(" ")}
+      />
+      {/* Outside the Advanced disclosure below: a required field hidden behind
+          a collapsed section is a submit button disabled for a reason off
+          screen. */}
+      <ProviderCredentialFields
+        provider={providerId}
+        values={credentials}
+        onChange={setCredentials}
+        errors={credentialErrors}
       />
       <button
         type="button"
@@ -248,19 +294,7 @@ function KnownProviderForm({ onClose }: { onClose: () => void }) {
         <Button variant="ghost" onPress={onClose}>
           Cancel
         </Button>
-        <ConnectionTest
-          getPayload={() =>
-            providerId === "" || !clientArgs.ok
-              ? null
-              : {
-                  instance: renamed ? name.trim() : providerId,
-                  provider_type: renamed ? providerId : null,
-                  api_base: apiBase.trim() || null,
-                  api_key: apiKey.trim() || null,
-                  client_args: clientArgs.value,
-                }
-          }
-        />
+        <ConnectionTest getPayload={buildPayload} />
       </div>
     </div>
   )
@@ -427,18 +461,48 @@ function EditProviderForm({
   const [apiBase, setApiBase] = useState(provider.api_base ?? "")
   const [replacingKey, setReplacingKey] = useState(false)
   const [apiKey, setApiKey] = useState("")
+  // An instance keeps its provider's name unless it was renamed, so the
+  // instance is what says which provider this is when provider_type is unset.
+  // Read the same way below, so the fields rendered are the ones the stored
+  // options were split against.
+  const providerId = providerType.trim() || provider.instance
+  const [stored] = useState(() =>
+    splitClientArgs(
+      credentialFieldsFor(provider.provider_type?.trim() || provider.instance),
+      provider.client_args,
+    ),
+  )
   const [clientArgsText, setClientArgsText] = useState(() =>
-    formatClientArgs(provider.client_args),
+    formatClientArgs(stored.rest),
+  )
+  const [credentials, setCredentials] = useState<CredentialFieldValues>(
+    () => stored.typed,
   )
   const clientArgs = parseClientArgs(clientArgsText)
+  const credentialFields = credentialFieldsFor(providerId)
+  const credentialErrors = validateCredentialFields(
+    credentialFields,
+    credentials,
+    stored.redacted,
+  )
 
   const submit = () => {
-    if (update.isPending || !clientArgs.ok) return
+    if (
+      update.isPending ||
+      !clientArgs.ok ||
+      Object.keys(credentialErrors).length > 0
+    )
+      return
     const body: UpdateStoredProviderRequest = {
       provider_type: providerType.trim() || null,
       api_base: apiBase.trim() || null,
       // Sent on every save, so emptying the field clears the stored options.
-      client_args: clientArgs.value,
+      client_args: mergeCredentialFields(
+        credentialFields,
+        credentials,
+        clientArgs.value,
+        stored.redacted,
+      ),
       // Guard against clobbering a concurrent edit; a 412 tells the operator to reload.
       expected_updated_at: provider.updated_at,
     }
@@ -517,6 +581,13 @@ function EditProviderForm({
           </div>
         )}
       </div>
+      <ProviderCredentialFields
+        provider={providerId}
+        values={credentials}
+        onChange={setCredentials}
+        errors={credentialErrors}
+        redacted={stored.redacted}
+      />
       <ClientArgsField
         value={clientArgsText}
         onChange={setClientArgsText}
@@ -525,7 +596,11 @@ function EditProviderForm({
       <div className="flex gap-2">
         <Button
           variant="primary"
-          isDisabled={update.isPending || !clientArgs.ok}
+          isDisabled={
+            update.isPending ||
+            !clientArgs.ok ||
+            Object.keys(credentialErrors).length > 0
+          }
           onPress={submit}
         >
           {update.isPending ? "Saving…" : "Save changes"}

--- a/web/src/features/providers/providerCredentialFields.test.ts
+++ b/web/src/features/providers/providerCredentialFields.test.ts
@@ -13,10 +13,9 @@ import {
 const bedrock = () => credentialFieldsFor("bedrock")
 
 describe("the registry", () => {
-  // These are boto3's own constructor keyword arguments, and they are the wire
-  // contract in docs/hybrid-mode-protocol.md that
-  // gateway/services/bedrock_gateway_auth.py reads. Pinned so a rename here has
-  // to be a deliberate edit on both sides rather than a silent one on this one.
+  // boto3's own constructor keyword arguments, spread into AnyLLM.create by
+  // gateway/services/provider_kwargs.py. Pinned so an edit here is a deliberate
+  // one; nothing checks them against the SDK that consumes them.
   it("names Bedrock's fields with the kwargs boto3 takes", () => {
     expect(bedrock().map((field) => field.key)).toEqual([
       "region_name",
@@ -33,7 +32,9 @@ describe("the registry", () => {
     ).toEqual(["region_name"])
   })
 
-  it("marks the IAM secret as a secret and the access key id as not one", () => {
+  it("masks the input for the IAM secret and not for the access key id", () => {
+    // `isSecret` decides how the control renders. What the gateway masks on
+    // read is a wider, key-name rule that catches the id as well.
     const byKey = new Map(bedrock().map((field) => [field.key, field]))
     expect(byKey.get("aws_secret_access_key")?.isSecret).toBe(true)
     expect(byKey.get("aws_access_key_id")?.isSecret).toBeUndefined()
@@ -76,17 +77,21 @@ describe("splitClientArgs", () => {
     })
   })
 
-  it("records a masked secret as set instead of putting the mask in the box", () => {
+  it("records a masked value as set instead of putting the mask in a control", () => {
+    // The gateway masks by key name, so both halves of the IAM pair come back
+    // as the mask: `aws_access_key_id` contains "key". Neither may be prefilled
+    // with it, or the operator reads a three-character placeholder as the value
+    // they stored.
     const split = splitClientArgs(bedrock(), {
       region_name: "eu-west-1",
-      aws_access_key_id: "AKIA…",
+      aws_access_key_id: REDACTED_CLIENT_ARG,
       aws_secret_access_key: REDACTED_CLIENT_ARG,
     })
-    expect(split.typed).toEqual({
-      region_name: "eu-west-1",
-      aws_access_key_id: "AKIA…",
-    })
-    expect(split.redacted).toEqual(["aws_secret_access_key"])
+    expect(split.typed).toEqual({ region_name: "eu-west-1" })
+    expect(split.redacted).toEqual([
+      "aws_access_key_id",
+      "aws_secret_access_key",
+    ])
   })
 
   it("leaves a non-string under a registered name in the JSON box", () => {
@@ -109,7 +114,6 @@ describe("mergeCredentialFields", () => {
   it("puts the typed values back beside whatever the JSON box still holds", () => {
     expect(
       mergeCredentialFields(
-        bedrock(),
         { region_name: "us-east-1" },
         {
           timeout: 1800,
@@ -119,29 +123,43 @@ describe("mergeCredentialFields", () => {
   })
 
   it("trims a value rather than storing the whitespace around it", () => {
-    expect(
-      mergeCredentialFields(bedrock(), { region_name: " us-east-1 " }, null),
-    ).toEqual({ region_name: "us-east-1" })
+    expect(mergeCredentialFields({ region_name: " us-east-1 " }, null)).toEqual(
+      { region_name: "us-east-1" },
+    )
   })
 
-  it("sends the mask back for a stored secret left blank, so the gateway keeps it", () => {
+  it("sends the mask back for a stored value left blank, so the gateway keeps it", () => {
     expect(
       mergeCredentialFields(
-        bedrock(),
         { region_name: "us-east-1", aws_secret_access_key: "" },
         null,
-        ["aws_secret_access_key"],
+        ["aws_access_key_id", "aws_secret_access_key"],
       ),
     ).toEqual({
       region_name: "us-east-1",
+      aws_access_key_id: REDACTED_CLIENT_ARG,
       aws_secret_access_key: REDACTED_CLIENT_ARG,
+    })
+  })
+
+  it("keeps a value whose field has stopped rendering", () => {
+    // `/providers` lets an instance's provider type be retyped mid-edit, which
+    // changes the field list under values that are already out of client_args.
+    // Dropping them here would delete the stored credential on save.
+    expect(
+      mergeCredentialFields({ region_name: "us-east-1" }, { timeout: 1800 }, [
+        "aws_secret_access_key",
+      ]),
+    ).toEqual({
+      region_name: "us-east-1",
+      aws_secret_access_key: REDACTED_CLIENT_ARG,
+      timeout: 1800,
     })
   })
 
   it("lets a filled-in field win over the same name in the JSON box", () => {
     expect(
       mergeCredentialFields(
-        bedrock(),
         { region_name: "us-east-1" },
         {
           region_name: "eu-west-1",
@@ -155,7 +173,6 @@ describe("mergeCredentialFields", () => {
     // is not an instruction to delete what is sitting there.
     expect(
       mergeCredentialFields(
-        bedrock(),
         { region_name: "" },
         {
           region_name: 42,
@@ -165,7 +182,7 @@ describe("mergeCredentialFields", () => {
   })
 
   it("reads an empty result as null, which is how the API clears the column", () => {
-    expect(mergeCredentialFields(bedrock(), {}, null)).toBeNull()
+    expect(mergeCredentialFields({}, null)).toBeNull()
   })
 })
 

--- a/web/src/features/providers/providerCredentialFields.test.ts
+++ b/web/src/features/providers/providerCredentialFields.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  BYO_UNSUPPORTED_PROVIDERS,
+  credentialFieldsFor,
+  credentialSpecFor,
+  mergeCredentialFields,
+  REDACTED_CLIENT_ARG,
+  splitClientArgs,
+  validateCredentialFields,
+} from "./providerCredentialFields"
+
+const bedrock = () => credentialFieldsFor("bedrock")
+
+describe("the registry", () => {
+  // These are boto3's own constructor keyword arguments, and they are the wire
+  // contract in docs/hybrid-mode-protocol.md that
+  // gateway/services/bedrock_gateway_auth.py reads. Pinned so a rename here has
+  // to be a deliberate edit on both sides rather than a silent one on this one.
+  it("names Bedrock's fields with the kwargs boto3 takes", () => {
+    expect(bedrock().map((field) => field.key)).toEqual([
+      "region_name",
+      "aws_access_key_id",
+      "aws_secret_access_key",
+    ])
+  })
+
+  it("requires only the region, which every Bedrock credential shape needs", () => {
+    expect(
+      bedrock()
+        .filter((field) => field.isRequired)
+        .map((field) => field.key),
+    ).toEqual(["region_name"])
+  })
+
+  it("marks the IAM secret as a secret and the access key id as not one", () => {
+    const byKey = new Map(bedrock().map((field) => [field.key, field]))
+    expect(byKey.get("aws_secret_access_key")?.isSecret).toBe(true)
+    expect(byKey.get("aws_access_key_id")?.isSecret).toBeUndefined()
+  })
+
+  it("renames the API key field where the provider does not call it one", () => {
+    expect(credentialSpecFor("bedrock")?.apiKeyLabel).toBe("Bedrock API key")
+    expect(credentialSpecFor("openai")).toBeUndefined()
+  })
+
+  it("leaves the providers that need nothing beyond an API key with no fields", () => {
+    expect(credentialFieldsFor("openai")).toEqual([])
+    expect(credentialFieldsFor("")).toEqual([])
+  })
+
+  it("withholds only the provider whose stored credential can never authenticate", () => {
+    expect(BYO_UNSUPPORTED_PROVIDERS).toEqual(["sagemaker"])
+  })
+})
+
+describe("splitClientArgs", () => {
+  it("routes registered keys to the typed fields and the rest to the JSON box", () => {
+    expect(
+      splitClientArgs(bedrock(), { region_name: "us-east-1", timeout: 1800 }),
+    ).toEqual({
+      typed: { region_name: "us-east-1" },
+      rest: { timeout: 1800 },
+      redacted: [],
+    })
+  })
+
+  it("records a masked secret as set instead of putting the mask in the box", () => {
+    const split = splitClientArgs(bedrock(), {
+      region_name: "eu-west-1",
+      aws_access_key_id: "AKIA…",
+      aws_secret_access_key: REDACTED_CLIENT_ARG,
+    })
+    expect(split.typed).toEqual({
+      region_name: "eu-west-1",
+      aws_access_key_id: "AKIA…",
+    })
+    expect(split.redacted).toEqual(["aws_secret_access_key"])
+  })
+
+  it("leaves a non-string under a registered name in the JSON box", () => {
+    // A text control would write it back as a string and change its meaning.
+    expect(splitClientArgs(bedrock(), { region_name: 42 }).rest).toEqual({
+      region_name: 42,
+    })
+  })
+
+  it("reads a key with no stored options as empty", () => {
+    expect(splitClientArgs(bedrock(), null)).toEqual({
+      typed: {},
+      rest: {},
+      redacted: [],
+    })
+  })
+})
+
+describe("mergeCredentialFields", () => {
+  it("puts the typed values back beside whatever the JSON box still holds", () => {
+    expect(
+      mergeCredentialFields(
+        bedrock(),
+        { region_name: "us-east-1" },
+        {
+          timeout: 1800,
+        },
+      ),
+    ).toEqual({ region_name: "us-east-1", timeout: 1800 })
+  })
+
+  it("trims a value rather than storing the whitespace around it", () => {
+    expect(
+      mergeCredentialFields(bedrock(), { region_name: " us-east-1 " }, null),
+    ).toEqual({ region_name: "us-east-1" })
+  })
+
+  it("sends the mask back for a stored secret left blank, so the gateway keeps it", () => {
+    expect(
+      mergeCredentialFields(
+        bedrock(),
+        { region_name: "us-east-1", aws_secret_access_key: "" },
+        null,
+        ["aws_secret_access_key"],
+      ),
+    ).toEqual({
+      region_name: "us-east-1",
+      aws_secret_access_key: REDACTED_CLIENT_ARG,
+    })
+  })
+
+  it("lets a filled-in field win over the same name in the JSON box", () => {
+    expect(
+      mergeCredentialFields(
+        bedrock(),
+        { region_name: "us-east-1" },
+        {
+          region_name: "eu-west-1",
+        },
+      ),
+    ).toEqual({ region_name: "us-east-1" })
+  })
+
+  it("leaves the JSON box alone where its field is blank", () => {
+    // The box only ever holds what a text control cannot edit, so a blank field
+    // is not an instruction to delete what is sitting there.
+    expect(
+      mergeCredentialFields(
+        bedrock(),
+        { region_name: "" },
+        {
+          region_name: 42,
+        },
+      ),
+    ).toEqual({ region_name: 42 })
+  })
+
+  it("reads an empty result as null, which is how the API clears the column", () => {
+    expect(mergeCredentialFields(bedrock(), {}, null)).toBeNull()
+  })
+})
+
+describe("validateCredentialFields", () => {
+  it("refuses a Bedrock credential with no region", () => {
+    expect(validateCredentialFields(bedrock(), {})).toEqual({
+      region_name: "AWS region is required for this provider.",
+    })
+  })
+
+  it("treats whitespace as absent", () => {
+    expect(validateCredentialFields(bedrock(), { region_name: "  " })).toEqual({
+      region_name: "AWS region is required for this provider.",
+    })
+  })
+
+  it("rejects a region that is not shaped like one", () => {
+    // boto3 raises InvalidRegionError while building the client, well past
+    // anything that could tell an operator which field was wrong.
+    expect(
+      validateCredentialFields(bedrock(), { region_name: "US East 1" }),
+    ).toEqual({
+      region_name:
+        "A region is lowercase letters, digits and hyphens, like us-east-1.",
+    })
+  })
+
+  it("accepts a filled-in classic IAM pair", () => {
+    expect(
+      validateCredentialFields(bedrock(), {
+        region_name: "ap-southeast-2",
+        aws_access_key_id: "AKIAIOSFODNN7EXAMPLE",
+        aws_secret_access_key: "secret",
+      }),
+    ).toEqual({})
+  })
+
+  it("counts an already-stored required secret as filled in", () => {
+    const fields = [
+      {
+        key: "token",
+        label: "Token",
+        isRequired: true,
+        isSecret: true,
+        helpText: "",
+      },
+    ]
+    expect(validateCredentialFields(fields, {}, ["token"])).toEqual({})
+    expect(validateCredentialFields(fields, {})).toEqual({
+      token: "Token is required for this provider.",
+    })
+  })
+
+  it("asks nothing of a provider with no registered fields", () => {
+    expect(validateCredentialFields(credentialFieldsFor("openai"), {})).toEqual(
+      {},
+    )
+  })
+})

--- a/web/src/features/providers/providerCredentialFields.test.ts
+++ b/web/src/features/providers/providerCredentialFields.test.ts
@@ -39,6 +39,17 @@ describe("the registry", () => {
     expect(byKey.get("aws_access_key_id")?.isSecret).toBeUndefined()
   })
 
+  it("pairs the two IAM fields from both sides", () => {
+    const byKey = new Map(bedrock().map((field) => [field.key, field]))
+    expect(byKey.get("aws_access_key_id")?.pairedWith).toBe(
+      "aws_secret_access_key",
+    )
+    expect(byKey.get("aws_secret_access_key")?.pairedWith).toBe(
+      "aws_access_key_id",
+    )
+    expect(byKey.get("region_name")?.pairedWith).toBeUndefined()
+  })
+
   it("renames the API key field where the provider does not call it one", () => {
     expect(credentialSpecFor("bedrock")?.apiKeyLabel).toBe("Bedrock API key")
     expect(credentialSpecFor("openai")).toBeUndefined()
@@ -189,6 +200,50 @@ describe("validateCredentialFields", () => {
         aws_access_key_id: "AKIAIOSFODNN7EXAMPLE",
         aws_secret_access_key: "secret",
       }),
+    ).toEqual({})
+  })
+
+  it("accepts the bearer-token shape, which fills in neither IAM field", () => {
+    // The API key field carries the whole credential there, so an empty pair is
+    // a complete answer rather than a half-filled one.
+    expect(
+      validateCredentialFields(bedrock(), { region_name: "us-east-1" }),
+    ).toEqual({})
+  })
+
+  it("asks for the secret when only the access key id is given", () => {
+    // An id with no secret reaches boto3 as a credential that cannot sign, and
+    // the gateway reads the id alone as "this is the classic IAM shape".
+    expect(
+      validateCredentialFields(bedrock(), {
+        region_name: "us-east-1",
+        aws_access_key_id: "AKIAIOSFODNN7EXAMPLE",
+      }),
+    ).toEqual({
+      aws_secret_access_key:
+        "AWS secret access key is required alongside AWS access key ID.",
+    })
+  })
+
+  it("asks for the access key id when only the secret is given", () => {
+    expect(
+      validateCredentialFields(bedrock(), {
+        region_name: "us-east-1",
+        aws_secret_access_key: "secret",
+      }),
+    ).toEqual({
+      aws_access_key_id:
+        "AWS access key ID is required alongside AWS secret access key.",
+    })
+  })
+
+  it("counts a stored, masked half of the pair as filled in", () => {
+    expect(
+      validateCredentialFields(
+        bedrock(),
+        { region_name: "us-east-1", aws_access_key_id: "AKIA…" },
+        ["aws_secret_access_key"],
+      ),
     ).toEqual({})
   })
 

--- a/web/src/features/providers/providerCredentialFields.ts
+++ b/web/src/features/providers/providerCredentialFields.ts
@@ -45,6 +45,14 @@ export interface ProviderCredentialFieldSpec {
   /** A non-empty value must match this, checked before the form can submit. */
   pattern?: RegExp
   patternMessage?: string
+  /**
+   * Another field of the same provider that has to be filled in with this one.
+   * Neither is required on its own, but half a pair is worse than none of it:
+   * it reaches the SDK as a credential that cannot authenticate, and for
+   * Bedrock it also decides which credential shape the gateway thinks is in
+   * play (`bedrock_uses_bearer_token` keys on `aws_access_key_id` alone).
+   */
+  pairedWith?: string
 }
 
 /** A provider whose credential fields differ from the plain api_key + api_base pair. */
@@ -88,15 +96,17 @@ const BEDROCK: ProviderCredentialSpec = {
       key: "aws_access_key_id",
       label: "AWS access key ID",
       isRequired: false,
+      pairedWith: "aws_secret_access_key",
       placeholder: "AKIAIOSFODNN7EXAMPLE",
       helpText:
-        "Only for a classic IAM key pair. Leave blank when the API key above is a Bedrock bearer token.",
+        "Only for a classic IAM key pair, and then both halves are needed. Leave blank when the API key above is a Bedrock bearer token.",
     },
     {
       key: "aws_secret_access_key",
       label: "AWS secret access key",
       isRequired: false,
       isSecret: true,
+      pairedWith: "aws_access_key_id",
       helpText:
         "The other half of the IAM key pair. Masked when read back, but stored unencrypted, unlike the API key above.",
     },
@@ -223,8 +233,9 @@ export function mergeCredentialFields(
 }
 
 /**
- * Per-field messages for what the form cannot submit, keyed by field. A
- * required secret already stored (and therefore masked) counts as filled in.
+ * Per-field messages for what the form cannot submit, keyed by field. A secret
+ * already stored (and therefore masked) counts as filled in, here as everywhere
+ * else: the form is not shown it and is not asking for it again.
  */
 export function validateCredentialFields(
   fields: ProviderCredentialFieldSpec[],
@@ -232,6 +243,10 @@ export function validateCredentialFields(
   redacted: readonly string[] = [],
 ): Record<string, string> {
   const errors: Record<string, string> = {}
+  const byKey = new Map(fields.map((field) => [field.key, field]))
+  const isFilled = (field: ProviderCredentialFieldSpec) =>
+    (values[field.key] ?? "").trim() !== "" || redacted.includes(field.key)
+
   for (const field of fields) {
     const value = (values[field.key] ?? "").trim()
     if (value === "") {
@@ -244,6 +259,15 @@ export function validateCredentialFields(
       errors[field.key] =
         field.patternMessage ?? `${field.label} is not in the expected format.`
     }
+  }
+
+  // Half a pair, reported on the half that is missing. Declared from both
+  // sides, so filling in either one alone asks for the other.
+  for (const field of fields) {
+    const partner = field.pairedWith ? byKey.get(field.pairedWith) : undefined
+    if (!partner || !isFilled(field) || isFilled(partner)) continue
+    errors[partner.key] ??=
+      `${partner.label} is required alongside ${field.label}.`
   }
   return errors
 }

--- a/web/src/features/providers/providerCredentialFields.ts
+++ b/web/src/features/providers/providerCredentialFields.ts
@@ -22,10 +22,13 @@
 // either a 403 on the page that needs it or a new public route for what is
 // static, per-release data with no deployment variance.
 //
-// The names themselves are the wire contract in `docs/hybrid-mode-protocol.md`
-// and are read gateway-side by `src/gateway/services/bedrock_gateway_auth.py`;
-// `providerCredentialFields.test.ts` pins them so a rename here has to be a
-// deliberate edit in both places.
+// The names are boto3's own, and nothing between this file and the SDK call
+// validates them: `org_provider_key_service` hands `client_args` to
+// `provider_kwargs.get_provider_kwargs`, which spreads it into `AnyLLM.create`.
+// `providerCredentialFields.test.ts` pins them against a silent edit here, not
+// against an upstream rename, which still surfaces as a provider error at
+// request time. `services/bedrock_gateway_auth.py` builds the same names on the
+// hybrid path, out of the platform's `extra_params` rather than out of these.
 
 /** One `client_args` entry a provider expects, and how to ask for it. */
 export interface ProviderCredentialFieldSpec {
@@ -34,10 +37,11 @@ export interface ProviderCredentialFieldSpec {
   label: string
   isRequired: boolean
   /**
-   * Holds a credential. Rendered masked, and never prefilled with what came
-   * back from the API: the gateway returns `REDACTED_CLIENT_ARG` in place of
-   * the stored value (`redact_secret_like_values`), and re-sending that mask
-   * is what keeps the stored value (`restore_redacted_values`).
+   * Rendered as a password input. Narrower than what the gateway masks on read:
+   * `redact_secret_like_values` matches a key *name* against "key", "secret",
+   * "token" and three more, so `aws_access_key_id` also comes back as
+   * `REDACTED_CLIENT_ARG` without being one. Whether a stored value came back
+   * masked is read off the value itself, in {@link splitClientArgs}.
    */
   isSecret?: boolean
   placeholder?: string
@@ -161,9 +165,9 @@ export type CredentialFieldValues = Record<string, string>
  * Split stored `client_args` into the values the typed fields own and the rest,
  * which stays in the JSON escape hatch.
  *
- * A secret whose stored value came back masked is dropped from `typed` rather
- * than shown: a masked value in a password box reads as a real one three
- * characters long. `redacted` records that it was set, so
+ * A value that came back masked is dropped from `typed` rather than shown: a
+ * mask in a control reads as a real value three characters long, and typing
+ * over it is the only way to tell. `redacted` records that it was set, so
  * {@link mergeCredentialFields} can send the mask back and keep it.
  */
 export function splitClientArgs(
@@ -185,7 +189,10 @@ export function splitClientArgs(
       rest[key] = value
       continue
     }
-    if (field.isSecret && value === REDACTED_CLIENT_ARG) {
+    // Keyed on the value, not on `isSecret`: the gateway masks by key name, so
+    // `aws_access_key_id` arrives masked too and a plain text field would show
+    // the mask as if the operator had typed it.
+    if (value === REDACTED_CLIENT_ARG) {
       redacted.push(key)
       continue
     }
@@ -204,7 +211,7 @@ export function splitClientArgs(
  * textarea still holds. Null when nothing is left, which is how the API reads
  * "clear it".
  *
- * A blank secret whose stored value was masked is sent as the mask, so the
+ * A blank field whose stored value was masked is sent as the mask, so the
  * gateway keeps what it has: the same bargain the API key field makes by
  * omitting itself when it was not retyped.
  *
@@ -213,20 +220,24 @@ export function splitClientArgs(
  * than deleting: `splitClientArgs` hands the box only what a text control
  * cannot edit, and dropping that would silently discard a value the operator
  * can see.
+ *
+ * Driven by what `splitClientArgs` took out rather than by the current field
+ * list, because the two can disagree: `/providers` lets an instance's provider
+ * type be retyped mid-edit, and a field that stops rendering must not take the
+ * stored option with it.
  */
 export function mergeCredentialFields(
-  fields: ProviderCredentialFieldSpec[],
   values: CredentialFieldValues,
   rest: Record<string, unknown> | null,
   redacted: readonly string[] = [],
 ): Record<string, unknown> | null {
   const merged: Record<string, unknown> = { ...(rest ?? {}) }
-  for (const field of fields) {
-    const value = (values[field.key] ?? "").trim()
+  for (const key of new Set([...Object.keys(values), ...redacted])) {
+    const value = (values[key] ?? "").trim()
     if (value !== "") {
-      merged[field.key] = value
-    } else if (field.isSecret && redacted.includes(field.key)) {
-      merged[field.key] = REDACTED_CLIENT_ARG
+      merged[key] = value
+    } else if (redacted.includes(key)) {
+      merged[key] = REDACTED_CLIENT_ARG
     }
   }
   return Object.keys(merged).length > 0 ? merged : null

--- a/web/src/features/providers/providerCredentialFields.ts
+++ b/web/src/features/providers/providerCredentialFields.ts
@@ -1,0 +1,249 @@
+// What one provider needs in `client_args` beyond an API key, described well
+// enough for a form to ask for it.
+//
+// `client_args` is forwarded verbatim to the provider's client constructor
+// (`AnyLLM.create(provider, api_key=…, api_base=…, **client_args)`), so its
+// contents are whichever keyword arguments that SDK takes. For almost every
+// provider that is optional transport tuning and a JSON textarea is the honest
+// control. Bedrock is the exception: boto3 builds no client without
+// `region_name`, and a credential omitted from a free-text JSON box surfaces
+// as a provider error on the first request rather than as a validation error
+// on the form.
+//
+// The registry lives here rather than being published by the gateway on
+// purpose. `client_args` is a passthrough on every otari code path that reads
+// an organization key, so there is no server-side call built from these specs
+// for the form to drift away from; the authority for the names below is
+// any-llm and boto3, which a server-side copy would be paraphrasing just as
+// this one does. The endpoint that would carry it, `/v1/providers/catalog`, is
+// `require_deployment_operator`-gated, and the page that most needs these
+// fields (`/organization/provider-keys`) is used by organization owners and
+// admins who hold no deployment authority. Publishing it there would mean
+// either a 403 on the page that needs it or a new public route for what is
+// static, per-release data with no deployment variance.
+//
+// The names themselves are the wire contract in `docs/hybrid-mode-protocol.md`
+// and are read gateway-side by `src/gateway/services/bedrock_gateway_auth.py`;
+// `providerCredentialFields.test.ts` pins them so a rename here has to be a
+// deliberate edit in both places.
+
+/** One `client_args` entry a provider expects, and how to ask for it. */
+export interface ProviderCredentialFieldSpec {
+  /** Literal SDK keyword argument, and the `client_args` key it is stored under. */
+  key: string
+  label: string
+  isRequired: boolean
+  /**
+   * Holds a credential. Rendered masked, and never prefilled with what came
+   * back from the API: the gateway returns `REDACTED_CLIENT_ARG` in place of
+   * the stored value (`redact_secret_like_values`), and re-sending that mask
+   * is what keeps the stored value (`restore_redacted_values`).
+   */
+  isSecret?: boolean
+  placeholder?: string
+  helpText: string
+  /** A non-empty value must match this, checked before the form can submit. */
+  pattern?: RegExp
+  patternMessage?: string
+}
+
+/** A provider whose credential fields differ from the plain api_key + api_base pair. */
+export interface ProviderCredentialSpec {
+  fields: ProviderCredentialFieldSpec[]
+  /** Overrides the "API key" label where the credential is not an opaque key. */
+  apiKeyLabel?: string
+  apiKeyHelpText?: string
+}
+
+// The value the gateway substitutes for a credential-shaped `client_args`
+// entry when it serializes a key, and the value that means "keep what is
+// stored" when it is sent back. Kept in step with `REDACTED_VALUE` in
+// `src/gateway/models/secret_fields.py`.
+export const REDACTED_CLIENT_ARG = "***"
+
+const AWS_REGION_PATTERN = /^[a-z0-9-]+$/
+
+const BEDROCK: ProviderCredentialSpec = {
+  // Bedrock takes either of two credential shapes, and the region under both. A
+  // bearer token ("Bedrock API key") goes in the API key field on its own; a
+  // classic IAM pair puts its id and secret in the fields below and leaves the
+  // API key field blank. Filling in both is ambiguous, which is what each
+  // field's help text is for.
+  apiKeyLabel: "Bedrock API key",
+  apiKeyHelpText:
+    "AWS's bearer token for Bedrock. Leave blank if you are using a classic IAM key pair below instead.",
+  fields: [
+    {
+      key: "region_name",
+      label: "AWS region",
+      isRequired: true,
+      placeholder: "us-east-1",
+      helpText:
+        "The region your Bedrock models are enabled in. Required for every credential shape: boto3 builds no client without one.",
+      pattern: AWS_REGION_PATTERN,
+      patternMessage:
+        "A region is lowercase letters, digits and hyphens, like us-east-1.",
+    },
+    {
+      key: "aws_access_key_id",
+      label: "AWS access key ID",
+      isRequired: false,
+      placeholder: "AKIAIOSFODNN7EXAMPLE",
+      helpText:
+        "Only for a classic IAM key pair. Leave blank when the API key above is a Bedrock bearer token.",
+    },
+    {
+      key: "aws_secret_access_key",
+      label: "AWS secret access key",
+      isRequired: false,
+      isSecret: true,
+      helpText:
+        "The other half of the IAM key pair. Masked when read back, but stored unencrypted, unlike the API key above.",
+    },
+  ],
+}
+
+const PROVIDER_CREDENTIAL_SPECS: Record<string, ProviderCredentialSpec> = {
+  bedrock: BEDROCK,
+}
+
+/** The credential spec for a provider, or undefined where api_key is the whole of it. */
+export function credentialSpecFor(
+  provider: string,
+): ProviderCredentialSpec | undefined {
+  return PROVIDER_CREDENTIAL_SPECS[provider]
+}
+
+/** The typed fields for a provider; empty for the vast majority of them. */
+export function credentialFieldsFor(
+  provider: string,
+): ProviderCredentialFieldSpec[] {
+  return PROVIDER_CREDENTIAL_SPECS[provider]?.fields ?? []
+}
+
+/**
+ * Providers a stored credential can never authenticate, so a form that
+ * collects one must not offer them.
+ *
+ * any-llm's SageMaker provider verifies against a bare `boto3.Session()`
+ * before its client is built, so it authenticates from the gateway's own
+ * ambient AWS chain and refuses outright when there is none, whatever was
+ * supplied. otari already treats it that way on the dispatch side
+ * (`_AMBIENT_CREDENTIAL_PROVIDERS` in `services/provider_kwargs.py` lets a
+ * SageMaker selector resolve with nothing configured), and it reports no model
+ * listing, so a connection test cannot tell an operator any of this either.
+ *
+ * Scoped to the call sites that collect a bring-your-own credential rather
+ * than applied to every picker: a deployment operator adding a SageMaker
+ * *instance* on `/providers` to give it an endpoint and a model list, backed
+ * by the host's own credentials, is a configuration that does work.
+ *
+ * The old platform form excluded `platform` here too. otari has no such
+ * pseudo-provider: `AnyLLM.get_supported_providers()` carries no `platform`
+ * entry, so there is nothing to exclude.
+ */
+export const BYO_UNSUPPORTED_PROVIDERS: readonly string[] = ["sagemaker"]
+
+/** The typed fields' current values, keyed by their SDK keyword argument. */
+export type CredentialFieldValues = Record<string, string>
+
+/**
+ * Split stored `client_args` into the values the typed fields own and the rest,
+ * which stays in the JSON escape hatch.
+ *
+ * A secret whose stored value came back masked is dropped from `typed` rather
+ * than shown: a masked value in a password box reads as a real one three
+ * characters long. `redacted` records that it was set, so
+ * {@link mergeCredentialFields} can send the mask back and keep it.
+ */
+export function splitClientArgs(
+  fields: ProviderCredentialFieldSpec[],
+  stored: Record<string, unknown> | null | undefined,
+): {
+  typed: CredentialFieldValues
+  rest: Record<string, unknown>
+  redacted: string[]
+} {
+  const typed: CredentialFieldValues = {}
+  const rest: Record<string, unknown> = {}
+  const redacted: string[] = []
+  const byKey = new Map(fields.map((field) => [field.key, field]))
+
+  for (const [key, value] of Object.entries(stored ?? {})) {
+    const field = byKey.get(key)
+    if (!field) {
+      rest[key] = value
+      continue
+    }
+    if (field.isSecret && value === REDACTED_CLIENT_ARG) {
+      redacted.push(key)
+      continue
+    }
+    // Only a string can be edited in a text field. Anything else an operator
+    // wrote under a registered name (a number, an object) keeps its meaning
+    // only as JSON, so it stays in the escape hatch rather than being
+    // stringified into a control that would write it back as text.
+    if (typeof value === "string") typed[key] = value
+    else rest[key] = value
+  }
+  return { typed, rest, redacted }
+}
+
+/**
+ * Rebuild the `client_args` payload from the typed fields and whatever the JSON
+ * textarea still holds. Null when nothing is left, which is how the API reads
+ * "clear it".
+ *
+ * A blank secret whose stored value was masked is sent as the mask, so the
+ * gateway keeps what it has: the same bargain the API key field makes by
+ * omitting itself when it was not retyped.
+ *
+ * A filled-in typed field overwrites the same name in the JSON box, so the two
+ * views cannot disagree about one option. A blank one writes nothing rather
+ * than deleting: `splitClientArgs` hands the box only what a text control
+ * cannot edit, and dropping that would silently discard a value the operator
+ * can see.
+ */
+export function mergeCredentialFields(
+  fields: ProviderCredentialFieldSpec[],
+  values: CredentialFieldValues,
+  rest: Record<string, unknown> | null,
+  redacted: readonly string[] = [],
+): Record<string, unknown> | null {
+  const merged: Record<string, unknown> = { ...(rest ?? {}) }
+  for (const field of fields) {
+    const value = (values[field.key] ?? "").trim()
+    if (value !== "") {
+      merged[field.key] = value
+    } else if (field.isSecret && redacted.includes(field.key)) {
+      merged[field.key] = REDACTED_CLIENT_ARG
+    }
+  }
+  return Object.keys(merged).length > 0 ? merged : null
+}
+
+/**
+ * Per-field messages for what the form cannot submit, keyed by field. A
+ * required secret already stored (and therefore masked) counts as filled in.
+ */
+export function validateCredentialFields(
+  fields: ProviderCredentialFieldSpec[],
+  values: CredentialFieldValues,
+  redacted: readonly string[] = [],
+): Record<string, string> {
+  const errors: Record<string, string> = {}
+  for (const field of fields) {
+    const value = (values[field.key] ?? "").trim()
+    if (value === "") {
+      if (field.isRequired && !redacted.includes(field.key)) {
+        errors[field.key] = `${field.label} is required for this provider.`
+      }
+      continue
+    }
+    if (field.pattern && !field.pattern.test(value)) {
+      errors[field.key] =
+        field.patternMessage ?? `${field.label} is not in the expected format.`
+    }
+  }
+  return errors
+}

--- a/web/src/features/providers/providerFields.tsx
+++ b/web/src/features/providers/providerFields.tsx
@@ -11,17 +11,24 @@ import {
 import { type ReactNode, useMemo, useState } from "react"
 
 import { useProviderCatalog } from "@/shared/api/providers"
+import { Field } from "@/shared/components/forms/Field"
 import { FieldMessages } from "@/shared/components/forms/FieldMessages"
+import { SecretField } from "@/shared/components/forms/SecretField"
 
-// The two form controls a provider credential needs wherever it is edited, and
-// the parsing that goes with one of them.
+import {
+  type CredentialFieldValues,
+  credentialFieldsFor,
+} from "./providerCredentialFields"
+
+// The form controls a provider credential needs wherever it is edited, and the
+// parsing that goes with them.
 //
 // Shared because the same credential is entered on two pages that are otherwise
 // unrelated: `/providers`, where it belongs to the process, and
 // `/organization/provider-keys`, where it belongs to the tenant. Both take a
 // provider name any-llm has to recognize and both take `client_args`, so a
-// second copy of either control would be a second place for the JSON guard and
-// the catalog lookup to drift.
+// second copy of any of these controls would be a second place for the JSON
+// guard, the catalog lookup and the per-provider field list to drift.
 
 // client_args is whatever the provider's SDK client constructor takes (timeouts,
 // custom headers), so it has no fixed schema and the form edits it as JSON. Blank
@@ -58,8 +65,71 @@ export function formatClientArgs(
     : ""
 }
 
-// The client_args editor. Options are passed straight to the provider client, so
-// a bad value is rejected here rather than sent (issue #517).
+// The typed fields a provider expects inside `client_args`, from the registry.
+// Renders nothing for the providers that need none, which is nearly all of them.
+export function ProviderCredentialFields({
+  provider,
+  values,
+  onChange,
+  errors,
+  redacted = [],
+}: {
+  provider: string
+  values: CredentialFieldValues
+  onChange: (next: CredentialFieldValues) => void
+  /** Per-field messages from `validateCredentialFields`, keyed by field key. */
+  errors: Record<string, string>
+  /** Fields whose stored secret came back masked, so blank means "keep it". */
+  redacted?: readonly string[]
+}) {
+  const fields = credentialFieldsFor(provider)
+  if (fields.length === 0) return null
+
+  return (
+    <>
+      {fields.map((field) => {
+        const value = values[field.key] ?? ""
+        const error = errors[field.key]
+        const set = (next: string) => onChange({ ...values, [field.key]: next })
+        if (field.isSecret) {
+          return (
+            <SecretField
+              key={field.key}
+              label={field.label}
+              value={value}
+              onChange={set}
+              placeholder={field.placeholder ?? "••••••••"}
+              description={
+                redacted.includes(field.key)
+                  ? `Set already, and never shown again. Leave blank to keep it. ${field.helpText}`
+                  : field.helpText
+              }
+              isInvalid={error !== undefined}
+              errorMessage={error}
+            />
+          )
+        }
+        return (
+          <Field
+            key={field.key}
+            label={field.label}
+            value={value}
+            onChange={set}
+            isRequired={field.isRequired}
+            placeholder={field.placeholder}
+            description={field.helpText}
+            isInvalid={error !== undefined}
+            errorMessage={error}
+          />
+        )
+      })}
+    </>
+  )
+}
+
+// The client_args editor: the escape hatch for whatever the typed fields above
+// do not describe. Options are passed straight to the provider client, so a bad
+// value is rejected here rather than sent (issue #517).
 export function ClientArgsField({
   value,
   onChange,
@@ -88,9 +158,12 @@ export function ClientArgsField({
           className={error ? "text-caption text-danger" : "text-caption"}
         >
           {error ??
-            // Unlike the API key, these are stored and returned unencrypted, so say
-            // so before someone puts a token in a custom header here.
-            "Passed to the provider's client, e.g. a request timeout in seconds or custom headers. Stored in plain text, so keep secrets out."}
+            // Both halves of that sentence are load-bearing, and blanket "keep
+            // secrets out" advice would be wrong: Bedrock's classic IAM shape
+            // genuinely needs a secret in here (`gateway/models/provider_keys.py`),
+            // `redact_secret_like_values` is why it does not come back, and
+            // `encrypted_api_key` is the protection it does not get.
+            "Passed to the provider's client, e.g. a request timeout in seconds or custom headers. An option named like a credential is masked when read back, but nothing here is encrypted at rest."}
         </Description>
       </FieldMessages>
     </TextField>
@@ -108,6 +181,7 @@ export function ProviderComboBox({
   placeholder,
   extra = [],
   includeCatalog = true,
+  excludeIds,
 }: {
   label: string
   value: string
@@ -118,18 +192,21 @@ export function ProviderComboBox({
   // When false, offer only `extra` (e.g. the two API dialects), not the full
   // provider catalog.
   includeCatalog?: boolean
+  // Catalog entries to leave out, for a form that cannot honor them. Per call
+  // site rather than a rule of the picker: which providers are offerable
+  // depends on what the form collects, not on the catalog. See
+  // `BYO_UNSUPPORTED_PROVIDERS`.
+  excludeIds?: readonly string[]
 }) {
   const catalog = useProviderCatalog()
-  const options = useMemo(
-    () =>
-      includeCatalog
-        ? [
-            ...extra,
-            ...(catalog.data ?? []).map((p) => ({ id: p.id, name: p.name })),
-          ]
-        : extra,
-    [catalog.data, extra, includeCatalog],
-  )
+  const options = useMemo(() => {
+    const catalogOptions = includeCatalog
+      ? (catalog.data ?? [])
+          .filter((p) => !excludeIds?.includes(p.id))
+          .map((p) => ({ id: p.id, name: p.name }))
+      : []
+    return [...extra, ...catalogOptions]
+  }, [catalog.data, extra, includeCatalog, excludeIds])
 
   // Seed the input with the selected option's display name. The field owns its
   // text after mount (updated on typing and on selection); syncing it back from

--- a/web/src/features/providers/providerFields.tsx
+++ b/web/src/features/providers/providerFields.tsx
@@ -79,7 +79,7 @@ export function ProviderCredentialFields({
   onChange: (next: CredentialFieldValues) => void
   /** Per-field messages from `validateCredentialFields`, keyed by field key. */
   errors: Record<string, string>
-  /** Fields whose stored secret came back masked, so blank means "keep it". */
+  /** Fields whose stored value came back masked, so blank means "keep it". */
   redacted?: readonly string[]
 }) {
   const fields = credentialFieldsFor(provider)
@@ -91,6 +91,12 @@ export function ProviderCredentialFields({
         const value = values[field.key] ?? ""
         const error = errors[field.key]
         const set = (next: string) => onChange({ ...values, [field.key]: next })
+        // The gateway masks anything credential-shaped by key name, so a stored
+        // value is often unreadable whether or not the registry calls it a
+        // secret. Say it is set instead of prefilling the mask.
+        const description = redacted.includes(field.key)
+          ? `Set already, and never shown again. Leave blank to keep it. ${field.helpText}`
+          : field.helpText
         if (field.isSecret) {
           return (
             <SecretField
@@ -99,11 +105,7 @@ export function ProviderCredentialFields({
               value={value}
               onChange={set}
               placeholder={field.placeholder ?? "••••••••"}
-              description={
-                redacted.includes(field.key)
-                  ? `Set already, and never shown again. Leave blank to keep it. ${field.helpText}`
-                  : field.helpText
-              }
+              description={description}
               isInvalid={error !== undefined}
               errorMessage={error}
             />
@@ -117,7 +119,7 @@ export function ProviderCredentialFields({
             onChange={set}
             isRequired={field.isRequired}
             placeholder={field.placeholder}
-            description={field.helpText}
+            description={description}
             isInvalid={error !== undefined}
             errorMessage={error}
           />

--- a/web/src/shared/components/forms/SecretField.tsx
+++ b/web/src/shared/components/forms/SecretField.tsx
@@ -1,4 +1,4 @@
-import { Description, Input, Label, TextField } from "@heroui/react"
+import { Description, FieldError, Input, Label, TextField } from "@heroui/react"
 import { FieldMessages } from "@/shared/components/forms/FieldMessages"
 
 // A masked, never-prefilled secret input. Native password masking protects
@@ -18,6 +18,8 @@ export function SecretField({
   label,
   placeholder,
   description,
+  isInvalid,
+  errorMessage,
   reserveMessage,
 }: {
   value: string
@@ -25,6 +27,10 @@ export function SecretField({
   label: string
   placeholder?: string
   description?: string
+  /** Marks the input invalid, which is what makes `errorMessage` render. */
+  isInvalid?: boolean
+  /** Shown under the field and announced with it. Needs `isInvalid` to appear. */
+  errorMessage?: string
   /** See `Field`: holds one caption line open so a message does not move the
       form. Off for a field in a table row or a toolbar. */
   reserveMessage?: boolean
@@ -33,6 +39,7 @@ export function SecretField({
     <TextField
       value={value}
       onChange={onChange}
+      isInvalid={isInvalid}
       className="flex max-w-md flex-col gap-1"
     >
       <Label className="text-body">{label}</Label>
@@ -49,6 +56,11 @@ export function SecretField({
       <FieldMessages reserve={reserveMessage}>
         {description ? (
           <Description className="text-muted">{description}</Description>
+        ) : null}
+        {/* Same slot wiring `Field` uses: the message is announced on the input
+            rather than left loose in the form. */}
+        {errorMessage ? (
+          <FieldError className="text-danger">{errorMessage}</FieldError>
         ) : null}
       </FieldMessages>
     </TextField>


### PR DESCRIPTION
## Description

`/providers` and `/organization/provider-keys` collected a provider, a name, an API key, an API base and a raw "Client options (JSON)" textarea. Bedrock builds no boto3 client without `region_name` in that JSON, and nothing on either form said so, so a missing or misspelled key surfaced as a provider error on the first request.

A per-provider field registry now describes what a provider expects inside `client_args`, and both forms render it from the shared controls in `providerFields.tsx`. The JSON textarea stays as the escape hatch for anything the registry does not describe; the typed fields and the textarea are two views of one object and are recombined on submit.

**Where the registry lives, and why client-side.** `web/src/features/providers/providerCredentialFields.ts`, not an endpoint. Three reasons:

- There is nothing server-side for the form to drift away from. On every otari path that reads an organization key, `client_args` is a passthrough (`org_provider_key_service._row_to_entry` → `provider_kwargs.get_provider_kwargs` → `AnyLLM.create(provider, **client_args)`). The authority for these names is any-llm and boto3; a gateway-side copy would be paraphrasing them exactly as this one does, one wire hop further away.
- The endpoint that would carry it, `/v1/providers/catalog`, sits on a `require_deployment_operator` router, and the page that most needs the fields (`/organization/provider-keys`) is used by organization owners and admins who hold no deployment authority. Publishing it there means a 403 on the page that needs it, or a new public route for what is static, per-release data with no deployment variance (unlike `env_key_present`, which genuinely varies by server).
- The names are pinned by `providerCredentialFields.test.ts` and cross-referenced to `docs/hybrid-mode-protocol.md` and `services/bedrock_gateway_auth.py`, so a rename has to be a deliberate edit on both sides.

**The two defects in the issue.**

*The secrets copy.* `ClientArgsField` said "Stored in plain text, so keep secrets out", which is advice against the only supported way to configure Bedrock's classic IAM shape. Checking `redact_secret_like_values` before rewriting it: a `client_args` entry whose key name contains `key`/`secret`/`token`/`password`/`authorization`/`credential` comes back as `***`, and `restore_redacted_values` keeps the stored value when that mask is sent back, so those values do **not** round-trip over the API. What is true is that they are not encrypted at rest the way `encrypted_api_key` is. The copy now says exactly that, and `aws_secret_access_key` is a typed secret field rather than something an operator hand-writes into a box that tells them not to.

*The picker.* Verified against the pinned any-llm before filtering: `SagemakerProvider._verify_and_set_api_key` builds a bare `boto3.Session()` and raises `MissingApiKeyError` when the gateway host has no ambient AWS credentials, and it runs before `_init_client` (`any_llm.py:167`), so a supplied credential is never what authenticates the call. `sagemaker` is withheld from the picker where a bring-your-own credential is collected, per call site rather than as a rule of the picker: a deployment operator adding a SageMaker *instance* on `/providers` backed by the host's own AWS chain is a configuration that does work, and otari already treats it that way (`_AMBIENT_CREDENTIAL_PROVIDERS` in `services/provider_kwargs.py`). The old form also excluded `platform`; otari's `AnyLLM.get_supported_providers()` carries no such entry, so there is nothing to exclude.

`SecretField` gained `isInvalid`/`errorMessage`, mirroring `Field`, so a registry secret marked required cannot fail validation with nothing rendered.

A field can also declare `pairedWith`, which is what keeps Bedrock's classic IAM shape whole: neither half is required on its own, so the bearer-token shape still submits with both blank, but filling in one asks for the other. Half a pair reaches boto3 as a credential that cannot sign, and an access key id with no secret is also what the gateway reads as "this key uses the classic IAM shape" (`bedrock_uses_bearer_token`).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Relevant issues

Refs mozilla-ai/otari-ai#2073

## Checklist

- [x] I understand the code I am submitting.
- [x] I have added or updated tests that cover my change (`tests/unit`, `tests/integration`).
- [ ] I ran the Definition of Done checks locally (`make lint`, `make typecheck`, `make test`). Two of the three; see below.
- [x] Documentation was updated where necessary.
- [x] If the API contract changed, I regenerated the OpenAPI spec (`uv run python scripts/generate_openapi.py`).

What that checklist means here, since the change is dashboard-only:

- `make lint` (architecture check, alembic heads, Ruff) and `make typecheck` (mypy, 567 files) are green.
- `pnpm --dir web run lint`, `pnpm --dir web run typecheck` and `pnpm --dir web test` are green: 136 files, 3903 tests.
- `make test` was **not** run here. Its integration half needs PostgreSQL, and this machine has no Docker, so the backend suites are CI's. No Python changed, so nothing in `src/` or `tests/` is in the diff to run against.
- No route, schema or route docstring moved, so `docs/public/openapi.json` and the Postman collection are unchanged. `pnpm --dir web run client:generate` regenerates `web/src/client/schema.ts` byte-identical, and `web/src/routeTree.gen.ts` is untouched.
- The OSS-edition smoke gate is not owed: no app, migration or dependency change.
- No page was added, so no screenshot entry is owed.
- `docs/dashboard.md` does not enumerate these form fields, so there was no doc to update.

New coverage: `providerCredentialFields.test.ts` pins the registry and its split/merge/validate helpers; `OrganizationProviderKeysPage.test.tsx` covers the Bedrock happy path (region reaches `client_args`), the error path (submit refused with no region, and with a region that is not shaped like one), the masked-secret round trip, the copy fix, and the withheld provider; `ProvidersPage.test.tsx` covers the same registry wiring on the known-provider and edit forms. All of it runs through the `fetch` spy those two spec files already use, which sits below `apiFetch`, so the real hooks, query keys and derivations still run.

## AI Usage

- [ ] No AI was used.
- [ ] AI was used for drafting/refactoring.
- [x] This is fully AI-generated.

**AI Model/Tool used:**

Claude Opus 5 (1M context), via Claude Code.

**Any additional AI details you'd like to share:**

Two findings worth a human's eye, neither changed here:

- The pinned any-llm's `BedrockProvider` now supports both credential shapes natively: a bearer token via `api_key` (a per-instance scoped token provider) and a classic IAM pair via `aws_access_key_id`/`aws_secret_access_key`/`region_name`, which it honors on both `boto3.Session()` and `Session.client()`. The comments in `services/bedrock_gateway_auth.py` and `models/provider_keys.py` still say `BedrockProvider` never forwards `api_key` into the boto3 client it builds, which was true of an older version. The hand-rolled unsigned client and the `aws_secret_access_key` alias may now be redundant.
- `/v1/providers/catalog` is deployment-operator-gated, so on a hosted deployment the provider picker on `/organization/provider-keys` has no catalog to offer an organization admin who is not also an operator. Pre-existing, and separate from this change.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code) by Claude Opus 5 (1M context)
